### PR TITLE
Get usagereport status from config dict

### DIFF
--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -20,7 +20,6 @@ from PyQt4 import QtGui # noqa
 
 import mantid # noqa
 from ErrorReporter import resources # noqa
-from mantid.kernel import UsageService # noqa
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
 from ErrorReporter.errorreport import CrashReportPage # noqa
 # Set path to look for package qt libraries
@@ -31,8 +30,9 @@ if command_line_args.qtdir is not None:
     )
 
 
+
 def main():
-    if not UsageService.isEnabled():
+    if mantid.config['usagereports.enabled'] != '1':
         return int(command_line_args.exit_code)
     app = QtGui.QApplication(sys.argv)
     form = CrashReportPage(show_continue_terminate=False)

--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -30,7 +30,6 @@ if command_line_args.qtdir is not None:
     )
 
 
-
 def main():
     if mantid.config['usagereports.enabled'] != '1':
         return int(command_line_args.exit_code)


### PR DESCRIPTION
**Description of work.**

This PR fixes #24256 

By getting the status of usagereports from the config dictionary the correct value is returned.

**To test:**

* Build a package of Mantid
* Run step 1 of http://developer.mantidproject.org/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.html
* Confirm that the error reporter GUI pops up

<!-- Instructions for testing. -->

Fixes  #24256. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it fixes an unreported bug.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
