### PR TITLE
Added systemtest to check errorreport server

### DIFF
--- a/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
+++ b/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
@@ -14,6 +14,7 @@ if sys.version_info.major < 3:
 else:
     from unittest import mock
 
+
 class ErrorReportServerTests(stresstesting.MantidStressTest):
     def setUp(self):
         mock_view = mock.MagicMock()

--- a/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
+++ b/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
@@ -1,0 +1,76 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import sys
+import stresstesting
+from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
+
+if sys.version_info.major < 3:
+    import mock
+else:
+    from unittest import mock
+
+class ErrorReportServerTests(stresstesting.MantidStressTest):
+    def setUp(self):
+        mock_view = mock.MagicMock()
+        self.error_report_presenter = ErrorReporterPresenter(mock_view, '1')
+
+    def test_no_share_sends_nothing(self):
+        status = self.error_report_presenter.error_handler(True, 2, '', '', '')
+        self.assertEqual(status, -1)
+
+    def test_share_non_identifiable_returns_created_status(self):
+        status = self.error_report_presenter.error_handler(True, 1, '', '', '')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_for_empty_values(self):
+        status = self.error_report_presenter.error_handler(True, 0, '', '', '')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_for_just_name(self):
+        status = self.error_report_presenter.error_handler(True, 0, 'public_name', '', '')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_for_just_email(self):
+        status = self.error_report_presenter.error_handler(True, 0, '', 'public_email', '')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_for_just_textbox(self):
+        status = self.error_report_presenter.error_handler(True, 0, '', '', 'Something went wrong')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_with_no_name(self):
+        status = self.error_report_presenter.error_handler(True, 0, '', 'public_email', 'Something went wrong')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_with_no_email(self):
+        status = self.error_report_presenter.error_handler(True, 0, 'public_name', '', 'Something went wrong')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_with_no_textbox(self):
+        status = self.error_report_presenter.error_handler(True, 0, 'public_name', 'public_email', '')
+        self.assertEqual(status, 201)
+
+    def test_share_identifiable_works_with_all(self):
+        status = self.error_report_presenter.error_handler(True, 0, 'public_name', 'public_email', 'Something went wrong')
+        self.assertEqual(status, 201)
+
+    def excludeInPullRequests(self):
+        return True
+
+    def runTest(self):
+        self.setUp()
+        self.test_no_share_sends_nothing()
+        self.test_share_non_identifiable_returns_created_status()
+        self.test_share_identifiable_works_for_empty_values()
+        self.test_share_identifiable_works_for_just_name()
+        self.test_share_identifiable_works_for_just_email()
+        self.test_share_identifiable_works_for_just_textbox()
+        self.test_share_identifiable_works_with_no_name()
+        self.test_share_identifiable_works_with_no_email()
+        self.test_share_identifiable_works_with_no_textbox()
+        self.test_share_identifiable_works_with_all()

--- a/scripts/ErrorReporter/error_report_presenter.py
+++ b/scripts/ErrorReporter/error_report_presenter.py
@@ -26,7 +26,7 @@ class ErrorReporterPresenter(object):
                 "mantidplot", UsageService.getUpTime(), self._exit_code, False, str(name), str(email), str(textBox))
             status = errorReporter.sendErrorReport()
 
-        if status != 201:
+        if status != 201 and status != -1:
             self._view.display_message_box('Error contacting server','There was an error when sending the report.'
                                            'Please contact mantid-help@mantidproject.org directly',
                                            'http request returned with status {}'.format(status))
@@ -37,6 +37,8 @@ class ErrorReporterPresenter(object):
             self._view.quit()
         else:
             self.error_log.error("Continue working.")
+
+        return status
 
     def show_view(self):
         self._view.show()


### PR DESCRIPTION
**Description of work.**

This adds a system test to check that the error report server is working. This system test is set to not be run on pull requests so that server downtime will not clog up the build servers so should be checked locally.

**Report to:** matthew <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Code review and running test 

<!-- Instructions for testing. -->


*There is no associated issue.*

This is does not require release notes as internal.
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
