### PR TITLE
Fix windows build link issues

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfoIterator.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfoIterator.h
@@ -8,7 +8,6 @@
 #define MANTID_API_SPECTRUMINFOITERATOR_H_
 
 #include "MantidAPI/SpectrumInfoItem.h"
-
 #include <boost/iterator/iterator_facade.hpp>
 
 using Mantid::API::SpectrumInfoItem;
@@ -28,7 +27,7 @@ iterator.
 */
 
 template <typename T>
-class MANTID_API_DLL SpectrumInfoIterator
+class SpectrumInfoIterator
     : public boost::iterator_facade<SpectrumInfoIterator<T>,
                                     SpectrumInfoItem<T> &,
                                     boost::random_access_traversal_tag> {

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfoIterator.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfoIterator.h
@@ -7,7 +7,6 @@
 #ifndef MANTID_GEOMETRY_DETECTORINFOITERATOR_H_
 #define MANTID_GEOMETRY_DETECTORINFOITERATOR_H_
 
-#include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/Instrument/DetectorInfoItem.h"
 #include <boost/iterator/iterator_facade.hpp>
 
@@ -27,7 +26,7 @@ iterator.
 @date 2018
 */
 template <typename T>
-class MANTID_GEOMETRY_DLL DetectorInfoIterator
+class DetectorInfoIterator
     : public boost::iterator_facade<DetectorInfoIterator<T>,
                                     DetectorInfoItem<T> &,
                                     boost::random_access_traversal_tag> {


### PR DESCRIPTION
Result from recent work on iterators. Symbols search failing but no symbols exported/imported.

Should be possible to build `PythonInterface` without issues.
