### PR TITLE
Simplify DirectILLIntegrateVanadium

### DIFF
--- a/docs/source/algorithms/DirectILLIntegrateVanadium-v1.rst
+++ b/docs/source/algorithms/DirectILLIntegrateVanadium-v1.rst
@@ -24,7 +24,7 @@ The *InputWorkspace* should be loaded using the :ref:`DirectILLCollectData <algm
 Vanadium temperature
 ####################
 
-A correction for the Debye-Waller factor is applied to the integrated vanadium, as explained in the documentation of :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>`. The temperature for the DWF calculation is taken from the 'Sample.temperature' sample log of the *InputWorkspace*. This value can be overridden by the *Temperature* property, if needed.
+A correction for the Debye-Waller factor is applied to the integrated vanadium, as explained in the documentation of :ref:`ComputeCalibrationCoefVan <algm-ComputeCalibrationCoefVan>`. The temperature for the DWF calculation is taken from the sample logs of the *InputWorkspace*. This value can be overridden by the *Temperature* property, if needed.
 
 Usage
 -----


### PR DESCRIPTION
The manual integration step in case of disabled Debye-Waller correction was be removed from `DirectILLIntegrateVanadium` thanks to recent changes in `ComputeCalibrationCoefVan`. `ComputeCalibartionCoefVan` now handles all our integration needs.

**Report to:** [nobody].

**To test:**

Make sure the unit test data directory is in the Mantid's data search directories. Run the following script on master and this branch: 
```python
collected = DirectILLCollectData('ILL/IN4/084446.nxs', OutputEPPWorkspace='epp')
int = DirectILLIntegrateVanadium(collected.OutputWorkspace, DebyeWallerCorrection='Correction OFF', EPPWorkspace=collected.OutputEPPWorkspace)

```

Compare the results. Note, that the data does *not* match perfectly as the original implementation integrated full bins only with DWF disabled while the new implementation using `ComputeCalibrationCoefVan` integrates partial bins as well. Thus the resulting *Y* in `int` from this branch and the integration ranges stored in the *X* array should be slightly greater than on master.

Fixes #23979.

*This does not require release notes* because there are no user-facing functional changes here.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
