### PR TITLE
Use NormalizeByIntegratedMonitors in CreateTransmissionWorkspace and CreateTransmissionWorkspaceAuto

### DIFF
--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -181,16 +181,12 @@ MatrixWorkspace_sptr CreateTransmissionWorkspace2::normalizeDetectorsByMonitors(
   }
 
   // Normalization by integrated monitors
-  // Only if both MonitorIntegrationWavelengthMin and
-  // MonitorIntegrationWavelengthMax are have been given
+  // Only if defined by property
+  const bool normalizeByIntegratedMonitors =
+      getProperty("NormalizeByIntegratedMonitors");
 
-  Property *intMinProperty = getProperty("MonitorIntegrationWavelengthMin");
-  Property *intMaxProperty = getProperty("MonitorIntegrationWavelengthMax");
-  const bool integratedMonitors =
-      !(intMinProperty->isDefault() || intMaxProperty->isDefault());
-
-  auto monitorWS = makeMonitorWS(IvsTOF, integratedMonitors);
-  if (!integratedMonitors)
+  auto monitorWS = makeMonitorWS(IvsTOF, normalizeByIntegratedMonitors);
+  if (!normalizeByIntegratedMonitors)
     detectorWS = rebinDetectorsToMonitors(detectorWS, monitorWS);
 
   return divide(detectorWS, monitorWS);

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -159,9 +159,6 @@ void ReflectometryReductionOne2::init() {
 
   // Init properties for monitors
   initMonitorProperties();
-  // Normalization by integrated monitors
-  declareProperty("NormalizeByIntegratedMonitors", true,
-                  "Normalize by dividing by the integrated monitors.");
 
   // Init properties for transmission normalization
   initTransmissionProperties();
@@ -535,6 +532,8 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("MonitorIntegrationWavelengthMax",
                           getPropertyValue("MonitorIntegrationWavelengthMax"));
     alg->setProperty("ProcessingInstructions", transmissionCommands);
+    alg->setProperty("NormalizeByIntegratedMonitors",
+                     getPropertyValue("NormalizeByIntegratedMonitors"));
     alg->setPropertyValue("Debug", getPropertyValue("Debug"));
     alg->execute();
     transmissionWS = alg->getProperty("OutputWorkspace");

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -259,9 +259,6 @@ void ReflectometryReductionOneAuto2::init() {
 
   // Monitor properties
   initMonitorProperties();
-  // Normalization by integrated monitors
-  declareProperty("NormalizeByIntegratedMonitors", true,
-                  "Normalize by dividing by the integrated monitors.");
 
   // Init properties for transmission normalization
   initTransmissionProperties();

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -555,7 +555,7 @@ void ReflectometryWorkflowBase2::populateMonitorProperties(
       this, "StartOverlap", instrument, "TransRunStartOverlap");
   if (startOverlap.is_initialized())
     alg->setProperty("StartOverlap", startOverlap.get());
-    
+
   const auto endOverlap = checkForOptionalInstrumentDefault<double>(
       this, "EndOverlap", instrument, "TransRunEndOverlap");
   if (endOverlap.is_initialized())

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -115,6 +115,9 @@ void ReflectometryWorkflowBase2::initMonitorProperties() {
                       "MonitorIntegrationWavelengthMax", Mantid::EMPTY_DBL(),
                       Direction::Input),
                   "Wavelength maximum for integration in angstroms.");
+  // Normalization by integrated monitors
+  declareProperty("NormalizeByIntegratedMonitors", true,
+                  "Normalize by dividing by the integrated monitors.");
 }
 
 /** Initialize properties related to transmission normalization
@@ -552,34 +555,46 @@ void ReflectometryWorkflowBase2::populateMonitorProperties(
       this, "StartOverlap", instrument, "TransRunStartOverlap");
   if (startOverlap.is_initialized())
     alg->setProperty("StartOverlap", startOverlap.get());
+    
   const auto endOverlap = checkForOptionalInstrumentDefault<double>(
       this, "EndOverlap", instrument, "TransRunEndOverlap");
   if (endOverlap.is_initialized())
     alg->setProperty("EndOverlap", endOverlap.get());
+
   const auto monitorIndex = checkForOptionalInstrumentDefault<int>(
       this, "I0MonitorIndex", instrument, "I0MonitorIndex");
   if (monitorIndex.is_initialized())
     alg->setProperty("I0MonitorIndex", monitorIndex.get());
+
   const auto backgroundMin = checkForOptionalInstrumentDefault<double>(
       this, "MonitorBackgroundWavelengthMin", instrument,
       "MonitorBackgroundMin");
   if (backgroundMin.is_initialized())
     alg->setProperty("MonitorBackgroundWavelengthMin", backgroundMin.get());
+
   const auto backgroundMax = checkForOptionalInstrumentDefault<double>(
       this, "MonitorBackgroundWavelengthMax", instrument,
       "MonitorBackgroundMax");
   if (backgroundMax.is_initialized())
     alg->setProperty("MonitorBackgroundWavelengthMax", backgroundMax.get());
+
   const auto integrationMin = checkForOptionalInstrumentDefault<double>(
       this, "MonitorIntegrationWavelengthMin", instrument,
       "MonitorIntegralMin");
   if (integrationMin.is_initialized())
     alg->setProperty("MonitorIntegrationWavelengthMin", integrationMin.get());
+
   const auto integrationMax = checkForOptionalInstrumentDefault<double>(
       this, "MonitorIntegrationWavelengthMax", instrument,
       "MonitorIntegralMax");
   if (integrationMax.is_initialized())
     alg->setProperty("MonitorIntegrationWavelengthMax", integrationMax.get());
+
+  const auto integrationBool = checkForOptionalInstrumentDefault<bool>(
+      this, "NormalizeByIntegratedMonitors", instrument,
+      "NormalizeByIntegratedMonitors");
+  if (integrationBool.is_initialized())
+    alg->setProperty("NormalizeByIntegratedMonitors", integrationBool.get());
 }
 
 /** Finding processing instructions from the parameters file

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -87,6 +87,7 @@ Improved
 - :ref:`algm-ReflectometryReductionOne` and :ref:`algm-ReflectometryReductionOneAuto` Now take a parameter to pass processing instructions to the transmission workspace algorithms and no longer accept strict spectrum checking
 - Common naming of slit component name and size properties across algorithms.
 - :ref:`algm-SpecularReflectionPositionCorrect` is now compatible with the reflectometers at ILL.
+- :ref:`algm-CreateTransmissionWorkspace` and :ref:`algm-CreateTransmissionWorkspaceAuto` now use NormalizeByIntegratedMontitors instead of using MonitorIntegrationWavelengthMin and MonitorIntegrationWavelengthMax being defined, to determine how to normalize. 
 
 Bug fixes
 #########

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSettingsPresenter.cpp
@@ -160,6 +160,8 @@ OptionsQMap ReflSettingsPresenter::getTransmissionOptions() const {
   }
 
   if (m_view->instrumentSettingsEnabled()) {
+    setTransmissionOption(options, "NormalizeByIntegratedMonitors",
+                          m_view->getIntMonCheck());
     setTransmissionOption(options, "MonitorIntegrationWavelengthMin",
                           m_view->getMonitorIntegralMin());
     setTransmissionOption(options, "MonitorIntegrationWavelengthMax",

--- a/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ReflSettingsPresenterTest.h
@@ -499,7 +499,7 @@ public:
     EXPECT_CALL(mockView, getStitchOptions()).Times(Exactly(0));
 
     // Instrument settings should be called
-    EXPECT_CALL(mockView, getIntMonCheck()).Times(Exactly(1));
+    EXPECT_CALL(mockView, getIntMonCheck()).Times(Exactly(2));
     EXPECT_CALL(mockView, getMonitorIntegralMin()).Times(Exactly(2));
     EXPECT_CALL(mockView, getMonitorIntegralMax()).Times(Exactly(2));
     EXPECT_CALL(mockView, getMonitorBackgroundMin()).Times(Exactly(2));


### PR DESCRIPTION
**Description of work.**
Make sure that CreateTransmissionWorkspace and CreateTransmissionWorkspaceAuto use NormalizeByIntegratedMonitors instead of using MonitorIntegrationWavelengthMin and MonitorIntegrationWavelengthMax being defined, to determine how to normalize. Made sure that when the GUI has it's settings tab variable set for NormalizeByIntegratedMonitors that it is also passed to the CreateTransmissionWorkspaceAuto call.

**To test:**
- Run this script to test ReflectometryReductionOneAuto's call to CreateTransmissionWorkspace
```python
OFFSPEC44956 = LoadISISNexus(Filename="OFFSPEC44956")
OFFSPEC44937 = LoadISISNexus(Filename="OFFSPEC44937")
ReflectometryReductionOneAuto(InputWorkspace='OFFSPEC44956', ThetaIn=0.7, 
  MomentumTransferStep=0.03, MomentumTransferMax=0.1, 
  OutputWorkspaceBinned='IvsQ_binned', OutputWorkspace='IvsQ', OutputWorkspaceWavelength='IvsLam',
  FirstTransmissionRun="OFFSPEC44937", AnalysisMode="MultiDetectorAnalysis",
  ProcessingInstructions="401-411", NormalizeByIntegratedMonitors=True)
```
- Then check the workspace history to check whether NormalizeByIntegratedMonitors was passed from ReflectometryReductionOneAuto via ReflectometryReductionOne to CreateTransmissionWorkspace and that it is set to true, you can alternatively try with false.



- Run this script to test CreateTransmissionWorkspaceAuto's call to CreateTransmissionWorkspace
```python
LoadNexus(Filename='/archive/ndxoffspec/Instrument/data/cycle_18_2/OFFSPEC00048561.nxs', OutputWorkspace='TRANS_48561')
LoadNexus(Filename='/archive/ndxoffspec/Instrument/data/cycle_18_2/OFFSPEC00048562.nxs', OutputWorkspace='TRANS_48562')
CreateTransmissionWorkspaceAuto(FirstTransmissionRun='TRANS_48561_1', SecondTransmissionRun='TRANS_48562_1', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-415', WavelengthMin=2, WavelengthMax=14, I0MonitorIndex=1, MonitorBackgroundWavelengthMin=15, MonitorBackgroundWavelengthMax=20, MonitorIntegrationWavelengthMin=2, MonitorIntegrationWavelengthMax=14, StartOverlap=10, EndOverlap=12, OutputWorkspace='TRANS_48561_48562_1', NormalizeByIntegratedMonitors=True)
```
- Then check the workspace history to check whether NormalizeByIntegratedMonitors was passed from CreateTransmissionWorkspaceAuto to CreateTransmissionWorkspace.



- Now test the GUI changes by going to Interfaces->Reflectometry->ISIS Reflectometry
- Go to the settings tab and check the value of NormalizeByIntegratedMonitors if it is ticked assume it's value to true and false if unticked.
- On the Runs tab add these to it:
![image](https://user-images.githubusercontent.com/24723609/48123935-0c489580-e273-11e8-981b-8c22ddac580d.png)
- Then check the workspace history to check whether NormalizeByIntegratedMonitors was passed from CreateTransmissionWorkspaceAuto to CreateTransmissionWorkspace and that it is the value set in the settings.
<!-- Instructions for testing. -->

Fixes #22172 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
