### PR TITLE
Update SNAP geometry

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -13,6 +13,7 @@ Diffraction Changes
 Improvements
 ############
 
+- SNAP instrument geometry updated to include downstream monitor.
 - :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` will not flip the even-numbered tubes when using the calibrated data, since they are flipped already in the nexus files.
 - :ref:`PowderDiffILLDetScanReduction <algm-PowderDiffILLDetScanReduction>` will scale the counts by 1M, when normalisation to monitor is requested, and it will also offer to enable/disable the tube alignment, and offer tube by tube reduction.
 - :ref:`PowderDiffILLDetEffCorr <algm-PowderDiffILLDetEffCorr>` now offers to use the raw or calibrated data blocks in the nexus files.

--- a/instrument/SNAP_Definition.xml
+++ b/instrument/SNAP_Definition.xml
@@ -33,7 +33,7 @@
   </component>
   <type name="sample-position" is="SamplePos"/>
 
-  <!--  ressonance monitor pixel with events -->
+  <!--MONITORS-->
   <idlist idname="Downstream_monitor">
     <id val="-2"/>
   </idlist>
@@ -47,7 +47,6 @@
    </component>
   </type>
 
-  <!--MONITORS-->
   <idlist idname="monitors">
     <id val="-1"/>
   </idlist>
@@ -60,8 +59,7 @@
     </component>
   </type>
 
-<!--  detector components -->
-
+  <!--DETECTORS-->
   <component type="East">
     <location >
       <parameter name="roty">

--- a/instrument/SNAP_Definition.xml
+++ b/instrument/SNAP_Definition.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
             name="SNAP" valid-from   ="2018-05-01 00:00:01"
                         valid-to     ="2100-01-31 23:59:59"
-		        last-modified="2018-05-14 14:00:00">
+		        last-modified="2018-11-07 14:00:00">
   <!--Data taken from /SNS/SNAP/2010_2_3_CAL/calibrations/SNAP_geom_2010_03_22.xml-->
   <!--Created by Vickie Lynch, modified by Janik Zikovsky -->
   <!-- Modified by Vickie Lynch, Feb 17,2011 Bank names changed from local_name to name -->
@@ -20,43 +20,45 @@
       <handedness val="right"/>
     </reference-frame>
   </defaults>
+
   <!--SOURCE-->
   <component type="moderator">
     <location z="-15.0"/>
   </component>
   <type name="moderator" is="Source"/>
+
   <!--SAMPLE-->
   <component type="sample-position">
     <location y="0.0" x="0.0" z="0.0"/>
   </component>
   <type name="sample-position" is="SamplePos"/>
-  <!--MONITORS-->
-  <component type="monitors" idlist="monitors">
-    <location/>
-  </component>
-  <type is="monitor" name="monitors">
-    <component type="monitor">
-      <location z="-3.0" name="monitor1"/>
-    </component>
-  </type>
 
-<!--  ressonance monitor pixel with events -->
-
+  <!--  ressonance monitor pixel with events -->
+  <idlist idname="Downstream_monitor">
+    <id val="-2"/>
+  </idlist>
   <component type="Downstream_monitor" idlist="Downstream_monitor">
     <properties />
     <location  />
   </component>
-
   <type is="monitor" name="Downstream_monitor">
    <component type="monitor">
     <location x="0.0" y="0.0" z="0.3" name="monitor2" />
    </component>
   </type>
 
-  <idlist idname="Downstream_monitor">
-    <id start="1179648" end="1179648" />
-    <!--id start="1342177280" end="1342177280" / -->
+  <!--MONITORS-->
+  <idlist idname="monitors">
+    <id val="-1"/>
   </idlist>
+  <component type="monitors" idlist="monitors">
+    <location/>
+  </component>
+  <type is="monitor" name="monitors">
+    <component type="monitor">
+      <location x="0.0" y="0.0" z="-3.0" name="monitor1"/>
+    </component>
+  </type>
 
 <!--  detector components -->
 
@@ -245,8 +247,4 @@
     <algebra val="some-shape"/>
   </type>
 
-  <!--MONITOR IDs-->
-  <idlist idname="monitors">
-    <id val="-1"/>
-  </idlist>
 </instrument>


### PR DESCRIPTION
When SNAP got upgraded to the new DAS its monitors were renumbered to be `-1` and `-2`. This was recently discovered when the team tried using live data.

**Report to:** SNAP team and DAS.

**To test:**

1. `LoadEventNexus` a recent SNAP run (e.g. `SNAP_42255`) with monitors
2. `LoadInstrument` the new geometry `instruments/SNAP_Definition.xml` onto the existing monitor workspace
3. Use the instrument view to see two monitors. On the pick tab, mousing over the monitors will show that the are ids -1 (upstream) and -2 (downstream).

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
