### PR TITLE
ISIS Powder Pearl, Focus Saving XYE

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -55,6 +55,7 @@ Improvements
 - Removed save_angles flag for Gem , as it was set by the texture mode.
 - Added save_all flag to Gem that is set to true by default, setting it to false disables the saving of .NXS files.
 - Changed spline coefficient so that the default for long_mode on and long_mode off can be set separately.
+- Focus on Pearl now saves out xye_tof files.
 
 Bugfixes
 ########

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -62,7 +62,8 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
     summed_spectra = mantid.ConvertUnits(InputWorkspace=summed_spectra, Target="dSpacing",
                                          OutputWorkspace=summed_spectra_name)
     mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=summed_spectra, Append=False)
-
+    mantid.SaveFocusedXYE(InputWorkspace=summed_spectra_name, Filename=output_file_paths["tof_xye_filename"],
+                          Append=False, IncludeHeader=False)
     output_list = [summed_spectra]
     for i in range(0, 5):
         spectra_index = (i + 9)  # Compensate for 0 based index
@@ -71,6 +72,8 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
 
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=ws_to_save, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws_to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 2)
+        mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=output_file_paths["tof_xye_filename"]+str(i+10),
+                              Append=False, IncludeHeader=False)
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=output_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=ws_to_save, Append=True)
 
@@ -95,7 +98,8 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
         ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws, Filename=output_file_paths["gss_filename"], Append=False,
                        Bank=index)
-
+        mantid.SaveFocusedXYE(InputWorkspace=ws, Filename=output_file_paths["tof_xye_filename"],
+                              Append=False, IncludeHeader=False)
         workspace_names = ws.name()
         ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=workspace_names, Target="dSpacing")
         output_list.append(ws)
@@ -112,6 +116,8 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
 
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=to_save, Target="TOF")
         mantid.SaveGSS(InputWorkspace=to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 5)
+        mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=output_file_paths["tof_xye_filename"]+str(i+10),
+                              Append=False, IncludeHeader=False)
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=monitor_ws_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=to_save, Append=True)
 
@@ -127,6 +133,8 @@ def _focus_mode_mods(output_file_paths, calibrated_spectra):
         output_name = output_file_paths["output_name"] + "_mod" + str(index + 1)
         tof_ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=output_name,
                                      Target=WORKSPACE_UNITS.tof)
+        mantid.SaveFocusedXYE(InputWorkspace=tof_ws, Filename=output_file_paths["tof_xye_filename"],
+                              Append=False, IncludeHeader=False)
         mantid.SaveGSS(InputWorkspace=tof_ws, Filename=output_file_paths["gss_filename"], Append=append, Bank=index + 1)
         dspacing_ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=output_name,
                                           Target=WORKSPACE_UNITS.d_spacing)

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -73,7 +73,7 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=ws_to_save, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws_to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 2)
         tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" + str(i + 10) \
-            + output_file_paths["tof_xye_filename"].split(".")[1]
+            + "." + output_file_paths["tof_xye_filename"].split(".")[1]
         mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=output_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=ws_to_save, Append=True)
@@ -116,8 +116,8 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
         to_save = mantid.CloneWorkspace(InputWorkspace=monitor_ws, OutputWorkspace=monitor_ws_name)
 
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=to_save, Target="TOF")
-        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" +str(i+10)\
-            + output_file_paths["tof_xye_filename"].split(".")[1]
+        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" + str(i+10)\
+            + "." + output_file_paths["tof_xye_filename"].split(".")[1]
         mantid.SaveGSS(InputWorkspace=to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 5)
         mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=monitor_ws_name, Target="dSpacing")
@@ -157,6 +157,7 @@ def _focus_mode_trans(output_file_paths, attenuation_filepath, calibrated_spectr
 
     summed_ws = mantid.ConvertUnits(InputWorkspace=summed_ws, Target="TOF")
     mantid.SaveGSS(InputWorkspace=summed_ws, Filename=output_file_paths["gss_filename"], Append=False, Bank=1)
+
     mantid.SaveFocusedXYE(InputWorkspace=summed_ws, Filename=output_file_paths["tof_xye_filename"],
                           Append=False, IncludeHeader=False)
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -72,8 +72,8 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
 
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=ws_to_save, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws_to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 2)
-        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" + str(i + 10) \
-            + "." + output_file_paths["tof_xye_filename"].split(".")[1]
+        splits = output_file_paths["tof_xye_filename"].split(".")
+        tof_xye_name = splits[0] + "-" + str(i + 10) + "." + splits[1]
         mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=output_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=ws_to_save, Append=True)
@@ -116,8 +116,8 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
         to_save = mantid.CloneWorkspace(InputWorkspace=monitor_ws, OutputWorkspace=monitor_ws_name)
 
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=to_save, Target="TOF")
-        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" + str(i+10)\
-            + "." + output_file_paths["tof_xye_filename"].split(".")[1]
+        splits = output_file_paths["tof_xye_filename"].split(".")
+        tof_xye_name = splits[0] + "-" + str(i+10) + "." + splits[1]
         mantid.SaveGSS(InputWorkspace=to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 5)
         mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=monitor_ws_name, Target="dSpacing")

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -72,8 +72,9 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
 
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=ws_to_save, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws_to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 2)
-        mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=output_file_paths["tof_xye_filename"]+str(i+10),
-                              Append=False, IncludeHeader=False)
+        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" + str(i + 10) \
+            + output_file_paths["tof_xye_filename"].split(".")[1]
+        mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=output_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=ws_to_save, Append=True)
 
@@ -115,9 +116,10 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
         to_save = mantid.CloneWorkspace(InputWorkspace=monitor_ws, OutputWorkspace=monitor_ws_name)
 
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=to_save, Target="TOF")
+        tof_xye_name = output_file_paths["tof_xye_filename"].split(".")[0] + "-" +str(i+10)\
+            + output_file_paths["tof_xye_filename"].split(".")[1]
         mantid.SaveGSS(InputWorkspace=to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 5)
-        mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=output_file_paths["tof_xye_filename"]+str(i+10),
-                              Append=False, IncludeHeader=False)
+        mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=monitor_ws_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=to_save, Append=True)
 


### PR DESCRIPTION
**Description of work.**
Altered pearl_output so that all the focus modes now output xye files for the TOF workspaces, (sometimes multiple, depending on the focus mode)

**To test:**
Run the following script, and check that the output folder contains `PRL101508-101515_tt70_tof_xye-0.dat` as well as a version with `-10`, `-11`, `-12`, `-13`, and `-14` Then repeat the test for the other focus modes, only all and groups should provide the numbered versions.
Use the following [files](https://github.com/mantidproject/mantid/files/2486472/PEARL.zip) (additional files may be necessary, but were too large for github)
```
from isis_powder import Pearl

config_file_path = r"/home/sjenkins/Documents/Isis Powder/PEARL/pearl_shared_config.yaml"
Pearl_example = Pearl(config_file=config_file_path,user_name="testold70")
Pearl_example.create_vanadium(run_in_cycle=101508, do_absorb_corrections=True)
Pearl_example.focus(run_number="101508-101515", focus_mode="all")
#Pearl_example.focus(run_number="101508-101515", focus_mode="trans")
#Pearl_example.focus(run_number="101508-101515", focus_mode="mods")
#Pearl_example.focus(run_number="101508-101515", focus_mode="groups")

```

ensure you update the paths both in the script and in the config.yaml
Re #23092 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
