### PR TITLE
Do not set empty event workspace to single bin

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2924,9 +2924,7 @@ double EventList::getTofMin() const {
  */
 double EventList::getTofMax() const {
   // set up as the minimum available double
-  double tMax =
-      -1. *
-      std::numeric_limits<double>::max(); // min is a small number, not negative
+  double tMax = std::numeric_limits<double>::lowest();
 
   // no events is a soft error
   if (this->empty())

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -328,6 +328,8 @@ DateAndTime EventWorkspace::getTimeAtSampleMax(double tofOffset) const {
 double EventWorkspace::getEventXMin() const {
   // set to crazy values to start
   double xmin = std::numeric_limits<double>::max();
+  if (this->getNumberEvents() == 0)
+    return xmin;
   size_t numWorkspace = this->data.size();
   for (size_t workspaceIndex = 0; workspaceIndex < numWorkspace;
        workspaceIndex++) {
@@ -352,6 +354,8 @@ double EventWorkspace::getEventXMin() const {
 double EventWorkspace::getEventXMax() const {
   // set to crazy values to start
   double xmax = std::numeric_limits<double>::lowest();
+  if (this->getNumberEvents() == 0)
+    return xmax;
   size_t numWorkspace = this->data.size();
   for (size_t workspaceIndex = 0; workspaceIndex < numWorkspace;
        workspaceIndex++) {
@@ -373,6 +377,9 @@ void EventWorkspace::getEventXMinMax(double &xmin, double &xmax) const {
   // set to crazy values to start
   xmin = std::numeric_limits<double>::max();
   xmax = -1.0 * xmin;
+  if (this->getNumberEvents() == 0)
+    return;
+
   int64_t numWorkspace = static_cast<int64_t>(this->data.size());
 #pragma omp parallel
   {

--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -425,6 +425,12 @@ Workspace_sptr LoadLiveData::appendMatrixWSChunk(Workspace_sptr accumWS,
 
 namespace {
 bool isUsingDefaultBinBoundaries(const EventWorkspace *workspace) {
+  // returning false for empty workspaces tells the caller not to try
+  // to rebin the data. See EventList::getEventXMinMax() for what the
+  // workspace binning will look like with this choice.
+  if (workspace->getNumberEvents() == 0)
+    return false;
+
   // only check first spectrum
   const auto &x = workspace->binEdges(0);
   if (x.size() > 2)


### PR DESCRIPTION
`EventWorkspace::resetAllXToSingleBin()` was getting nonsense values for
data range in an empty event workspace. The new behavior is to not
rebin the data in `LoadLiveData` to a single bin for this case. This
should move the segfault that was seen on REF_M to a `ValueError` the
first time `Rebin` is called in their post processing script.

**To test:**

The best test is to run REF_M live reduction on a *very* low count rate. Otherwise, code review will have to do.

*There is no associated issue.*

*This does not require release notes* because it is only seen infrequently on REF_M.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
