### PR TITLE
TOFTOF GUI: add empty can factor for vanadium

### DIFF
--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -60,6 +60,7 @@ class TOFTOFScriptElement(BaseScriptElement):
     # default values
     DEF_prefix     = 'ws'
     DEF_ecFactor   = 1.0
+    DEF_vanEcFactor = 1.0
 
     DEF_binEon     = True
     DEF_binEstart  = 0.0
@@ -100,6 +101,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         self.vanRuns  = ''
         self.vanCmnt  = ''
         self.vanTemp  = OptionalFloat()
+        self.vanEcFactor = self.DEF_vanEcFactor
 
         # empty can runs, comment, and factor
         self.ecRuns   = ''
@@ -150,6 +152,7 @@ class TOFTOFScriptElement(BaseScriptElement):
         put('van_runs',        self.vanRuns)
         put('van_comment',     self.vanCmnt)
         put('van_temperature', self.vanTemp)
+        put('van_ec_factor',   self.vanEcFactor)
 
         put('ec_runs',     self.ecRuns)
         put('ec_temp',     self.ecTemp)
@@ -225,6 +228,7 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.vanRuns  = get_str('van_runs')
             self.vanCmnt  = get_str('van_comment')
             self.vanTemp  = get_optFloat('van_temperature')
+            self.vanEcFactor = get_flt('van_ec_factor', self.DEF_vanEcFactor)
 
             self.ecRuns   = get_str('ec_runs')
             self.ecTemp   = get_optFloat('ec_temp')

--- a/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
+++ b/scripts/Interface/reduction_gui/reduction/toftof/toftof_reduction.py
@@ -601,10 +601,16 @@ class TOFTOFScriptElement(BaseScriptElement):
             self.l("{} = Scale({}, Factor=ecFactor, Operation='Multiply')"
                    .format(scaledEC, wsECNorm))
             self.l("{} = Minus({}, {})" .format(gDataSubEC, gDataNorm, scaledEC))
+            wslist = [scaledEC]
             if self.subtractECVan:
                 wsVanSubEC = wsVan + 'SubEC'
-                self.l("{} = Minus({}, {})" .format(wsVanSubEC, wsVanNorm, scaledEC))
-            self.delete_workspaces([scaledEC])
+                scaledECvan = self.prefix + 'ScaledECvan'
+                self.l("van_ecFactor = {:.3f}" .format(self.vanEcFactor))
+                self.l("{} = Scale({}, Factor=van_ecFactor, Operation='Multiply')"
+                       .format(scaledECvan, wsECNorm))
+                self.l("{} = Minus({}, {})" .format(wsVanSubEC, wsVanNorm, scaledECvan))
+                wslist.append(scaledECvan)
+            self.delete_workspaces(wslist)
 
         self.l("# group data for processing")
         gDataSource = gDataSubEC if self.ecRuns else gDataNorm

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -141,7 +141,6 @@ class TOFTOFSetupWidget(BaseWidget):
         self.vanRuns   = tip(QLineEdit(), self.TIP_vanRuns)
         self.vanCmnt   = tip(QLineEdit(), self.TIP_vanCmnt)
         self.vanTemp   = tip(DoubleEdit(), self.TIP_vanTemp)
-        # self.vanEcFactor see below
 
         self.ecRuns    = tip(SmallQLineEdit(), self.TIP_ecRuns)
         self.ecTemp    = tip(DoubleEdit(), self.TIP_ecTemp)
@@ -180,7 +179,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.btnSaveDir          = tip(QPushButton('Browse'), self.TIP_btnSaveDir)
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
-        self.vanEcFactor  = setEnabled(tip(QDoubleSpinBox(), self.TIP_vanEcFactor), self.chkSubtractECVan)
+        self.vanEcFactor  	 = setEnabled(tip(QDoubleSpinBox(), self.TIP_vanEcFactor), self.chkSubtractECVan)
         set_spin(self.vanEcFactor, 0, 1)
         self.chkReplaceNaNs      = setEnabled(tip(QCheckBox(u'Replace special values in S(Q, ω) with 0'), self.TIP_chkReplaceNaNs),
                                               self.binEon)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -179,7 +179,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.btnSaveDir          = tip(QPushButton('Browse'), self.TIP_btnSaveDir)
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
-        self.vanEcFactor  	 = setEnabled(tip(QDoubleSpinBox(), self.TIP_vanEcFactor), self.chkSubtractECVan)
+        self.vanEcFactor         = setEnabled(tip(QDoubleSpinBox(), self.TIP_vanEcFactor), self.chkSubtractECVan)
         set_spin(self.vanEcFactor, 0, 1)
         self.chkReplaceNaNs      = setEnabled(tip(QCheckBox(u'Replace special values in S(Q, ω) with 0'), self.TIP_chkReplaceNaNs),
                                               self.binEon)

--- a/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/toftof/toftof_setup.py
@@ -55,6 +55,7 @@ class TOFTOFSetupWidget(BaseWidget):
     TIP_vanRuns = ''
     TIP_vanCmnt = ''
     TIP_vanTemp = 'Temperature (K). Optional.'
+    TIP_vanEcFactor = ''
 
     TIP_ecRuns = ''
     TIP_ecTemp = 'Temperature (K). Optional.'
@@ -140,6 +141,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.vanRuns   = tip(QLineEdit(), self.TIP_vanRuns)
         self.vanCmnt   = tip(QLineEdit(), self.TIP_vanCmnt)
         self.vanTemp   = tip(DoubleEdit(), self.TIP_vanTemp)
+        # self.vanEcFactor see below
 
         self.ecRuns    = tip(SmallQLineEdit(), self.TIP_ecRuns)
         self.ecTemp    = tip(DoubleEdit(), self.TIP_ecTemp)
@@ -178,6 +180,8 @@ class TOFTOFSetupWidget(BaseWidget):
         self.btnSaveDir          = tip(QPushButton('Browse'), self.TIP_btnSaveDir)
 
         self.chkSubtractECVan    = tip(QCheckBox('Subtract empty can from vanadium'), self.TIP_chkSubtractECVan)
+        self.vanEcFactor  = setEnabled(tip(QDoubleSpinBox(), self.TIP_vanEcFactor), self.chkSubtractECVan)
+        set_spin(self.vanEcFactor, 0, 1)
         self.chkReplaceNaNs      = setEnabled(tip(QCheckBox(u'Replace special values in S(Q, ω) with 0'), self.TIP_chkReplaceNaNs),
                                               self.binEon)
         self.chkCreateDiff       = setEnabled(tip(QCheckBox('Create diffractograms'), self.TIP_chkCreateDiff), self.binEon)
@@ -271,7 +275,8 @@ class TOFTOFSetupWidget(BaseWidget):
         grid.addWidget(QLabel('Vanadium runs'), 0, 0)
         grid.addWidget(self.vanRuns,            0, 1, 1, 3)
         grid.addWidget(QLabel('Van. comment'),  1, 0)
-        grid.addWidget(self.vanCmnt,            1, 1, 1, 2)
+        grid.addWidget(self.vanCmnt,            1, 1, 1, 1)
+        grid.addLayout(hbox(QLabel('EC factor'), self.vanEcFactor), 1, 2, 1, 1)
         grid.addLayout(hbox(QLabel('T (K)'), self.vanTemp),         1, 3)
         grid.addWidget(QLabel('Empty can runs'),2, 0)
         grid.addWidget(self.ecRuns,             2, 1, 1, 1)
@@ -359,6 +364,7 @@ class TOFTOFSetupWidget(BaseWidget):
         elem.vanRuns        = line_text(self.vanRuns)
         elem.vanCmnt        = line_text(self.vanCmnt)
         elem.vanTemp        = OptionalFloat(line_text(self.vanTemp))
+        elem.vanEcFactor    = self.vanEcFactor.value()
 
         elem.ecRuns         = line_text(self.ecRuns)
         elem.ecTemp         = OptionalFloat(line_text(self.ecTemp))
@@ -409,6 +415,7 @@ class TOFTOFSetupWidget(BaseWidget):
         self.vanRuns.setText(elem.vanRuns)
         self.vanCmnt.setText(elem.vanCmnt)
         self.vanTemp.setText(str(elem.vanTemp))
+        self.vanEcFactor.setValue(elem.vanEcFactor)
 
         self.ecRuns.setText(elem.ecRuns)
         self.ecTemp.setText(str(elem.ecTemp))


### PR DESCRIPTION
**Description of work.**

This PR adds a separate field to enter the empty can scaling factor for Vanadium runs.

**To test:**

<!-- Instructions for testing. -->
Download test dataset: [testdata.zip](https://github.com/mantidproject/mantid/files/2599163/testdata.zip)
Test the TOFTOF data reduction GUI (Interfaces->Direct->DGS Reduction->(MLZ, TOFTOF)) in both, MantidPlot and workbench. Nothing should get broken.

Test dataset contains xml file which could be loaded via File->Open to the TOFTOF Reduction GUI. It is important to set the correct **Data search directory**. 

Vary the empty can factor for Vanadium, vary the state of the checkbox "Subtract empty can from Vanadium". Check that the Python script (click `Export` to get it) changes appropriately. Feel free also to vary other data reduction options.

Fixes #23072. 

*This does not require release notes* because **it is a minor change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
