### PR TITLE
MR: add option not to perform final rebin

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -95,6 +95,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         self.declareProperty("RoundUpPixel", True, doc="If True, round up pixel position of the specular reflectivity")
         self.declareProperty("UseSANGLE", False, doc="If True, use SANGLE as the scattering angle")
         self.declareProperty("SpecularPixel", 180.0, doc="Pixel position of the specular reflectivity")
+        self.declareProperty("FinalRebin", True, doc="If True, the final reflectivity will be rebinned")
         self.declareProperty("QMin", 0.005, doc="Minimum Q-value")
         self.declareProperty("QStep", 0.02, doc="Step size in Q. Enter a negative value to get a log scale")
         self.declareProperty("AngleOffset", 0.0, doc="angle offset (rad)")
@@ -442,13 +443,22 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         q_workspace = SortXAxis(InputWorkspace=q_workspace, OutputWorkspace=str(q_workspace))
 
         name_output_ws = str(workspace)+'_reflectivity'
-        try:
-            q_rebin = Rebin(InputWorkspace=q_workspace, Params=q_range,
-                            OutputWorkspace=name_output_ws)
-        except:
-            raise RuntimeError("Could not rebin with %s" % str(q_range))
+        do_q_rebin = self.getProperty("FinalRebin").value
 
-        AnalysisDataService.remove(str(q_workspace))
+        if do_q_rebin:
+            try:
+                q_rebin = Rebin(InputWorkspace=q_workspace, Params=q_range,
+                                OutputWorkspace=name_output_ws)
+                AnalysisDataService.remove(str(q_workspace))
+            except:
+                logger.error("Could not rebin with %s" % str(q_range))
+                do_q_rebin = False
+
+        # If we either didn't want to rebin or we failed to rebin,
+        # rename the reflectivity workspace and proceed with it.
+        if not do_q_rebin:
+            q_rebin = RenameWorkspace(InputWorkspace=q_workspace,
+                                      OutputWorkspace=name_output_ws)
 
         return q_rebin
 

--- a/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/MagnetismReflectometryReductionTest.py
@@ -78,6 +78,38 @@ class MagnetismReflectometryReductionConstQTest(systemtesting.MantidSystemTest):
         return math.fabs(refl[1] - 0.648596877775159) < 0.002
 
 
+class MagnetismReflectometryReductionSkipRebinTest(systemtesting.MantidSystemTest):
+    def runTest(self):
+        wsg = MRFilterCrossSections(Filename="REF_M_24949")
+        MagnetismReflectometryReduction(InputWorkspace=wsg[0],
+                                        NormalizationRunNumber=24945,
+                                        SignalPeakPixelRange=[125, 129],
+                                        SubtractSignalBackground=True,
+                                        SignalBackgroundPixelRange=[15, 105],
+                                        ApplyNormalization=True,
+                                        NormPeakPixelRange=[201, 205],
+                                        SubtractNormBackground=True,
+                                        NormBackgroundPixelRange=[10,127],
+                                        CutLowResDataAxis=True,
+                                        LowResDataAxisPixelRange=[91, 161],
+                                        CutLowResNormAxis=True,
+                                        LowResNormAxisPixelRange=[86, 174],
+                                        CutTimeAxis=True,
+                                        UseWLTimeAxis=False,
+                                        FinalRebin=False,
+                                        QMin=0.005,
+                                        QStep=-0.01,
+                                        TimeAxisStep=40,
+                                        TimeAxisRange=[25000, 54000],
+                                        SpecularPixel=126.9,
+                                        ConstantQBinning=False,
+                                        OutputWorkspace="r_24949")
+
+    def validate(self):
+        q_values = mtd["r_24949"].dataX(0)
+        return math.fabs(q_values[0] - 0.005) > 0.001
+
+
 class MagnetismReflectometryReductionConstQWLCutTest(systemtesting.MantidSystemTest):
     def runTest(self):
         wsg = MRFilterCrossSections(Filename="REF_M_24949")

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -50,6 +50,7 @@ Magnetism Reflectometer
 -----------------------
 
 - Added option to overwrite :literal:`DIRPIX` and :literal:`DANGLE0`.
+- Added option to skip the final rebinning.
 
 ISIS Reflectometry Interface
 ----------------------------


### PR DESCRIPTION
**Description of work.**
Sometimes users don't want to rebin the final reflectivity but want to use the binning that is produced by the original TOF binning. Simply add an option to skip the final binning.

**Report to:** nobody

**To test:**
- Inspect code
- Make sure tests pass

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
