### PR TITLE
Indirect - ConvFit Fit parameter errors not updating when changing  Plot Spectrum

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -198,8 +198,14 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
           m_plotPresenter.get(), SLOT(setStartX(double)));
   connect(m_fitPropertyBrowser, SIGNAL(endXChanged(double)),
           m_plotPresenter.get(), SLOT(setEndX(double)));
-  connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)),
-          m_plotPresenter.get(), SLOT(setPlotSpectrum(int)));
+  connect(m_fitPropertyBrowser, SIGNAL(updatePlotSpectrum(int)),
+          m_plotPresenter.get(), SLOT(updatePlotSpectrum(int)));
+	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+		      SLOT(setBrowserWorkspaceIndex(int)));
+	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+		      SLOT(updateAttributeValues()));
+	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+		      SLOT(updateParameterValues()));
 
   connect(m_plotPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(setBrowserStartX(double)));
@@ -410,7 +416,11 @@ void IndirectFitAnalysisTab::setBrowserWorkspace(std::size_t dataIndex) {
 }
 
 void IndirectFitAnalysisTab::setBrowserWorkspaceIndex(std::size_t spectrum) {
-  m_fitPropertyBrowser->setWorkspaceIndex(boost::numeric_cast<int>(spectrum));
+	setBrowserWorkspaceIndex(boost::numeric_cast<int>(spectrum));
+}
+
+void IndirectFitAnalysisTab::setBrowserWorkspaceIndex(int spectrum) {
+	m_fitPropertyBrowser->setWorkspaceIndex(spectrum);
 }
 
 void IndirectFitAnalysisTab::tableStartXChanged(double startX,

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -114,10 +114,6 @@ void IndirectFitAnalysisTab::setup() {
           SLOT(updateResultOptions()));
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
           SLOT(updateParameterValues()));
-  connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
-          this, SLOT(updateParameterValues()));
-  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-          SLOT(updateParameterValues()));
 
   connect(m_plotPresenter.get(),
           SIGNAL(fitSingleSpectrum(std::size_t, std::size_t)), this,
@@ -183,14 +179,20 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
           SLOT(setBrowserWorkspaceIndex(std::size_t)));
   connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
           this, SLOT(setBrowserWorkspace(std::size_t)));
-  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-          SLOT(setBrowserWorkspaceIndex(std::size_t)));
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
           SLOT(updateAttributeValues()));
   connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
           this, SLOT(updateAttributeValues()));
-  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-          SLOT(updateAttributeValues()));
+	connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
+		      this, SLOT(updateParameterValues()));
+	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+		      SLOT(setBrowserWorkspaceIndex(std::size_t)));
+	// Update attributes before parameters as the parameters may depend on the 
+	// attribute values
+	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+		      SLOT(updateAttributeValues()));
+	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+		      SLOT(updateParameterValues()));
 
   connect(m_fitPropertyBrowser, SIGNAL(startXChanged(double)),
           m_plotPresenter.get(), SLOT(setStartX(double)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -200,12 +200,12 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
           m_plotPresenter.get(), SLOT(setEndX(double)));
   connect(m_fitPropertyBrowser, SIGNAL(updatePlotSpectrum(int)),
           m_plotPresenter.get(), SLOT(updatePlotSpectrum(int)));
-	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
-		      SLOT(setBrowserWorkspaceIndex(int)));
-	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
-		      SLOT(updateAttributeValues()));
-	connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
-		      SLOT(updateParameterValues()));
+  connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+          SLOT(setBrowserWorkspaceIndex(int)));
+  connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+          SLOT(updateAttributeValues()));
+  connect(m_fitPropertyBrowser, SIGNAL(workspaceIndexChanged(int)), this,
+          SLOT(updateParameterValues()));
 
   connect(m_plotPresenter.get(), SIGNAL(startXChanged(double)), this,
           SLOT(setBrowserStartX(double)));
@@ -416,11 +416,11 @@ void IndirectFitAnalysisTab::setBrowserWorkspace(std::size_t dataIndex) {
 }
 
 void IndirectFitAnalysisTab::setBrowserWorkspaceIndex(std::size_t spectrum) {
-	setBrowserWorkspaceIndex(boost::numeric_cast<int>(spectrum));
+  setBrowserWorkspaceIndex(boost::numeric_cast<int>(spectrum));
 }
 
 void IndirectFitAnalysisTab::setBrowserWorkspaceIndex(int spectrum) {
-	m_fitPropertyBrowser->setWorkspaceIndex(spectrum);
+  m_fitPropertyBrowser->setWorkspaceIndex(spectrum);
 }
 
 void IndirectFitAnalysisTab::tableStartXChanged(double startX,

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -183,16 +183,16 @@ void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
           SLOT(updateAttributeValues()));
   connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
           this, SLOT(updateAttributeValues()));
-	connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
-		      this, SLOT(updateParameterValues()));
-	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-		      SLOT(setBrowserWorkspaceIndex(std::size_t)));
-	// Update attributes before parameters as the parameters may depend on the 
-	// attribute values
-	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-		      SLOT(updateAttributeValues()));
-	connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
-		      SLOT(updateParameterValues()));
+  connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
+          this, SLOT(updateParameterValues()));
+  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+          SLOT(setBrowserWorkspaceIndex(std::size_t)));
+  // Update attributes before parameters as the parameters may depend on the
+  // attribute values
+  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+          SLOT(updateAttributeValues()));
+  connect(m_plotPresenter.get(), SIGNAL(plotSpectrumChanged(std::size_t)), this,
+          SLOT(updateParameterValues()));
 
   connect(m_fitPropertyBrowser, SIGNAL(startXChanged(double)),
           m_plotPresenter.get(), SLOT(setStartX(double)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -173,7 +173,8 @@ protected slots:
   void updateBrowserFittingRange();
   void setBrowserWorkspace();
   void setBrowserWorkspace(std::size_t dataIndex);
-  void setBrowserWorkspaceIndex(std::size_t spectrum);
+	void setBrowserWorkspaceIndex(std::size_t spectrum);
+  void setBrowserWorkspaceIndex(int spectrum);
   void tableStartXChanged(double startX, std::size_t dataIndex,
                           std::size_t spectrum);
   void tableEndXChanged(double endX, std::size_t dataIndex,

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -173,7 +173,7 @@ protected slots:
   void updateBrowserFittingRange();
   void setBrowserWorkspace();
   void setBrowserWorkspace(std::size_t dataIndex);
-	void setBrowserWorkspaceIndex(std::size_t spectrum);
+  void setBrowserWorkspaceIndex(std::size_t spectrum);
   void setBrowserWorkspaceIndex(int spectrum);
   void tableStartXChanged(double startX, std::size_t dataIndex,
                           std::size_t spectrum);

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -171,8 +171,11 @@ void IndirectFitPlotPresenter::setEndX(double endX) {
   m_view->setFitRangeMaximum(endX);
 }
 
-void IndirectFitPlotPresenter::setPlotSpectrum(int spectrum) {
-  m_view->setPlotSpectrum(spectrum);
+void IndirectFitPlotPresenter::updatePlotSpectrum(int spectrum) {
+	m_view->setPlotSpectrum(spectrum);
+	setActiveSpectrum(static_cast<std::size_t>(spectrum));
+	updatePlots();
+	updateFitRangeSelector();
 }
 
 void IndirectFitPlotPresenter::updateRangeSelectors() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -172,10 +172,10 @@ void IndirectFitPlotPresenter::setEndX(double endX) {
 }
 
 void IndirectFitPlotPresenter::updatePlotSpectrum(int spectrum) {
-	m_view->setPlotSpectrum(spectrum);
-	setActiveSpectrum(static_cast<std::size_t>(spectrum));
-	updatePlots();
-	updateFitRangeSelector();
+  m_view->setPlotSpectrum(spectrum);
+  setActiveSpectrum(static_cast<std::size_t>(spectrum));
+  updatePlots();
+  updateFitRangeSelector();
 }
 
 void IndirectFitPlotPresenter::updateRangeSelectors() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -30,7 +30,7 @@ public:
 public slots:
   void setStartX(double);
   void setEndX(double);
-  void setPlotSpectrum(int spectrum);
+  void updatePlotSpectrum(int spectrum);
   void hideMultipleDataSelection();
   void showMultipleDataSelection();
   void updateRangeSelectors();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -107,8 +107,8 @@ void IndirectFitPlotView::setMaximumSpectrum(int maximum) {
 }
 
 void IndirectFitPlotView::setPlotSpectrum(int spectrum) {
-	//MantidQt::API::SignalBlocker<QObject> blocker(m_plotForm->spPlotSpectrum);
-  //m_plotForm->spPlotSpectrum->setValue(spectrum);
+  // MantidQt::API::SignalBlocker<QObject> blocker(m_plotForm->spPlotSpectrum);
+  // m_plotForm->spPlotSpectrum->setValue(spectrum);
 }
 
 void IndirectFitPlotView::setBackgroundLevel(double value) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -107,7 +107,8 @@ void IndirectFitPlotView::setMaximumSpectrum(int maximum) {
 }
 
 void IndirectFitPlotView::setPlotSpectrum(int spectrum) {
-  m_plotForm->spPlotSpectrum->setValue(spectrum);
+	//MantidQt::API::SignalBlocker<QObject> blocker(m_plotForm->spPlotSpectrum);
+  //m_plotForm->spPlotSpectrum->setValue(spectrum);
 }
 
 void IndirectFitPlotView::setBackgroundLevel(double value) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -107,8 +107,8 @@ void IndirectFitPlotView::setMaximumSpectrum(int maximum) {
 }
 
 void IndirectFitPlotView::setPlotSpectrum(int spectrum) {
-  // MantidQt::API::SignalBlocker<QObject> blocker(m_plotForm->spPlotSpectrum);
-  // m_plotForm->spPlotSpectrum->setValue(spectrum);
+  MantidQt::API::SignalBlocker<QObject> blocker(m_plotForm->spPlotSpectrum);
+  m_plotForm->spPlotSpectrum->setValue(spectrum);
 }
 
 void IndirectFitPlotView::setBackgroundLevel(double value) {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -276,7 +276,8 @@ signals:
   void currentChanged() const;
   void functionRemoved();
   void algorithmFinished(const QString &);
-  void workspaceIndexChanged(int i);
+  void workspaceIndexChanged(int index);
+	void updatePlotSpectrum(int index);
   void workspaceNameChanged(const QString &);
 
   void wsChangePPAssign(const QString &);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -277,7 +277,7 @@ signals:
   void functionRemoved();
   void algorithmFinished(const QString &);
   void workspaceIndexChanged(int index);
-	void updatePlotSpectrum(int index);
+  void updatePlotSpectrum(int index);
   void workspaceNameChanged(const QString &);
 
   void wsChangePPAssign(const QString &);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1359,6 +1359,7 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
       h->setAttribute(prop);
       setWorkspaceIndex(index);
       emit workspaceIndexChanged(index);
+			emit updatePlotSpectrum(index);
     }
   } else if (prop == m_maxIterations || prop == m_peakRadius) {
     QSettings settings;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1359,7 +1359,7 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
       h->setAttribute(prop);
       setWorkspaceIndex(index);
       emit workspaceIndexChanged(index);
-			emit updatePlotSpectrum(index);
+      emit updatePlotSpectrum(index);
     }
   } else if (prop == m_maxIterations || prop == m_peakRadius) {
     QSettings settings;


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the errors of the fit parameters in Indirect Data Analysis ConvFit are not updated when the `Plot Spectrum` number is changed.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load data below
3. Fit type: Teixeira Water
4. Tick Delta Function
5. Flat Background
4. Tick Show Parameter errors
5. Click Run and wait
6. Change the Plot Spectrum and the errors next to the fit parameters should update

**Data**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2610732/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2610733/irs26173_graphite002_res.zip)

Fixes #24086

No release notes are required as this bug was introduced after the last release.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
