### PR TITLE
Dealt with nans in ISIS Gem Texture mode output

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -128,11 +128,15 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
     if instrument.get_instrument_prefix() == "GEM":
         divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum,
                                 StoreInADS=False)
+        complete = mantid.ReplaceSpecialValues(InputWorkspace=divided, NaNValue=0, StoreInADS=False)
         # crop based off max between 1000 and 2000 tof as the vanadium peak on Gem will always occur here
-        return _crop_spline_to_percent_of_max(rebinned_spline, divided, spectrum, 1000, 2000)
+        return _crop_spline_to_percent_of_max(rebinned_spline, complete, spectrum, 1000, 2000)
 
-    divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum)
-    return divided
+    divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum,
+                            StoreInADS=False)
+    complete = mantid.ReplaceSpecialValues(InputWorkspace=divided, NaNValue=0)
+
+    return complete
 
 
 def _divide_by_vanadium_splines(spectra_list, vanadium_splines, instrument):

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -132,9 +132,9 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
         # crop based off max between 1000 and 2000 tof as the vanadium peak on Gem will always occur here
         return _crop_spline_to_percent_of_max(rebinned_spline, complete, spectrum, 1000, 2000)
 
-    divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline, OutputWorkspace=spectrum,
+    divided = mantid.Divide(LHSWorkspace=spectrum, RHSWorkspace=rebinned_spline,
                             StoreInADS=False)
-    complete = mantid.ReplaceSpecialValues(InputWorkspace=divided, NaNValue=0)
+    complete = mantid.ReplaceSpecialValues(InputWorkspace=divided, NaNValue=0, OutputWorkspace=spectrum)
 
     return complete
 


### PR DESCRIPTION
**Description of work.**
added `replacespecialvalues` to divide by single spline to deal with nans caused by inputs where both the sample and vanadium have a spectrum of zeros

**To test:**
run the following script with these [files](https://github.com/mantidproject/mantid/files/2603753/Gem.zip)


(if you don't have access to the isis data search archive you will require additional files from me)
```
from isis_powder import Gem
config_file_path = r"/path/to/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no="86105",texture_mode=True, save_all=False)
Gem_example.focus(input_mode="Individual", run_number="86105",texture_mode=True, save_all=False)
```
ensure all paths in the files and script are updated.
the plot the workspace `86100,86101-ResultD_20` it should be made up of only zero's

Re #23170 



*This does not require release notes* because **Deals with problem only visible in nightly build**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
