### PR TITLE
Replace use of old IDFs_for_UNIT_TESTING directory name

### DIFF
--- a/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaHistoStreamDecoderTest.h
@@ -39,14 +39,13 @@ public:
     auto &config = ConfigService::Instance();
     auto baseInstDir = config.getInstrumentDirectory();
     Poco::Path testFile =
-        Poco::Path(baseInstDir)
-            .resolve("IDFs_for_UNIT_TESTING/UnitTestFacilities.xml");
+        Poco::Path(baseInstDir).resolve("unit_testing/UnitTestFacilities.xml");
     // Load the test facilities file
     config.updateFacilities(testFile.toString());
     config.setFacility("TEST");
     // Update instrument search directory
     config.setString("instrumentDefinition.directory",
-                     baseInstDir + "/IDFs_for_UNIT_TESTING");
+                     baseInstDir + "/unit_testing");
   }
 
   void tearDown() override {


### PR DESCRIPTION
**Description of work.**

The  old `IDFs_for_UNIT_TESTING` directory was renamed in #23946. #23749 contained a reference to this directory but the PR builds for it ran *before*  #23946 was merged so everything looked okay. Once #23946 was merged the path in #23749 became invalid and create build errors when merged to `master`.

This renames the directory reference to `unit_testing`.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Checkout master and the `ctest -R Kafka` unit tests should fail. Merging this will fix them.

*There is no associated issue.*

*This does not require release notes* because **fixes a developer build issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
