### PR TITLE
Project Recovery: Adding project recovery preferences

### DIFF
--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -85,6 +85,10 @@ Description          : Preferences dialog
 using namespace MantidQt::API;
 using Mantid::Kernel::ConfigService;
 
+namespace {
+Mantid::Kernel::Logger g_log("ConfigDialog");
+}
+
 ConfigDialog::ConfigDialog(QWidget *parent, Qt::WFlags fl)
     : QDialog(parent, fl) {
   // get current values from app window
@@ -734,6 +738,61 @@ void ConfigDialog::initMantidPage() {
   initCurveFittingTab();
   initSendToProgramTab();
   initMantidOptionsTab();
+  initProjectRecoveryTab();
+}
+
+void ConfigDialog::initProjectRecoveryTab() {
+  projectRecovery = new QWidget();
+  QVBoxLayout *projRecLayout = new QVBoxLayout(projectRecovery);
+  QGroupBox *frame = new QGroupBox();
+  projRecLayout->addWidget(frame);
+  QGridLayout *grid = new QGridLayout(frame);
+  mtdTabWidget->addTab(projectRecovery, "Project Recovery");
+
+  ckEnableProjectRecovery = new QCheckBox("Enable Project Recovery");
+  ckEnableProjectRecovery->setChecked(
+      ConfigService::Instance().getString("projectRecovery.enabled") == "true");
+  ckEnableProjectRecovery->setToolTip(
+      "Requires a restart of mantid to take effect");
+  grid->addWidget(ckEnableProjectRecovery, 0, 0);
+
+  lblTimeBetweenCheckpoints = new QLabel("Time between recovery checkpoints");
+  lblTimeBetweenCheckpoints->setToolTip(
+      "Requires a restart of mantid to take effect");
+  grid->addWidget(lblTimeBetweenCheckpoints, 1, 0);
+  boxTimeBetweenCheckpoints = new QSpinBox();
+  boxTimeBetweenCheckpoints->setRange(1, 1000);
+  boxTimeBetweenCheckpoints->setSingleStep(1);
+  auto secondsBetween = 60;
+  try {
+    secondsBetween = std::stoi(
+        ConfigService::Instance().getString("projectRecovery.secondsBetween"));
+  } catch (...) {
+    g_log.warning("projectRecovery.secondsBetween is set to a none number "
+                  "value in the properties file");
+  }
+  boxTimeBetweenCheckpoints->setValue(secondsBetween);
+  boxTimeBetweenCheckpoints->setToolTip(
+      "Requires a restart of mantid to take effect");
+  grid->addWidget(boxTimeBetweenCheckpoints, 1, 1);
+
+  lblNumCheckpoints = new QLabel("Total number of checkpoints to be made");
+  lblNumCheckpoints->setToolTip("Requires a restart of mantid to take effect");
+  grid->addWidget(lblNumCheckpoints, 2, 0);
+  boxNumCheckpoint = new QSpinBox();
+  boxNumCheckpoint->setRange(1, 10);
+  boxNumCheckpoint->setSingleStep(1);
+  auto numCheckpoint = 5;
+  try {
+    numCheckpoint = std::stoi(ConfigService::Instance().getString(
+        "projectRecovery.numberOfCheckpoints"));
+  } catch (...) {
+    g_log.warning("projectRecovery.numberOfCheckpoints is set to a none number "
+                  "value in the properties file");
+  }
+  boxNumCheckpoint->setValue(numCheckpoint);
+  boxNumCheckpoint->setToolTip("Requires a restart of mantid to take effect");
+  grid->addWidget(boxNumCheckpoint, 2, 1);
 }
 
 /**
@@ -2683,6 +2742,7 @@ void ConfigDialog::apply() {
   updateDirSearchSettings();
   updateCurveFitSettings();
   updateMantidOptionsTab();
+  updateProjectRecovery();
   updateSendToTab();
 
   try {
@@ -2696,6 +2756,19 @@ void ConfigDialog::apply() {
   // MD Plotting
   updateMdPlottingSettings();
   emit app->configModified();
+}
+
+void ConfigDialog::updateProjectRecovery() {
+  auto &cfgSvc = Mantid::Kernel::ConfigService::Instance();
+  if (ckEnableProjectRecovery->isChecked()) {
+    cfgSvc.setString("projectRecovery.enabled", "true");
+  } else {
+    cfgSvc.setString("projectRecovery.enabled", "false");
+  }
+  cfgSvc.setString("projectRecovery.secondsBetween",
+                   std::to_string(boxTimeBetweenCheckpoints->value()));
+  cfgSvc.setString("projectRecovery.numberOfCheckpoints",
+                   std::to_string(boxNumCheckpoint->value()));
 }
 
 /**

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -240,7 +240,6 @@ private:
   QLabel *lblNumCheckpoints;
   QSpinBox *boxNumCheckpoint;
 
-
   // MDPlotting
   QTabWidget *mdPlottingTabWidget;
   QWidget *vsiPage, *mdPlottingGeneralPage;

--- a/MantidPlot/src/ConfigDialog.h
+++ b/MantidPlot/src/ConfigDialog.h
@@ -138,6 +138,8 @@ private:
   void initMantidPage();
   void initDirSearchTab();
   void initCurveFittingTab();
+  void initProjectRecoveryTab();
+  void updateProjectRecovery();
 
   void initCurvesPage();
   void initPlots3DPage();
@@ -229,6 +231,15 @@ private:
   QCheckBox *m_sendToPrograms;
   QTreeWidget *treeCategories;
   QTreeWidget *treePrograms;
+  /// mantid project recovery pahe
+  QWidget *projectRecovery;
+  QLabel *lblWarningToRestartProjRec;
+  QCheckBox *ckEnableProjectRecovery;
+  QLabel *lblTimeBetweenCheckpoints;
+  QSpinBox *boxTimeBetweenCheckpoints;
+  QLabel *lblNumCheckpoints;
+  QSpinBox *boxNumCheckpoint;
+
 
   // MDPlotting
   QTabWidget *mdPlottingTabWidget;

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -26,6 +26,7 @@ New
 ###
 - Project Recovery can now make a recovery checkpoint on command using mantidplot.app.saveRecoveryCheckpoint() in either the interpreter or script windows in python
 - Project Recovery now adds a lock file at the start of saving so if MantidPlot crashes when saving it will no longer use that checkpoint as it is incomplete.
+- Project Recovery now has the ability to be changed from inside of MantidPlot without using the config files directly, this can be found in view->preferences->mantid->projectrecovery
 
 Changes
 #######


### PR DESCRIPTION
**Description of work.**
I added an extra tab to the mantid section of preferences. This tab will change the config options when you click apply and thus will take effect on a restart of mantid, which is the best way to currently handle changing these options until further developments into project recovery are merged into master.

**To test:**
- Open Mantid and navigate to view->preferences->mantid->projectrecovery
- Change all of the settings to something ideally a number for number based settings etc, (It's handled and use a default), then click apply.
- Check the Mantid.user.properties file and see that the relevant lines have been added to the bottom find it in either .mantid for linux or in your %APPDATA%/mantidproject folder on windows.
- Restart mantid and check that the effects of your changes have come true

<!-- Instructions for testing. -->

Fixes #23885 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
