### PR TITLE
Change update interval for live monitor

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.cpp
@@ -851,7 +851,7 @@ IAlgorithm_sptr ReflRunsTabPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("OutputWorkspace", "IvsQ_binned_live");
   alg->setProperty("AccumulationWorkspace", "TOF_live");
   alg->setProperty("AccumulationMethod", "Replace");
-  alg->setProperty("UpdateEvery", "60");
+  alg->setProperty("UpdateEvery", "20");
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
   alg->setProperty("PostProcessingProperties",
                    liveDataReductionOptions(instrument));


### PR DESCRIPTION
**Description of work.**

Change the hard-coded live date monitoring interval from 60 to 20 seconds in the ISIS reflectometry interface. Longer term we will make this customisable but for now the shorter interval will help users.

**Report to:** Max at ISIS

**To test:**
You will need to be at ISIS and on site or on the VPN for this to work. Ideally cycle should be running.
- Open the `ISIS Reflectometry` interface
- Set the instrument to INTER
- Click `Start monitor`
- Check the log. Some text saying that MonitorLiveData has started will be printed and then there should be around a 20 second delay before the next text ("Loading live data chunk...") is printed.

*There is no associated issue.*

*This does not require release notes* because the update interval is not documented anyway.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
