### PR TITLE
Move QE coverage to workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -263,6 +263,7 @@ class MainWindow(QMainWindow):
         # TODO need to make *anything* compatible
         GUI_WHITELIST = ['DGSPlanner.py',
                          'FilterEvents.py',
+                         'QECoverage.py',
                          'TofConverter.py']
 
         # detect the python interfaces

--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -15,6 +15,7 @@ import sys
 import mantid
 from .ValidateOL import ValidateOL
 import matplotlib
+from gui_helper import show_interface_help
 from MPLwidgets import *
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
@@ -116,12 +117,13 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         self.instrumentWidget.updateAll()
         self.dimensionWidget.updateChanges()
         # help
-        self.assistantProcess = QtCore.QProcess(self)
+        self.assistant_process = QtCore.QProcess(self)
         # pylint: disable=protected-access
-        self.collectionFile = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
+        self.mantidplot_name='DGS Planner'
+        self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
         version = ".".join(mantid.__version__.split(".")[:2])
-        self.qtUrl = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/DGS Planner.html'
-        self.externalUrl = 'http://docs.mantidproject.org/nightly/interfaces/DGS Planner.html'
+        self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/DGS Planner.html'
+        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/DGS Planner.html'
         # control for cancel button
         self.iterations = 0
         self.progress_canceled = False
@@ -146,35 +148,15 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         self.masterDict.update(copy.deepcopy(d))
 
     def help(self):
-        try:
-            import pymantidplot
-            pymantidplot.proxies.showCustomInterfaceHelp('DGS Planner')
-        except ImportError:
-            self.assistantProcess.close()
-            self.assistantProcess.waitForFinished()
-            helpapp = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.BinariesPath) + QtCore.QDir.separator()
-            helpapp += 'assistant'
-            args = ['-enableRemoteControl', '-collectionFile', self.collectionFile, '-showUrl', self.qtUrl]
-            if os.path.isfile(helpapp) and os.path.isfile(self.collectionFile):
-                self.assistantProcess.close()
-                self.assistantProcess.waitForFinished()
-                self.assistantProcess.start(helpapp, args)
-            else:
-                try:
-                    from mantidqtpython.MantidQt.API.MantidDesktopServices import openUrl
-                except ImportError:
-                    openUrl=QtGui.QDesktopServices.openUrl
-                sysenv=QtCore.QProcessEnvironment.systemEnvironment()
-                ldp=sysenv.value('LD_PRELOAD')
-                if ldp:
-                    del os.environ['LD_PRELOAD']
-                openUrl(QtCore.QUrl(self.externalUrl))
-                if ldp:
-                    os.environ['LD_PRELOAD']=ldp
+        show_interface_help(self.mantidplot_name, 
+                            self.assistant_process,
+                            self.collection_file, 
+                            self.qt_url, 
+                            self.external_url)
 
     def closeEvent(self, event):
-        self.assistantProcess.close()
-        self.assistantProcess.waitForFinished()
+        self.assistant_process.close()
+        self.assistant_process.waitForFinished()
         event.accept()
 
     def _create_goniometer_workspaces(self, gonioAxis0values, gonioAxis1values, gonioAxis2values, progressDialog):

--- a/scripts/DGSPlanner/DGSPlannerGUI.py
+++ b/scripts/DGSPlanner/DGSPlannerGUI.py
@@ -10,7 +10,7 @@ from . import InstrumentSetupWidget
 from . import ClassicUBInputWidget
 from . import MatrixUBInputWidget
 from . import DimensionSelectorWidget
-from qtpy import QtCore, QtGui,QtWidgets
+from qtpy import QtCore, QtWidgets
 import sys
 import mantid
 from .ValidateOL import ValidateOL
@@ -148,10 +148,10 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         self.masterDict.update(copy.deepcopy(d))
 
     def help(self):
-        show_interface_help(self.mantidplot_name, 
+        show_interface_help(self.mantidplot_name,
                             self.assistant_process,
-                            self.collection_file, 
-                            self.qt_url, 
+                            self.collection_file,
+                            self.qt_url,
                             self.external_url)
 
     def closeEvent(self, event):

--- a/scripts/QECoverage.py
+++ b/scripts/QECoverage.py
@@ -214,11 +214,11 @@ class QECoverageGUI(QtWidgets.QWidget):
         #register startup
         mantid.UsageService.registerFeatureUsage("Interface","QECoverage",False)
 
-    def onHelp(self):        
-        show_interface_help(self.mantidplot_name, 
+    def onHelp(self):
+        show_interface_help(self.mantidplot_name,
                             self.assistant_process,
-                            self.collection_file, 
-                            self.qt_url, 
+                            self.collection_file,
+                            self.qt_url,
                             self.external_url)
 
     def closeEvent(self, event):

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -8,9 +8,14 @@
 from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import QMainWindow, QMessageBox
 from qtpy.QtGui import QDoubleValidator
+from qtpy import QtCore
+import os
 from mantid.kernel import Logger
+import mantid
+from gui_helper import show_interface_help
 import math
 import TofConverter.convertUnits
+
 
 try:
     from mantidqt.utils.qt import load_ui
@@ -75,6 +80,16 @@ class MainWindow(QMainWindow):
         self.Theta = -1.0
         self.output = 0.0
 
+        #help
+        self.assistant_process = QtCore.QProcess(self)
+        # pylint: disable=protected-access
+        import mantid
+        self.mantidplot_name='TOF Converter'
+        self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
+        version = ".".join(mantid.__version__.split(".")[:2])
+        self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/TOF Converter.html'
+        self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/TOF Converter.html'
+
         try:
             import mantid
             #register startup
@@ -83,9 +98,16 @@ class MainWindow(QMainWindow):
             pass
 
     def helpClicked(self):
-        # Temporary import while method is in the wrong place
-        from pymantidplot.proxies import showCustomInterfaceHelp
-        showCustomInterfaceHelp("TOF Converter")
+        show_interface_help(self.mantidplot_name,
+                            self.assistant_process,
+                            self.collection_file,
+                            self.qt_url,
+                            self.external_url)
+
+    def closeEvent(self, event):
+        self.assistant_process.close()
+        self.assistant_process.waitForFinished()
+        event.accept()
 
     def convert(self):
         #Always reset these values before conversion.

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -11,7 +11,6 @@ from qtpy.QtGui import QDoubleValidator
 from qtpy import QtCore
 import os
 from mantid.kernel import Logger
-import mantid
 from gui_helper import show_interface_help
 import math
 import TofConverter.convertUnits

--- a/scripts/gui_helper.py
+++ b/scripts/gui_helper.py
@@ -8,7 +8,8 @@ from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import (QApplication)  # noqa
 from qtpy import QtCore, QtGui
 import matplotlib
-import sys, os
+import sys
+import os
 
 
 def set_matplotlib_backend():
@@ -48,6 +49,7 @@ def get_qapplication():
         return app, app.applicationName().lower().startswith('mantid')
     else:
         return QApplication(sys.argv), False
+
 
 def show_interface_help(mantidplot_name, assistant_process, collection_file, qt_url, external_url):
     ''' Shows the help page for a custom interface

--- a/scripts/gui_helper.py
+++ b/scripts/gui_helper.py
@@ -6,8 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import (QApplication)  # noqa
+from qtpy import QtCore, QtGui
 import matplotlib
-import sys
+import sys, os
 
 
 def set_matplotlib_backend():
@@ -47,3 +48,58 @@ def get_qapplication():
         return app, app.applicationName().lower().startswith('mantid')
     else:
         return QApplication(sys.argv), False
+
+def show_interface_help(mantidplot_name, assistant_process, collection_file, qt_url, external_url):
+    ''' Shows the help page for a custom interface
+    @param mantidplot_name: used by showCustomInterfaceHelp
+    @param assistant_process: needs to be started/closed from outside (see example below)
+    @param collection_file: qth file containing the help in format used by qtassistant
+    @param qt_url: location of the help in the qth file
+    @param external_url: location of external page to be displayed in the default browser
+
+    Example:
+
+    #in the __init__ function of the GUI add:
+    self.assistant_process = QtCore.QProcess(self)
+    self.mantidplot_name='DGS Planner'
+    self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
+    version = ".".join(mantid.__version__.split(".")[:2])
+    self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/DGS Planner.html'
+    self.external_url = 'http://docs.mantidproject.org/nightly/interfaces/DGS Planner.html'
+
+    #add a help function in the GUI
+    def help(self):
+       show_interface_help(self.mantidplot_name,
+                           self.assistant_process,
+                           self.collection_file,
+                           self.qt_url,
+                           self.external_url)
+
+    #make sure you close the qtassistant when the GUI is closed
+    def closeEvent(self, event):
+        self.assistant_process.close()
+        self.assistant_process.waitForFinished()
+        event.accept()
+    '''
+    try:
+        import pymantidplot
+        pymantidplot.proxies.showCustomInterfaceHelp(mantidplot_name)
+    except: #(ImportError, ModuleNotFoundError) raises the wrong type of error
+        assistant_process.close()
+        assistant_process.waitForFinished()
+        helpapp = QtCore.QLibraryInfo.location(QtCore.QLibraryInfo.BinariesPath) + QtCore.QDir.separator()
+        helpapp += 'assistant'
+        args = ['-enableRemoteControl', '-collectionFile', collection_file, '-showUrl', qt_url]
+        if os.path.isfile(helpapp) and os.path.isfile(collection_file):
+            assistant_process.close()
+            assistant_process.waitForFinished()
+            assistant_process.start(helpapp, args)
+        else:
+            openUrl=QtGui.QDesktopServices.openUrl
+            sysenv=QtCore.QProcessEnvironment.systemEnvironment()
+            ldp=sysenv.value('LD_PRELOAD')
+            if ldp:
+                del os.environ['LD_PRELOAD']
+            openUrl(QtCore.QUrl(external_url))
+            if ldp:
+                os.environ['LD_PRELOAD']=ldp


### PR DESCRIPTION
Move QE coverage to qtpy, so it can be used in the new workbench
Also, added a `show_interface_help`, so people can expose the help for interface in the new workbench
*There is no associated issue.*
*This does not require release notes* because **workbench**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
