### PR TITLE
PyChop qt4/qt5 compatible

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -251,20 +251,24 @@ class MainWindow(QMainWindow):
         add_actions(self.view_menu, self.view_menu_actions)
 
     def launchCustomGUI(self, script):
-        exec(open(script).read(), globals())
+        exec(open(script).read(), globals(), {'__name__':'__main__'})
 
     def populateAfterMantidImport(self):
         from mantid.kernel import ConfigService, logger
-        # TODO ConfigService should accept unicode strings
+        # TODO ConfigService should accept unicode strings https://github.com/mantidproject/mantid/pull/23826
         interface_dir = ConfigService[str('mantidqt.python_interfaces_directory')]
         items = ConfigService[str('mantidqt.python_interfaces')].split()
 
-        # list of custom interfaces that have been made qt4/qt5 compatible
-        # TODO need to make *anything* compatible
-        GUI_WHITELIST = ['DGSPlanner.py',
-                         'FilterEvents.py',
-                         'QECoverage.py',
-                         'TofConverter.py']
+        # list of custom interfaces that are not qt4/qt5 compatible
+        GUI_BLACKLIST = ['DGS_Reduction.py',
+                         'MSlice.py',
+                         'ORNL_SANS.py',
+                         'ISIS_Reflectometry_Old.py',
+                         'Powder_Diffraction_Reduction.py',
+                         'HFIR_4Circle_Reduction.py',
+                         'ISIS_SANS_v2_experimental.py',
+                         'Frequency_Domain_Analysis.py',
+                         'Elemental_Analysis.py']
 
         # detect the python interfaces
         interfaces = {}
@@ -273,7 +277,7 @@ class MainWindow(QMainWindow):
             if not os.path.exists(os.path.join(interface_dir, scriptname)):
                 logger.warning('Failed to find script "{}" in "{}"'.format(scriptname, interface_dir))
                 continue
-            if scriptname not in GUI_WHITELIST:
+            if scriptname in GUI_BLACKLIST:
                 logger.information('Not adding gui "{}"'.format(scriptname))
                 continue
             temp = interfaces.get(key, [])

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -251,7 +251,7 @@ class MainWindow(QMainWindow):
         add_actions(self.view_menu, self.view_menu_actions)
 
     def launchCustomGUI(self, script):
-        exec(open(script).read(), globals(), {'__name__':'__main__'})
+        exec(open(script).read(), globals())
 
     def populateAfterMantidImport(self):
         from mantid.kernel import ConfigService, logger

--- a/scripts/PyChop.py
+++ b/scripts/PyChop.py
@@ -15,9 +15,8 @@ from PyChop import PyChopGui
 from gui_helper import set_matplotlib_backend, get_qapplication
 set_matplotlib_backend()  # must be called before anything tries to use matplotlib
 
-if __name__ == '__main__':
-    app, within_mantid = get_qapplication()
-    window = PyChopGui.PyChopGui()
-    window.show()
-    if not within_mantid:
-        sys.exit(app.exec_())
+app, within_mantid = get_qapplication()
+window = PyChopGui.PyChopGui()
+window.show()
+if not within_mantid:
+    sys.exit(app.exec_())

--- a/scripts/PyChop.py
+++ b/scripts/PyChop.py
@@ -11,17 +11,13 @@ Module to import and run the PyChop GUI for use either on the commandline or as 
 """
 
 import sys
-from PyQt4 import QtGui
 from PyChop import PyChopGui
+from gui_helper import set_matplotlib_backend, get_qapplication
+set_matplotlib_backend()  # must be called before anything tries to use matplotlib
 
 if __name__ == '__main__':
-    if QtGui.QApplication.instance():
-        app = QtGui.QApplication.instance()
-    else:
-        app = QtGui.QApplication(sys.argv)
+    app, within_mantid = get_qapplication()
     window = PyChopGui.PyChopGui()
     window.show()
-    try: # check if started from within mantidplot
-        import mantidplot # noqa
-    except ImportError:
+    if not within_mantid:
         sys.exit(app.exec_())

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -23,14 +23,17 @@ import os
 import warnings
 import copy
 from .Instruments import Instrument
-from PyQt4 import QtGui, QtCore
-from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg as FigureCanvas
-from matplotlib.backends.backend_qt4agg import NavigationToolbar2QT as NavigationToolbar
+from qtpy.QtCore import (QEventLoop, Qt)  # noqa
+from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QDialog, QFileDialog, QGridLayout, QHBoxLayout, QMenu, QLabel,
+                            QLineEdit, QMainWindow, QMessageBox, QPushButton, QSizePolicy, QSpacerItem, QTabWidget,
+                            QTextEdit, QVBoxLayout, QWidget)  # noqa
+from MPLwidgets import FigureCanvasQTAgg as FigureCanvas
+from MPLwidgets import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.figure import Figure
 from matplotlib.widgets import Slider
 
 
-class PyChopGui(QtGui.QMainWindow):
+class PyChopGui(QMainWindow):
     """
     GUI Class using PyQT for PyChop to help users plan inelastic neutron experiments
     at spallation sources by calculating the resolution and flux at a given neutron energies.
@@ -451,13 +454,13 @@ class PyChopGui(QtGui.QMainWindow):
             self.scrtab.hide()
 
     def errormessage(self, message):
-        msg = QtGui.QMessageBox()
+        msg = QMessageBox()
         msg.setText(str(message))
-        msg.setStandardButtons(QtGui.QMessageBox.Ok)
+        msg.setStandardButtons(QMessageBox.Ok)
         msg.exec_()
 
     def loadYaml(self):
-        yaml_file = str(QtGui.QFileDialog().getOpenFileName(self.mainWidget, 'Open Instrument YAML File', self.folder, 'Files (*.yaml)'))
+        yaml_file = str(QFileDialog().getOpenFileName(self.mainWidget, 'Open Instrument YAML File', self.folder, 'Files (*.yaml)'))
         new_folder = os.path.dirname(yaml_file)
         if new_folder != self.folder:
             self.folder = new_folder
@@ -483,11 +486,11 @@ class PyChopGui(QtGui.QMainWindow):
         self.setInstrument(newname)
 
     def _ask_overwrite(self):
-        msg = QtGui.QDialog()
+        msg = QDialog()
         msg.setWindowTitle('Load overwrite')
-        layout = QtGui.QGridLayout()
-        layout.addWidget(QtGui.QLabel('Instrument %s already exists in memory. Overwrite this?'), 0, 0, 1, -1)
-        buttons = [QtGui.QPushButton(label) for label in ['Load and overwrite', 'Cancel Load', 'Load and rename to']]
+        layout = QGridLayout()
+        layout.addWidget(QLabel('Instrument %s already exists in memory. Overwrite this?'), 0, 0, 1, -1)
+        buttons = [QPushButton(label) for label in ['Load and overwrite', 'Cancel Load', 'Load and rename to']]
         locations = [[1, 0], [1, 1], [2, 0]]
         self.overwrite_flag = 1
 
@@ -497,7 +500,7 @@ class PyChopGui(QtGui.QMainWindow):
         for idx, button in enumerate(buttons):
             button.clicked.connect(lambda _, idx=idx: overwriteCB(idx))
             layout.addWidget(button, locations[idx][0], locations[idx][1])
-        newname = QtGui.QLineEdit()
+        newname = QLineEdit()
         newname.editingFinished.connect(lambda: overwriteCB(2))
         layout.addWidget(newname, 2, 1)
         msg.setLayout(layout)
@@ -591,29 +594,29 @@ class PyChopGui(QtGui.QMainWindow):
             generatedText = self.genText()
         except ValueError:
             return
-        self.txtwin = QtGui.QDialog()
-        self.txtedt = QtGui.QTextEdit()
-        self.txtbtn = QtGui.QPushButton('OK')
-        self.txtwin.layout = QtGui.QVBoxLayout(self.txtwin)
+        self.txtwin = QDialog()
+        self.txtedt = QTextEdit()
+        self.txtbtn = QPushButton('OK')
+        self.txtwin.layout = QVBoxLayout(self.txtwin)
         self.txtwin.layout.addWidget(self.txtedt)
         self.txtwin.layout.addWidget(self.txtbtn)
         self.txtbtn.clicked.connect(self.txtwin.deleteLater)
         self.txtedt.setText(generatedText)
         self.txtedt.setReadOnly(True)
         self.txtwin.setWindowTitle('Resolution information')
-        self.txtwin.setWindowModality(QtCore.Qt.ApplicationModal)
-        self.txtwin.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.txtwin.setWindowModality(Qt.ApplicationModal)
+        self.txtwin.setAttribute(Qt.WA_DeleteOnClose)
         self.txtwin.setMinimumSize(400, 600)
         self.txtwin.resize(400, 600)
         self.txtwin.show()
-        self.txtloop = QtCore.QEventLoop()
+        self.txtloop = QEventLoop,()
         self.txtloop.exec_()
 
     def saveText(self):
         """
         Saves the generated text to a file (opens file dialog).
         """
-        fname = QtGui.QFileDialog.getSaveFileName(self, 'Open file', '')
+        fname = QFileDialog.getSaveFileName(self, 'Open file', '')
         fid = open(fname, 'w')
         fid.write(self.genText())
         fid.close()
@@ -657,20 +660,20 @@ class PyChopGui(QtGui.QMainWindow):
             helpTxt += "all graphs will be updated. If the 'Hold current plot'\ncheck box is ticked, additional settings will be\n"
             helpTxt += "overplotted on the existing graphs if they are\ndifferent from previous settings.\n\nMore in-depth help "
             helpTxt += "can be obtained from the\nMantid help pages."
-            self.hlpwin = QtGui.QDialog()
-            self.hlpedt = QtGui.QLabel(helpTxt)
-            self.hlpbtn = QtGui.QPushButton('OK')
-            self.hlpwin.layout = QtGui.QVBoxLayout(self.hlpwin)
+            self.hlpwin = QDialog()
+            self.hlpedt = QLabel(helpTxt)
+            self.hlpbtn = QPushButton('OK')
+            self.hlpwin.layout = QVBoxLayout(self.hlpwin)
             self.hlpwin.layout.addWidget(self.hlpedt)
             self.hlpwin.layout.addWidget(self.hlpbtn)
             self.hlpbtn.clicked.connect(self.hlpwin.deleteLater)
             self.hlpwin.setWindowTitle('Help')
-            self.hlpwin.setWindowModality(QtCore.Qt.ApplicationModal)
-            self.hlpwin.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+            self.hlpwin.setWindowModality(Qt.ApplicationModal)
+            self.hlpwin.setAttribute(Qt.WA_DeleteOnClose)
             self.hlpwin.setMinimumSize(370, 300)
             self.hlpwin.resize(370, 300)
             self.hlpwin.show()
-            self.hlploop = QtCore.QEventLoop()
+            self.hlploop = QEventLoop,()
             self.hlploop.exec_()
 
     def drawLayout(self):
@@ -697,21 +700,21 @@ class PyChopGui(QtGui.QMainWindow):
         self.singles = []
         self.widgets = {}
 
-        self.leftPanel = QtGui.QVBoxLayout()
-        self.rightPanel = QtGui.QVBoxLayout()
-        self.tabs = QtGui.QTabWidget(self)
-        self.fullWindow = QtGui.QGridLayout()
+        self.leftPanel = QVBoxLayout()
+        self.rightPanel = QVBoxLayout()
+        self.tabs = QTabWidget(self)
+        self.fullWindow = QGridLayout()
         for widget in self.widgetslist:
             if 'pair' in widget[0]:
-                self.droplabels.append(QtGui.QLabel(widget[2]))
+                self.droplabels.append(QLabel(widget[2]))
                 if 'combo' in widget[3]:
-                    self.dropboxes.append(QtGui.QComboBox(self))
+                    self.dropboxes.append(QComboBox(self))
                     self.dropboxes[-1].activated['QString'].connect(widget[5])
                     for item in widget[4]:
                         self.dropboxes[-1].addItem(item)
                     self.widgets[widget[-1]] = {'Combo':self.dropboxes[-1], 'Label':self.droplabels[-1]}
                 elif 'edit' in widget[3]:
-                    self.dropboxes.append(QtGui.QLineEdit(self))
+                    self.dropboxes.append(QLineEdit(self))
                     self.dropboxes[-1].returnPressed.connect(widget[5])
                     self.widgets[widget[-1]] = {'Edit':self.dropboxes[-1], 'Label':self.droplabels[-1]}
                 else:
@@ -723,10 +726,10 @@ class PyChopGui(QtGui.QMainWindow):
                     self.dropboxes[-1].hide()
             elif 'single' in widget[0]:
                 if 'check' in widget[3]:
-                    self.singles.append(QtGui.QCheckBox(widget[2], self))
+                    self.singles.append(QCheckBox(widget[2], self))
                     self.singles[-1].stateChanged.connect(widget[4])
                 elif 'button' in widget[3]:
-                    self.singles.append(QtGui.QPushButton(widget[2]))
+                    self.singles.append(QPushButton(widget[2]))
                     self.singles[-1].clicked.connect(widget[4])
                 else:
                     raise RuntimeError('Bug in code - widget %s is not recognised.' % (widget[3]))
@@ -735,7 +738,7 @@ class PyChopGui(QtGui.QMainWindow):
                     self.singles[-1].hide()
                 self.widgets[widget[-1]] = self.singles[-1]
             elif 'spacer' in widget[0]:
-                self.leftPanel.addItem(QtGui.QSpacerItem(0, 35))
+                self.leftPanel.addItem(QSpacerItem(0, 35))
             else:
                 raise RuntimeError('Bug in code - widget class %s is not recognised.' % (widget[0]))
 
@@ -748,8 +751,8 @@ class PyChopGui(QtGui.QMainWindow):
         self.resaxes.set_xlabel('Energy Transfer (meV)')
         self.resaxes.set_ylabel(r'$\Delta$E (meV FWHM)')
         self.resfig_controls = NavigationToolbar(self.rescanvas, self)
-        self.restab = QtGui.QWidget(self.tabs)
-        self.restabbox = QtGui.QVBoxLayout()
+        self.restab = QWidget(self.tabs)
+        self.restabbox = QVBoxLayout()
         self.restabbox.addWidget(self.rescanvas)
         self.restabbox.addWidget(self.resfig_controls)
         self.restab.setLayout(self.restabbox)
@@ -771,19 +774,19 @@ class PyChopGui(QtGui.QMainWindow):
         self.flxslder = Slider(self.flxsldax, 'Ei (meV)', 0, 100, valinit=100)
         self.flxslder.valtext.set_visible(False)
         self.flxslder.on_changed(self.update_slider)
-        self.flxedt = QtGui.QLineEdit()
+        self.flxedt = QLineEdit()
         self.flxedt.setText('1000')
         self.flxedt.returnPressed.connect(self.update_slider)
-        self.flxtab = QtGui.QWidget(self.tabs)
-        self.flxsldbox = QtGui.QHBoxLayout()
+        self.flxtab = QWidget(self.tabs)
+        self.flxsldbox = QHBoxLayout()
         self.flxsldbox.addWidget(self.flxsldcv)
         self.flxsldbox.addWidget(self.flxedt)
-        self.flxsldwdg = QtGui.QWidget()
+        self.flxsldwdg = QWidget()
         self.flxsldwdg.setLayout(self.flxsldbox)
         sz = self.flxsldwdg.maximumSize()
         sz.setHeight(50)
         self.flxsldwdg.setMaximumSize(sz)
-        self.flxtabbox = QtGui.QVBoxLayout()
+        self.flxtabbox = QVBoxLayout()
         self.flxtabbox.addWidget(self.flxcanvas)
         self.flxtabbox.addWidget(self.flxsldwdg)
         self.flxtabbox.addWidget(self.flxfig_controls)
@@ -799,8 +802,8 @@ class PyChopGui(QtGui.QMainWindow):
         self.frqaxes1.set_xlabel('Chopper Frequency (Hz)')
         self.frqaxes2.set_ylabel('Elastic Resolution FWHM (meV)')
         self.frqfig_controls = NavigationToolbar(self.frqcanvas, self)
-        self.frqtab = QtGui.QWidget(self.tabs)
-        self.frqtabbox = QtGui.QVBoxLayout()
+        self.frqtab = QWidget(self.tabs)
+        self.frqtabbox = QVBoxLayout()
         self.frqtabbox.addWidget(self.frqcanvas)
         self.frqtabbox.addWidget(self.frqfig_controls)
         self.frqtab.setLayout(self.frqtabbox)
@@ -813,19 +816,19 @@ class PyChopGui(QtGui.QMainWindow):
         self.repaxes.set_xlabel(r'TOF ($\mu$sec)')
         self.repaxes.set_ylabel('Distance (m)')
         self.repfig_controls = NavigationToolbar(self.repcanvas, self)
-        self.repfig_nframe_label = QtGui.QLabel('Number of frames to plot')
-        self.repfig_nframe_edit = QtGui.QLineEdit('1')
-        self.repfig_nframe_button = QtGui.QPushButton('Replot')
+        self.repfig_nframe_label = QLabel('Number of frames to plot')
+        self.repfig_nframe_edit = QLineEdit('1')
+        self.repfig_nframe_button = QPushButton('Replot')
         self.repfig_nframe_button.clicked.connect(lambda: self.plot_frame())
-        self.repfig_nframe_box = QtGui.QHBoxLayout()
+        self.repfig_nframe_box = QHBoxLayout()
         self.repfig_nframe_box.addWidget(self.repfig_nframe_label)
         self.repfig_nframe_box.addWidget(self.repfig_nframe_edit)
         self.repfig_nframe_box.addWidget(self.repfig_nframe_button)
-        self.reptab = QtGui.QWidget(self.tabs)
-        self.repfig_nframe = QtGui.QWidget(self.reptab)
+        self.reptab = QWidget(self.tabs)
+        self.repfig_nframe = QWidget(self.reptab)
         self.repfig_nframe.setLayout(self.repfig_nframe_box)
-        self.repfig_nframe.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed))
-        self.reptabbox = QtGui.QVBoxLayout()
+        self.repfig_nframe.setSizePolicy(QSizePolicy(QSizePolicy.Preferred, QSizePolicy.Fixed))
+        self.reptabbox = QVBoxLayout()
         self.reptabbox.addWidget(self.repcanvas)
         self.reptabbox.addWidget(self.repfig_nframe)
         self.reptabbox.addWidget(self.repfig_controls)
@@ -839,17 +842,17 @@ class PyChopGui(QtGui.QMainWindow):
         self.qeaxes.set_xlabel(r'$|Q| (\mathrm{\AA}^{-1})$')
         self.qeaxes.set_ylabel('Energy Transfer (meV)')
         self.qefig_controls = NavigationToolbar(self.qecanvas, self)
-        self.qetabbox = QtGui.QVBoxLayout()
+        self.qetabbox = QVBoxLayout()
         self.qetabbox.addWidget(self.qecanvas)
         self.qetabbox.addWidget(self.qefig_controls)
-        self.qetab = QtGui.QWidget(self.tabs)
+        self.qetab = QWidget(self.tabs)
         self.qetab.setLayout(self.qetabbox)
 
-        self.scrtab = QtGui.QWidget(self.tabs)
-        self.scredt = QtGui.QTextEdit()
-        self.scrcls = QtGui.QPushButton("Clear")
+        self.scrtab = QWidget(self.tabs)
+        self.scredt = QTextEdit()
+        self.scrcls = QPushButton("Clear")
         self.scrcls.clicked.connect(lambda: self.scredt.clear())
-        self.scrbox = QtGui.QVBoxLayout()
+        self.scrbox = QVBoxLayout()
         self.scrbox.addWidget(self.scredt)
         self.scrbox.addWidget(self.scrcls)
         self.scrtab.setLayout(self.scrbox)
@@ -867,65 +870,33 @@ class PyChopGui(QtGui.QMainWindow):
         self.scrtabID = 5
         self.rightPanel.addWidget(self.tabs)
 
-        self.menuLoad = QtGui.QMenu('Load')
-        self.loadAct = QtGui.QAction('Load YAML', self.menuLoad)
+        self.menuLoad = QMenu('Load')
+        self.loadAct = QAction('Load YAML', self.menuLoad)
         self.loadAct.triggered.connect(self.loadYaml)
         self.menuLoad.addAction(self.loadAct)
-        self.menuOptions = QtGui.QMenu('Options')
-        self.instSciAct = QtGui.QAction('Instrument Scientist Mode', self.menuOptions, checkable=True)
+        self.menuOptions = QMenu('Options')
+        self.instSciAct = QAction('Instrument Scientist Mode', self.menuOptions, checkable=True)
         self.instSciAct.triggered.connect(self.instSciCB)
         self.menuOptions.addAction(self.instSciAct)
-        self.eiPlots = QtGui.QAction('Press Enter in Ei box updates plots', self.menuOptions, checkable=True)
+        self.eiPlots = QAction('Press Enter in Ei box updates plots', self.menuOptions, checkable=True)
         self.menuOptions.addAction(self.eiPlots)
-        self.overwriteload = QtGui.QAction('Always overwrite instruments in memory', self.menuOptions, checkable=True)
+        self.overwriteload = QAction('Always overwrite instruments in memory', self.menuOptions, checkable=True)
         self.menuOptions.addAction(self.overwriteload)
         self.menuBar().addMenu(self.menuLoad)
         self.menuBar().addMenu(self.menuOptions)
 
-        self.leftPanelWidget = QtGui.QWidget()
+        self.leftPanelWidget = QWidget()
         self.leftPanelWidget.setLayout(self.leftPanel)
-        self.leftPanelWidget.setSizePolicy(QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Preferred))
+        self.leftPanelWidget.setSizePolicy(QSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred))
         self.fullWindow.addWidget(self.leftPanelWidget, 0, 0)
         self.fullWindow.addLayout(self.rightPanel, 0, 1)
-        self.helpbtn = QtGui.QPushButton("?", self)
+        self.helpbtn = QPushButton("?", self)
         self.helpbtn.setMaximumWidth(30)
         self.helpbtn.clicked.connect(self.onHelp)
         self.fullWindow.addWidget(self.helpbtn, 1, 0, 1, -1)
 
-        self.mainWidget = QtGui.QWidget()
+        self.mainWidget = QWidget()
         self.mainWidget.setLayout(self.fullWindow)
         self.setCentralWidget(self.mainWidget)
         self.setWindowTitle('PyChopGUI')
         self.show()
-
-
-def show():
-    """
-    Create a Qt window in Python, or interactively in IPython with Qt GUI
-    event loop integration.
-    """
-    app_created = False
-    app = QtCore.QCoreApplication.instance()
-    if app is None:
-        app = QtGui.QApplication(sys.argv)
-        app_created = True
-    app.references = set()
-    window = PyChopGui()
-    app.references.add(window)
-    window.show()
-    if app_created:
-        app.exec_()
-    return window
-
-
-if __name__ == '__main__':
-    if QtGui.QApplication.instance():
-        app = QtGui.QApplication.instance()
-    else:
-        app = QtGui.QApplication(sys.argv)
-    window = PyChopGui()
-    window.show()
-    try: # check if started from within mantidplot
-        import mantidplot # noqa
-    except ImportError:
-        sys.exit(app.exec_())

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -609,7 +609,7 @@ class PyChopGui(QMainWindow):
         self.txtwin.setMinimumSize(400, 600)
         self.txtwin.resize(400, 600)
         self.txtwin.show()
-        self.txtloop = QEventLoop,()
+        self.txtloop = QEventLoop()
         self.txtloop.exec_()
 
     def saveText(self):
@@ -673,7 +673,7 @@ class PyChopGui(QMainWindow):
             self.hlpwin.setMinimumSize(370, 300)
             self.hlpwin.resize(370, 300)
             self.hlpwin.show()
-            self.hlploop = QEventLoop,()
+            self.hlploop = QEventLoop()
             self.hlploop.exec_()
 
     def drawLayout(self):

--- a/tools/scripts/pyqt4_to_qtpy.py
+++ b/tools/scripts/pyqt4_to_qtpy.py
@@ -71,8 +71,8 @@ def convert_signal_connect(cmd, linenum):
 
     return '{0}{1}.{2}.connect({3})\n'.format(whitespace, widget_name, signal_call, handler_method)
 
-QT4_TO_QTPY_FIXES = {'QtCore.QEventLoop': ('qtpy.QtCore', 'QEventLoop,'),
-                     'QtCore.QFileInfo': ('qtpy.QtCore', 'QFileInfo,'),
+QT4_TO_QTPY_FIXES = {'QtCore.QEventLoop': ('qtpy.QtCore', 'QEventLoop'),
+                     'QtCore.QFileInfo': ('qtpy.QtCore', 'QFileInfo'),
                      'QtCore.QRegExp': ('qtpy.QtCore', 'QRegExp'),
                      'QtCore.QSettings': ('qtpy.QtCore', 'QSettings'),
                      'QtGui.QAction': ('qtpy.QtWidgets', 'QAction'),

--- a/tools/scripts/pyqt4_to_qtpy.py
+++ b/tools/scripts/pyqt4_to_qtpy.py
@@ -71,18 +71,36 @@ def convert_signal_connect(cmd, linenum):
 
     return '{0}{1}.{2}.connect({3})\n'.format(whitespace, widget_name, signal_call, handler_method)
 
-QT4_TO_QTPY_FIXES = {'QtCore.QFileInfo': ('qtpy.QtCore', 'QFileInfo,'),
+QT4_TO_QTPY_FIXES = {'QtCore.QEventLoop': ('qtpy.QtCore', 'QEventLoop,'),
+                     'QtCore.QFileInfo': ('qtpy.QtCore', 'QFileInfo,'),
                      'QtCore.QRegExp': ('qtpy.QtCore', 'QRegExp'),
                      'QtCore.QSettings': ('qtpy.QtCore', 'QSettings'),
+                     'QtGui.QAction': ('qtpy.QtWidgets', 'QAction'),
                      'QtGui.QButtonGroup': ('qtpy.QtWidgets', 'QButtonGroup'),
+                     'QtGui.QCheckBox': ('qtpy.QtWidgets', 'QCheckBox'),
+                     'QtGui.QComboBox': ('qtpy.QtWidgets', 'QComboBox'),
                      'QtGui.QDialog': ('qtpy.QtWidgets', 'QDialog'),
                      'QtGui.QDoubleValidator': ('qtpy.QtGui', 'QDoubleValidator'),
                      'QtGui.QFileDialog': ('qtpy.QtWidgets', 'QFileDialog'),
                      'QtGui.QFrame': ('qtpy.QtWidgets', 'QFrame'),
+                     'QtGui.QGridLayout': ('qtpy.QtWidgets', 'QGridLayout'),
                      'QtGui.QGroupBox': ('qtpy.QtWidgets', 'QGroupBox'),
+                     'QtGui.QHBoxLayout': ('qtpy.QtWidgets', 'QHBoxLayout'),
                      'QtGui.QIntValidator': ('qtpy.QtGui', 'QIntValidator'),
+                     'QtGui.QMenu': ('qtpy.QtWidgets', 'QMenu'),
+                     'QtGui.QLabel': ('qtpy.QtWidgets', 'QLabel'),
+                     'QtGui.QLineEdit': ('qtpy.QtWidgets', 'QLineEdit'),
+                     'QtGui.QMainWindow': ('qtpy.QtWidgets', 'QMainWindow'),
                      'QtGui.QMessageBox': ('qtpy.QtWidgets', 'QMessageBox'),
-                     'QtGui.QRegExpValidator': ('qtpy.QtGui', 'QRegExpValidator')}
+                     'QtGui.QPushButton': ('qtpy.QtWidgets', 'QPushButton'),
+                     'QtGui.QRegExpValidator': ('qtpy.QtGui', 'QRegExpValidator'),
+                     'QtGui.QSizePolicy': ('qtpy.QtWidgets', 'QSizePolicy'),
+                     'QtGui.QSpacerItem': ('qtpy.QtWidgets', 'QSpacerItem'),
+                     'QtGui.QTabWidget': ('qtpy.QtWidgets', 'QTabWidget'),
+                     'QtGui.QTextEdit': ('qtpy.QtWidgets', 'QTextEdit'),
+                     'QtGui.QVBoxLayout': ('qtpy.QtWidgets', 'QVBoxLayout'),
+                     'QtGui.QWidget': ('qtpy.QtWidgets', 'QWidget'),
+                     }
 
 
 def convertToQtPy(command, linenum):


### PR DESCRIPTION
Add PyChop to the workbench. There is many more qtpy classes added to the conversion script as well.

**To test:**

Launch it from `mantidplot`, `mantidworkbench`, and `mantidpython`.

*There is no associated issue.*

*This does not require release notes* because workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
