### PR TITLE
Checks for muon analysis x range

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -18,6 +18,7 @@ Bugfixes
 ########
 - Results table now includes all logs that are common to all of the loaded files.
 - When turning TF Asymmetry mode off it no longer resets the global options.
+- The x limits on the settings tab will now correct themselves if bad values are entered. 
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1948,7 +1948,7 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
     QMessageBox::warning(
         this, tr("Muon Analysis"),
         tr("Upper bound is beyond data range.\n"
-           "Setting end time to last time value (minus 1e-6)."),
+           "Setting end time to last time value (minus 1)."),
         QMessageBox::Ok, QMessageBox::Ok);
     // subtract a small amount off to prevent a crash from using the exact end
     upper = *max_element(xData.begin(), xData.end()) - 1.;
@@ -1957,9 +1957,9 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
   if (upper < *min_element(xData.begin(), xData.end())) {
     QMessageBox::warning(this, tr("Muon Analysis"),
                          tr("No data in selected range.\n"
-                            "Setting end time to last time value."),
+                            "Setting end time to last time value (minus 1)."),
                          QMessageBox::Ok, QMessageBox::Ok);
-    upper = *max_element(xData.begin(), xData.end()) - 1.e-6;
+    upper = *max_element(xData.begin(), xData.end()) - 1.;
     m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
   }
   params["XAxisMax"] = QString::number(upper);

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -40,7 +40,7 @@
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <Poco/StringTokenizer.h>
-
+#include <math.h>
 #include <boost/lexical_cast.hpp>
 
 #include <algorithm>
@@ -1936,8 +1936,6 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
   // Get parameter values from the options tab
   QMap<QString, QString> params = m_optionTab->parsePlotStyleParams();
   auto upper = m_uiForm.timeAxisFinishAtInput->text().toDouble();
-  params["XAxisMax"] =
-	  QString::number(upper);
 
   Workspace_sptr ws_ptr =
 	  AnalysisDataService::Instance().retrieve(wsName.toStdString());
@@ -1947,6 +1945,17 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
 
   auto lower =
 	  m_uiForm.timeAxisStartAtInput->text().toDouble();
+  if (upper < *min_element(xData.begin(), xData.end())) {
+	  QMessageBox::warning(this, tr("Muon Analysis"),
+		  tr("No data in selected range.\n"
+			  "Setting end time to last time value."),
+		  QMessageBox::Ok, QMessageBox::Ok);
+	  upper = *max_element(xData.begin(), xData.end());
+	  m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
+
+  }
+  params["XAxisMax"] =
+	  QString::number(upper);
   if (lower > upper) {
 	  QMessageBox::warning(this, tr("Muon Analysis"),
 		  tr("Time max is less than time min.\n"
@@ -1967,6 +1976,7 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
   }
   params["XAxisMin"] =
 	  QString::number(lower);
+
   // If autoscale disabled
   if (params["YAxisAuto"] == "False") {
     // Get specified min/max values for Y axis

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1945,11 +1945,10 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
 
   auto lower = m_uiForm.timeAxisStartAtInput->text().toDouble();
   if (upper > *max_element(xData.begin(), xData.end())) {
-    QMessageBox::warning(
-        this, tr("Muon Analysis"),
-        tr("Upper bound is beyond data range.\n"
-           "Setting end time to last time value (minus 1)."),
-        QMessageBox::Ok, QMessageBox::Ok);
+    QMessageBox::warning(this, tr("Muon Analysis"),
+                         tr("Upper bound is beyond data range.\n"
+                            "Setting end time to last time value (minus 1)."),
+                         QMessageBox::Ok, QMessageBox::Ok);
     // subtract a small amount off to prevent a crash from using the exact end
     upper = *max_element(xData.begin(), xData.end()) - 1.;
     m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1945,13 +1945,14 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
 
   auto lower = m_uiForm.timeAxisStartAtInput->text().toDouble();
   if (upper > *max_element(xData.begin(), xData.end())) {
-	  QMessageBox::warning(this, tr("Muon Analysis"),
-		  tr("Upper bound is beyond data range.\n"
-			  "Setting end time to last time value (minus 1e-6)."),
-		  QMessageBox::Ok, QMessageBox::Ok);
-	  // subtract a small amount off to prevent a crash from using the exact end
-	  upper = *max_element(xData.begin(), xData.end()) - 1.;
-	  m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
+    QMessageBox::warning(
+        this, tr("Muon Analysis"),
+        tr("Upper bound is beyond data range.\n"
+           "Setting end time to last time value (minus 1e-6)."),
+        QMessageBox::Ok, QMessageBox::Ok);
+    // subtract a small amount off to prevent a crash from using the exact end
+    upper = *max_element(xData.begin(), xData.end()) - 1.;
+    m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
   }
   if (upper < *min_element(xData.begin(), xData.end())) {
     QMessageBox::warning(this, tr("Muon Analysis"),

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -1937,10 +1937,10 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
   QMap<QString, QString> params = m_optionTab->parsePlotStyleParams();
   auto upper = m_uiForm.timeAxisFinishAtInput->text().toDouble();
 
-  Workspace_sptr ws_ptr =
+  Workspace_const_sptr ws_ptr =
       AnalysisDataService::Instance().retrieve(wsName.toStdString());
   MatrixWorkspace_const_sptr matrix_workspace =
-      boost::dynamic_pointer_cast<MatrixWorkspace>(ws_ptr);
+      boost::dynamic_pointer_cast<const MatrixWorkspace>(ws_ptr);
   const auto &xData = matrix_workspace->x(0);
 
   auto lower = m_uiForm.timeAxisStartAtInput->text().toDouble();

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -40,8 +40,8 @@
 #include <Poco/File.h>
 #include <Poco/Path.h>
 #include <Poco/StringTokenizer.h>
-#include <math.h>
 #include <boost/lexical_cast.hpp>
+#include <math.h>
 
 #include <algorithm>
 
@@ -1938,44 +1938,39 @@ QMap<QString, QString> MuonAnalysis::getPlotStyleParams(const QString &wsName) {
   auto upper = m_uiForm.timeAxisFinishAtInput->text().toDouble();
 
   Workspace_sptr ws_ptr =
-	  AnalysisDataService::Instance().retrieve(wsName.toStdString());
+      AnalysisDataService::Instance().retrieve(wsName.toStdString());
   MatrixWorkspace_sptr matrix_workspace =
-	  boost::dynamic_pointer_cast<MatrixWorkspace>(ws_ptr);
+      boost::dynamic_pointer_cast<MatrixWorkspace>(ws_ptr);
   const auto &xData = matrix_workspace->x(0);
 
-  auto lower =
-	  m_uiForm.timeAxisStartAtInput->text().toDouble();
+  auto lower = m_uiForm.timeAxisStartAtInput->text().toDouble();
   if (upper < *min_element(xData.begin(), xData.end())) {
-	  QMessageBox::warning(this, tr("Muon Analysis"),
-		  tr("No data in selected range.\n"
-			  "Setting end time to last time value."),
-		  QMessageBox::Ok, QMessageBox::Ok);
-	  upper = *max_element(xData.begin(), xData.end());
-	  m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
-
+    QMessageBox::warning(this, tr("Muon Analysis"),
+                         tr("No data in selected range.\n"
+                            "Setting end time to last time value."),
+                         QMessageBox::Ok, QMessageBox::Ok);
+    upper = *max_element(xData.begin(), xData.end());
+    m_uiForm.timeAxisFinishAtInput->setText(QString::number(upper));
   }
-  params["XAxisMax"] =
-	  QString::number(upper);
+  params["XAxisMax"] = QString::number(upper);
   if (lower > upper) {
-	  QMessageBox::warning(this, tr("Muon Analysis"),
-		  tr("Time max is less than time min.\n"
-			  "Will change time min."),
-		  QMessageBox::Ok, QMessageBox::Ok);
-	  lower = upper - 1.0; // we know it will always be lower
-						   //update UI
-	  m_uiForm.timeAxisStartAtInput->setText(QString::number(lower));
+    QMessageBox::warning(this, tr("Muon Analysis"),
+                         tr("Time max is less than time min.\n"
+                            "Will change time min."),
+                         QMessageBox::Ok, QMessageBox::Ok);
+    lower = upper - 1.0; // we know it will always be lower
+                         // update UI
+    m_uiForm.timeAxisStartAtInput->setText(QString::number(lower));
   }
   if (lower > *max_element(xData.begin(), xData.end())) {
-	  QMessageBox::warning(this, tr("Muon Analysis"),
-		  tr("No data in selected range.\n"
-			  "Setting start time to first time value."),
-		  QMessageBox::Ok, QMessageBox::Ok);
-	  lower = *min_element(xData.begin(), xData.end());
-	  m_uiForm.timeAxisStartAtInput->setText(QString::number(lower));
-
+    QMessageBox::warning(this, tr("Muon Analysis"),
+                         tr("No data in selected range.\n"
+                            "Setting start time to first time value."),
+                         QMessageBox::Ok, QMessageBox::Ok);
+    lower = *min_element(xData.begin(), xData.end());
+    m_uiForm.timeAxisStartAtInput->setText(QString::number(lower));
   }
-  params["XAxisMin"] =
-	  QString::number(lower);
+  params["XAxisMin"] = QString::number(lower);
 
   // If autoscale disabled
   if (params["YAxisAuto"] == "False") {


### PR DESCRIPTION
**Description of work.**
Muon analysis was crashing Mantid when the x range was invalid. This PR is to fix it. 
**Report to:** James. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
1. Open Muon Analysis
2. Load some data 
3. Go to the settings tab
4. Change the time axis, start value to be greater than the end time (use to crash)
5. Change the time axis end value to 50 and then the start value to 40 (use to crash)
6.  Change the time axis end value to -10 and then the start value to -20 (use to show no data)
<!-- Instructions for testing. -->

Fixes #24052. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
