### PR TITLE
Set default suffix for files being saved to .py

### DIFF
--- a/qt/python/mantidqt/io.py
+++ b/qt/python/mantidqt/io.py
@@ -14,15 +14,16 @@ from qtpy.QtCore import QDir
 _LAST_SAVE_DIRECTORY = None
 
 
-def open_a_file_dialog(parent=None,  default_suffix=None, directory=None, file_filter=None, saving=True, any_file=True):
+def open_a_file_dialog(parent=None,  default_suffix=None, directory=None, file_filter=None, accept_mode=None,
+                       file_mode=None):
     """
     Open a dialog asking for a file location and name to and return it
     :param parent: QWidget; The parent QWidget of the created dialog
     :param default_suffix: String; The default suffix to be passed
     :param directory: String; Directory to which the dialog will open
     :param file_filter: String; The filter name and file type e.g. "Python files (*.py)"
-    :param any_file: bool; Whether you can select any file or only existing files (Allows selecting non-existant files)
-    :param saving: bool; Whether or not this is a Saving dialog (True) or a loading dialog (False)
+    :param accept_mode: enum AcceptMode; Defines the AcceptMode of the dialog, check QFileDialog Class for details
+    :param file_mode: enum FileMode; Defines the FileMode of the dialog, check QFileDialog Class for details
     :return: String; The filename that was selected, it is possible to return a directory so look out for that.
     """
     global _LAST_SAVE_DIRECTORY
@@ -41,11 +42,11 @@ def open_a_file_dialog(parent=None,  default_suffix=None, directory=None, file_f
     if default_suffix is not None:
         dialog.setDefaultSuffix(default_suffix)
 
-    if any_file:
-        dialog.setFileMode(QFileDialog.AnyFile)
+    if file_mode is not None:
+        dialog.setFileMode(file_mode)
 
-    if saving:
-        dialog.setAcceptMode(QFileDialog.AcceptSave)
+    if accept_mode is not None:
+        dialog.setAcceptMode(accept_mode)
 
     # Connect the actual filename setter
     dialog.fileSelected.connect(_set_last_save)

--- a/qt/python/mantidqt/io.py
+++ b/qt/python/mantidqt/io.py
@@ -1,0 +1,71 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+#
+
+import os.path
+from qtpy.QtWidgets import QFileDialog
+from qtpy.QtCore import QDir
+
+_LAST_SAVE_DIRECTORY = None
+
+
+def open_a_file_dialog(parent=None,  default_suffix=None, directory=None, file_filter=None, saving=True, any_file=True):
+    """
+    Open a dialog asking for a file location and name to and return it
+    :param parent: QWidget; The parent QWidget of the created dialog
+    :param default_suffix: String; The default suffix to be passed
+    :param directory: String; Directory to which the dialog will open
+    :param file_filter: String; The filter name and file type e.g. "Python files (*.py)"
+    :param any_file: bool; Whether you can select any file or only existing files (Allows selecting non-existant files)
+    :param saving: bool; Whether or not this is a Saving dialog (True) or a loading dialog (False)
+    :return: String; The filename that was selected, it is possible to return a directory so look out for that.
+    """
+    global _LAST_SAVE_DIRECTORY
+    dialog = QFileDialog(parent)
+    if _LAST_SAVE_DIRECTORY is not None and directory is None:
+        dialog.setDirectory(_LAST_SAVE_DIRECTORY)
+    elif directory is not None:
+        dialog.setDirectory(directory)
+    else:
+        dialog.setDirectory(os.path.expanduser("~"))
+
+    if file_filter is not None:
+        dialog.setFilter(QDir.Files)
+        dialog.setNameFilter(file_filter)
+
+    if default_suffix is not None:
+        dialog.setDefaultSuffix(default_suffix)
+
+    if any_file:
+        dialog.setFileMode(QFileDialog.AnyFile)
+
+    if saving:
+        dialog.setAcceptMode(QFileDialog.AcceptSave)
+
+    # Connect the actual filename setter
+    dialog.fileSelected.connect(_set_last_save)
+
+    # Wait for dialog to finish before allowing continuation of code
+    dialog.exec_()
+
+    filename = _LAST_SAVE_DIRECTORY
+    # Make sure that the _LAST_SAVE_DIRECTORY is set
+    if _LAST_SAVE_DIRECTORY is not None and not os.path.isdir(_LAST_SAVE_DIRECTORY):
+        # Remove the file for last directory
+        _LAST_SAVE_DIRECTORY = os.path.dirname(os.path.abspath(_LAST_SAVE_DIRECTORY))
+
+    return filename
+
+
+def _set_last_save(filename):
+    """
+    Uses the global _LOCAL_SAVE_DIRECTORY to store output from connected signal
+    :param filename: String; Value to set _LAST_SAVE_DIRECTORY
+    """
+    global _LAST_SAVE_DIRECTORY
+    _LAST_SAVE_DIRECTORY = filename

--- a/qt/python/mantidqt/io.py
+++ b/qt/python/mantidqt/io.py
@@ -28,6 +28,9 @@ def open_a_file_dialog(parent=None,  default_suffix=None, directory=None, file_f
     """
     global _LAST_SAVE_DIRECTORY
     dialog = QFileDialog(parent)
+
+    # It is the intention to only save the user's last used directory until workbench is restarted similar to other
+    # applications (VSCode, Gedit etc)
     if _LAST_SAVE_DIRECTORY is not None and directory is None:
         dialog.setDirectory(_LAST_SAVE_DIRECTORY)
     elif directory is not None:

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -16,7 +16,7 @@ import os.path
 # 3rd party imports
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtGui import QColor, QFontMetrics
-from qtpy.QtWidgets import QFileDialog, QMessageBox, QStatusBar, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QMessageBox, QStatusBar, QVBoxLayout, QWidget
 
 # local imports
 from mantidqt.widgets.codeeditor.editor import CodeEditor

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 
 # std imports
 import sys
+import os.path
 
 # 3rd party imports
 from qtpy.QtCore import QObject, Signal
@@ -21,6 +22,7 @@ from qtpy.QtWidgets import QFileDialog, QMessageBox, QStatusBar, QVBoxLayout, QW
 from mantidqt.widgets.codeeditor.editor import CodeEditor
 from mantidqt.widgets.codeeditor.errorformatter import ErrorFormatter
 from mantidqt.widgets.codeeditor.execution import PythonCodeExecution
+from mantidqt.io import open_a_file_dialog
 
 # Status messages
 IDLE_STATUS_MSG = "Status: Idle."
@@ -38,7 +40,10 @@ class EditorIO(object):
         self.editor = editor
 
     def ask_for_filename(self):
-        filename, _ = QFileDialog.getSaveFileName(self.editor, "Choose filename...")
+        filename = open_a_file_dialog(self.editor, ".py", None, "Python Files (*.py)", True, True)
+        if filename is not None and os.path.isdir(filename):
+            # Return None because it is a directory and it's possible to get a directory
+            filename = None
         return filename
 
     def save_if_required(self, confirm=True):

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -17,7 +17,7 @@ import traceback
 # 3rd party imports
 from qtpy.QtCore import QObject, Signal
 from qtpy.QtGui import QColor, QFontMetrics
-from qtpy.QtWidgets import QMessageBox, QStatusBar, QVBoxLayout, QWidget
+from qtpy.QtWidgets import QMessageBox, QStatusBar, QVBoxLayout, QWidget, QFileDialog
 
 # local imports
 from mantidqt.widgets.codeeditor.editor import CodeEditor
@@ -41,9 +41,10 @@ class EditorIO(object):
         self.editor = editor
 
     def ask_for_filename(self):
-        filename = open_a_file_dialog(self.editor, ".py", None, "Python Files (*.py)", True, True)
+        filename = open_a_file_dialog(parent=self.editor, default_suffix=".py", file_filter="Python Files (*.py)",
+                                      accept_mode=QFileDialog.AcceptSave, file_mode=QFileDialog.AnyFile)
         if filename is not None and os.path.isdir(filename):
-            # Return None because it is a directory and it's possible to get a directory
+            # Set value to None as, we do not want to be saving a directory, it is possible to receive a directory
             filename = None
         return filename
 


### PR DESCRIPTION
**Description of work.**
So the task was to make the default file type for saving in Workbench be .py files. To do saving originally workbench employed a static pyqt function which didn't allow this, so I introduced a new module that has a similar function but allows definition of default suffix when called, then I changed the usage for saving to that.

**To test:**
- Load Workbench
- Change the file a bit
- Save that file and notice the dialog pop up
- In the bottom right it should be showing "Python Files" and only python files should be displayed alongside directories in your home directoy or whatever $HOME is set to on your machine's path.
- You should be able to create a new file anywhere on your machine
- Make sure to save it without a .py at the end
- Check it saved with a .py at the end
- Try and save another new file and notice how it is the last directory you saved something into (You may need to try the first few steps again to notice a change as the default is your home directory)
<!-- Instructions for testing. -->

Fixes #21665  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Release notes apparently don't need to be done on Workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
