### PR TITLE
Add Qt5 qscintilla dependency to deb requirements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,12 +371,18 @@ if ( ENABLE_CPACK )
                                            "libqscintilla2-12v5,"
                                            "ipython-notebook,"
                                            "libhdf5-cpp-11" )
+        if (ENABLE_WORKBENCH)
+          set ( CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS},libqt5scintilla2-12v5" )
+        endif()
       else()  # bionic and newer
         set ( CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS},libgsl23,"
                                            "liboce-foundation11,liboce-modeling11,"
                                            "libqscintilla2-qt4-13,"
                                            "jupyter-notebook,"
                                            "libhdf5-cpp-100" )
+        if (ENABLE_WORKBENCH)
+          set ( CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS},libqscintilla2-qt5-13" )
+        endif()
       endif()
 
       if ( PYTHON_VERSION_MAJOR EQUAL 3 )


### PR DESCRIPTION
**Description of work.**

Fixes the Ubuntu package to depend on the Qt5 build of qscintilla. Without it you get

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: libqt5scintilla2.so.12: cannot open shared object file: No such file or directory
```

on a clean system when trying to start the workbench.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Build the package, install it on clean system and start the workbench.

*There is no associated issue.*

*This does not require release notes* because **it fixes a bug in the workbench that is not yet advertised.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
