### PR TITLE
Pass in system value of QT_API

### DIFF
--- a/buildconfig/CMake/Packaging/mantidpython.in
+++ b/buildconfig/CMake/Packaging/mantidpython.in
@@ -27,6 +27,13 @@ if [ -n "${PYTHONPATH}" ]; then
     LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
 fi
 
+# Define which qt backend to use
+if [ -n "${QT_API}" ]; then
+    LOCAL_QT_API=${QT_API}
+else
+    LOCAL_QT_API="pyqt" # force to use qt4
+fi
+
 if [ -n "$1" ] && [ "$1" = "--classic" ]; then
     shift
     set -- @WRAPPER_PREFIX@@PYTHON_EXECUTABLE@ $*@WRAPPER_POSTFIX@
@@ -42,7 +49,7 @@ fi
 LD_PRELOAD=${LOCAL_PRELOAD} TCMALLOC_RELEASE_RATE=${TCM_RELEASE} \
     TCMALLOC_LARGE_ALLOC_REPORT_THRESHOLD=${TCM_REPORT} \
     PYTHONPATH=${LOCAL_PYTHONPATH} \
+    QT_API=${LOCAL_QT_API} \
     LD_LIBRARY_PATH=${LOCAL_LDPATH} \
     PV_PLUGIN_PATH=${PV_PLUGIN_PATH} \
     exec "$@"
-#


### PR DESCRIPTION
This modifies `mantidpython` to use qt4 by default in qtpy. 

**To test:**

Code review is appropriate.

*There is no associated issue.*

*This does not require release notes* because it us to protect the existing usage of `mantidpython` as more gui code is switching to qtpy.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
