### PR TITLE
Add fitPenalty as argument to TOF functions

### DIFF
--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -38,7 +38,7 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
                     n_events, peak=peak, box=box, qMask=qMask, calc_pp_lambda=True, padeCoefficients=padeCoefficients,
                     neigh_length_m=neigh_length_m, pp_lambda=None, pplmin_frac=pplmin_frac,
                     pplmax_frac=pplmax_frac, mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                    peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                    peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
         YTOF, fICC, x_lims = fitTOFCoordinate(
                     box, peak, padeCoefficients, dtSpread=dtSpread, qMask=qMask, bgPolyOrder=bgPolyOrder, zBG=zBG,
                     plotResults=plotResults, pp_lambda=pp_lambda, neigh_length_m=neigh_length_m, pplmin_frac=pplmin_frac,
@@ -58,7 +58,7 @@ def get3DPeak(peak, peaks_ws, box, padeCoefficients, qMask, nTheta=150, nPhi=150
         fICC['KConv'] = fICCParams[11]
         goodIDX, _ = ICCFT.getBGRemovedIndices(
             n_events, pp_lambda=pp_lambda, qMask=qMask, peakMaskSize=peakMaskSize,
-            iccFitDict=iccFitDict)
+            iccFitDict=iccFitDict, fitPenalty=fitPenalty)
         chiSqTOF = fICCParams[4] #Last entry
 
         # Get the 3D TOF component, YTOF
@@ -304,8 +304,7 @@ def fitTOFCoordinate(box, peak, padeCoefficients, dtSpread=0.03, minFracPixels=0
                                 neigh_length_m=neigh_length_m, zBG=zBG, pp_lambda=pp_lambda,
                                 pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,
                                 mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                                peakMaskSize=peakMaskSize,
-                                iccFitDict=iccFitDict)
+                                peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
 
     fitResults, fICC = ICCFT.doICCFit(tofWS, energy, flightPath,
                                       padeCoefficients, fitOrder=bgPolyOrder, constraintScheme=1,

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -114,7 +114,7 @@ def getQXQYQZ(box):
 
 def getQuickTOFWS(box, peak, padeCoefficients, goodIDX=None, dtSpread=0.03, qMask=None,
                   pp_lambda=None, minppl_frac=0.8, maxppl_frac=1.5, mindtBinWidth=1, maxdtBinWidth=50,
-                  constraintScheme=1, peakMaskSize=5, iccFitDict=None):
+                  constraintScheme=1, peakMaskSize=5, iccFitDict=None, fitPenalty=None):
     """
     getQuickTOFWS - generates a quick-and-dirty TOFWS.  Useful for determining the background.
     Input:
@@ -153,10 +153,10 @@ def getQuickTOFWS(box, peak, padeCoefficients, goodIDX=None, dtSpread=0.03, qMas
                           minFracPixels=0.01, neigh_length_m=3, zBG=1.96, pp_lambda=pp_lambda,
                           calc_pp_lambda=calc_pp_lambda, pplmin_frac=minppl_frac, pplmax_frac=minppl_frac,
                           mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                          peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                          peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
     fitResults, fICC = doICCFit(
         tofWS, energy, flightPath, padeCoefficients, fitOrder=1, constraintScheme=constraintScheme,
-        iccFitDict=iccFitDict)
+        iccFitDict=iccFitDict, fitPenalty=fitPenalty)
     h = [tofWS.readY(0), tofWS.readX(0)]
     chiSq = fitResults.OutputChi2overDoF
 
@@ -220,7 +220,7 @@ def getPoissionGoodIDX(n_events, zBG=1.96, neigh_length_m=3):
 def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, qMask=None,
                         peak=None, box=None, pp_lambda=None, peakNumber=-1, minppl_frac=0.8,
                         maxppl_frac=1.5, mindtBinWidth=1, maxdtBinWidth=50,
-                        constraintScheme=1, peakMaskSize=5, iccFitDict=None):
+                        constraintScheme=1, peakMaskSize=5, iccFitDict=None, fitPenalty=None):
     """
     getOptimizedGoodIDX - returns a numpy arrays which is true if the voxel contains events at
             the zBG z level (1.96=95%CI).  Rather than using Poission statistics, this function
@@ -308,7 +308,7 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
                 chiSq, h, intens, sigma = getQuickTOFWS(box, peak, padeCoefficients, goodIDX=goodIDX, qMask=qMask, pp_lambda=pp_lambda,
                                                         minppl_frac=minppl_frac, maxppl_frac=maxppl_frac, mindtBinWidth=mindtBinWidth,
                                                         maxdtBinWidth=maxdtBinWidth, constraintScheme=constraintScheme,
-                                                        peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                                                        peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
             except:
                 #raise
                 break
@@ -332,8 +332,7 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
     chiSq, h, intens, sigma = getQuickTOFWS(box, peak, padeCoefficients, goodIDX=goodIDX, qMask=qMask,
                                             pp_lambda=pp_lambda, minppl_frac=minppl_frac, maxppl_frac=maxppl_frac,
                                             mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                                            peakMaskSize=peakMaskSize,
-                                            iccFitDict=iccFitDict)
+                                            peakMaskSize=peakMaskSize, iccFitDict=iccFitDict, fitPenalty=fitPenalty)
     if qMask is not None:
         return goodIDX*qMask, pp_lambda
     return goodIDX, pp_lambda
@@ -342,7 +341,7 @@ def getOptimizedGoodIDX(n_events, padeCoefficients, zBG=1.96, neigh_length_m=3, 
 def getBGRemovedIndices(n_events, zBG=1.96, calc_pp_lambda=False, neigh_length_m=3, qMask=None,
                         peak=None, box=None, pp_lambda=None, peakNumber=-1, padeCoefficients=None,
                         pplmin_frac=0.8, pplmax_frac=1.5, mindtBinWidth=1, maxdtBinWidth=50,
-                        constraintScheme=1, peakMaskSize=5, iccFitDict=None):
+                        constraintScheme=1, peakMaskSize=5, iccFitDict=None, fitPenalty=None):
     """
     getBGRemovedIndices - A wrapper for getOptimizedGoodIDX
     Input:
@@ -400,8 +399,8 @@ def getBGRemovedIndices(n_events, zBG=1.96, calc_pp_lambda=False, neigh_length_m
                                            minppl_frac=pplmin_frac, maxppl_frac=pplmax_frac, qMask=qMask, peak=peak,
                                            box=box, pp_lambda=pp_lambda, peakNumber=peakNumber,
                                            mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                                           constraintScheme=constraintScheme,
-                                           peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                                           constraintScheme=constraintScheme, peakMaskSize=peakMaskSize,
+                                           iccFitDict=iccFitDict, fitPenalty=fitPenalty)
             except KeyboardInterrupt:
                 sys.exit()
             except:
@@ -562,7 +561,7 @@ def get_pp_lambda(n_events, hasEventsIDX):
 def getTOFWS(box, flightPath, scatteringHalfAngle, tofPeak, peak, qMask, zBG=-1.0, dtSpread=0.02,
              minFracPixels=0.005, workspaceNumber=None, neigh_length_m=0, pp_lambda=None, calc_pp_lambda=False,
              padeCoefficients=None, pplmin_frac=0.8, pplmax_frac=1.5, peakMaskSize=5,
-             mindtBinWidth=1, maxdtBinWidth=50, constraintScheme=1, iccFitDict=None):
+             mindtBinWidth=1, maxdtBinWidth=50, constraintScheme=1, iccFitDict=None, fitPenalty=None):
     """
     Builds a TOF profile from the data in box which is nominally centered around a peak.
     Input:
@@ -606,8 +605,8 @@ def getTOFWS(box, flightPath, scatteringHalfAngle, tofPeak, peak, qMask, zBG=-1.
                                                  calc_pp_lambda=calc_pp_lambda, padeCoefficients=padeCoefficients,
                                                  pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,
                                                  mindtBinWidth=mindtBinWidth, maxdtBinWidth=maxdtBinWidth,
-                                                 constraintScheme=constraintScheme,
-                                                 peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                                                 constraintScheme=constraintScheme, peakMaskSize=peakMaskSize,
+                                                 iccFitDict=iccFitDict, fitPenalty=fitPenalty)
         hasEventsIDX = np.logical_and(goodIDX, qMask)
         boxMeanIDX = np.where(hasEventsIDX)
     else:  # don't do background removal - just consider one pixel at a time
@@ -903,7 +902,6 @@ def doICCFit(tofWS, energy, flightPath, padeCoefficients, constraintScheme=None,
                                          0.0, 1.0e10], T00=[0, 1.0e10], KConv0=[100., 140.], penalty=fitPenalty)
     f = FunctionWrapper(fICC)
     bg = Polynomial(n=fitOrder)
-
     for i in range(fitOrder+1):
         bg['A'+str(fitOrder-i)] = bgx0[i]
     bg.constrain('-1.0 < A%i < 1.0' % fitOrder)
@@ -918,7 +916,7 @@ def integrateSample(run, MDdata, peaks_ws, paramList, UBMatrix, dQ, qMask, padeC
                     dQPixel=0.005, p=None, neigh_length_m=0, zBG=-1.0, bgPolyOrder=1,
                     doIterativeBackgroundFitting=False, q_frame='sample',
                     progressFile=None, minpplfrac=0.8, maxpplfrac=1.5, mindtBinWidth=1, maxdtBinWidth=50,
-                    keepFitDict=False, constraintScheme=1, peakMaskSize=5, iccFitDict=None):
+                    keepFitDict=False, constraintScheme=1, peakMaskSize=5, iccFitDict=None, fitPenalty=None):
     """
     integrateSample contains the loop that integrates over all of the peaks in a run and saves the results.  Importantly, it also handles
     errors (mostly by passing and recording special values for failed fits.)
@@ -994,13 +992,13 @@ def integrateSample(run, MDdata, peaks_ws, paramList, UBMatrix, dQ, qMask, padeC
                                                          mindtBinWidth=mindtBinWidth,
                                                          maxdtBinWidth=maxdtBinWidth,
                                                          pplmin_frac=minpplfrac, pplmax_frac=maxpplfrac,
-                                                         constraintScheme=constraintScheme,
-                                                         peakMaskSize=peakMaskSize, iccFitDict=iccFitDict)
+                                                         constraintScheme=constraintScheme, peakMaskSize=peakMaskSize,
+                                                         iccFitDict=iccFitDict, fitPenalty=fitPenalty)
                 tofWS = mtd['__tofWS']
 
                 fitResults, fICC = doICCFit(
                     tofWS, energy, flightPath, padeCoefficients, fitOrder=bgPolyOrder, constraintScheme=constraintScheme,
-                    iccFitDict=iccFitDict)
+                    iccFitDict=iccFitDict, fitPenalty=fitPenalty)
                 chiSq = fitResults.OutputChi2overDoF
 
                 r = mtd['fit_Workspace']


### PR DESCRIPTION
**Description of work.**
Correction for PR #23841 - forgot to correctly propogate the penalty when doing fits to determine the background threshold. This corrects it. 

**To test:**
Extract [this](https://www.dropbox.com/s/wargm3g5hz56n5t/test_constraints.zip?dl=0) directory from Dropbox and cd into it from Mantid. Then run the following:
```python
from mantid.simpleapi import *
import matplotlib.pyplot as plt
plt.ion()
import numpy as np
import pickle
import sys
import ICCFitTools as ICCFT
import BVGFitTools as BVGFT

#beta lac july 2018 second xtal
peaksFile = 'beta_lac_july2018_secondxtal.integrate'
UBFile = 'beta_lac_july2018_secondxtal.mat'
DetCalFile = 'MANDI_June2018.DetCal'
workDir = None
nxsTemplate = '/SNS/MANDI/IPTS-8776/nexus/MANDI_%i.nxs.h5'
dQPixel=0.003
q_frame = 'lab'
pplmin_frac=0.9; pplmax_frac=1.1; mindtBinWidth=15; maxdtBinWidth=50
moderatorFile = 'bl11_moderatorCoefficients_2018.dat'
strongPeaksParamsFile = 'strongPeaksParams_betalac_july2018_secondxtal.pkl'
peakToGet=14

#Load stuff
peaks_ws = LoadIsawPeaks(Filename = peaksFile)
LoadIsawUB(InputWorkspace=peaks_ws, FileName=UBFile)
UBMatrix = peaks_ws.sample().getOrientedLattice().getUB()
peak = peaks_ws.getPeak(peakToGet)
fileName = nxsTemplate%peak.getRunNumber()
MDdata = ICCFT.getSample(peak.getRunNumber(), DetCalFile, workDir, fileName, q_frame=q_frame)

dQ = np.abs(ICCFT.getDQFracHKL(UBMatrix, frac=0.5))
dQ[dQ>0.25]=0.25
dQPixel = peaks_ws.getInstrument().getNumberParameter("dQPixel")[0]
Box = ICCFT.getBoxFracHKL(peak, peaks_ws, MDdata, UBMatrix, peakToGet, dQ, fracHKL=0.5,dQPixel=dQPixel,  q_frame=q_frame)
box = Box
qMask = ICCFT.getHKLMask(UBMatrix, frac=0.25, dQPixel=dQPixel, dQ=dQ)
strongPeakParams = pickle.load(open(strongPeaksParamsFile, 'rb'))
padeCoefficients = ICCFT.getModeratorCoefficients(moderatorFile)
mindtBinWidth = peaks_ws.getInstrument().getNumberParameter("minDTBinWidth")[0]
maxdtBinWidth = peaks_ws.getInstrument().getNumberParameter("maxDTBinWidth")[0]
nTheta = peaks_ws.getInstrument().getIntParameter("numBinsTheta")[0]
nPhi   = peaks_ws.getInstrument().getIntParameter("numBinsPhi")[0]
iccFitDict = ICCFT.parseConstraints(peaks_ws)

# Default penalty
Y3D, gIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,nTheta=nTheta, nPhi=nPhi, plotResults=False, zBG=1.96,fracBoxToHistogram=1.0,bgPolyOrder=1, strongPeakParams=strongPeakParams, q_frame=q_frame, mindtBinWidth=mindtBinWidth, pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,forceCutoff=200,edgeCutoff=3,maxdtBinWidth=maxdtBinWidth, iccFitDict=iccFitDict)

X = mtd['__bvgfit_Workspace'].readX(0).reshape([49,49,2])
Ymeas = mtd['__bvgfit_Workspace'].readY(0).reshape([49,49,2])
Yfit = mtd['__bvgfit_Workspace'].readY(1).reshape([49,49,2])
plt.figure(10); plt.clf();
plt.subplot(2,2,1); plt.imshow(Ymeas[:,:,0]); plt.title('Default Penalty Data');
plt.subplot(2,2,3); plt.imshow(Yfit[:,:,0]); plt.title('Default Penalty Fit');
sigXDefault = mtd['__bvgfit_Parameters'].row(3)['Value']

# High Penalty
Y3D, gIDX, pp_lambda, params = BVGFT.get3DPeak(peak, peaks_ws, box, padeCoefficients,qMask,nTheta=nTheta, nPhi=nPhi, plotResults=False, zBG=1.96,fracBoxToHistogram=1.0,bgPolyOrder=1, strongPeakParams=strongPeakParams, q_frame=q_frame, mindtBinWidth=mindtBinWidth, pplmin_frac=pplmin_frac, pplmax_frac=pplmax_frac,forceCutoff=200,edgeCutoff=3,maxdtBinWidth=maxdtBinWidth, iccFitDict=iccFitDict, fitPenalty=1.e7)

plt.figure(10);
X = mtd['__bvgfit_Workspace'].readX(0).reshape([49,49,2])
Ymeas = mtd['__bvgfit_Workspace'].readY(0).reshape([49,49,2])
Yfit = mtd['__bvgfit_Workspace'].readY(1).reshape([49,49,2])
plt.subplot(2,2,4); plt.imshow(Yfit[:,:,0]); plt.title('High Penalty Fit');
sigXHighPenalty = mtd['__bvgfit_Parameters'].row(3)['Value']

# Forced Profile
q0 = peak.getQLabFrame()
ph = np.arctan2(q0[1], q0[0])
th = np.arctan2(q0[2], np.hypot(q0[0], q0[1]))
phthPeak = np.array([ph, th])
tmp = strongPeakParams[:, :2] - phthPeak
distSq = tmp[:, 0]**2 + tmp[:, 1]**2
nnIDX = np.argmin(distSq)
h = Ymeas[:,:,0]
m = BivariateGaussian()
m['A'] = 0.1
m['MuX'] = X[:,:,0][np.unravel_index(h.argmax(), h.shape)]
m['MuY'] = X[:,:,1][np.unravel_index(h.argmax(), h.shape)]
m['SigX'] = strongPeakParams[nnIDX][5]
m['SigY'] = strongPeakParams[nnIDX][6]
m['SigP'] = strongPeakParams[nnIDX][7]
m['Bg'] = 0.0
m.setAttributeValue("nX", 49)
m.setAttributeValue("nY", 49)
YProfile = m(X.ravel()).reshape(X.shape)
plt.subplot(2,2,2); plt.imshow(YProfile[:,:,0]); plt.title('Strong Neighbor Profile');

#Check we get the same answer through the algorithm
IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws', InputWorkspace='MDdata', 
                             PeaksWorkspace='peaks_ws', ModeratorCoefficientsFile=moderatorFile, DQMax=0.2,
                             MinpplFrac=0.9, MaxpplFrac=1.1, FracStop=0.05, EdgeCutoff=15,
                             IntensityCutoff=200, StrongPeakParamsFile=strongPeaksParamsFile,PeakNumber=peakToGet)
sigXAlgo = mtd['params_ws'].column('SigX')[0]

print('SigX Default penalty:\t%4.4f\n'%sigXDefault)
print('SigX High penalty:\t%4.4f\n'%sigXHighPenalty)
print('SigX from Algorithm:\t%4.4f\n'%sigXAlgo)
print('The algorithm uses the high penalty, so the last two should be the same')
```
Fixes #23883 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
