### PR TITLE
Start mantidplot in systemtest

### DIFF
--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -56,4 +56,6 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
             f.write('raise RuntimeError("GUITest")')
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
+        mantid.kernel.logger.error(str(out))
+        mantid.kernel.logger.error(str(err))
         self.assertTrue(b'Fatal' in err)

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -1,0 +1,50 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, print_function)
+import os, subprocess
+import systemtesting
+import mantid
+
+
+class GUIStartupTest(systemtesting.MantidSystemTest):
+
+    def __init__(self):
+        super(GUIStartupTest, self).__init__()
+        #create simple script
+        self.script=os.path.join(mantid.config.getString('defaultsave.directory'),'GUIStartupTest_script.py')
+        with open(self.script,'w') as f:
+            f.write('import mantid\n'
+                    'mantid.config["logging.channels.consoleChannel.class"]="StdoutChannel"\n'
+                    'print("Hello Mantid")\n')
+
+    def skipTests(self):
+        #we rely on finding launch_mantidplot.sh
+        import platform
+        return "Linux" not in platform.platform()
+
+    def cleanup(self):
+        if os.path.exists(self.script):
+            os.remove(self.script)
+
+    def runTest(self):
+        mantid_exe = os.path.join(os.path.dirname(mantid.__file__),"../launch_mantidplot.sh")
+        cmd='{0} -xq {1}'.format(mantid_exe,self.script)
+        # good startup
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        out, err = p.communicate()
+
+        self.assertEquals(out, b'Hello Mantid\n')
+        self.assertFalse(b'Fatal' in err)
+
+        # failing script
+        with open(self.script,'a') as f:
+            f.write('raise RuntimeError("GUITest")')
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
+        out, err = p.communicate()
+        self.assertEquals(out, b'Hello Mantid\n')
+        self.assertTrue(b'Fatal' in err)
+

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -13,6 +13,11 @@ import mantid
 
 
 class GUIStartupTest(systemtesting.MantidSystemTest):
+    '''
+    This test is supposed to start MantidPlot, and execute a simple script
+    If the script is run correctly, the "Hello Mantid" will be printed to stdout
+    If the script fails, there will be a fatal error mesage in stderr
+    '''
 
     def __init__(self):
         super(GUIStartupTest, self).__init__()
@@ -43,7 +48,6 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         # good startup
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
-
         self.assertEquals(out, b'Hello Mantid\n')
         self.assertFalse(b'Fatal' in err)
 

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -21,11 +21,11 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
 
     def __init__(self):
         super(GUIStartupTest, self).__init__()
+        self.maxDiff = None
         #create simple script
         self.script=os.path.join(mantid.config.getString('defaultsave.directory'),'GUIStartupTest_script.py')
         with open(self.script,'w') as f:
             f.write('import mantid\n'
-                    'mantid.config["logging.channels.consoleChannel.class"]="StdoutChannel"\n'
                     'print("Hello Mantid")\n')
         #get the mantidplot executable
         current_platform = platform.platform()
@@ -56,5 +56,5 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
             f.write('raise RuntimeError("GUITest")')
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
-        self.assertEquals(str(err),'some string')
+        self.assertEquals(str(out),"b'Hello Mantid\\n'")
         self.assertTrue(b'Fatal' in err)

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -56,6 +56,5 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
             f.write('raise RuntimeError("GUITest")')
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
-        mantid.kernel.logger.error(str(out))
-        mantid.kernel.logger.error(str(err))
+        self.assertEquals(str(err),'some string')
         self.assertTrue(b'Fatal' in err)

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -5,7 +5,8 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
-import os, subprocess
+import os
+import subprocess
 import systemtesting
 import mantid
 
@@ -47,4 +48,3 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         out, err = p.communicate()
         self.assertEquals(out, b'Hello Mantid\n')
         self.assertTrue(b'Fatal' in err)
-

--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -49,12 +49,12 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
         self.assertEquals(out, b'Hello Mantid\n')
-        self.assertFalse(b'Fatal' in err)
 
         # failing script
         with open(self.script,'a') as f:
             f.write('raise RuntimeError("GUITest")')
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
-        self.assertEquals(str(out),"b'Hello Mantid\\n'")
-        self.assertTrue(b'Fatal' in err)
+        out += err
+        self.assertTrue(b'Hello Mantid\n' in out)
+        self.assertTrue(b'RuntimeError: GUITest' in out)


### PR DESCRIPTION
**Description of work.**

Created a systemtest that starts mantidplot (the GUI) and expects no errors on a good script and fatal error on a bad script

**To test:**

Run systemtest locally on a linux machine with  `./systemtest -R GUIStartup`. MantidPlot should start up twice.

Fixes #7843
*This does not require release notes* because **users don't care about systemtests**


**Note:** this does not currently test the new workbench
 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
