### PR TITLE
ConvertToMD uses the time average value of logs

### DIFF
--- a/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
+++ b/Framework/MDAlgorithms/test/ConvertToMDMinMaxLocalTest.h
@@ -193,9 +193,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.execute(););
     TS_ASSERT(alg.isExecuted());
     // Check the results
-
-    TS_ASSERT_EQUALS(alg.getPropertyValue("MinValues"), "0.12187,9.99");
-    TS_ASSERT_EQUALS(alg.getPropertyValue("MaxValues"), "0.126745,9.99");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("MinValues"), "0.12187,7.69667");
+    TS_ASSERT_EQUALS(alg.getPropertyValue("MaxValues"), "0.126745,7.69667");
     // Remove workspace from the data service.
     Mantid::API::AnalysisDataService::Instance().remove(WSName);
   }
@@ -249,6 +248,8 @@ private:
     Mantid::Geometry::OrientedLattice latt(2, 3, 4, 90, 90, 90);
     ws->mutableSample().setOrientedLattice(&latt);
 
+    // time average value of this is the simple average
+    // of the first three values = 7.69667
     Mantid::Kernel::TimeSeriesProperty<double> *p =
         new Mantid::Kernel::TimeSeriesProperty<double>("doubleProp");
     TS_ASSERT_THROWS_NOTHING(p->addValue("2007-11-30T16:17:00", 9.99));

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -82,6 +82,7 @@ Bugfixes
 - Fixed a crash in :ref:`MaskDetectors <algm-MaskDetectors>` when a non-existent component was given in ``ComponentList``.
 - History for algorithms that took groups sometimes would get incorrect history causing history to be incomplete, so now full group history is saved for all items belonging to the group.
 - Fixed a bug in `SetGoniometer <algm-SetGoniometer>` where it would use the mean log value rather than the time series average value for goniometer angles.
+- `ConvertToMD <algm-ConvertToMD>` now uses the time-average value for logs when using them as ``OtherDimensions``
 
 
 Python


### PR DESCRIPTION
... rather than the "hack" which just used the first log value. The way this is done will also add support for other log types rather than just things that are already doubles.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
