### PR TITLE
Fix warnings building on MacOS High Sierra.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ if (POLICY CMP0072)
   cmake_policy (SET CMP0072 OLD)
 endif ()
 
+if (POLICY CMP0074)
+  cmake_policy (SET CMP0074 NEW)
+endif ()
+
 # System package target is important for the windows builds as it allows us to package only the dlls and exes and exclude libs. Defaults to empty for other platforms.
 set ( SYSTEM_PACKAGE_TARGET "" )
 

--- a/Framework/Catalog/inc/MantidCatalog/OAuth.h
+++ b/Framework/Catalog/inc/MantidCatalog/OAuth.h
@@ -66,6 +66,7 @@ class MANTID_CATALOG_DLL IOAuthTokenStore {
 public:
   virtual void setToken(const boost::optional<OAuthToken> &token) = 0;
   virtual boost::optional<OAuthToken> getToken() = 0;
+  virtual ~IOAuthTokenStore() = default;
 };
 
 class MANTID_CATALOG_DLL ConfigServiceTokenStore : public IOAuthTokenStore {
@@ -73,7 +74,7 @@ public:
   ConfigServiceTokenStore() = default;
   ConfigServiceTokenStore &
   operator=(const ConfigServiceTokenStore &other) = default;
-  ~ConfigServiceTokenStore();
+  ~ConfigServiceTokenStore() override;
 
   void setToken(const boost::optional<OAuthToken> &token) override;
   boost::optional<OAuthToken> getToken() override;


### PR DESCRIPTION
**Description of work.**

Fixes a couple warnings found when building Mantid on a machine updated to MacOS High Sierra.

```
CMake Warning (dev) at buildconfig/CMake/CommonSetup.cmake:79 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable HDF5_ROOT is set to:

    /usr/local/opt/hdf5

  For compatibility, CMake is ignoring the variable.
Call Stack (most recent call first):
  CMakeLists.txt:93 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
```
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/Catalog/src/ONCat.cpp:7:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/Catalog/inc/MantidCatalog/ONCat.h:11:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/Catalog/inc/MantidCatalog/OAuth.h:11:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/Kernel/inc/MantidKernel/DateAndTime.h:11:
In file included from /Users/svh/Documents/MantidProject/mantid/Framework/Types/inc/MantidTypes/Core/DateAndTime.h:12:
In file included from /usr/local/include/boost/date_time/posix_time/posix_time.hpp:15:
In file included from /usr/local/include/boost/date_time/posix_time/ptime.hpp:12:
In file included from /usr/local/include/boost/date_time/posix_time/posix_time_system.hpp:13:
In file included from /usr/local/include/boost/date_time/posix_time/posix_time_config.hpp:17:
In file included from /usr/local/include/boost/date_time/time_resolution_traits.hpp:15:
In file included from /usr/local/include/boost/date_time/int_adapter.hpp:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ostream:138:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:15:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string:477:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/string_view:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__string:56:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/algorithm:643:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:2285:5: warning: delete called on non-final 'Mantid::Catalog::OAuth::ConfigServiceTokenStore' that has virtual functions but non-virtual destructor [-Wdelete-non-virtual-dtor]
    delete __ptr;
    ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:2598:7: note: in instantiation of member function 'std::__1::default_delete<Mantid::Catalog::OAuth::ConfigServiceTokenStore>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/memory:2552:19: note: in instantiation of member function 'std::__1::unique_ptr<Mantid::Catalog::OAuth::ConfigServiceTokenStore, std::__1::default_delete<Mantid::Catalog::OAuth::ConfigServiceTokenStore> >::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
/Users/svh/Documents/MantidProject/mantid/Framework/Catalog/src/ONCat.cpp:114:16: note: in instantiation of member function 'std::__1::unique_ptr<Mantid::Catalog::OAuth::ConfigServiceTokenStore, std::__1::default_delete<Mantid::Catalog::OAuth::ConfigServiceTokenStore> >::~unique_ptr' requested here
               Mantid::Kernel::make_unique<ConfigServiceTokenStore>(),
               ^
2 warnings generated.
```

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

<!-- Instructions for testing. -->

Verify that the above warnings go away.

*There is no associated issue.*

*This does not require release notes* because **fill in an explanation of why**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
