### PR TITLE
Add CLEAN_XVFB option to buildscript

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -12,6 +12,19 @@
 SCRIPT_DIR=$(dirname "$0")
 
 ###############################################################################
+# Terminate existing Xvfb sessions
+###############################################################################
+if [[ -n ${CLEAN_XVFB} && "${CLEAN_XVFB}" == true ]] && [ $(command -v xvfb-run) ]; then
+  echo "Terminating existing Xvfb sessions"
+
+  # Kill Xvfb processes
+  killall Xvfb || true
+
+  # Remove Xvfb X server lock files
+  rm -f /tmp/.X*-lock
+fi
+
+###############################################################################
 # System discovery
 ###############################################################################
 USE_CORE_DUMPS=true


### PR DESCRIPTION
**Description of work.**

Will terminate all Xvfb processes and remove any leftover Xvfb X server
lock files.

Should be used when a build fails with error messages saying that Xvfb
failed to start.

If the build continues to fail on the same server then something may
genuinely be horribly wrong.

**Report to:** @peterfpeterson.

**To test:**

- See that build script changes are not completely insane.

*This does not require release notes* because it only affects build servers.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
