### PR TITLE
ISIS Powder Pearl Remove Vanadium Splines from workspace after focus

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -118,6 +118,8 @@ def _batched_run_focusing(instrument, perform_vanadium_norm, run_number_string, 
         output = _focus_one_ws(input_workspace=ws, run_number=run_number_string, instrument=instrument,
                                perform_vanadium_norm=perform_vanadium_norm, absorb=absorb,
                                sample_details=sample_details, vanadium_path=vanadium_splines)
+    if instrument.get_instrument_prefix() == "PEARL":
+        mantid.DeleteWorkspace(vanadium_splines.OutputWorkspace)
     return output
 
 
@@ -161,6 +163,8 @@ def _individual_run_focusing(instrument, perform_vanadium_norm, run_number, abso
         output = _focus_one_ws(input_workspace=ws[0], run_number=run, instrument=instrument, absorb=absorb,
                                perform_vanadium_norm=perform_vanadium_norm, sample_details=sample_details,
                                vanadium_path=vanadium_splines)
+        if instrument.get_instrument_prefix() == "PEARL":
+            mantid.DeleteWorkspace(vanadium_splines.OutputWorkspace)
     return output
 
 

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -118,7 +118,7 @@ def _batched_run_focusing(instrument, perform_vanadium_norm, run_number_string, 
         output = _focus_one_ws(input_workspace=ws, run_number=run_number_string, instrument=instrument,
                                perform_vanadium_norm=perform_vanadium_norm, absorb=absorb,
                                sample_details=sample_details, vanadium_path=vanadium_splines)
-    if instrument.get_instrument_prefix() == "PEARL":
+    if instrument.get_instrument_prefix() == "PEARL" and vanadium_splines is not None :
         mantid.DeleteWorkspace(vanadium_splines.OutputWorkspace)
     return output
 
@@ -163,8 +163,6 @@ def _individual_run_focusing(instrument, perform_vanadium_norm, run_number, abso
         output = _focus_one_ws(input_workspace=ws[0], run_number=run, instrument=instrument, absorb=absorb,
                                perform_vanadium_norm=perform_vanadium_norm, sample_details=sample_details,
                                vanadium_path=vanadium_splines)
-        if instrument.get_instrument_prefix() == "PEARL":
-            mantid.DeleteWorkspace(vanadium_splines.OutputWorkspace)
     return output
 
 


### PR DESCRIPTION
**Description of work.**
At the end of a batched or individual focus, checks if the instrument is pearl and if it is, removes the Vanadium Splines from the ADS.
**To test:**
(this test requires access to the ISIS Data Search Archive to access some of the files)
Run the following script with these [files](https://github.com/mantidproject/mantid/files/2495235/PEARL.zip)   (note some additional files are required, but they were to large to transfer via github, please message me on slack to receive them)
```
from isis_powder import Pearl

config_file_path = r"/Path/to/pearl_shared_config.yaml"
Pearl_example = Pearl(config_file=config_file_path,user_name="testold70")
Pearl_example.create_vanadium(run_in_cycle=101508, do_absorb_corrections=True)
AnalysisDataService.clear()
Pearl_example.focus(run_number="101508-101515", focus_mode="all")
```
you will need to update the paths both in the script and in pearl_shared_config.yaml
There should be no workspace group named "Van_splines" in the ADS
Re #23092


*This does not require release notes* because **it is an extremely minor change**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
