### PR TITLE
Fixes the input validator for MostLikelyMean

### DIFF
--- a/Framework/Algorithms/src/MostLikelyMean.cpp
+++ b/Framework/Algorithms/src/MostLikelyMean.cpp
@@ -5,18 +5,19 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/MostLikelyMean.h"
+#include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/NullValidator.h"
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/MultiThreaded.h"
 
 #include "boost/multi_array.hpp"
 
 namespace Mantid {
 namespace Algorithms {
 
+using Mantid::Kernel::ArrayLengthValidator;
 using Mantid::Kernel::ArrayProperty;
 using Mantid::Kernel::Direction;
-using Mantid::Kernel::NullValidator;
 using Mantid::Kernel::PropertyWithValue;
 
 // Register the algorithm into the AlgorithmFactory
@@ -43,9 +44,10 @@ const std::string MostLikelyMean::summary() const {
 /** Initialize the algorithm's properties.
  */
 void MostLikelyMean::init() {
-  auto nullValidator = boost::make_shared<NullValidator>();
+  auto lengthValidator = boost::make_shared<ArrayLengthValidator<double>>();
+  lengthValidator->setLengthMin(1);
   declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "InputArray", nullValidator, Direction::Input),
+                      "InputArray", lengthValidator, Direction::Input),
                   "An input array.");
   declareProperty(Kernel::make_unique<PropertyWithValue<double>>(
                       "Output", 0., Direction::Output),
@@ -59,7 +61,7 @@ void MostLikelyMean::exec() {
   const std::vector<double> input = getProperty("InputArray");
   const int size = static_cast<int>(input.size());
   boost::multi_array<double, 2> cov(boost::extents[size][size]);
-  PARALLEL_FOR_IF(true)
+  PARALLEL_FOR_NO_WSP_CHECK()
   for (int i = 0; i < size; ++i) {
     for (int j = 0; j <= i; ++j) {
       double diff = sqrt(fabs(input[i] - input[j]));

--- a/Framework/Algorithms/src/MostLikelyMean.cpp
+++ b/Framework/Algorithms/src/MostLikelyMean.cpp
@@ -7,8 +7,8 @@
 #include "MantidAlgorithms/MostLikelyMean.h"
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/PropertyWithValue.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "MantidKernel/PropertyWithValue.h"
 
 #include "boost/multi_array.hpp"
 

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -80,12 +80,12 @@ Bugfixes
 - Fixed an issue where if a workspace's history wouldn't update for some algorithms
 - Fixed a ``std::bad_cast`` error in :ref:`algm-LoadLiveData` when the data size changes.
 - :ref:`Fit <algm-Fit>` now applies the ties in correct order independently on the order they are set. If any circular dependencies are found Fit will give an error.
-- Fixed a rare bug in :ref:`MaskDetectors <algm-MaskDetectors>` where a workspace could become invalidaded in Python if it was a ``MaskWorkspace``.
+- Fixed a rare bug in :ref:`MaskDetectors <algm-MaskDetectors>` where a workspace could become invalidated in Python if it was a ``MaskWorkspace``.
 - Fixed a crash in :ref:`MaskDetectors <algm-MaskDetectors>` when a non-existent component was given in ``ComponentList``.
 - History for algorithms that took groups sometimes would get incorrect history causing history to be incomplete, so now full group history is saved for all items belonging to the group.
 - Fixed a bug in `SetGoniometer <algm-SetGoniometer>` where it would use the mean log value rather than the time series average value for goniometer angles.
 - `ConvertToMD <algm-ConvertToMD>` now uses the time-average value for logs when using them as ``OtherDimensions``
-
+- The input validator is fixed in :ref:`MostLikelyMean <algm-MostLikelyMean>` avoiding a segmentation fault.
 
 Python
 ------


### PR DESCRIPTION
**Description of work.**

Fits in the title.

**To test:**

Start the dialog of the algorithm, do not specify any input, click Run. This should not crash mantid.

Fixes #24209 .

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
