### PR TITLE
Take care of deprecated hold in PyChop

### DIFF
--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -29,6 +29,7 @@ from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QDialog, QFileDialog,
                             QTextEdit, QVBoxLayout, QWidget)  # noqa
 from MPLwidgets import FigureCanvasQTAgg as FigureCanvas
 from MPLwidgets import NavigationToolbar2QT as NavigationToolbar
+import matplotlib
 from matplotlib.figure import Figure
 from matplotlib.widgets import Slider
 
@@ -232,7 +233,8 @@ class PyChopGui(QMainWindow):
     def _set_overplot(self, overplot, axisname):
         axis = getattr(self, axisname)
         if overplot:
-            axis.hold(True)
+            if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                axis.hold(True)
         else:
             setattr(self, axisname+'_xlim', 0)
             axis.clear()
@@ -251,7 +253,8 @@ class PyChopGui(QMainWindow):
         if hasattr(freq, '__len__'):
             freq = freq[0]
         if multiplot:
-            self.resaxes.hold(True)
+            if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                self.resaxes.hold(True)
             for ie, Ei in enumerate(self.eis):
                 en = np.linspace(0, 0.95*Ei, 200)
                 if any(self.res[ie]):
@@ -263,7 +266,8 @@ class PyChopGui(QMainWindow):
                     if self.tabs.isTabEnabled(self.qetabID):
                         self.plot_qe(Ei, label_text, hold=True)
                     self.resaxes_xlim = max(Ei, self.resaxes_xlim)
-            self.resaxes.hold(False)
+            if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                self.resaxes.hold(False)
         else:
             ei = self.engine.getEi()
             en = np.linspace(0, 0.95*ei, 200)
@@ -329,8 +333,9 @@ class PyChopGui(QMainWindow):
         if update:
             self.flxaxes1.clear()
             self.flxaxes2.clear()
-            self.flxaxes1.hold(True)
-            self.flxaxes2.hold(True)
+            if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                self.flxaxes1.hold(True)
+                self.flxaxes2.hold(True)
             for ii, instrument in enumerate(tmpinst):
                 for ie, ei in enumerate(eis):
                     with warnings.catch_warnings(record=True):
@@ -347,8 +352,9 @@ class PyChopGui(QMainWindow):
                     flux[ie] = self.engine.getFlux(ei)
                     elres[ie] = self.engine.getResolution(0., ei)[0]
             if overplot:
-                self.flxaxes1.hold(True)
-                self.flxaxes2.hold(True)
+                if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                    self.flxaxes1.hold(True)
+                    self.flxaxes2.hold(True)
             else:
                 self.flxaxes1.clear()
                 self.flxaxes2.clear()
@@ -413,8 +419,9 @@ class PyChopGui(QMainWindow):
                 flux[ie] = self.engine.getFlux(ei)
                 elres[ie] = self.engine.getResolution(0., ei)[0]
         if overplot:
-            self.frqaxes1.hold(True)
-            self.frqaxes2.hold(True)
+            if matplotlib.compare_versions('2.1.0',matplotlib.__version__):
+                self.frqaxes1.hold(True)
+                self.frqaxes2.hold(True)
         else:
             self.frqaxes1.clear()
             self.frqaxes2.clear()


### PR DESCRIPTION
**Description of work.**
Matplotlib deprecated `axes.hold` It is now True by default.


**To test:**
Code review. Make sure the holding/not holding behavior still works as expected

*There is no associated issue.*
*This does not require release notes* because **workbench**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
