### PR TITLE
Remove mock dependency from MatrixWorkspaceDisplay model

### DIFF
--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
@@ -24,7 +24,7 @@ class MatrixWorkspaceDisplayModel(object):
 
     def __init__(self, ws):
         if not any(isinstance(ws, allowed_type) for allowed_type in self.ALLOWED_WORKSPACE_TYPES):
-            raise ValueError("The workspace type is not supported: {0}".format(type(ws).__name__))
+            raise ValueError("The workspace type is not supported: {0}".format(ws))
 
         self._ws = ws
 
@@ -32,6 +32,6 @@ class MatrixWorkspaceDisplayModel(object):
         return self._ws.name()
 
     def get_item_model(self):
-        return MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x), \
-            MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y), \
-            MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e)
+        return MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x),
+        MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y),
+        MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e)

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
@@ -32,6 +32,6 @@ class MatrixWorkspaceDisplayModel(object):
         return self._ws.name()
 
     def get_item_model(self):
-        return MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x),
-        MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y),
-        MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e)
+        return (MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x),
+                MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y),
+                MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e))

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/model.py
@@ -14,19 +14,17 @@ from mantid.api import MatrixWorkspace
 from mantid.dataobjects import EventWorkspace, Workspace2D
 from mantidqt.widgets.matrixworkspacedisplay.table_view_model import MatrixWorkspaceTableViewModel, \
     MatrixWorkspaceTableViewModelType
-from mantidqt.widgets.matrixworkspacedisplay.test_helpers.matrixworkspacedisplay_common import MockWorkspace
 
 
 class MatrixWorkspaceDisplayModel(object):
     SPECTRUM_PLOT_LEGEND_STRING = '{}-{}'
     BIN_PLOT_LEGEND_STRING = '{}-bin-{}'
 
+    ALLOWED_WORKSPACE_TYPES = [MatrixWorkspace, Workspace2D, EventWorkspace]
+
     def __init__(self, ws):
-        if not isinstance(ws, MatrixWorkspace) \
-                and not isinstance(ws, Workspace2D) \
-                and not isinstance(ws, EventWorkspace) \
-                and not isinstance(ws, MockWorkspace):
-            raise ValueError("The workspace type is not supported: {0}".format(type(ws)))
+        if not any(isinstance(ws, allowed_type) for allowed_type in self.ALLOWED_WORKSPACE_TYPES):
+            raise ValueError("The workspace type is not supported: {0}".format(type(ws).__name__))
 
         self._ws = ws
 
@@ -35,5 +33,5 @@ class MatrixWorkspaceDisplayModel(object):
 
     def get_item_model(self):
         return MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x), \
-               MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y), \
-               MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e)
+            MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.y), \
+            MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.e)

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_model.py
@@ -21,6 +21,10 @@ from mantidqt.widgets.matrixworkspacedisplay.test_helpers.matrixworkspacedisplay
 
 
 class MatrixWorkspaceDisplayModelTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Allow the MockWorkspace to work within the model
+        MatrixWorkspaceDisplayModel.ALLOWED_WORKSPACE_TYPES.append(MockWorkspace)
 
     def test_get_name(self):
         ws = MockWorkspace()
@@ -43,9 +47,6 @@ class MatrixWorkspaceDisplayModelTest(unittest.TestCase):
         self.assertEqual(e_model.type, MatrixWorkspaceTableViewModelType.e)
 
     def test_raises_with_unsupported_workspace(self):
-        # ws = MockWorkspace()
-        # expected_name = "TEST_WORKSPACE"
-        # ws.name = Mock(return_value=expected_name)
         self.assertRaises(ValueError, lambda: MatrixWorkspaceDisplayModel([]))
         self.assertRaises(ValueError, lambda: MatrixWorkspaceDisplayModel(1))
         self.assertRaises(ValueError, lambda: MatrixWorkspaceDisplayModel("test_string"))

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_presenter.py
@@ -14,6 +14,7 @@ import unittest
 from mock import Mock
 
 from mantidqt.widgets.matrixworkspacedisplay.presenter import MatrixWorkspaceDisplay
+from mantidqt.widgets.matrixworkspacedisplay.model import MatrixWorkspaceDisplayModel
 from mantidqt.widgets.matrixworkspacedisplay.test_helpers.matrixworkspacedisplay_common import MockQModelIndex, \
     MockWorkspace
 from mantidqt.widgets.matrixworkspacedisplay.test_helpers.mock_matrixworkspacedisplay import \
@@ -21,6 +22,11 @@ from mantidqt.widgets.matrixworkspacedisplay.test_helpers.mock_matrixworkspacedi
 
 
 class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Allow the MockWorkspace to work within the model
+        MatrixWorkspaceDisplayModel.ALLOWED_WORKSPACE_TYPES.append(MockWorkspace)
+
     def assertNotCalled(self, mock):
         self.assertEqual(0, mock.call_count)
 

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_presenter.py
@@ -13,8 +13,8 @@ import unittest
 
 from mock import Mock
 
-from mantidqt.widgets.matrixworkspacedisplay.presenter import MatrixWorkspaceDisplay
 from mantidqt.widgets.matrixworkspacedisplay.model import MatrixWorkspaceDisplayModel
+from mantidqt.widgets.matrixworkspacedisplay.presenter import MatrixWorkspaceDisplay
 from mantidqt.widgets.matrixworkspacedisplay.test_helpers.matrixworkspacedisplay_common import MockQModelIndex, \
     MockWorkspace
 from mantidqt.widgets.matrixworkspacedisplay.test_helpers.mock_matrixworkspacedisplay import \


### PR DESCRIPTION
**Description of work.**
Added class parameter to MatrixWorkspaceDisplay model that contains a list of supported workspaces.

Tests now append `MockWorkspace` to it in `setUpClass`. This prevents the need to import `MockWorkspace` and its dependencies in the model itself.

**To test:**
Run Workbench with a Python env that doesn't have `mock` installed. 
 - As long as it's not possible to import `mock` this PR can be tested.

<!-- Instructions for testing. -->

Fixes #24275

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
