### PR TITLE
Moved scanIntervals() outside for loop to optimize MergeRuns

### DIFF
--- a/Framework/Algorithms/src/MergeRuns.cpp
+++ b/Framework/Algorithms/src/MergeRuns.cpp
@@ -729,14 +729,17 @@ std::vector<SpectrumDefinition> MergeRuns::buildScanIntervals(
     const DetectorInfo &addeeDetInfo, const DetectorInfo &newOutDetInfo) {
   std::vector<SpectrumDefinition> newAddeeSpecDefs(addeeSpecDefs.size());
 
+  auto addeeScanIntervals = addeeDetInfo.scanIntervals();
+  auto newOutScanIntervals = newOutDetInfo.scanIntervals();
+
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t i = 0; i < int64_t(addeeSpecDefs.size()); ++i) {
     for (auto &index : addeeSpecDefs[i]) {
       SpectrumDefinition newSpecDef;
       for (size_t time_index = 0; time_index < newOutDetInfo.scanCount();
            time_index++) {
-        if (addeeDetInfo.scanIntervals()[index.second] ==
-            newOutDetInfo.scanIntervals()[time_index]) {
+        if (addeeScanIntervals[index.second] ==
+            newOutScanIntervals[time_index]) {
           newSpecDef.add(index.first, time_index);
         }
       }


### PR DESCRIPTION
**Description of work.**

Moved two calls to `scanIntervals()`, which get an entire vector, outside of a `for` loop to regain some lost performance in the `MergeRunsPerformance` test.

**To test:**

 Run
```
ctest -V -R MergeRunsTestPerformance
```

With these changes runtime should be ~10s for a non-debug build, instead of the ~50s in the current master.

Fixes #24294 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
