### PR TITLE
Workbench: Disable show instrument if no instrument exists

### DIFF
--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -6,14 +6,15 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h"
 #include "MantidQtWidgets/Common/MantidTreeModel.h"
-#include <MantidQtWidgets/Common/MantidTreeWidget.h>
-#include <MantidQtWidgets/Common/MantidTreeWidgetItem.h>
+#include "MantidQtWidgets/Common/MantidTreeWidget.h"
+#include "MantidQtWidgets/Common/MantidTreeWidgetItem.h"
 
-#include <MantidAPI/AlgorithmManager.h>
-#include <MantidAPI/FileProperty.h>
-#include <MantidAPI/ITableWorkspace.h>
-#include <MantidAPI/MatrixWorkspace.h>
-#include <MantidAPI/WorkspaceGroup.h>
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidGeometry/Instrument.h"
 
 #include <QMenu>
 #include <QSignalMapper>
@@ -85,7 +86,8 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     } catch (Exception::NotFoundError &) {
       return;
     }
-    if (boost::dynamic_pointer_cast<MatrixWorkspace>(workspace)) {
+    if (auto matrixWS =
+            boost::dynamic_pointer_cast<MatrixWorkspace>(workspace)) {
       QMenu *plotSubMenu(new QMenu("Plot", menu));
       plotSubMenu->addAction(m_plotSpectrum);
       plotSubMenu->addAction(m_overplotSpectrum);
@@ -97,6 +99,9 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       menu->addSeparator();
       menu->addAction(m_showData);
       menu->addAction(m_showInstrument);
+      m_showInstrument->setEnabled(
+          matrixWS->getInstrument() &&
+          !matrixWS->getInstrument()->getName().empty());
       menu->addSeparator();
     }
     menu->addAction(m_rename);


### PR DESCRIPTION
**Description of work.**

Disables the workspace tree menu item "show instrument" if the workspace has not instrument to show. Avoids a segfault.

**Report to:** [nobody]. 

**To test:**

Load `DocTest/poldi_2_phases_theoretical_reference.nxs` from the DocTest data in the workbench and observe that the instrument option is disabled.

Also try a workspace with an instrument to check you can see it.

*There is no associated issue.*

*This does not require release notes* because **workbench is not released yet.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
