### PR TITLE
WavelengthRange according to documentation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
@@ -8,11 +8,13 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspaceProperty, PropertyMode, WorkspaceUnitValidator)
+from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspaceProperty, PropertyMode,
+                        WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, FloatArrayBoundedValidator, FloatArrayProperty,
-                           IntArrayBoundedValidator, IntArrayLengthValidator, IntArrayProperty, Property, StringListValidator)
-from mantid.simpleapi import (AddSampleLog, CropWorkspace, Divide, ExtractSingleSpectrum, RebinToWorkspace,ReflectometryBeamStatistics,
-                              ReflectometrySumInQ)
+                           IntArrayBoundedValidator, IntArrayLengthValidator, IntArrayProperty, Property,
+                           PropertyCriterion, StringListValidator, VisibleWhenProperty)
+from mantid.simpleapi import (AddSampleLog, CropWorkspace, Divide, ExtractSingleSpectrum, RebinToWorkspace,
+                              ReflectometryBeamStatistics, ReflectometrySumInQ)
 import numpy
 import ReflectometryILL_common as common
 
@@ -155,6 +157,8 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
                 values=[0.],
                 validator=nonnegativeFloatArray),
             doc='The wavelength bounds when summing in Q.')
+        wavelengthRange = VisibleWhenProperty(Prop.SUM_TYPE, PropertyCriterion.IsEqualTo, SumType.IN_LAMBDA)
+        self.setPropertySettings(Prop.WAVELENGTH_RANGE, wavelengthRange)
 
     def validateInputs(self):
         """Validate the algorithm's input properties."""
@@ -210,6 +214,8 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
     def _applyWavelengthRange(self, ws):
         """Cut wavelengths outside the wavelength range from a TOF workspace."""
         if self.getProperty(Prop.WAVELENGTH_RANGE).isDefault:
+            return ws
+        if self.getProperty(Prop.SUM_TYPE) == SumType.IN_LAMBDA:
             return ws
         wRange = self.getProperty(Prop.WAVELENGTH_RANGE).value
         rangeProp = {'XMin': wRange[0]}


### PR DESCRIPTION
**Description of work.**

The documentation of `ReflectometryILLSumForeground` states that only summation in Q needs or takes into account the `WavelengthRange` property.
Thus, the implementation should skip cropping the workspace according to a given wavelength range for summation in lambda.
Additionally, the automatic interface can be invisible accordingly for a better user understanding.

**To test:**

<!-- Instructions for testing. -->

All tests should pass

Fixes #23848.

*This does not require release notes*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
