### PR TITLE
Indirect - Iqt Tiled plot range bug

### DIFF
--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -23,32 +23,35 @@ namespace {
 Mantid::Kernel::Logger g_log("Iqt");
 
 MatrixWorkspace_sptr getADSWorkspace(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      workspaceName);
 }
 
 std::size_t getWsNumberOfSpectra(std::string const &workspaceName) {
-	return getADSWorkspace(workspaceName)->getNumberHistograms();
+  return getADSWorkspace(workspaceName)->getNumberHistograms();
 }
 
-bool checkADSForWorkspace(std::string const &workspaceName) { 
-	return AnalysisDataService::Instance().doesExist(workspaceName); 
+bool checkADSForWorkspace(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
-void cloneWorkspace(std::string const &workspaceName, std::string const &cloneName) {
-	auto cloner = AlgorithmManager::Instance().create("CloneWorkspace");
-	cloner->initialize();
-	cloner->setProperty("InputWorkspace", workspaceName);
-	cloner->setProperty("OutputWorkspace", cloneName);
-	cloner->execute();
+void cloneWorkspace(std::string const &workspaceName,
+                    std::string const &cloneName) {
+  auto cloner = AlgorithmManager::Instance().create("CloneWorkspace");
+  cloner->initialize();
+  cloner->setProperty("InputWorkspace", workspaceName);
+  cloner->setProperty("OutputWorkspace", cloneName);
+  cloner->execute();
 }
 
-void cropWorkspace(std::string const &name, std::string const &newName, double const &cropValue) {
-	auto croper = AlgorithmManager::Instance().create("CropWorkspace");
-	croper->initialize();
-	croper->setProperty("InputWorkspace", name);
-	croper->setProperty("OutputWorkspace", newName);
-	croper->setProperty("XMin", cropValue);
-	croper->execute();
+void cropWorkspace(std::string const &name, std::string const &newName,
+                   double const &cropValue) {
+  auto croper = AlgorithmManager::Instance().create("CropWorkspace");
+  croper->initialize();
+  croper->setProperty("InputWorkspace", name);
+  croper->setProperty("OutputWorkspace", newName);
+  croper->setProperty("XMin", cropValue);
+  croper->execute();
 }
 
 /**
@@ -224,13 +227,14 @@ void Iqt::algorithmComplete(bool error) {
     setTiledPlotEnabled(false);
     setSaveResultEnabled(false);
   } else {
-		auto const lastSpectrumIndex = static_cast<int>(getWsNumberOfSpectra(m_pythonExportWsName)) - 1;
-		auto const selectedSpec = selectedSpectrum();
+    auto const lastSpectrumIndex =
+        static_cast<int>(getWsNumberOfSpectra(m_pythonExportWsName)) - 1;
+    auto const selectedSpec = selectedSpectrum();
 
     setPlotSpectrumIndexMax(lastSpectrumIndex);
     setPlotSpectrumIndex(selectedSpec);
-		setMinMaxOfTiledPlotFirstIndex(0, lastSpectrumIndex);
-		setMinMaxOfTiledPlotLastIndex(0, lastSpectrumIndex);
+    setMinMaxOfTiledPlotFirstIndex(0, lastSpectrumIndex);
+    setMinMaxOfTiledPlotLastIndex(0, lastSpectrumIndex);
     setTiledPlotFirstIndex(selectedSpec);
     setTiledPlotLastIndex(lastSpectrumIndex);
   }
@@ -294,14 +298,14 @@ void Iqt::plotTiled() {
   auto const firstTiledPlot = m_uiForm.spTiledPlotFirst->text().toInt();
   auto const lastTiledPlot = m_uiForm.spTiledPlotLast->text().toInt();
 
-	// Clone workspace before cropping to keep in ADS
-	if (!checkADSForWorkspace(tiledPlotWsName))
-		cloneWorkspace(outWs->getName(), tiledPlotWsName);
+  // Clone workspace before cropping to keep in ADS
+  if (!checkADSForWorkspace(tiledPlotWsName))
+    cloneWorkspace(outWs->getName(), tiledPlotWsName);
 
-	// Get first x value which corresponds to a y value below 1
-	auto const cropValue =
-		getXMinValue(outWs, static_cast<std::size_t>(firstTiledPlot));
-	cropWorkspace(tiledPlotWsName, tiledPlotWsName, cropValue);
+  // Get first x value which corresponds to a y value below 1
+  auto const cropValue =
+      getXMinValue(outWs, static_cast<std::size_t>(firstTiledPlot));
+  cropWorkspace(tiledPlotWsName, tiledPlotWsName, cropValue);
 
   auto const tiledPlotWs = getADSWorkspace(tiledPlotWsName);
 
@@ -515,26 +519,30 @@ void Iqt::updateRS(QtProperty *prop, double val) {
 void Iqt::setTiledPlotFirstPlot(int value) {
   MantidQt::API::SignalBlocker<QObject> blocker(m_uiForm.spTiledPlotFirst);
   auto const lastPlotIndex = m_uiForm.spTiledPlotLast->text().toInt();
-	auto const rangeSize = lastPlotIndex - value;
-	if (value > lastPlotIndex)
-		setTiledPlotFirstIndex(lastPlotIndex);
-	else if (rangeSize > m_maxTiledPlots) {
-		auto const lastSpectrumIndex = static_cast<int>(getWsNumberOfSpectra(m_pythonExportWsName)) - 1;
-		auto const lastIndex = value + m_maxTiledPlots <= lastSpectrumIndex ? value + m_maxTiledPlots : lastSpectrumIndex;
-		setTiledPlotLastIndex(lastIndex);
-	}
+  auto const rangeSize = lastPlotIndex - value;
+  if (value > lastPlotIndex)
+    setTiledPlotFirstIndex(lastPlotIndex);
+  else if (rangeSize > m_maxTiledPlots) {
+    auto const lastSpectrumIndex =
+        static_cast<int>(getWsNumberOfSpectra(m_pythonExportWsName)) - 1;
+    auto const lastIndex = value + m_maxTiledPlots <= lastSpectrumIndex
+                               ? value + m_maxTiledPlots
+                               : lastSpectrumIndex;
+    setTiledPlotLastIndex(lastIndex);
+  }
 }
 
 void Iqt::setTiledPlotLastPlot(int value) {
   MantidQt::API::SignalBlocker<QObject> blocker(m_uiForm.spTiledPlotLast);
   auto const firstPlotIndex = m_uiForm.spTiledPlotFirst->text().toInt();
-	auto const rangeSize = value - firstPlotIndex;
-	if (value < firstPlotIndex)
+  auto const rangeSize = value - firstPlotIndex;
+  if (value < firstPlotIndex)
     setTiledPlotLastIndex(firstPlotIndex);
-	else if (rangeSize > m_maxTiledPlots) {
-		auto const firstIndex = value - m_maxTiledPlots >= 0 ? value - m_maxTiledPlots : 0;
-		setTiledPlotFirstIndex(firstIndex);
-	}
+  else if (rangeSize > m_maxTiledPlots) {
+    auto const firstIndex =
+        value - m_maxTiledPlots >= 0 ? value - m_maxTiledPlots : 0;
+    setTiledPlotFirstIndex(firstIndex);
+  }
 }
 
 void Iqt::setMinMaxOfTiledPlotFirstIndex(int minimum, int maximum) {
@@ -556,8 +564,8 @@ void Iqt::setTiledPlotLastIndex(int value) {
   MantidQt::API::SignalBlocker<QObject> blocker(m_uiForm.spTiledPlotLast);
   auto const firstPlotIndex = m_uiForm.spTiledPlotFirst->text().toInt();
   auto const lastPlotIndex = value - m_maxTiledPlots > firstPlotIndex
-                           ? firstPlotIndex + m_maxTiledPlots
-                           : value;
+                                 ? firstPlotIndex + m_maxTiledPlots
+                                 : value;
   m_uiForm.spTiledPlotLast->setValue(lastPlotIndex);
 }
 

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -27,9 +27,6 @@ private:
 
   bool isErrorsEnabled();
 
-  Mantid::API::MatrixWorkspace_const_sptr
-  getADSWorkspace(std::string const &name) const;
-  std::size_t getOutWsNumberOfSpectra() const;
   std::size_t getXMinIndex(Mantid::MantidVec const &firstSpectraYData,
                            std::vector<double>::const_iterator iter);
   double getXMinValue(Mantid::API::MatrixWorkspace_const_sptr workspace,

--- a/qt/scientific_interfaces/Indirect/Iqt.ui
+++ b/qt/scientific_interfaces/Indirect/Iqt.ui
@@ -400,7 +400,7 @@
          <item>
           <widget class="QLabel" name="label_3">
            <property name="text">
-            <string>Spectra (max 18):</string>
+            <string>Range (max 18):</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where it was possible to select a spectra range with indices larger than the number of spectra in the _tiled workspace.
It also fixed a bug where the tiled plots were not being plotted.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`Iqt` tab
2. Load the data below
3. Click Run and wait
4. Increase the lower bound of the Tiled plot to 17. Try raising the upper bound, it shouldn't go any higher.

**Data Files**
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2625538/iris26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2625539/irs26173_graphite002_res.zip)


Fixes #24127

No release notes required for this fix as this feature was not in the previous release.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
