### PR TITLE
Indirect -Error when clicking plot guess from Display without reduced workspace

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -58,6 +58,8 @@ Bugfixes
 - A bug where fixed parameters don't remain fixed when using the FABADA minimizer in ConvFit has been corrected.
 - The expression for the Fit type Yi in MSDFit was incorrect and has now been corrected.
 - The x-axis labels in the output plots for MSDFit are now correct.
+- An unexpected error is now prevented when clicking Plot Guess from the Display combo box in ConvFit without first loading 
+  a reduced file.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -115,9 +115,10 @@ void IndirectFitAnalysisTab::setup() {
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
           SLOT(updateParameterValues()));
 
-	connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this, SLOT(updatePlotGuess()));
-	connect(m_fitPropertyBrowser, SIGNAL(workspaceNameChanged(const QString &)), this,
-		SLOT(updatePlotGuess()));
+  connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
+          SLOT(updatePlotGuess()));
+  connect(m_fitPropertyBrowser, SIGNAL(workspaceNameChanged(const QString &)),
+          this, SLOT(updatePlotGuess()));
 
   connect(m_plotPresenter.get(),
           SIGNAL(fitSingleSpectrum(std::size_t, std::size_t)), this,
@@ -846,8 +847,9 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValues() {
  * Enables Plot Guess in the FitPropertyBrowser if a sample workspace is loaded
  */
 void IndirectFitAnalysisTab::updatePlotGuess() {
-	auto const sampleWorkspace = m_fittingModel->getWorkspace(getSelectedDataIndex());
-	m_fitPropertyBrowser->updatePlotGuess(sampleWorkspace);
+  auto const sampleWorkspace =
+      m_fittingModel->getWorkspace(getSelectedDataIndex());
+  m_fitPropertyBrowser->updatePlotGuess(sampleWorkspace);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -115,6 +115,10 @@ void IndirectFitAnalysisTab::setup() {
   connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this,
           SLOT(updateParameterValues()));
 
+	connect(m_fitPropertyBrowser, SIGNAL(functionChanged()), this, SLOT(updatePlotGuess()));
+	connect(m_fitPropertyBrowser, SIGNAL(workspaceNameChanged(const QString &)), this,
+		SLOT(updatePlotGuess()));
+
   connect(m_plotPresenter.get(),
           SIGNAL(fitSingleSpectrum(std::size_t, std::size_t)), this,
           SLOT(singleFit(std::size_t, std::size_t)));
@@ -838,12 +842,20 @@ void IndirectFitAnalysisTab::updateFitBrowserParameterValues() {
   m_fitPropertyBrowser->updateParameters();
 }
 
-/*
+/**
+ * Enables Plot Guess in the FitPropertyBrowser if a sample workspace is loaded
+ */
+void IndirectFitAnalysisTab::updatePlotGuess() {
+	auto const sampleWorkspace = m_fittingModel->getWorkspace(getSelectedDataIndex());
+	m_fitPropertyBrowser->updatePlotGuess(sampleWorkspace);
+}
+
+/**
  * Saves the result workspace in the default save directory.
  */
 void IndirectFitAnalysisTab::saveResult() { m_fittingModel->saveResult(); }
 
-/*
+/**
  * Plots the result workspace with the specified name, using the specified
  * plot type. Plot type can either be 'None', 'All' or the name of a
  * parameter. In the case of 'None', nothing will be plotted. In the case of

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -213,6 +213,7 @@ protected slots:
   void saveResult();
 
 private slots:
+  void updatePlotGuess();
   void emitUpdateFitTypes();
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -133,7 +133,7 @@ public:
 
   void setWorkspaceIndex(int i) override;
 
-  void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr workspace);
+  void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr sampleWorkspace);
 
 public slots:
   void fit() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -133,7 +133,7 @@ public:
 
   void setWorkspaceIndex(int i) override;
 
-	void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr workspace);
+  void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr workspace);
 
 public slots:
   void fit() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -133,7 +133,7 @@ public:
 
   void setWorkspaceIndex(int i) override;
 
-  void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr sampleWorkspace);
+  void updatePlotGuess(Mantid::API::MatrixWorkspace_const_sptr sampleWorkspace);
 
 public slots:
   void fit() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -133,6 +133,8 @@ public:
 
   void setWorkspaceIndex(int i) override;
 
+	void updatePlotGuess(Mantid::API::MatrixWorkspace_sptr workspace);
+
 public slots:
   void fit() override;
   void sequentialFit() override;
@@ -151,8 +153,6 @@ protected slots:
   void clear() override;
 
   void clearAllCustomFunctions();
-
-  void updatePlotGuess();
 
   void browserVisibilityChanged(bool isVisible);
 

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -818,7 +818,7 @@ void IndirectFitPropertyBrowser::clearAllCustomFunctions() {
  * @param sampleWorkspace :: The workspace loaded as sample
  */
 void IndirectFitPropertyBrowser::updatePlotGuess(
-    MatrixWorkspace_sptr sampleWorkspace) {
+    MatrixWorkspace_const_sptr sampleWorkspace) {
   if (sampleWorkspace && compositeFunction()->nFunctions() > 0)
     setPeakToolOn(true);
   else

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -53,6 +53,21 @@
 
 using namespace Mantid::API;
 
+namespace {
+
+std::string getWorkspaceSuffix(std::string const &workspaceName) {
+	return workspaceName.substr(workspaceName.length() - 3);
+}
+
+bool canPlotGuess(std::string const &workspaceName) {
+	if (!workspaceName.empty())
+		return getWorkspaceSuffix(workspaceName) == "red" ? true : false;
+	else
+		return false;
+}
+
+}
+
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -820,11 +835,10 @@ void IndirectFitPropertyBrowser::clearAllCustomFunctions() {
  * Updates the plot guess feature in this indirect fit property browser.
  */
 void IndirectFitPropertyBrowser::updatePlotGuess() {
-
-  if (getWorkspace() && compositeFunction()->nFunctions() > 0)
-    setPeakToolOn(true);
-  else
-    setPeakToolOn(false);
+	if (canPlotGuess(workspaceName()) && compositeFunction()->nFunctions() > 0)
+		setPeakToolOn(true);
+	else
+		setPeakToolOn(false);	
 }
 
 /**

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -817,7 +817,8 @@ void IndirectFitPropertyBrowser::clearAllCustomFunctions() {
  * Updates the plot guess feature in this indirect fit property browser.
  * @param sampleWorkspace :: The workspace loaded as sample
  */
-void IndirectFitPropertyBrowser::updatePlotGuess(MatrixWorkspace_sptr sampleWorkspace) {
+void IndirectFitPropertyBrowser::updatePlotGuess(
+    MatrixWorkspace_sptr sampleWorkspace) {
   if (sampleWorkspace && compositeFunction()->nFunctions() > 0)
     setPeakToolOn(true);
   else

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -53,21 +53,6 @@
 
 using namespace Mantid::API;
 
-namespace {
-
-std::string getWorkspaceSuffix(std::string const &workspaceName) {
-  return workspaceName.substr(workspaceName.length() - 3);
-}
-
-bool canPlotGuess(std::string const &workspaceName) {
-  if (!workspaceName.empty())
-    return getWorkspaceSuffix(workspaceName) == "red" ? true : false;
-  else
-    return false;
-}
-
-} // namespace
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -189,9 +174,6 @@ void IndirectFitPropertyBrowser::init() {
   m_functionsGroup = m_browser->addProperty(functionsGroup);
   m_settingsGroup = m_browser->addProperty(settingsGroup);
 
-  connect(this, SIGNAL(functionChanged()), this, SLOT(updatePlotGuess()));
-  connect(this, SIGNAL(workspaceNameChanged(const QString &)), this,
-          SLOT(updatePlotGuess()));
   connect(this, SIGNAL(visibilityChanged(bool)), this,
           SLOT(browserVisibilityChanged(bool)));
   connect(this, SIGNAL(customSettingChanged(QtProperty *)), this,
@@ -833,9 +815,10 @@ void IndirectFitPropertyBrowser::clearAllCustomFunctions() {
 
 /**
  * Updates the plot guess feature in this indirect fit property browser.
+ * @param sampleWorkspace :: The workspace loaded as sample
  */
-void IndirectFitPropertyBrowser::updatePlotGuess() {
-  if (canPlotGuess(workspaceName()) && compositeFunction()->nFunctions() > 0)
+void IndirectFitPropertyBrowser::updatePlotGuess(MatrixWorkspace_sptr sampleWorkspace) {
+  if (sampleWorkspace && compositeFunction()->nFunctions() > 0)
     setPeakToolOn(true);
   else
     setPeakToolOn(false);

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -56,17 +56,17 @@ using namespace Mantid::API;
 namespace {
 
 std::string getWorkspaceSuffix(std::string const &workspaceName) {
-	return workspaceName.substr(workspaceName.length() - 3);
+  return workspaceName.substr(workspaceName.length() - 3);
 }
 
 bool canPlotGuess(std::string const &workspaceName) {
-	if (!workspaceName.empty())
-		return getWorkspaceSuffix(workspaceName) == "red" ? true : false;
-	else
-		return false;
+  if (!workspaceName.empty())
+    return getWorkspaceSuffix(workspaceName) == "red" ? true : false;
+  else
+    return false;
 }
 
-}
+} // namespace
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -835,10 +835,10 @@ void IndirectFitPropertyBrowser::clearAllCustomFunctions() {
  * Updates the plot guess feature in this indirect fit property browser.
  */
 void IndirectFitPropertyBrowser::updatePlotGuess() {
-	if (canPlotGuess(workspaceName()) && compositeFunction()->nFunctions() > 0)
-		setPeakToolOn(true);
-	else
-		setPeakToolOn(false);	
+  if (canPlotGuess(workspaceName()) && compositeFunction()->nFunctions() > 0)
+    setPeakToolOn(true);
+  else
+    setPeakToolOn(false);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR ensures you cannot Plot Guess using the display combo box when a reduced workspace is not loaded.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load the resolution file below
3. Select Fit type to be Teixeira Water
4. Click the Display combo box above the FitPropertyBrowser. Plot Guess should be disabled
5. Load the reduced file below
6. Click the Display combo box above the FitPropertyBrowser. Plot Guess should be enabled - click this and a new plot window should open.

Fixes #24202 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
