### PR TITLE
Change SANS workflow to fix Non-compatibility Mode

### DIFF
--- a/Framework/API/inc/MantidAPI/ISpectrum.h
+++ b/Framework/API/inc/MantidAPI/ISpectrum.h
@@ -70,6 +70,8 @@ public:
   virtual size_t getMemorySize() const = 0;
 
   virtual std::pair<double, double> getXDataRange() const;
+
+  virtual void applyBinWeight(const size_t &binIndex, const double &weight) = 0;
   // ---------------------------------------------------------
   void addDetectorID(const detid_t detID);
   void addDetectorIDs(const std::set<detid_t> &detIDs);

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1055,19 +1055,20 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   // this function is marked parallel critical
   flagMasked(workspaceIndex, binIndex, weight);
 
-  // this is the actual result of the masking that most algorithms and plotting
-  // implementations will see, the bin mask flags defined above are used by only
-  // some algorithms
-  // If the weight is 0, nothing more needs to be done after flagMasked above
-  // (i.e. NaN and Inf will also stay intact)
-  // If the weight is not 0, NaN and Inf values are set to 0,
-  // whereas other values are scaled by (1 - weight)
-  if (weight != 0.) {
-    double &y = this->mutableY(workspaceIndex)[binIndex];
-    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
-    double &e = this->mutableE(workspaceIndex)[binIndex];
-    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
-  }
+  this->getSpectrum(workspaceIndex).applyBinWeight(binIndex, weight);
+//  // this is the actual result of the masking that most algorithms and plotting
+//  // implementations will see, the bin mask flags defined above are used by only
+//  // some algorithms
+//  // If the weight is 0, nothing more needs to be done after flagMasked above
+//  // (i.e. NaN and Inf will also stay intact)
+//  // If the weight is not 0, NaN and Inf values are set to 0,
+//  // whereas other values are scaled by (1 - weight)
+//  if (weight != 0.) {
+//    double &y = this->mutableY(workspaceIndex)[binIndex];
+//    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
+//    double &e = this->mutableE(workspaceIndex)[binIndex];
+//    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
+//  }
 }
 
 /** Writes the masking weight to m_masks (doesn't alter y-values). Contains a

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1056,19 +1056,6 @@ void MatrixWorkspace::maskBin(const size_t &workspaceIndex,
   flagMasked(workspaceIndex, binIndex, weight);
 
   this->getSpectrum(workspaceIndex).applyBinWeight(binIndex, weight);
-//  // this is the actual result of the masking that most algorithms and plotting
-//  // implementations will see, the bin mask flags defined above are used by only
-//  // some algorithms
-//  // If the weight is 0, nothing more needs to be done after flagMasked above
-//  // (i.e. NaN and Inf will also stay intact)
-//  // If the weight is not 0, NaN and Inf values are set to 0,
-//  // whereas other values are scaled by (1 - weight)
-//  if (weight != 0.) {
-//    double &y = this->mutableY(workspaceIndex)[binIndex];
-//    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
-//    double &e = this->mutableE(workspaceIndex)[binIndex];
-//    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
-//  }
 }
 
 /** Writes the masking weight to m_masks (doesn't alter y-values). Contains a

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -90,7 +90,7 @@ void MaskBins::exec() {
 
   if (boost::dynamic_pointer_cast<const EventWorkspace>(inputWS)) {
     this->execEvent();
-  } // else {
+  }
     MantidVec::difference_type startBin(0), endBin(0);
 
     // If the binning is the same throughout, we only need to find the index
@@ -117,7 +117,6 @@ void MaskBins::exec() {
       }
       progress.report();
     }
-  // }
 }
 
 /** Execution code for EventWorkspaces

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -90,7 +90,7 @@ void MaskBins::exec() {
 
   if (boost::dynamic_pointer_cast<const EventWorkspace>(inputWS)) {
     this->execEvent();
-  } else {
+  } // else {
     MantidVec::difference_type startBin(0), endBin(0);
 
     // If the binning is the same throughout, we only need to find the index
@@ -117,7 +117,7 @@ void MaskBins::exec() {
       }
       progress.report();
     }
-  }
+  // }
 }
 
 /** Execution code for EventWorkspaces

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -241,6 +241,8 @@ public:
 
   void addTof(const double offset) override;
 
+  void applyBinWeight(const size_t &binIndex, const double &weight) override;
+
   void addPulsetime(const double seconds) override;
 
   void maskTof(const double tofMin, const double tofMax) override;

--- a/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Histogram1D.h
@@ -48,6 +48,8 @@ public:
   /// Zero the data (Y&E) in this spectrum
   void clearData() override;
 
+  void applyBinWeight(const size_t &binIndex, const double &weight) override;
+
   /// Deprecated, use y() instead. Returns the y data const
   const MantidVec &dataY() const override { return m_histogram.dataY(); }
   /// Deprecated, use e() instead. Returns the error data const

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2576,6 +2576,20 @@ void EventList::scaleTof(const double factor) { this->convertTof(factor, 0.0); }
 void EventList::addTof(const double offset) { this->convertTof(1.0, offset); }
 
 // --------------------------------------------------------------------------
+/**
+ * Moved from MatrixWorkspace. Functionality diverges for EventWorkspaces and
+ * Histogram2D (so act differently on EventList and Histogram1D).
+ *
+ * Applies bin weighting for masking workspaces.
+ * No bin weighting required for EventWorkspaces
+ *
+ * @param binIndex ::  The index of the bin in the spectrum
+ * @param weight   ::  How heavily the bin is to be masked. =1 for full
+ */
+void EventList::applyBinWeight(const size_t &binIndex, const double &weight) {
+}
+
+// --------------------------------------------------------------------------
 /** Add an offset to the pulsetime (wall-clock time) of each event in the list.
  *
  * @param events :: reference to a vector of events to change.

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2586,8 +2586,7 @@ void EventList::addTof(const double offset) { this->convertTof(1.0, offset); }
  * @param binIndex ::  The index of the bin in the spectrum
  * @param weight   ::  How heavily the bin is to be masked. =1 for full
  */
-void EventList::applyBinWeight(const size_t &binIndex, const double &weight) {
-}
+void EventList::applyBinWeight(const size_t &binIndex, const double &weight) {}
 
 // --------------------------------------------------------------------------
 /** Add an offset to the pulsetime (wall-clock time) of each event in the list.

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2586,7 +2586,10 @@ void EventList::addTof(const double offset) { this->convertTof(1.0, offset); }
  * @param binIndex ::  The index of the bin in the spectrum
  * @param weight   ::  How heavily the bin is to be masked. =1 for full
  */
-void EventList::applyBinWeight(const size_t &binIndex, const double &weight) {}
+void EventList::applyBinWeight(const size_t &binIndex, const double &weight) {
+  UNUSED_ARG(binIndex);
+  UNUSED_ARG(weight);
+}
 
 // --------------------------------------------------------------------------
 /** Add an offset to the pulsetime (wall-clock time) of each event in the list.

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -53,8 +53,8 @@ void Histogram1D::clearData() {
   std::fill(eValues.begin(), eValues.end(), 0.0);
 }
 
-/// Moved from MatrixWorkspace. Separate implementations for Hist1D and EventList.
-/// Applies bin weighting for masking workspaces.
+/// Moved from MatrixWorkspace. Separate implementations for Hist1D and
+/// EventList. Applies bin weighting for masking workspaces.
 ///
 /// @param binIndex ::  The index of the bin in the spectrum
 /// @param weight   ::  How heavily the bin is to be masked. =1 for full

--- a/Framework/DataObjects/src/Histogram1D.cpp
+++ b/Framework/DataObjects/src/Histogram1D.cpp
@@ -53,6 +53,20 @@ void Histogram1D::clearData() {
   std::fill(eValues.begin(), eValues.end(), 0.0);
 }
 
+/// Moved from MatrixWorkspace. Separate implementations for Hist1D and EventList.
+/// Applies bin weighting for masking workspaces.
+///
+/// @param binIndex ::  The index of the bin in the spectrum
+/// @param weight   ::  How heavily the bin is to be masked. =1 for full
+void Histogram1D::applyBinWeight(const size_t &binIndex, const double &weight) {
+  if (weight != 0.) {
+    double &y = this->mutableY()[binIndex];
+    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
+    double &e = this->mutableE()[binIndex];
+    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
+  }
+}
+
 /// Deprecated, use setSharedX() instead. Sets the x data.
 /// @param X :: vector of X data
 void Histogram1D::setX(const Kernel::cow_ptr<HistogramData::HistogramX> &X) {

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
@@ -167,16 +167,18 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
         monitor_workspace = self._move(state_serialized, monitor_workspace, component_as_string)
 
         # --------------------------------------------------------------------------------------------------------------
-        # 5. Apply masking (pixel masking and time masking)
-        # --------------------------------------------------------------------------------------------------------------q
-        progress.report("Masking ...")
-        workspace = self._mask(state_serialized, workspace, component_as_string)
-
-        # --------------------------------------------------------------------------------------------------------------
-        # 6. Convert to Wavelength
+        # 5. Convert to Wavelength
+        #    Note (5) and (6) have swapped order to avoid EventWS mask rebinning issue
+        #    look to swap them back when/if this is fixed
         # --------------------------------------------------------------------------------------------------------------
         progress.report("Converting to wavelength ...")
         workspace = self._convert_to_wavelength(state_serialized, workspace)
+
+        # --------------------------------------------------------------------------------------------------------------
+        # 6. Apply masking (pixel masking and time masking)
+        # --------------------------------------------------------------------------------------------------------------q
+        progress.report("Masking ...")
+        workspace = self._mask(state_serialized, workspace, component_as_string)
 
         # --------------------------------------------------------------------------------------------------------------
         # 7. Multiply by volume and absolute scale

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
@@ -167,8 +167,7 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
 
         # --------------------------------------------------------------------------------------------------------------
         # 5. Apply masking (pixel masking and time masking)
-        # --------------------------------------------------------------------------------------------------------------
-        workspace = rebin_alg.getProperty("OutputWorkspace").value
+        # --------------------------------------------------------------------------------------------------------------q
         progress.report("Masking ...")
         workspace = self._mask(state_serialized, workspace, component_as_string)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
@@ -24,7 +24,7 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
         return 'SANS\\Reduction'
 
     def summary(self):
-        return ' Runs the the core reduction elements.'
+        return ' Runs the core reduction elements.'
 
     def PyInit(self):
         # ----------
@@ -133,29 +133,25 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         compatibility = state.compatibility
         is_event_workspace = isinstance(workspace, IEventWorkspace)
-        if compatibility.use_compatibility_mode and is_event_workspace:
-            # We convert the workspace here to a histogram workspace, since we cannot otherwise
-            # compare the results between the old and the new reduction workspace in a meaningful manner.
-            # The old one is histogram and the new one is event.
-            # Rebin to monitor workspace
-            if compatibility.time_rebin_string:
-                rebin_name = "Rebin"
-                rebin_option = {"InputWorkspace": workspace,
-                                "Params": compatibility.time_rebin_string,
-                                "OutputWorkspace": EMPTY_NAME,
-                                "PreserveEvents": False}
-                rebin_alg = create_child_algorithm(self, rebin_name, **rebin_option)
-                rebin_alg.execute()
-                workspace = rebin_alg.getProperty("OutputWorkspace").value
-            else:
-                rebin_name = "RebinToWorkspace"
-                rebin_option = {"WorkspaceToRebin": workspace,
-                                "WorkspaceToMatch": monitor_workspace,
-                                "OutputWorkspace": EMPTY_NAME,
-                                "PreserveEvents": False}
-                rebin_alg = create_child_algorithm(self, rebin_name, **rebin_option)
-                rebin_alg.execute()
-                workspace = rebin_alg.getProperty("OutputWorkspace").value
+        preserve_events = False if (compatibility.use_compatibility_mode and is_event_workspace) else True
+
+        if compatibility.time_rebin_string:
+            rebin_name = "Rebin"
+            rebin_option = {"InputWorkspace": workspace,
+                            "Params": compatibility.time_rebin_string,
+                            "OutputWorkspace": EMPTY_NAME,
+                            "PreserveEvents": preserve_events}
+        else:
+            rebin_name = "RebinToWorkspace"
+            rebin_option = {"WorkspaceToRebin": workspace,
+                            "WorkspaceToMatch": monitor_workspace,
+                            "OutputWorkspace": EMPTY_NAME,
+                            "PreserveEvents": preserve_events}
+
+        rebin_alg = create_child_algorithm(self, rebin_name, **rebin_option)
+        rebin_alg.execute()
+        workspace = rebin_alg.getProperty("OutputWorkspace").value
+
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # COMPATIBILITY END
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -172,6 +168,7 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
         # --------------------------------------------------------------------------------------------------------------
         # 5. Apply masking (pixel masking and time masking)
         # --------------------------------------------------------------------------------------------------------------
+        workspace = rebin_alg.getProperty("OutputWorkspace").value
         progress.report("Masking ...")
         workspace = self._mask(state_serialized, workspace, component_as_string)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSReductionCore.py
@@ -133,24 +133,25 @@ class SANSReductionCore(DistributedDataProcessorAlgorithm):
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         compatibility = state.compatibility
         is_event_workspace = isinstance(workspace, IEventWorkspace)
-        preserve_events = False if (compatibility.use_compatibility_mode and is_event_workspace) else True
+        if is_event_workspace:
+            preserve_events = False if compatibility.use_compatibility_mode else True
 
-        if compatibility.time_rebin_string:
-            rebin_name = "Rebin"
-            rebin_option = {"InputWorkspace": workspace,
-                            "Params": compatibility.time_rebin_string,
-                            "OutputWorkspace": EMPTY_NAME,
-                            "PreserveEvents": preserve_events}
-        else:
-            rebin_name = "RebinToWorkspace"
-            rebin_option = {"WorkspaceToRebin": workspace,
-                            "WorkspaceToMatch": monitor_workspace,
-                            "OutputWorkspace": EMPTY_NAME,
-                            "PreserveEvents": preserve_events}
+            if compatibility.time_rebin_string:
+                rebin_name = "Rebin"
+                rebin_option = {"InputWorkspace": workspace,
+                                "Params": compatibility.time_rebin_string,
+                                "OutputWorkspace": EMPTY_NAME,
+                                "PreserveEvents": preserve_events}
+            else:
+                rebin_name = "RebinToWorkspace"
+                rebin_option = {"WorkspaceToRebin": workspace,
+                                "WorkspaceToMatch": monitor_workspace,
+                                "OutputWorkspace": EMPTY_NAME,
+                                "PreserveEvents": preserve_events}
 
-        rebin_alg = create_child_algorithm(self, rebin_name, **rebin_option)
-        rebin_alg.execute()
-        workspace = rebin_alg.getProperty("OutputWorkspace").value
+            rebin_alg = create_child_algorithm(self, rebin_name, **rebin_option)
+            rebin_alg.execute()
+            workspace = rebin_alg.getProperty("OutputWorkspace").value
 
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         # COMPATIBILITY END

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -37,6 +37,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/DetectorGroup.h"
 #include "MantidGeometry/MDGeometry/MDHistoDimension.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/cow_ptr.h"
 
@@ -96,6 +97,10 @@ public:
   size_t getMemorySize() const override {
     return readY().size() * sizeof(double) * 2;
   }
+
+  void applyBinWeight(const size_t &, const double &) override {
+    throw Mantid::Kernel::Exception::NotImplementedError("applyBinWeight not implemented.");
+  };
 
   /// Mask the spectrum to this value
   void clearData() override {

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -98,9 +98,13 @@ public:
     return readY().size() * sizeof(double) * 2;
   }
 
-  void applyBinWeight(const size_t &, const double &) override {
-    throw Mantid::Kernel::Exception::NotImplementedError(
-        "applyBinWeight not implemented.");
+  void applyBinWeight(const size_t &binIndex, const double &weight) override {
+    if (weight != 0.) {
+    double &y = this->mutableY()[binIndex];
+    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
+    double &e = this->mutableE()[binIndex];
+    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
+  }
   };
 
   /// Mask the spectrum to this value

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -104,7 +104,7 @@ public:
       (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
       double &e = this->mutableE()[binIndex];
       (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
-  }
+    }
   };
 
   /// Mask the spectrum to this value

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -99,7 +99,8 @@ public:
   }
 
   void applyBinWeight(const size_t &, const double &) override {
-    throw Mantid::Kernel::Exception::NotImplementedError("applyBinWeight not implemented.");
+    throw Mantid::Kernel::Exception::NotImplementedError(
+        "applyBinWeight not implemented.");
   };
 
   /// Mask the spectrum to this value

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -100,10 +100,10 @@ public:
 
   void applyBinWeight(const size_t &binIndex, const double &weight) override {
     if (weight != 0.) {
-    double &y = this->mutableY()[binIndex];
-    (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
-    double &e = this->mutableE()[binIndex];
-    (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
+      double &y = this->mutableY()[binIndex];
+      (std::isnan(y) || std::isinf(y)) ? y = 0. : y *= (1 - weight);
+      double &e = this->mutableE()[binIndex];
+      (std::isnan(e) || std::isinf(e)) ? e = 0. : e *= (1 - weight);
   }
   };
 

--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -23,6 +23,7 @@ Improved
 * Updated file adding to prefix the instrument name
 * Updated file finding to be able to find added runs withour instrument name prefix
 * Updated GUI code so calculated merge scale and shift are shown after reduction.
+* Added display of current save directory.
 
 Bug fixes
 #########
@@ -32,6 +33,7 @@ Bug fixes
 * The GUI no longer hangs whilst searching the archive for files.
 * Updated the options and units displayed in wavelength and momentum range combo boxes.
 * Fixed a bug which crashed the beam centre finder if a phi mask was set.
+* Fixed normalisation discrepancy between Compatibility and Non-compatibility modes when time masking EventWorkspaces
 
 Improvements
 ############

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -396,6 +396,7 @@ class RunTabPresenter(object):
                 self.on_processing_error(row, error)
 
             if not states:
+                self.sans_logger.information("No states. Ending processing of batch table.")
                 self.on_processing_finished(None)
                 return
 
@@ -596,11 +597,22 @@ class RunTabPresenter(object):
             states, errors = create_states(state_model_with_view_update, table_model, self._view.instrument
                                            , self._facility, row_index=row_index, file_lookup=file_lookup)
         else:
+            if not table_model:
+                self.sans_logger.information("table_model returned None.")
+            if not state_model_with_view_update:
+                self.sans_logger.information("state_model_with_view_update returned None.")
+
             states = None
             errors = None
         stop_time_state_generation = time.time()
         time_taken = stop_time_state_generation - start_time_state_generation
         self.sans_logger.information("The generation of all states took {}s".format(time_taken))
+
+        if errors:
+            self.sans_logger.warning("Errors in getting states...")
+            for _, v in errors.items():
+                self.sans_logger.warning("{}".format(v))
+
         return states, errors
 
     def get_state_for_row(self, row_index, file_lookup=True):


### PR DESCRIPTION
**Description of work.**
Changed MaskBins to add mask flags to EventWorkspaces (in addition to removing the events).
Reordered SANS reduction workflow (swapped convert to wavelength and masking) to avoid the mask rebin issue.
This removes the discrepancy between compatibility and non-compatibility modes in SANS gui.

Additionally added extra logging commands to run tab presenter to stop silent failing if a user file is loaded from a directory not added to directory manager.

**Report to:** [nobody]

**To test:**
With a user file containing time masking on an EventWorkspace, run the reduction. Change the name of the output workspace and turn on compatibility mode (in settings tab, there is a radio button for compatibility) and process again.

Plot the two output workspaces and change the axes to log-log. The lines should closely match and there should be no obvious divergence.

Fixes #23973 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
