### PR TITLE
Fix TOFTOF scripter for Workbench

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -535,7 +535,13 @@ class TOFTOFScriptElement(BaseScriptElement):
         # generated script
         self.script = ['']
 
+        self.l("from __future__ import (absolute_import, division, print_function, unicode_literals)")
+        self.l()
+        self.l("# import mantid algorithms, numpy and matplotlib")
+        self.l("from mantid.simpleapi import *")
+        self.l("import matplotlib.pyplot as plt")
         self.l("import numpy as np")
+        self.l()
         self.l("from os.path import join")
         self.l()
         self.l("config['default.facility'] = '{}'"   .format(self.facility_name))

--- a/scripts/test/TOFTOF/TOFTOFScriptElementTest.py
+++ b/scripts/test/TOFTOF/TOFTOFScriptElementTest.py
@@ -180,7 +180,7 @@ class TOFTOFScriptElementTest(unittest.TestCase):
         self.scriptElement.createDiff    = True
         self.scriptElement.keepSteps     = True
 
-        testhelpers.assertRaisesNothing(self, self.execScript, 'from mantid.simpleapi import *\n' + self.scriptElement.to_script())
+        testhelpers.assertRaisesNothing(self, self.execScript, self.scriptElement.to_script())
 
     def test_that_script_has_correct_syntax(self):
         self.scriptElement.binEon = False


### PR DESCRIPTION
**Description of work.**

This PR adjusts scripter for the TOFTOF data reduction GUI to produce script which works in the Workbench. Now scripter writes the same imports in the data reduction script header as in the Workbench Editor by default.

The import
```python
from mantid.simpleapi import *
```
is a wish of the instrument scientist, since the script is generated for users.

**To test:**

<!-- Instructions for testing. -->
Download test dataset: [testdata.zip](https://github.com/mantidproject/mantid/files/2599163/testdata.zip)
Test the TOFTOF data reduction GUI (Interfaces->Direct->DGS Reduction->(MLZ, TOFTOF)) in both, MantidPlot and workbench. Nothing should get broken.

Test dataset contains xml file which could be loaded via File->Open to the TOFTOF Reduction GUI. It is important to set the correct **Data search directory**. Feel free also to vary other data reduction options.

`Export` button will allow to save the data reduction script to the file. The python file should contain the following imports in the beginning:

```python
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
```



Fixes #24047. 

*This does not require release notes* because it is a minor fix.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
