### PR TITLE
Add imshow to the list of matplotlib plotting wrappers

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -73,19 +73,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.scatter` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.scatter(workspace,'rs',specNum=1) #for workspaces
             ax.scatter(x,y,'bo')                 #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.scatter`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -98,19 +98,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.errorbar` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.errorbar(workspace,'rs',specNum=1) #for workspaces
             ax.errorbar(x,y,yerr,'bo')            #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.errorbar`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -123,19 +123,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.pcolor` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.pcolor(workspace) #for workspaces
             ax.pcolor(x,y,C)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.pcolor`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -148,19 +148,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.pcolorfast` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.pcolorfast(workspace) #for workspaces
             ax.pcolorfast(x,y,C)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.pcolorfast`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -173,19 +173,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.pcolormesh` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.pcolormesh(workspace) #for workspaces
             ax.pcolormesh(x,y,C)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.pcolormesh`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -194,23 +194,48 @@ class MantidAxes(Axes):
         else:
             return Axes.pcolormesh(self, *args, **kwargs)
 
+    def imshow(self, *args, **kwargs):
+        '''
+        If the **mantid** projection is chosen, it can be
+        used the same as :py:meth:`matplotlib.axes.Axes.imshow` for arrays,
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
+        or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
+
+            import matplotlib.pyplot as plt
+            from mantid import plots
+
+            ...
+
+            fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
+            ax.imshow(workspace) #for workspaces
+            ax.imshow(C)     #for arrays
+            fig.show()
+
+        For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.pcolormesh`
+        '''
+        if mantid.plots.helperfunctions.validate_args(*args):
+            mantid.kernel.logger.debug('using mantid.plots.plotfunctions')
+            return mantid.plots.plotfunctions.imshow(self, *args, **kwargs)
+        else:
+            return Axes.imshow(self, *args, **kwargs)
+
     def contour(self, *args, **kwargs):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.contour` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.contour(workspace) #for workspaces
             ax.contour(x,y,z)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.contour`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -223,19 +248,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.contourf` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.contourf(workspace) #for workspaces
             ax.contourf(x,y,z)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.contourf`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -248,19 +273,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.tripcolor` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.tripcolor(workspace) #for workspaces
             ax.tripcolor(x,y,C)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.tripcolor`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -273,19 +298,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.tricontour` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.tricontour(workspace) #for workspaces
             ax.tricontour(x,y,z)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.tricontour`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
@@ -298,19 +323,19 @@ class MantidAxes(Axes):
         '''
         If the **mantid** projection is chosen, it can be
         used the same as :py:meth:`matplotlib.axes.Axes.tricontourf` for arrays,
-        or it can be used to plot :class:`mantid.api.MatrixWorkspace` 
+        or it can be used to plot :class:`mantid.api.MatrixWorkspace`
         or :class:`mantid.api.IMDHistoWorkspace`. You can have something like::
-        
+
             import matplotlib.pyplot as plt
             from mantid import plots
-            
+
             ...
-            
+
             fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
             ax.tricontourf(workspace) #for workspaces
             ax.tricontourf(x,y,z)     #for arrays
             fig.show()
-        
+
         For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.tricontourf`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):

--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -211,7 +211,7 @@ class MantidAxes(Axes):
             ax.imshow(C)     #for arrays
             fig.show()
 
-        For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.pcolormesh`
+        For keywords related to workspaces, see :func:`mantid.plots.plotfunctions.imshow`
         '''
         if mantid.plots.helperfunctions.validate_args(*args):
             mantid.kernel.logger.debug('using mantid.plots.plotfunctions')

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -357,6 +357,35 @@ def pcolormesh(axes, workspace, *args, **kwargs):
 
     return axes.pcolormesh(x, y, z, *args, **kwargs)
 
+def imshow(axes, workspace, *args, **kwargs):
+    '''
+    Essentially the same as :meth:`matplotlib.axes.Axes.pcolormesh`.
+
+    :param axes:      :class:`matplotlib.axes.Axes` object that will do the plotting
+    :param workspace: :class:`mantid.api.MatrixWorkspace` or :class:`mantid.api.IMDHistoWorkspace`
+                      to extract the data from
+    :param distribution: ``None`` (default) asks the workspace. ``False`` means
+                         divide by bin width. ``True`` means do not divide by bin width.
+                         Applies only when the the matrix workspace is a histogram.
+    :param normalization: ``None`` (default) ask the workspace. Applies to MDHisto workspaces. It can override
+                          the value from displayNormalizationHisto. It checks only if
+                          the normalization is mantid.api.MDNormalization.NumEventsNormalization
+    :param axisaligned: ``False`` (default). If ``True``, or if the workspace has a variable
+                        number of bins, the polygons will be aligned with the axes
+    '''
+    _setLabels2D(axes, workspace)
+    if isinstance(workspace, mantid.dataobjects.MDHistoWorkspace):
+        (normalization, kwargs) = get_normalization(workspace, **kwargs)
+        x, y, z = get_md_data2d_bin_bounds(workspace, normalization)
+    else:
+        (aligned, kwargs) = get_data_uneven_flag(workspace, **kwargs)
+        (distribution, kwargs) = get_distribution(workspace, **kwargs)
+        if aligned:
+            raise Exception('Variable number of bins is not supported by imshow.')
+        else:
+            (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True)
+    kwargs['extent'] = [x[0,0],x[0,-1],y[0,0],y[-1,0]]
+    return axes.imshow(z, *args, **kwargs)
 
 def tripcolor(axes, workspace, *args, **kwargs):
     '''

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -378,12 +378,19 @@ def imshow(axes, workspace, *args, **kwargs):
         (normalization, kwargs) = get_normalization(workspace, **kwargs)
         x, y, z = get_md_data2d_bin_bounds(workspace, normalization)
     else:
-        (aligned, kwargs) = get_data_uneven_flag(workspace, **kwargs)
+        (uneven_bins, kwargs) = get_data_uneven_flag(workspace, **kwargs)
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
-        if aligned:
+        if uneven_bins:
             raise Exception('Variable number of bins is not supported by imshow.')
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True)
+
+    diffs = numpy.diff(x, axis=1)
+    x_spacing_equal = numpy.alltrue(diffs == diffs[0])
+    diffs = numpy.diff(y, axis=0)
+    y_spacing_equal = numpy.alltrue(diffs == diffs[0])
+    if not x_spacing_equal or not y_spacing_equal:
+        raise Exception('Unevenly spaced bins are not supported by imshow')
     kwargs['extent'] = [x[0,0],x[0,-1],y[0,0],y[-1,0]]
     return axes.imshow(z, *args, **kwargs)
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -121,6 +121,7 @@ class PlotFunctionsTest(unittest.TestCase):
         funcs.tripcolor(ax, self.ws2d_histo, vmin=0)
         funcs.pcolormesh(ax, self.ws_MD_2d)
         funcs.pcolorfast(ax, self.ws2d_point_uneven, vmin=-1)
+        funcs.imshow(ax, self.ws2d_histo_rag)
 
     def test_1d_plots_with_unplottable_type_raises_attributeerror(self):
         table = CreateEmptyTableWorkspace()

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -121,7 +121,7 @@ class PlotFunctionsTest(unittest.TestCase):
         funcs.tripcolor(ax, self.ws2d_histo, vmin=0)
         funcs.pcolormesh(ax, self.ws_MD_2d)
         funcs.pcolorfast(ax, self.ws2d_point_uneven, vmin=-1)
-        funcs.imshow(ax, self.ws2d_histo_rag)
+        funcs.imshow(ax, self.ws2d_histo)
 
     def test_1d_plots_with_unplottable_type_raises_attributeerror(self):
         table = CreateEmptyTableWorkspace()


### PR DESCRIPTION
**Description of work.**

This adds [imshow](https://matplotlib.org/api/_as_gen/matplotlib.axes.Axes.imshow.html) to the matplotlib wrappers in Mantid. Should provide a faster figure when the workspace grid is regular.

**To test:**

<!-- Instructions for testing. -->

```python
import time
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from mantid import plots
########## load/generate data

start = time.time()
w = LoadEventNexus(Filename='PG3_42283', OutputWorkspace='PG3_42283')
w = Rebin(InputWorkspace='PG3_42283', OutputWorkspace='PG3_42283', Params=1)
print('generation took {} (s)'.format(time.time() - start))

########## plot
start = time.time()
fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
ax.imshow(w, cmap='viridis', interpolation='nearest')
ax.set_aspect('auto')
fig.set_tight_layout(True)
fig.show()
print('plot took ', time.time() - start, '(s)')
```

*There is no associated issue.*

*This does not require release notes* because incremental improvement not ready for prime time.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
