### PR TITLE
Instrument View: Convert histogram to points when plotting summed detectors

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -600,14 +600,14 @@ void InstrumentActor::sumDetectorsRagged(const std::vector<size_t> &dets,
 
     const auto &commonX = ws->points(0);
     const auto &firstY = ws->y(0);
-    x.assign(commonX.begin(), commonX.end());
-    y.assign(firstY.begin(), firstY.end());
+    x.assign(std::cbegin(commonX), std::cend(commonX));
+    y.assign(std::cbegin(firstY), std::cend(firstY));
 
     // add the spectra
     for (size_t i = 0; i < nSpec; ++i) {
       const auto &specY = ws->y(i);
-      std::transform(y.begin(), y.end(), specY.begin(), y.begin(),
-                     std::plus<double>());
+      std::transform(std::cbegin(y), std::cend(y), std::cbegin(specY),
+                     std::begin(y), std::plus<double>());
     }
   } catch (std::invalid_argument &) {
     // wrong Params for any reason

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -598,15 +598,15 @@ void InstrumentActor::sumDetectorsRagged(const std::vector<size_t> &dets,
         Mantid::API::AnalysisDataService::Instance().retrieve(outName));
     Mantid::API::AnalysisDataService::Instance().remove(outName);
 
-    const auto &X = ws->x(0);
-    const auto &Y = ws->y(0);
-    x.assign(X.begin(), X.end());
-    y.assign(Y.begin(), Y.end());
+    const auto &commonX = ws->points(0);
+    const auto &firstY = ws->y(0);
+    x.assign(commonX.begin(), commonX.end());
+    y.assign(firstY.begin(), firstY.end());
 
     // add the spectra
     for (size_t i = 0; i < nSpec; ++i) {
-      const auto &Y = ws->y(i);
-      std::transform(y.begin(), y.end(), Y.begin(), y.begin(),
+      const auto &specY = ws->y(i);
+      std::transform(y.begin(), y.end(), specY.begin(), y.begin(),
                      std::plus<double>());
     }
   } catch (std::invalid_argument &) {


### PR DESCRIPTION
**Description of work.**

The original instrument view miniplot code used C arrays and passed the length of the Y array as a parameter. In the case of a bin edge X array the last X value was just ignored (technically incorrect). In #23789 the code was updated to use vectors and check on their sizes was introduced. This required them to be equal and exposed the bug that the X bin edges were used for plotting in the case of a detector sum and not the bin centres as they should. This fixes the issue and used bin centres for the summed detector case.

**Report to:** Fabio Orlandi, ISIS

**To test:**

See the original issue for test instructions.

Fixes #23966 

*This does not require release notes* because **as it was a regression introduced in this development cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
