### PR TITLE
Indirect Tools - Move and disable run button

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -102,3 +102,12 @@ Improvements
 
 - The Run button is now above the output options.
 - The Run, Plot and Save buttons are now disabled while running and plotting is taking place.
+
+
+Tools Interface
+---------------
+
+Improvements
+############
+
+- The Run button has been moved in the Transmission tab, and is disabled while running.

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
@@ -19,7 +19,7 @@ namespace CustomInterfaces {
 IndirectLoadILL::IndirectLoadILL(QWidget *parent) : IndirectToolsTab(parent) {
   m_uiForm.setupUi(parent);
 
-	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
 
   connect(m_uiForm.mwRun, SIGNAL(filesFound()), this, SLOT(handleFilesFound()));
   connect(m_uiForm.chkUseMap, SIGNAL(toggled(bool)), m_uiForm.mwMapFile,
@@ -151,9 +151,7 @@ void IndirectLoadILL::handleFilesFound() {
   }
 }
 
-void IndirectLoadILL::runClicked() {
-	runTab();
-}
+void IndirectLoadILL::runClicked() { runTab(); }
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
@@ -19,6 +19,8 @@ namespace CustomInterfaces {
 IndirectLoadILL::IndirectLoadILL(QWidget *parent) : IndirectToolsTab(parent) {
   m_uiForm.setupUi(parent);
 
+	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
+
   connect(m_uiForm.mwRun, SIGNAL(filesFound()), this, SLOT(handleFilesFound()));
   connect(m_uiForm.chkUseMap, SIGNAL(toggled(bool)), m_uiForm.mwMapFile,
           SLOT(setEnabled(bool)));
@@ -147,6 +149,10 @@ void IndirectLoadILL::handleFilesFound() {
     // Check if the first part of the name is in the instruments list
     m_uiForm.iicInstrumentConfiguration->setInstrument(fnameParts[0]);
   }
+}
+
+void IndirectLoadILL::runClicked() {
+	runTab();
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
@@ -34,7 +34,7 @@ protected:
 private slots:
   /// Set the instrument based on the file name if possible
   void handleFilesFound();
-	void runClicked();
+  void runClicked();
 
 private:
   /// Map to store instrument analysers and reflections for this instrument

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
@@ -34,6 +34,7 @@ protected:
 private slots:
   /// Set the instrument based on the file name if possible
   void handleFilesFound();
+	void runClicked();
 
 private:
   /// Map to store instrument analysers and reflections for this instrument

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="MantidQt::API::MWRunFiles" name="mwRun">
+    <widget class="MantidQt::API::MWRunFiles" name="mwRun" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -25,7 +25,7 @@
      <property name="label" stdset="0">
       <string>Run:</string>
      </property>
-     <property name="fileExtensions">
+     <property name="fileExtensions" stdset="0">
       <stringlist>
        <string>.asc</string>
        <string>.inx</string>
@@ -64,7 +64,7 @@
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="MantidQt::API::MWRunFiles" name="mwMapFile">
+      <widget class="MantidQt::API::MWRunFiles" name="mwMapFile" native="true">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -77,7 +77,7 @@
        <property name="label" stdset="0">
         <string>Map File:</string>
        </property>
-       <property name="fileExtensions">
+       <property name="fileExtensions" stdset="0">
         <stringlist>
          <string>.map</string>
         </stringlist>
@@ -115,6 +115,63 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>350</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">

--- a/qt/scientific_interfaces/Indirect/IndirectTools.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.cpp
@@ -51,7 +51,6 @@ void IndirectTools::initLayout() {
 
   // Connect statements for the buttons shared between all tabs on the Indirect
   // Bayes interface
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(helpClicked()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
           SLOT(manageUserDirectories()));

--- a/qt/scientific_interfaces/Indirect/IndirectTools.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.ui
@@ -14,97 +14,77 @@
    <string>Indirect Tools</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QTabWidget" name="IndirectToolsTabs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="tabTransmissionCalc">
-      <attribute name="title">
-       <string>Transmission</string>
-      </attribute>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="IndirectToolsTabs">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="tabTransmissionCalc">
+       <attribute name="title">
+        <string>Transmission</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabLoadILL">
+       <attribute name="title">
+        <string>Load ILL</string>
+       </attribute>
+      </widget>
      </widget>
-     <widget class="QWidget" name="tabLoadILL">
-      <attribute name="title">
-       <string>Load ILL</string>
-      </attribute>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="layout_bottom">
-     <item>
-      <widget class="QPushButton" name="pbHelp">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>?</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_14">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pbRun">
-       <property name="text">
-        <string>Run</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_11">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pbManageDirs">
-       <property name="text">
-        <string>Manage Directories</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layout_bottom">
+      <item>
+       <widget class="QPushButton" name="pbHelp">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>?</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_11">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbManageDirs">
+        <property name="text">
+         <string>Manage Directories</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
   </widget>
  </widget>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
@@ -26,6 +26,8 @@ IndirectTransmissionCalc::IndirectTransmissionCalc(QWidget *parent)
     : IndirectToolsTab(parent) {
   m_uiForm.setupUi(parent);
 
+	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
+
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
 }
@@ -130,6 +132,10 @@ void IndirectTransmissionCalc::algorithmComplete(bool error) {
  */
 void IndirectTransmissionCalc::loadSettings(const QSettings &settings) {
   UNUSED_ARG(settings);
+}
+
+void IndirectTransmissionCalc::runClicked() {
+	runTab();
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
@@ -26,7 +26,7 @@ IndirectTransmissionCalc::IndirectTransmissionCalc(QWidget *parent)
     : IndirectToolsTab(parent) {
   m_uiForm.setupUi(parent);
 
-	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
@@ -63,7 +63,7 @@ bool IndirectTransmissionCalc::validate() {
  * Run the tab, invoking the IndirectTransmission algorithm.
  */
 void IndirectTransmissionCalc::run() {
-	setRunIsRunning(true);
+  setRunIsRunning(true);
 
   std::string instrumentName =
       m_uiForm.iicInstrumentConfiguration->getInstrumentName().toStdString();
@@ -99,32 +99,31 @@ void IndirectTransmissionCalc::run() {
  * @param error If the algorithm encountered an error during execution
  */
 void IndirectTransmissionCalc::algorithmComplete(bool error) {
-	setRunIsRunning(false);
+  setRunIsRunning(false);
 
   if (!error) {
-		std::string const instrumentName =
-			m_uiForm.iicInstrumentConfiguration->getInstrumentName().toStdString();
-		std::string const outWsName = instrumentName + "_transmission";
+    std::string const instrumentName =
+        m_uiForm.iicInstrumentConfiguration->getInstrumentName().toStdString();
+    std::string const outWsName = instrumentName + "_transmission";
 
-		auto resultTable =
-			AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(outWsName);
-		Column_const_sptr propertyNames = resultTable->getColumn("Name");
-		Column_const_sptr propertyValues = resultTable->getColumn("Value");
+    auto resultTable =
+        AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(outWsName);
+    Column_const_sptr propertyNames = resultTable->getColumn("Name");
+    Column_const_sptr propertyValues = resultTable->getColumn("Value");
 
-		// Update the table in the GUI
-		m_uiForm.tvResultsTable->clear();
+    // Update the table in the GUI
+    m_uiForm.tvResultsTable->clear();
 
-		for (auto i = 0u; i < resultTable->rowCount(); ++i) {
-			QTreeWidgetItem *item = new QTreeWidgetItem();
-			item->setText(0,
-				QString::fromStdString(propertyNames->cell<std::string>(i)));
-			item->setText(1, QString::number(propertyValues->cell<double>(i)));
-			m_uiForm.tvResultsTable->addTopLevelItem(item);
-		}
-  }
-	else
-		emit showMessageBox("Failed to execute IndirectTransmission "
-			"algorithm.\nSee Results Log for details.");
+    for (auto i = 0u; i < resultTable->rowCount(); ++i) {
+      QTreeWidgetItem *item = new QTreeWidgetItem();
+      item->setText(
+          0, QString::fromStdString(propertyNames->cell<std::string>(i)));
+      item->setText(1, QString::number(propertyValues->cell<double>(i)));
+      m_uiForm.tvResultsTable->addTopLevelItem(item);
+    }
+  } else
+    emit showMessageBox("Failed to execute IndirectTransmission "
+                        "algorithm.\nSee Results Log for details.");
 }
 
 /**
@@ -137,17 +136,15 @@ void IndirectTransmissionCalc::loadSettings(const QSettings &settings) {
   UNUSED_ARG(settings);
 }
 
-void IndirectTransmissionCalc::runClicked() {
-	runTab();
-}
+void IndirectTransmissionCalc::runClicked() { runTab(); }
 
 void IndirectTransmissionCalc::setRunIsRunning(bool running) {
-	m_uiForm.pbRun->setText(running ? "Running..." : "Run");
-	setRunEnabled(!running);
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
 }
 
 void IndirectTransmissionCalc::setRunEnabled(bool enabled) {
-	m_uiForm.pbRun->setEnabled(enabled);
+  m_uiForm.pbRun->setEnabled(enabled);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
@@ -37,6 +37,9 @@ private slots:
 	void runClicked();
 
 private:
+	void setRunIsRunning(bool running);
+	void setRunEnabled(bool enabled);
+
   /// The UI form
   Ui::IndirectTransmissionCalc m_uiForm;
   /// The name of the current instrument

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
@@ -34,6 +34,7 @@ protected:
 private slots:
   /// Handles completion of the algorithm
   void algorithmComplete(bool error);
+	void runClicked();
 
 private:
   /// The UI form

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.h
@@ -34,11 +34,11 @@ protected:
 private slots:
   /// Handles completion of the algorithm
   void algorithmComplete(bool error);
-	void runClicked();
+  void runClicked();
 
 private:
-	void setRunIsRunning(bool running);
-	void setRunEnabled(bool enabled);
+  void setRunIsRunning(bool running);
+  void setRunEnabled(bool enabled);
 
   /// The UI form
   Ui::IndirectTransmissionCalc m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <widget class="QGroupBox" name="gbInstrumentConfig">
@@ -159,7 +159,7 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="0" column="1">
     <widget class="QTreeWidget" name="tvResultsTable">
      <property name="columnCount">
       <number>2</number>
@@ -180,6 +180,63 @@
        <string>Value</string>
       </property>
      </column>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>350</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>349</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
**Description of work.**
This PR moves the run button on the Transmission tab of the Indirect tools interface to allow for the Run button to be disabled while running is taking place.

**To test:**
1. `Interfaces`->`Indirect`->`Tools`->`Transmission` tab
2. Chemical Formula: `H2-O`
3. Mass density: 1.0
4. Click `Run` and make sure the run button is disabled while running

Fixes #24064

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
