### PR TITLE
Indirect Qt Signal warnings

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -175,8 +175,6 @@ void IndirectFitAnalysisTab::connectSpectrumAndPlotPresenters() {
 }
 
 void IndirectFitAnalysisTab::connectFitBrowserAndPlotPresenter() {
-  connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
-          SLOT(setBrowserWorkspaceIndex(std::size_t)));
   connect(m_plotPresenter.get(), SIGNAL(selectedFitDataChanged(std::size_t)),
           this, SLOT(setBrowserWorkspace(std::size_t)));
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,


### PR DESCRIPTION
**Description of work.**
This PR fixes a warning caused by an incorrect connect statement in `IndirectFitAnalysisTab`.

**To test:**
1. Launch MantidPlot
2. Open *Interfaces* > *Indirect* > *Data Analysis*
3. Check that the command prompt doesn't contain:

```
QObject::connect: Incompatible sender/receiver arguments
        MantidQt::MantidWidgets::IndirectFitPropertyBrowser::functionChanged() --> MantidQt::CustomInterfaces::IDA::MSDFit::setBrowserWorkspaceIndex(std::size_t)
QObject::connect: Incompatible sender/receiver arguments
        MantidQt::MantidWidgets::IndirectFitPropertyBrowser::functionChanged() --> MantidQt::CustomInterfaces::IDA::IqtFit::setBrowserWorkspaceIndex(std::size_t)
QObject::connect: Incompatible sender/receiver arguments
        MantidQt::MantidWidgets::IndirectFitPropertyBrowser::functionChanged() --> MantidQt::CustomInterfaces::IDA::ConvFit::setBrowserWorkspaceIndex(std::size_t)
QObject::connect: Incompatible sender/receiver arguments
        MantidQt::MantidWidgets::IndirectFitPropertyBrowser::functionChanged() --> MantidQt::CustomInterfaces::IDA::JumpFit::setBrowserWorkspaceIndex(std::size_t)
```

Fixes #24094 

No release notes required as this unwanted warning was introduced after the last release.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
