### PR TITLE
Fix RPATH in python wrapper for instrument view

### DIFF
--- a/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
@@ -27,6 +27,6 @@ mtd_add_sip_module (
   INSTALL_DIR
     ${LIB_DIR}/mantidqt/widgets/instrumentview
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/.."
+    "\$ORIGIN/../../.."
   FOLDER Qt5
 )


### PR DESCRIPTION
**Description of work.**

Fixes the RPATH for the `_instrumentviewqt5.so` module. It was incorrectly set and it couldn't find the `libMantidQtWidgetsInstrumentViewQt5` library.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Build the linux package, install and start the workbench.

*There is no associated issue.*

*This does not require release notes* because **workbench is not advertised yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
