### PR TITLE
Project Recovery: Script Builder Logging turned off

### DIFF
--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -264,11 +264,11 @@ const std::string ScriptBuilder::buildPropertyString(
     if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(),
              propHistory.type()) != nonWorkspaceTypes.end() &&
         propHistory.direction() == Direction::Output) {
-      // If algs are to be ignored (Common use case is project recovery) ignore 
-      if(m_algsToIgnore.size() == 0){
-        g_log.debug() << "Ignoring property " << propHistory.name() << " of type "
-                    << propHistory.type() << '\n';
-      }    
+      // If algs are to be ignored (Common use case is project recovery) ignore
+      if (m_algsToIgnore.size() == 0) {
+        g_log.debug() << "Ignoring property " << propHistory.name()
+                      << " of type " << propHistory.type() << '\n';
+      }
       // Handle numerical properties
     } else if (propHistory.type() == "number") {
       prop = propHistory.name() + "=" + propHistory.value();

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -264,8 +264,11 @@ const std::string ScriptBuilder::buildPropertyString(
     if (find(nonWorkspaceTypes.begin(), nonWorkspaceTypes.end(),
              propHistory.type()) != nonWorkspaceTypes.end() &&
         propHistory.direction() == Direction::Output) {
-      g_log.debug() << "Ignoring property " << propHistory.name() << " of type "
+      // If algs are to be ignored (Common use case is project recovery) ignore 
+      if(m_algsToIgnore.size() == 0){
+        g_log.debug() << "Ignoring property " << propHistory.name() << " of type "
                     << propHistory.type() << '\n';
+      }    
       // Handle numerical properties
     } else if (propHistory.type() == "number") {
       prop = propHistory.name() + "=" + propHistory.value();

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -33,6 +33,7 @@ Changes
 - MantidPlot no longer checks for the existence of files in the "Recent Files" menu. Fixes case where files on slow mounted network drives can cause a lag on MantidPlot startup.
 - Workspaces now save locally as a number of how many workspaces have already been saved instead of workspace names
 - Project Recovery will now attempt to recover multiple instances of mantid that are ran at the same time.
+- Project Recovery will now output less unhelpful logging information into the results log
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**
Project Recovery will no longer print out to the console when using ScriptBuilder which should drastically reduce the amount of useless logging (When on Debug level) that happens when calling Project Recovery

**To test:**
- Start mantid, run this script if you have ISIS Powder diffraction setup for GEM.
``` python
from isis_powder import Gem
config_file_path = r"YOUR/PATH/TO/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no="85374" ,texture_mode=False)
Gem_example.focus(input_mode="Individual", run_number="85416",texture_mode=False) 
```
Otherwise you can probably create any number of workspaces using a workflow algorithm.
- Wait for project recovery to run or run ```mantidplot.app.saveRecoveryCheckpoint()```
- If ScriptBuilder does not put anything into the Result Log then it works
<!-- Instructions for testing. -->

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
