### PR TITLE
Indirect IqtFit - Prevent plotting of one spectra

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -34,8 +34,8 @@ Improvements
 - When the InelasticDiffSphere, InelasticDiffRotDiscreteCircle, ElasticDiffSphere or ElasticDiffRotDiscreteCircle
   Fit Types are selected in the ConvFit Tab, the Q values are retrieved from the workspaces, preventing a crash
   when plotting a guess.
-- The Plot buttons in MSDFit and F(Q)Fit are disabled after a Run when the result workspace only has one
-  data point to plot.
+- The Plot buttons in MSDFit, I(Q,t)Fit, ConvFit and F(Q)Fit are disabled after a Run when the result workspace only 
+  has one data point to plot.
 - There is now an option to choose which output parameter to plot in MSDFit.
 - An option to skip the calculation of Monte Carlo Errors on the I(Q,t) Tab has been added.
 - During the calculation of Monte Carlo Errors, a progress bar is now shown.

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -181,25 +181,26 @@ std::string ConvFit::fitTypeString() const {
 void ConvFit::runClicked() { runTab(); }
 
 void ConvFit::setRunIsRunning(bool running) {
-	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-	setButtonsEnabled(!running);
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
 }
 
 void ConvFit::setFitSingleSpectrumIsFitting(bool fitting) {
-	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
-	setButtonsEnabled(!fitting);
+  m_uiForm->pvFitPlotView->setFitSingleSpectrumText(
+      fitting ? "Fitting..." : "Fit Single Spectrum");
+  setButtonsEnabled(!fitting);
 }
 
 void ConvFit::setPlotResultIsPlotting(bool plotting) {
-	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-	setButtonsEnabled(!plotting);
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setButtonsEnabled(!plotting);
 }
 
 void ConvFit::setButtonsEnabled(bool enabled) {
-	setRunEnabled(enabled);
-	setPlotResultEnabled(enabled);
-	setSaveResultEnabled(enabled);
-	setFitSingleSpectrumEnabled(enabled);
+  setRunEnabled(enabled);
+  setPlotResultEnabled(enabled);
+  setSaveResultEnabled(enabled);
+  setFitSingleSpectrumEnabled(enabled);
 }
 
 void ConvFit::setRunEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -178,6 +178,30 @@ std::string ConvFit::fitTypeString() const {
   return fitType;
 }
 
+void ConvFit::runClicked() { runTab(); }
+
+void ConvFit::setRunIsRunning(bool running) {
+	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+	setButtonsEnabled(!running);
+}
+
+void ConvFit::setFitSingleSpectrumIsFitting(bool fitting) {
+	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
+	setButtonsEnabled(!fitting);
+}
+
+void ConvFit::setPlotResultIsPlotting(bool plotting) {
+	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+	setButtonsEnabled(!plotting);
+}
+
+void ConvFit::setButtonsEnabled(bool enabled) {
+	setRunEnabled(enabled);
+	setPlotResultEnabled(enabled);
+	setSaveResultEnabled(enabled);
+	setFitSingleSpectrumEnabled(enabled);
+}
+
 void ConvFit::setRunEnabled(bool enabled) {
   m_uiForm->pbRun->setEnabled(enabled);
 }
@@ -194,25 +218,6 @@ void ConvFit::setFitSingleSpectrumEnabled(bool enabled) {
 void ConvFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
-
-void ConvFit::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setPlotResultEnabled(enabled);
-  setSaveResultEnabled(enabled);
-  setFitSingleSpectrumEnabled(enabled);
-}
-
-void ConvFit::setRunIsRunning(bool running) {
-  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
-}
-
-void ConvFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-  setButtonsEnabled(!plotting);
-}
-
-void ConvFit::runClicked() { runTab(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -33,19 +33,19 @@ protected slots:
   void fitFunctionChanged();
 
 protected:
+	void setRunIsRunning(bool running) override;
+	void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
-
-  void setRunIsRunning(bool running) override;
 
 private:
   void setupFitTab() override;
   void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
 
+	void setPlotResultIsPlotting(bool plotting);
+	void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-  void setPlotResultIsPlotting(bool plotting);
 
   std::string fitTypeString() const;
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -33,8 +33,6 @@ protected slots:
   void fitFunctionChanged();
 
 protected:
-  bool shouldEnablePlotResult() override { return true; };
-
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -33,8 +33,8 @@ protected slots:
   void fitFunctionChanged();
 
 protected:
-	void setRunIsRunning(bool running) override;
-	void setFitSingleSpectrumIsFitting(bool fitting) override;
+  void setRunIsRunning(bool running) override;
+  void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
@@ -42,8 +42,8 @@ private:
   void setupFitTab() override;
   void setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
 
-	void setPlotResultIsPlotting(bool plotting);
-	void setButtonsEnabled(bool enabled);
+  void setPlotResultIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
 

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -21,14 +21,15 @@ namespace {
 Mantid::Kernel::Logger g_log("Elwin");
 
 MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      workspaceName);
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
-	return workspace->blocksize() > 1 ? true : false;
+  return workspace->blocksize() > 1 ? true : false;
 }
 
-}
+} // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -482,22 +483,23 @@ void Elwin::plotClicked() {
   auto const workspaceBaseName =
       getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 
-	plotResult(workspaceBaseName + "_eq");
-	plotResult(workspaceBaseName + "_eq2");
-	plotResult(workspaceBaseName + "_elf");
-	plotResult(workspaceBaseName + "_elt");
+  plotResult(workspaceBaseName + "_eq");
+  plotResult(workspaceBaseName + "_eq2");
+  plotResult(workspaceBaseName + "_elf");
+  plotResult(workspaceBaseName + "_elt");
 
   setPlotResultIsPlotting(false);
 }
 
 void Elwin::plotResult(QString const &workspaceName) {
-	auto const name = workspaceName.toStdString();
-	if (checkADSForPlotSaveWorkspace(name, true)) {
-		if (isWorkspacePlottable(getADSMatrixWorkspace(name)))
-		  plotSpectrum(workspaceName);
-		else
-			showMessageBox("Plotting a spectrum of the workspace " + workspaceName + " failed : Workspace only has one data point");
-	}
+  auto const name = workspaceName.toStdString();
+  if (checkADSForPlotSaveWorkspace(name, true)) {
+    if (isWorkspacePlottable(getADSMatrixWorkspace(name)))
+      plotSpectrum(workspaceName);
+    else
+      showMessageBox("Plotting a spectrum of the workspace " + workspaceName +
+                     " failed : Workspace only has one data point");
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -26,7 +26,7 @@ MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
-  return workspace->blocksize() > 1 ? true : false;
+	return workspace->y(0).size() > 1;
 }
 
 } // namespace

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -26,7 +26,7 @@ MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
-	return workspace->y(0).size() > 1;
+  return workspace->y(0).size() > 1;
 }
 
 } // namespace

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -42,6 +42,8 @@ private:
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
 
+	void plotResult(QString const &workspaceName);
+
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -42,7 +42,7 @@ private:
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
 
-	void plotResult(QString const &workspaceName);
+  void plotResult(QString const &workspaceName);
 
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -60,6 +60,7 @@ public:
   virtual void removeFromBottomPreview(const QString &name) = 0;
 
   virtual void enableFitSingleSpectrum(bool enable) = 0;
+	virtual void setFitSingleSpectrumText(QString const &text) = 0;
   virtual void enablePlotGuess(bool enable) = 0;
   virtual void enableSpectrumSelection(bool enable) = 0;
   virtual void enableFitRangeSelection(bool enable) = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -64,7 +64,7 @@ public:
   virtual void enableSpectrumSelection(bool enable) = 0;
   virtual void enableFitRangeSelection(bool enable) = 0;
 
-	virtual void setFitSingleSpectrumText(QString const &text) = 0;
+  virtual void setFitSingleSpectrumText(QString const &text) = 0;
 
   virtual void setBackgroundLevel(double value) = 0;
 

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -60,10 +60,11 @@ public:
   virtual void removeFromBottomPreview(const QString &name) = 0;
 
   virtual void enableFitSingleSpectrum(bool enable) = 0;
-	virtual void setFitSingleSpectrumText(QString const &text) = 0;
   virtual void enablePlotGuess(bool enable) = 0;
   virtual void enableSpectrumSelection(bool enable) = 0;
   virtual void enableFitRangeSelection(bool enable) = 0;
+
+	virtual void setFitSingleSpectrumText(QString const &text) = 0;
 
   virtual void setBackgroundLevel(double value) = 0;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -34,11 +34,11 @@ MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
 }
 
 std::size_t numberOfColumns(Workspace_sptr workspace) {
-  return convertToMatrixWorkspace(workspace)->blocksize();
+  return convertToMatrixWorkspace(workspace)->y(0).size();
 }
 
 bool isWorkspacePlottable(Workspace_sptr workspace) {
-  return numberOfColumns(workspace) > 1 ? true : false;
+  return numberOfColumns(workspace) > 1;
 }
 
 bool containsPlottableWorkspace(WorkspaceGroup_sptr workspaceGroup) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -34,25 +34,25 @@ MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
 }
 
 std::size_t numberOfColumns(Workspace_sptr workspace) {
-	return convertToMatrixWorkspace(workspace)->blocksize();
+  return convertToMatrixWorkspace(workspace)->blocksize();
 }
 
 bool isWorkspacePlottable(Workspace_sptr workspace) {
-	return numberOfColumns(workspace) > 1 ? true : false;
+  return numberOfColumns(workspace) > 1 ? true : false;
 }
 
 bool containsPlottableWorkspace(WorkspaceGroup_sptr workspaceGroup) {
-	for (auto const &workspace : *workspaceGroup)
-		if (isWorkspacePlottable(workspace))
-			return true;
-	return false;
+  for (auto const &workspace : *workspaceGroup)
+    if (isWorkspacePlottable(workspace))
+      return true;
+  return false;
 }
 
 bool isGroupPlottable(WorkspaceGroup_sptr workspaceGroup) {
-	if (workspaceGroup)
-		return containsPlottableWorkspace(workspaceGroup);
-	else
-		return false;
+  if (workspaceGroup)
+    return containsPlottableWorkspace(workspaceGroup);
+  else
+    return false;
 };
 
 void updateParameters(
@@ -1055,7 +1055,8 @@ void IndirectFitAnalysisTab::updatePlotOptions(QComboBox *cbPlotType) {
 
 void IndirectFitAnalysisTab::enablePlotResult(bool error) {
   if (!error)
-    setPlotResultEnabled(isGroupPlottable(m_fittingModel->getResultWorkspace()));
+    setPlotResultEnabled(
+        isGroupPlottable(m_fittingModel->getResultWorkspace()));
   else
     setPlotResultEnabled(!error);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -868,22 +868,18 @@ void IndirectFitAnalysisTab::plotResult(const QString &plotType) {
 
 void IndirectFitAnalysisTab::plotAll(
     Mantid::API::WorkspaceGroup_sptr workspaces) {
-  for (auto index = 0u; index < workspaces->size(); ++index)
-    plotAll(boost::dynamic_pointer_cast<MatrixWorkspace>(
-                workspaces->getItem(index)),
-            index);
+	for (auto const &workspace : *workspaces)
+		plotAll(convertToMatrixWorkspace(workspace));
 }
 
 void IndirectFitAnalysisTab::plotParameter(
-    Mantid::API::WorkspaceGroup_sptr workspaces, const std::string &parameter) {
-  for (auto index = 0u; index < workspaces->size(); ++index)
-    plotParameter(boost::dynamic_pointer_cast<MatrixWorkspace>(
-                      workspaces->getItem(index)),
-                  parameter, index);
+    Mantid::API::WorkspaceGroup_sptr workspaces, std::string const &parameter) {
+	for (auto const &workspace : *workspaces)
+		plotParameter(convertToMatrixWorkspace(workspace), parameter);
 }
 
 void IndirectFitAnalysisTab::plotAll(
-    Mantid::API::MatrixWorkspace_sptr workspace, const std::size_t &index) {
+    Mantid::API::MatrixWorkspace_sptr workspace) {
   auto const numberOfDataPoints = workspace->blocksize();
   if (numberOfDataPoints > 1)
     plotSpectrum(workspace);
@@ -895,7 +891,7 @@ void IndirectFitAnalysisTab::plotAll(
 
 void IndirectFitAnalysisTab::plotParameter(
     Mantid::API::MatrixWorkspace_sptr workspace,
-    const std::string &parameterToPlot, const std::size_t &index) {
+    const std::string &parameterToPlot) {
   auto const numberOfDataPoints = workspace->blocksize();
   if (numberOfDataPoints > 1)
     plotSpectrum(workspace, parameterToPlot);
@@ -1041,8 +1037,7 @@ void IndirectFitAnalysisTab::enablePlotResult(bool error) {
 
 bool IndirectFitAnalysisTab::isResultWorkspacePlottable() const {
   auto const resultWorkspaces = m_fittingModel->getResultWorkspace();
-  if (resultWorkspaces)
-    return isResultWorkspacePlottable(resultWorkspaces);
+	return resultWorkspaces ? isResultWorkspacePlottable(resultWorkspaces) : false;
 };
 
 bool IndirectFitAnalysisTab::isResultWorkspacePlottable(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -53,7 +53,7 @@ bool isGroupPlottable(WorkspaceGroup_sptr workspaceGroup) {
     return containsPlottableWorkspace(workspaceGroup);
   else
     return false;
-};
+}
 
 void updateParameters(
     IFunction_sptr function,

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -726,6 +726,7 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
   setRunIsRunning(false);
+	setFitSingleSpectrumIsFitting(false);
   enablePlotResult(error);
   setSaveResultEnabled(!error);
   updateParameterValues();
@@ -931,8 +932,10 @@ void IndirectFitAnalysisTab::singleFit() {
 
 void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
                                        std::size_t spectrum) {
-  if (validate())
-    runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
+	if (validate()) {
+		setFitSingleSpectrumIsFitting(true);
+		runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
+	}
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -726,7 +726,7 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
   setRunIsRunning(false);
-	setFitSingleSpectrumIsFitting(false);
+  setFitSingleSpectrumIsFitting(false);
   enablePlotResult(error);
   setSaveResultEnabled(!error);
   updateParameterValues();
@@ -869,14 +869,14 @@ void IndirectFitAnalysisTab::plotResult(const QString &plotType) {
 
 void IndirectFitAnalysisTab::plotAll(
     Mantid::API::WorkspaceGroup_sptr workspaces) {
-	for (auto const &workspace : *workspaces)
-		plotAll(convertToMatrixWorkspace(workspace));
+  for (auto const &workspace : *workspaces)
+    plotAll(convertToMatrixWorkspace(workspace));
 }
 
 void IndirectFitAnalysisTab::plotParameter(
     Mantid::API::WorkspaceGroup_sptr workspaces, std::string const &parameter) {
-	for (auto const &workspace : *workspaces)
-		plotParameter(convertToMatrixWorkspace(workspace), parameter);
+  for (auto const &workspace : *workspaces)
+    plotParameter(convertToMatrixWorkspace(workspace), parameter);
 }
 
 void IndirectFitAnalysisTab::plotAll(
@@ -932,10 +932,10 @@ void IndirectFitAnalysisTab::singleFit() {
 
 void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
                                        std::size_t spectrum) {
-	if (validate()) {
-		setFitSingleSpectrumIsFitting(true);
-		runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
-	}
+  if (validate()) {
+    setFitSingleSpectrumIsFitting(true);
+    runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
+  }
 }
 
 /**
@@ -1040,7 +1040,8 @@ void IndirectFitAnalysisTab::enablePlotResult(bool error) {
 
 bool IndirectFitAnalysisTab::isResultWorkspacePlottable() const {
   auto const resultWorkspaces = m_fittingModel->getResultWorkspace();
-	return resultWorkspaces ? isResultWorkspacePlottable(resultWorkspaces) : false;
+  return resultWorkspaces ? isResultWorkspacePlottable(resultWorkspaces)
+                          : false;
 };
 
 bool IndirectFitAnalysisTab::isResultWorkspacePlottable(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -33,6 +33,26 @@ MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
   return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
 }
 
+bool isWorkspacePlottable(Workspace_sptr workspace) {
+	auto const numberOfDataPoints =
+		convertToMatrixWorkspace(workspace)->blocksize();
+	return numberOfDataPoints > 1 ? true : false;
+}
+
+bool containsPlottableWorkspace(WorkspaceGroup_sptr workspaceGroup) {
+	for (auto const &workspace : *workspaceGroup)
+		if (isWorkspacePlottable(workspace))
+			return true;
+	return false;
+}
+
+bool isGroupPlottable(WorkspaceGroup_sptr workspaceGroup) {
+	if (workspaceGroup)
+		return containsPlottableWorkspace(workspaceGroup);
+	else
+		return false;
+};
+
 void updateParameters(
     IFunction_sptr function,
     std::unordered_map<std::string, ParameterValue> const &parameters) {
@@ -1033,27 +1053,10 @@ void IndirectFitAnalysisTab::updatePlotOptions(QComboBox *cbPlotType) {
 
 void IndirectFitAnalysisTab::enablePlotResult(bool error) {
   if (!error)
-    setPlotResultEnabled(isResultWorkspacePlottable());
+    setPlotResultEnabled(isGroupPlottable(m_fittingModel->getResultWorkspace()));
   else
     setPlotResultEnabled(!error);
 }
-
-bool IndirectFitAnalysisTab::isResultWorkspacePlottable() const {
-  auto const resultWorkspaces = m_fittingModel->getResultWorkspace();
-  return resultWorkspaces ? isResultWorkspacePlottable(resultWorkspaces)
-                          : false;
-};
-
-bool IndirectFitAnalysisTab::isResultWorkspacePlottable(
-    Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const {
-  for (auto const &workspace : *resultWorkspaces) {
-    auto const numberOfDataPoints =
-        convertToMatrixWorkspace(workspace)->blocksize();
-    if (numberOfDataPoints > 1)
-      return true;
-  }
-  return false;
-};
 
 /**
  * Fills the specified combo box, with the specified parameters.

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -33,10 +33,12 @@ MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
   return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
 }
 
+std::size_t numberOfColumns(Workspace_sptr workspace) {
+	return convertToMatrixWorkspace(workspace)->blocksize();
+}
+
 bool isWorkspacePlottable(Workspace_sptr workspace) {
-	auto const numberOfDataPoints =
-		convertToMatrixWorkspace(workspace)->blocksize();
-	return numberOfDataPoints > 1 ? true : false;
+	return numberOfColumns(workspace) > 1 ? true : false;
 }
 
 bool containsPlottableWorkspace(WorkspaceGroup_sptr workspaceGroup) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -1043,7 +1043,7 @@ bool IndirectFitAnalysisTab::isResultWorkspacePlottable() const {
 		return isResultWorkspacePlottable(resultWorkspaces);
 };
 
-bool IndirectFitAnalysisTab::isResultWorkspacePlottable(WorkspaceGroup_sptr resultWorkspaces) const {
+bool IndirectFitAnalysisTab::isResultWorkspacePlottable(Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const {
 	for (auto const &workspace : *resultWorkspaces) {
 		auto const numberOfDataPoints = convertToMatrixWorkspace(workspace)->blocksize();
 		if (numberOfDataPoints > 1)

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -30,7 +30,7 @@ namespace {
 using namespace MantidQt::CustomInterfaces::IDA;
 
 MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
-	return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+  return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
 }
 
 void updateParameters(
@@ -888,19 +888,21 @@ void IndirectFitAnalysisTab::plotAll(
   if (numberOfDataPoints > 1)
     plotSpectrum(workspace);
   else
-    showMessageBox("The plotting of data in one of the result workspaces failed:\n\n "
-                   "Workspace has only one data point");
+    showMessageBox(
+        "The plotting of data in one of the result workspaces failed:\n\n "
+        "Workspace has only one data point");
 }
 
 void IndirectFitAnalysisTab::plotParameter(
     Mantid::API::MatrixWorkspace_sptr workspace,
     const std::string &parameterToPlot, const std::size_t &index) {
-	auto const numberOfDataPoints = workspace->blocksize();
+  auto const numberOfDataPoints = workspace->blocksize();
   if (numberOfDataPoints > 1)
     plotSpectrum(workspace, parameterToPlot);
   else
-		showMessageBox("The plotting of data in one of the result workspaces failed:\n\n "
-			"Workspace has only one data point");
+    showMessageBox(
+        "The plotting of data in one of the result workspaces failed:\n\n "
+        "Workspace has only one data point");
 }
 
 void IndirectFitAnalysisTab::plotSpectrum(
@@ -1031,25 +1033,27 @@ void IndirectFitAnalysisTab::updatePlotOptions(QComboBox *cbPlotType) {
 }
 
 void IndirectFitAnalysisTab::enablePlotResult(bool error) {
-	if (!error)
-		setPlotResultEnabled(isResultWorkspacePlottable());
-	else
-		setPlotResultEnabled(!error);
+  if (!error)
+    setPlotResultEnabled(isResultWorkspacePlottable());
+  else
+    setPlotResultEnabled(!error);
 }
 
 bool IndirectFitAnalysisTab::isResultWorkspacePlottable() const {
-	auto const resultWorkspaces = m_fittingModel->getResultWorkspace();
-	if (resultWorkspaces)
-		return isResultWorkspacePlottable(resultWorkspaces);
+  auto const resultWorkspaces = m_fittingModel->getResultWorkspace();
+  if (resultWorkspaces)
+    return isResultWorkspacePlottable(resultWorkspaces);
 };
 
-bool IndirectFitAnalysisTab::isResultWorkspacePlottable(Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const {
-	for (auto const &workspace : *resultWorkspaces) {
-		auto const numberOfDataPoints = convertToMatrixWorkspace(workspace)->blocksize();
-		if (numberOfDataPoints > 1)
-			return true;
-	}
-	return false;
+bool IndirectFitAnalysisTab::isResultWorkspacePlottable(
+    Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const {
+  for (auto const &workspace : *resultWorkspaces) {
+    auto const numberOfDataPoints =
+        convertToMatrixWorkspace(workspace)->blocksize();
+    if (numberOfDataPoints > 1)
+      return true;
+  }
+  return false;
 };
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -153,6 +153,7 @@ protected:
   virtual void setSaveResultEnabled(bool enabled) = 0;
 
   virtual void setRunIsRunning(bool running) = 0;
+	virtual void setFitSingleSpectrumIsFitting(bool fitting) = 0;
 
 signals:
   void functionChanged();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -140,8 +140,9 @@ protected:
 
   void updatePlotOptions(QComboBox *cbPlotType);
   void enablePlotResult(bool error);
-	bool isResultWorkspacePlottable() const;
-	bool isResultWorkspacePlottable(Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const;
+  bool isResultWorkspacePlottable() const;
+  bool isResultWorkspacePlottable(
+      Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const;
 
   void setPlotOptions(QComboBox *cbPlotType,
                       const std::vector<std::string> &parameters) const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -153,7 +153,7 @@ protected:
   virtual void setSaveResultEnabled(bool enabled) = 0;
 
   virtual void setRunIsRunning(bool running) = 0;
-	virtual void setFitSingleSpectrumIsFitting(bool fitting) = 0;
+  virtual void setFitSingleSpectrumIsFitting(bool fitting) = 0;
 
 signals:
   void functionChanged();

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -125,10 +125,9 @@ protected:
   void plotAll(Mantid::API::WorkspaceGroup_sptr workspaces);
   void plotParameter(Mantid::API::WorkspaceGroup_sptr workspace,
                      const std::string &parameter);
-  void plotAll(Mantid::API::MatrixWorkspace_sptr workspace,
-               const std::size_t &index);
+  void plotAll(Mantid::API::MatrixWorkspace_sptr workspace);
   void plotParameter(Mantid::API::MatrixWorkspace_sptr workspace,
-                     const std::string &parameter, const std::size_t &index);
+                     const std::string &parameter);
   void plotSpectrum(Mantid::API::MatrixWorkspace_sptr workspace);
   void plotSpectrum(Mantid::API::MatrixWorkspace_sptr workspace,
                     const std::string &parameterToPlot);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -140,14 +140,14 @@ protected:
 
   void updatePlotOptions(QComboBox *cbPlotType);
   void enablePlotResult(bool error);
+	bool isResultWorkspacePlottable() const;
+	bool isResultWorkspacePlottable(Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const;
 
   void setPlotOptions(QComboBox *cbPlotType,
                       const std::vector<std::string> &parameters) const;
 
   void setPlotOptions(QComboBox *cbPlotType,
                       const QSet<QString> &options) const;
-
-  virtual bool shouldEnablePlotResult() = 0;
 
   virtual void setPlotResultEnabled(bool enabled) = 0;
   virtual void setSaveResultEnabled(bool enabled) = 0;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -139,9 +139,6 @@ protected:
 
   void updatePlotOptions(QComboBox *cbPlotType);
   void enablePlotResult(bool error);
-  bool isResultWorkspacePlottable() const;
-  bool isResultWorkspacePlottable(
-      Mantid::API::WorkspaceGroup_sptr resultWorkspaces) const;
 
   void setPlotOptions(QComboBox *cbPlotType,
                       const std::vector<std::string> &parameters) const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -180,6 +180,10 @@ void IndirectFitPlotView::enableFitSingleSpectrum(bool enable) {
   m_plotForm->pbFitSingle->setEnabled(enable);
 }
 
+void IndirectFitPlotView::setFitSingleSpectrumText(QString const &text) {
+	m_plotForm->pbFitSingle->setText(text);
+}
+
 void IndirectFitPlotView::enableSpectrumSelection(bool enable) {
   if (!enable)
     m_plotForm->spPlotSpectrum->setValue(0);

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -191,7 +191,7 @@ void IndirectFitPlotView::enableFitRangeSelection(bool enable) {
 }
 
 void IndirectFitPlotView::setFitSingleSpectrumText(QString const &text) {
-	m_plotForm->pbFitSingle->setText(text);
+  m_plotForm->pbFitSingle->setText(text);
 }
 
 void IndirectFitPlotView::clearTopPreview() { m_plotForm->ppPlotTop->clear(); }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -180,10 +180,6 @@ void IndirectFitPlotView::enableFitSingleSpectrum(bool enable) {
   m_plotForm->pbFitSingle->setEnabled(enable);
 }
 
-void IndirectFitPlotView::setFitSingleSpectrumText(QString const &text) {
-	m_plotForm->pbFitSingle->setText(text);
-}
-
 void IndirectFitPlotView::enableSpectrumSelection(bool enable) {
   if (!enable)
     m_plotForm->spPlotSpectrum->setValue(0);
@@ -192,6 +188,10 @@ void IndirectFitPlotView::enableSpectrumSelection(bool enable) {
 
 void IndirectFitPlotView::enableFitRangeSelection(bool enable) {
   m_plotForm->ppPlotTop->getRangeSelector("FitRange")->setVisible(enable);
+}
+
+void IndirectFitPlotView::setFitSingleSpectrumText(QString const &text) {
+	m_plotForm->pbFitSingle->setText(text);
 }
 
 void IndirectFitPlotView::clearTopPreview() { m_plotForm->ppPlotTop->clear(); }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -64,7 +64,7 @@ public:
   void enableSpectrumSelection(bool enable) override;
   void enableFitRangeSelection(bool enable) override;
 
-	void setFitSingleSpectrumText(QString const &text) override;
+  void setFitSingleSpectrumText(QString const &text) override;
 
   void setBackgroundLevel(double value) override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -60,10 +60,11 @@ public:
   void removeFromBottomPreview(const QString &name) override;
 
   void enableFitSingleSpectrum(bool enable) override;
-	void setFitSingleSpectrumText(QString const &text) override;
   void enablePlotGuess(bool enable) override;
   void enableSpectrumSelection(bool enable) override;
   void enableFitRangeSelection(bool enable) override;
+
+	void setFitSingleSpectrumText(QString const &text) override;
 
   void setBackgroundLevel(double value) override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -60,6 +60,7 @@ public:
   void removeFromBottomPreview(const QString &name) override;
 
   void enableFitSingleSpectrum(bool enable) override;
+	void setFitSingleSpectrumText(QString const &text) override;
   void enablePlotGuess(bool enable) override;
   void enableSpectrumSelection(bool enable) override;
   void enableFitRangeSelection(bool enable) override;

--- a/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
@@ -111,6 +111,12 @@
      </item>
      <item>
       <widget class="QPushButton" name="pbFitSingle">
+       <property name="minimumSize">
+        <size>
+         <width>99</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string>Fit Single Spectrum</string>
        </property>

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -49,13 +49,13 @@ void cloneWorkspace(std::string const &workspaceName,
 }
 
 void cropWorkspace(std::string const &name, std::string const &newName,
-	double const &cropValue) {
-	auto croper = AlgorithmManager::Instance().create("CropWorkspace");
-	croper->initialize();
-	croper->setProperty("InputWorkspace", name);
-	croper->setProperty("OutputWorkspace", newName);
-	croper->setProperty("XMin", cropValue);
-	croper->execute();
+                   double const &cropValue) {
+  auto croper = AlgorithmManager::Instance().create("CropWorkspace");
+  croper->initialize();
+  croper->setProperty("InputWorkspace", name);
+  croper->setProperty("OutputWorkspace", newName);
+  croper->setProperty("XMin", cropValue);
+  croper->execute();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -87,10 +87,10 @@ calculateBinParameters(QString wsName, QString resName, double energyMin,
     propsTable = toIqt->getProperty("ParameterWorkspace");
     // the algorithm can create output even if it failed...
     auto deleter = AlgorithmManager::Instance().create("DeleteWorkspace");
-		deleter->initialize();
-		deleter->setChild(true);
-		deleter->setProperty("Workspace", paramTableName);
-		deleter->execute();
+    deleter->initialize();
+    deleter->setChild(true);
+    deleter->setProperty("Workspace", paramTableName);
+    deleter->execute();
   } catch (std::exception &) {
     return std::make_tuple(false, 0.0f, 0, 0);
   }

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -36,7 +36,7 @@ bool checkADSForWorkspace(std::string const &workspaceName) {
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
-  return workspace->blocksize() > 1 ? true : false;
+  return workspace->y(0).size() > 1;
 }
 
 void cloneWorkspace(std::string const &workspaceName,

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -12,7 +12,6 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 #include "MantidQtWidgets/LegacyQwt/RangeSelector.h"
-#include "MantidAPI/MatrixWorkspace.h"
 
 #include <qwt_plot.h>
 
@@ -24,7 +23,8 @@ namespace {
 Mantid::Kernel::Logger g_log("Iqt");
 
 MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      workspaceName);
 }
 
 std::size_t getWsNumberOfSpectra(std::string const &workspaceName) {
@@ -36,7 +36,7 @@ bool checkADSForWorkspace(std::string const &workspaceName) {
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
-	return workspace->blocksize() > 1 ? true : false;
+  return workspace->blocksize() > 1 ? true : false;
 }
 
 void cloneWorkspace(std::string const &workspaceName,
@@ -254,21 +254,22 @@ void Iqt::saveClicked() {
  * Handle mantid plotting
  */
 void Iqt::plotClicked() {
-	setPlotSpectrumIsPlotting(true);
+  setPlotSpectrumIsPlotting(true);
 
-	plotResult(QString::fromStdString(m_pythonExportWsName));
+  plotResult(QString::fromStdString(m_pythonExportWsName));
 
   setPlotSpectrumIsPlotting(false);
 }
 
 void Iqt::plotResult(QString const &workspaceName) {
-	auto const name = workspaceName.toStdString();
-	if (checkADSForPlotSaveWorkspace(name, true)) {
-		if (isWorkspacePlottable(getADSMatrixWorkspace(name)))
-			plotSpectrum(workspaceName, getPlotSpectrumIndex());
-		else
-			showMessageBox("Plotting a spectrum of the workspace " + workspaceName + " failed : Workspace only has one data point");
-	}
+  auto const name = workspaceName.toStdString();
+  if (checkADSForPlotSaveWorkspace(name, true)) {
+    if (isWorkspacePlottable(getADSMatrixWorkspace(name)))
+      plotSpectrum(workspaceName, getPlotSpectrumIndex());
+    else
+      showMessageBox("Plotting a spectrum of the workspace " + workspaceName +
+                     " failed : Workspace only has one data point");
+  }
 }
 
 void Iqt::runClicked() { runTab(); }

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -86,12 +86,11 @@ calculateBinParameters(QString wsName, QString resName, double energyMin,
     toIqt->execute();
     propsTable = toIqt->getProperty("ParameterWorkspace");
     // the algorithm can create output even if it failed...
-    IAlgorithm_sptr deleteAlg =
-        AlgorithmManager::Instance().create("DeleteWorkspace");
-    deleteAlg->initialize();
-    deleteAlg->setChild(true);
-    deleteAlg->setProperty("Workspace", paramTableName);
-    deleteAlg->execute();
+    auto deleter = AlgorithmManager::Instance().create("DeleteWorkspace");
+		deleter->initialize();
+		deleter->setChild(true);
+		deleter->setProperty("Workspace", paramTableName);
+		deleter->execute();
   } catch (std::exception &) {
     return std::make_tuple(false, 0.0f, 0, 0);
   }

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -32,7 +32,7 @@ private:
   double getXMinValue(Mantid::API::MatrixWorkspace_const_sptr workspace,
                       std::size_t const &index);
 
-	void plotResult(QString const &workspaceName);
+  void plotResult(QString const &workspaceName);
 
   void setRunEnabled(bool enabled);
   void setPlotSpectrumEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -32,6 +32,8 @@ private:
   double getXMinValue(Mantid::API::MatrixWorkspace_const_sptr workspace,
                       std::size_t const &index);
 
+	void plotResult(QString const &workspaceName);
+
   void setRunEnabled(bool enabled);
   void setPlotSpectrumEnabled(bool enabled);
   void setTiledPlotEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -138,20 +138,20 @@ void IqtFit::plotResult() {
 void IqtFit::runClicked() { runTab(); }
 
 void IqtFit::setRunIsRunning(bool running) {
-	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-	setButtonsEnabled(!running);
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
 }
 
 void IqtFit::setPlotResultIsPlotting(bool plotting) {
-	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-	setButtonsEnabled(!plotting);
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setButtonsEnabled(!plotting);
 }
 
 void IqtFit::setButtonsEnabled(bool enabled) {
-	setRunEnabled(enabled);
-	setPlotResultEnabled(enabled);
-	setSaveResultEnabled(enabled);
-	setFitSingleSpectrumEnabled(enabled);
+  setRunEnabled(enabled);
+  setPlotResultEnabled(enabled);
+  setSaveResultEnabled(enabled);
+  setFitSingleSpectrumEnabled(enabled);
 }
 
 void IqtFit::setRunEnabled(bool enabled) {
@@ -168,7 +168,7 @@ void IqtFit::setSaveResultEnabled(bool enabled) {
 }
 
 void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
-	m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -143,8 +143,9 @@ void IqtFit::setRunIsRunning(bool running) {
 }
 
 void IqtFit::setFitSingleSpectrumIsFitting(bool fitting) {
-	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
-	setButtonsEnabled(!fitting);
+  m_uiForm->pvFitPlotView->setFitSingleSpectrumText(
+      fitting ? "Fitting..." : "Fit Single Spectrum");
+  setButtonsEnabled(!fitting);
 }
 
 void IqtFit::setPlotResultIsPlotting(bool plotting) {
@@ -169,7 +170,7 @@ void IqtFit::setPlotResultEnabled(bool enabled) {
 }
 
 void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
-	m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
+  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
 void IqtFit::setSaveResultEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -129,17 +129,22 @@ void IqtFit::setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) {
   IndirectFitAnalysisTab::setupFit(fitAlgorithm);
 }
 
+void IqtFit::runClicked() { runTab(); }
+
 void IqtFit::plotResult() {
   setPlotResultIsPlotting(true);
   IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
   setPlotResultIsPlotting(false);
 }
 
-void IqtFit::runClicked() { runTab(); }
-
 void IqtFit::setRunIsRunning(bool running) {
   m_uiForm->pbRun->setText(running ? "Running..." : "Run");
   setButtonsEnabled(!running);
+}
+
+void IqtFit::setFitSingleSpectrumIsFitting(bool fitting) {
+	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
+	setButtonsEnabled(!fitting);
 }
 
 void IqtFit::setPlotResultIsPlotting(bool plotting) {
@@ -163,12 +168,12 @@ void IqtFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->cbPlotType->setEnabled(enabled);
 }
 
-void IqtFit::setSaveResultEnabled(bool enabled) {
-  m_uiForm->pbSave->setEnabled(enabled);
+void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
+	m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
 
-void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
+void IqtFit::setSaveResultEnabled(bool enabled) {
+  m_uiForm->pbSave->setEnabled(enabled);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -15,7 +15,6 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidAPI/Workspace.h"
 
 #include <QMenu>
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/Workspace.h"
 
 #include <QMenu>
 
@@ -135,6 +136,25 @@ void IqtFit::plotResult() {
   setPlotResultIsPlotting(false);
 }
 
+void IqtFit::runClicked() { runTab(); }
+
+void IqtFit::setRunIsRunning(bool running) {
+	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+	setButtonsEnabled(!running);
+}
+
+void IqtFit::setPlotResultIsPlotting(bool plotting) {
+	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+	setButtonsEnabled(!plotting);
+}
+
+void IqtFit::setButtonsEnabled(bool enabled) {
+	setRunEnabled(enabled);
+	setPlotResultEnabled(enabled);
+	setSaveResultEnabled(enabled);
+	setFitSingleSpectrumEnabled(enabled);
+}
+
 void IqtFit::setRunEnabled(bool enabled) {
   m_uiForm->pbRun->setEnabled(enabled);
 }
@@ -144,32 +164,13 @@ void IqtFit::setPlotResultEnabled(bool enabled) {
   m_uiForm->cbPlotType->setEnabled(enabled);
 }
 
-void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
-  m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
-}
-
 void IqtFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
 
-void IqtFit::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setPlotResultEnabled(enabled);
-  setSaveResultEnabled(enabled);
-  setFitSingleSpectrumEnabled(enabled);
+void IqtFit::setFitSingleSpectrumEnabled(bool enabled) {
+	m_uiForm->pvFitPlotView->enableFitSingleSpectrum(enabled);
 }
-
-void IqtFit::setRunIsRunning(bool running) {
-  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
-}
-
-void IqtFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-  setButtonsEnabled(!plotting);
-}
-
-void IqtFit::runClicked() { runTab(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -43,7 +43,7 @@ protected slots:
 
 protected:
   void setRunIsRunning(bool running) override;
-	void setFitSingleSpectrumIsFitting(bool fitting) override;
+  void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -43,6 +43,7 @@ protected slots:
 
 protected:
   void setRunIsRunning(bool running) override;
+	void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -42,8 +42,6 @@ protected slots:
   void runClicked();
 
 protected:
-  bool shouldEnablePlotResult() override { return true; };
-
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -42,7 +42,7 @@ protected slots:
   void runClicked();
 
 protected:
-	void setRunIsRunning(bool running) override;
+  void setRunIsRunning(bool running) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
@@ -52,8 +52,8 @@ private:
 
   void setupFitTab() override;
 
-	void setPlotResultIsPlotting(bool plotting);
-	void setButtonsEnabled(bool enabled);
+  void setPlotResultIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -42,10 +42,9 @@ protected slots:
   void runClicked();
 
 protected:
+	void setRunIsRunning(bool running) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
-
-  void setRunIsRunning(bool running) override;
 
 private:
   void setConstrainIntensitiesEnabled(bool enabled);
@@ -53,11 +52,10 @@ private:
 
   void setupFitTab() override;
 
+	void setPlotResultIsPlotting(bool plotting);
+	void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-
-  void setPlotResultIsPlotting(bool plotting);
 
   IqtFitModel *m_iqtFittingModel;
   std::unique_ptr<Ui::IqtFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -107,10 +107,34 @@ void JumpFit::updatePlotOptions() {
   IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
 }
 
+void JumpFit::runClicked() { runTab(); }
+
 void JumpFit::plotClicked() {
   setPlotResultIsPlotting(true);
   IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
   setPlotResultIsPlotting(false);
+}
+
+void JumpFit::setRunIsRunning(bool running) {
+	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+	setButtonsEnabled(!running);
+}
+
+void JumpFit::setFitSingleSpectrumIsFitting(bool fitting) {
+	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
+	setButtonsEnabled(!fitting);
+}
+
+void JumpFit::setPlotResultIsPlotting(bool plotting) {
+	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+	setButtonsEnabled(!plotting);
+}
+
+void JumpFit::setButtonsEnabled(bool enabled) {
+	setRunEnabled(enabled);
+	setPlotResultEnabled(enabled);
+	setSaveResultEnabled(enabled);
+	setFitSingleSpectrumEnabled(enabled);
 }
 
 void JumpFit::setRunEnabled(bool enabled) {
@@ -129,25 +153,6 @@ void JumpFit::setFitSingleSpectrumEnabled(bool enabled) {
 void JumpFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
-
-void JumpFit::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setPlotResultEnabled(enabled);
-  setSaveResultEnabled(enabled);
-  setFitSingleSpectrumEnabled(enabled);
-}
-
-void JumpFit::setRunIsRunning(bool running) {
-  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
-}
-
-void JumpFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-  setButtonsEnabled(!plotting);
-}
-
-void JumpFit::runClicked() { runTab(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -113,13 +113,6 @@ void JumpFit::plotClicked() {
   setPlotResultIsPlotting(false);
 }
 
-bool JumpFit::shouldEnablePlotResult() {
-  for (auto i = 0u; i < m_jumpFittingModel->numberOfWorkspaces(); ++i)
-    if (m_jumpFittingModel->getNumberOfSpectra(i) > 1)
-      return true;
-  return false;
-}
-
 void JumpFit::setRunEnabled(bool enabled) {
   m_uiForm->pbRun->setEnabled(enabled);
 }

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -116,25 +116,26 @@ void JumpFit::plotClicked() {
 }
 
 void JumpFit::setRunIsRunning(bool running) {
-	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-	setButtonsEnabled(!running);
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
 }
 
 void JumpFit::setFitSingleSpectrumIsFitting(bool fitting) {
-	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
-	setButtonsEnabled(!fitting);
+  m_uiForm->pvFitPlotView->setFitSingleSpectrumText(
+      fitting ? "Fitting..." : "Fit Single Spectrum");
+  setButtonsEnabled(!fitting);
 }
 
 void JumpFit::setPlotResultIsPlotting(bool plotting) {
-	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-	setButtonsEnabled(!plotting);
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setButtonsEnabled(!plotting);
 }
 
 void JumpFit::setButtonsEnabled(bool enabled) {
-	setRunEnabled(enabled);
-	setPlotResultEnabled(enabled);
-	setSaveResultEnabled(enabled);
-	setFitSingleSpectrumEnabled(enabled);
+  setRunEnabled(enabled);
+  setPlotResultEnabled(enabled);
+  setSaveResultEnabled(enabled);
+  setFitSingleSpectrumEnabled(enabled);
 }
 
 void JumpFit::setRunEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -32,8 +32,8 @@ protected slots:
   void runClicked();
 
 protected:
-	void setRunIsRunning(bool running) override;
-	void setFitSingleSpectrumIsFitting(bool fitting) override;
+  void setRunIsRunning(bool running) override;
+  void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
@@ -44,8 +44,8 @@ private:
   void addEISFFunctionsToFitTypeComboBox();
   void addWidthFunctionsToFitTypeComboBox();
 
-	void setPlotResultIsPlotting(bool plotting);
-	void setButtonsEnabled(bool enabled);
+  void setPlotResultIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
 

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -32,10 +32,10 @@ protected slots:
   void runClicked();
 
 protected:
+	void setRunIsRunning(bool running) override;
+	void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
-
-  void setRunIsRunning(bool running) override;
 
 private slots:
   void updateParameterFitTypes();
@@ -44,10 +44,10 @@ private:
   void addEISFFunctionsToFitTypeComboBox();
   void addWidthFunctionsToFitTypeComboBox();
 
+	void setPlotResultIsPlotting(bool plotting);
+	void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-  void setPlotResultIsPlotting(bool plotting);
 
   JumpFitModel *m_jumpFittingModel;
   std::unique_ptr<Ui::JumpFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/JumpFit.h
+++ b/qt/scientific_interfaces/Indirect/JumpFit.h
@@ -32,8 +32,6 @@ protected slots:
   void runClicked();
 
 protected:
-  bool shouldEnablePlotResult() override;
-
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -77,25 +77,26 @@ void MSDFit::plotClicked() {
 }
 
 void MSDFit::setRunIsRunning(bool running) {
-	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-	setButtonsEnabled(!running);
+  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
 }
 
 void MSDFit::setFitSingleSpectrumIsFitting(bool fitting) {
-	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
-	setButtonsEnabled(!fitting);
+  m_uiForm->pvFitPlotView->setFitSingleSpectrumText(
+      fitting ? "Fitting..." : "Fit Single Spectrum");
+  setButtonsEnabled(!fitting);
 }
 
 void MSDFit::setPlotResultIsPlotting(bool plotting) {
-	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-	setButtonsEnabled(!plotting);
+  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+  setButtonsEnabled(!plotting);
 }
 
 void MSDFit::setButtonsEnabled(bool enabled) {
-	setRunEnabled(enabled);
-	setPlotResultEnabled(enabled);
-	setSaveResultEnabled(enabled);
-	setFitSingleSpectrumEnabled(enabled);
+  setRunEnabled(enabled);
+  setPlotResultEnabled(enabled);
+  setSaveResultEnabled(enabled);
+  setFitSingleSpectrumEnabled(enabled);
 }
 
 void MSDFit::setRunEnabled(bool enabled) {

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -74,13 +74,6 @@ void MSDFit::plotClicked() {
   setPlotResultIsPlotting(false);
 }
 
-bool MSDFit::shouldEnablePlotResult() {
-  for (auto i = 0u; i < m_msdFittingModel->numberOfWorkspaces(); ++i)
-    if (m_msdFittingModel->getNumberOfSpectra(i) > 1)
-      return true;
-  return false;
-}
-
 void MSDFit::setRunEnabled(bool enabled) {
   m_uiForm->pbRun->setEnabled(enabled);
 }

--- a/qt/scientific_interfaces/Indirect/MSDFit.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFit.cpp
@@ -68,10 +68,34 @@ void MSDFit::updatePlotOptions() {
   IndirectFitAnalysisTab::updatePlotOptions(m_uiForm->cbPlotType);
 }
 
+void MSDFit::runClicked() { runTab(); }
+
 void MSDFit::plotClicked() {
   setPlotResultIsPlotting(true);
   IndirectFitAnalysisTab::plotResult(m_uiForm->cbPlotType->currentText());
   setPlotResultIsPlotting(false);
+}
+
+void MSDFit::setRunIsRunning(bool running) {
+	m_uiForm->pbRun->setText(running ? "Running..." : "Run");
+	setButtonsEnabled(!running);
+}
+
+void MSDFit::setFitSingleSpectrumIsFitting(bool fitting) {
+	m_uiForm->pvFitPlotView->setFitSingleSpectrumText(fitting ? "Fitting..." : "Fit Single Spectrum");
+	setButtonsEnabled(!fitting);
+}
+
+void MSDFit::setPlotResultIsPlotting(bool plotting) {
+	m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
+	setButtonsEnabled(!plotting);
+}
+
+void MSDFit::setButtonsEnabled(bool enabled) {
+	setRunEnabled(enabled);
+	setPlotResultEnabled(enabled);
+	setSaveResultEnabled(enabled);
+	setFitSingleSpectrumEnabled(enabled);
 }
 
 void MSDFit::setRunEnabled(bool enabled) {
@@ -90,25 +114,6 @@ void MSDFit::setFitSingleSpectrumEnabled(bool enabled) {
 void MSDFit::setSaveResultEnabled(bool enabled) {
   m_uiForm->pbSave->setEnabled(enabled);
 }
-
-void MSDFit::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setPlotResultEnabled(enabled);
-  setSaveResultEnabled(enabled);
-  setFitSingleSpectrumEnabled(enabled);
-}
-
-void MSDFit::setRunIsRunning(bool running) {
-  m_uiForm->pbRun->setText(running ? "Running..." : "Run");
-  setButtonsEnabled(!running);
-}
-
-void MSDFit::setPlotResultIsPlotting(bool plotting) {
-  m_uiForm->pbPlot->setText(plotting ? "Plotting..." : "Plot");
-  setButtonsEnabled(!plotting);
-}
-
-void MSDFit::runClicked() { runTab(); }
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -29,8 +29,6 @@ protected slots:
   void updateModelFitTypeString();
 
 protected:
-  bool shouldEnablePlotResult() override;
-
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -29,16 +29,16 @@ protected slots:
   void updateModelFitTypeString();
 
 protected:
-	void setRunIsRunning(bool running) override;
-	void setFitSingleSpectrumIsFitting(bool fitting) override;
+  void setRunIsRunning(bool running) override;
+  void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
 
 private:
   void setupFitTab() override;
 
-	void setPlotResultIsPlotting(bool plotting);
-	void setButtonsEnabled(bool enabled);
+  void setPlotResultIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
 

--- a/qt/scientific_interfaces/Indirect/MSDFit.h
+++ b/qt/scientific_interfaces/Indirect/MSDFit.h
@@ -29,18 +29,18 @@ protected slots:
   void updateModelFitTypeString();
 
 protected:
+	void setRunIsRunning(bool running) override;
+	void setFitSingleSpectrumIsFitting(bool fitting) override;
   void setPlotResultEnabled(bool enabled) override;
   void setSaveResultEnabled(bool enabled) override;
-
-  void setRunIsRunning(bool running) override;
 
 private:
   void setupFitTab() override;
 
+	void setPlotResultIsPlotting(bool plotting);
+	void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setFitSingleSpectrumEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-  void setPlotResultIsPlotting(bool plotting);
 
   MSDFitModel *m_msdFittingModel;
   std::unique_ptr<Ui::MSDFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -121,6 +121,8 @@ public:
   MOCK_METHOD1(enableSpectrumSelection, void(bool enable));
   MOCK_METHOD1(enableFitRangeSelection, void(bool enable));
 
+	MOCK_METHOD1(setFitSingleSpectrumText, void(QString const &text));
+
   MOCK_METHOD1(setBackgroundLevel, void(double value));
 
   MOCK_METHOD2(setFitRange, void(double minimum, double maximum));

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotPresenterTest.h
@@ -121,7 +121,7 @@ public:
   MOCK_METHOD1(enableSpectrumSelection, void(bool enable));
   MOCK_METHOD1(enableFitRangeSelection, void(bool enable));
 
-	MOCK_METHOD1(setFitSingleSpectrumText, void(QString const &text));
+  MOCK_METHOD1(setFitSingleSpectrumText, void(QString const &text));
 
   MOCK_METHOD1(setBackgroundLevel, void(double value));
 


### PR DESCRIPTION
**Description of work.**
**A.** This PR ensures that you cannot attempt a plot of a workspace that has only one data point to be plotted.
**B.** This PR also makes sure the `Fit Single Spectrum` button is disabled when fitting a single spectrum for instance in ConvFit.

**To test:**
**A.**
1. Go to `Interfaces` > `Indirect` > `Data Analysis`
2. Go to the I(Q, T) tab
3. Load the irs26176_graphite002_red.nxs file from the sample data
4. Load the resolution file irs26173_graphite002_res.nxs from the sample data
5. Click Run, a new workspace with the suffix _iqt should appear

6. Go to the I(Q, T) Fit tab
7. Load the _iqt workspace 
8. Set Exponential to 1
9. Set EndX to 0.14
10. Change `Fit spectra` to String and set this to 3
11. Click Run

`Plot` in the output options should be disabled as there is only one data point to be plotted.

**B.**
1. Go to the ConvFit tab
2. Load the data below
3. Select `TeixeiraWater` as Fit Type
4. Click `Fit Single Spectrum` and make sure it is disabled while fitting and then re-enabled

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2634132/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2634133/irs26173_graphite002_res.zip)

Fixes #24151

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
