### PR TITLE
Revert "Switch WANDPowderReduction to use Rebin"

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -56,22 +56,24 @@ class WANDPowderReductionTest(unittest.TestCase):
         # data normalised by monitor
         pd_out=WANDPowderReduction(InputWorkspace=data,
                                    Target='Theta',
-                                   Params=0.04)
+                                   NumberBins=1000)
 
         x = pd_out.extractX()
         y = pd_out.extractY()
 
-        self.assertAlmostEqual(x.min(),  8.06946698)
-        self.assertAlmostEqual(x.max(), 50.83030150)
-        self.assertAlmostEqual(y.min(),  0.00306758)
-        self.assertAlmostEqual(y.max(),  4.37085727)
-        self.assertAlmostEqual(x[0,y.argmax()], 45.10946698)
+        self.assertAlmostEqual(x.min(),  8.07086781)
+        self.assertAlmostEqual(x.max(), 50.82973519)
+        self.assertAlmostEqual(y.min(),  0.00328244)
+        self.assertAlmostEqual(y.max(),  4.88908824)
+        self.assertAlmostEqual(x[0,y.argmax()], 45.094311535)
 
         # data and calibration, limited range
         pd_out2=WANDPowderReduction(InputWorkspace=data,
                                     CalibrationWorkspace=cal,
                                     Target='Theta',
-                                    Params='10,0.015,40')
+                                    NumberBins=2000,
+                                    XMin=10,
+                                    XMax=40)
 
         x = pd_out2.extractX()
         y = pd_out2.extractY()
@@ -87,17 +89,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     CalibrationWorkspace=cal,
                                     BackgroundWorkspace=bkg,
                                     Target='Theta',
-                                    Params=0.04,
+                                    NumberBins=1000,
                                     NormaliseBy='Time')
 
         x = pd_out3.extractX()
         y = pd_out3.extractY()
 
-        self.assertAlmostEqual(x.min(),  8.06946698)
-        self.assertAlmostEqual(x.max(), 50.83030150)
+        self.assertAlmostEqual(x.min(), 8.07086781)
+        self.assertAlmostEqual(x.max(), 50.82973519)
         self.assertAlmostEqual(y.min(),  0)
-        self.assertAlmostEqual(y.max(), 19.97454882)
-        self.assertAlmostEqual(x[0,y.argmax()], 44.98946698)
+        self.assertAlmostEqual(y.max(), 19.97968357)
+        self.assertAlmostEqual(x[0,y.argmax()], 45.008708196)
 
         # data, cal and background. To d spacing
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -105,16 +107,16 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     Target='ElasticDSpacing',
                                     EFixed=30,
-                                    Params=0.002)
+                                    NumberBins=1000)
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(),  1.92408134)
-        self.assertAlmostEqual(x.max(), 11.76333605)
+        self.assertAlmostEqual(x.min(), 1.92800159)
+        self.assertAlmostEqual(x.max(), 11.7586705)
         self.assertAlmostEqual(y.min(),  0)
-        self.assertAlmostEqual(y.max(), 19.96633911)
-        self.assertAlmostEqual(x[0,y.argmax()], 2.15808134)
+        self.assertAlmostEqual(y.max(), 19.03642005)
+        self.assertAlmostEqual(x[0,y.argmax()], 2.1543333)
 
         # data, cal and background with mask angle, to Q.
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -122,17 +124,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     Target='ElasticQ',
                                     EFixed=30,
-                                    Params=0.0035,
+                                    NumberBins=2000,
                                     MaskAngle=60)
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(), 0.53587138, places=4)
-        self.assertAlmostEqual(x.max(), 3.21632108, places=4)
+        self.assertAlmostEqual(x.min(), 0.53479223, places=4)
+        self.assertAlmostEqual(x.max(), 3.21684994, places=4)
         self.assertAlmostEqual(y.min(),  0, places=4)
-        self.assertAlmostEqual(y.max(), 19.9705871, places=4)
-        self.assertAlmostEqual(x[0,y.argmax()], 2.91237138, places=4)
+        self.assertAlmostEqual(y.max(), 19.9948756, places=4)
+        self.assertAlmostEqual(x[0,y.argmax()], 2.9122841, places=4)
 
         # data, cal and background, scale background
         pd_out4=WANDPowderReduction(InputWorkspace=data,
@@ -140,17 +142,17 @@ class WANDPowderReductionTest(unittest.TestCase):
                                     BackgroundWorkspace=bkg,
                                     BackgroundScale=0.5,
                                     Target='Theta',
-                                    Params=0.04,
+                                    NumberBins=1000,
                                     NormaliseBy='Time')
 
         x = pd_out4.extractX()
         y = pd_out4.extractY()
 
-        self.assertAlmostEqual(x.min(),  8.06946698)
-        self.assertAlmostEqual(x.max(), 50.83030150)
+        self.assertAlmostEqual(x.min(), 8.07086781)
+        self.assertAlmostEqual(x.max(), 50.82973519)
         self.assertAlmostEqual(y.min(),  0.75)
-        self.assertAlmostEqual(y.max(), 20.72454882)
-        self.assertAlmostEqual(x[0,y.argmax()], 44.98946698)
+        self.assertAlmostEqual(y.max(), 20.72968357)
+        self.assertAlmostEqual(x[0,y.argmax()], 45.008708196)
 
 
 if __name__ == '__main__':

--- a/docs/source/algorithms/WANDPowderReduction-v1.rst
+++ b/docs/source/algorithms/WANDPowderReduction-v1.rst
@@ -24,8 +24,6 @@ algorithm will work on data loaded with :ref:`LoadEventNexus
 <algm-FilterEvents>` but you will need to specify `EFixed` if
 converting to anything except `Theta`.
 
-:ref:`Rebin <algm-Rebin>` is used to bin the data so see it's
-documentation for use of the `Params` parameter.
 
 MaskAngle
 #########
@@ -51,7 +49,7 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon,
                        CalibrationWorkspace=vanadium,
                        Target='Theta',
-                       Params=0.1,
+                       NumberBins=1000,
                        OutputWorkspace='silicon_powder')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder.png
@@ -66,7 +64,9 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon,
                        CalibrationWorkspace=vanadium,
                        Target='ElasticQ',
-                       Params='4.5,0.0035,6.25',
+                       XMin=4.5,
+                       Xmax=6.25,
+                       NumberBins=500,
                        OutputWorkspace='silicon_powder_q')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_q.png
@@ -81,7 +81,7 @@ Usage
    WANDPowderReduction(InputWorkspace=silicon2,
                        CalibrationWorkspace=vanadium,
                        Target='ElasticDSpacing',
-                       Params=0.002,
+                       NumberBins=1000,
                        OutputWorkspace='silicon_powder_d_spacing')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_d.png
@@ -103,7 +103,7 @@ Usage
                        CalibrationWorkspace=vanadium,
                        BackgroundWorkspace=bkg,
                        Target='Theta',
-                       Params=0.1,
+                       NumberBins=1000,
                        OutputWorkspace='silicon_powder_background')
 
    # Scale background by 50%
@@ -112,7 +112,7 @@ Usage
                        BackgroundWorkspace=bkg,
                        BackgroundScale=0.5,
                        Target='Theta',
-                       Params=0.1,
+                       NumberBins=1000,
                        OutputWorkspace='silicon_powder_background_0.5')
 
 .. figure:: /images/WANDPowderReduction_silicon_powder_bkg.png

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -22,7 +22,6 @@ Improvements
 - :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>` and :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now support outputting the unfocussed data and weighted events (with time). This allows for event filtering **after** processing the data.
 - :ref:`LoadWAND <algm-LoadWAND>` has grouping option added and loads faster
 - Mask workspace option added to :ref:`WANDPowderReduction <algm-WANDPowderReduction>`
-- :ref:`WANDPowderReduction <algm-WANDPowderReduction>` has been change from using ResampleX to Rebin so that bin size can be specified instead of number of bins as requested by the instrument scientist.
 - :ref:`Le Bail concept page <Le Bail Fit>` moved from mediawiki
 - Rework of :ref:`powder diffraction calibration <Powder Diffraction Calibration>` documentation
 


### PR DESCRIPTION
Reverts mantidproject/mantid#24055

Reverting this for now until I work out the correct way to do it.

This fails in some cases _e.g._
```python
data = LoadWAND('/HFIR/HB2C/IPTS-7776/nexus/HB2C_143232.nxs.h5', Grouping='4x4')
out = WANDPowderReduction(InputWorkspace=data, Target='Theta', Params='0.1')
```
gives
```
WANDPowderReduction-[Error] Error in execution of algorithm WANDPowderReduction:
WANDPowderReduction-[Error] Rebin: error (see log)
WANDPowderReduction-[Error]   at line 110 in '/home/rwp/mantid/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py'
WANDPowderReduction-[Error]   caused by line 1102 in '/home/rwp/build/mantid/bin/mantid/simpleapi.py'