### PR TITLE
Add explicit check for pyqt4 to be initialized

### DIFF
--- a/MantidPlot/mantidplot.py
+++ b/MantidPlot/mantidplot.py
@@ -20,6 +20,9 @@ from pymantidplot import *
 # and the old qtiplot stuff
 import pymantidplot.qtiplot
 
+# error early if PyQt4 cannot be used
+import PyQt4
+
 def load_ui(caller_filename, ui_relfilename, baseinstance=None):
     '''This is copied from mantidqt.utils.qt and should be deprecated as
     soon as possible.'''


### PR DESCRIPTION
This is moving the error to happen earlier for users of the package
since mantidplot only has sip exports for qt4.

**To test:**

If both the workbench and mantidplot start without issue, this is largely fine.

*There is no associated issue.*

*This does not require release notes* because it only reports `ImportError` to developers of the workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
