### PR TITLE
Indirect Diffraction - Move and disable run button

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -102,3 +102,13 @@ Improvements
 
 - The Run button is now above the output options.
 - The Run, Plot and Save buttons are now disabled while running and plotting is taking place.
+
+
+Diffraction Interface
+---------------------
+
+Improvements
+############
+
+- The Run button is now above the output options.
+- The Run, Plot and Save buttons are now disabled while running and plotting is taking place.

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -125,6 +125,8 @@ void IndirectDiffractionReduction::connectRunButtonValidation(
  * Runs a diffraction reduction when the user clicks Run.
  */
 void IndirectDiffractionReduction::run() {
+	setRunIsRunning(true);
+
   QString instName = m_uiForm.iicInstrumentConfiguration->getInstrumentName();
   QString mode = m_uiForm.iicInstrumentConfiguration->getReflectionName();
   if (!m_uiForm.rfSampleFiles->isValid()) {
@@ -177,38 +179,36 @@ void IndirectDiffractionReduction::algorithmComplete(bool error) {
     deleteGroupingWorkspace();
   }
 
-  if (error) {
-    showInformationBox(
-        "Error running diffraction reduction.\nSee Results Log for details.");
-    return;
-  }
-  // Ungroup the output workspace if generic reducer was used
-  if (AnalysisDataService::Instance().doesExist(
-          "IndirectDiffraction_Workspaces")) {
-    WorkspaceGroup_sptr diffResultsGroup =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            "IndirectDiffraction_Workspaces");
+	setRunIsRunning(false);
 
-    m_plotWorkspaces.clear();
-    m_plotWorkspaces = diffResultsGroup->getNames();
+	if (!error) {
+		// Ungroup the output workspace if generic reducer was used
+		if (AnalysisDataService::Instance().doesExist(
+			"IndirectDiffraction_Workspaces")) {
+			WorkspaceGroup_sptr diffResultsGroup =
+				AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+					"IndirectDiffraction_Workspaces");
 
-    diffResultsGroup->removeAll();
-    AnalysisDataService::Instance().remove("IndirectDiffraction_Workspaces");
-  }
-  // Enable plotting
-  m_uiForm.pbPlot->setEnabled(true);
-  m_uiForm.cbPlotType->setEnabled(true);
-  // Enable saving
-  m_uiForm.ckAscii->setEnabled(true);
-  m_uiForm.ckGSS->setEnabled(true);
-  m_uiForm.ckNexus->setEnabled(true);
-  m_uiForm.pbSave->setEnabled(true);
+			m_plotWorkspaces.clear();
+			m_plotWorkspaces = diffResultsGroup->getNames();
+
+			diffResultsGroup->removeAll();
+			AnalysisDataService::Instance().remove("IndirectDiffraction_Workspaces");
+		}
+	}
+	else {
+		setPlotEnabled(false);
+		setSaveEnabled(false);
+		showInformationBox(
+			"Error running diffraction reduction.\nSee Results Log for details.");
+	}
 }
 
 /**
  * Handles plotting result spectra from algorithm chains.
  */
 void IndirectDiffractionReduction::plotResults() {
+	setPlotIsPlotting(true);
 
   QString instName = m_uiForm.iicInstrumentConfiguration->getInstrumentName();
   QString mode = m_uiForm.iicInstrumentConfiguration->getReflectionName();
@@ -242,6 +242,8 @@ void IndirectDiffractionReduction::plotResults() {
   }
 
   runPythonCode(pyInput);
+
+	setPlotIsPlotting(false);
 }
 
 /**
@@ -917,5 +919,38 @@ void IndirectDiffractionReduction::manualGroupingToggled(int state) {
     return;
   }
 }
+
+void IndirectDiffractionReduction::setRunIsRunning(bool running) {
+	m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+	setButtonsEnabled(!running);
+}
+
+void IndirectDiffractionReduction::setPlotIsPlotting(bool plotting) {
+	m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
+	setButtonsEnabled(!plotting);
+}
+
+void IndirectDiffractionReduction::setButtonsEnabled(bool enabled) {
+	setRunEnabled(enabled);
+	setPlotEnabled(enabled);
+	setSaveEnabled(enabled);
+}
+
+void IndirectDiffractionReduction::setRunEnabled(bool enabled) {
+	m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectDiffractionReduction::setPlotEnabled(bool enabled) {
+	m_uiForm.pbPlot->setEnabled(enabled);
+	m_uiForm.cbPlotType->setEnabled(enabled);
+}
+
+void IndirectDiffractionReduction::setSaveEnabled(bool enabled) {
+	m_uiForm.pbSave->setEnabled(enabled);
+	m_uiForm.ckAscii->setEnabled(enabled);
+	m_uiForm.ckGSS->setEnabled(enabled);
+	m_uiForm.ckNexus->setEnabled(enabled);
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -125,7 +125,7 @@ void IndirectDiffractionReduction::connectRunButtonValidation(
  * Runs a diffraction reduction when the user clicks Run.
  */
 void IndirectDiffractionReduction::run() {
-	setRunIsRunning(true);
+  setRunIsRunning(true);
 
   QString instName = m_uiForm.iicInstrumentConfiguration->getInstrumentName();
   QString mode = m_uiForm.iicInstrumentConfiguration->getReflectionName();
@@ -179,36 +179,35 @@ void IndirectDiffractionReduction::algorithmComplete(bool error) {
     deleteGroupingWorkspace();
   }
 
-	setRunIsRunning(false);
+  setRunIsRunning(false);
 
-	if (!error) {
-		// Ungroup the output workspace if generic reducer was used
-		if (AnalysisDataService::Instance().doesExist(
-			"IndirectDiffraction_Workspaces")) {
-			WorkspaceGroup_sptr diffResultsGroup =
-				AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-					"IndirectDiffraction_Workspaces");
+  if (!error) {
+    // Ungroup the output workspace if generic reducer was used
+    if (AnalysisDataService::Instance().doesExist(
+            "IndirectDiffraction_Workspaces")) {
+      WorkspaceGroup_sptr diffResultsGroup =
+          AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+              "IndirectDiffraction_Workspaces");
 
-			m_plotWorkspaces.clear();
-			m_plotWorkspaces = diffResultsGroup->getNames();
+      m_plotWorkspaces.clear();
+      m_plotWorkspaces = diffResultsGroup->getNames();
 
-			diffResultsGroup->removeAll();
-			AnalysisDataService::Instance().remove("IndirectDiffraction_Workspaces");
-		}
-	}
-	else {
-		setPlotEnabled(false);
-		setSaveEnabled(false);
-		showInformationBox(
-			"Error running diffraction reduction.\nSee Results Log for details.");
-	}
+      diffResultsGroup->removeAll();
+      AnalysisDataService::Instance().remove("IndirectDiffraction_Workspaces");
+    }
+  } else {
+    setPlotEnabled(false);
+    setSaveEnabled(false);
+    showInformationBox(
+        "Error running diffraction reduction.\nSee Results Log for details.");
+  }
 }
 
 /**
  * Handles plotting result spectra from algorithm chains.
  */
 void IndirectDiffractionReduction::plotResults() {
-	setPlotIsPlotting(true);
+  setPlotIsPlotting(true);
 
   QString instName = m_uiForm.iicInstrumentConfiguration->getInstrumentName();
   QString mode = m_uiForm.iicInstrumentConfiguration->getReflectionName();
@@ -243,7 +242,7 @@ void IndirectDiffractionReduction::plotResults() {
 
   runPythonCode(pyInput);
 
-	setPlotIsPlotting(false);
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -921,35 +920,35 @@ void IndirectDiffractionReduction::manualGroupingToggled(int state) {
 }
 
 void IndirectDiffractionReduction::setRunIsRunning(bool running) {
-	m_uiForm.pbRun->setText(running ? "Running..." : "Run");
-	setButtonsEnabled(!running);
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
 }
 
 void IndirectDiffractionReduction::setPlotIsPlotting(bool plotting) {
-	m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
-	setButtonsEnabled(!plotting);
+  m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setButtonsEnabled(!plotting);
 }
 
 void IndirectDiffractionReduction::setButtonsEnabled(bool enabled) {
-	setRunEnabled(enabled);
-	setPlotEnabled(enabled);
-	setSaveEnabled(enabled);
+  setRunEnabled(enabled);
+  setPlotEnabled(enabled);
+  setSaveEnabled(enabled);
 }
 
 void IndirectDiffractionReduction::setRunEnabled(bool enabled) {
-	m_uiForm.pbRun->setEnabled(enabled);
+  m_uiForm.pbRun->setEnabled(enabled);
 }
 
 void IndirectDiffractionReduction::setPlotEnabled(bool enabled) {
-	m_uiForm.pbPlot->setEnabled(enabled);
-	m_uiForm.cbPlotType->setEnabled(enabled);
+  m_uiForm.pbPlot->setEnabled(enabled);
+  m_uiForm.cbPlotType->setEnabled(enabled);
 }
 
 void IndirectDiffractionReduction::setSaveEnabled(bool enabled) {
-	m_uiForm.pbSave->setEnabled(enabled);
-	m_uiForm.ckAscii->setEnabled(enabled);
-	m_uiForm.ckGSS->setEnabled(enabled);
-	m_uiForm.ckNexus->setEnabled(enabled);
+  m_uiForm.pbSave->setEnabled(enabled);
+  m_uiForm.ckAscii->setEnabled(enabled);
+  m_uiForm.ckGSS->setEnabled(enabled);
+  m_uiForm.ckNexus->setEnabled(enabled);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
@@ -82,6 +82,13 @@ private:
   void runOSIRISdiffonlyReduction();
   void createGroupingWorkspace(const std::string &outputWsName);
 
+	void setRunIsRunning(bool running);
+	void setPlotIsPlotting(bool plotting);
+	void setButtonsEnabled(bool enabled);
+	void setRunEnabled(bool enabled);
+	void setPlotEnabled(bool enabled);
+	void setSaveEnabled(bool enabled);
+
 private:
   Ui::IndirectDiffractionReduction
       m_uiForm; /// The form generated using Qt Designer

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
@@ -82,12 +82,12 @@ private:
   void runOSIRISdiffonlyReduction();
   void createGroupingWorkspace(const std::string &outputWsName);
 
-	void setRunIsRunning(bool running);
-	void setPlotIsPlotting(bool plotting);
-	void setButtonsEnabled(bool enabled);
-	void setRunEnabled(bool enabled);
-	void setPlotEnabled(bool enabled);
-	void setSaveEnabled(bool enabled);
+  void setRunIsRunning(bool running);
+  void setPlotIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
 
 private:
   Ui::IndirectDiffractionReduction

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>600</height>
+    <width>551</width>
+    <height>623</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -60,7 +60,16 @@
        <string>Input</string>
       </property>
       <layout class="QGridLayout" name="gridLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
         <number>6</number>
        </property>
        <item row="2" column="0">
@@ -186,7 +195,16 @@
       </property>
       <widget class="QWidget" name="pageCalibration">
        <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -195,7 +213,16 @@
            <string>Calibration</string>
           </property>
           <layout class="QGridLayout" name="gridLayout_2">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
             <number>6</number>
            </property>
            <item row="4" column="0" colspan="2">
@@ -251,7 +278,16 @@
       </widget>
       <widget class="QWidget" name="pageCalibOnly">
        <layout class="QVBoxLayout" name="verticalLayout_8">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -355,7 +391,16 @@
            <property name="spacing">
             <number>6</number>
            </property>
-           <property name="margin">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
             <number>6</number>
            </property>
            <item>
@@ -431,7 +476,16 @@
         </sizepolicy>
        </property>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -443,7 +497,16 @@
            <property name="spacing">
             <number>6</number>
            </property>
-           <property name="margin">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
             <number>6</number>
            </property>
            <item>
@@ -560,12 +623,93 @@
      </widget>
     </item>
     <item>
+     <widget class="QGroupBox" name="groupBox">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>50</height>
+       </size>
+      </property>
+      <property name="title">
+       <string>Run</string>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>7</number>
+       </property>
+       <item>
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pbRun">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Run</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </item>
+    <item>
      <widget class="QGroupBox" name="gbOutput">
       <property name="title">
        <string>Output</string>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
         <number>6</number>
        </property>
        <item>
@@ -609,7 +753,16 @@
        <string>Save Formats</string>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>6</number>
+       </property>
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <property name="rightMargin">
+        <number>6</number>
+       </property>
+       <property name="bottomMargin">
         <number>6</number>
        </property>
        <item>
@@ -693,26 +846,6 @@
        </spacer>
       </item>
       <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_11">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
        <widget class="QPushButton" name="pbManageDirs">
         <property name="text">
          <string>Manage Directories</string>
@@ -756,7 +889,6 @@
   <tabstop>ckNexus</tabstop>
   <tabstop>ckAscii</tabstop>
   <tabstop>pbHelp</tabstop>
-  <tabstop>pbRun</tabstop>
   <tabstop>pbManageDirs</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
**Description of work.**
This PR moves the run button to be above the output options in Indirect Diffraction.
It also ensures the run and plot buttons are disabled while running and plotting is taking place.

**To test:**
1. `Interfaces`->`Indirect`->`Diffraction`
2. Enter the run number `26176`. Click enter and wait for the data to load
3. Click `Run` and ensure the run, plot and save options are all disabled and then re-enabled when running is complete.
4. Click `Plot` and ensure the run, plot and save options are all disabled and then re-enabled.

Fixes #24062 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
