### PR TITLE
Indirect - Disable Fit and Fit Sequential while fitting

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -44,6 +44,7 @@ Improvements
   maximum of 18 plots.
 - The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed.
   This improvement can be seen in ConvFit when functions which depend on Q value are selected.
+- Fit and Fit Sequential in the Fit combobox above the FitPropertyBrowser are now disabled while fitting is taking place.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -752,7 +752,7 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  * and completed within this interface.
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
-	enableFitAnalysisButtons(true);
+  enableFitAnalysisButtons(true);
   enablePlotResult(error);
   setSaveResultEnabled(!error);
   updateParameterValues();
@@ -967,10 +967,10 @@ void IndirectFitAnalysisTab::singleFit() {
 
 void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
                                        std::size_t spectrum) {
-	if (validate()) {
-		enableFitAnalysisButtons(false);
-		runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
-	}
+  if (validate()) {
+    enableFitAnalysisButtons(false);
+    runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
+  }
 }
 
 /**
@@ -978,10 +978,10 @@ void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
  * tab.
  */
 void IndirectFitAnalysisTab::executeFit() {
-	if (validate()) {
-		enableFitAnalysisButtons(false);
-		runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
-	}
+  if (validate()) {
+    enableFitAnalysisButtons(false);
+    runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
+  }
 }
 
 bool IndirectFitAnalysisTab::validate() {
@@ -1002,7 +1002,7 @@ bool IndirectFitAnalysisTab::validate() {
  * Called when the 'Run' button is called in the IndirectTab.
  */
 void IndirectFitAnalysisTab::run() {
-	enableFitAnalysisButtons(false);
+  enableFitAnalysisButtons(false);
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -752,8 +752,7 @@ void IndirectFitAnalysisTab::updateSingleFitOutput(bool error) {
  * and completed within this interface.
  */
 void IndirectFitAnalysisTab::fitAlgorithmComplete(bool error) {
-  setRunIsRunning(false);
-  setFitSingleSpectrumIsFitting(false);
+	enableFitAnalysisButtons(true);
   enablePlotResult(error);
   setSaveResultEnabled(!error);
   updateParameterValues();
@@ -1001,8 +1000,14 @@ bool IndirectFitAnalysisTab::validate() {
  * Called when the 'Run' button is called in the IndirectTab.
  */
 void IndirectFitAnalysisTab::run() {
-  setRunIsRunning(true);
+	enableFitAnalysisButtons(false);
   runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
+}
+
+void IndirectFitAnalysisTab::enableFitAnalysisButtons(bool enable) {
+	setRunIsRunning(!enable);
+	setFitSingleSpectrumIsFitting(!enable);
+	m_fitPropertyBrowser->setFitEnabled(enable);
 }
 
 void IndirectFitAnalysisTab::setAlgorithmProperties(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -1007,9 +1007,9 @@ void IndirectFitAnalysisTab::run() {
 }
 
 void IndirectFitAnalysisTab::enableFitAnalysisButtons(bool enable) {
-	setRunIsRunning(!enable);
-	setFitSingleSpectrumIsFitting(!enable);
-	m_fitPropertyBrowser->setFitEnabled(enable);
+  setRunIsRunning(!enable);
+  setFitSingleSpectrumIsFitting(!enable);
+  m_fitPropertyBrowser->setFitEnabled(enable);
 }
 
 void IndirectFitAnalysisTab::setAlgorithmProperties(

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -967,10 +967,10 @@ void IndirectFitAnalysisTab::singleFit() {
 
 void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
                                        std::size_t spectrum) {
-  if (validate()) {
-    setFitSingleSpectrumIsFitting(true);
-    runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
-  }
+	if (validate()) {
+		enableFitAnalysisButtons(false);
+		runSingleFit(m_fittingModel->getSingleFit(dataIndex, spectrum));
+	}
 }
 
 /**
@@ -978,8 +978,10 @@ void IndirectFitAnalysisTab::singleFit(std::size_t dataIndex,
  * tab.
  */
 void IndirectFitAnalysisTab::executeFit() {
-  if (validate())
-    runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
+	if (validate()) {
+		enableFitAnalysisButtons(false);
+		runFitAlgorithm(m_fittingModel->getFittingAlgorithm());
+	}
 }
 
 bool IndirectFitAnalysisTab::validate() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -229,7 +229,7 @@ private:
   void connectDataAndSpectrumPresenters();
   void connectDataAndFitBrowserPresenters();
 
-	void enableFitAnalysisButtons(bool enable);
+  void enableFitAnalysisButtons(bool enable);
 
   std::unique_ptr<IndirectFittingModel> m_fittingModel;
   MantidWidgets::IndirectFitPropertyBrowser *m_fitPropertyBrowser;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -229,6 +229,8 @@ private:
   void connectDataAndSpectrumPresenters();
   void connectDataAndFitBrowserPresenters();
 
+	void enableFitAnalysisButtons(bool enable);
+
   std::unique_ptr<IndirectFittingModel> m_fittingModel;
   MantidWidgets::IndirectFitPropertyBrowser *m_fitPropertyBrowser;
   std::unique_ptr<IndirectFitDataPresenter> m_dataPresenter;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -201,8 +201,8 @@ public:
   /// Returns true if the function is ready for a fit
   bool isFitEnabled() const;
 
-	/// Enable/disable the Fit button;
-	virtual void setFitEnabled(bool enable);
+  /// Enable/disable the Fit button;
+  virtual void setFitEnabled(bool enable);
 
   /// Display a tip
   void setTip(const QString &txt);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -201,6 +201,9 @@ public:
   /// Returns true if the function is ready for a fit
   bool isFitEnabled() const;
 
+	/// Enable/disable the Fit button;
+	virtual void setFitEnabled(bool enable);
+
   /// Display a tip
   void setTip(const QString &txt);
 
@@ -521,8 +524,6 @@ private:
 
   /// disable undo when the function changes
   void disableUndo();
-  /// Enable/disable the Fit button;
-  virtual void setFitEnabled(bool yes);
   /// Create a string property and set some settings
   QtProperty *addStringProperty(const QString &name) const;
   void setStringPropertyValue(QtProperty *prop, const QString &value) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -201,7 +201,7 @@ public:
   /// Returns true if the function is ready for a fit
   bool isFitEnabled() const;
 
-  /// Enable/disable the Fit button;
+  /// Enable/disable the Fit buttons;
   virtual void setFitEnabled(bool enable);
 
   /// Display a tip

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -65,7 +65,7 @@ public:
 
   void setCustomSettingEnabled(const QString &customName, bool enabled);
 
-  void setFitEnabled(bool enable);
+  void setFitEnabled(bool enable) override;
 
   void addCheckBoxFunctionGroup(
       const QString &groupName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -65,7 +65,7 @@ public:
 
   void setCustomSettingEnabled(const QString &customName, bool enabled);
 
-	void setFitEnabled(bool enable);
+  void setFitEnabled(bool enable);
 
   void addCheckBoxFunctionGroup(
       const QString &groupName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -65,7 +65,7 @@ public:
 
   void setCustomSettingEnabled(const QString &customName, bool enabled);
 
-	void setFitEnabled(bool enabled);
+	void setFitEnabled(bool enable);
 
   void addCheckBoxFunctionGroup(
       const QString &groupName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IndirectFitPropertyBrowser.h
@@ -65,6 +65,8 @@ public:
 
   void setCustomSettingEnabled(const QString &customName, bool enabled);
 
+	void setFitEnabled(bool enabled);
+
   void addCheckBoxFunctionGroup(
       const QString &groupName,
       const std::vector<Mantid::API::IFunction_sptr> &functions,

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2027,9 +2027,9 @@ bool FitPropertyBrowser::isUndoEnabled() const {
 }
 
 /// Enable/disable the Fit button;
-void FitPropertyBrowser::setFitEnabled(bool yes) {
-  m_fitActionFit->setEnabled(yes);
-  m_fitActionSeqFit->setEnabled(yes);
+void FitPropertyBrowser::setFitEnabled(bool enable) {
+  m_fitActionFit->setEnabled(enable);
+  m_fitActionSeqFit->setEnabled(enable);
 }
 
 /// Returns true if the function is ready for a fit

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2026,7 +2026,7 @@ bool FitPropertyBrowser::isUndoEnabled() const {
          compositeFunction()->nParams() == m_initialParameters.size();
 }
 
-/// Enable/disable the Fit button;
+/// Enable/disable the Fit buttons;
 void FitPropertyBrowser::setFitEnabled(bool enable) {
   m_fitActionFit->setEnabled(enable);
   m_fitActionSeqFit->setEnabled(enable);

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -949,6 +949,10 @@ void IndirectFitPropertyBrowser::setWorkspaceIndex(int i) {
   FitPropertyBrowser::setWorkspaceIndex(i);
 }
 
+void IndirectFitPropertyBrowser::setFitEnabled(bool enable) {
+	FitPropertyBrowser::setFitEnabled(enable);
+}
+
 /**
  * Schedules a fit.
  */

--- a/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/IndirectFitPropertyBrowser.cpp
@@ -950,7 +950,7 @@ void IndirectFitPropertyBrowser::setWorkspaceIndex(int i) {
 }
 
 void IndirectFitPropertyBrowser::setFitEnabled(bool enable) {
-	FitPropertyBrowser::setFitEnabled(enable);
+  FitPropertyBrowser::setFitEnabled(enable);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR ensures that the `Fit` and `Fit Sequential` options in the Fit combobox above the FitPropertyBrowser in the Data Analysis interfaces is disabled while a fit is be run.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load the data below
3. Select TeixeiraWater as fit type
4. Go to the Fit combo box and click `Fit Sequential`. Make sure that `Fit`, `Fit Sequential` and `Run` are all disabled while fitting and then re-enabled when fitting is finished.
5. When this has finished, run the fit again by clicking `Run` and make sure that `Fit` and `Fit Sequential` in the Fit combo box are disabled and then re-enabled when the fitting has finished.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2640253/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2640254/irs26173_graphite002_res.zip)

Fixes #24201

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
