### PR TITLE
Multiple fitting crash when setting values after tie

### DIFF
--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -1379,10 +1379,12 @@ Mantid::API::IFunction_sptr FunctionBrowser::getFunction(QtProperty *prop,
   {
     auto from = m_ties.lowerBound(prop);
     auto to = m_ties.upperBound(prop);
-    QList<QtProperty *> failedTies; // ties can become invalid after some editing
+    // ties can become invalid after some editing
+    QList<QtProperty *> failedTies;
     for (auto it = from; it != to; ++it) {
       auto const tie =
-          (it->paramName + "=" + m_tieManager->value(it.value().tieProp)).toStdString();
+          (it->paramName + "=" + m_tieManager->value(it.value().tieProp))
+              .toStdString();
       try {
         fun->addTies(tie);
       } catch (...) {

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -1379,22 +1379,24 @@ Mantid::API::IFunction_sptr FunctionBrowser::getFunction(QtProperty *prop,
   {
     auto from = m_ties.lowerBound(prop);
     auto to = m_ties.upperBound(prop);
-    QList<QtProperty *> filedTies; // ties can become invalid after some editing
+    QList<QtProperty *> failedTies; // ties can become invalid after some editing
     for (auto it = from; it != to; ++it) {
+      auto const tie =
+          (it->paramName + "=" + m_tieManager->value(it.value().tieProp)).toStdString();
       try {
-        QString tie =
-            it->paramName + "=" + m_tieManager->value(it.value().tieProp);
-        fun->addTies(tie.toStdString());
+        fun->addTies(tie);
       } catch (...) {
-        filedTies << it.value().tieProp;
+        failedTies << it.value().tieProp;
+        g_log.warning() << "Invalid tie has been removed: " << tie << std::endl;
       }
     }
     // remove failed ties from the browser
-    foreach (QtProperty *p, filedTies) {
+    foreach (QtProperty *p, failedTies) {
       auto paramProp = getParentParameterProperty(p);
       if (isLocalParameterProperty(paramProp)) {
-        auto paramName = paramProp->propertyName();
-        setLocalParameterTie(paramName, m_currentDataset, "");
+        auto const paramName = paramProp->propertyName();
+        auto const index = getIndex(paramProp);
+        setLocalParameterTie(index + paramName, m_currentDataset, "");
       }
       removeProperty(p);
     }


### PR DESCRIPTION
**Description of work.**
Found the reason for the crash.  If an invalid tie is found remove it and log a warning.

**To test:**
* Open the multi-dataset browser.
* Set some function
* Set one or more invalid ties to any of the parameters
* Try: set a value of any of the parameters, run a fit

The invalid ties should be removed, warnings logged.

Fixes #24207, #24208 

*This does not require release notes* because hopefully the users have not noticed this bug.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
