### PR TITLE
Use Xvfb on Linux build servers

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -15,7 +15,7 @@ SCRIPT_DIR=$(dirname "$0")
 # System discovery
 ###############################################################################
 USE_CORE_DUMPS=true
-X11_RUNNER=""
+X11_RUNNER="eval"
 X11_RUNNER_ARGS=""
 if [[ ${NODE_LABELS} == *rhel7* ]] || [[ ${NODE_LABELS} == *centos7* ]] || [[ ${NODE_LABELS} == *scilin7* ]]; then
   ON_RHEL7=true

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -15,11 +15,14 @@ SCRIPT_DIR=$(dirname "$0")
 # System discovery
 ###############################################################################
 USE_CORE_DUMPS=true
+X11_RUNNER=""
 if [[ ${NODE_LABELS} == *rhel7* ]] || [[ ${NODE_LABELS} == *centos7* ]] || [[ ${NODE_LABELS} == *scilin7* ]]; then
   ON_RHEL7=true
+  X11_RUNNER="xvfb-run"
 fi
 if [[ ${NODE_LABELS} == *ubuntu* ]]; then
   ON_UBUNTU=true
+  X11_RUNNER="xvfb-run"
 fi
 if [[ ${NODE_LABELS} == *osx* ]]; then
   ON_MACOS=true
@@ -347,7 +350,7 @@ userprops_file=$userconfig_dir/Mantid.user.properties
 echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
-  $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+  ${X11_RUNNER} $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
 fi
 
 ###############################################################################
@@ -362,8 +365,8 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
     rm -fr $BUILD_DIR/docs/doctrees/*
   fi
   # Build HTML to verify that no referencing errors have crept in.
-  ${CMAKE_EXE} --build . --target docs-html
-  ${CMAKE_EXE} --build . --target docs-test
+  ${X11_RUNNER} ${CMAKE_EXE} --build . --target docs-html
+  ${X11_RUNNER} ${CMAKE_EXE} --build . --target docs-test
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -16,13 +16,16 @@ SCRIPT_DIR=$(dirname "$0")
 ###############################################################################
 USE_CORE_DUMPS=true
 X11_RUNNER=""
+X11_RUNNER_ARGS=""
 if [[ ${NODE_LABELS} == *rhel7* ]] || [[ ${NODE_LABELS} == *centos7* ]] || [[ ${NODE_LABELS} == *scilin7* ]]; then
   ON_RHEL7=true
   X11_RUNNER="xvfb-run"
+  X11_RUNNER_ARGS=--server-args="-screen 0 640x480x24"
 fi
 if [[ ${NODE_LABELS} == *ubuntu* ]]; then
   ON_UBUNTU=true
   X11_RUNNER="xvfb-run"
+  X11_RUNNER_ARGS=--server-args="-screen 0 640x480x24"
 fi
 if [[ ${NODE_LABELS} == *osx* ]]; then
   ON_MACOS=true
@@ -350,7 +353,7 @@ userprops_file=$userconfig_dir/Mantid.user.properties
 echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
-  ${X11_RUNNER} $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+  ${X11_RUNNER} "${X11_RUNNER_ARGS}" $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
 fi
 
 ###############################################################################
@@ -365,8 +368,8 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
     rm -fr $BUILD_DIR/docs/doctrees/*
   fi
   # Build HTML to verify that no referencing errors have crept in.
-  ${X11_RUNNER} ${CMAKE_EXE} --build . --target docs-html
-  ${X11_RUNNER} ${CMAKE_EXE} --build . --target docs-test
+  ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-html
+  ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-test
 fi
 
 ###############################################################################

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -101,14 +101,9 @@ Service" has completed you should
 Linux
 -----
 
-Install an ssh server.
+Install an ssh server, ``ccache``, ``curl`` and ``xvfb``.
 
-Install ``ccache``. After installing run ``ccache --max-size=20G`` from the ``builder`` account.
-
-Install a vnc server and from the ``builder`` account run ``vncpasswd`` to set a password on the VNC server. It
-can be any password.
-
-Ensure ``curl`` is installed
+From the ``builder`` account run ``ccache --max-size=20G``.
 
 Any machines acting as performance test servers will require ``mysqldb`` to be installed.
 


### PR DESCRIPTION
**Description of work.**

Creates an X server for unit tests and user documentation generation and tests.

**Report to:** @martyngigg 

**To test:**

<!-- Instructions for testing. -->

See that the RHEL and Ubuntu builds pass.

*This does not require release notes* because users couldn't care less about the X server we use to test their software.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
