### PR TITLE
Fix documentation build with sphinx 1.8.1

### DIFF
--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -24,10 +24,14 @@ if sphinx_version > "1.6":
 extensions = [
     # we use pngmath over mathjax so that the the offline help isn't reliant on
     # anything external and we don't need to include the large mathjax package
-    'sphinx.ext.pngmath',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx'
 ]
+
+if sphinx_version > "1.8":
+    extensions.append('sphinx.ext.imgmath')
+else:
+    extensions.append('sphinx.ext.pngmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -7,11 +7,12 @@ import os
 
 from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme
+from distutils.version import LooseVersion
 
 
 # -- General configuration ------------------------------------------------
 
-if sphinx_version > "1.6":
+if LooseVersion(sphinx_version) > LooseVersion("1.6"):
     def setup(app):
         """Called automatically by Sphinx when starting the build process
         """
@@ -28,7 +29,7 @@ extensions = [
     'sphinx.ext.intersphinx'
 ]
 
-if sphinx_version > "1.8":
+if LooseVersion(sphinx_version) > LooseVersion("1.8"):
     extensions.append('sphinx.ext.imgmath')
 else:
     extensions.append('sphinx.ext.pngmath')

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,7 +30,6 @@ if sphinx_version > "1.6":
 extensions = [
      # we use pngmath over mathjax so that the the offline help isn't reliant on
      # anything external and we don't need to include the large mathjax package
-    'sphinx.ext.pngmath',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.doctest',
@@ -39,6 +38,10 @@ extensions = [
     'mantiddoc.doctest',
     'matplotlib.sphinxext.plot_directive'
 ]
+if sphinx_version > "1.8":
+    extensions.append('sphinx.ext.imgmath')
+else:
+    extensions.append('sphinx.ext.pngmath')
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,6 +9,7 @@ from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme # checked at cmake time
 import mantid
 from mantid.kernel import ConfigService
+from distutils.version import LooseVersion
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -17,7 +18,7 @@ sys.path.insert(0, os.path.abspath(os.path.join('..', 'sphinxext')))
 
 # -- General configuration ------------------------------------------------
 
-if sphinx_version > "1.6":
+if LooseVersion(sphinx_version) > LooseVersion("1.6"):
     def setup(app):
         """Called automatically by Sphinx when starting the build process
         """
@@ -38,7 +39,7 @@ extensions = [
     'mantiddoc.doctest',
     'matplotlib.sphinxext.plot_directive'
 ]
-if sphinx_version > "1.8":
+if LooseVersion(sphinx_version) > LooseVersion("1.8"):
     extensions.append('sphinx.ext.imgmath')
 else:
     extensions.append('sphinx.ext.pngmath')


### PR DESCRIPTION
**Description of work.**

This PR fixes a problem to build Mantid documentation with the Sphinx versions newer than 1.8.


**To test:**

Run `make docs-qthelp` to build the documentation. Check that nothing got broken.

<!-- Instructions for testing. -->

Fixes #23953. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
