### PR TITLE
Fix error running matplotlib containing interfaces in workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -251,7 +251,7 @@ class MainWindow(QMainWindow):
         add_actions(self.view_menu, self.view_menu_actions)
 
     def launchCustomGUI(self, script):
-        exec(open(script).read())
+        exec(open(script).read(), globals())
 
     def populateAfterMantidImport(self):
         from mantid.kernel import ConfigService, logger
@@ -269,12 +269,11 @@ class MainWindow(QMainWindow):
         interfaces = {}
         for item in items:
             key, scriptname = item.split('/')
-            # TODO logger should accept unicode
             if not os.path.exists(os.path.join(interface_dir, scriptname)):
-                logger.warning(str('Failed to find script "{}" in "{}"'.format(scriptname, interface_dir)))
+                logger.warning('Failed to find script "{}" in "{}"'.format(scriptname, interface_dir))
                 continue
             if scriptname not in GUI_WHITELIST:
-                logger.information(str('Not adding gui "{}"'.format(scriptname)))
+                logger.information('Not adding gui "{}"'.format(scriptname))
                 continue
             temp = interfaces.get(key, [])
             temp.append(scriptname)


### PR DESCRIPTION
Apparently, it is necessary to pass the list of global variables into `exec` for it to not lose track of things.

**To test:**

Try running guis containing matplotlib in workbench. They shouldn't randomly crash anymore.

*There is no associated issue.*

*This does not require release notes* because **workbench!**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
