### PR TITLE
Refactor wish to use align and focus powder

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_WISHPowderReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_WISHPowderReductionTest.py
@@ -58,6 +58,7 @@ class WISHPowderReductionTest(MantidSystemTest):
         self.clearWorkspaces()
 
     def validate(self):
+        self.tolerence = 1.e-8
         validation_files = []
         for panel in [x for x in panels if x < 6]:
             validation_files = validation_files + \
@@ -93,6 +94,7 @@ class WISHPowderReductionNoAbsorptionTest(MantidSystemTest):
         self.clearWorkspaces()
 
     def validate(self):
+        self.tolerence = 1.e-8
         validation_files = []
         for panel in [x for x in panels if x < 6]:
             validation_files = validation_files + ["w40503-{0}_{1}foc".format(panel, linked_panels.get(panel)),
@@ -124,6 +126,7 @@ class WISHPowderReductionCreateVanadiumTest(MantidSystemTest):
         wish_test.create_vanadium_run(19612, 19618, panels)
 
     def validate(self):
+        self.tolerence = 1.e-8
         validation_files = []
         for panel in [x for x in panels if x < 6]:
             validation_files = validation_files + ["w19612-{}foc".format(panel),

--- a/scripts/Diffraction/wish/reduce.py
+++ b/scripts/Diffraction/wish/reduce.py
@@ -197,8 +197,9 @@ class Wish:
         cal = "WISH_diff{}"
         if cal.format("_cal") not in simple.mtd:
             simple.LoadDiffCal(filename=self.get_cal(), InstrumentName="WISH", WorkspaceName=cal.format(""))
-        simple.AlignDetectors(InputWorkspace=work, OutputWorkspace=work, CalibrationWorkspace=cal.format("_cal"))
-        simple.DiffractionFocussing(InputWorkspace=work, OutputWorkspace=focus, GroupingWorkspace=cal.format("_group"))
+        simple.AlignAndFocusPowder(InputWorkspace=work, OutputWorkspace=focus, GroupingWorkspace=cal.format("_group"),
+                                   CalibrationWorkspace=cal.format("_cal"), Dspacing=True, params="-0.00063")
+        simple.ConvertUnits(InputWorkspace=focus, OutputWorkspace=focus, Target="dSpacing")
         if self.deleteWorkspace:
             simple.DeleteWorkspace(work)
         if panel == 5 or panel == 6:


### PR DESCRIPTION
**Re-Writing in progress due to #24267**

**Description of work.**
Updated and Refactored Wish powder reduction script to use `AlignAndFocusPowder` (added option to `AlignAndFocusPowder` to not rebin to allow this)

**To test:**
Build the system tests then change `ISIS_WISHPowderReductionTest` to not skip and run it, all tests should pass

Fixes #23869 

This still needs further refactoring, and should eventually use `AlignAndFocusPowderFromFiles` however this is all ready a large pull request

DO NOT MERGE UNTIL ~~#23796~~ AND #24037 ARE MERGED

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
