### PR TITLE
Fix GuiStartupTest on Windows

### DIFF
--- a/Testing/SystemTests/tests/analysis/GUIStartupTest.py
+++ b/Testing/SystemTests/tests/analysis/GUIStartupTest.py
@@ -21,7 +21,6 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
 
     def __init__(self):
         super(GUIStartupTest, self).__init__()
-        self.maxDiff = None
         # create simple script
         self.script = os.path.join(mantid.config.getString('defaultsave.directory'),
                                    'GUIStartupTest_script.py')
@@ -36,8 +35,7 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         elif 'Darwin' in current_platform:
             mantid_exe = os.path.join(mantid_init_dirname, "../MantidPlot")
         elif 'Windows' in current_platform:
-            mantid_exe = 'wscript.exe {}'.format(os.path.join(mantid_init_dirname,
-                                                              "../bin/launch_mantidplot.vbs"))
+            mantid_exe = os.path.join(mantid_init_dirname, "..", "launch_mantidplot.bat")
         else:
             raise RuntimeError("Unknown operating system")
 
@@ -58,7 +56,8 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         # good startup
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
-        self.assertEquals(out, b'Hello Mantid\n')
+        # Do not check line ending as it's different on Windows
+        self.assertTrue(b'Hello Mantid' in out)
 
         # failing script
         with open(self.script, 'a') as f:
@@ -66,5 +65,5 @@ class GUIStartupTest(systemtesting.MantidSystemTest):
         p = subprocess.Popen(self.cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
         out, err = p.communicate()
         out += err
-        self.assertTrue(b'Hello Mantid\n' in out)
+        self.assertTrue(b'Hello Mantid' in out)
         self.assertTrue(b'RuntimeError: GUITest' in out)

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -128,6 +128,7 @@ else ()
   set (PARAVIEW_PYTHON_PATHS "" )
 endif ()
 
+# mantidpython
 configure_file ( ${PACKAGING_DIR}/mantidpython.bat.in
     ${PROJECT_BINARY_DIR}/mantidpython.bat.in @ONLY )
 # place it in the appropriate directory
@@ -139,7 +140,6 @@ file(GENERATE
   )
 # install version
 set ( MANTIDPYTHON_PREAMBLE "set PYTHONHOME=%_BIN_DIR%\nset PATH=%_BIN_DIR%;%_BIN_DIR%\\..\\plugins;%_BIN_DIR%\\..\\PVPlugins;%PATH%" )
-
 if (MAKE_VATES)
   set ( PV_LIBS "%_BIN_DIR%\\..\\lib\\paraview-${PARAVIEW_VERSION_MAJOR}.${PARAVIEW_VERSION_MINOR}")
   set ( PARAVIEW_PYTHON_PATHS ";${PV_LIBS}\\site-packages;${PV_LIBS}\\site-packages\\vtk" )
@@ -149,6 +149,33 @@ endif ()
 
 configure_file ( ${PACKAGING_DIR}/mantidpython.bat.in
     ${PROJECT_BINARY_DIR}/mantidpython.bat.install @ONLY )
+
+# launch_mantidplot
+set ( QT_PLUGINS "")
+if ( MAKE_VATES )
+  set ( PV_PLUGINS "" )
+else ()
+  set ( PV_PLUGINS "%_BIN_DIR%\\plugins\\paraview\\qt4" )
+endif ()
+configure_file ( ${PACKAGING_DIR}/launch_mantidplot.bat.in
+    ${PROJECT_BINARY_DIR}/launch_mantidplot.bat.in @ONLY )
+# place it in the appropriate directory
+file(GENERATE
+     OUTPUT
+     ${PROJECT_BINARY_DIR}/bin/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>/launch_mantidplot.bat
+     INPUT
+     ${PROJECT_BINARY_DIR}/launch_mantidplot.bat.in
+  )
+
+# install version
+set ( QT_PLUGINS "%_BIN_DIR%\\..\\plugins\\qt4")
+if ( MAKE_VATES )
+  set ( PV_PLUGINS "" )
+else ()
+  set ( PV_PLUGINS "%_BIN_DIR%\\..\\plugins\\paraview\\qt4" )
+endif ()
+configure_file ( ${PACKAGING_DIR}/launch_mantidplot.bat.in
+    ${PROJECT_BINARY_DIR}/launch_mantidplot.bat.install @ONLY )
 
 ###########################################################################
 # (Fake) installation variables to keep windows sweet

--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat.in
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat.in
@@ -1,0 +1,41 @@
+@echo off
+setlocal enableextensions
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Launch script for MantidPlot
+::
+:: Sets the required environment variables for MantidPlot to run correctly.
+:: All variables that are passed to this script are passed directly to
+:: MantidPlot.exe
+::
+:: It is not advised to start MantidPlot.exe directly as this is unlikely
+:: to work.
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Assume this is placed next to the dlls and executable
+set _SCRIPT_DIR=%~dp0
+set _BIN_DIR=%_SCRIPT_DIR:~,-1%
+set _QT_PLUGINS=@QT_PLUGINS@
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Required environment variables for Mantid
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+set PATH=%_BIN_DIR%;%_QT_PLUGINS%;%PATH%
+set PV_PLUGIN_PATH=@PV_PLUGINS@
+
+:: Matplotlib backend should default to Qt if not set (requires matplotlib >= 1.5)
+if "%MPLBACKEND%"=="" (
+  set MPLBACKEND=qt4agg
+)
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Start MantidPlot
+:: The working directory is whatever is set by the caller
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+start "MantidPlot" /B /WAIT %_BIN_DIR%\MantidPlot.exe %*
+
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+:: Check if Mantidplot exited correctly
+:: If not launch the error reporter
+:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+if %errorlevel% NEQ 0 (
+  python %_INSTALL_DIR%\scripts\ErrorReporter\error_dialog_app.py --exitcode=%1 --directory=%_BIN_DIR%
+)

--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -140,9 +140,9 @@ include( WindowsNSISQt5 )
 ###########################################################################
 # Startup files
 ###########################################################################
-install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/Packaging/launch_mantidplot.bat DESTINATION bin )
-install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/Packaging/launch_mantidplot.vbs DESTINATION bin )
+install ( FILES ${PROJECT_BINARY_DIR}/launch_mantidplot.bat.install DESTINATION bin )
 install ( FILES ${PROJECT_BINARY_DIR}/mantidpython.bat.install DESTINATION bin RENAME mantidpython.bat )
+install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/Packaging/launch_mantidplot.vbs DESTINATION bin )
 
 # On Windows we don't use the setuptools install executable at the moment, because it is
 # generated with a hard coded path to the build Python, that fails to run on


### PR DESCRIPTION
**Description of work.**

The test was always being skipped as `wscript.exe ...` is not a valid path. We were also missing the `launch_mantidplot` script for the development builds so this has been added so the test can work on a development copy. 

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Checkout and build the code. Run the `GuiStartup` system test and check it passes. 

*There is no associated issue.*

*This does not require release notes* because **it's an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
