### PR TITLE
Add an option to set the number of lines of log messages to retain

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -73,6 +73,7 @@ Changes
 
 - All File Browser dialog boxes will now (by default) display all valid file extensions as the first file filter.
 - Plot -> Advanced now allows for plotting against any property in the ``Run`` object that can be represented as a single number. It uses the time-average value for time series properties and the average for others.
+- A new option in the right-click menu for the results log allows users to set the number of lines retained by the widget. The default is 8192. This avoids memory problems for long running instances.
 
 BugFixes
 ########

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
@@ -104,6 +104,12 @@ private slots:
   void showContextMenu(const QPoint &event);
   /// Set the global logging level
   void setLogLevel(int priority);
+  /// Set the number of blocks kept by the display
+  void setScrollbackLimit();
+  /// Return the maximum number of lines displayed
+  int maximumLineCount() const;
+  /// Set the maximum number of lines displayed
+  void setMaximumLineCount(int count);
 
 private:
   /// Setup the actions

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -15,6 +15,7 @@
 #include <QAction>
 #include <QActionGroup>
 #include <QHBoxLayout>
+#include <QInputDialog>
 #include <QMenu>
 #include <QPlainTextEdit>
 #include <QPoint>
@@ -29,6 +30,11 @@
 namespace {
 // Track number of attachments to generate a unique channel name
 int ATTACH_COUNT = 0;
+
+int DEFAULT_LINE_COUNT_MAX = 8192;
+const char *PRIORITY_KEY_NAME = "MessageDisplayPriority";
+const char *LINE_COUNT_MAX_KEY_NAME = "MessageDisplayLineCountMax";
+
 } // namespace
 
 using Mantid::Kernel::ConfigService;
@@ -47,10 +53,12 @@ namespace MantidWidgets {
  * at the group containing the values
  */
 void MessageDisplay::readSettings(const QSettings &storage) {
-  const int logLevel = storage.value("MessageDisplayPriority", 0).toInt();
+  const int logLevel = storage.value(PRIORITY_KEY_NAME, 0).toInt();
   if (logLevel > 0) {
     ConfigService::Instance().setLogLevel(logLevel, true);
   }
+  setMaximumLineCount(
+      storage.value(LINE_COUNT_MAX_KEY_NAME, DEFAULT_LINE_COUNT_MAX).toInt());
 }
 
 /**
@@ -60,7 +68,8 @@ void MessageDisplay::readSettings(const QSettings &storage) {
  * at the group where the values should be stored.
  */
 void MessageDisplay::writeSettings(QSettings &storage) const {
-  storage.setValue("MessageDisplayPriority", Poco::Logger::root().getLevel());
+  storage.setValue(PRIORITY_KEY_NAME, Poco::Logger::root().getLevel());
+  storage.setValue(LINE_COUNT_MAX_KEY_NAME, maximumLineCount());
 }
 
 /**
@@ -242,20 +251,20 @@ void MessageDisplay::scrollToBottom() {
       m_textDisplay->verticalScrollBar()->maximum());
 }
 
-//------------------------------------------------------------------------------
-// Protected members
-//------------------------------------------------------------------------------
-
 //-----------------------------------------------------------------------------
 // Private slot member functions
 //-----------------------------------------------------------------------------
 
 void MessageDisplay::showContextMenu(const QPoint &mousePos) {
   QMenu *menu = m_textDisplay->createStandardContextMenu();
-  if (!m_textDisplay->document()->isEmpty())
-    menu->addAction("Clear", m_textDisplay, SLOT(clear()));
-
   menu->addSeparator();
+  if (!m_textDisplay->document()->isEmpty()) {
+    menu->addAction("Clear", m_textDisplay, SLOT(clear()));
+    menu->addSeparator();
+  }
+  menu->addAction("&Scrollback limit", this, SLOT(setScrollbackLimit()));
+  menu->addSeparator();
+
   QMenu *logLevelMenu = menu->addMenu("&Log Level");
   logLevelMenu->addAction(m_error);
   logLevelMenu->addAction(m_warning);
@@ -286,6 +295,38 @@ void MessageDisplay::showContextMenu(const QPoint &mousePos) {
  */
 void MessageDisplay::setLogLevel(int priority) {
   ConfigService::Instance().setLogLevel(priority);
+}
+
+/**
+ * Set the maximum number of blocks kept by the text edit
+ */
+void MessageDisplay::setScrollbackLimit() {
+  constexpr int minLineCountAllowed(-1);
+  setMaximumLineCount(
+      QInputDialog::getInt(this, "", "No. of lines\n(-1 keeps all content)",
+                           maximumLineCount(), minLineCountAllowed));
+}
+
+// The text edit works in blocks but it is not entirely clear what a block
+// is defined as. Experiments showed setting a max block count=1 suppressed
+// all output and a min(block count)==2 was required to see a single line.
+// We have asked the user for lines so add 1 to get the behaviour they
+// would expect. Equally we subtract 1 for the value we show them to
+// keep it consistent
+
+/**
+ * @return The maximum number of lines displayed in the text edit
+ */
+int MessageDisplay::maximumLineCount() const {
+  return m_textDisplay->maximumBlockCount() - 1;
+}
+
+/**
+ * The maximum number of lines that are to be displayed in the text edit
+ * @param count The new maximum number of lines to retain.
+ */
+void MessageDisplay::setMaximumLineCount(int count) {
+  m_textDisplay->setMaximumBlockCount(count + 1);
 }
 
 //-----------------------------------------------------------------------------
@@ -346,6 +387,7 @@ void MessageDisplay::initFormats() {
 void MessageDisplay::setupTextArea() {
   m_textDisplay->setReadOnly(true);
   m_textDisplay->ensureCursorVisible();
+  setMaximumLineCount(DEFAULT_LINE_COUNT_MAX);
   m_textDisplay->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
   m_textDisplay->setMouseTracking(true);
   m_textDisplay->setUndoRedoEnabled(false);


### PR DESCRIPTION
**Description of work.**

Adds an option to the context menu of the results log (in MantidPlot and MantidWorkbench) to set the number of lines of logging retained for a session. Avoid problems with memory fragmentation over long running sessions.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Start MantidPlot
* See the logging as normal
* Right-click on the results log and see the new option "Scrollback limit"
  * click it and the default number should be 8192
* Set the number to `1`
* Run an algorithm and see the display only contains 1 line
* Set the number lines retained to `0` and see that any operation causes displays any text
* Set the number of lines to `-1` and see that all content is retained.
* Restart MantidPlot and confirm your settings were saved and reloaded.

Do the same tests for the messages window in the workbench.

Refs #23903 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
