### PR TITLE
Bugfix gui remembering linear/logarithmic binning

### DIFF
--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -73,6 +73,7 @@ Bugfixes
 - multiple_scattering flag is now optional for Polaris focus when absorb_correction is true.
 - Normalisation is fixed in :ref:`SumOverlappingTubes <algm-SumOverlappingTubes>`, which was causing very low peak to background ratio for reduced D2B data.
 - sudden drops at either end of spectra in Pearl caused by partial bins are now cropped.
+- The Powder Diffraction GUI now remembers whether linear or logorithmic binning was selected between uses
 
 New
 ###

--- a/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
@@ -154,9 +154,8 @@ class RunSetupWidget(BaseWidget):
 
         self._content.help_button.clicked.connect(self._show_help)
 
-        # Validated widgets
-
-        return
+        # mutex for whether to update the linear/log drop-down
+        self._content._binning_edit_mutex = False
 
     def set_state(self, state):
         """ Populate the UI elements with the data from the given state.
@@ -177,6 +176,7 @@ class RunSetupWidget(BaseWidget):
             binning_str = '%.6f' % abs(binning_float)
         except ValueError:
             binning_str = str(state.binning)
+        self._content._binning_edit_mutex = True
         self._content.binning_edit.setText(binning_str)
         # Set ResampleX
         try:
@@ -185,6 +185,7 @@ class RunSetupWidget(BaseWidget):
         except ValueError:
             resamplex_str = str(state.resamplex)
         self._content.resamplex_edit.setText(resamplex_str)
+        self._content._binning_edit_mutex = False
 
         # Set binning type (logarithm=1 or linear=0) - must be done after the
         # binning/resamplex boxes are set or it will be lost
@@ -354,6 +355,8 @@ class RunSetupWidget(BaseWidget):
     def _bintype_process(self):
         """ Handling bin type changed
         """
+        if self._content._binning_edit_mutex:
+            return
         currindex = self._content.bintype_combo.currentIndex()
         curbinning = self._content.binning_edit.text()
         if curbinning != "" and curbinning is not None:

--- a/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/diffraction/diffraction_run_setup.py
@@ -170,7 +170,24 @@ class RunSetupWidget(BaseWidget):
         self._content.lineEdit_expIniFile.setText(state.exp_ini_file_name)
         self._content.charfile_edit.setText(state.charfilename)
         self._content.sum_checkbox.setChecked(state.dosum)
-        # Set binning type (logarithm or linear)
+
+        # Set binning parameter
+        try:
+            binning_float = float(state.binning)
+            binning_str = '%.6f' % abs(binning_float)
+        except ValueError:
+            binning_str = str(state.binning)
+        self._content.binning_edit.setText(binning_str)
+        # Set ResampleX
+        try:
+            resamplex_i = int(state.resamplex)
+            resamplex_str = '%d' % abs(resamplex_i)
+        except ValueError:
+            resamplex_str = str(state.resamplex)
+        self._content.resamplex_edit.setText(resamplex_str)
+
+        # Set binning type (logarithm=1 or linear=0) - must be done after the
+        # binning/resamplex boxes are set or it will be lost
         bintype_index = 1
         if state.doresamplex is True:
             # resample x
@@ -189,20 +206,6 @@ class RunSetupWidget(BaseWidget):
         # END-IF-ELSE
         self._content.bintype_combo.setCurrentIndex(bintype_index)
 
-        # Set binning parameter
-        try:
-            binning_float = float(state.binning)
-            binning_str = '%.6f' % abs(binning_float)
-        except ValueError:
-            binning_str = str(state.binning)
-        self._content.binning_edit.setText(binning_str)
-        # Set ResampleX
-        try:
-            resamplex_i = int(state.resamplex)
-            resamplex_str = '%d' % abs(resamplex_i)
-        except ValueError:
-            resamplex_str = str(state.resamplex)
-        self._content.resamplex_edit.setText(resamplex_str)
         # Others
         self._content.binind_checkbox.setChecked(state.binindspace)
         self._content.outputdir_edit.setText(state.outputdir)
@@ -307,8 +310,6 @@ class RunSetupWidget(BaseWidget):
         if fname:
             self._content.calfile_edit.setText(fname)
 
-        return
-
     def _charfile_browse(self):
         """ Event handing for browsing calibration file
         """
@@ -316,16 +317,12 @@ class RunSetupWidget(BaseWidget):
         if fname:
             self._content.charfile_edit.setText(','.join(fname))
 
-        return
-
     def _groupfile_browse(self):
         ''' Event handling for browsing for a grouping file
         '''
         fname = self.data_browse_dialog(data_type='*.xml;;*.h5;;*')
         if fname:
             self._content.groupfile_edit.setText(fname)
-
-        return
 
     def do_browse_ini_file(self):
         """ Event handling for browsing Exp Ini file
@@ -335,16 +332,12 @@ class RunSetupWidget(BaseWidget):
         if exp_ini_file_name:
             self._content.lineEdit_expIniFile.setText(exp_ini_file_name)
 
-        return
-
     def _outputdir_browse(self):
         """ Event handling for browing output directory
         """
         dirname = self.dir_browse_dialog()
         if dirname:
             self._content.outputdir_edit.setText(dirname)
-
-        return
 
     def _binvalue_edit(self):
         """ Handling event for binning value changed
@@ -357,8 +350,6 @@ class RunSetupWidget(BaseWidget):
             self._content.bintype_combo.setCurrentIndex(1)
         else:
             self._content.bintype_combo.setCurrentIndex(0)
-
-        return
 
     def _bintype_process(self):
         """ Handling bin type changed
@@ -373,8 +364,6 @@ class RunSetupWidget(BaseWidget):
                 self._content.binning_edit.setText(str(-1.0*abs(curbinning)))
             #ENDIFELSE
         #ENDIF
-
-        return
 
     def validateIntegerList(self, intliststring):
         """ Validate whether the string can be divided into integer strings.


### PR DESCRIPTION
The GUI that calls SNSPowderReduction was forgetting the linear/logarithmic binning choice after pressing "reduce". 

**Report to:** Huq

**To test:**

Setup a reduction with logarithmic binning and run it. After it is finished, the gui should still show logarithmic binning.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
