### PR TITLE
Add min number of events for rebinning

### DIFF
--- a/Framework/LiveData/src/LoadLiveData.cpp
+++ b/Framework/LiveData/src/LoadLiveData.cpp
@@ -425,10 +425,11 @@ Workspace_sptr LoadLiveData::appendMatrixWSChunk(Workspace_sptr accumWS,
 
 namespace {
 bool isUsingDefaultBinBoundaries(const EventWorkspace *workspace) {
-  // returning false for empty workspaces tells the caller not to try
+  // returning false for workspaces where we don't have enough events
+  // for a meaningful rebinning, and tells the caller not to try
   // to rebin the data. See EventList::getEventXMinMax() for what the
   // workspace binning will look like with this choice.
-  if (workspace->getNumberEvents() == 0)
+  if (workspace->getNumberEvents() <= 2)
     return false;
 
   // only check first spectrum


### PR DESCRIPTION
**Description of work.**
The live data listener wants to rebin the data after a new block of events is read in.
When we have too few events, rebinning is no meaningful and causes an exception to be thrown.
This PR changes the minimum number of events required to try a rebin.

**Report to:** nobody

**To test:**
- Start the live listener on BL4A
- Inspect code

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
