### PR TITLE
Indirect - ConvFit - Q value not updating when spectrum changed

### DIFF
--- a/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
+++ b/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
@@ -70,14 +70,11 @@ void FunctionQDepends::setAttribute(const std::string &attName,
                                     const Attr &attValue) {
   // Q value is tied to WorkspaceIndex if we have a list of Q values
   if (attName == "WorkspaceIndex") {
-    auto const index = attValue.type() == "double"
-                           ? static_cast<int>(attValue.asDouble())
-                           : attValue.asInt();
-    auto const workspaceIndex = static_cast<std::size_t>(index);
-    if (!m_vQ.empty() && workspaceIndex < m_vQ.size()) {
+    size_t wi{static_cast<size_t>(
+        attValue.asInt())}; // ah!, the "joys" of C++ strong typing.
+    if (!m_vQ.empty() && wi < m_vQ.size()) {
       Mantid::API::IFunction::setAttribute(attName, attValue);
-      Mantid::API::IFunction::setAttribute("Q",
-                                           Attribute(m_vQ.at(workspaceIndex)));
+      Mantid::API::IFunction::setAttribute("Q", Attribute(m_vQ.at(wi)));
     }
   }
   // Q can be manually changed by user only if list of Q values is empty

--- a/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
+++ b/Framework/CurveFitting/src/Functions/FunctionQDepends.cpp
@@ -70,11 +70,14 @@ void FunctionQDepends::setAttribute(const std::string &attName,
                                     const Attr &attValue) {
   // Q value is tied to WorkspaceIndex if we have a list of Q values
   if (attName == "WorkspaceIndex") {
-    size_t wi{static_cast<size_t>(
-        attValue.asInt())}; // ah!, the "joys" of C++ strong typing.
-    if (!m_vQ.empty() && wi < m_vQ.size()) {
+    auto const index = attValue.type() == "double"
+                           ? static_cast<int>(attValue.asDouble())
+                           : attValue.asInt();
+    auto const workspaceIndex = static_cast<std::size_t>(index);
+    if (!m_vQ.empty() && workspaceIndex < m_vQ.size()) {
       Mantid::API::IFunction::setAttribute(attName, attValue);
-      Mantid::API::IFunction::setAttribute("Q", Attribute(m_vQ.at(wi)));
+      Mantid::API::IFunction::setAttribute("Q",
+                                           Attribute(m_vQ.at(workspaceIndex)));
     }
   }
   // Q can be manually changed by user only if list of Q values is empty

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -42,6 +42,8 @@ Improvements
 - In the I(Q,t) Tab, it is now possible to select which spectrum you want to plot for Plot Spectrum.
 - In the I(Q,t) Tab, it is now possible to select a range of spectra for a Tiled Plot. The interface allows a
   maximum of 18 plots.
+- The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed. 
+  This improvement can be seen in ConvFit when functions which depend on Q value are selected.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -487,7 +487,7 @@ CompositeFunction_sptr ConvFitModel::getMultiDomainFunction() const {
 std::vector<std::string> ConvFitModel::getSpectrumDependentAttributes() const {
   /// Q value also depends on spectrum but is automatically updated when
   /// the WorkspaceIndex is changed
-  return std::vector<std::string>{ "WorkspaceIndex" };
+  return std::vector<std::string>{"WorkspaceIndex"};
 }
 
 void ConvFitModel::setFitFunction(IFunction_sptr function) {

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -484,6 +484,12 @@ CompositeFunction_sptr ConvFitModel::getMultiDomainFunction() const {
   return function;
 }
 
+std::vector<std::string> ConvFitModel::getSpectrumDependentAttributes() const {
+  /// Q value also depends on spectrum but is automatically updated when
+  /// the WorkspaceIndex is changed
+  return std::vector<std::string>{ "WorkspaceIndex" };
+}
+
 void ConvFitModel::setFitFunction(IFunction_sptr function) {
   auto composite = boost::dynamic_pointer_cast<CompositeFunction>(function);
   m_backgroundIndex = getFirstInCategory(composite, "Background");

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -123,12 +123,12 @@ IAlgorithm_sptr loadParameterFileAlgorithm(MatrixWorkspace_sptr workspace,
 
 void readAnalyserFromFile(const std::string &analyser,
                           MatrixWorkspace_sptr workspace) {
-  auto instrument = workspace->getInstrument();
-  auto idfDirectory = Mantid::Kernel::ConfigService::Instance().getString(
+  auto const instrument = workspace->getInstrument();
+  auto const idfDirectory = Mantid::Kernel::ConfigService::Instance().getString(
       "instrumentDefinition.directory");
-  auto reflection = instrument->getStringParameter("reflection")[0];
-  auto parameterFile = idfDirectory + instrument->getName() + "_" + analyser +
-                       "_" + reflection + "_Parameters.xml";
+  auto const reflection = instrument->getStringParameter("reflection")[0];
+  auto const parameterFile = idfDirectory + instrument->getName() + "_" +
+                             analyser + "_" + reflection + "_Parameters.xml";
 
   IAlgorithm_sptr loadParamFile =
       loadParameterFileAlgorithm(workspace, parameterFile);
@@ -487,11 +487,12 @@ CompositeFunction_sptr ConvFitModel::getMultiDomainFunction() const {
 std::vector<std::string> ConvFitModel::getSpectrumDependentAttributes() const {
   /// Q value also depends on spectrum but is automatically updated when
   /// the WorkspaceIndex is changed
-  return std::vector<std::string>{"WorkspaceIndex"};
+  return {"WorkspaceIndex"};
 }
 
 void ConvFitModel::setFitFunction(IFunction_sptr function) {
-  auto composite = boost::dynamic_pointer_cast<CompositeFunction>(function);
+  auto const composite =
+      boost::dynamic_pointer_cast<CompositeFunction>(function);
   m_backgroundIndex = getFirstInCategory(composite, "Background");
   setParameterNameChanges(*function, m_backgroundIndex);
 

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.h
@@ -23,6 +23,8 @@ public:
   std::size_t getNumberHistograms(std::size_t index) const;
   Mantid::API::MatrixWorkspace_sptr getResolution(std::size_t index) const;
 
+  std::vector<std::string> getSpectrumDependentAttributes() const override;
+
   void setFitFunction(Mantid::API::IFunction_sptr function) override;
   void setTemperature(const boost::optional<double> &temperature);
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -197,7 +197,7 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
   connect(m_fitPropertyBrowser, SIGNAL(endXChanged(double)),
           m_plotPresenter.get(), SLOT(setEndX(double)));
   connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)),
-	      m_plotPresenter.get(), SLOT(setPlotSpectrum(int)));
+          m_plotPresenter.get(), SLOT(setPlotSpectrum(int)));
 
   connect(m_plotPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(setBrowserStartX(double)));
@@ -727,24 +727,24 @@ void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
 }
 
 /**
- * Updates the attribute values which are dependent on which spectrum is selected. 
- * They are updated in the function and in the FitPropertyBrowser.
+ * Updates the attribute values which are dependent on which spectrum is
+ * selected. They are updated in the function and in the FitPropertyBrowser.
  */
 void IndirectFitAnalysisTab::updateAttributeValues() {
   auto const attributeNames = m_fittingModel->getSpectrumDependentAttributes();
   if (!attributeNames.empty()) {
     for (auto i = 0; i < m_fitPropertyBrowser->count(); ++i) {
-	  auto function = m_fitPropertyBrowser->getFunctionAtIndex(i);
-	  updateAttributeValues(function, attributeNames);
-	}
+      auto function = m_fitPropertyBrowser->getFunctionAtIndex(i);
+      updateAttributeValues(function, attributeNames);
+    }
   }
 }
 
-void IndirectFitAnalysisTab::updateAttributeValues(IFunction_sptr function, 
-	                                               std::vector<std::string> const &attributeNames) {
+void IndirectFitAnalysisTab::updateAttributeValues(
+    IFunction_sptr function, std::vector<std::string> const &attributeNames) {
   auto const attributes = getAttributes(function, attributeNames);
   if (!attributes.empty())
-	updateAttributeValues(function, attributeNames, attributes);
+    updateAttributeValues(function, attributeNames, attributes);
 }
 
 void IndirectFitAnalysisTab::updateAttributeValues(
@@ -754,7 +754,8 @@ void IndirectFitAnalysisTab::updateAttributeValues(
     updateAttributes(fitFunction, attributeNames, attributes);
     updateFitBrowserAttributeValues();
   } catch (const std::runtime_error &) {
-	showMessageBox("An unexpected error occured:\n The setting of attribute values failed.");
+    showMessageBox("An unexpected error occured:\n The setting of attribute "
+                   "values failed.");
   }
 }
 
@@ -764,13 +765,16 @@ void IndirectFitAnalysisTab::updateFitBrowserAttributeValues() {
 }
 
 std::unordered_map<std::string, IFunction::Attribute>
-IndirectFitAnalysisTab::getAttributes(IFunction_sptr const &function,
-	std::vector<std::string> const &attributeNames) {
+IndirectFitAnalysisTab::getAttributes(
+    IFunction_sptr const &function,
+    std::vector<std::string> const &attributeNames) {
   std::unordered_map<std::string, IFunction::Attribute> attributes;
   for (auto const &name : attributeNames)
     if (function->hasAttribute(name))
-	  attributes[name] = name == "WorkspaceIndex" ? IFunction::Attribute(m_fitPropertyBrowser->workspaceIndex())
-			                                      : function->getAttribute(name);
+      attributes[name] =
+          name == "WorkspaceIndex"
+              ? IFunction::Attribute(m_fitPropertyBrowser->workspaceIndex())
+              : function->getAttribute(name);
   return attributes;
 }
 
@@ -857,7 +861,7 @@ void IndirectFitAnalysisTab::plotAll(
     plotSpectrum(workspace);
   else
     showMessageBox("Plotting the result of a workspace failed:\n\n "
-                           "Workspace result has only one data point");
+                   "Workspace result has only one data point");
 }
 
 void IndirectFitAnalysisTab::plotParameter(
@@ -869,7 +873,7 @@ void IndirectFitAnalysisTab::plotParameter(
     plotSpectrum(workspace, parameterToPlot);
   else
     showMessageBox("Plotting the result of a workspace failed:\n\n "
-                           "Workspace result has only one data point");
+                   "Workspace result has only one data point");
 }
 
 void IndirectFitAnalysisTab::plotSpectrum(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -740,6 +740,12 @@ void IndirectFitAnalysisTab::updateAttributeValues() {
   }
 }
 
+/**
+ * Updates the attribute values in the function provided and in the fit property
+ * browser.
+ * @param function        The function containing the attributes
+ * @param attributeNames  The attributes to update
+ */
 void IndirectFitAnalysisTab::updateAttributeValues(
     IFunction_sptr function, std::vector<std::string> const &attributeNames) {
   auto const attributes = getAttributes(function, attributeNames);
@@ -759,11 +765,20 @@ void IndirectFitAnalysisTab::updateAttributeValues(
   }
 }
 
+/**
+ * Updates the attribute values in the the fit property browser.
+ */
 void IndirectFitAnalysisTab::updateFitBrowserAttributeValues() {
   MantidQt::API::SignalBlocker<QObject> blocker(m_fitPropertyBrowser);
   m_fitPropertyBrowser->updateAttributes();
 }
 
+/**
+ * Gets the new attribute values to be updated in the function and in the fit
+ * property browser.
+ * @param function        The function containing the attributes
+ * @param attributeNames  The names of the attributes to update
+ */
 std::unordered_map<std::string, IFunction::Attribute>
 IndirectFitAnalysisTab::getAttributes(
     IFunction_sptr const &function,

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -728,8 +728,6 @@ void IndirectFitAnalysisTab::updateWorkspaceIndexValue() {
   for (auto i = 0; i < m_fitPropertyBrowser->count(); ++i) {
     auto function = m_fitPropertyBrowser->getFunctionAtIndex(i);
     auto const attributeNames = function->getAttributeNames();
-    // if (std::find(attributeNames.begin(), attributeNames.end(),
-    //              "WorkspaceIndex") != attributeNames.end())
     if (!attributeNames.empty())
       updateAttributeValues(function, attributeNames,
                             getWorkspaceIndexAttribute());

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -196,6 +196,8 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
           m_plotPresenter.get(), SLOT(setStartX(double)));
   connect(m_fitPropertyBrowser, SIGNAL(endXChanged(double)),
           m_plotPresenter.get(), SLOT(setEndX(double)));
+  connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)),
+	      m_plotPresenter.get(), SLOT(setPlotSpectrum(int)));
 
   connect(m_plotPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(setBrowserStartX(double)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -194,6 +194,7 @@ protected slots:
   getWorkspaceIndexAttribute();
   void updateAttributeValues(
       Mantid::API::IFunction_sptr fitFunction,
+      std::vector<std::string> const &attributeNames,
       std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
           &attributes);
   void updateFitBrowserAttributeValues();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -191,15 +191,16 @@ protected slots:
 
   void updateAttributeValues();
   void updateAttributeValues(Mantid::API::IFunction_sptr function,
-	                         std::vector<std::string> const &attributeNames);
-  void updateAttributeValues(Mantid::API::IFunction_sptr function,
-	                         std::vector<std::string> const &attributeNames,
-	  std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
-	  &attributes);
+                             std::vector<std::string> const &attributeNames);
+  void updateAttributeValues(
+      Mantid::API::IFunction_sptr function,
+      std::vector<std::string> const &attributeNames,
+      std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
+          &attributes);
   void updateFitBrowserAttributeValues();
-  std::unordered_map<std::string, Mantid::API::IFunction::Attribute> 
+  std::unordered_map<std::string, Mantid::API::IFunction::Attribute>
   getAttributes(Mantid::API::IFunction_sptr const &function,
-	            std::vector<std::string> const &attributeNames);
+                std::vector<std::string> const &attributeNames);
   void updateParameterValues();
   void updateParameterValues(
       const std::unordered_map<std::string, ParameterValue> &parameters);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -189,15 +189,17 @@ protected slots:
   void singleFit(std::size_t dataIndex, std::size_t spectrum);
   void executeFit();
 
-  void updateWorkspaceIndexValue();
-  std::unordered_map<std::string, Mantid::API::IFunction::Attribute>
-  getWorkspaceIndexAttribute();
-  void updateAttributeValues(
-      Mantid::API::IFunction_sptr fitFunction,
-      std::vector<std::string> const &attributeNames,
-      std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
-          &attributes);
+  void updateAttributeValues();
+  void updateAttributeValues(Mantid::API::IFunction_sptr function,
+	                         std::vector<std::string> const &attributeNames);
+  void updateAttributeValues(Mantid::API::IFunction_sptr function,
+	                         std::vector<std::string> const &attributeNames,
+	  std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
+	  &attributes);
   void updateFitBrowserAttributeValues();
+  std::unordered_map<std::string, Mantid::API::IFunction::Attribute> 
+  getAttributes(Mantid::API::IFunction_sptr const &function,
+	            std::vector<std::string> const &attributeNames);
   void updateParameterValues();
   void updateParameterValues(
       const std::unordered_map<std::string, ParameterValue> &parameters);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -189,10 +189,18 @@ protected slots:
   void singleFit(std::size_t dataIndex, std::size_t spectrum);
   void executeFit();
 
-  void updateFitBrowserParameterValues();
+  void updateWorkspaceIndexValue();
+  std::unordered_map<std::string, Mantid::API::IFunction::Attribute>
+  getWorkspaceIndexAttribute();
+  void updateAttributeValues(
+      Mantid::API::IFunction_sptr fitFunction,
+      std::unordered_map<std::string, Mantid::API::IFunction::Attribute> const
+          &attributes);
+  void updateFitBrowserAttributeValues();
   void updateParameterValues();
   void updateParameterValues(
       const std::unordered_map<std::string, ParameterValue> &parameters);
+  void updateFitBrowserParameterValues();
 
   virtual void updatePlotOptions() = 0;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -171,6 +171,10 @@ void IndirectFitPlotPresenter::setEndX(double endX) {
   m_view->setFitRangeMaximum(endX);
 }
 
+void IndirectFitPlotPresenter::setPlotSpectrum(int spectrum) {
+  m_view->setPlotSpectrum(spectrum);
+}
+
 void IndirectFitPlotPresenter::updateRangeSelectors() {
   updateBackgroundSelector();
   updateHWHMSelector();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -30,6 +30,7 @@ public:
 public slots:
   void setStartX(double);
   void setEndX(double);
+  void setPlotSpectrum(int spectrum);
   void hideMultipleDataSelection();
   void showMultipleDataSelection();
   void updateRangeSelectors();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -106,6 +106,10 @@ void IndirectFitPlotView::setMaximumSpectrum(int maximum) {
   m_plotForm->spPlotSpectrum->setMaximum(maximum);
 }
 
+void IndirectFitPlotView::setPlotSpectrum(int spectrum) {
+  m_plotForm->spPlotSpectrum->setValue(spectrum);
+}
+
 void IndirectFitPlotView::setBackgroundLevel(double value) {
   auto selector = m_plotForm->ppPlotTop->getRangeSelector("Background");
   MantidQt::API::SignalBlocker<QObject> blocker(selector);

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -38,6 +38,7 @@ public:
 
   void setMinimumSpectrum(int minimum);
   void setMaximumSpectrum(int maximum);
+  void setPlotSpectrum(int spectrum);
   void appendToDataSelection(const std::string &dataName);
   void setNameInDataSelection(const std::string &dataName, std::size_t index);
   void clearDataSelection();

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -66,6 +66,8 @@ public:
   std::vector<std::string> getFitParameterNames() const;
   virtual Mantid::API::IFunction_sptr getFittingFunction() const;
 
+  virtual std::vector<std::string> getSpectrumDependentAttributes() const = 0;
+
   void setFittingData(PrivateFittingData &&fittingData);
   void setSpectra(const std::string &spectra, std::size_t dataIndex);
   void setSpectra(Spectra &&spectra, std::size_t dataIndex);

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
@@ -200,7 +200,7 @@ IAlgorithm_sptr IqtFitModel::getFittingAlgorithm() const {
 }
 
 std::vector<std::string> IqtFitModel::getSpectrumDependentAttributes() const {
-  return std::vector<std::string>();
+  return {};
 }
 
 IAlgorithm_sptr IqtFitModel::sequentialFitAlgorithm() const {
@@ -218,7 +218,7 @@ IAlgorithm_sptr IqtFitModel::simultaneousFitAlgorithm() const {
 std::string IqtFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
     return "MultiIqtFit_" + m_fitType + "_Result";
-  auto fitString = getFitString(getWorkspace(0));
+  auto const fitString = getFitString(getWorkspace(0));
   return createOutputName("%1%" + fitString + "_" + m_fitType + "_s%2%", "_to_",
                           0);
 }
@@ -226,14 +226,14 @@ std::string IqtFitModel::sequentialFitOutputName() const {
 std::string IqtFitModel::simultaneousFitOutputName() const {
   if (isMultiFit())
     return "MultiSimultaneousIqtFit_" + m_fitType + "_Result";
-  auto fitString = getFitString(getWorkspace(0));
+  auto const fitString = getFitString(getWorkspace(0));
   return createOutputName("%1%" + fitString + "_mult" + m_fitType + "_s%2%",
                           "_to_", 0);
 }
 
 std::string IqtFitModel::singleFitOutputName(std::size_t index,
                                              std::size_t spectrum) const {
-  auto fitString = getFitString(getWorkspace(0));
+  auto const fitString = getFitString(getWorkspace(0));
   return createSingleFitOutputName(
       "%1%" + fitString + "_" + m_fitType + "_s%2%", index, spectrum);
 }

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
@@ -199,6 +199,10 @@ IAlgorithm_sptr IqtFitModel::getFittingAlgorithm() const {
   return IndirectFittingModel::getFittingAlgorithm();
 }
 
+std::vector<std::string> IqtFitModel::getSpectrumDependentAttributes() const {
+  return std::vector<std::string>();
+}
+
 IAlgorithm_sptr IqtFitModel::sequentialFitAlgorithm() const {
   auto algorithm = AlgorithmManager::Instance().create("IqtFitSequential");
   algorithm->setProperty("IgnoreInvalidData", true);

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.h
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.h
@@ -19,6 +19,8 @@ public:
 
   Mantid::API::IAlgorithm_sptr getFittingAlgorithm() const override;
 
+  std::vector<std::string> getSpectrumDependentAttributes() const override;
+
   void setFitTypeString(const std::string &fitType);
 
   void setFitFunction(Mantid::API::IFunction_sptr function) override;

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -286,6 +286,10 @@ bool JumpFitModel::isMultiFit() const {
   return !allWorkspacesEqual(getWorkspace(0));
 }
 
+std::vector<std::string> JumpFitModel::getSpectrumDependentAttributes() const {
+  return std::vector<std::string>();
+}
+
 std::vector<std::string> JumpFitModel::getWidths(std::size_t dataIndex) const {
   const auto parameters = findJumpFitParameters(dataIndex);
   if (parameters != m_jumpParameters.end())

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -287,7 +287,7 @@ bool JumpFitModel::isMultiFit() const {
 }
 
 std::vector<std::string> JumpFitModel::getSpectrumDependentAttributes() const {
-  return std::vector<std::string>();
+  return {};
 }
 
 std::vector<std::string> JumpFitModel::getWidths(std::size_t dataIndex) const {
@@ -339,8 +339,8 @@ std::string JumpFitModel::singleFitOutputName(std::size_t, std::size_t) const {
 std::string JumpFitModel::getResultXAxisUnit() const { return ""; }
 
 std::string JumpFitModel::constructOutputName() const {
-  auto name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
-  auto position = name.find("_Result");
+  auto const name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
+  auto const position = name.find("_Result");
   if (position != std::string::npos)
     return name.substr(0, position) + name.substr(position + 7, name.size());
   return name;

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -32,6 +32,8 @@ public:
 
   bool isMultiFit() const override;
 
+  std::vector<std::string> getSpectrumDependentAttributes() const override;
+
   std::string getFitParameterName(std::size_t dataIndex,
                                   std::size_t spectrum) const;
   std::vector<std::string> getWidths(std::size_t dataIndex) const;

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
@@ -33,7 +33,7 @@ std::string MSDFitModel::singleFitOutputName(std::size_t index,
 }
 
 std::vector<std::string> MSDFitModel::getSpectrumDependentAttributes() const {
-  return std::vector<std::string>();
+  return {};
 }
 
 std::string MSDFitModel::getResultXAxisUnit() const { return "Temperature"; }

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
@@ -32,6 +32,10 @@ std::string MSDFitModel::singleFitOutputName(std::size_t index,
                                    spectrum);
 }
 
+std::vector<std::string> MSDFitModel::getSpectrumDependentAttributes() const {
+  return std::vector<std::string>();
+}
+
 std::string MSDFitModel::getResultXAxisUnit() const { return "Temperature"; }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.h
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.h
@@ -22,6 +22,8 @@ public:
   std::string singleFitOutputName(std::size_t index,
                                   std::size_t spectrum) const override;
 
+  std::vector<std::string> getSpectrumDependentAttributes() const override;
+
 private:
   std::string getResultXAxisUnit() const override;
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
@@ -54,6 +54,10 @@ private:
     (void)spectrum;
     return "";
   };
+
+  std::vector<std::string> getSpectrumDependentAttributes() const override {
+    return std::vector<std::string>();
+  }
 };
 
 void setFittingFunction(IndirectFittingModel *model,

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -42,6 +42,10 @@ private:
     (void)spectrum;
     return "";
   };
+
+  std::vector<std::string> getSpectrumDependentAttributes() const override {
+    return std::vector<std::string>();
+  }
 };
 
 std::unique_ptr<DummyModel> getEmptyModel() {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -15,7 +15,6 @@
 #include <QHash>
 #include <QList>
 #include <QMap>
-#include <unordered_map>
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -119,6 +119,9 @@ public:
 
   /// Return the fitting function
   Mantid::API::IFunction_sptr getFittingFunction() const;
+  /// Return a function at a specific index in the composite function
+  Mantid::API::IFunction_sptr
+  getFunctionAtIndex(std::size_t const &index) const;
 
   /// Get the default function type
   std::string defaultFunctionType() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -15,6 +15,7 @@
 #include <QHash>
 #include <QList>
 #include <QMap>
+#include <unordered_map>
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -98,6 +99,8 @@ public:
   boost::shared_ptr<const Mantid::API::IFunction> theFunction() const;
   /// Update the function parameters
   void updateParameters();
+  /// Update the function attributes
+  void updateAttributes();
   /// Get function parameter values
   QList<double> getParameterValues() const;
   /// Get function parameter names

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -126,18 +126,12 @@ public:
                     Mantid::API::IFunction::Attribute const &attValue);
 
   /**
-   * Set function's integer attribute
+   * Set function's attribute
    * @param attName :: The name of the attribute
    * @param attValue :: The new attribute value
    */
-  void setAttribute(QString const &attName, int const &attValue);
-
-  /**
-   * Set function's double attribute
-   * @param attName :: The name of the attribute
-   * @param attValue :: The new attribute value
-   */
-  void setAttribute(const QString &attName, const double &attValue);
+  template <typename AttributeType>
+  void setAttribute(QString const &attName, AttributeType const &attValue);
 
   /**
    * Set function's attribute of any type.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -118,6 +118,21 @@ public:
   bool setAttribute(QtProperty *prop, bool resetProperties = true);
 
   /**
+   * Set function's attribute
+   * @param attName :: The name of the attribute
+   * @param attValue :: The new attribute value
+   */
+  void setAttribute(QString const &attName,
+                    Mantid::API::IFunction::Attribute const &attValue);
+
+  /**
+   * Set function's integer attribute
+   * @param attName :: The name of the attribute
+   * @param attValue :: The new attribute value
+   */
+  void setAttribute(QString const &attName, int const &attValue);
+
+  /**
    * Set function's double attribute
    * @param attName :: The name of the attribute
    * @param attValue :: The new attribute value
@@ -137,6 +152,9 @@ public:
 
   /// Sync all parameter values with the manager
   void updateParameters();
+
+  /// Sync all parameter values with the manager
+  void updateAttributes();
 
   /// Set all parameter error values in the manager
   void updateErrors();
@@ -252,6 +270,12 @@ private:
 
   /// Applies given function to all the parameter properties recursively
   void applyToAllParameters(void (PropertyHandler::*func)(QtProperty *));
+
+  /// Sync function attribute value with the manager
+  void updateAttribute(QtProperty *prop);
+
+  /// Applies given function to all the attribute properties recursively
+  void applyToAllAttributes(void (PropertyHandler::*func)(QtProperty *));
 
   friend class CreateAttributeProperty;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -118,7 +118,7 @@ public:
   bool setAttribute(QtProperty *prop, bool resetProperties = true);
 
   /**
-   * Set function's attribute
+   * Set function attribute value
    * @param attName :: The name of the attribute
    * @param attValue :: The new attribute value
    */
@@ -126,7 +126,7 @@ public:
                     Mantid::API::IFunction::Attribute const &attValue);
 
   /**
-   * Set function's attribute
+   * Set function's attribute if it has type double or int
    * @param attName :: The name of the attribute
    * @param attValue :: The new attribute value
    */

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1634,9 +1634,17 @@ Mantid::API::IFunction_sptr FitPropertyBrowser::getFittingFunction() const {
   if (m_compositeFunction->nFunctions() > 1) {
     function = m_compositeFunction;
   } else {
-    function = m_compositeFunction->getFunction(0);
+    function = getFunctionAtIndex(0);
   }
   return function;
+}
+
+/**
+ * Return the function within a composite function at the position specified
+ */
+Mantid::API::IFunction_sptr
+FitPropertyBrowser::getFunctionAtIndex(std::size_t const &index) const {
+  return m_compositeFunction->getFunction(index);
 }
 
 void FitPropertyBrowser::finishHandle(const Mantid::API::IAlgorithm *alg) {
@@ -2788,7 +2796,7 @@ void FitPropertyBrowser::setupMultifit() {
             Mantid::API::AnalysisDataService::Instance().retrieve(
                 workspaceName()));
     if (mws) {
-      auto fun = m_compositeFunction->getFunction(0);
+      auto fun = getFunctionAtIndex(0);
       QString fun1Ini = QString::fromStdString(fun->asString());
       QString funIni = "composite=MultiBG;" + fun1Ini + ",Workspace=" + wsName +
                        ",WSParam=(WorkspaceIndex=0);";
@@ -2825,7 +2833,7 @@ void FitPropertyBrowser::processMultiBGResults() {
 
   // check if member functions are the same
   QStringList parNames;
-  auto fun0 = compositeFunction()->getFunction(0);
+  auto fun0 = getFunctionAtIndex(0);
   if (!fun0) {
     throw std::runtime_error(
         "IFunction expected but func function of another type");
@@ -2835,7 +2843,7 @@ void FitPropertyBrowser::processMultiBGResults() {
   }
 
   for (size_t i = 1; i < compositeFunction()->nFunctions(); ++i) {
-    auto fun = compositeFunction()->getFunction(i);
+    auto fun = getFunctionAtIndex(i);
     if (!fun) {
       throw std::runtime_error(
           "IFunction expected but func function of another type");

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1910,6 +1910,13 @@ void FitPropertyBrowser::updateParameters() {
 }
 
 /**
+ * Update the function attributes specified
+ */
+void FitPropertyBrowser::updateAttributes() {
+  getHandler()->updateAttributes();
+}
+
+/**
  * Slot. Removes all functions.
  */
 void FitPropertyBrowser::clear() {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1926,7 +1926,7 @@ void FitPropertyBrowser::updateParameters() {
 }
 
 /**
- * Update the function attributes specified
+ * Update the function attributes which have changed
  */
 void FitPropertyBrowser::updateAttributes() {
   getHandler()->updateAttributes();

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1348,10 +1348,18 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
     }
     emit workspaceIndexChanged(wi);
   } else if (prop->propertyName() == "Workspace Index") {
-    PropertyHandler *h = getHandler()->findHandler(prop);
-    if (!h)
-      return;
-    h->setFunctionWorkspace();
+	PropertyHandler *h = getHandler()->findHandler(prop);
+	if (!h)
+	  return;
+	h->setFunctionWorkspace();
+  } else if (prop->propertyName() == "WorkspaceIndex"){
+	PropertyHandler *h = getHandler()->findHandler(prop);
+	auto const index = prop->valueText().toInt();
+	if (h && index != workspaceIndex()) {
+      h->setAttribute(prop);
+	  setWorkspaceIndex(index);
+	  emit workspaceIndexChanged(index);
+	}
   } else if (prop == m_maxIterations || prop == m_peakRadius) {
     QSettings settings;
     settings.beginGroup("Mantid/FitBrowser");

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1348,18 +1348,18 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
     }
     emit workspaceIndexChanged(wi);
   } else if (prop->propertyName() == "Workspace Index") {
-	PropertyHandler *h = getHandler()->findHandler(prop);
-	if (!h)
-	  return;
-	h->setFunctionWorkspace();
-  } else if (prop->propertyName() == "WorkspaceIndex"){
-	PropertyHandler *h = getHandler()->findHandler(prop);
-	auto const index = prop->valueText().toInt();
-	if (h && index != workspaceIndex()) {
+    PropertyHandler *h = getHandler()->findHandler(prop);
+    if (!h)
+      return;
+    h->setFunctionWorkspace();
+  } else if (prop->propertyName() == "WorkspaceIndex") {
+    PropertyHandler *h = getHandler()->findHandler(prop);
+    auto const index = prop->valueText().toInt();
+    if (h && index != workspaceIndex()) {
       h->setAttribute(prop);
-	  setWorkspaceIndex(index);
-	  emit workspaceIndexChanged(index);
-	}
+      setWorkspaceIndex(index);
+      emit workspaceIndexChanged(index);
+    }
   } else if (prop == m_maxIterations || prop == m_peakRadius) {
     QSettings settings;
     settings.beginGroup("Mantid/FitBrowser");

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -797,6 +797,11 @@ bool PropertyHandler::setAttribute(QtProperty *prop, bool resetProperties) {
   return false;
 }
 
+/**
+ * Set function attribute value
+ * @param attName :: The name of the attribute
+ * @param attValue :: The value of the attribute
+ */
 void PropertyHandler::setAttribute(
     QString const &attName, Mantid::API::IFunction::Attribute const &attValue) {
   auto const attributeType = attValue.type();
@@ -808,6 +813,11 @@ void PropertyHandler::setAttribute(
     setAttribute(attName, QString::fromStdString(attValue.asString()));
 }
 
+/**
+ * Sets the function attribute value if it has type double or int
+ * @param attName :: The name of the attribute
+ * @param attValue :: The value of the attribute
+ */
 template <typename AttributeType>
 void PropertyHandler::setAttribute(QString const &attName,
                                    AttributeType const &attValue) {
@@ -828,13 +838,18 @@ void PropertyHandler::setAttribute(QString const &attName,
     }
   }
   if (cfun()) {
-    for (size_t i = 0; i < cfun()->nFunctions(); ++i) {
+    for (auto i = 0u; i < cfun()->nFunctions(); ++i) {
       PropertyHandler *h = getHandler(i);
       h->setAttribute(attName, attValue);
     }
   }
 }
 
+/**
+ * Sets the function attribute value if it has type QString
+ * @param attName :: The name of the attribute
+ * @param attValue :: The value of the attribute
+ */
 void PropertyHandler::setAttribute(const QString &attName,
                                    const QString &attValue) {
   const std::string name = attName.toStdString();
@@ -888,6 +903,10 @@ void PropertyHandler::applyToAllAttributes(
       getHandler(i)->applyToAllAttributes(func);
 }
 
+/**
+ * Updates all string, double and int attributes which have changed in a
+ * function
+ */
 void PropertyHandler::updateAttributes() {
   applyToAllAttributes(&PropertyHandler::updateAttribute);
 }

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -799,41 +799,18 @@ bool PropertyHandler::setAttribute(QtProperty *prop, bool resetProperties) {
 
 void PropertyHandler::setAttribute(
     QString const &attName, Mantid::API::IFunction::Attribute const &attValue) {
-  auto const type = attValue.type();
-  if (type == "double")
-    setAttribute(attName, attValue.asDouble());
-  else if (type == "int")
-    setAttribute(attName, attValue.asInt());
+  auto const attributeType = attValue.type();
+  if (attributeType == "int")
+	  setAttribute(attName, attValue.asInt());
+  else if (attributeType == "double")
+	  setAttribute(attName, attValue.asDouble());
+  else if (attributeType == "std::string")
+	  setAttribute(attName, QString::fromStdString(attValue.asString()));
 }
 
+template <typename AttributeType>
 void PropertyHandler::setAttribute(QString const &attName,
-                                   int const &attValue) {
-  if (m_fun->hasAttribute(attName.toStdString())) {
-    try {
-      m_fun->setAttribute(attName.toStdString(),
-                          Mantid::API::IFunction::Attribute(attValue));
-      m_browser->compositeFunction()->checkFunction();
-      foreach (QtProperty *prop, m_attributes) {
-        if (prop->propertyName() == attName) {
-          // re-insert the attribute and parameter properties as they may
-          // depend on the value of the attribute being set
-          initAttributes();
-          initParameters();
-        }
-      }
-    } catch (...) {
-    }
-  }
-  if (cfun()) {
-    for (size_t i = 0; i < cfun()->nFunctions(); ++i) {
-      PropertyHandler *h = getHandler(i);
-      h->setAttribute(attName, attValue);
-    }
-  }
-}
-
-void PropertyHandler::setAttribute(const QString &attName,
-                                   const double &attValue) {
+	                               AttributeType const &attValue) {
   if (m_fun->hasAttribute(attName.toStdString())) {
     try {
       m_fun->setAttribute(attName.toStdString(),

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -801,16 +801,16 @@ void PropertyHandler::setAttribute(
     QString const &attName, Mantid::API::IFunction::Attribute const &attValue) {
   auto const attributeType = attValue.type();
   if (attributeType == "int")
-	  setAttribute(attName, attValue.asInt());
+    setAttribute(attName, attValue.asInt());
   else if (attributeType == "double")
-	  setAttribute(attName, attValue.asDouble());
+    setAttribute(attName, attValue.asDouble());
   else if (attributeType == "std::string")
-	  setAttribute(attName, QString::fromStdString(attValue.asString()));
+    setAttribute(attName, QString::fromStdString(attValue.asString()));
 }
 
 template <typename AttributeType>
 void PropertyHandler::setAttribute(QString const &attName,
-	                               AttributeType const &attValue) {
+                                   AttributeType const &attValue) {
   if (m_fun->hasAttribute(attName.toStdString())) {
     try {
       m_fun->setAttribute(attName.toStdString(),


### PR DESCRIPTION
**Description of work.**
This PR ensures that the Q value and WorkspaceIndex in ConvFit is updated when the spectrum has been changed using the `PlotSpectrum` spinbox.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load the data below
3. FitType is `TeixeiraWater`
4. Background is `FlatBackground`
4. Look for Q value and workspace Index in the FitPropertyBrowser
5. Change the spectrum selected using the `Plot Spectrum` spinbox
6. The Q value and WorkspaceIndex should update!
7. Change the WorkspaceIndex using the FitPropertyBrowser, the `PlotSpectrum` spinbox number should change.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2561154/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2561153/irs26173_graphite002_res.zip)

Fixes #23950 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
