### PR TITLE
Indirect - ConvFit - Fix bug with reading Q values from wrong workspace

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -224,6 +224,8 @@ void IndirectFitAnalysisTab::connectDataAndSpectrumPresenters() {
 void IndirectFitAnalysisTab::connectDataAndFitBrowserPresenters() {
   connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
           SLOT(updateBrowserFittingRange()));
+  connect(m_dataPresenter.get(), SIGNAL(dataChanged()), this,
+          SLOT(setBrowserWorkspace()));
   connect(m_fitPropertyBrowser, SIGNAL(startXChanged(double)), this,
           SLOT(setDataTableStartX(double)));
   connect(m_fitPropertyBrowser, SIGNAL(endXChanged(double)), this,
@@ -369,6 +371,14 @@ void IndirectFitAnalysisTab::updateBrowserFittingRange() {
                                                      getSelectedSpectrum());
   setBrowserStartX(range.first);
   setBrowserEndX(range.second);
+}
+
+void IndirectFitAnalysisTab::setBrowserWorkspace() {
+  if (m_fittingModel->numberOfWorkspaces() != 0) {
+    auto const name =
+        m_fittingModel->getWorkspace(getSelectedDataIndex())->getName();
+    m_fitPropertyBrowser->setWorkspaceName(QString::fromStdString(name));
+  }
 }
 
 void IndirectFitAnalysisTab::setBrowserWorkspace(std::size_t dataIndex) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -171,6 +171,7 @@ protected slots:
   void setBrowserStartX(double startX);
   void setBrowserEndX(double endX);
   void updateBrowserFittingRange();
+  void setBrowserWorkspace();
   void setBrowserWorkspace(std::size_t dataIndex);
   void setBrowserWorkspaceIndex(std::size_t spectrum);
   void tableStartXChanged(double startX, std::size_t dataIndex,


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the Q values of the wrong workspace (on a different tab) are read instead of the Q values from the ConvFit Tab workspace.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`MSDFit`
2. Load MSD data below
3. Change to `ConvFit` tab
4. Load data below
5. Select Fit Type to be TeixWater or one of the Diff functions
6. Check that the Q value in the FitPropertyBrowser is reasonable (around 0.5ish)

**Data**

**MSD Fit**
[osi104367-104371_graphite002_red_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2495149/osi104367-104371_graphite002_red_elwin_eq.zip)

**ConvFit**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2495157/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2495158/irs26173_graphite002_res.zip)
Fit Type: `TeixeiraWater` or a `Diff` function

Fixes #23859

This needs no release notes as the reading of Q values is already mentioned in the release notes already.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
