### PR TITLE
fix doppler phase bug for emu loader (no ticket)

### DIFF
--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -206,8 +206,8 @@ class ConvertTOF {
 public:
   ConvertTOF(double Amp, double freq, double phase, double L1, double v2,
              std::vector<double> &L2)
-      : m_w(2 * M_PI * freq), m_phi(M_PI * phase / 180.0), 
-	    m_L0(L1), m_v2(v2), m_A(Amp), m_L2(L2) {}
+      : m_w(2 * M_PI * freq), m_phi(M_PI * phase / 180.0), m_L0(L1), m_v2(v2),
+        m_A(Amp), m_L2(L2) {}
 
   double directTOF(size_t detID, double tobs) const {
 

--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -206,8 +206,8 @@ class ConvertTOF {
 public:
   ConvertTOF(double Amp, double freq, double phase, double L1, double v2,
              std::vector<double> &L2)
-      : m_w(2 * M_PI * freq), m_phi(phase), m_L0(L1), m_v2(v2), m_A(Amp),
-        m_L2(L2) {}
+      : m_w(2 * M_PI * freq), m_phi(M_PI * phase / 180.0), 
+	    m_L0(L1), m_v2(v2), m_A(Amp), m_L2(L2) {}
 
   double directTOF(size_t detID, double tobs) const {
 


### PR DESCRIPTION
Fix a missing phase degree to radian conversion for the EMU loader.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
--> Addition of EMU loader added to 3.14 release notes added with initial pull request.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
