### PR TITLE
Decref Python object after copying to C++ std::string

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
+++ b/Framework/PythonInterface/mantid/kernel/src/kernel.cpp.in
@@ -59,11 +59,11 @@ struct from_unicode_py2 {
     const char *value = PyString_AsString(pyutf8);
     if (value == 0)
       boost::python::throw_error_already_set();
-    Py_DECREF(pyutf8);
     using rvalue_from_python_std_string = converter::rvalue_from_python_storage<std::string>;
     void *storage = reinterpret_cast<rvalue_from_python_std_string*>(data)->storage.bytes;
     new (storage) std::string(value);
     data->convertible = storage;
+    Py_DECREF(pyutf8); // Must be deleted after the std::string has taken a copy
   }
 };
 #endif


### PR DESCRIPTION
**Description of work.**

Fixes an issue with object lifetime when converting a unicode Python string to C++. This has been causing the recent [RHEL 7 clean build](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/857/) to fail.

The core dump showed the following stacktrace:

```
(gdb) f 0
#0  0x00007f99bbe2cf8f in __strlen_sse42 () from /lib64/libc.so.6
(gdb) up
#1  0x00007f99bba9f765 in std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string(char const*, std::allocator<char> const&) () from /lib64/libstdc++.so.6
(gdb) 
#2  0x00007f99b3aa1f21 in from_unicode_py2::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) () from /home/builder/Jenkins/workspace/master_clean-rhel7/build/bin/mantid/kernel/_kernel.so
(gdb) 
#3  0x00007f99b3979b48 in boost::python::objects::caller_py_function_impl<boost::python::detail::caller<void (Mantid::Kernel::ConfigServiceImpl::*)(std::string const&), boost::python::default_call_policies, boost::mpl::vector3<void, Mantid::Kernel::ConfigServiceImpl&, std::string const&> > >::operator()(_object*, _object*) () from /home/builder/Jenkins/workspace/master_clean-rhel7/build/bin/mantid/kernel/_kernel.so
(gdb) f 2
#2  0x00007f99b3aa1f21 in from_unicode_py2::construct(_object*, boost::python::converter::rvalue_from_python_stage1_data*) () from /home/builder/Jenkins/workspace/master_clean-rhel7/build/bin/mantid/kernel/_kernel.so
(gdb) disassemble
Dump of assembler code for function _ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE:
   0x00007f99b3aa1ed0 <+0>:     push   %r12
   0x00007f99b3aa1ed2 <+2>:     push   %rbp
   0x00007f99b3aa1ed3 <+3>:     mov    %rsi,%rbp
   0x00007f99b3aa1ed6 <+6>:     push   %rbx
   0x00007f99b3aa1ed7 <+7>:     sub    $0x10,%rsp
   0x00007f99b3aa1edb <+11>:    callq  0x7f99b3964a80 <PyUnicodeUCS4_AsUTF8String@plt>
   0x00007f99b3aa1ee0 <+16>:    test   %rax,%rax
   0x00007f99b3aa1ee3 <+19>:    mov    %rax,%rbx
   0x00007f99b3aa1ee6 <+22>:    je     0x7f99b3aa1f30 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+96>
   0x00007f99b3aa1ee8 <+24>:    mov    %rbx,%rdi
   0x00007f99b3aa1eeb <+27>:    callq  0x7f99b3966600 <PyString_AsString@plt>
   0x00007f99b3aa1ef0 <+32>:    test   %rax,%rax
   0x00007f99b3aa1ef3 <+35>:    mov    %rax,%r12
   0x00007f99b3aa1ef6 <+38>:    je     0x7f99b3aa1f48 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+120>
   0x00007f99b3aa1ef8 <+40>:    subq   $0x1,(%rbx)
   0x00007f99b3aa1efc <+44>:    jne    0x7f99b3aa1f08 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+56>
   0x00007f99b3aa1efe <+46>:    mov    0x8(%rbx),%rax
   0x00007f99b3aa1f02 <+50>:    mov    %rbx,%rdi
   0x00007f99b3aa1f05 <+53>:    callq  *0x30(%rax)
   0x00007f99b3aa1f08 <+56>:    mov    %rbp,%rbx
   0x00007f99b3aa1f0b <+59>:    add    $0x10,%rbx
   0x00007f99b3aa1f0f <+63>:    je     0x7f99b3aa1f21 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+81>
   0x00007f99b3aa1f11 <+65>:    lea    0xf(%rsp),%rdx
   0x00007f99b3aa1f16 <+70>:    mov    %r12,%rsi
   0x00007f99b3aa1f19 <+73>:    mov    %rbx,%rdi
   0x00007f99b3aa1f1c <+76>:    callq  0x7f99b3966a80 <_ZNSsC1EPKcRKSaIcE@plt>
=> 0x00007f99b3aa1f21 <+81>:    mov    %rbx,0x0(%rbp)
   0x00007f99b3aa1f25 <+85>:    add    $0x10,%rsp
   0x00007f99b3aa1f29 <+89>:    pop    %rbx
   0x00007f99b3aa1f2a <+90>:    pop    %rbp
   0x00007f99b3aa1f2b <+91>:    pop    %r12
   0x00007f99b3aa1f2d <+93>:    retq   
   0x00007f99b3aa1f2e <+94>:    xchg   %ax,%ax
   0x00007f99b3aa1f30 <+96>:    callq  0x7f99b3964b40 <_ZN5boost6python23throw_error_already_setEv@plt>
   0x00007f99b3aa1f35 <+101>:   mov    %rbx,%rdi
   0x00007f99b3aa1f38 <+104>:   callq  0x7f99b3966600 <PyString_AsString@plt>
   0x00007f99b3aa1f3d <+109>:   test   %rax,%rax
   0x00007f99b3aa1f40 <+112>:   mov    %rax,%r12
   0x00007f99b3aa1f43 <+115>:   jne    0x7f99b3aa1ef8 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+40>
   0x00007f99b3aa1f45 <+117>:   nopl   (%rax)
   0x00007f99b3aa1f48 <+120>:   callq  0x7f99b3964b40 <_ZN5boost6python23throw_error_already_setEv@plt>
   0x00007f99b3aa1f4d <+125>:   jmp    0x7f99b3aa1ef8 <_ZN16from_unicode_py29constructEP7_objectPN5boost6python9converter30rvalue_from_python_stage1_dataE+40>
End of assembler dump.
```

The key line is `=> 0x00007f99b3aa1f21 <+81>:    mov    %rbx,0x0(%rbp)` where we have a null pointer being passed to the `std::string` constructor.

It turns out that `PyString_AsString` just returns the string object's internal char array so calling decref *before* passing the value to `std::string` will lead to problems if the garbage collector destroys the string object before doing the copy.


**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Code review

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
