### PR TITLE
Change IntegratePeaksUsingClusters to treat NaN's as background

### DIFF
--- a/Framework/Crystal/src/HardThresholdBackground.cpp
+++ b/Framework/Crystal/src/HardThresholdBackground.cpp
@@ -29,7 +29,8 @@ void HardThresholdBackground::configureIterator(
 
 bool HardThresholdBackground::isBackground(
     Mantid::API::IMDIterator *iterator) const {
-  return iterator->getNormalizedSignal() <= m_thresholdSignal;
+  auto signal = iterator->getNormalizedSignal();
+  return signal <= m_thresholdSignal || std::isnan(signal);
 }
 
 } // namespace Crystal

--- a/docs/source/algorithms/IntegratePeaksUsingClusters-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksUsingClusters-v1.rst
@@ -32,7 +32,8 @@ A threshold for the Peak should be defined below which, parts of the
 image are treated as background. The normalization method in combination
 with the threshold may both be used to define a background. We suggest
 keeping the default of VolumeNormalization so that changes in the
-effective bin size do not affect the background filtering.
+effective bin size do not affect the background filtering. NaN is always
+considered background.
 
 This algorithm uses an imaging technique, and it is therefore important
 that the MDHistoWorkspace you are using is binned to a sufficient

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -39,6 +39,7 @@ Improvements
 - :ref:`IntegratePeaksMD <algm-IntegratePeaksMD>` with Cylinder=True now has improved fits using BackToBackExponential and IkedaCarpenterPV functions.
 - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` now has option to renumber peaks sequentially.
 - SCD Event Data Reduction Diffraction Interface now has option to create MD HKL workspace.
+- :ref:`IntegratePeaksUsingClusters <algm-IntegratePeaksUsingClusters>` will now treat NaN's as background.
 
 Bugfixes
 ########


### PR DESCRIPTION
Currently `NaN`'s get included in the integration when using `IntegratePeaksUsingClusters` and you end up with a lot of intensities that are `NaN`,  this makes them act as background.

**To test:**
Either download [KCl.nxs](https://www.dropbox.com/s/hhj0sgu2iqeidob/KCl.nxs?dl=0) first or just run the following if at ORNL
```
KCl=LoadMD('/SNS/users/rwp/tmp/KCl.nxs')
PredictPeaks(InputWorkspace='KCl', MinDSpacing=0.87, CalculateGoniometerForCW=True, Wavelength=1.488, MaxAngle=0, ReflectionCondition='All-face centred', OutputWorkspace='peaks')
IntegratePeaksUsingClusters(InputWorkspace='KCl', PeaksWorkspace='peaks', Threshold=5000, OutputWorkspace='integrated', OutputWorkspaceMD='labeled')
```
Look at the`integrated` peak workspace and see that you now have intensities. Currently in master you end up with a lot of `NaN`'s and you get the following warnings
```
IntegratePeaksUsingClusters-[Notice] IntegratePeaksUsingClusters started
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 31 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 8 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 6 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 33 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 4 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 30 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 26 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 12 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 27 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 24 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 25 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 16 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 28 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 14 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 10 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 18 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 22 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 0 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 34 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 35 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 29 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 2 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 20 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 17 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 3 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 1 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 9 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 19 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 5 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 7 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 13 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 15 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 23 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Warning] Overlapping Peaks. Peak: 21 overlaps with another Peak: 32 and shares label id: 1
IntegratePeaksUsingClusters-[Notice] IntegratePeaksUsingClusters successful, Duration 16.70 seconds
```


*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
