### PR TITLE
No duplicate peak numbers

### DIFF
--- a/Framework/Crystal/src/SaveIsawPeaks.cpp
+++ b/Framework/Crystal/src/SaveIsawPeaks.cpp
@@ -173,6 +173,7 @@ void SaveIsawPeaks::exec() {
 
     infile.close();
     out.open(filename.c_str(), std::ios::app);
+    appendPeakNumb = appendPeakNumb + 1;
   } else {
     out.open(filename.c_str());
 
@@ -341,8 +342,8 @@ void SaveIsawPeaks::exec() {
 
           // Sequence (run) number
           if (renumber) {
-            sequenceNumber++;
             out << "3" << std::setw(7) << sequenceNumber;
+            sequenceNumber++;
           } else {
             out << "3" << std::setw(7) << p.getPeakNumber() + appendPeakNumb;
           }

--- a/Framework/Crystal/test/SaveIsawPeaksTest.h
+++ b/Framework/Crystal/test/SaveIsawPeaksTest.h
@@ -52,8 +52,9 @@ public:
           p.setIntensity(static_cast<double>(i) + 0.1);
           p.setSigmaIntensity(sqrt(static_cast<double>(i)));
           p.setBinCount(static_cast<double>(i));
-          p.setPeakNumber( (run - 1000) * static_cast<int>(numBanks * numPeaksPerBank) +
-                               static_cast<int>(b * numPeaksPerBank + i));
+          p.setPeakNumber((run - 1000) *
+                              static_cast<int>(numBanks * numPeaksPerBank) +
+                          static_cast<int>(b * numPeaksPerBank + i));
           ws->addPeak(p);
         }
 

--- a/Framework/Crystal/test/SaveIsawPeaksTest.h
+++ b/Framework/Crystal/test/SaveIsawPeaksTest.h
@@ -77,7 +77,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg2.execute(););
 
     // Get the file
-    if (numPeaksPerBank > 0){
+    if (numPeaksPerBank > 0) {
       outfile = alg2.getPropertyValue("Filename");
       TS_ASSERT(Poco::File(outfile).exists());
       std::ifstream in(outfile.c_str());
@@ -90,8 +90,8 @@ public:
         line = line0;
       }
       TS_ASSERT_EQUALS(line, "3     71   -3   -3   -3    3.00     4.00    "
-                               "27086  2061.553   0.24498   0.92730   3.500000   "
-                               "14.3227        3       3.10    1.73   310");
+                             "27086  2061.553   0.24498   0.92730   3.500000   "
+                             "14.3227        3       3.10    1.73   310");
     }
 
     if (Poco::File(outfile).exists())

--- a/Framework/Crystal/test/SaveIsawPeaksTest.h
+++ b/Framework/Crystal/test/SaveIsawPeaksTest.h
@@ -52,7 +52,9 @@ public:
           p.setIntensity(static_cast<double>(i) + 0.1);
           p.setSigmaIntensity(sqrt(static_cast<double>(i)));
           p.setBinCount(static_cast<double>(i));
-          p.setPeakNumber(static_cast<int>((run-1000)*numBanks*numPeaksPerBank+b*numPeaksPerBank+i));
+          p.setPeakNumber(
+              static_cast<int>((run - 1000) * numBanks * numPeaksPerBank +
+                               b * numPeaksPerBank + i));
           ws->addPeak(p);
         }
 
@@ -87,8 +89,10 @@ public:
       line = line0;
     }
     if (numPeaksPerBank > 0)
-    TS_ASSERT_EQUALS(line, "3     71   -3   -3   -3    3.00     4.00    27086  2061.553   0.24498   0.92730   3.500000   14.3227        3       3.10    1.73   310");
-      
+      TS_ASSERT_EQUALS(line, "3     71   -3   -3   -3    3.00     4.00    "
+                             "27086  2061.553   0.24498   0.92730   3.500000   "
+                             "14.3227        3       3.10    1.73   310");
+
     if (Poco::File(outfile).exists())
       Poco::File(outfile).remove();
   }

--- a/Framework/Crystal/test/SaveIsawPeaksTest.h
+++ b/Framework/Crystal/test/SaveIsawPeaksTest.h
@@ -77,21 +77,22 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg2.execute(););
 
     // Get the file
-    outfile = alg2.getPropertyValue("Filename");
-    TS_ASSERT(Poco::File(outfile).exists());
-    std::ifstream in(outfile.c_str());
-    std::string line, line0;
-    while (!in.eof()) // To get you all the lines.
-    {
-      getline(in, line0); // Saves the line in STRING.
-      if (in.eof())
-        break;
-      line = line0;
-    }
-    if (numPeaksPerBank > 0)
+    if (numPeaksPerBank > 0){
+      outfile = alg2.getPropertyValue("Filename");
+      TS_ASSERT(Poco::File(outfile).exists());
+      std::ifstream in(outfile.c_str());
+      std::string line, line0;
+      while (!in.eof()) // To get you all the lines.
+      {
+        getline(in, line0); // Saves the line in STRING.
+        if (in.eof())
+          break;
+        line = line0;
+      }
       TS_ASSERT_EQUALS(line, "3     71   -3   -3   -3    3.00     4.00    "
-                             "27086  2061.553   0.24498   0.92730   3.500000   "
-                             "14.3227        3       3.10    1.73   310");
+                               "27086  2061.553   0.24498   0.92730   3.500000   "
+                               "14.3227        3       3.10    1.73   310");
+    }
 
     if (Poco::File(outfile).exists())
       Poco::File(outfile).remove();

--- a/Framework/Crystal/test/SaveIsawPeaksTest.h
+++ b/Framework/Crystal/test/SaveIsawPeaksTest.h
@@ -52,9 +52,8 @@ public:
           p.setIntensity(static_cast<double>(i) + 0.1);
           p.setSigmaIntensity(sqrt(static_cast<double>(i)));
           p.setBinCount(static_cast<double>(i));
-          p.setPeakNumber(
-              static_cast<int>((run - 1000) * numBanks * numPeaksPerBank +
-                               b * numPeaksPerBank + i));
+          p.setPeakNumber( (run - 1000) * static_cast<int>(numBanks * numPeaksPerBank) +
+                               static_cast<int>(b * numPeaksPerBank + i));
           ws->addPeak(p);
         }
 


### PR DESCRIPTION
**Description of work.**
Eliminate duplicate peak numbers when combining runs. Added unit test to check the peak numbers after appending.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
LoadIsawPeaks(Filename='/home/vel/mantid/release/ExternalData/Testing/Data/UnitTest/Peaks5637.integrate', OutputWorkspace='First')
LoadIsawPeaks(Filename='/home/vel/mantid/release/ExternalData/Testing/Data/UnitTest/Peaks5643.integrate', OutputWorkspace='Second')
SaveIsawPeaks(InputWorkspace="First",Filename="origNumber.peaks")
SaveIsawPeaks(InputWorkspace="Second",Filename="origNumber.peaks",AppendFile=True)
SaveIsawPeaks(InputWorkspace="First",Filename="seqNumber.peaks",RenumberPeaks=True)
SaveIsawPeaks(InputWorkspace="Second",Filename="seqNumber.peaks",AppendFile=True,RenumberPeaks=True)
````

Fixes #23840 

*This does not require release notes* because **it is already there**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
