### PR TITLE
Change AsyncTaskFailure to contain raw stacktrace

### DIFF
--- a/qt/python/mantidqt/utils/test/test_async.py
+++ b/qt/python/mantidqt/utils/test/test_async.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import
 
 # system imports
+import traceback
 import unittest
 
 # 3rdparty imports
@@ -33,7 +34,7 @@ class AsyncTaskTest(unittest.TestCase):
             self.error_cb_called = True
             self.task_exc_type = task_result.exc_type
             self.task_exc = task_result.exc_value
-            self.task_exc_stack = task_result.stack
+            self.task_exc_stack = traceback.extract_tb(task_result.stack)
 
         def on_finished(self):
             self.finished_cb_called = True
@@ -104,11 +105,12 @@ class AsyncTaskTest(unittest.TestCase):
         self.assertTrue(recv.error_cb_called)
         self.assertTrue(isinstance(recv.task_exc, RuntimeError),
                         msg="Expected RuntimeError, found " + recv.task_exc.__class__.__name__)
+
         self.assertEqual(2, len(recv.task_exc_stack))
         # line number of self.target in asynchronous.py
-        self.assertEqual(93, recv.task_exc_stack[0][1])
+        self.assertEqual(90, recv.task_exc_stack[0][1])
         # line number of raise statement above
-        self.assertEqual(94, recv.task_exc_stack[1][1])
+        self.assertEqual(95, recv.task_exc_stack[1][1])
 
     def test_unsuccessful_args_and_kwargs_operation_calls_error_and_finished_callback(self):
         def foo(scale, shift):
@@ -126,7 +128,7 @@ class AsyncTaskTest(unittest.TestCase):
         self.assertTrue(recv.error_cb_called)
         self.assertTrue(isinstance(recv.task_exc, RuntimeError))
 
-    def test_unsuccessful_operation_with_error_cb_and_stack_chop(self):
+    def test_unsuccessful_operation_with_error_cb(self):
         def foo(scale, shift):
             def bar():
                 raise RuntimeError("Bad operation")
@@ -134,15 +136,15 @@ class AsyncTaskTest(unittest.TestCase):
 
         recv = AsyncTaskTest.Receiver()
         scale, shift = 2, 4
-        t = AsyncTask(foo, args = (scale,), kwargs={'shift': shift}, stack_chop=1,
+        t = AsyncTask(foo, args = (scale,), kwargs={'shift': shift},
                       error_cb=recv.on_error)
         t.start()
         t.join()
         self.assertTrue(recv.error_cb_called)
         self.assertTrue(isinstance(recv.task_exc, RuntimeError))
-        self.assertEqual(2, len(recv.task_exc_stack))
-        self.assertEqual(133, recv.task_exc_stack[0][1])
-        self.assertEqual(132, recv.task_exc_stack[1][1])
+        self.assertEqual(3, len(recv.task_exc_stack))
+        self.assertEqual(135, recv.task_exc_stack[1][1])
+        self.assertEqual(134, recv.task_exc_stack[2][1])
 
     # ---------------------------------------------------------------
     # Failure cases

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -136,7 +136,6 @@ class PythonCodeExecution(QObject):
         # Stack is chopped on error to avoid the  AsyncTask.run->self.execute calls appearing
         # as these are not useful for the user in this context
         task = AsyncTask(self.execute, args=(code_str, filename),
-                         stack_chop=2,
                          success_cb=self._on_success, error_cb=self._on_error)
         task.start()
         self._task = task

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 
 # std imports
 import sys
+import traceback
 
 # 3rd party imports
 from qtpy.QtCore import QObject, Signal
@@ -172,6 +173,7 @@ class PythonFileInterpreter(QWidget):
 
 class PythonFileInterpreterPresenter(QObject):
     """Presenter part of MVP to control actions on the editor"""
+    MAX_STACKTRACE_LENGTH = 2
 
     def __init__(self, view, model):
         super(PythonFileInterpreterPresenter, self).__init__()
@@ -234,6 +236,7 @@ class PythonFileInterpreterPresenter(QObject):
     def _on_exec_error(self, task_error):
         exc_type, exc_value, exc_stack = task_error.exc_type, task_error.exc_value, \
                                          task_error.stack
+        exc_stack = traceback.extract_tb(exc_stack)[self.MAX_STACKTRACE_LENGTH:]
         if hasattr(exc_value, 'lineno'):
             lineno = exc_value.lineno + self._code_start_offset
         elif exc_stack is not None:

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -10,6 +10,7 @@
 from __future__ import (absolute_import, unicode_literals)
 
 # std imports
+import traceback
 import unittest
 
 # 3rdparty imports
@@ -30,7 +31,7 @@ class Receiver(QObject):
     def on_error(self, task_result):
         self.error_cb_called = True
         self.task_exc = task_result.exc_value
-        self.error_stack = task_result.stack
+        self.error_stack = traceback.extract_tb(task_result.stack)
 
 
 class ReceiverWithProgress(Receiver):
@@ -116,11 +117,11 @@ foo()
                         msg="Unexpected exception found. "
                             "NameError expected, found {}".format(recv.task_exc.__class__.__name__))
         # Test the stack has been chopped as expected
-        self.assertEqual(3, len(recv.error_stack))
+        self.assertEqual(5, len(recv.error_stack))
         # check line numbers
-        self.assertEqual(8, recv.error_stack[0][1])
-        self.assertEqual(7, recv.error_stack[1][1])
-        self.assertEqual(5, recv.error_stack[2][1])
+        self.assertEqual(8, recv.error_stack[2][1])
+        self.assertEqual(7, recv.error_stack[3][1])
+        self.assertEqual(5, recv.error_stack[4][1])
 
     # ---------------------------------------------------------------------------
     # Progress tests
@@ -192,7 +193,7 @@ squared = sum*sum
         filename = 'test.py'
         executor, recv = self._run_async_code(code, filename=filename)
         self.assertTrue(recv.error_cb_called)
-        self.assertEqual(filename, recv.error_stack[0][0])
+        self.assertEqual(filename, recv.error_stack[-1][0])
 
     # -------------------------------------------------------------------------
     # Helpers


### PR DESCRIPTION
To allow for throwing the exception that was generated with the original stacktrace, the object contained by `AsyncTaskFailure` had to change.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because it is a change in implementation.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
