### PR TITLE
Expose MatrixWorkspace::isCommonBins to python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -370,7 +370,9 @@ void export_MatrixWorkspace() {
            "some subsequent algorithms may expect it to be "
            "monitor workspace later.")
       .def("clearMonitorWorkspace", &clearMonitorWorkspace, args("self"),
-           "Forget about monitor workspace, attached to the current workspace");
+           "Forget about monitor workspace, attached to the current workspace")
+      .def("isCommonBins", &MatrixWorkspace::isCommonBins,
+           "Returns true if the workspace has common X bins.");
 
   RegisterWorkspacePtrToPython<MatrixWorkspace>();
 }

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -417,6 +417,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertEquals(specInfo.isMasked(0), False)
         self.assertEquals(specInfo.isMasked(1), False)
 
+    def test_isCommonBins(self):
+        self.assertTrue(self._test_ws.isCommonBins())
+
 if __name__ == '__main__':
     unittest.main()
     #Testing particular test from Mantid


### PR DESCRIPTION
**Description of work.**

This exposes MatrixWorkspace::isCommonBins to python so that it will be used to speed up calls to Matplotlib's pcolorfast.

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

*There is no associated issue.*

*This does not require release notes* because it is to be used internally for plotting. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
