### PR TITLE
Indirect - Crash when loading F(Q) Fit data

### DIFF
--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -38,7 +38,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-	void setBrowserWorkspace() override {};
+  void setBrowserWorkspace() override{};
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -38,6 +38,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
+	void setActiveBrowserWorkspace() override {};
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -38,7 +38,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-	void setActiveBrowserWorkspace() override {};
+	void setBrowserWorkspace() override {};
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
@@ -86,6 +86,7 @@ void IndirectDataAnalysis::initLayout() {
             SLOT(showMessageBox(const QString &)));
   }
 
+	connect(m_uiForm.twIDATabs, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)));
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
           SLOT(exportTabPython()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
@@ -121,6 +122,13 @@ void IndirectDataAnalysis::loadSettings() {
     tab->second->loadTabSettings(settings);
 
   settings.endGroup();
+}
+
+/**
+ * Sets the active workspace in the selected tab
+ */
+void IndirectDataAnalysis::tabChanged(int index) {
+	m_tabs[index]->setActiveWorkspace();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
@@ -86,7 +86,8 @@ void IndirectDataAnalysis::initLayout() {
             SLOT(showMessageBox(const QString &)));
   }
 
-	connect(m_uiForm.twIDATabs, SIGNAL(currentChanged(int)), this, SLOT(tabChanged(int)));
+  connect(m_uiForm.twIDATabs, SIGNAL(currentChanged(int)), this,
+          SLOT(tabChanged(int)));
   connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
           SLOT(exportTabPython()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));
@@ -128,7 +129,7 @@ void IndirectDataAnalysis::loadSettings() {
  * Sets the active workspace in the selected tab
  */
 void IndirectDataAnalysis::tabChanged(int index) {
-	m_tabs[index]->setActiveWorkspace();
+  m_tabs[index]->setActiveWorkspace();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
@@ -71,6 +71,8 @@ private:
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
 
 private slots:
+  /// Sets the active workspace in the selected tab
+  void tabChanged(int index);
   /// Called when the user clicks the Py button
   void exportTabPython();
   /// Opens a directory dialog.

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -50,8 +50,11 @@ void IndirectDataAnalysisTab::loadTabSettings(const QSettings &settings) {
   loadSettings(settings);
 }
 
+/**
+ * Sets the active browser workspace when the tab is changed
+ */
 void IndirectDataAnalysisTab::setActiveWorkspace() {
-	setActiveBrowserWorkspace();
+	setBrowserWorkspace();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -53,9 +53,7 @@ void IndirectDataAnalysisTab::loadTabSettings(const QSettings &settings) {
 /**
  * Sets the active browser workspace when the tab is changed
  */
-void IndirectDataAnalysisTab::setActiveWorkspace() {
-	setBrowserWorkspace();
-}
+void IndirectDataAnalysisTab::setActiveWorkspace() { setBrowserWorkspace(); }
 
 /**
  * Slot that can be called when a user edits an input.

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -50,6 +50,10 @@ void IndirectDataAnalysisTab::loadTabSettings(const QSettings &settings) {
   loadSettings(settings);
 }
 
+void IndirectDataAnalysisTab::setActiveWorkspace() {
+	setActiveBrowserWorkspace();
+}
+
 /**
  * Slot that can be called when a user edits an input.
  */

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -148,11 +148,9 @@ private:
   void run() override = 0;
   /// Overidden by child class.
   bool validate() override = 0;
-
   /// Overidden by child class.
   virtual void loadSettings(const QSettings &settings) = 0;
-
-	virtual void setActiveBrowserWorkspace() = 0;
+	virtual void setBrowserWorkspace() = 0;
 
   /// A pointer to the parent (friend) IndirectDataAnalysis object.
   IndirectDataAnalysis *m_parent;

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -61,8 +61,8 @@ public:
   /// Loads the tab's settings.
   void loadTabSettings(const QSettings &settings);
 
-	/// Sets the active workspace in the selected tab
-	void setActiveWorkspace();
+  /// Sets the active workspace in the selected tab
+  void setActiveWorkspace();
 
 protected:
   /// Function to run a string as python code
@@ -150,7 +150,7 @@ private:
   bool validate() override = 0;
   /// Overidden by child class.
   virtual void loadSettings(const QSettings &settings) = 0;
-	virtual void setBrowserWorkspace() = 0;
+  virtual void setBrowserWorkspace() = 0;
 
   /// A pointer to the parent (friend) IndirectDataAnalysis object.
   IndirectDataAnalysis *m_parent;

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -61,6 +61,9 @@ public:
   /// Loads the tab's settings.
   void loadTabSettings(const QSettings &settings);
 
+	/// Sets the active workspace in the selected tab
+	void setActiveWorkspace();
+
 protected:
   /// Function to run a string as python code
   void runPythonScript(const QString &pyInput);
@@ -148,6 +151,8 @@ private:
 
   /// Overidden by child class.
   virtual void loadSettings(const QSettings &settings) = 0;
+
+	virtual void setActiveBrowserWorkspace() = 0;
 
   /// A pointer to the parent (friend) IndirectDataAnalysis object.
   IndirectDataAnalysis *m_parent;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -400,10 +400,6 @@ void IndirectFitAnalysisTab::updateBrowserFittingRange() {
   setBrowserEndX(range.second);
 }
 
-void	IndirectFitAnalysisTab::setActiveBrowserWorkspace() {
-	setBrowserWorkspace();
-}
-
 void IndirectFitAnalysisTab::setBrowserWorkspace() {
   if (m_fittingModel->numberOfWorkspaces() > 0) {
     auto const name =

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -400,8 +400,12 @@ void IndirectFitAnalysisTab::updateBrowserFittingRange() {
   setBrowserEndX(range.second);
 }
 
+void	IndirectFitAnalysisTab::setActiveBrowserWorkspace() {
+	setBrowserWorkspace();
+}
+
 void IndirectFitAnalysisTab::setBrowserWorkspace() {
-  if (m_fittingModel->numberOfWorkspaces() != 0) {
+  if (m_fittingModel->numberOfWorkspaces() > 0) {
     auto const name =
         m_fittingModel->getWorkspace(getSelectedDataIndex())->getName();
     m_fitPropertyBrowser->setWorkspaceName(QString::fromStdString(name));

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -113,7 +113,7 @@ public:
                                        bool changesFunction);
 
 public slots:
-  void setBrowserWorkspace();
+  void setBrowserWorkspace() override;
 
 protected:
   IndirectFittingModel *fittingModel() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -113,7 +113,7 @@ public:
                                        bool changesFunction);
 
 public slots:
-	void setBrowserWorkspace();
+  void setBrowserWorkspace();
 
 protected:
   IndirectFittingModel *fittingModel() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -41,8 +41,6 @@ public:
   void
   setFitPropertyBrowser(MantidWidgets::IndirectFitPropertyBrowser *browser);
 
-	void setActiveBrowserWorkspace();
-
   std::size_t getSelectedDataIndex() const;
   std::size_t getSelectedSpectrum() const;
   bool isRangeCurrentlySelected(std::size_t dataIndex,
@@ -114,6 +112,9 @@ public:
   void setCustomSettingChangesFunction(const QString &settingKey,
                                        bool changesFunction);
 
+public slots:
+	void setBrowserWorkspace();
+
 protected:
   IndirectFittingModel *fittingModel() const;
 
@@ -173,7 +174,6 @@ protected slots:
   void setBrowserStartX(double startX);
   void setBrowserEndX(double endX);
   void updateBrowserFittingRange();
-  void setBrowserWorkspace();
   void setBrowserWorkspace(std::size_t dataIndex);
   void setBrowserWorkspaceIndex(std::size_t spectrum);
   void setBrowserWorkspaceIndex(int spectrum);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -41,6 +41,8 @@ public:
   void
   setFitPropertyBrowser(MantidWidgets::IndirectFitPropertyBrowser *browser);
 
+	void setActiveBrowserWorkspace();
+
   std::size_t getSelectedDataIndex() const;
   std::size_t getSelectedSpectrum() const;
   bool isRangeCurrentlySelected(std::size_t dataIndex,

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -24,7 +24,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-	void setActiveBrowserWorkspace() override {};
+	void setBrowserWorkspace() override {};
 
   bool isErrorsEnabled();
 

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -24,6 +24,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
+	void setActiveBrowserWorkspace() override {};
 
   bool isErrorsEnabled();
 

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -24,7 +24,7 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-	void setBrowserWorkspace() override {};
+  void setBrowserWorkspace() override{};
 
   bool isErrorsEnabled();
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -66,18 +66,18 @@ Mantid::Kernel::Logger g_log("FitPropertyBrowser");
 using namespace Mantid::API;
 
 Workspace_sptr getADSWorkspace(std::string const &workspaceName) {
-	return AnalysisDataService::Instance().retrieve(workspaceName);
+  return AnalysisDataService::Instance().retrieve(workspaceName);
 }
 
 MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
-	return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+  return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
 }
 
-int getNumberOfSpectra(MatrixWorkspace_sptr workspace) { 
-	return static_cast<int>(workspace->getNumberHistograms());
+int getNumberOfSpectra(MatrixWorkspace_sptr workspace) {
+  return static_cast<int>(workspace->getNumberHistograms());
 }
 
-}
+} // namespace
 
 /**
  * Constructor
@@ -1346,23 +1346,22 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
     return;
 
   if (prop == m_workspaceIndex) {
-    auto const workspace = convertToMatrixWorkspace(getADSWorkspace(workspaceName()));
+    auto const workspace =
+        convertToMatrixWorkspace(getADSWorkspace(workspaceName()));
 
-		if (workspace) {
-			int const numberOfSpectra = getNumberOfSpectra(workspace);
-			int const currentIndex = workspaceIndex();
+    if (workspace) {
+      int const numberOfSpectra = getNumberOfSpectra(workspace);
+      int const currentIndex = workspaceIndex();
 
-			if (currentIndex < 0) {
-				setWorkspaceIndex(0);
-				emit workspaceIndexChanged(0);
-			}
-			else if (currentIndex >= numberOfSpectra) {
-				setWorkspaceIndex(numberOfSpectra - 1);
-				emit workspaceIndexChanged(numberOfSpectra - 1);
-			}
-		}
-		else
-			setWorkspaceIndex(0);
+      if (currentIndex < 0) {
+        setWorkspaceIndex(0);
+        emit workspaceIndexChanged(0);
+      } else if (currentIndex >= numberOfSpectra) {
+        setWorkspaceIndex(numberOfSpectra - 1);
+        emit workspaceIndexChanged(numberOfSpectra - 1);
+      }
+    } else
+      setWorkspaceIndex(0);
   } else if (prop->propertyName() == "Workspace Index") {
     PropertyHandler *h = getHandler()->findHandler(prop);
     if (!h)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug which causes a crash when loading data across multiple Data Analysis interfaces.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` Tab
2. Load the data below
3. Go to the F(Q)Fit tab and load the data below
crash!

**Data Files**
**ConvFit**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2640133/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2640134/irs26173_graphite002_res.zip)
**F(Q)Fit**
[iris26174_graphite002_s0-17_Result.zip](https://github.com/mantidproject/mantid/files/2640135/iris26174_graphite002_s0-17_Result.zip)

Fixes #24199 

No release notes required as this crash doesn't happen in the current released version.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
