### PR TITLE
Typecast peak number for profile fitting

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksProfileFitting.py
@@ -245,6 +245,7 @@ class IntegratePeaksProfileFitting(PythonAlgorithm):
         sigX0Params, sigY0, sigP0Params = self.getBVGInitialGuesses(peaks_ws, strongPeakParams_ws)
 
         for fitNumber, peakNumber in enumerate(peaksToFit):#range(peaks_ws.getNumberPeaks()):
+            peakNumber = int(peakNumber)
             peak = peaks_ws_out.getPeak(peakNumber)
             progress.report(' ')
             if peak.getRunNumber() != MDdata.getExperimentInfo(0).getRunNumber():


### PR DESCRIPTION
typecast so there's no error on SNS analysis machines.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
From an SNS analysis node:
```python
from __future__ import (absolute_import, division, print_function)
import pickle
from mantid.simpleapi import *
import matplotlib.pyplot as plt
plt.ion()

runNumber = 9291
nxsFormat = '/SNS/MANDI/IPTS-20460/nexus/MANDI_%i.nxs.h5'
rA = 0.020
rB = 0.021
rC = 0.023
minD = 14.0
maxD = 50.0
tol = 0.15
moderatorFile = '/SNS/MANDI/shared/ProfileFitting/franz_coefficients_2017.dat'
predictPeaks = False
min_pred_dspacing = 1.5
max_pred_dspacing = 15.0
min_pred_wl = 2.
max_pred_wl = 4.
StrongPeaksParamsFile = None
IntensityCutoff = 200
EdgeCutoff = 3
FracStop = 0.05
MinpplFrac = 0.9; MaxpplFrac = 1.1
DQMax = 0.15
a = 17.89; b = 30.77; c = 43.71
alpha = 90.; beta = 90.; gamma = 90.


event_ws = Load(Filename=nxsFormat%runNumber, OutputWorkspace='event_ws')
MDdata = ConvertToMD(InputWorkspace='event_ws', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_lab', OutputWorkspace='MDdata', MinValues='-5,-5,-5', MaxValues='5,5,5', MaxRecursionDepth=10)
peaks_ws = FindPeaksMD(InputWorkspace='MDdata', MaxPeaks=150, DensityThresholdFactor=500, OutputWorkspace='peaks_ws')
try:
    FindUBUsingFFT(PeaksWorkspace='peaks_ws', MinD=minD, MaxD=maxD, Tolerance=tol, Iterations=10, DegreesPerStep=1.0)
except:
    FindUBUsingLatticeParameters(PeaksWorkspace='peaks_ws', a=a, b=b, c=c, alpha=alpha, beta=beta, 
                                 gamma=gamma, NumInitial=50, Tolerance=tol,Iterations=1000)
IndexPeaks(PeaksWorkspace='peaks_ws')
mtd.remove('event_ws') #Free up memory

print("PREDICTING peaks to integrate....")
peaks_ws = PredictPeaks(InputWorkspace=peaks_ws,
                            WavelengthMin=min_pred_wl, WavelengthMax=max_pred_wl,
                            MinDSpacing=min_pred_dspacing, MaxDSpacing=max_pred_dspacing,
                            ReflectionCondition='Primitive' )

IntegratePeaksMD(InputWorkspace='MDdata', PeakRadius=rA, BackgroundInnerRadius=rB, BackgroundOuterRadius=rC, 
                 PeaksWorkspace='peaks_ws', OutputWorkspace='peaks_ws', CylinderLength=0.4, PercentBackground=20,
                 ProfileFunction='IkedaCarpenterPV')

IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws', InputWorkspace='MDdata', 
                             PeaksWorkspace='peaks_ws', ModeratorCoefficientsFile=moderatorFile, DQMax=DQMax,
                             MinpplFrac=MinpplFrac, MaxpplFrac=MaxpplFrac, FracStop=FracStop, EdgeCutoff=EdgeCutoff,
                             IntensityCutoff=IntensityCutoff, StrongPeakParamsFile=StrongPeaksParamsFile)

plt.plot(mtd['peaks_ws'].column('Intens'), mtd['peaks_ws_out'].column('Intens'),'.')
plt.xlabel('I (spherical)')
plt.ylabel('I (profile fit)')

```
Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
