### PR TITLE
Fix toftof scripter unit test

### DIFF
--- a/scripts/test/TOFTOF/TOFTOFScriptElementTest.py
+++ b/scripts/test/TOFTOF/TOFTOFScriptElementTest.py
@@ -180,7 +180,8 @@ class TOFTOFScriptElementTest(unittest.TestCase):
         self.scriptElement.createDiff    = True
         self.scriptElement.keepSteps     = True
 
-        testhelpers.assertRaisesNothing(self, self.execScript, self.scriptElement.to_script())
+        testhelpers.assertRaisesNothing(self, self.execScript, 
+                                        self.scriptElement.to_script().replace('import matplotlib.pyplot as plt', ''))
 
     def test_that_script_has_correct_syntax(self):
         self.scriptElement.binEon = False


### PR DESCRIPTION
**Description of work.**

Fixes the TOFTOF scripter unit test failure on some build servers. Since script does not need any plotting, the easiest way is just to remove `import matplotlib.pyplot` from the script while testing.

**To test:**

Check that builds don't fail any more.

<!-- Instructions for testing. -->


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
