### PR TITLE
ISIS Reflectometry GUI SaveASCII Tab saving fix on windows

### DIFF
--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -68,7 +68,7 @@ Improved
 Bug fixes
 #########
 
-
+- The SaveASCII tab from the interface was unable to save in some places on Windows and that has now been fixed.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/ISISReflectometry/ReflAsciiSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflAsciiSaver.cpp
@@ -53,7 +53,7 @@ bool ReflAsciiSaver::isValidSaveDirectory(std::string const &path) const {
     try {
       auto pocoPath = Poco::Path().parseDirectory(path);
       auto pocoFile = Poco::File(pocoPath);
-      return pocoFile.exists() && pocoFile.canWrite();
+      return pocoFile.exists();
     } catch (Poco::PathSyntaxException &) {
       return false;
     }


### PR DESCRIPTION
**Description of work.**
So currently on Windows the SaveAscii tab of the Reflectometry GUI does a call to Poco::File::isWritable which on windows checks whether or not the file or parent folders are read-only and if they are return false etc. Due to recent updates on ISIS computers this was broken.

**Report to:**  Max(ISIS). <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
- Open Interfaces->Reflectometry->ISIS Reflectometry->SaveAscii
- Have a workspace in the ADS and select it in the GUI
- Pick a directory to save it into on your local machine (Specifically in your user directory on windows at ISIS)
- Click save
<!-- Instructions for testing. -->

Fixes #23904<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
