### PR TITLE
Fix linking errors to libCatalog.so

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -117,9 +117,7 @@ include_directories (DataObjects/inc)
 add_subdirectory (DataObjects)
 set ( MANTIDLIBS ${MANTIDLIBS} DataObjects )
 
-include_directories (Catalog/inc)
 add_subdirectory (Catalog)
-set ( MANTIDLIBS ${MANTIDLIBS} Catalog )
 
 add_subdirectory (Nexus)
 add_subdirectory (DataHandling)

--- a/Framework/Catalog/CMakeLists.txt
+++ b/Framework/Catalog/CMakeLists.txt
@@ -49,7 +49,7 @@ endif ()
 # Add to the 'Framework' group in VS
 set_property ( TARGET Catalog PROPERTY FOLDER "MantidFramework" )
 
-include_directories ( inc )
+target_include_directories ( Catalog PUBLIC inc/ )
 
 target_link_libraries ( Catalog LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${MANTIDLIBS} ${OPENSSL_LIBRARIES} ${JSONCPP_LIBRARIES})
 

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -587,7 +587,7 @@ set_target_properties ( DataHandling PROPERTIES OUTPUT_NAME MantidDataHandling
 if (OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties(DataHandling PROPERTIES INSTALL_RPATH "@loader_path/../Contents/MacOS")
 elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(DataHandling PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
+  set_target_properties(DataHandling PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR};\$ORIGIN/../${PLUGINS_DIR}")
 endif ()
 
 # Add to the 'Framework' group in VS


### PR DESCRIPTION
**Description of work.**

**Report to:** Peter Parker 

**To test:**

<!-- Instructions for testing. -->

* Download an install RPM from build servers.
* Verify that MantidPlot starts without errors.

*There is no associated issue.*

*This does not require release notes* because issue introduced since the last release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
