### PR TITLE
Bundle matplotlib with macOS packaging

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -335,22 +335,30 @@ end
 
 #Copy over python libraries not included with OSX.
 #currently missing epics
-path = "/Library/Python/2.7/site-packages"
+system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
+pip_site_packages = "/Library/Python/2.7/site-packages"
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
-               "certifi","tornado","markupsafe","jinja2","jsonschema","functools32","ptyprocess","CifFile","yaml"]
+               "certifi","tornado","markupsafe","matplotlib","mpl_toolkits", "jinja2","jsonschema","functools32",
+               "ptyprocess","CifFile","yaml"]
 directories.each do |directory|
-  addPythonLibrary("#{path}/#{directory}","Contents/MacOS/")
+  module_dir = "#{pip_site_packages}/#{directory}"
+  if !File.exist?(module_dir)
+    module_dir = "#{system_python_extras}/#{directory}"
+    if !File.exist?(module_dir)
+      p "Cannot find python module #{directory} to copy into bundle"
+      exit 1
+    end
+  end
+  addPythonLibrary(module_dir,"Contents/MacOS/")
 end
 
-# System mpl_toolkits in macOS 10.12 and above do not have __init__.py which causes a problem importing
-# So we pack the mpl_toolkits and touch an empty file to temporarily work around it
-#TODO: consider installing mpl_toolkits (thus matplotlib) with pip
-system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
-modules = ["mpl_toolkits"]
-modules.each do |directory|
-  addPythonLibrary("#{system_python_extras}/#{directory}","Contents/MacOS/")
+# Some versions of mpltool_kits are missing their __init__ file
+mpltoolkit_init = "Contents/MacOS/mpl_toolkits/__init__.py"
+if !File.exist?(mpltoolkit_init)
+  p "Creating missing #{mpltoolkit_init}"
+  `touch #{mpltoolkit_init}`
 end
-`touch Contents/MacOS/mpl_toolkits/__init__.py`
+
 
 if( "@MAKE_VATES@" == "ON" )
   addPythonLibrariesInDirectory("#{ParaView_dir}/lib/site-packages","Contents/Python/")
@@ -389,13 +397,13 @@ h5py_patterns.each do |pattern|
   end
 end
 
-files = ["gnureadline.so","readline.py","pyparsing.py","mistune.py"]
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py"]
 files.each do |file|
-  copyFile("#{path}/#{file}")
+  copyFile("#{pip_site_packages}/#{file}")
 end
 
-#mistune.so isn't present in v0.7
-copyOptionalFile("#{path}/mistune.so")
+# mistune.so isn't present in v0.7
+copyOptionalFile("#{pip_site_packages}/mistune.so")
 
 `mkdir Contents/MacOS/bin`
 `cp /usr/local/bin/ipython@PYTHON_VERSION_MAJOR@ Contents/MacOS/bin/`


### PR DESCRIPTION
**Description of work.**

Bundles matplotlib with the macOS installer. The system version is tool old on Yosemite as it is
missing `cycler`. 

**To test:**

Build the package on Mac and test it installs and starts cleanly.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **it should not be visible.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
