### PR TITLE
ISIS Powder prevent reloading of loaded vanadium

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -65,6 +65,7 @@ Improvements
 - Focus on Pearl now has a focused_bin_widths parameter in pearl_advanced_config.py to allow setting default rebin values.
 - Focus on Pearl now saves out xye_tof files.
 - :ref:`PDLoadCharacterizations <algm-PDLoadCharacterizations>` now sets the same run numbers for all rows when using an ``exp.ini`` file.
+- Focus now checks if the vanadium for a run is already loaded before loading it in to prevent reloading the same vanadium multiple times.
 
 
 Bugfixes

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -113,12 +113,10 @@ def _batched_run_focusing(instrument, perform_vanadium_norm, run_number_string, 
     van = "van_{}".format(run_details.vanadium_run_numbers)
     if perform_vanadium_norm:
         if van not in mantid.mtd:
-            print ("load van")
             vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path,
                                                 OutputWorkspace=van)
         else:
             vanadium_splines = mantid.mtd[van]
-            print(vanadium_splines)
 
     output = None
     for ws in read_ws_list:
@@ -167,7 +165,6 @@ def _individual_run_focusing(instrument, perform_vanadium_norm, run_number, abso
     van = "van_{}".format(run_details.vanadium_run_numbers)
     if perform_vanadium_norm:
         if van not in mantid.mtd:
-            print("load van")
             vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path,
                                                 OutputWorkspace=van)
         else:

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -143,7 +143,7 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
 def _divide_by_vanadium_splines(spectra_list, vanadium_splines, instrument):
     if hasattr(vanadium_splines, "OutputWorkspace"):
         vanadium_splines = vanadium_splines.OutputWorkspace
-    if type(vanadium_splines)is WorkspaceGroup:  # vanadium splines is a workspacegroup
+    if type(vanadium_splines) is WorkspaceGroup:  # vanadium splines is a workspacegroup
         num_splines = len(vanadium_splines)
         num_spectra = len(spectra_list)
         if num_splines != num_spectra:

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -5,7 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
-
+from mantid.api import WorkspaceGroup
 import mantid.simpleapi as mantid
 
 import isis_powder.routines.common as common
@@ -110,8 +110,15 @@ def _batched_run_focusing(instrument, perform_vanadium_norm, run_number_string, 
                                                           instrument=instrument)
     run_details = instrument._get_run_details(run_number_string=run_number_string)
     vanadium_splines = None
+    van = "van_{}".format(run_details.vanadium_run_numbers)
     if perform_vanadium_norm:
-        vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path)
+        if van not in mantid.mtd:
+            print ("load van")
+            vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path,
+                                                OutputWorkspace=van)
+        else:
+            vanadium_splines = mantid.mtd[van]
+            print(vanadium_splines)
 
     output = None
     for ws in read_ws_list:
@@ -136,8 +143,9 @@ def _divide_one_spectrum_by_spline(spectrum, spline, instrument):
 
 
 def _divide_by_vanadium_splines(spectra_list, vanadium_splines, instrument):
-    if hasattr(vanadium_splines, "OutputWorkspace"):  # vanadium_splines is a group
+    if hasattr(vanadium_splines, "OutputWorkspace"):
         vanadium_splines = vanadium_splines.OutputWorkspace
+    if type(vanadium_splines)is WorkspaceGroup:  # vanadium splines is a workspacegroup
         num_splines = len(vanadium_splines)
         num_spectra = len(spectra_list)
         if num_splines != num_spectra:
@@ -146,7 +154,7 @@ def _divide_by_vanadium_splines(spectra_list, vanadium_splines, instrument):
         output_list = [_divide_one_spectrum_by_spline(data_ws, van_ws, instrument)
                        for data_ws, van_ws in zip(spectra_list, vanadium_splines)]
         return output_list
-    output_list = [_divide_one_spectrum_by_spline(spectra_list[0], vanadium_splines)]
+    output_list = [_divide_one_spectrum_by_spline(spectra_list[0], vanadium_splines, instrument)]
     common.remove_intermediate_workspace(vanadium_splines)
     return output_list
 
@@ -156,8 +164,15 @@ def _individual_run_focusing(instrument, perform_vanadium_norm, run_number, abso
     run_numbers = common.generate_run_numbers(run_number_string=run_number)
     run_details = instrument._get_run_details(run_number_string=run_number)
     vanadium_splines = None
+    van = "van_{}".format(run_details.vanadium_run_numbers)
     if perform_vanadium_norm:
-        vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path)
+        if van not in mantid.mtd:
+            print("load van")
+            vanadium_splines = mantid.LoadNexus(Filename=run_details.splined_vanadium_file_path,
+                                                OutputWorkspace=van)
+        else:
+            vanadium_splines = mantid.mtd[van]
+
     output = None
     for run in run_numbers:
         ws = common.load_current_normalised_ws_list(run_number_string=run, instrument=instrument)


### PR DESCRIPTION
**Description of work.**
changed naming of vanadium workspaces so that a check can be made to see if the required vanadium has already been loaded, to prevent loading the workpace multiple times if multiple runs within a cycle are focused

**To test:**
Run the following script with these [files](https://github.com/mantidproject/mantid/files/2608762/Gem.zip)

```
from isis_powder import Gem
config_file_path = r"path/to/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.create_vanadium(input_mode="Individual",first_cycle_run_no="84213",texture_mode=False, save_all=False)
```
then clear the ads and run the following script twice
```
from isis_powder import Gem
config_file_path = r"path/to/Gem_config_example.yaml"
Gem_example = Gem(config_file=config_file_path,user_name="test")
Gem_example.focus(input_mode="Individual", run_number="84214",texture_mode=False, save_all=False)
```
The workspace van_84246 should be loaded only on the first run
(This test assumes access to the ISIS Data Search Archive, and will require additional files if you dont have access to it)

Fixes #22698 (this also suggests doing it for empty's but as empty's are deleted after they are subtracted that isn't currently possible)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
