### PR TITLE
Add algorithm profiling instrumentation and doc

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -362,6 +362,15 @@ set ( INC_FILES
 	inc/MantidAPI/Workspace_fwd.h
 )
 
+option(PROFILE_ALGORITHM_LINUX "Profile algorithm execution on Linux and OSX" OFF)
+if(PROFILE_ALGORITHM_LINUX)
+	set(SRC_FILES "${SRC_FILES}" "src/AlgorithmExecuteProfile.cpp" "src/AlgoTimeRegister.cpp")
+	set(INC_FILES "${INC_FILES}" "inc/MantidAPI/AlgoTimeRegister.h")
+else()
+	set(SRC_FILES "${SRC_FILES}" "src/AlgorithmExecute.cpp")
+endif()
+unset(PROFILE_ALGORITHM_LINUX CACHE)
+
 set ( TEST_FILES
 	#	IkedaCarpenterModeratorTest.h
 	ADSValidatorTest.h

--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -362,7 +362,7 @@ set ( INC_FILES
 	inc/MantidAPI/Workspace_fwd.h
 )
 
-option(PROFILE_ALGORITHM_LINUX "Profile algorithm execution on Linux and OSX" OFF)
+option(PROFILE_ALGORITHM_LINUX "Profile algorithm execution on Linux" OFF)
 if(PROFILE_ALGORITHM_LINUX)
 	set(SRC_FILES "${SRC_FILES}" "src/AlgorithmExecuteProfile.cpp" "src/AlgoTimeRegister.cpp")
 	set(INC_FILES "${INC_FILES}" "inc/MantidAPI/AlgoTimeRegister.h")

--- a/Framework/API/inc/MantidAPI/AlgoTimeRegister.h
+++ b/Framework/API/inc/MantidAPI/AlgoTimeRegister.h
@@ -1,0 +1,62 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_API_ALGOTIMEREGISTER_H_
+#define MANTID_API_ALGOTIMEREGISTER_H_
+
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "MantidAPI/DllConfig.h"
+
+class timespec;
+
+namespace Mantid {
+namespace Instrumentation {
+
+/** AlgoTimeRegister : simple class to dump information about executed
+ * algorithms
+ */
+class AlgoTimeRegister {
+public:
+  static AlgoTimeRegister globalAlgoTimeRegister;
+  static timespec diff(timespec start, timespec end);
+  struct Info {
+    std::string m_name;
+    std::thread::id m_threadId;
+    timespec m_begin;
+    timespec m_end;
+
+    Info(const std::string &nm, const std::thread::id &id, const timespec &be,
+         const timespec &en)
+        : m_name(nm), m_threadId(id), m_begin(be), m_end(en) {}
+  };
+
+  class Dump {
+    AlgoTimeRegister &m_algoTimeRegister;
+    timespec m_regStart;
+    const std::string m_name;
+
+  public:
+    Dump(AlgoTimeRegister &atr, const std::string &nm);
+    ~Dump();
+  };
+
+  AlgoTimeRegister();
+  ~AlgoTimeRegister();
+
+private:
+  std::mutex m_mutex;
+  std::vector<Info> m_info;
+  timespec m_hstart;
+  std::chrono::high_resolution_clock::time_point m_start;
+};
+
+} // namespace Instrumentation
+} // namespace Mantid
+
+#endif /* MANTID_API_ALGOTIMEREGISTER_H_ */

--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -216,7 +216,7 @@ public:
 
   /** @name IAlgorithm methods */
   void initialize() override;
-  bool execute() override;
+  bool execute() override final;
   void executeAsChildAlg() override;
   std::map<std::string, std::string> validateInputs() override;
   bool isInitialized() const override;
@@ -414,6 +414,8 @@ private:
   void linkHistoryWithLastChild();
 
   void logAlgorithmInfo() const;
+
+  bool executeInternal();
 
   bool executeAsyncImpl(const Poco::Void &i);
 

--- a/Framework/API/src/AlgoTimeRegister.cpp
+++ b/Framework/API/src/AlgoTimeRegister.cpp
@@ -1,0 +1,59 @@
+#include "MantidAPI/AlgoTimeRegister.h"
+#include "MantidKernel/MultiThreaded.h"
+#include <fstream>
+#include <time.h>
+
+namespace Mantid {
+namespace Instrumentation {
+
+AlgoTimeRegister::Dump::Dump(AlgoTimeRegister &atr, const std::string &nm)
+    : m_algoTimeRegister(atr), m_name(nm) {
+  clock_gettime(CLOCK_MONOTONIC, &m_regStart);
+}
+
+timespec AlgoTimeRegister::diff(timespec start, timespec end) {
+  timespec temp;
+  if ((end.tv_nsec - start.tv_nsec) < 0) {
+    temp.tv_sec = end.tv_sec - start.tv_sec - 1;
+    temp.tv_nsec = 1000000000 + end.tv_nsec - start.tv_nsec;
+  } else {
+    temp.tv_sec = end.tv_sec - start.tv_sec;
+    temp.tv_nsec = end.tv_nsec - start.tv_nsec;
+  }
+  return temp;
+}
+
+AlgoTimeRegister::Dump::~Dump() {
+  timespec regFinish;
+  clock_gettime(CLOCK_MONOTONIC, &regFinish);
+  {
+    std::lock_guard<std::mutex> lock(m_algoTimeRegister.m_mutex);
+    m_algoTimeRegister.m_info.emplace_back(m_name, std::this_thread::get_id(),
+                                           m_regStart, regFinish);
+  }
+}
+
+AlgoTimeRegister::AlgoTimeRegister()
+    : m_start(std::chrono::high_resolution_clock::now()) {
+  clock_gettime(CLOCK_MONOTONIC, &m_hstart);
+}
+
+AlgoTimeRegister::~AlgoTimeRegister() {
+  std::fstream fs;
+  fs.open("./algotimeregister.out", std::ios::out);
+  fs << "START_POINT: "
+     << std::chrono::duration_cast<std::chrono::nanoseconds>(
+            m_start.time_since_epoch())
+            .count()
+     << " MAX_THREAD: " << PARALLEL_GET_MAX_THREADS << "\n";
+  for (auto &elem : m_info) {
+    auto st = diff(m_hstart, elem.m_begin);
+    auto fi = diff(m_hstart, elem.m_end);
+    fs << elem.m_threadId << ">>" << elem.m_name << ":"
+       << std::size_t(st.tv_sec * 1000000000) + st.tv_nsec << "<>"
+       << std::size_t(fi.tv_sec * 1000000000) + fi.tv_nsec << "\n";
+  }
+}
+
+} // namespace Instrumentation
+} // namespace Mantid

--- a/Framework/API/src/AlgoTimeRegister.cpp
+++ b/Framework/API/src/AlgoTimeRegister.cpp
@@ -49,9 +49,11 @@ AlgoTimeRegister::~AlgoTimeRegister() {
   for (auto &elem : m_info) {
     auto st = diff(m_hstart, elem.m_begin);
     auto fi = diff(m_hstart, elem.m_end);
-    fs << elem.m_threadId << ">>" << elem.m_name << ":"
-       << std::size_t(st.tv_sec * 1000000000) + st.tv_nsec << "<>"
-       << std::size_t(fi.tv_sec * 1000000000) + fi.tv_nsec << "\n";
+    fs << "ThreadID=" << elem.m_threadId
+       << ", AlgorithmName=" << elem.m_name
+       << ", StartTime=" << std::size_t(st.tv_sec * 1000000000) + st.tv_nsec
+       << ", EndTime=" << std::size_t(fi.tv_sec * 1000000000) + fi.tv_nsec
+       << "\n";
   }
 }
 

--- a/Framework/API/src/AlgoTimeRegister.cpp
+++ b/Framework/API/src/AlgoTimeRegister.cpp
@@ -49,8 +49,7 @@ AlgoTimeRegister::~AlgoTimeRegister() {
   for (auto &elem : m_info) {
     auto st = diff(m_hstart, elem.m_begin);
     auto fi = diff(m_hstart, elem.m_end);
-    fs << "ThreadID=" << elem.m_threadId
-       << ", AlgorithmName=" << elem.m_name
+    fs << "ThreadID=" << elem.m_threadId << ", AlgorithmName=" << elem.m_name
        << ", StartTime=" << std::size_t(st.tv_sec * 1000000000) + st.tv_nsec
        << ", EndTime=" << std::size_t(fi.tv_sec * 1000000000) + fi.tv_nsec
        << "\n";

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -434,17 +434,11 @@ void Algorithm::unlockWorkspaces() {
 }
 
 //---------------------------------------------------------------------------------------------
-/** The actions to be performed by the algorithm on a dataset. This method is
- *  invoked for top level algorithms by the application manager.
- *  This method invokes exec() method.
- *  For Child Algorithms either the execute() method or exec() method
- *  must be EXPLICITLY invoked by the parent algorithm.
- *
- *  @throw runtime_error Thrown if algorithm or Child Algorithm cannot be
- *executed
- *  @return true if executed successfully.
+/** Invoced internally in execute()
  */
-bool Algorithm::execute() {
+
+
+bool Algorithm::executeInternal() {
   Timer timer;
   AlgorithmManager::Instance().notifyAlgorithmStarting(this->getAlgorithmID());
   {

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -437,7 +437,6 @@ void Algorithm::unlockWorkspaces() {
 /** Invoced internally in execute()
  */
 
-
 bool Algorithm::executeInternal() {
   Timer timer;
   AlgorithmManager::Instance().notifyAlgorithmStarting(this->getAlgorithmID());

--- a/Framework/API/src/AlgorithmExecute.cpp
+++ b/Framework/API/src/AlgorithmExecute.cpp
@@ -1,0 +1,27 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAPI/Algorithm.h"
+
+namespace Mantid {
+namespace API {
+//---------------------------------------------------------------------------------------------
+/** The actions to be performed by the algorithm on a dataset. This method is
+ *  invoked for top level algorithms by the application manager.
+ *  This method invokes exec() method.
+ *  For Child Algorithms either the execute() method or exec() method
+ *  must be EXPLICITLY invoked by the parent algorithm.
+ *
+ *  @throw runtime_error Thrown if algorithm or Child Algorithm cannot be
+ *executed
+ *  @return true if executed successfully.
+ */
+bool Algorithm::execute() {
+  return executeInternal();
+}
+}
+}

--- a/Framework/API/src/AlgorithmExecute.cpp
+++ b/Framework/API/src/AlgorithmExecute.cpp
@@ -20,8 +20,6 @@ namespace API {
  *executed
  *  @return true if executed successfully.
  */
-bool Algorithm::execute() {
-  return executeInternal();
-}
-}
-}
+bool Algorithm::execute() { return executeInternal(); }
+} // namespace API
+} // namespace Mantid

--- a/Framework/API/src/AlgorithmExecuteProfile.cpp
+++ b/Framework/API/src/AlgorithmExecuteProfile.cpp
@@ -1,0 +1,32 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/AlgoTimeRegister.h"
+
+namespace Mantid {
+Instrumentation::AlgoTimeRegister Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister;
+namespace API {
+
+//---------------------------------------------------------------------------------------------
+/** The actions to be performed by the algorithm on a dataset. This method is
+ *  invoked for top level algorithms by the application manager.
+ *  This method invokes exec() method.
+ *  For Child Algorithms either the execute() method or exec() method
+ *  must be EXPLICITLY invoked by the parent algorithm.
+ *
+ *  @throw runtime_error Thrown if algorithm or Child Algorithm cannot be
+ *executed
+ *  @return true if executed successfully.
+ */
+bool Algorithm::execute() {
+  Instrumentation::AlgoTimeRegister::AlgoTimeRegister::Dump
+      dmp(Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister, name());
+  return executeInternal();
+}
+}
+}

--- a/Framework/API/src/AlgorithmExecuteProfile.cpp
+++ b/Framework/API/src/AlgorithmExecuteProfile.cpp
@@ -5,11 +5,12 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/AlgoTimeRegister.h"
+#include "MantidAPI/Algorithm.h"
 
 namespace Mantid {
-Instrumentation::AlgoTimeRegister Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister;
+Instrumentation::AlgoTimeRegister
+    Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister;
 namespace API {
 
 //---------------------------------------------------------------------------------------------
@@ -24,9 +25,9 @@ namespace API {
  *  @return true if executed successfully.
  */
 bool Algorithm::execute() {
-  Instrumentation::AlgoTimeRegister::AlgoTimeRegister::Dump
-      dmp(Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister, name());
+  Instrumentation::AlgoTimeRegister::AlgoTimeRegister::Dump dmp(
+      Instrumentation::AlgoTimeRegister::globalAlgoTimeRegister, name());
   return executeInternal();
 }
-}
-}
+} // namespace API
+} // namespace Mantid

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -1,0 +1,40 @@
+==============================
+Work flows algorithm profiling
+==============================
+
+.. contents:: Contents
+    :local:
+
+Summary
+^^^^^^^
+
+Due to the need of investigation of algorithms performance issues, the proper method
+is introduced. It consists two to parts: special mantid build and analytical tool.
+Available for Linux only.
+
+Mantid build
+^^^^^^^^^^^^
+
+To build mantid for profiling run ``cmake`` with the additional option ``-DPROFILE_ALGORITHM_LINUX=ON``.
+Built in such a way mantid creates a dump file ``algotimeregister.out`` in the running directory.
+This file contains the time stamps for start and finish of executed algorithms with ~nanocecond
+precision in a very simple text format.
+
+Analysing tool
+^^^^^^^^^^^^^^
+
+The project is available here: https://github.com/nvaytet/mantid-profiler. It provides the nice graphical
+tool to interpret the information from dumped file.
+
+Windows development
+^^^^^^^^^^^^^^^^^^^
+
+Precise timers are different for Linux and Windows (chrono is not good enough), so we need to treat them
+separately. The suggestion is either to modify files ``Framework/API/inc/MantidAPI/AlgoTimeRegister.h`` and
+``Framework/API/src/AlgoTimeRegister.cpp`` in manner ``#ifdef __WIN32`` or create the specific files with
+the ``AlgoTimeRegister`` class for Windows and then in ``Framework/API/CMakeLists.txt`` edit the chunk that
+describes option PROFILE_ALGORITHM_LINUX combined with OS defied flags e.g., also in this case
+``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted.
+``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``. QueryPerformanceCounter supposed to be used on windows,
+instead of clock_gettime.
+

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -33,7 +33,7 @@ Precise timers are different for Linux and Windows (chrono is not good enough), 
 separately. The suggestion is either to modify files ``Framework/API/inc/MantidAPI/AlgoTimeRegister.h`` and
 ``Framework/API/src/AlgoTimeRegister.cpp`` in manner ``#ifdef __WIN32`` or create the specific files with
 the ``AlgoTimeRegister`` class for Windows and then in ``Framework/API/CMakeLists.txt`` edit the chunk that
-describes option PROFILE_ALGORITHM_LINUX combined with OS defied flags e.g., also in this case
+describes option PROFILE_ALGORITHM_LINUX combined with OS defined flags. In this case
 ``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted.
 ``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``. QueryPerformanceCounter supposed to be used on windows,
 instead of clock_gettime.

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -18,7 +18,7 @@ Mantid build
 To build mantid version with profiling functionality enabled run ``cmake`` with the additional option
 ``-DPROFILE_ALGORITHM_LINUX=ON``. Built in such a way mantid creates a dump file ``algotimeregister.out``
 in the running directory. This file contains the time stamps for start and finish of executed algorithms with
-~nanoceconds precision in a very simple text format.
+~nanosecond precision in a very simple text format.
 
 Analysing tool
 ^^^^^^^^^^^^^^

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -34,7 +34,7 @@ separately. The suggestion is either to modify files ``Framework/API/inc/MantidA
 ``Framework/API/src/AlgoTimeRegister.cpp`` by including ``#ifdef __WIN32``, or create the specific files with
 the ``AlgoTimeRegister`` class for Windows and then in ``Framework/API/CMakeLists.txt`` edit the chunk that
 describes option PROFILE_ALGORITHM_LINUX combined with OS defined flags. In this case
-``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted.
+``Framework/API/src/AlgorithmExecuteProfile.cpp`` also needs to be modified or substituted.
 ``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``. QueryPerformanceCounter supposed to be used on windows,
 instead of clock_gettime.
 

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -31,7 +31,7 @@ Windows development
 
 Precise timers are different for Linux and Windows (chrono is not good enough), so we need to treat them
 separately. The suggestion is either to modify files ``Framework/API/inc/MantidAPI/AlgoTimeRegister.h`` and
-``Framework/API/src/AlgoTimeRegister.cpp`` in manner ``#ifdef __WIN32`` or create the specific files with
+``Framework/API/src/AlgoTimeRegister.cpp`` by including ``#ifdef __WIN32``, or create the specific files with
 the ``AlgoTimeRegister`` class for Windows and then in ``Framework/API/CMakeLists.txt`` edit the chunk that
 describes option PROFILE_ALGORITHM_LINUX combined with OS defined flags. In this case
 ``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted.

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -18,7 +18,7 @@ Mantid build
 To build mantid version with profiling functionality enabled run ``cmake`` with the additional option
 ``-DPROFILE_ALGORITHM_LINUX=ON``. Built in such a way mantid creates a dump file ``algotimeregister.out``
 in the running directory. This file contains the time stamps for start and finish of executed algorithms with
-~nanocecond precision in a very simple text format.
+~nanoceconds precision in a very simple text format.
 
 Analysing tool
 ^^^^^^^^^^^^^^
@@ -35,5 +35,5 @@ separately. The suggestion is either to modify files ``Framework/API/inc/MantidA
 the ``AlgoTimeRegister`` class defined for Windows.  In the second case an inclusion of OS specific files should be
 done correctly in ``Framework/API/CMakeLists.txt`  using ``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``,
 ``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted according to the type of OS.
-QueryPerformanceCounter supposed to be used on windows, instead of clock_gettime.
+``QueryPerformanceCounter`` supposed to be used on windows, instead of ``clock_gettime``.
 

--- a/dev-docs/source/AlgorithmProfiler.rst
+++ b/dev-docs/source/AlgorithmProfiler.rst
@@ -15,16 +15,16 @@ Available for Linux only.
 Mantid build
 ^^^^^^^^^^^^
 
-To build mantid for profiling run ``cmake`` with the additional option ``-DPROFILE_ALGORITHM_LINUX=ON``.
-Built in such a way mantid creates a dump file ``algotimeregister.out`` in the running directory.
-This file contains the time stamps for start and finish of executed algorithms with ~nanocecond
-precision in a very simple text format.
+To build mantid version with profiling functionality enabled run ``cmake`` with the additional option
+``-DPROFILE_ALGORITHM_LINUX=ON``. Built in such a way mantid creates a dump file ``algotimeregister.out``
+in the running directory. This file contains the time stamps for start and finish of executed algorithms with
+~nanocecond precision in a very simple text format.
 
 Analysing tool
 ^^^^^^^^^^^^^^
 
 The project is available here: https://github.com/nvaytet/mantid-profiler. It provides the nice graphical
-tool to interpret the information from dumped file.
+tool to interpret the information contained in the dumped file.
 
 Windows development
 ^^^^^^^^^^^^^^^^^^^
@@ -32,9 +32,8 @@ Windows development
 Precise timers are different for Linux and Windows (chrono is not good enough), so we need to treat them
 separately. The suggestion is either to modify files ``Framework/API/inc/MantidAPI/AlgoTimeRegister.h`` and
 ``Framework/API/src/AlgoTimeRegister.cpp`` by including ``#ifdef __WIN32``, or create the specific files with
-the ``AlgoTimeRegister`` class for Windows and then in ``Framework/API/CMakeLists.txt`` edit the chunk that
-describes option PROFILE_ALGORITHM_LINUX combined with OS defined flags. In this case
-``Framework/API/src/AlgorithmExecuteProfile.cpp`` also needs to be modified or substituted.
-``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``. QueryPerformanceCounter supposed to be used on windows,
-instead of clock_gettime.
+the ``AlgoTimeRegister`` class defined for Windows.  In the second case an inclusion of OS specific files should be
+done correctly in ``Framework/API/CMakeLists.txt`  using ``${CMAKE_SYSTEM_NAME} MATCHES "Windows"``,
+``Framework/API/src/AlgorithmExecuteProfile.cpp`` needs to be modified or substituted according to the type of OS.
+QueryPerformanceCounter supposed to be used on windows, instead of clock_gettime.
 


### PR DESCRIPTION
re #0

**Description of work.**
The functionality for profiling the algorithm ``execute()`` function is added for Linux.  It creates a dump file ``algotimeregister.out`` in the running directory with some information about execution of algorithms, 
should be used together with the utility [mantid-profiler](https://github.com/nvaytet/mantid-profiler). See
AlgorithmProfiler.rst.

**To test:**
Build mantid with ``cmake -DPROFILE_ALGORITHM_LINUX=ON ...``. Follow the instructions here [mantid-profiler](https://github.com/nvaytet/mantid-profiler).

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because ** it is developer tool**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
