### PR TITLE
Add conda bin directory to `Mantid.properties` search path

### DIFF
--- a/Framework/PythonInterface/mantid/__init__.py
+++ b/Framework/PythonInterface/mantid/__init__.py
@@ -40,12 +40,29 @@ def apiVersion():
     return 2
 
 
+def _bin_dirs():
+    """
+    Generate a list of possible paths that contain the Mantid.properties file
+    """
+    _moduledir = os.path.dirname(os.path.abspath(os.path.dirname(__file__)))
+    # std install
+    yield _moduledir
+    # conda layout
+    yield os.path.dirname(sys.executable)
+
+
 # Bail out early if a Mantid.properties files is not found in the
-# parent directory - it indicates a broken installation or build.
-_moduledir = os.path.abspath(os.path.dirname(__file__))
-_bindir = os.path.dirname(_moduledir)
-if not os.path.exists(os.path.join(_bindir, 'Mantid.properties')):
-    raise ImportError("Unable to find Mantid.properties file next to this package - broken installation!")
+# 1 of the expected places - it indicates a broken installation or build.
+_bindir = None
+for path in _bin_dirs():
+    if os.path.exists(os.path.join(path, "Mantid.properties")):
+        _bindir = path
+        break
+
+if _bindir is None:
+    raise ImportError(
+        "Broken installation! Unable to find Mantid.properties file.\n"
+        "Directories searched: {}".format(', '.join(_bin_dirs())))
 
 # Windows doesn"t have rpath settings so make sure the C-extensions can find the rest of the
 # mantid dlls. We assume they will be next to the properties file.


### PR DESCRIPTION
**Description of work.**

In #23875 the behaviour of `mantid/__init__.py` was changed to raise an `ImportError` early if it looks like the `Mantid.properties` file is missing as this likely indicates the installation is broken. The change did not take into account the fact that the conda build puts `mantid` into a different directory that the standard package installs.

This PR corrects the search and adds a fallback conda path if it can find the properties file in the standard place.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Build the conda package and try `import mantid` on it - it should be successful.

*This does not require release notes* because **it broken this development cycle**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
