### PR TITLE
Re-enable Display Mask button upon Error

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -165,18 +165,22 @@ class MaskingTablePresenter(object):
         # Disable the button
         self._view.set_display_mask_button_to_processing()
 
-        row_index = self._view.get_current_row()
-        state = self.get_state(row_index)
+        try:
+            row_index = self._view.get_current_row()
+            state = self.get_state(row_index)
+        except Exception as e:
+            self.on_processing_error_masking_display(e)
+            raise Exception(e)  # propagate errors for run_tab_presenter to deal with
+        else:
+            if not state:
+                self._logger.information("You can only show a masked workspace if a user file has been loaded and there"
+                                         "valid sample scatter entry has been provided in the selected row.")
+                return
 
-        if not state:
-            self._logger.information("You can only show a masked workspace if a user file has been loaded and there"
-                                     "valid sample scatter entry has been provided in the selected row.")
-            return
-
-        # Run the task
-        listener = MaskingTablePresenter.DisplayMaskListener(self)
-        state_copy = copy.copy(state)
-        self._work_handler.process(listener, load_and_mask_workspace, 0, state_copy, self.DISPLAY_WORKSPACE_NAME)
+            # Run the task
+            listener = MaskingTablePresenter.DisplayMaskListener(self)
+            state_copy = copy.copy(state)
+            self._work_handler.process(listener, load_and_mask_workspace, 0, state_copy, self.DISPLAY_WORKSPACE_NAME)
 
     def on_processing_finished_masking_display(self, result):
         # Enable button

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -170,7 +170,7 @@ class MaskingTablePresenter(object):
             state = self.get_state(row_index)
         except Exception as e:
             self.on_processing_error_masking_display(e)
-            raise Exception(e)  # propagate errors for run_tab_presenter to deal with
+            raise Exception(str(e))  # propagate errors for run_tab_presenter to deal with
         else:
             if not state:
                 self._logger.information("You can only show a masked workspace if a user file has been loaded and there"

--- a/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
@@ -42,6 +42,29 @@ class MaskingTablePresenterTest(unittest.TestCase):
                                  masking_information(first='Phi', second='', third='L/PHI -90.0 90.0')])  # noqa
         view.set_table.assert_has_calls([first_call, second_call])
 
+    def test_that_checks_display_mask_is_reenabled_after_error(self):
+        # Arrange
+        parent_presenter = create_run_tab_presenter_mock(use_fake_state=False)
+        presenter = MaskingTablePresenter(parent_presenter)
+
+        presenter.on_processing_error_masking_display = mock.MagicMock()
+        presenter._view = mock.MagicMock()
+        presenter._view.set_display_mask_button_to_processing = mock.MagicMock()
+        presenter._view.get_current_row.side_effect = RuntimeError("Mock get_current_row failure")
+
+        try:
+            presenter.on_display()
+        except Exception as e:
+            self.assertEqual(str(e), "Mock get_current_row failure")
+        else:
+            self.assertFalse(True)  # As we expect an error to be raised
+
+        # Confirm that on_processing_error_masking_display was called
+        self.assertEqual(
+            presenter.on_processing_error_masking_display.call_count, 1,
+            "Expected on_processing_error_masking_display to have been called. Called {} times.".format(
+                presenter.on_processing_error_masking_display.call_count))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
In ISIS SANS, the button to display mask is now re-enabled if any error occurs in getting table states.

**Report to:** @robertapplin 

**To test:**
1. Interfaces -> SANS -> SANS v2
2. Choose Load User File; from the ISIS sample data in the loqdemo folder, choose Maskfile.txt
3. Choose Load Batch File; from the ISIS sample data in the loqdemo folder, choose batch_mode_reduction.csv
4. In the Settings tab:
    - Go to Mask
    - Click Display Mask

If no error occurs, force an error by adding a line such as 
`raise RuntimeError("Intentional failure")`
to the `get_states` method in `run_tab_presenter.py`, and redo steps 1-4

The Display mask button should not remain disabled, and in the dialog box in MantidPlot you should see
`Exception: Intentional failure` (or other error if you did not have to manually induce one)

Additionally, all tests should pass when running:
`ctest --output-on-failure -R masking_table_presenter_test`

Fixes #24220  

*This does not require release notes* because **internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
