### PR TITLE
Indirect  - Separate plot contour and spectrum options for S(Q,w) Tab

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -74,3 +74,4 @@ Improvements
 - ISISEnergyTransfer now allows overlapping detector grouping.
 - The Run button has been moved to be above the output options. The run button, save button and plotting options 
   are now disabled while a tab is running or plotting.  
+- It is now possible to choose which spectrum to Plot Output for in the S(Q,w) Tab.

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -8,6 +8,7 @@
 #include "../General/UserInputValidator.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <QFileInfo>
 
@@ -142,6 +143,15 @@ void IndirectSqw::run() {
   m_batchAlgoRunner->executeBatch();
 }
 
+MatrixWorkspace_const_sptr
+IndirectSqw::getADSWorkspace(std::string const &name) const {
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+}
+
+std::size_t IndirectSqw::getOutWsNumberOfSpectra() const {
+  return getADSWorkspace(m_pythonExportWsName)->getNumberHistograms();
+}
+
 /**
  * Handles plotting the S(Q, w) workspace when the algorithm chain is finished.
  *
@@ -152,7 +162,14 @@ void IndirectSqw::sqwAlgDone(bool error) {
     setPlotSpectrumEnabled(true);
     setPlotContourEnabled(true);
     setSaveEnabled(true);
+
+    setPlotSpectrumIndexMax(static_cast<int>(getOutWsNumberOfSpectra()) - 1);
   }
+}
+
+void IndirectSqw::setPlotSpectrumIndexMax(int maximum) {
+  MantidQt::API::SignalBlocker<QObject> blocker(m_uiForm.spSpectrum);
+  m_uiForm.spSpectrum->setMaximum(maximum);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -45,16 +45,20 @@ private slots:
                        QString const tooltip = "");
 
 private:
+  Mantid::API::MatrixWorkspace_const_sptr
+  getADSWorkspace(std::string const &name) const;
+  std::size_t getOutWsNumberOfSpectra() const;
+
+  void setPlotSpectrumIndexMax(int maximum);
+
   void setRunEnabled(bool enabled);
   void setPlotSpectrumEnabled(bool enabled);
   void setPlotContourEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
   void setOutputButtonsEnabled(std::string const &enableOutputButtons);
-
   void setPlotSpectrumIsPlotting(bool plotting);
   void setPlotContourIsPlotting(bool plotting);
 
-private:
   Ui::IndirectSqw m_uiForm;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -35,18 +35,24 @@ private slots:
   void sqwAlgDone(bool error);
 
   void runClicked();
-  void plotClicked();
+  void plotSpectrumClicked();
+  void plotContourClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
-  void setPlotEnabled(bool enabled);
-  void setSaveEnabled(bool enabled);
-  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
   void updateRunButton(bool enabled = true,
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
-  void setPlotIsPlotting(bool plotting);
+
+private:
+  void setRunEnabled(bool enabled);
+  void setPlotSpectrumEnabled(bool enabled);
+  void setPlotContourEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
+
+  void setPlotSpectrumIsPlotting(bool plotting);
+  void setPlotContourIsPlotting(bool plotting);
 
 private:
   Ui::IndirectSqw m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>601</width>
-    <height>268</height>
+    <height>303</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -442,46 +442,34 @@
       <item>
        <widget class="QLabel" name="lbPlotOutput">
         <property name="text">
-         <string>Plot Output:</string>
+         <string>Plot Spectrum:</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="cbPlotType">
+       <widget class="QSpinBox" name="spSpectrum">
         <property name="enabled">
          <bool>false</bool>
         </property>
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <item>
-         <property name="text">
-          <string>Contour</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Spectra</string>
-         </property>
-        </item>
        </widget>
       </item>
       <item>
-       <widget class="QPushButton" name="pbPlot">
+       <widget class="QPushButton" name="pbPlotSpectrum">
         <property name="enabled">
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Plot</string>
+         <string>Plot Spectrum</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbPlotContour">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Plot Contour</string>
         </property>
        </widget>
       </item>
@@ -528,7 +516,6 @@
   <tabstop>spELow</tabstop>
   <tabstop>spEWidth</tabstop>
   <tabstop>spEHigh</tabstop>
-  <tabstop>cbPlotType</tabstop>
   <tabstop>pbSave</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
**Description of work.**
This PR introduces separate Plot Spectrum and Plot Contour options so that you are able to choose which spectrum you want to plot. This is in the `S(Q,w)` Tab of `Indirect Data Reduction`.

**To test:**
1.`Interfaces`->`Indirect`->`Data Reduction`->`S(Q,w)` tab
2. Load the data below
3. Click `Run` and wait for the plotting options to be enabled
4. Select spectrum and click `Plot Spectrum`. The other plotting options as well as Run and Save should be disabled while plotting. The maximum number allowed in the spectrum spin box for this instance should be 22.
5. Click `Plot Contour`. Ensure all other plotting options as well as Run and save are disabled while plotting.

**Data**
Input File: [irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2486896/irs26176_graphite002_red.zip)
QLow: 0.45                      
QWidth: 0.05                     
QHigh: 1.6
ELow: -0.5                      
EWidth: 0.005                     
EHigh: 0.5

Fixes #23831

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
