### PR TITLE
Fix side by side instrument view crash

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -63,7 +63,7 @@ protected:
 
   void processStructured(size_t rootIndex);
 
-  void processTubes(size_t rootIndex);
+  boost::optional<size_t> processTubes(size_t rootIndex);
 
   void processGrid(size_t rootIndex);
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -82,7 +82,7 @@ protected:
                                         Mantid::Kernel::V3D normal) const;
   // Add a detector from an assembly
   void addDetector(size_t detIndex, const Mantid::Kernel::V3D &refPos,
-                   int index, Mantid::Kernel::Quat &rotation);
+                   int index, const Mantid::Kernel::Quat &rotation);
   // Spread the banks over the projection plane
   void spreadBanks();
   // Find index of the largest bank
@@ -103,8 +103,8 @@ protected:
 
   /// Keep info of the flat banks
   QList<FlatBankInfo *> m_flatBanks;
-  /// Maps detector ids to indices of FlatBankInfos in m_flatBanks
-  QMap<size_t, int> m_detector2bankMap;
+  /// Maps detector indices to indices of FlatBankInfos in m_flatBanks
+  std::vector<int> m_detector2bankMap;
 
   friend struct FlatBankInfo;
 };

--- a/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentRenderer.cpp
@@ -359,7 +359,7 @@ void InstrumentRenderer::resetColors() {
   std::function<bool(size_t)> isMasked;
   if (maskWS) {
     isMasked = [&detInfo, &detectorIDs, &maskWS](size_t index) {
-      return maskWS->isMasked(detectorIDs[index]) && detInfo.isMasked(index);
+      return maskWS->isMasked(detectorIDs[index]) || detInfo.isMasked(index);
     };
   } else {
     isMasked = [&detInfo](size_t index) { return detInfo.isMasked(index); };

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -385,11 +385,13 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
     bankChildren = &componentInfo.children(bankIndex);
   }
 
-  auto tubes = (bankIndex == bankIndex0) ? *bankChildren : std::vector<size_t>();
+  auto tubes =
+      (bankIndex == bankIndex0) ? *bankChildren : std::vector<size_t>();
   if (tubes.empty()) {
-    for(auto index: *bankChildren) {
+    for (auto index : *bankChildren) {
       boost::optional<size_t> tubeIndex = index;
-      while (componentInfo.componentType(tubeIndex.value()) != ComponentType::OutlineComposite) {
+      while (componentInfo.componentType(tubeIndex.value()) !=
+             ComponentType::OutlineComposite) {
         auto &children = componentInfo.children(tubeIndex.value());
         if (children.empty()) {
           tubeIndex = boost::none;
@@ -406,7 +408,8 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   }
 
   auto name = componentInfo.name(bankIndex);
-  auto normal = tubes.size() > 1 ? calculateBankNormal(componentInfo, tubes) : V3D();
+  auto normal =
+      tubes.size() > 1 ? calculateBankNormal(componentInfo, tubes) : V3D();
 
   if (normal.nullVector() ||
       !isBankFlat(componentInfo, bankIndex, tubes, normal))

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -390,9 +390,9 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   if (tubes.empty()) {
     for (auto index : *bankChildren) {
       boost::optional<size_t> tubeIndex = index;
-      while (componentInfo.componentType(tubeIndex.value()) !=
+      while (componentInfo.componentType(tubeIndex.get()) !=
              ComponentType::OutlineComposite) {
-        auto &children = componentInfo.children(tubeIndex.value());
+        auto &children = componentInfo.children(tubeIndex.get());
         if (children.empty()) {
           tubeIndex = boost::none;
           break;
@@ -400,7 +400,7 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
         tubeIndex = children[0];
       }
       if (tubeIndex) {
-        tubes.emplace_back(tubeIndex.value());
+        tubes.emplace_back(tubeIndex.get());
       }
     }
     if (tubes.empty())
@@ -536,7 +536,7 @@ PanelsSurface::findFlatPanels(size_t rootIndex, std::vector<bool> &visited) {
   if (componentType == ComponentType::OutlineComposite) {
     const auto bankIndex = processTubes(rootIndex);
     if (bankIndex) {
-      setBankVisited(componentInfo, bankIndex.value(), visited);
+      setBankVisited(componentInfo, bankIndex.get(), visited);
     } else {
       setBankVisited(componentInfo, parentIndex, visited);
     }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -317,12 +317,12 @@ void PanelsSurface::addFlatBankOfDetectors(
   QVector<QPointF> vert;
   vert << p1 << p0;
   info->polygon = QPolygonF(vert);
-  #pragma omp parallel for ordered
+#pragma omp parallel for ordered
   for (int i = 0; i < static_cast<int>(detectors.size()); ++i) {
     auto detector = detectors[i];
     addDetector(detector, pos0, index, info->rotation);
     UnwrappedDetector &udet = m_unwrappedDetectors[detector];
-    #pragma omp ordered
+#pragma omp ordered
     info->polygon << QPointF(udet.u, udet.v);
   }
 }
@@ -375,7 +375,7 @@ void PanelsSurface::processGrid(size_t rootIndex) {
 
 /// Find an assembly containing detector tubes placed next to each other
 /// and forming a flat surface.
-/// @param rootIndex :: Index of a component that contains at least on tube 
+/// @param rootIndex :: Index of a component that contains at least on tube
 ///   as a direct child.
 /// @return Optional index of the bank that contains all of the tubes forming
 ///   the surface. If the surface isn't flat return boost::none.
@@ -398,8 +398,8 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   auto tubes =
       (bankIndex == bankIndex0) ? *bankChildren : std::vector<size_t>();
   if (tubes.empty()) {
-    // If tubes is empty then the flat assembly includes the tubes as grand children.
-    // Go down the tree to find all these tubes.
+    // If tubes is empty then the flat assembly includes the tubes as grand
+    // children. Go down the tree to find all these tubes.
     for (auto index : *bankChildren) {
       boost::optional<size_t> tubeIndex = index;
       while (componentInfo.componentType(tubeIndex.get()) !=
@@ -425,7 +425,8 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   auto normal =
       tubes.size() > 1 ? calculateBankNormal(componentInfo, tubes) : V3D();
 
-  // If some of the tubes are not perpendicular to the normal the structure isn't flat
+  // If some of the tubes are not perpendicular to the normal the structure
+  // isn't flat
   if (normal.nullVector() ||
       !isBankFlat(componentInfo, bankIndex, tubes, normal))
     return boost::none;
@@ -438,7 +439,8 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   info->startDetectorIndex = componentInfo.children(tubes.front()).front();
   info->endDetectorIndex = componentInfo.children(tubes.back()).back();
 
-  // Now go over all detectors in the tubes and put them onto the unwrapped surfeace.
+  // Now go over all detectors in the tubes and put them onto the unwrapped
+  // surfeace.
   auto pos0 =
       componentInfo.position(componentInfo.children(tubes.front()).front());
   auto pos1 =

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -317,11 +317,12 @@ void PanelsSurface::addFlatBankOfDetectors(
   QVector<QPointF> vert;
   vert << p1 << p0;
   info->polygon = QPolygonF(vert);
+  #pragma omp parallel for ordered
   for (int i = 0; i < static_cast<int>(detectors.size()); ++i) {
     auto detector = detectors[i];
     addDetector(detector, pos0, index, info->rotation);
     UnwrappedDetector &udet = m_unwrappedDetectors[detector];
-    // this isn't thread-safe
+    #pragma omp ordered
     info->polygon << QPointF(udet.u, udet.v);
   }
 }


### PR DESCRIPTION
**Description of work.**
* Two OMP loops contained thread unsafe code. Serialised one of the loops and changed the container type in the other.
* Restored the view for the VISION instrument by checking deeper component structures.
* Restored mask application to the view.

**To test:**
* Display the VISION instrument in the side by side view. It should show all banks including the ring of tubes.
* Draw a mask shape in the mask tab (any workspace/instrument). Apply mask to view. The masked detectors should be drawn in the mask colour (grey).

Fixes #24089

*This does not require release notes* because it wasn't an issue in 3.13

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
