### PR TITLE
Maximum 12 threads to be used in systemtests

### DIFF
--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -82,5 +82,9 @@ default_save_directory=${WORKSPACE}/build/Testing/SystemTests/scripts/
 find ${default_save_directory} -name "*-mismatch*" -delete
 
 # Run
+NTHREADS=${BUILD_THREADS:?}
+if [ ${NTHREADS} -gt 12 ]; then
+  NTHREADS=12
+fi
 PKGDIR=${WORKSPACE}/build
-${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${BUILD_THREADS:?} $EXTRA_ARGS
+${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${NTHREADS} $EXTRA_ARGS

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -83,8 +83,9 @@ find ${default_save_directory} -name "*-mismatch*" -delete
 
 # Run
 NTHREADS=${BUILD_THREADS:?}
-if [ ${NTHREADS} -gt 12 ]; then
-  NTHREADS=12
+MAXTHREADS=8
+if [ ${NTHREADS} -gt ${MAXTHREADS} ]; then
+  NTHREADS=${MAXTHREADS}
 fi
 PKGDIR=${WORKSPACE}/build
 ${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${NTHREADS} $EXTRA_ARGS

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -83,7 +83,7 @@ find ${default_save_directory} -name "*-mismatch*" -delete
 
 # Run
 NTHREADS=${BUILD_THREADS:?}
-MAXTHREADS=8
+MAXTHREADS=12
 if [ ${NTHREADS} -gt ${MAXTHREADS} ]; then
   NTHREADS=${MAXTHREADS}
 fi

--- a/buildconfig/Jenkins/systemtests.bat
+++ b/buildconfig/Jenkins/systemtests.bat
@@ -81,6 +81,7 @@ set PKGDIR=%WORKSPACE%\build
 :: A completely clean build will not have Mantid installed but will need Python to
 :: run the testing setup scripts. Assume it is in the PATH
 set NTHREADS=%BUILD_THREADS%
-if %NTHREADS% gtr 12 set NTHREADS=12
+set MAXTHREADS=8
+if %NTHREADS% gtr %MAXTHREADS% set NTHREADS=%MAXTHREADS%
 set PYTHON_EXE=python.exe
 %PYTHON_EXE% %WORKSPACE%\Testing\SystemTests\scripts\InstallerTests.py -o -d %PKGDIR% -j %NTHREADS% %EXTRA_ARGS%

--- a/buildconfig/Jenkins/systemtests.bat
+++ b/buildconfig/Jenkins/systemtests.bat
@@ -80,5 +80,7 @@ echo CheckMantidVersion.OnStartup = 0 >> %USERPROPS%
 set PKGDIR=%WORKSPACE%\build
 :: A completely clean build will not have Mantid installed but will need Python to
 :: run the testing setup scripts. Assume it is in the PATH
+set NTHREADS=%BUILD_THREADS%
+if %NTHREADS% gtr 12 set NTHREADS=12
 set PYTHON_EXE=python.exe
-%PYTHON_EXE% %WORKSPACE%\Testing\SystemTests\scripts\InstallerTests.py -o -d %PKGDIR% -j %BUILD_THREADS% %EXTRA_ARGS%
+%PYTHON_EXE% %WORKSPACE%\Testing\SystemTests\scripts\InstallerTests.py -o -d %PKGDIR% -j %NTHREADS% %EXTRA_ARGS%

--- a/buildconfig/Jenkins/systemtests.bat
+++ b/buildconfig/Jenkins/systemtests.bat
@@ -81,7 +81,7 @@ set PKGDIR=%WORKSPACE%\build
 :: A completely clean build will not have Mantid installed but will need Python to
 :: run the testing setup scripts. Assume it is in the PATH
 set NTHREADS=%BUILD_THREADS%
-set MAXTHREADS=8
+set MAXTHREADS=12
 if %NTHREADS% gtr %MAXTHREADS% set NTHREADS=%MAXTHREADS%
 set PYTHON_EXE=python.exe
 %PYTHON_EXE% %WORKSPACE%\Testing\SystemTests\scripts\InstallerTests.py -o -d %PKGDIR% -j %NTHREADS% %EXTRA_ARGS%


### PR DESCRIPTION
**Description of work.**

Running System Tests with a large number of cores (e.g. 25) has led to some memory issues and slow downs.
Here we capped the number of cores used by Jenkins for the System Tests to 12 (each running test still uses 2 OpenMP threads).

**To test:**

Wait for builds to complete.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
