### PR TITLE
Disable Sum Runs and Integral while processing

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -38,6 +38,7 @@ Bug fixes
 * The GUI no longer hangs whilst searching the archive for files.
 * Updated the options and units displayed in wavelength and momentum range combo boxes.
 * Fixed a bug which crashed the beam centre finder if a phi mask was set.
+* Removed option to process in non-compatibility mode to avoid calculation issues
 
 Improvements
 ############

--- a/scripts/Interface/ui/sans_isis/diagnostics_page.py
+++ b/scripts/Interface/ui/sans_isis/diagnostics_page.py
@@ -197,3 +197,16 @@ class DiagnosticsPage(QtGui.QWidget, ui_diagnostics_page.Ui_DiagnosticsPage):
     @detector.setter
     def detector(self, value):
         self.detector_combo_box.currentText(value)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # Activate buttons
+    # ------------------------------------------------------------------------------------------------------------------
+    def enable_integrals(self):
+        self.horizontal_button.setEnabled(True)
+        self.vertical_button.setEnabled(True)
+        self.time_button.setEnabled(True)
+
+    def disable_integrals(self):
+        self.horizontal_button.setEnabled(False)
+        self.vertical_button.setEnabled(False)
+        self.time_button.setEnabled(False)

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -230,7 +230,7 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         self.main_stacked_widget.setCurrentIndex(index)
 
     def _setup_add_runs_page(self):
-        self.add_runs_presenter = AddRunsPagePresenter(RunSummation(WorkHandler()),
+        self.add_runs_presenter = AddRunsPagePresenter(RunSummation(WorkHandler(), self.add_runs_page),
                                                        RunSelectorPresenterFactory('Runs To Sum',
                                                                                    SummableRunFinder(SANSFileInformationFactory())),
                                                        _make_run_summation_settings_presenter,

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -202,8 +202,6 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         self.delete_row_button.clicked.connect(self._remove_rows_requested_from_button)
         self.insert_row_button.clicked.connect(self._on_insert_button_pressed)
 
-        self.event_binning_group_box.clicked.connect(self.on_compatibility_unchecked)
-
         # Attach validators
         self._attach_validators()
 
@@ -925,6 +923,8 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
     @compatibility_mode.setter
     def compatibility_mode(self, value):
         self.event_binning_group_box.setChecked(value)
+        if not value:
+            self._on_compatibility_unchecked()
 
     @property
     def show_transmission(self):
@@ -1952,7 +1952,3 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         self.data_processor_table.hideColumn(15)
         self.data_processor_table.hideColumn(16)
         self.data_processor_table.hideColumn(17)
-
-    def on_compatibility_unchecked(self):
-        if not self.event_binning_group_box.isChecked():
-            self._on_compatibility_unchecked()

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -155,6 +155,10 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         def on_cut_rows(self):
             pass
 
+        @abstractmethod
+        def on_compatibility_unchecked(self):
+            pass
+
     def __init__(self):
         """
         Initialise the interface
@@ -197,6 +201,8 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
 
         self.delete_row_button.clicked.connect(self._remove_rows_requested_from_button)
         self.insert_row_button.clicked.connect(self._on_insert_button_pressed)
+
+        self.event_binning_group_box.clicked.connect(self.on_compatibility_unchecked)
 
         # Attach validators
         self._attach_validators()
@@ -459,6 +465,9 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
 
     def _on_insert_button_pressed(self):
         self._call_settings_listeners(lambda listener: listener.on_insert_row())
+
+    def _on_compatibility_unchecked(self):
+        self._call_settings_listeners(lambda listener: listener.on_compatibility_unchecked())
 
     def _on_help_button_clicked(self):
         pymantidplot.proxies.showCustomInterfaceHelp('ISIS SANS v2')
@@ -1943,3 +1952,7 @@ class SANSDataProcessorGui(QMainWindow, ui_sans_data_processor_window.Ui_SansDat
         self.data_processor_table.hideColumn(15)
         self.data_processor_table.hideColumn(16)
         self.data_processor_table.hideColumn(17)
+
+    def on_compatibility_unchecked(self):
+        if not self.event_binning_group_box.isChecked():
+            self._on_compatibility_unchecked()

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -804,7 +804,11 @@ QGroupBox::title {
                         </widget>
                        </item>
                        <item row="0" column="1">
-                        <widget class="QLineEdit" name="slice_event_line_edit"/>
+                        <widget class="QLineEdit" name="slice_event_line_edit">
+                         <property name="enabled">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
                        </item>
                       </layout>
                      </item>
@@ -814,10 +818,10 @@ QGroupBox::title {
                   <item>
                    <widget class="QGroupBox" name="event_binning_group_box">
                     <property name="enabled">
-                     <bool>true</bool>
+                     <bool>false</bool>
                     </property>
                     <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the data reduction will run in the compatibility mode. This means that the reduction workflow is equivalent to the previous legacy reduction workflow. &lt;/p&gt;&lt;p&gt;ONLY UNCHECK THIS IF NOT PERFORMING BIN MASKING&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the data reduction will run in the compatibility mode. This means that the reduction workflow is equivalent to the previous legacy reduction workflow. &lt;/p&gt;&lt;p&gt;Left checked as there exist known issues with non-compatibility mode. This will be fixed in future releases.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="title">
                      <string>&amp;Use compatibility mode</string>
@@ -831,9 +835,6 @@ QGroupBox::title {
                     <layout class="QGridLayout" name="gridLayout_16">
                      <item row="0" column="0">
                       <widget class="QLabel" name="event_binning_label">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
                        <property name="toolTip">
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compaptibility mode (ie when following the old reduction model). Note that this will only have an effect on event workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
@@ -844,9 +845,6 @@ QGroupBox::title {
                      </item>
                      <item row="0" column="1">
                       <widget class="QLineEdit" name="event_binning_line_edit">
-                       <property name="enabled">
-                        <bool>true</bool>
-                       </property>
                        <property name="toolTip">
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Rebin string for the initial time-of-flight workspace. This is only needed when using the compaptibility mode (ie when following the old reduction model). Note that this will only have an effect on event workspaces.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>

--- a/scripts/SANS/sans/gui_logic/models/run_summation.py
+++ b/scripts/SANS/sans/gui_logic/models/run_summation.py
@@ -9,18 +9,25 @@ from ui.sans_isis.work_handler import WorkHandler
 
 
 class RunSummation(object):
-    def __init__(self, work_handler):
+    def __init__(self, work_handler, view=None):
         self._work_handler = work_handler
+        self._view = view
 
     class Listener(WorkHandler.WorkListener):
+        def __init__(self, presenter):
+            self._presenter = presenter
+
         def on_processing_finished(self, result):
-            pass
+            self._presenter.on_processing_finished(result)
 
         def on_processing_error(self, error):
-            pass
+            # currently no different functionality required between
+            # processing finished and processing error,
+            # so call the same method
+            self._presenter.on_processing_finished(error)
 
     def __call__(self, run_selection, settings, base_file_name):
-        self._work_handler.process(RunSummation.Listener(), self.run, 0, run_selection, settings, base_file_name)
+        self._work_handler.process(RunSummation.Listener(self), self.run, 0, run_selection, settings, base_file_name)
 
     def run(self, run_selection, settings, base_file_name):
         run_selection = self._run_selection_as_path_list(run_selection)
@@ -61,3 +68,7 @@ class RunSummation(object):
 
     def _should_save_as_event_workspaces(self, settings):
         return settings.should_save_as_event_workspaces()
+
+    def on_processing_finished(self, result):
+        if self._view:
+            self._view.enable_sum()

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -99,8 +99,10 @@ class AddRunsPagePresenter(object):
         run_selection = self._run_selector_presenter.run_selection()
         settings = self._summation_settings_presenter.settings()
         if self._output_directory_is_not_empty(settings):
+            self._view.disable_sum()
             self._sum_runs(run_selection,
                            settings,
                            self._sum_base_file_name(run_selection))
+            self._view.enable_sum()
         else:
             self._view.no_save_directory()

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -103,6 +103,5 @@ class AddRunsPagePresenter(object):
             self._sum_runs(run_selection,
                            settings,
                            self._sum_base_file_name(run_selection))
-            self._view.enable_sum()
         else:
             self._view.no_save_directory()

--- a/scripts/SANS/sans/gui_logic/presenter/diagnostic_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/diagnostic_presenter.py
@@ -70,6 +70,7 @@ class DiagnosticsPagePresenter(object):
         self._view.user_file_name = user_file
 
     def on_horizontal_clicked(self):
+        self._view.disable_integrals()
         input_file = self._view.run_input
         period = self._view.period
         state_model_with_view_update = self._parent_presenter._get_state_model_with_view_update()
@@ -82,6 +83,7 @@ class DiagnosticsPagePresenter(object):
                                    detector, state)
 
     def on_vertical_clicked(self):
+        self._view.disable_integrals()
         input_file = self._view.run_input
         period = self._view.period
         state_model_with_view_update = self._parent_presenter._get_state_model_with_view_update()
@@ -94,6 +96,7 @@ class DiagnosticsPagePresenter(object):
                                    detector, state)
 
     def on_time_clicked(self):
+        self._view.disable_integrals()
         input_file = self._view.run_input
         period = self._view.period
         state_model_with_view_update = self._parent_presenter._get_state_model_with_view_update()
@@ -106,7 +109,7 @@ class DiagnosticsPagePresenter(object):
                                    detector, state)
 
     def on_processing_finished_integral(self, result):
-        pass
+        self._view.enable_integrals()
 
     def on_processing_error_integral(self, error):
-        pass
+        self._view.enable_integrals()

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -106,6 +106,9 @@ class RunTabPresenter(object):
         def on_sample_geometry_selection(self, show_geometry):
             self._presenter.on_sample_geometry_view_changed(show_geometry)
 
+        def on_compatibility_unchecked(self):
+            self._presenter.on_compatibility_unchecked()
+
     class ProcessListener(WorkHandler.WorkListener):
         def __init__(self, presenter):
             super(RunTabPresenter.ProcessListener, self).__init__()
@@ -535,6 +538,11 @@ class RunTabPresenter(object):
             self._view.show_geometry()
         else:
             self._view.hide_geometry()
+
+    def on_compatibility_unchecked(self):
+        self.display_warning_box('Warning', 'Are you sure you want to uncheck compatibility mode?',
+                                 'Non-compatibility mode has known issues. DO NOT USE if applying bin masking'
+                                 ' to event workspaces.')
 
     def get_row_indices(self):
         """


### PR DESCRIPTION
**Description of work.**
Disable Sum Runs and Integral buttons while processing, and re-enable upon processing finished (successful or unsuccessful)

Also disabled user ability to uncheck compatibility mode

**Report to:** @robertapplin 

**To test:**
Interfaces -> SANS -> SANS v2
Sum runs:
1. click sum runs tab on the left of the interface
2. Enter `74044, 74019` in the top line and click `Add`
3. Enter any output file name
4. Ensure that output directory is in managed paths
5. Repeatedly click  Sum button 

This should not crash, because the Sum button should be disabled after the first click, and re-enable only when summing is done..

Integral:
1. Click diagnostic page tab
2. Browse -> load any nxs file from sample data (e.g. LOQ74044.nxs)
3. Click any one of the integral buttons multiple times

All multiple buttons should disable after the first click. Upon processing finished you will be taken to a plot on MantidPlot. Clicking back onto the SANS v2 gui (it has been moved backwards, not closed) you should see that the integral buttons are re-enabled.

Finally, on Settings tab, you should not be able to uncheck the `Use compatibility mode` checkbox

Fixes #24245 
Fixes #24162 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
