### PR TITLE
ISIS Powder Gem Add keyword to allow disabling of subtract empty

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -56,6 +56,7 @@ Improvements
 - Focusing on Gem now crops values that would be divided by very small or zero vanadium values
 - Removed save_angles flag for Gem , as it was set by the texture mode.
 - Added save_all flag to Gem that is set to true by default, setting it to false disables the saving of .NXS files.
+- Added subtract_empty_instrument flag to Gem that is true by default, setting it to false disables subrtracting the empty.
 - Changed spline coefficient so that the default for long_mode on and long_mode off can be set separately.
 
 Bugfixes

--- a/scripts/Diffraction/isis_powder/gem.py
+++ b/scripts/Diffraction/isis_powder/gem.py
@@ -29,15 +29,16 @@ class Gem(AbstractInst):
     # Public API
 
     def focus(self, **kwargs):
-        self._switch_texture_mode_specific_inst_settings(kwargs.get("texture_mode"))
         self._inst_settings.update_attributes(kwargs=kwargs)
+        self._switch_texture_mode_specific_inst_settings(kwargs.get("texture_mode"))
+
         return self._focus(
             run_number_string=self._inst_settings.run_number, do_van_normalisation=self._inst_settings.do_van_norm,
             do_absorb_corrections=self._inst_settings.do_absorb_corrections)
 
     def create_vanadium(self, **kwargs):
-        self._switch_texture_mode_specific_inst_settings(kwargs.get("texture_mode"))
         self._inst_settings.update_attributes(kwargs=kwargs)
+        self._switch_texture_mode_specific_inst_settings(kwargs.get("texture_mode"))
 
         return self._create_vanadium(run_number_string=self._inst_settings.run_in_range,
                                      do_absorb_corrections=self._inst_settings.do_absorb_corrections)
@@ -49,6 +50,9 @@ class Gem(AbstractInst):
             exception_msg="The argument containing sample details was not found. Please"
                           " set the following argument: " + kwarg_name)
         self._sample_details = sample_details_obj
+
+    def should_subtract_empty_inst(self):
+        return self._inst_settings.subtract_empty_inst
 
     # Private methods
 
@@ -176,8 +180,10 @@ class Gem(AbstractInst):
         if mode is None and hasattr(self._inst_settings, "texture_mode"):
             mode = self._inst_settings.texture_mode
         save_all = not hasattr(self._inst_settings, "save_all")
-        self._inst_settings.update_attributes(advanced_config=gem_advanced_config.get_mode_specific_variables(mode,
-                                                                                                              save_all),
+        adv_config_variables = gem_advanced_config.get_mode_specific_variables(mode, save_all)
+        if self.should_subtract_empty_inst() is None:
+            adv_config_variables.update({"subtract_empty_instrument": True})
+        self._inst_settings.update_attributes(advanced_config=adv_config_variables,
                                               suppress_warnings=True)
 
 

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
@@ -35,6 +35,7 @@ attr_mapping = \
      ParamMapEntry(ext_name="save_maud_calib",           int_name="save_maud_calib"),
      ParamMapEntry(ext_name="save_maud",                 int_name="save_maud"),
      ParamMapEntry(ext_name="spline_coefficient",        int_name="spline_coeff"),
+     ParamMapEntry(ext_name="subtract_empty_instrument", int_name="subtract_empty_inst", optional =True),
      ParamMapEntry(ext_name="suffix",                    int_name="suffix",         optional=True),
      ParamMapEntry(ext_name="texture_mode",              int_name="texture_mode",         optional=True),
      ParamMapEntry(ext_name="output_directory",          int_name="output_dir"),


### PR DESCRIPTION
**Description of work.**
Added the subtract_empty_instrument that Pearl has to Gem to allow disabling of subtracting the empty, also re-ordered some code slightly in gem focus and create_vanadium to prevent more print lines from parameters being changed than were necessary.

**Report to:** Winfried Kockelmann

**To test:**
Run the following script with these [files](https://github.com/mantidproject/mantid/files/2518371/GemTest.zip)

(note this requires access to the ISIS data search archive)
```
from isis_powder import Gem
config_file_path = r"/home/sjenkins/Documents/Isis Powder/Gem/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no="85374",texture_mode=False, subtract_empty_instrument=True)
Gem_example.focus(input_mode="Individual", run_number="85416",texture_mode=False, subtract_empty_instrument=True)
```
and plot some of the workspaces.
Then change the subtract_empty_instrument values to False and run the script again, verify that the workspaces produced are different.

Fixes #23890 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
