### PR TITLE
Fix Segfault when Keep Open option is checked in Algorithm Dialog

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmObserver.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmObserver.cpp
@@ -30,6 +30,11 @@ void observeProgress(AlgorithmObserver &self, boost::python::object alg) {
   self.observeProgress(calg);
 }
 
+void stopObserving(AlgorithmObserver &self, boost::python::object alg) {
+  IAlgorithm_sptr &calg = boost::python::extract<IAlgorithm_sptr &>(alg);
+  self.stopObserving(calg);
+}
+
 GET_POINTER_SPECIALIZATION(AlgorithmObserver)
 
 void export_algorithm_observer() {
@@ -47,5 +52,7 @@ void export_algorithm_observer() {
       .def("observeError", &observeError, (arg("self"), arg("alg")),
            "Observe algorithm for its error notification.")
       .def("observeProgress", &observeProgress, (arg("self"), arg("alg")),
-           "Observe algorithm for its progress notification.");
+           "Observe algorithm for its progress notification.")
+      .def("stopObserving", &stopObserving, (arg("self"), arg("alg")),
+           "Remove all observers from the algorithm.");
 }

--- a/qt/python/mantidqt/widgets/algorithmprogress/model.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/model.py
@@ -14,6 +14,7 @@ class ProgressObserver(AlgorithmObserver):
     Observes a single algorithm for its progress and finish notifications
     and updates presenter accordingly.
     """
+
     def __init__(self, model, alg):
         super(ProgressObserver, self).__init__()
         self.model = model
@@ -52,6 +53,7 @@ class AlgorithmProgressModel(AlgorithmObserver):
     Observes AlgorithmManager for new algorithms and starts
     ProgressObservers.
     """
+
     def __init__(self):
         super(AlgorithmProgressModel, self).__init__()
         self.presenters = []
@@ -102,6 +104,9 @@ class AlgorithmProgressModel(AlgorithmObserver):
         if index >= 0:
             del self.progress_observers[index]
             self.update_presenter()
+            # Remove the observers from the algorithm, otherwise we
+            # leave dangling pointers to the now-deleted observers in the algorithm
+            progress_observer.stopObserving(progress_observer.algorithm)
 
     def get_running_algorithms(self):
         return [obs.algorithm for obs in self.progress_observers]


### PR DESCRIPTION
**Description of work.**
Correctly stops observing when observer is removed.

The `AlgorithmObserver::stopObserving` was exposed to Python and is now being called when the `ProgressObserver.finishHandle` is triggered (i.e. when the algorithm has finished

**Report to:** S. Howells. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
1. Run Workbench. 
1. Open Load dialog from WorkspaceWidget
1. Check `Keep Open` option
1. Run the Load algorithm multiple times, Workbench, or anything, should not crash
1. Try out with other algorithms, the behaviour is generic for the AlgorithmDialog, and should work everywhere

<!-- Instructions for testing. -->

Fixes #24002 
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
