### PR TITLE
Fix the facilities list in CatalogLogin

### DIFF
--- a/Framework/ICat/src/CatalogLogin.cpp
+++ b/Framework/ICat/src/CatalogLogin.cpp
@@ -29,8 +29,9 @@ std::vector<std::string> namesOfFacilitiesWithICAT() {
   };
 
   auto result = Kernel::ConfigService::Instance().getFacilityNames();
-  result.erase(std::remove_if(result.begin(), result.end(), facilityDoesNotHaveICAT),
-               result.end());
+  result.erase(
+      std::remove_if(result.begin(), result.end(), facilityDoesNotHaveICAT),
+      result.end());
 
   return result;
 }

--- a/Framework/ICat/src/CatalogLogin.cpp
+++ b/Framework/ICat/src/CatalogLogin.cpp
@@ -24,12 +24,12 @@ namespace {
 std::vector<std::string> namesOfFacilitiesWithICAT() {
   const auto &config = Kernel::ConfigService::Instance();
 
-  const auto facilityHasICAT = [&](std::string name) {
-    return !config.getFacility(name).catalogInfo().soapEndPoint().empty();
+  const auto facilityDoesNotHaveICAT = [&](std::string name) {
+    return config.getFacility(name).catalogInfo().soapEndPoint().empty();
   };
 
   auto result = Kernel::ConfigService::Instance().getFacilityNames();
-  result.erase(std::remove_if(result.begin(), result.end(), facilityHasICAT),
+  result.erase(std::remove_if(result.begin(), result.end(), facilityDoesNotHaveICAT),
                result.end());
 
   return result;


### PR DESCRIPTION
PR #23879 introduced a check for which facilities have ICat but the check was the wrong way round.

**Report to:** nobody

**To test:**

- Open the CatalogLogin algorithm
- Check that ISIS is the only facility in the drop-down list

*There is no associated issue.*

*This does not require release notes* because it fixes a regression in the nightly build

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
