### PR TITLE
Fix mpl_toolkits import error on OSX

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -20,7 +20,27 @@ import mantid.plots.plotfunctions
 import mantid.plots.plotfunctions3D
 from matplotlib.axes import Axes
 from matplotlib.projections import register_projection
-from mpl_toolkits.mplot3d.axes3d import Axes3D
+
+try:
+    from mpl_toolkits.mplot3d.axes3d import Axes3D
+except ImportError:
+    # Special case to handle issues with importing mpl_toolkits
+    #
+    # Matplotlib adds a *nspkg.pth file to the user site packages directory.
+    # When that file is processed a fake built-in mpl_toolkits is imported
+    # which forces the site packages version to take precidence over our
+    # local copy regardless of python sys path settings.
+    #
+    # Work around by removing the fake built-in module from sys modules,
+    # then forcing python to search the path as expected.
+    #
+    # This is mostly but not necessarily limited to being an issue on OSX
+    # where there are multiple versions of matplotlib installed across the
+    # system.
+    import sys
+    del sys.modules['mpl_toolkits']
+    from mpl_toolkits.mplot3d.axes3d import Axes3D
+
 
 
 class MantidAxes(Axes):


### PR DESCRIPTION
**Description of work.**
Importing `mpl_toolkits` can fail on OSX when there are multiple versions of the matplotlib on the same machine. The issue is that importing matplotlib has a *nspkg.pth file which inserts `mpl_toolkits` as a "built-in" module. This means we can end up with an incompatible version as it does not correctly pick up the right `mpl_toolkits` from the sys path.

**Report to:** nobody. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Build the package on OSX and check that python is initialised correctly when starting MantidPlot.

*There is no associated issue.*

*This does not require release notes* because it's an internal fix for packaging purposes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
