### PR TITLE
Indirect Bayes - Stretch tab Contour Plot

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesStretch.py
@@ -311,7 +311,7 @@ class BayesStretch(PythonAlgorithm):
             unitx.setLabel('beta', '')
             unity.setLabel('sigma', '')
         else:
-            if name[:4] == 'Beta':
+            if name[-4:] == 'Beta':
                 unitx.setLabel('beta', '')
             else:
                 unitx.setLabel('sigma', '')

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -83,6 +83,10 @@ Improvements
 Bayes Interface
 ---------------
 
+New Features
+############
+- It is now possible to produce a contour plot from the output on the Stretch Tab.
+
 Improvements
 ############
 

--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -112,9 +112,6 @@ void Stretch::run() {
   auto const resName =
       m_uiForm.dsResolution->getCurrentDataName().toStdString();
 
-  // Obtain save and plot state
-  m_plotType = m_uiForm.cbPlot->currentText().toStdString();
-
   // Collect input from options section
   auto const background = m_uiForm.cbBackground->currentText().toStdString();
 
@@ -154,8 +151,6 @@ void Stretch::run() {
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
   m_batchAlgoRunner->executeBatchAsync();
-
-  m_plotType = m_uiForm.cbPlot->currentText().toStdString();
 
   // Set the name of the result workspace for Python export
   QString contourName =
@@ -251,17 +246,11 @@ void Stretch::plotWorkspaces() {
   if (sigma.right(5).compare("Sigma") == 0 &&
       beta.right(4).compare("Beta") == 0) {
 
-    QString pyInput = "from mantidplot import plot2D\n";
-    pyInput += "importMatrixWorkspace('";
-
-    if (m_plotType.compare("All") == 0 || m_plotType.compare("Beta") == 0)
-      pyInput += beta;
-    if (m_plotType.compare("All") == 0 || m_plotType.compare("Sigma") == 0)
-      pyInput += sigma;
-
-    pyInput += "').plotGraph2D()\n";
-    m_pythonRunner.runPythonCode(pyInput);
-
+    std::string const plotType = m_uiForm.cbPlot->currentText().toStdString();
+    if (plotType == "All" || plotType == "Beta")
+      plotSpectrum(beta);
+    if (plotType == "All" || plotType == "Sigma")
+      plotSpectrum(sigma);
   } else {
     g_log.error(
         "Beta and Sigma workspace were not found and could not be plotted.");

--- a/qt/scientific_interfaces/Indirect/Stretch.h
+++ b/qt/scientific_interfaces/Indirect/Stretch.h
@@ -40,6 +40,7 @@ private slots:
 
   void runClicked();
   void plotWorkspaces();
+  void plotContourClicked();
   void algorithmComplete(const bool &error);
   void plotCurrentPreview();
   void previewSpecChanged(int value);
@@ -50,10 +51,12 @@ private:
 
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
+  void setPlotContourEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);
   void setButtonsEnabled(bool enabled);
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);
+  void setPlotContourIsPlotting(bool plotting);
 
   /// Current preview spectrum
   int m_previewSpec;

--- a/qt/scientific_interfaces/Indirect/Stretch.h
+++ b/qt/scientific_interfaces/Indirect/Stretch.h
@@ -66,7 +66,6 @@ private:
   std::string m_fitWorkspaceName;
   std::string m_contourWorkspaceName;
   // state of plot and save when algorithm is run
-  std::string m_plotType;
   bool m_save;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/Stretch.h
+++ b/qt/scientific_interfaces/Indirect/Stretch.h
@@ -46,6 +46,7 @@ private slots:
   void previewSpecChanged(int value);
 
 private:
+  void populateContourWorkspaceComboBox();
   void displayMessageAndRun(std::string const &saveDirectory);
   int displaySaveDirectoryMessage();
 

--- a/qt/scientific_interfaces/Indirect/Stretch.ui
+++ b/qt/scientific_interfaces/Indirect/Stretch.ui
@@ -348,6 +348,26 @@
             </widget>
            </item>
            <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Workspace: </string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cbPlotContour">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>200</width>
+               <height>0</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+           <item>
             <widget class="QPushButton" name="pbPlotContour">
              <property name="enabled">
               <bool>false</bool>

--- a/qt/scientific_interfaces/Indirect/Stretch.ui
+++ b/qt/scientific_interfaces/Indirect/Stretch.ui
@@ -348,6 +348,16 @@
             </widget>
            </item>
            <item>
+            <widget class="QPushButton" name="pbPlotContour">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Plot Contour</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="horizontalSpacer_18">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
**Description of work.**
This PR introduces an option to produces a contour plot from the output of the Stretch Tab. You have to choose which workspace you want to plot this for.
It also fixes a problem where Sigma would be plotted instead of Beta when Beta was selected in the Plot Output combo box.

**To test:**
1. `Interfaces`->`Indirect`->`Bayes`->`Stretch` tab
2. Load the data below
3. Click `Run` and wait
4. Click `Plot Contour`, and ensure a contour plot is produced
5. Choose `Beta` and `Sigma` individually and plot them. Make sure that the Beta graph is plotted when `Beta` is selected.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2549444/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2549445/irs26173_graphite002_res.zip)

Fixes #23830 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
