### PR TITLE
Project Recovery: Ignore empty groups when they are present in the ADS during save

### DIFF
--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -629,8 +629,7 @@ void ProjectRecovery::saveWsHistories(const Poco::Path &historyDestFolder) {
   const auto &ads = Mantid::API::AnalysisDataService::Instance();
 
   // Hold a copy to the shared pointers so they do not get deleted under us
-  std::vector<boost::shared_ptr<Mantid::API::Workspace>> wsHandles =
-      ads.getObjects(Mantid::Kernel::DataServiceHidden::Include);
+  auto wsHandles = ads.getObjects(Mantid::Kernel::DataServiceHidden::Include);
 
   removeEmptyGroupsFromADS(wsHandles);
 

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -7,8 +7,8 @@
 #ifndef PROJECT_RECOVERY_H_
 #define PROJECT_RECOVERY_H_
 
-#include "MantidKernel/ConfigService.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidKernel/ConfigService.h"
 
 #include <Poco/NObserver.h>
 

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -8,6 +8,7 @@
 #define PROJECT_RECOVERY_H_
 
 #include "MantidKernel/ConfigService.h"
+#include "MantidAPI/Workspace.h"
 
 #include <Poco/NObserver.h>
 
@@ -113,6 +114,10 @@ private:
 
   // Return true if the folder at the end of the path is older than a month.
   bool olderThanAGivenTime(const Poco::Path &path, int64_t elapsedTime);
+
+  // Remove Empty WorkspaceGroups from the ADS and passed vector
+  void removeEmptyGroupsFromADS(
+      std::vector<boost::shared_ptr<Mantid::API::Workspace>> &wsHandles);
 
   /// Background thread which runs the saving body
   std::thread m_backgroundSavingThread;

--- a/MantidPlot/src/ProjectRecovery.h
+++ b/MantidPlot/src/ProjectRecovery.h
@@ -115,10 +115,6 @@ private:
   // Return true if the folder at the end of the path is older than a month.
   bool olderThanAGivenTime(const Poco::Path &path, int64_t elapsedTime);
 
-  // Remove Empty WorkspaceGroups from the ADS and passed vector
-  void removeEmptyGroupsFromADS(
-      std::vector<boost::shared_ptr<Mantid::API::Workspace>> &wsHandles);
-
   /// Background thread which runs the saving body
   std::thread m_backgroundSavingThread;
 

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -42,6 +42,7 @@ Bugfixes
 - Project Recovery will now run normally when you select no or the recovery fails when recovering from a ungraceful exit.
 - When autosaving or saving a recovery checkpoint with the Instrument View open the results log would be filled with excess logging and no longer does this.
 - Fixed an issue where Project Recovery would start regardless of the config options
+- If an empty group workspace is present in the ADS it will no longer crash the save thread of project recovery and instead will delete it from the ADS and ignore it.
 
 MantidPlot
 ----------


### PR DESCRIPTION
**Description of work.**
Project Recovery's save thread could be segfault'd by an empty group being present in the ADS, this handles that situation by removing it before it can be acted on. 

**To test:**
- Start Mantid
- Run the Script
``` Python
ws = CreateSampleWorkspace()
ws1 = CreateSampleWorkspace()
output = GroupWorkspaces(InputWorkspaces="ws,ws1")
groupWorkspace = AnalysisDataService.retrieve("output")
groupWorkspace.remove("ws")
groupWorkspace.remove("ws1")
mantidplot.app.saveRecoveryCheckpoint()
Segfault(Dryrun=0)
```
- Re-launch mantid
- Click yes/reload last checkpoint when project recovery pops up.

Fixes #23901 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
