### PR TITLE
Skip the test if mantidplot launcher doesn't exist

### DIFF
--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -13,32 +13,42 @@ import mantid
 
 
 class GUIStartupTest(systemtesting.MantidSystemTest):
-    '''
-    This test is supposed to start MantidPlot, and execute a simple script
-    If the script is run correctly, the "Hello Mantid" will be printed to stdout
-    If the script fails, there will be a fatal error mesage in stderr
+    '''This test is supposed to start MantidPlot, and execute a simple
+    script If the script is run correctly, the "Hello Mantid" will be
+    printed to stdout If the script fails, there will be a fatal error
+    mesage in stderr
     '''
 
     def __init__(self):
         super(GUIStartupTest, self).__init__()
         self.maxDiff = None
-        #create simple script
-        self.script=os.path.join(mantid.config.getString('defaultsave.directory'),'GUIStartupTest_script.py')
-        with open(self.script,'w') as f:
+        # create simple script
+        self.script = os.path.join(mantid.config.getString('defaultsave.directory'),
+                                   'GUIStartupTest_script.py')
+        with open(self.script, 'w') as f:
             f.write('import mantid\n'
                     'print("Hello Mantid")\n')
-        #get the mantidplot executable
+        # get the mantidplot executable
         current_platform = platform.platform()
         mantid_init_dirname = os.path.dirname(os.path.abspath(mantid.__file__))
         if 'Linux' in current_platform:
-            mantid_exe = os.path.join(mantid_init_dirname,"../launch_mantidplot.sh")
+            mantid_exe = os.path.join(mantid_init_dirname, "../launch_mantidplot.sh")
         elif 'Darwin' in current_platform:
-            mantid_exe = os.path.join(mantid_init_dirname,"../MantidPlot")
+            mantid_exe = os.path.join(mantid_init_dirname, "../MantidPlot")
         elif 'Windows' in current_platform:
-            mantid_exe = 'wscript.exe {}'.format(os.path.join(mantid_init_dirname,"../bin/launch_mantidplot.vbs"))
+            mantid_exe = 'wscript.exe {}'.format(os.path.join(mantid_init_dirname,
+                                                              "../bin/launch_mantidplot.vbs"))
         else:
             raise RuntimeError("Unknown operating system")
-        self.cmd='{0} -xq {1}'.format(mantid_exe,self.script)
+
+        # verify the launch script exists
+        if os.path.exists(mantid_exe):
+            self.cmd = '{0} -xq {1}'.format(mantid_exe, self.script)
+        else:
+            self.cmd = None
+
+    def skipTests(self):
+        return self.cmd is None
 
     def cleanup(self):
         if os.path.exists(self.script):
@@ -51,7 +61,7 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         self.assertEquals(out, b'Hello Mantid\n')
 
         # failing script
-        with open(self.script,'a') as f:
+        with open(self.script, 'a') as f:
             f.write('raise RuntimeError("GUITest")')
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()


### PR DESCRIPTION
This is intended to fix the failing conda systemtest build due to #24076 (merged yesterday), which is framework only. The other changes are to reduce pep8/flake8 warnings.

**To test:**

Look at the code and see that the builds pass.

*There is no associated issue.*

*This does not require release notes* because the earlier PR didn't have any either.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
