### PR TITLE
Add aplication icon

### DIFF
--- a/qt/applications/workbench/resources.qrc
+++ b/qt/applications/workbench/resources.qrc
@@ -1,5 +1,6 @@
 <!DOCTYPE RCC><RCC version="1.0">
 <qresource prefix="/images">
     <file alias="MantidSplashScreen.png">../../../images/MantidSplashScreen.png</file>
+    <file alias="MantidIcon.ico">../../../images/mantid_workbench.ico</file>
 </qresource>
 </RCC>

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -38,7 +38,7 @@ requirements.check_qt()
 # Qt
 # -----------------------------------------------------------------------------
 from qtpy.QtCore import (QEventLoop, Qt, QCoreApplication, QPoint, QSize)  # noqa
-from qtpy.QtGui import (QColor, QPixmap)  # noqa
+from qtpy.QtGui import (QColor, QPixmap, QIcon)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog,
                             QMainWindow, QSplashScreen)  # noqa
 from mantidqt.utils.qt import plugins, widget_updates_disabled  # noqa
@@ -507,6 +507,7 @@ def start_workbench(app, command_line_options):
     importlib.import_module('mantid')
     main_window.populateAfterMantidImport()
     main_window.show()
+    main_window.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
 
     if main_window.splash:
         main_window.splash.hide()


### PR DESCRIPTION
**Description of work.**
Add icon to the workbench

**To test:**
Build and start the workbench. See that the workbench icon appears in the applications  bar
This is how it looks on my Ubuntu 18.04

![screenshot from 2018-11-13 18-12-16](https://user-images.githubusercontent.com/1128952/48449236-b2af0200-e76f-11e8-918c-8ea30540e410.png)

*There is no associated issue.*
*This does not require release notes* because **workbench**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
