### PR TITLE
Project Recovery: Made call to config earlier

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16667,8 +16667,13 @@ void ApplicationWindow::onAboutToStart() {
   resultsLog->scrollToTop();
 
   // Kick off project recovery
-  g_log.debug("Starting project autosaving.");
-  checkForProjectRecovery();
+  if (Mantid::Kernel::ConfigService::Instance().getString(
+          "projectRecovery.enabled") == "true") {
+    g_log.debug("Starting project autosaving.");
+    checkForProjectRecovery();
+  } else {
+    g_log.debug("Project Recovery is disabled.");
+  }
 }
 
 /**

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -77,9 +77,6 @@ private:
   /// Captures the current object in the background thread
   std::thread createBackgroundThread();
 
-  /// Triggers when the config key is updated to a new value
-  void configKeyChanged(Mantid::Kernel::ConfigValChangeNotification_ptr notif);
-
   /// Creates a recovery script based on all .py scripts in a folder
   void compileRecoveryScript(const Poco::Path &inputFolder,
                              const Poco::Path &outputFile);
@@ -128,10 +125,6 @@ private:
 
   /// Atomic to detect when the thread should fire or exit
   std::condition_variable m_threadNotifier;
-
-  /// Config observer to monitor the key
-  Poco::NObserver<ProjectRecovery, Mantid::Kernel::ConfigValChangeNotification>
-      m_configKeyObserver;
 
   /// Pointer to main GUI window
   ApplicationWindow *m_windowPtr;

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -40,6 +40,7 @@ Bugfixes
 - Project Recovery will actually recover fully cases where multiple workspaces were passed as a list to an algorithm (Fixes a known bug with GroupWorkspaces as well)
 - Project Recovery will now run normally when you select no or the recovery fails when recovering from a ungraceful exit.
 - When autosaving or saving a recovery checkpoint with the Instrument View open the results log would be filled with excess logging and no longer does this.
+- Fixed an issue where Project Recovery would start regardless of the config options
 
 MantidPlot
 ----------


### PR DESCRIPTION
**Description of work.**
Moved the check for config much earlier than previous so excess checks aren't done before the threads are spooled up (which is where previous check was)

**To test:**
- Start up mantid, notice how it says as Debug 'Starting auto saving' or something similar
- close mantid
- Edit your mantid.user.properties and add the line `projectRecovery.enabled=false`
- Start mantid again notice how is says as Debug 'ProjectRecovery is disabled'

<!-- Instructions for testing. -->

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
