### PR TITLE
Remember Last Loaded User File in SANS

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -21,8 +21,10 @@ Improved
 * Added tabbing support to table.
 * Added error notifications on a row by row basis.
 * Updated file adding to prefix the instrument name
-* Updated file finding to be able to find added runs withour instrument name prefix
+* Updated file finding to be able to find added runs without instrument name prefix
 * Updated GUI code so calculated merge scale and shift are shown after reduction.
+* Automatically remembers last loaded user file
+* Added display of current save directory
 
 Bug fixes
 #########

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -497,7 +497,7 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         """
         load_default_file(self.user_file_line_edit, self.__generic_settings, self.__user_file_key)
 
-        if str(self.user_file_line_edit.text()) != "":
+        if self.get_user_file_path() != "":
             self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
     def _on_batch_file_load(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -35,7 +35,8 @@ from sans.common.enums import (ReductionDimensionality, OutputMode, SaveType, SA
 from sans.common.file_information import SANSFileInformationFactory
 from sans.gui_logic.gui_common import (get_reduction_mode_from_gui_selection, get_reduction_mode_strings_for_gui,
                                        get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file,
-                                       get_instrument_from_gui_selection, get_string_for_gui_from_instrument)
+                                       load_default_file, get_instrument_from_gui_selection,
+                                       get_string_for_gui_from_instrument)
 
 from sans.common.general_functions import get_instrument
 
@@ -484,6 +485,15 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
                   self.get_user_file_path)
 
         # Notify presenters
+        self._call_settings_listeners(lambda listener: listener.on_user_file_load())
+
+    def set_out_default_user_file(self, path):
+        """
+        Load a default user file, called on view set-up
+        :param path: string. The last accepted user file
+        """
+        load_default_file(self.user_file_line_edit, self.__generic_settings, self.__path_key, path)
+
         self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
     def _on_batch_file_load(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -35,7 +35,7 @@ from sans.common.enums import (ReductionDimensionality, OutputMode, SaveType, SA
 from sans.common.file_information import SANSFileInformationFactory
 from sans.gui_logic.gui_common import (get_reduction_mode_from_gui_selection, get_reduction_mode_strings_for_gui,
                                        get_string_for_gui_from_reduction_mode, GENERIC_SETTINGS, load_file,
-                                       load_default_file, get_instrument_from_gui_selection,
+                                       load_default_file, set_setting, get_instrument_from_gui_selection,
                                        get_string_for_gui_from_instrument)
 
 from sans.common.general_functions import get_instrument
@@ -168,6 +168,7 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         # Q Settings
         self.__generic_settings = GENERIC_SETTINGS
         self.__path_key = "sans_path"
+        self.__user_file_key = "user_file"
         self.__instrument_name = "sans_instrument"
         self.__mask_file_input_path_key = "mask_files"
 
@@ -484,17 +485,20 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         load_file(self.user_file_line_edit, "*.*", self.__generic_settings, self.__path_key,
                   self.get_user_file_path)
 
+        # Set full user file path for default loading
+        set_setting(self.__generic_settings, self.__user_file_key, self.get_user_file_path())
+
         # Notify presenters
         self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
-    def set_out_default_user_file(self, path):
+    def set_out_default_user_file(self):
         """
         Load a default user file, called on view set-up
-        :param path: string. The last accepted user file
         """
-        load_default_file(self.user_file_line_edit, self.__generic_settings, self.__path_key, path)
+        load_default_file(self.user_file_line_edit, self.__generic_settings, self.__user_file_key)
 
-        self._call_settings_listeners(lambda listener: listener.on_user_file_load())
+        if str(self.user_file_line_edit.text()) != "":
+            self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
     def _on_batch_file_load(self):
         """

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -191,6 +191,14 @@ def load_file(line_edit_field, filter_for_dialog, q_settings_group_key, q_settin
         settings.setValue(q_settings_key, new_path)
         settings.endGroup()
 
+def load_default_file(line_edit_field, q_settings_group_key, q_settings_key, default_file):
+    line_edit_field.setText(default_file)
+
+    settings = QSettings()
+    settings.beginGroup(q_settings_group_key)
+    settings.setValue(q_settings_key, default_file)
+    settings.endGroup()
+
 
 def open_file_dialog(line_edit, filter_text, directory):
     file_name = QFileDialog.getOpenFileName(None, 'Open', directory, filter_text)

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -186,17 +186,22 @@ def load_file(line_edit_field, filter_for_dialog, q_settings_group_key, q_settin
     # Save the new location
     new_path, _ = os.path.split(func())
     if new_path:
-        settings = QSettings()
-        settings.beginGroup(q_settings_group_key)
-        settings.setValue(q_settings_key, new_path)
-        settings.endGroup()
+        set_setting(q_settings_group_key, q_settings_key, new_path)
 
-def load_default_file(line_edit_field, q_settings_group_key, q_settings_key, default_file):
-    line_edit_field.setText(default_file)
 
+def load_default_file(line_edit_field, q_settings_group_key, q_settings_key):
     settings = QSettings()
     settings.beginGroup(q_settings_group_key)
-    settings.setValue(q_settings_key, default_file)
+    default_file = settings.value(q_settings_key, "", type=str)
+    settings.endGroup()
+
+    line_edit_field.setText(default_file)
+
+
+def set_setting(q_settings_group_key, q_settings_key, value):
+    settings = QSettings()
+    settings.beginGroup(q_settings_group_key)
+    settings.setValue(q_settings_key, value)
     settings.endGroup()
 
 

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -237,9 +237,10 @@ class RunTabPresenter(object):
 
             self._view.setup_layout()
             self._view.set_out_file_directory(ConfigService.Instance().getString("defaultsave.directory"))
-            default_user_file = None
-            if default_user_file is not None:
-                self._view.set_out_default_user_file("Test")
+
+
+            self._view.set_out_default_user_file()
+
             self._view.set_hinting_line_edit_for_column(
                 self._table_model.column_name_converter.index('options_column_model'),
                 self._table_model.get_options_hint_strategy())

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -237,6 +237,9 @@ class RunTabPresenter(object):
 
             self._view.setup_layout()
             self._view.set_out_file_directory(ConfigService.Instance().getString("defaultsave.directory"))
+            default_user_file = None
+            if default_user_file is not None:
+                self._view.set_out_default_user_file("Test")
             self._view.set_hinting_line_edit_for_column(
                 self._table_model.column_name_converter.index('options_column_model'),
                 self._table_model.get_options_hint_strategy())

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -399,6 +399,7 @@ class RunTabPresenter(object):
                 self.on_processing_error(row, error)
 
             if not states:
+                self.sans_logger.warning("No states. Ending processing of batch table.")
                 self.on_processing_finished(None)
                 return
 
@@ -604,6 +605,12 @@ class RunTabPresenter(object):
         stop_time_state_generation = time.time()
         time_taken = stop_time_state_generation - start_time_state_generation
         self.sans_logger.information("The generation of all states took {}s".format(time_taken))
+
+        if errors:
+            self.sans_logger.warning("Errors in getting states...")
+            for _, v in errors.item():
+                self.sans_logger.warning("{}".format(v))
+
         return states, errors
 
     def get_state_for_row(self, row_index, file_lookup=True):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -238,7 +238,6 @@ class RunTabPresenter(object):
             self._view.setup_layout()
             self._view.set_out_file_directory(ConfigService.Instance().getString("defaultsave.directory"))
 
-
             self._view.set_out_default_user_file()
 
             self._view.set_hinting_line_edit_for_column(

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -158,8 +158,7 @@ class RunTabPresenterTest(unittest.TestCase):
 
     def test_that_checks_default_user_file(self):
         # Setup presenter and mock view
-        user_file_path = create_user_file(sample_user_file)
-        view, settings_diagnostic_tab, _ = create_mock_view(user_file_path)
+        view, settings_diagnostic_tab, _ = create_mock_view("")
         presenter = RunTabPresenter(SANSFacility.ISIS)
         presenter.set_view(view)
 

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -162,7 +162,7 @@ class RunTabPresenterTest(unittest.TestCase):
         presenter = RunTabPresenter(SANSFacility.ISIS)
         presenter.set_view(view)
 
-        presenter._view.set_out_default_user_file.assert_called_once()
+        presenter._view.set_out_default_user_file.assert_called_once_with()
         presenter._view._call_settings_listeners.assert_not_called()   # as default user file should be ""
 
     def test_fails_silently_when_user_file_does_not_exist(self):

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -156,6 +156,16 @@ class RunTabPresenterTest(unittest.TestCase):
         # clean up
         remove_file(user_file_path)
 
+    def test_that_checks_default_user_file(self):
+        # Setup presenter and mock view
+        user_file_path = create_user_file(sample_user_file)
+        view, settings_diagnostic_tab, _ = create_mock_view(user_file_path)
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        presenter.set_view(view)
+
+        presenter._view.set_out_default_user_file.assert_called_once()
+        presenter._view._call_settings_listeners.assert_not_called()   # as default user file should be ""
+
     def test_fails_silently_when_user_file_does_not_exist(self):
         self.os_patcher.stop()
         view, _, _ = create_mock_view("non_existent_user_file")

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -162,8 +162,15 @@ class RunTabPresenterTest(unittest.TestCase):
         presenter = RunTabPresenter(SANSFacility.ISIS)
         presenter.set_view(view)
 
-        presenter._view.set_out_default_user_file.assert_called_once_with()
-        presenter._view._call_settings_listeners.assert_not_called()   # as default user file should be ""
+        self.assertEqual(
+            presenter._view.set_out_default_user_file.call_count, 1,
+            "Expected mock to have been called once. Called {} times.".format(
+                presenter._view.set_out_default_user_file.call_count))
+
+        self.assertEqual(
+            presenter._view._call_settings_listeners.call_count, 0,
+            "Expected mock to not have been called. Called {} times.".format(
+                presenter._view._call_settings_listeners.call_count))
 
     def test_fails_silently_when_user_file_does_not_exist(self):
         self.os_patcher.stop()


### PR DESCRIPTION
**Description of work.**
Added a QSetting for last loaded user file. Upon initialization of a view in RunTabPresenter, view now checks if this setting has a value. If there is a value, the user file is automatically loaded.

**Report to:** [nobody]

**To test:**
Bring up the SANS v2 gui, and load in an accepted user file. Close MantidPlot and re-launch. Upon opening the SANS gui again, the user file you selected should already be populated in the text box. After adding a batch file, you will be able to process the data without having to re-select the user file.

Additionally, added `test_that_checks_default_user_file` in `PythonSANSQt4.run_tab_presenter_test`

Fixes #23963 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
