### PR TITLE
ComputeIncoherentDOS: enable S(2theta,W) as input

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
+++ b/Framework/PythonInterface/plugins/algorithms/ComputeIncoherentDOS.py
@@ -10,28 +10,112 @@ from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from scipy import constants
 from mantid.kernel import CompositeValidator, Direction, FloatBoundedValidator
-from mantid.api import mtd, AlgorithmFactory, CommonBinsValidator, HistogramValidator, MatrixWorkspaceProperty, PythonAlgorithm
+from mantid.api import AlgorithmFactory, CommonBinsValidator, HistogramValidator, MatrixWorkspaceProperty, PythonAlgorithm
 from mantid.simpleapi import *
 
 
+def cut1D(dos2d, qqgrid, spectrum_binning, dosebin):
+    if qqgrid.shape[1] > 1:
+        dSpectrum = spectrum_binning[1] - spectrum_binning[0]
+        dos1d = Rebin2D(dos2d, [spectrum_binning[0], dSpectrum, spectrum_binning[1]], dosebin,
+                        UseFractionalArea=True, Transpose=True, StoreInADS=False)
+    else:
+        dos2d = Transpose(dos2d, StoreInADS=False)
+        dos1d = Rebin(dos2d, dosebin, StoreInADS=False)
+    return dos1d
+
+
 def evaluateEbin(Emin, Emax, Ei, strn):
-    if strn.count(',') != 2:
-        raise ValueError('EnergyBinning must be a comma separated string with three values.')
+    splits = strn.split(',')
+    if len(splits) < 2 or len(splits) > 3:
+        raise ValueError('EnergyBinning must be a comma separated string with two or three values.')
     try:
-        out = [eval(estr, None, {'Emax':Emax, 'Emin':Emin, 'Ei':Ei}) for estr in strn.split(',')]
+        out = [eval(estr, None, {'Emax':Emax, 'Emin':Emin, 'Ei':Ei}) for estr in splits]
     except NameError:
-        raise ValueError('Only the variables ''Emin'', ''Emax'' or ''Ei'' are allowed in EnergyBinning.')
+        raise ValueError("Malformed EnergyBinning. Only the variables 'Emin', 'Emax' or 'Ei' are allowed.")
     return out
 
 
 def evaluateQRange(Qmin, Qmax, strn):
-    if strn.count(',') != 1:
+    splits = strn.split(',')
+    if len(splits) != 2:
         raise ValueError('QSumRange must be a comma separated string with two values.')
     try:
-        out = [eval(qstr, None, {'Qmin':Qmin, 'Qmax':Qmax}) for qstr in strn.split(',')]
+        out = [eval(qstr, None, {'Qmin':Qmin, 'Qmax':Qmax}) for qstr in splits]
     except NameError:
-        raise ValueError('Only the variables ''Qmin'' and ''Qmax'' is allowed in QSumRange.')
+        raise ValueError("Malformed QSumRange. Only the variables 'Qmin' and 'Qmax' are allowed.")
     return out
+
+
+def evaluateTwoThetaRange(Twothetamin, Twothetamax, strn):
+    splits = strn.split(',')
+    if len(splits) != 2:
+        raise ValueError('TwoThetaSumRange must be a comma separated string with two values.')
+    try:
+        out = [eval(qstr, None, {'Twothetamin':Twothetamin, 'Twothetamax':Twothetamax}) for qstr in splits]
+    except NameError:
+        raise ValueError("Malformed TwoThetaSumRange. Only the variables 'Twothetamin' and 'Twothetamax' are allowed.")
+    return out
+
+
+def binPreservingRebinninParams(Xs, Xmin, Xmax):
+    Xs = Xs[Xs > Xmin]
+    Xs = Xs[Xs < Xmax]
+    Xs = np.concatenate(([Xmin], Xs, [Xmax]))
+    dXs = np.diff(Xs)
+    params = np.empty(2 * len(Xs) - 1)
+    params[0::2] = Xs
+    params[1:-1:2] = dXs
+    return params
+
+
+def qGridFromTwoTheta(two_theta, en, ei):
+    en = en * constants.e * 1e-3
+    ei = ei * constants.e * 1e-3
+    ef = ei - en
+    kisq = 2. * constants.m_n * ei / (constants.hbar**2)
+    kfsq = 2. * constants.m_n * ef / (constants.hbar**2)
+    a = -2. * np.sqrt(kisq * kfsq)
+    b = np.cos(two_theta)
+    # This builds the 2D array
+    q = np.multiply.outer(a, b)
+    q += np.reshape((kisq + kfsq), (len(kfsq), 1))
+    return np.sqrt(q) * 1e-10
+
+
+def scaleUnits(dos1d, cm, input_en_in_meV, mev2cm):
+    if cm and input_en_in_meV:
+        dos1d.getAxis(0).setUnit('DeltaE_inWavenumber')
+        dos1d = ScaleX(dos1d, mev2cm, StoreInADS=False)
+    elif not cm and not input_en_in_meV:
+        dos1d.getAxis(0).setUnit('DeltaE')
+        dos1d = ScaleX(dos1d, 1/mev2cm, StoreInADS=False)
+    return dos1d
+
+
+def unitError():
+    raise ValueError('Input workspace must be in (Q,E) [momentum and energy transfer]'
+                     + ' or (2theta, E) [scattering angle and energy transfer.]')
+
+
+def usingQ(spectrum_unit):
+    if spectrum_unit == 'MomentumTransfer':
+        using_q = True
+    elif spectrum_unit == 'Degrees':
+        using_q = False
+    else:
+        unitError()
+    return using_q
+
+
+def yLabel(absunits, cm):
+    label = 'g^{neutron}(E) (arb. units)'
+    if absunits:
+        if cm:
+            label = 'g(E) (states/cm^-1)'
+        else:
+            label = 'g(E) (states/meV)'
+    return label
 
 
 class ComputeIncoherentDOS(PythonAlgorithm):
@@ -71,7 +155,7 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         validators.add(CommonBinsValidator())
         self.declareProperty(MatrixWorkspaceProperty(name='InputWorkspace', defaultValue='',
                                                      direction=Direction.Input, validator=validators),
-                             doc='Input MatrixWorkspace containing the reduced inelastic neutron spectrum in (Q,E) space.')
+                             doc='Input MatrixWorkspace containing the reduced inelastic neutron spectrum in (Q,E) or (2theta,E) space.')
         self.declareProperty(name='Temperature', defaultValue=300., validator=FloatBoundedValidator(lower=0),
                              doc='Sample temperature in Kelvin.')
         self.declareProperty(name='MeanSquareDisplacement', defaultValue=0., validator=FloatBoundedValidator(lower=0),
@@ -79,7 +163,7 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         self.declareProperty(name='QSumRange', defaultValue='0,Qmax',
                              doc='Range in Q (in Angstroms^-1) to sum data over.')
         self.declareProperty(name='EnergyBinning', defaultValue='0,Emax/50,Emax*0.9',
-                             doc='Energy binning parameters [Emin, Estep, Emax] in meV.')
+                             doc='Energy binning parameters [Emin, Emax] or [Emin, Estep, Emax] in meV.')
         self.declareProperty(name='Wavenumbers', defaultValue=False,
                              doc='Should the output be in Wavenumbers (cm^-1)?')
         self.declareProperty(name='StatesPerEnergy', defaultValue=False,
@@ -87,73 +171,87 @@ class ComputeIncoherentDOS(PythonAlgorithm):
                              '(Only for pure elements, need to set the sample material information)')
         self.declareProperty(MatrixWorkspaceProperty(name='OutputWorkspace', defaultValue='', direction=Direction.Output),
                              doc='Output workspace name.')
+        self.declareProperty(name='TwoThetaSumRange', defaultValue='Twothetamin, Twothetamax',
+                             doc='Range in 2theta (in degrees) to sum data over.')
 
     def PyExec(self):
-        inws = mtd[self.getPropertyValue('InputWorkspace')]
-        Temperature = float(self.getPropertyValue('Temperature'))
-        msd = float(self.getPropertyValue('MeanSquareDisplacement'))
-        QSumRange = self.getPropertyValue('QSumRange')
-        EnergyBinning = self.getPropertyValue('EnergyBinning')
-        cm = int(self.getPropertyValue('Wavenumbers'))
-        absunits = int(self.getPropertyValue('StatesPerEnergy'))
+        inws = self.getProperty('InputWorkspace').value
+        Temperature = self.getProperty('Temperature').value
+        msd = self.getProperty('MeanSquareDisplacement').value
+        QSumRange = self.getProperty('QSumRange').value
+        EnergyBinning = self.getProperty('EnergyBinning').value
+        cm = self.getProperty('Wavenumbers').value
+        TwoThetaSumRange = self.getProperty('TwoThetaSumRange').value
 
-        # Checks if the input workspace is valid, and which way around it is (Q along x or Q along y).
-        u0 = inws.getAxis(0).getUnit().unitID()
-        u1 = inws.getAxis(1).getUnit().unitID()
-        if u0 == 'MomentumTransfer' and (u1 == 'DeltaE' or u1 == 'DeltaE_inWavenumber'):
-            iqq = 0
-            ien = 1
-        elif u1 == 'MomentumTransfer' and (u0 == 'DeltaE' or u0 == 'DeltaE_inWavenumber'):
-            iqq = 1
-            ien = 0
-        else:
-            raise ValueError('Input workspace must be in (Q,E) [momentum and energy transfer]')
+        # Checks if the units are valid, and which way around the input workspace is
+        # (Q or 2theta along horizontal or vertical axes).
+        energy_axis_index = 0
+        spectrum_axis_index = 1
+        energy_unit = inws.getAxis(energy_axis_index).getUnit().unitID()
+        spectrum_unit = inws.getAxis(spectrum_axis_index).getUnit().unitID()
+        if energy_unit not in ['DeltaE', 'DeltaE_inWavenumber']:
+            if spectrum_unit in ['DeltaE', 'DeltaE_inWavenumber']:
+                # Input workspace is transposed.
+                (energy_unit, spectrum_unit) = (spectrum_unit, energy_unit)
+                energy_axis_index = 1
+                spectrum_axis_index = 0
+            else:
+                unitError()
+        using_q = usingQ(spectrum_unit)
 
-        # (Mantid stores the bin boundaries by default rather than bin centers)
-        qq = inws.getAxis(iqq).extractValues()
-        en = inws.getAxis(ien).extractValues()
-        qq = (qq[1:len(qq)]+qq[0:len(qq)-1])/2
-        en = (en[1:len(en)]+en[0:len(en)-1])/2
-
-        # Checks qrange is valid. Do it in a member function so no variables can be evaluated other than Qmin and Qmax.
-        dq = evaluateQRange(min(qq), max(qq), QSumRange)
+        eBins = inws.getAxis(energy_axis_index).extractValues()
+        if energy_axis_index == 0 or len(eBins) != inws.getNumberHistograms():
+            en = (eBins[1:]+eBins[:-1])/2
 
         # Gets meV to cm^-1 conversion
         mev2cm = (constants.elementary_charge / 1000) / (constants.h * constants.c * 100)
         # Gets meV to Kelvin conversion
-        # Note: constants.Boltzmann alias for constants.k not used here because it is not available on RHEL6
         mev2k = (constants.elementary_charge / 1000) / constants.k
 
         # Converts energy to meV for bose factor later
-        input_en_in_meV = 1
-        if u0 == 'DeltaE_inWavenumber' or u1 == 'DeltaE_inWavenumber':
+        input_en_in_meV = energy_unit == 'DeltaE'
+        if not input_en_in_meV:
             en = en / mev2cm
-            input_en_in_meV = 0
 
         # Gets the incident energy from the workspace - either if it is set as an attribute or from the energy axis.
         try:
             ei = inws.getEFixed(1)
         except RuntimeError:
-            ei = max(en)
-        # Checks energy bins are ok. Do it in a function so no variables can be evaluated except Emin, Emax and Ei.
+            ei = np.amax(en)
+            self.log().warning('Could not find EFixed. Using {}mev'.format(ei))
         if not input_en_in_meV:
-            dosebin = evaluateEbin(min(en*mev2cm), max(en*mev2cm), ei*mev2cm, EnergyBinning)
+            dosebin = evaluateEbin(np.amin(eBins*mev2cm), np.amax(eBins*mev2cm), ei*mev2cm, EnergyBinning)
         else:
-            dosebin = evaluateEbin(min(en), max(en), ei, EnergyBinning)
+            dosebin = evaluateEbin(np.amin(eBins), np.amax(eBins), ei, EnergyBinning)
+        if len(dosebin) == 2:
+            dosebin = binPreservingRebinninParams(eBins, dosebin[0], dosebin[-1])
 
-        # Extracts the intensity (y) and errors (e) from inws.
         y = inws.extractY()
         e = inws.extractE()
-        if iqq == 1:
+        if spectrum_axis_index == 1:
             y = np.transpose(y)
             e = np.transpose(e)
 
         # Creates a grid the same size as the intensity (y) array populated by the q and energy values
-        qqgrid = np.tile(np.array(qq), (np.shape(y)[0], 1))
-        engrid = np.transpose(np.tile(np.array(en), (np.shape(y)[1], 1)))
+        if using_q:
+            qq = inws.getAxis(spectrum_axis_index).extractValues()
+            spectrum_binning = evaluateQRange(np.amin(qq), np.amax(qq), QSumRange)
+            if spectrum_axis_index == 0 or len(qq) != inws.getNumberHistograms():
+                qq = (qq[1:] + qq[:-1]) / 2.
+            qqgrid = np.tile(qq, (np.shape(y)[0], 1))
+        else:
+            theta_axis = inws.getAxis(spectrum_axis_index)
+            two_theta = theta_axis.extractValues()
+            spectrum_binning = evaluateTwoThetaRange(np.amin(two_theta), np.amax(two_theta), TwoThetaSumRange)
+            if spectrum_axis_index == 0 or len(two_theta) != inws.getNumberHistograms():
+                two_theta = (two_theta[1:] + two_theta[:-1]) / 2.
+            two_theta = np.deg2rad(two_theta)
+            qqgrid = qGridFromTwoTheta(two_theta, en ,ei)
 
+        engrid = np.transpose(np.tile(en, (np.shape(y)[1], 1)))
         # Calculates the Debye-Waller and Bose factors from the Temperature and mean-squared displacements
-        DWF = np.exp(-2*(qqgrid**2*msd))
+        qqgridsq = qqgrid**2
+        DWF = np.exp(-2*(qqgridsq*msd))
         idm = np.where(engrid < 0)
         idp = np.where(engrid >= 0)
         # The expression for the population (Bose) factor and phonon energy dependence below actually refer to the phonon
@@ -161,63 +259,55 @@ class ComputeIncoherentDOS(PythonAlgorithm):
         engrid = np.abs(engrid)
         expm = np.exp(-engrid[idm]*mev2k/Temperature)
         expp = np.exp(-engrid[idp]*mev2k/Temperature)
-        Bose = DWF*0
+        Bose = np.empty_like(DWF)
         Bose[idm] = expm / (1 - expm)      # n energy gain, phonon annihilation
         Bose[idp] = expp / (1 - expp) + 1  # n energy loss, phonon creation
         # Calculates the density of states from S(q,w)
-        y = y * (engrid/qqgrid**2) / (Bose*DWF)
-        e = e * (engrid/qqgrid**2) / (Bose*DWF)
+        f = (engrid/qqgridsq) / (Bose*DWF)
+        y *= f
+        e *= f
 
         # Checks if the user wants output in States/energy.
         atoms, _ = inws.sample().getMaterial().chemicalFormula()
-        ylabel = 'g^{neutron}(E) (arb. units)'
-        if absunits:
-            if len(atoms) != 1:
-                self.log().warning('Sample material information not set, or sample is not a pure element. '
-                                   'Ignoring StatesPerEnergy property.')
-                absunits = False
-            else:
-                if cm:
-                    ylabel = 'g(E) (states/cm^-1)'
-                else:
-                    ylabel = 'g(E) (states/meV)'
+        absunits = self.absoluteUnits(atoms)
+        ylabel = yLabel(absunits, cm)
 
         # Convert to wavenumbers if requested (y-axis is in mbarns/sr/fu/meV -> mb/sr/fu/cm^-1)
         if cm:
-            y = y/mev2cm
-            e = e/mev2cm
+            y /= mev2cm
+            e /= mev2cm
             #yunit = 'DeltaE_inWavenumber'
         #else:
             #yunit = 'DeltaE'
 
         # Outputs the calculated density of states to another workspace
-        dos2d = CloneWorkspace(inws)
-        if iqq == 1:
-            dos2d = Transpose(dos2d)
+        dos2d = CloneWorkspace(inws, StoreInADS=False)
+        if spectrum_axis_index == 1:
+            dos2d = Transpose(dos2d, StoreInADS=False)
         for i in range(len(y)):
             dos2d.setY(i, y[i,:])
             dos2d.setE(i, e[i,:])
         dos2d.setYUnitLabel(ylabel)
 
-        # Make a 1D (energy dependent) cut
-        dos1d = Rebin2D(dos2d, [dq[0], dq[1]-dq[0], dq[1]], dosebin, True, True)
-        if cm and input_en_in_meV:
-            dos1d.getAxis(0).setUnit('DeltaE_inWavenumber')
-            dos1d = ScaleX(dos1d, mev2cm)
-        elif not cm and not input_en_in_meV:
-            dos1d.getAxis(0).setUnit('DeltaE')
-            dos1d = ScaleX(dos1d, 1/mev2cm)
+        dos1d = cut1D(dos2d, qqgrid, spectrum_binning, dosebin)
+        dos1d = scaleUnits(dos1d, cm, input_en_in_meV, mev2cm)
 
         if absunits:
-            print("Converting to states/energy")
-            # cross-section information is given in barns, but data is in milibarns.
+            self.log().notice("Converting to states/energy")
+            # cross-section information is given in barns, but data is in millibarns.
             sigma = atoms[0].neutron()['tot_scatt_xs'] * 1000
             mass = atoms[0].mass
-            dos1d = dos1d * (mass/sigma) * 4 * np.pi
+            dos1d *= (mass/sigma) * 4 * np.pi
 
         self.setProperty("OutputWorkspace", dos1d)
-        DeleteWorkspace(dos2d)
-        DeleteWorkspace(dos1d)
+
+    def absoluteUnits(self, atoms):
+        absunits = self.getProperty('StatesPerEnergy').value
+        if absunits and len(atoms) != 1:
+            self.log().warning('Sample material information not set, or sample is not a pure element. '
+                               'Ignoring StatesPerEnergy property.')
+            absunits = False
+        return absunits
 
 
 AlgorithmFactory.subscribe(ComputeIncoherentDOS)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ComputeIncoherentDOSTest.py
@@ -7,9 +7,12 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-from mantid.simpleapi import ComputeIncoherentDOS, CreateSampleWorkspace, LoadInstrument, ScaleX, Scale, SetSampleMaterial, SofQW3, Transpose
+from mantid.simpleapi import (AddSampleLog, ComputeIncoherentDOS, CreateSampleWorkspace, CreateWorkspace, LoadInstrument, ScaleX, Scale,
+                              SetInstrumentParameter, SetSampleMaterial, SofQW3, Transpose)
 import numpy as np
+from numpy import testing
 from scipy import constants
+import testhelpers
 
 class ComputeIncoherentDOSTest(unittest.TestCase):
 
@@ -27,6 +30,25 @@ class ComputeIncoherentDOSTest(unittest.TestCase):
             ws.setE(i, ws.readE(i)*qq[i]**2)
         return ws
 
+    def compute(self, qs, energyBins, msd=0., temperature=300.):
+        ws = (energyBins[1:] + energyBins[:-1]) / 2.
+        if len(qs) > 1:
+            qs = (qs[:-1] + qs[1:]) / 2.
+        g = qs**-2 * np.exp(2*msd * qs**2) * (1. - np.exp(-ws * constants.e * 1e-3 / constants.k / temperature)) * ws
+        return g
+
+    def computeFromTwoTheta(self, twoThetas, energyBins, msd=0., temperature=300.):
+        ws = (energyBins[1:] + energyBins[:-1]) / 2.
+        if len(twoThetas) > 1:
+            twoThetas = (twoThetas[:-1] + twoThetas[1:]) / 2.
+        twoTheta = np.deg2rad(twoThetas)
+        EFixed = 8.
+        Ei = EFixed * constants.e * 1e-3
+        Ef = (EFixed - ws) * constants.e * 1e-3
+        qs = np.sqrt(2. * constants.m_n / constants.hbar**2 *((Ei + Ef) - 2. * np.sqrt(Ei * Ef) * np.cos(twoTheta))) * 1e-10
+        g = qs**-2 * np.exp(2*msd * qs**2) * (1. - np.exp(-ws * constants.e * 1e-3 / constants.k / temperature)) * ws
+        return g
+
     def convertToWavenumber(self, ws):
         mev2cm = (constants.elementary_charge / 1000) / (constants.h * constants.c * 100)
         u0 = ws.getAxis(0).getUnit().unitID()
@@ -39,6 +61,28 @@ class ComputeIncoherentDOSTest(unittest.TestCase):
             ws = Scale(ws, 1/mev2cm)
             if u0 == 'MomentumTransfer':
                 ws = Transpose(ws)
+        return ws
+
+    def unitySQWSingleHistogram(self, energyBins, qs):
+        EFixed = 8.
+        Ys = np.ones(len(energyBins) - 1)
+        Es = Ys
+        verticalAxis = [str(q) for q in qs]
+        ws = CreateWorkspace(energyBins, Ys, Es, UnitX='DeltaE',
+                             VerticalAxisUnit='MomentumTransfer', VerticalAxisValues=verticalAxis, StoreInADS=False)
+        LoadInstrument(ws, InstrumentName='IN4', RewriteSpectraMap=False, StoreInADS=False)
+        AddSampleLog(ws, LogName='Ei', LogText=str(EFixed), LogType='Number', LogUnit='meV', StoreInADS=False)
+        return ws
+
+    def unitySTwoThetaWSingleHistogram(self, energyBins, qs):
+        EFixed = 8.
+        Ys = np.ones(len(energyBins) - 1)
+        Es = Ys
+        verticalAxis = [str(q) for q in qs]
+        ws = CreateWorkspace(energyBins, Ys, Es, UnitX='DeltaE',
+                             VerticalAxisUnit='Degrees', VerticalAxisValues=verticalAxis, StoreInADS=False)
+        LoadInstrument(ws, InstrumentName='IN4', RewriteSpectraMap=False, StoreInADS=False)
+        AddSampleLog(ws, LogName='Ei', LogText=str(EFixed), LogType='Number', LogUnit='meV', StoreInADS=False)
         return ws
 
     def test_computeincoherentdos(self):
@@ -73,6 +117,141 @@ class ComputeIncoherentDOSTest(unittest.TestCase):
         material = ws.sample().getMaterial()
         factor = material.relativeMolecularMass() / (material.totalScatterXSection() * 1000) * 4 * np.pi
         self.assertAlmostEqual(np.max(ws_DOSn.readY(0)) / (np.max(ws_DOS.readY(0))*factor), 1., places=1)
+
+    def test_computation_nontransposed_QW(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        qs = np.array([2.3])
+        ws = self.unitySQWSingleHistogram(energyBins, qs)
+        dos = ComputeIncoherentDOS(ws, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.compute(qs, energyBins)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], g[i])
+
+    def test_computation_nontransposed_TwoThetaW(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        twoThetas = np.array([17.])
+        ws = self.unitySTwoThetaWSingleHistogram(energyBins, twoThetas)
+        dos = ComputeIncoherentDOS(ws, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.computeFromTwoTheta(twoThetas, energyBins)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], g[i])
+
+    def test_computation_transposed_TwoThetaW(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        twoThetas = np.array([16.5, 17.5])
+        ws = self.unitySTwoThetaWSingleHistogram(energyBins, twoThetas)
+        ws = Transpose(ws, StoreInADS=False)
+        dos = ComputeIncoherentDOS(ws, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.computeFromTwoTheta(twoThetas, energyBins)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], g[i])
+
+    def test_computation_transposed_QW(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        qs = np.array([2.15, 2.25])
+        ws = self.unitySQWSingleHistogram(energyBins, qs)
+        ws = Transpose(ws, StoreInADS=False)
+        dos = ComputeIncoherentDOS(ws, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.compute(qs, energyBins)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], g[i])
+
+    def test_nonzero_MDS(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        qs = np.array([2.3])
+        msd = 5.5
+        ws = self.unitySQWSingleHistogram(energyBins, qs)
+        dos = ComputeIncoherentDOS(ws, MeanSquareDisplacement=msd, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.compute(qs, energyBins, msd=msd)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i], delta=g[i] * 1e-12)
+            self.assertAlmostEquals(dos_Es[i], g[i], delta=g[i] * 1e-12)
+
+    def test_nondefault_temperature(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        qs = np.array([2.3])
+        temperature = 666.7
+        ws = self.unitySQWSingleHistogram(energyBins, qs)
+        dos = ComputeIncoherentDOS(ws, Temperature=temperature, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g = self.compute(qs, energyBins, temperature=temperature)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], g[i])
+
+    def test_multiple_histograms(self):
+        energyBins = np.arange(-7., 7., 0.13)
+        qs = np.array([1.1, 1.3, 1.5, 1.7])
+        EFixed = 8.
+        Ys = np.ones(3 * (len(energyBins) - 1))
+        Es = Ys
+        verticalAxis = [str(q) for q in qs]
+        ws = CreateWorkspace(energyBins, Ys, Es, NSpec=3, UnitX='DeltaE',
+                             VerticalAxisUnit='MomentumTransfer', VerticalAxisValues=verticalAxis, StoreInADS=False)
+        LoadInstrument(ws, InstrumentName='IN4', RewriteSpectraMap=False, StoreInADS=False)
+        AddSampleLog(ws, LogName='Ei', LogText=str(EFixed), LogType='Number', LogUnit='meV', StoreInADS=False)
+        dos = ComputeIncoherentDOS(ws, EnergyBinning='Emin, Emax', StoreInADS=False)
+        self.assertEquals(dos.getNumberHistograms(), 1)
+        self.assertEquals(dos.getAxis(0).getUnit().unitID(), 'DeltaE')
+        dos_Xs = dos.readX(0)
+        self.assertEquals(len(dos_Xs), len(energyBins))
+        dos_Ys = dos.readY(0)
+        dos_Es = dos.readE(0)
+        g1 = self.compute(qs[0:2], energyBins)
+        g2 = self.compute(qs[1:3], energyBins)
+        g3 = self.compute(qs[2:4], energyBins)
+        g = g1 + g2 + g3
+        gE = np.sqrt(g1**2 + g2**2 + g3**2)
+        np.testing.assert_equal(dos_Xs, energyBins)
+        for i in range(len(dos_Ys)):
+            self.assertAlmostEquals(dos_Ys[i], g[i])
+            self.assertAlmostEquals(dos_Es[i], gE[i])
+
 
 if __name__=="__main__":
     unittest.main()

--- a/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
+++ b/docs/source/algorithms/ComputeIncoherentDOS-v1.rst
@@ -11,21 +11,28 @@ Description
 
 Computes the phonon density of states from an inelastic neutron 
 scattering measurement of a powder or polycrystalline sample,
-assuming that all scattering is incoherent, using the formula 
-(Thermodynamic Properties of Solids, eds. Chaplot, Mittal, Choudhury,
-Chapter 3) for the 1-phonon incoherent scattering function:
+assuming that all scattering is incoherent, using the formula
+for the 1-phonon incoherent scattering function [#CHAPLOT]_:
 
-:math:`S^{(1)}_{\mathrm{inc}}(Q,E) = \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}}{2m_k} g_k(E) \right]`
+.. math::
 
-where the term in square brackets is the neutron weighted densiy of 
+    S^{(1)}_{\mathrm{inc}}(Q,E) = \exp\left(-2\bar{W}(Q)\right) \frac{Q^2}{E} \langle n+\frac{1}{2}\pm\frac{1}{2} \rangle \left[ \sum_k \frac{\sigma_k^{\mathrm{scatt}}}{2m_k} g_k(E) \right],
+
+where the term in square brackets is the neutron weighted density of 
 states which is calculated by this algorithm, and :math:`g_k(E)` is
 the partial density of states for each component (element or isotope)
 :math:`k` in the material. :math:`m_k` is the relative atomic mass of the
 component.
 
 The average Debye-Waller factor :math:`\exp\left(-2\bar{W}(Q)\right)` is
-calculated using an average mean-square displacement :math:`\langle u \rangle`,
-using :math:`W=Q^2\langle u\rangle/2`. 
+calculated using an average mean-square displacement :math:`\langle u^2 \rangle`,
+using :math:`W=Q^2\langle u^2\rangle/2`. 
+
+The algorithm accepts both :math:`S(Q,E)` workspaces as well as
+:math:`S(2\theta,E)` workspaces. In the latter case :math:`Q` values are
+calculated from :math:`2\theta` and :math:`E` before applying the formula
+above. Note, that ``QSumRange`` is only applicable with :math:`S(Q,E)` while
+``TwoThetaSumRange`` works only for :math:`S(2\theta,E)`.
 
 If the data has been normalised to a Vanadium standard measurement, the
 output of this algorithm is the neutron weighted density of states in
@@ -38,7 +45,7 @@ relative atomic mass.
 Restrictions on the Input Workspace
 ###################################
 
-The input workspace must have units of Momentum Transfer and
+The input workspace must have units of Momentum Transfer or Degrees and
 contain histogram data with common binning on all spectra.
 
 Usage
@@ -64,6 +71,27 @@ measurement of a large Aluminium sample from the neutron training course.
     SetSampleMaterial(ws_sqw,'Al')
     ws_dos = ComputeIncoherentDOS(ws_sqw, Temperature=5, StatesPerEnergy=True)
 
+**ILL  Example using S(2theta, E) as input**
+
+.. plot::
+   :include-source:
+
+    from mantid import mtd
+    from mantid.simpleapi import *
+    import matplotlib.pyplot as plt
+    
+    ws = DirectILLCollectData('ILL/IN4/087294.nxs')
+    DirectILLReduction(ws, OutputWorkspace='sqw', OutputSofThetaEnergyWorkspace='stw')
+    temperature = ws.run().getProperty('sample.temperature').value
+    dos = ComputeIncoherentDOS('stw',  Temperature=temperature, EnergyBinning='0, Emax')
+    
+    fig, axis = plt.subplots(subplot_kw={'projection':'mantid'})
+    axis.errorbar(dos)
+    axis.set_title('Density of states from $S(2\\theta,W)$')
+    # Uncomment the line below to show the plot.
+    #fig.show()
+    mtd.clear()
+
 **Test Example**
 
 This example uses a generated dataset so that it will run on automated tests
@@ -80,6 +108,11 @@ of the build system where the above datafiles do not exist.
 Output
 
 .. testoutput:: ExGenerated
+
+References
+----------
+
+.. [#CHAPLOT] Thermodynamic Properties of Solids, eds. Chaplot, Mittal, Choudhury, Chapter 3
 
 .. categories::
 

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -28,6 +28,8 @@ Improvements
   - The temperature sample log entry can be given in an instrument parameter ``temperature_sample_log``.
   - The temperature sample log can now be a time series.
 
+- :ref:`ComputeIncoherentDOS <algm-ComputeIncoherentDOS>` now supports computation from :math:`S(2\theta,E)` workspace.
+
 Bugfixes
 ########
 


### PR DESCRIPTION
This PR makes `ComputeIncoherentDOS` to accept S(2theta,W) workspaces as input. This makes the scientists at ILL feel more comfortable with Mantid although the results are very close to what one would get when using S(Q,W).

**Report to:** [nobody]. 

**To test:**

First, ensure the unit test data directories are in Mantid's data search directories. Then, run the following script:
```
ws = DirectILLCollectData('ILL/IN4/084447.nxs')
DirectILLReduction(ws, OutputWorkspace='sqw', OutputSofThetaEnergyWorkspace='stw')
temperature = ws.run().getProperty('sample.temperature').value
dos_stw = ComputeIncoherentDOS('stw',  Temperature=temperature, EnergyBinning='0, Emax')
dos_sqt = ComputeIncoherentDOS('sqw',  Temperature=temperature, EnergyBinning='0, Emax')
```

The `dos_stw` workspace is computed from S(2theta,W) while `dos_sqw` from S(Q,W). Check that the data roughly matches between these two workspaces.


Fixes #23935.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
