### PR TITLE
Indirect - Fix incorrect detector grouping during Data Reduction

### DIFF
--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -592,7 +592,7 @@ def get_group_from_string(grouping_string):
         return [int(grouping_string)]
 
 
-def create_group_from_string(input_workspace, grouping_string, group_detectors):
+def create_group_from_string(group_detectors, grouping_string):
     group_detectors.setProperty("WorkspaceIndexList", get_group_from_string(grouping_string))
     group_detectors.setProperty("OutputWorkspace", "__temp")
     group_detectors.execute()
@@ -608,11 +608,9 @@ def conjoin_workspaces(*workspaces):
     return conjoined
 
 
-def group_on_string(input_workspace, grouping_string, group_detectors):
+def group_on_string(group_detectors, grouping_string):
     grouping_string.replace(' ', '')
-    logger.error(grouping_string)
-    groups = [create_group_from_string(input_workspace, group, group_detectors) for group in grouping_string.split(',')]
-    logger.error(grouping_string)
+    groups = [create_group_from_string(group_detectors, group) for group in grouping_string.split(',')]
     return conjoin_workspaces(*groups)
 
 
@@ -711,7 +709,7 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
         # Mask detectors if required
         if len(masked_detectors) > 0:
             _mask_detectors(workspace, masked_detectors)
-        return group_on_string(workspace, group_string, group_detectors)
+        return group_on_string(group_detectors, group_string)
 
     else:
         raise RuntimeError('Invalid grouping method %s for workspace %s' % (grouping_method, workspace.getName()))

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -592,12 +592,11 @@ def get_group_from_string(grouping_string):
         return [int(grouping_string)]
 
 
-def create_group_from_string(input_workspace, grouping_string):
-    from mantid.simpleapi import GroupDetectors
-    return GroupDetectors(InputWorkspace=input_workspace,
-                          Behaviour='Average',
-                          SpectraList=get_group_from_string(grouping_string),
-                          StoreInADS=False)
+def create_group_from_string(input_workspace, grouping_string, group_detectors):
+    group_detectors.setProperty("WorkspaceIndexList", get_group_from_string(grouping_string))
+    group_detectors.setProperty("OutputWorkspace", "__temp")
+    group_detectors.execute()
+    return group_detectors.getProperty("OutputWorkspace").value
 
 
 def conjoin_workspaces(*workspaces):
@@ -609,9 +608,11 @@ def conjoin_workspaces(*workspaces):
     return conjoined
 
 
-def group_on_string(input_workspace, grouping_string):
+def group_on_string(input_workspace, grouping_string, group_detectors):
     grouping_string.replace(' ', '')
-    groups = [create_group_from_string(input_workspace, group) for group in grouping_string.split(',')]
+    logger.error(grouping_string)
+    groups = [create_group_from_string(input_workspace, group, group_detectors) for group in grouping_string.split(',')]
+    logger.error(grouping_string)
     return conjoin_workspaces(*groups)
 
 
@@ -710,7 +711,7 @@ def group_spectra_of(workspace, masked_detectors, method, group_file=None, group
         # Mask detectors if required
         if len(masked_detectors) > 0:
             _mask_detectors(workspace, masked_detectors)
-        return group_on_string(workspace, group_string)
+        return group_on_string(workspace, group_string, group_detectors)
 
     else:
         raise RuntimeError('Invalid grouping method %s for workspace %s' % (grouping_method, workspace.getName()))


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where the detector grouping within Indirect Data Reduction Energy Transfer is done wrong (due to the use of the wrong algorithm property - `SpectraList` was being used instead of `WorkspaceIndexList`)

**To test:**
1. `Interfaces`->`Indirect`->`Data Reduction`->`ISISEnergyTransfer` Tab
2. Enter run number `26176`
3. Choose detector grouping to be `Groups`
4. Enter the number of groups to be 13 or above
5. Click `Run` and wait

The algorithm should successfully finish and produce a workspace called `irs26176_graphite002_red`.

Fixes #23909 

This PR doesn't need release notes because this was a problem introduced after the last release.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
