### PR TITLE
Switch WANDPowderReduction to use Rebin

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -9,7 +9,7 @@ from mantid.api import (DataProcessorAlgorithm, AlgorithmFactory,
                         MatrixWorkspaceProperty, PropertyMode)
 from mantid.dataobjects import MaskWorkspaceProperty
 from mantid.simpleapi import (ConvertSpectrumAxis, Transpose,
-                              ResampleX, CopyInstrumentParameters,
+                              Rebin, CopyInstrumentParameters,
                               Divide, DeleteWorkspace, Scale,
                               MaskAngle, ExtractMask, Minus,
                               ExtractUnmaskedSpectra, mtd,
@@ -63,7 +63,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
 
         self.copyProperties('ConvertSpectrumAxis', ['Target', 'EFixed'])
 
-        self.copyProperties('ResampleX', ['XMin', 'XMax', 'NumberBins', 'LogBinning'])
+        self.copyProperties('Rebin', ['Params'])
 
         self.declareProperty('NormaliseBy', 'Monitor', StringListValidator(['None', 'Time', 'Monitor']), "Normalise to monitor or time. ")
 
@@ -81,9 +81,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         mask = self.getProperty("MaskWorkspace").value
         target = self.getProperty("Target").value
         eFixed = self.getProperty("EFixed").value
-        xMin = self.getProperty("XMin").value
-        xMax = self.getProperty("XMax").value
-        numberBins = self.getProperty("NumberBins").value
+        params = self.getProperty("Params").value
         normaliseBy = self.getProperty("NormaliseBy").value
         maskAngle = self.getProperty("MaskAngle").value
         outWS = self.getPropertyValue("OutputWorkspace")
@@ -109,15 +107,14 @@ class WANDPowderReduction(DataProcessorAlgorithm):
         ExtractUnmaskedSpectra(InputWorkspace=data, MaskWorkspace='__mask_tmp', OutputWorkspace='__data_tmp', EnableLogging=False)
         ConvertSpectrumAxis(InputWorkspace='__data_tmp', Target=target, EFixed=eFixed, OutputWorkspace=outWS, EnableLogging=False)
         Transpose(InputWorkspace=outWS, OutputWorkspace=outWS, EnableLogging=False)
-        ResampleX(InputWorkspace=outWS, OutputWorkspace=outWS, XMin=xMin, XMax=xMax, NumberBins=numberBins, EnableLogging=False)
+        Rebin(InputWorkspace=outWS, OutputWorkspace=outWS, Params=params, EnableLogging=False)
 
         if cal is not None:
             ExtractUnmaskedSpectra(InputWorkspace=cal, MaskWorkspace='__mask_tmp', OutputWorkspace='__cal_tmp', EnableLogging=False)
             CopyInstrumentParameters(data, '__cal_tmp', EnableLogging=False)
             ConvertSpectrumAxis(InputWorkspace='__cal_tmp', Target=target, EFixed=eFixed, OutputWorkspace='__cal_tmp', EnableLogging=False)
             Transpose(InputWorkspace='__cal_tmp', OutputWorkspace='__cal_tmp', EnableLogging=False)
-            ResampleX(InputWorkspace='__cal_tmp', OutputWorkspace='__cal_tmp', XMin=xMin, XMax=xMax, NumberBins=numberBins,
-                      EnableLogging=False)
+            Rebin(InputWorkspace='__cal_tmp', OutputWorkspace='__cal_tmp', Params=params, EnableLogging=False)
             Divide(LHSWorkspace=outWS, RHSWorkspace='__cal_tmp', OutputWorkspace=outWS, EnableLogging=False)
             if normaliseBy == "Monitor":
                 cal_scale = cal.run().getProtonCharge()
@@ -131,8 +128,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
             CopyInstrumentParameters(data, '__bkg_tmp', EnableLogging=False)
             ConvertSpectrumAxis(InputWorkspace='__bkg_tmp', Target=target, EFixed=eFixed, OutputWorkspace='__bkg_tmp', EnableLogging=False)
             Transpose(InputWorkspace='__bkg_tmp', OutputWorkspace='__bkg_tmp', EnableLogging=False)
-            ResampleX(InputWorkspace='__bkg_tmp', OutputWorkspace='__bkg_tmp', XMin=xMin, XMax=xMax, NumberBins=numberBins,
-                      EnableLogging=False)
+            Rebin(InputWorkspace='__bkg_tmp', OutputWorkspace='__bkg_tmp', Params=params, EnableLogging=False)
             if cal is not None:
                 Divide(LHSWorkspace='__bkg_tmp', RHSWorkspace='__cal_tmp', OutputWorkspace='__bkg_tmp', EnableLogging=False)
             if normaliseBy == "Monitor":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -56,24 +56,22 @@ class WANDPowderReductionTest(unittest.TestCase):
         # data normalised by monitor
         pd_out=WANDPowderReduction(InputWorkspace=data,
                                    Target='Theta',
-                                   NumberBins=1000)
+                                   Params=0.04)
 
         x = pd_out.extractX()
         y = pd_out.extractY()
 
-        self.assertAlmostEqual(x.min(),  8.07086781)
-        self.assertAlmostEqual(x.max(), 50.82973519)
-        self.assertAlmostEqual(y.min(),  0.00328244)
-        self.assertAlmostEqual(y.max(),  4.88908824)
-        self.assertAlmostEqual(x[0,y.argmax()], 45.094311535)
+        self.assertAlmostEqual(x.min(),  8.06946698)
+        self.assertAlmostEqual(x.max(), 50.83030150)
+        self.assertAlmostEqual(y.min(),  0.00306758)
+        self.assertAlmostEqual(y.max(),  4.37085727)
+        self.assertAlmostEqual(x[0,y.argmax()], 45.10946698)
 
         # data and calibration, limited range
         pd_out2=WANDPowderReduction(InputWorkspace=data,
                                     CalibrationWorkspace=cal,
                                     Target='Theta',
-                                    NumberBins=2000,
-                                    XMin=10,
-                                    XMax=40)
+                                    Params='10,0.015,40')
 
         x = pd_out2.extractX()
         y = pd_out2.extractY()
@@ -89,17 +87,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     CalibrationWorkspace=cal,
                                     BackgroundWorkspace=bkg,
                                     Target='Theta',
-                                    NumberBins=1000,
+                                    Params=0.04,
                                     NormaliseBy='Time')
 
         x = pd_out3.extractX()
         y = pd_out3.extractY()
 
-        self.assertAlmostEqual(x.min(), 8.07086781)
-        self.assertAlmostEqual(x.max(), 50.82973519)
+        self.assertAlmostEqual(x.min(),  8.06946698)
+        self.assertAlmostEqual(x.max(), 50.83030150)
         self.assertAlmostEqual(y.min(),  0)
-        self.assertAlmostEqual(y.max(), 19.97968357)
-        self.assertAlmostEqual(x[0,y.argmax()], 45.008708196)
+        self.assertAlmostEqual(y.max(), 19.97454882)
+        self.assertAlmostEqual(x[0,y.argmax()], 44.98946698)
 
         # data, cal and background. To d spacing
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -107,16 +105,16 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     Target='ElasticDSpacing',
                                     EFixed=30,
-                                    NumberBins=1000)
+                                    Params=0.002)
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(), 1.92800159)
-        self.assertAlmostEqual(x.max(), 11.7586705)
+        self.assertAlmostEqual(x.min(),  1.92408134)
+        self.assertAlmostEqual(x.max(), 11.76333605)
         self.assertAlmostEqual(y.min(),  0)
-        self.assertAlmostEqual(y.max(), 19.03642005)
-        self.assertAlmostEqual(x[0,y.argmax()], 2.1543333)
+        self.assertAlmostEqual(y.max(), 19.96633911)
+        self.assertAlmostEqual(x[0,y.argmax()], 2.15808134)
 
         # data, cal and background with mask angle, to Q.
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -124,17 +122,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     Target='ElasticQ',
                                     EFixed=30,
-                                    NumberBins=2000,
+                                    Params=0.0035,
                                     MaskAngle=60)
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(), 0.53479223, places=4)
-        self.assertAlmostEqual(x.max(), 3.21684994, places=4)
+        self.assertAlmostEqual(x.min(), 0.53587138, places=4)
+        self.assertAlmostEqual(x.max(), 3.21632108, places=4)
         self.assertAlmostEqual(y.min(),  0, places=4)
-        self.assertAlmostEqual(y.max(), 19.9948756, places=4)
-        self.assertAlmostEqual(x[0,y.argmax()], 2.9122841, places=4)
+        self.assertAlmostEqual(y.max(), 19.9705871, places=4)
+        self.assertAlmostEqual(x[0,y.argmax()], 2.91237138, places=4)
 
         # data, cal and background, scale background
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -142,17 +140,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     BackgroundScale=0.5,
                                     Target='Theta',
-                                    NumberBins=1000,
+                                    Params=0.04,
                                     NormaliseBy='Time')
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(), 8.07086781)
-        self.assertAlmostEqual(x.max(), 50.82973519)
+        self.assertAlmostEqual(x.min(),  8.06946698)
+        self.assertAlmostEqual(x.max(), 50.83030150)
         self.assertAlmostEqual(y.min(),  0.75)
-        self.assertAlmostEqual(y.max(), 20.72968357)
-        self.assertAlmostEqual(x[0,y.argmax()], 45.008708196)
+        self.assertAlmostEqual(y.max(), 20.72454882)
+        self.assertAlmostEqual(x[0,y.argmax()], 44.98946698)
 
 
 if __name__ == '__main__':

--- a/docs/source/algorithms/WANDPowderReduction-v1.rst
+++ b/docs/source/algorithms/WANDPowderReduction-v1.rst
@@ -24,6 +24,8 @@ algorithm will work on data loaded with :ref:`LoadEventNexus
 <algm-FilterEvents>` but you will need to specify `EFixed` if
 converting to anything except `Theta`.
 
+:ref:`Rebin <algm-Rebin>` is used to bin the data so see it's
+documentation for use of the `Params` parameter.
 
 MaskAngle
 #########
@@ -49,7 +51,7 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon,
                        CalibrationWorkspace=vanadium,
                        Target='Theta',
-                       NumberBins=1000,
+                       Params=0.1,
                        OutputWorkspace='silicon_powder')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder.png
@@ -64,9 +66,7 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon,
                        CalibrationWorkspace=vanadium,
                        Target='ElasticQ',
-                       XMin=4.5,
-                       Xmax=6.25,
-                       NumberBins=500,
+                       Params='4.5,0.0035,6.25',
                        OutputWorkspace='silicon_powder_q')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_q.png
@@ -81,7 +81,7 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon2,
                        CalibrationWorkspace=vanadium,
                        Target='ElasticDSpacing',
-                       NumberBins=1000,
+                       Params=0.002,
                        OutputWorkspace='silicon_powder_d_spacing')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_d.png
@@ -103,7 +103,7 @@ Usage
                        CalibrationWorkspace=vanadium,
                        BackgroundWorkspace=bkg,
                        Target='Theta',
-                       NumberBins=1000,
+                       Params=0.1,
                        OutputWorkspace='silicon_powder_background')
 
    # Scale background by 50%
@@ -112,7 +112,7 @@ Usage
                        BackgroundWorkspace=bkg,
                        BackgroundScale=0.5,
                        Target='Theta',
-                       NumberBins=1000,
+                       Params=0.1,
                        OutputWorkspace='silicon_powder_background_0.5')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_bkg.png

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -22,6 +22,7 @@ Improvements
 - :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` and :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now support outputting the unfocussed data and weighted events (with time). This allows for event filtering **after** processing the data.
 - :ref:`LoadWAND <algm-LoadWAND>` has grouping option added and loads faster
 - Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
+- :ref:`WANDPowderReduction <algm-WANDPowderReduction>` has been change from using ResampleX to Rebin so that bin size can be specified instead of number of bins as requested by the instrument scientist.
 - :ref:`Le Bail concept page <Le Bail Fit>` moved from mediawiki
 - Rework of :ref:`powder diffraction calibration <Powder Diffraction Calibration>` documentation
 


### PR DESCRIPTION
WANDPowderReduction has been change from using ResampleX to Rebin so that bin size can be specified instead of number of bins as requested by the instrument scientist.

**Report to:** Matthias Frontzek

**To test:**
Look at the updated usage examples

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
