### PR TITLE
systemtests: support of testing mantid-framework conda package

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -12,6 +12,11 @@ or by importing them into MantidPlot.
 File change history is stored at: <https://github.com/mantidproject/systemtests>.
 """
 from __future__ import (absolute_import, division, print_function)
+# == for testing conda build of mantid-framework ==========
+import os
+if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
+    import matplotlib
+# =========================================================
 from six import PY3
 import datetime
 import difflib
@@ -22,7 +27,6 @@ from mantid.api import FrameworkManager
 from mantid.kernel import config, MemoryStats
 from mantid.simpleapi import AlgorithmManager, Load, SaveNexus
 import numpy
-import os
 import platform
 import re
 import shutil

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -15,6 +15,7 @@ from __future__ import (absolute_import, division, print_function)
 # == for testing conda build of mantid-framework ==========
 import os
 if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
+    # conda build of mantid-framework sometimes require importing matplotlib before mantid
     import matplotlib
 # =========================================================
 from six import PY3

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -61,25 +61,28 @@ if options.doInstall:
 else:
     installer.no_uninstall = True
 
-try:
-    # Keep hold of the version that was run
-    version = run(installer.mantidPlotPath + ' -v')
-    version_tested = open(os.path.join(output_dir,'version_tested.log'),'w')
-    if version and len(version) > 0:
-        version_tested.write(version)
-    version_tested.close()
-except Exception as err:
-    scriptfailure('Version test failed: '+str(err), installer)
+# conda mantid-framework does not have mantid plot. skip these
+if not os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
+    try:
+        # Keep hold of the version that was run
+        version = run(installer.mantidPlotPath + ' -v')
+        version_tested = open(os.path.join(output_dir,'version_tested.log'),'w')
+        if version and len(version) > 0:
+            version_tested.write(version)
+        version_tested.close()
+    except Exception as err:
+        scriptfailure('Version test failed: '+str(err), installer)
 
-try:
-    # Now get the revision number/git commit ID (remove the leading 'g' that isn't part of it)
-    revision = run(installer.mantidPlotPath + ' -r').lstrip('g')
-    revision_tested = open(os.path.join(output_dir, 'revision_tested.log'), 'w')
-    if revision and len(version) > 0:
-        revision_tested.write(revision)
-    revision_tested.close()
-except Exception as err:
-    scriptfailure('Revision test failed: '+str(err), installer)
+    try:
+        # Now get the revision number/git commit ID (remove the leading 'g' that isn't part of it)
+        revision = run(installer.mantidPlotPath + ' -r').lstrip('g')
+        revision_tested = open(os.path.join(output_dir, 'revision_tested.log'), 'w')
+        if revision and len(version) > 0:
+            revision_tested.write(revision)
+        revision_tested.close()
+    except Exception as err:
+        scriptfailure('Revision test failed: '+str(err), installer)
+
 
 log("Running system tests. Log files are: '%s' and '%s'" % (testRunLogPath,testRunErrPath))
 try:

--- a/Testing/SystemTests/scripts/install_conda_mantid.sh
+++ b/Testing/SystemTests/scripts/install_conda_mantid.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# * install miniconda2 in $HOME/jenkins-systemtests-opt/miniconda2
+# * create env "mantid"
+# * install mantid-framework from "jenkins" channel
+
+wget --no-verbose http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
+
+unset PYTHONPATH
+CONDA_PREFIX=$HOME/jenkins-systemtests-opt/miniconda2
+bash miniconda.sh -b -p $CONDA_PREFIX
+export PATH=$CONDA_PREFIX/bin:$PATH
+conda config --add channels conda-forge
+conda config --add channels mantid
+conda config --set always_yes true
+
+## anaconda client
+conda install -n root --yes --quiet anaconda-client
+
+## upload conda pkg to mantid jenkins channel
+anaconda -t $ANACONDA_ACCESS_KEY upload -l jenkins --force $1
+
+## Establish mantid environment
+conda create --yes --quiet --name mantid python=2.7.14
+## install
+source activate mantid
+pwd
+which conda
+
+conda env list
+cat ~/.condarc
+conda remove mantid-framework
+conda search mantid-framework
+conda install --yes -c mantid/label/jenkins mantid-framework
+conda list
+which python
+python -c "import numpy"
+python -c "import matplotlib; import mantid"

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -311,7 +311,7 @@ class CondaInstaller(MantidInstaller):
         package = os.path.basename(self.mantidInstaller)
         self.conda_prefix = os.path.expanduser('~/jenkins-systemtests-opt/miniconda2')
         self.conda_mantid_env_prefix = install_prefix = os.path.join(self.conda_prefix, 'envs', 'mantid')
-        self.mantidPlotPath = "conda mantid-framework does not include mantidplot"
+        self.mantidPlotPath = None # conda mantid-framework does not include mantidplot
         self.python_cmd = install_prefix + '/bin/python'
 
     def do_install(self):

--- a/Testing/SystemTests/scripts/mantidinstaller.py
+++ b/Testing/SystemTests/scripts/mantidinstaller.py
@@ -75,6 +75,11 @@ def get_installer(package_dir, do_install=True):
         @param package_dir :: The directory to search for packages
         @param do_install :: True if installation is to be performed
     """
+    # == for testing conda build of mantid-framework ==========
+    import os
+    if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
+        return CondaInstaller(package_dir, do_install)
+    # =========================================================
     system = platform.system()
     if system == 'Windows':
         return NSISInstaller(package_dir, do_install)
@@ -294,6 +299,33 @@ class DMGInstaller(MantidInstaller):
 
     def do_uninstall(self):
         run('sudo rm -fr /Applications/MantidPlot.app/')
+
+
+class CondaInstaller(MantidInstaller):
+
+    python_args = "" # not mantidpython. just normal python
+
+    def __init__(self, package_dir, do_install=True):
+        filepattern = "mantid-framework*.tar.bz2"
+        MantidInstaller.__init__(self, package_dir, filepattern, do_install)
+        package = os.path.basename(self.mantidInstaller)
+        self.conda_prefix = os.path.expanduser('~/jenkins-systemtests-opt/miniconda2')
+        self.conda_mantid_env_prefix = install_prefix = os.path.join(self.conda_prefix, 'envs', 'mantid')
+        self.mantidPlotPath = "conda mantid-framework does not include mantidplot"
+        self.python_cmd = install_prefix + '/bin/python'
+
+    def do_install(self):
+        """Uses gdebi to run the install
+        """
+        thisdir = os.path.dirname(__file__)
+        script = os.path.join(thisdir, 'install_conda_mantid.sh')
+        run('%s %s' % (script, self.mantidInstaller))
+
+    def do_uninstall(self):
+        """Removes the debian package
+        """
+        # run('rm -rf %s' % self.conda_mantid_env_prefix)
+
 
 #-------------------------------------------------------------------------------
 # Main


### PR DESCRIPTION
**Description of work.**
systemtests is now failing at mantid jenkins builder for mantid-framework conda package. This revision allows for running systemtests for conda package by setting the environment variable `MANTID_FRAMEWORK_CONDA_SYSTEMTEST`, and normal behavior without it.

The failure earlier was due to recent revisions to the systemtests harness in mantid. Before, I have some code in the `conda-recipe` repo https://github.com/mantidproject/conda-recipes/tree/master/jenkins/Testing/SystemTests that contains revisions to the test harness in `mantid` repo https://github.com/mantidproject/mantid/tree/master/Testing/SystemTests. Those revisions allowed systemtests for conda package to run. Recently the harness changed in the mantid repo, and my revisions does not work any more. In this PR, I added those revisions directly into the mantid repository. This will work better in the long run.

**To test:**
Make sure systemtests work for both normal mantid builds and conda builds


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
