### PR TITLE
DirectILLApplySelfShielding: remove upper limit from empty cell scaling

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShielding.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShielding.py
@@ -49,7 +49,7 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
         return common.CATEGORIES
 
     def seeAlso(self):
-        return [ "DirectILLReduction" ]
+        return [ 'DirectILLReduction', 'DirectILLApplySelfShielding' ]
 
     def name(self):
         """Return the algorithm's name."""
@@ -94,7 +94,7 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
         inputWorkspaceValidator = CompositeValidator()
         inputWorkspaceValidator.add(InstrumentValidator())
         inputWorkspaceValidator.add(WorkspaceUnitValidator('TOF'))
-        scalingFactor = FloatBoundedValidator(lower=0, upper=1)
+        mustBePositive = FloatBoundedValidator(lower=0)
 
         # Properties.
         self.declareProperty(MatrixWorkspaceProperty(
@@ -131,7 +131,7 @@ class DirectILLApplySelfShielding(DataProcessorAlgorithm):
             doc='An empty container workspace for subtraction from the input workspace.')
         self.declareProperty(name=common.PROP_EC_SCALING,
                              defaultValue=1.0,
-                             validator=scalingFactor,
+                             validator=mustBePositive,
                              direction=Direction.Input,
                              doc='A multiplier (transmission, if no self ' +
                                  'shielding is applied) for the empty container.')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShielding.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShielding.py
@@ -28,7 +28,7 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
         return common.CATEGORIES
 
     def seeAlso(self):
-        return [ "DirectILLReduction" ]
+        return [ 'DirectILLApplySelfShielding', 'DirectILLReduction' ]
 
     def name(self):
         """Return the algorithm's name."""

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -29,6 +29,7 @@ Improvements
   - The temperature sample log can now be a time series.
 
 - :ref:`ComputeIncoherentDOS <algm-ComputeIncoherentDOS>` now supports computation from :math:`S(2\theta,E)` workspace.
+- The upper limit of the empty container scaling factor in :ref:`DirectILLApplySelfShielding <algm-DirectILLApplySelfShielding>` has been removed.
 
 Bugfixes
 ########


### PR DESCRIPTION
This PR removes the upper limit for the `EmptyContainerScaling` property in `DirectILLApplySelfShielding` as requested by the instrument scientists.

**Description of work.**

**Report to:** Björn Fåk/ILL

**To test:**

Code review should suffice.

Fixes #21945.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
