### PR TITLE
ConvFitDataPresenter and JumpFitDataPresenter Unit tests

### DIFF
--- a/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
+++ b/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
@@ -89,15 +89,15 @@ public:
 
   void
   test_that_createWorkspaceWithTextAxis_returns_a_workspace_with_the_number_of_spectra_specified() {
-    auto const workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
+    auto const workspace = createWorkspaceWithTextAxis(3, getTextAxisLabels());
     TS_ASSERT(workspace);
-    TS_ASSERT_EQUALS(workspace->getNumberHistograms(), 6);
+    TS_ASSERT_EQUALS(workspace->getNumberHistograms(), 3);
   }
 
   void
   test_that_createWorkspaceWithTextAxis_returns_a_workspace_with_the_text_axis_labels_specified() {
     auto const labels = getTextAxisLabels();
-    auto const workspace = createWorkspaceWithTextAxis(6, labels);
+    auto const workspace = createWorkspaceWithTextAxis(3, labels);
 
     auto const yAxis = workspace->getAxis(1);
 

--- a/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
+++ b/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
@@ -12,6 +12,10 @@ using namespace Mantid::IndirectFitDataCreationHelper;
 
 namespace {
 
+std::vector<std::string> getTextAxisLabels() {
+  return {"f0.Width", "f1.Width", "f2.EISF"};
+}
+
 void storeWorkspaceInADS(std::string const &workspaceName,
                          MatrixWorkspace_sptr workspace) {
   SetUpADSWithWorkspace ads(workspaceName, workspace);
@@ -63,6 +67,12 @@ public:
 
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
+  void test_that_the_constant_variables_have_the_values_expected() {
+    TS_ASSERT_EQUALS(START_X_COLUMN, 2);
+    TS_ASSERT_EQUALS(END_X_COLUMN, 3);
+    TS_ASSERT_EQUALS(EXCLUDE_REGION_COLUMN, 4);
+  }
+
   void
   test_that_createWorkspace_returns_a_workspace_with_the_number_of_spectra_specified() {
     auto const workspace = createWorkspace(10);
@@ -75,6 +85,31 @@ public:
     auto const workspace = createInstrumentWorkspace(6, 5);
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace->getNumberHistograms(), 6);
+  }
+
+  void
+  test_that_createWorkspaceWithTextAxis_returns_a_workspace_with_the_number_of_spectra_specified() {
+    auto const workspace = createWorkspaceWithTextAxis(6, getTextAxisLabels());
+    TS_ASSERT(workspace);
+    TS_ASSERT_EQUALS(workspace->getNumberHistograms(), 6);
+  }
+
+  void
+  test_that_createWorkspaceWithTextAxis_returns_a_workspace_with_the_text_axis_labels_specified() {
+    auto const labels = getTextAxisLabels();
+    auto const workspace = createWorkspaceWithTextAxis(6, labels);
+
+    auto const yAxis = workspace->getAxis(1);
+
+    for (auto index = 0; index < workspace->getNumberHistograms(); ++index)
+      TS_ASSERT_EQUALS(yAxis->label(index), labels[index]);
+  }
+
+  void
+  test_that_createWorkspaceWithTextAxis_throws_when_the_number_of_spectra_is_not_equal_to_the_number_of_labels() {
+    auto const labels = std::vector<std::string>({"f0.Width", "f1.EISF"});
+    TS_ASSERT_THROWS(createWorkspaceWithTextAxis(6, labels),
+                     std::runtime_error);
   }
 
   void

--- a/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
+++ b/Framework/Algorithms/test/IndirectFitDataCreationHelperTest.h
@@ -101,7 +101,7 @@ public:
 
     auto const yAxis = workspace->getAxis(1);
 
-    for (auto index = 0; index < workspace->getNumberHistograms(); ++index)
+    for (auto index = 0u; index < workspace->getNumberHistograms(); ++index)
       TS_ASSERT_EQUALS(yAxis->label(index), labels[index]);
   }
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
@@ -1,3 +1,9 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_INDIRECTFITDATACREATIONHELPER_H_
 #define MANTID_INDIRECTFITDATACREATIONHELPER_H_
 
@@ -13,6 +19,10 @@
 
 namespace Mantid {
 namespace IndirectFitDataCreationHelper {
+/// Commonly used constant variables
+int const START_X_COLUMN(2);
+int const END_X_COLUMN(3);
+int const EXCLUDE_REGION_COLUMN(4);
 
 /// Functions used in the creation of workspaces
 Mantid::API::MatrixWorkspace_sptr createWorkspace(int const &numberOfSpectra);

--- a/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/IndirectFitDataCreationHelper.h
@@ -9,6 +9,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidHistogramData/BinEdges.h"
 
 #include <string>
@@ -28,6 +29,13 @@ int const EXCLUDE_REGION_COLUMN(4);
 Mantid::API::MatrixWorkspace_sptr createWorkspace(int const &numberOfSpectra);
 Mantid::API::MatrixWorkspace_sptr createInstrumentWorkspace(int const &xLength,
                                                             int const &yLength);
+Mantid::API::MatrixWorkspace_sptr
+createWorkspaceWithTextAxis(int const &numberOfSpectra,
+                            std::vector<std::string> const &labels);
+
+Mantid::API::TextAxis *getTextAxis(int const &numberOfSpectra,
+                                   std::vector<std::string> const &labels);
+
 Mantid::API::MatrixWorkspace_sptr
 setWorkspaceEFixed(Mantid::API::MatrixWorkspace_sptr workspace,
                    int const &xLength);

--- a/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
+++ b/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
@@ -15,6 +15,26 @@ MatrixWorkspace_sptr createInstrumentWorkspace(int const &xLength,
       xLength, yLength - 1, false, false, true, "testInst");
 }
 
+MatrixWorkspace_sptr
+createWorkspaceWithTextAxis(int const &numberOfSpectra,
+                            std::vector<std::string> const &labels) {
+  if (numberOfSpectra == labels.size()) {
+    auto workspace = createWorkspace(numberOfSpectra);
+    workspace->replaceAxis(1, getTextAxis(numberOfSpectra, labels));
+    return workspace;
+  } else
+    throw std::runtime_error(
+        "The number of spectra is not equal to the number of labels");
+}
+
+TextAxis *getTextAxis(int const &numberOfSpectra,
+                      std::vector<std::string> const &labels) {
+  auto axis = new TextAxis(numberOfSpectra);
+  for (auto index = 0; index < numberOfSpectra; ++index)
+    axis->setLabel(index, labels[index]);
+  return axis;
+}
+
 MatrixWorkspace_sptr setWorkspaceEFixed(MatrixWorkspace_sptr workspace,
                                         int const &xLength) {
   for (int i = 0; i < xLength; ++i)

--- a/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
+++ b/Framework/TestHelpers/src/IndirectFitDataCreationHelper.cpp
@@ -18,7 +18,7 @@ MatrixWorkspace_sptr createInstrumentWorkspace(int const &xLength,
 MatrixWorkspace_sptr
 createWorkspaceWithTextAxis(int const &numberOfSpectra,
                             std::vector<std::string> const &labels) {
-  if (numberOfSpectra == labels.size()) {
+  if (static_cast<std::size_t>(numberOfSpectra) == labels.size()) {
     auto workspace = createWorkspace(numberOfSpectra);
     workspace->replaceAxis(1, getTextAxis(numberOfSpectra, labels));
     return workspace;

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -81,6 +81,7 @@ set ( INC_FILES
 	DensityOfStates.h
 	Elwin.h
 	IAddWorkspaceDialog.h
+	IIndirectFitDataView.h
 	IIndirectFitPlotView.h
 	ILLEnergyTransfer.h
 	ISISCalibration.h
@@ -148,6 +149,7 @@ set ( MOC_FILES
     CorrectionsTab.h
     DensityOfStates.h
     Elwin.h
+    IIndirectFitDataView.h
     IIndirectFitPlotView.h
     ILLEnergyTransfer.h
     IndirectAddWorkspaceDialog.h

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.cpp
@@ -25,7 +25,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 ConvFitDataPresenter::ConvFitDataPresenter(ConvFitModel *model,
-                                           IndirectFitDataView *view)
+                                           IIndirectFitDataView *view)
     : IndirectFitDataPresenter(
           model, view,
           Mantid::Kernel::make_unique<ConvFitDataTablePresenter>(

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
@@ -22,7 +22,7 @@ class ConvFitAddWorkspaceDialog;
 class DLLExport ConvFitDataPresenter : public IndirectFitDataPresenter {
   Q_OBJECT
 public:
-  ConvFitDataPresenter(ConvFitModel *model, IndirectFitDataView *view);
+  ConvFitDataPresenter(ConvFitModel *model, IIndirectFitDataView *view);
 
 private slots:
   void setModelResolution(const QString &name);

--- a/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataPresenter.h
@@ -16,10 +16,8 @@ namespace IDA {
 
 class ConvFitAddWorkspaceDialog;
 
-/**
-  A presenter.
-*/
-class DLLExport ConvFitDataPresenter : public IndirectFitDataPresenter {
+class MANTIDQT_INDIRECT_DLL ConvFitDataPresenter
+    : public IndirectFitDataPresenter {
   Q_OBJECT
 public:
   ConvFitDataPresenter(ConvFitModel *model, IIndirectFitDataView *view);

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.h
@@ -15,6 +15,8 @@ namespace IDA {
 
 class DLLExport ConvFitModel : public IndirectFittingModel {
 public:
+  using IndirectFittingModel::addWorkspace;
+
   ConvFitModel();
   ~ConvFitModel() override;
 

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -7,60 +7,59 @@
 #ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
 #define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
 
-#include "DllConfig.h"
 #include "../General/UserInputValidator.h"
+#include "DllConfig.h"
 
 #include <QObject>
 #include <QTabWidget>
 #include <QTableWidget>
 
 namespace MantidQt {
-	namespace CustomInterfaces {
-		namespace IDA {
+namespace CustomInterfaces {
+namespace IDA {
 
-			class MANTIDQT_INDIRECT_DLL IIndirectFitDataView : public QTabWidget {
-				Q_OBJECT
+class MANTIDQT_INDIRECT_DLL IIndirectFitDataView : public QTabWidget {
+  Q_OBJECT
 
-			public:
-				IIndirectFitDataView(QWidget *parent = nullptr) : QTabWidget(parent) {};
-				virtual ~IIndirectFitDataView() {};
+public:
+  IIndirectFitDataView(QWidget *parent = nullptr) : QTabWidget(parent){};
+  virtual ~IIndirectFitDataView(){};
 
-				virtual QTableWidget *getDataTable() const = 0;
-				virtual bool isMultipleDataTabSelected() const = 0;
-				virtual bool isResolutionHidden() const = 0;
-				virtual void setResolutionHidden(bool hide) = 0;
-				virtual void disableMultipleDataTab() = 0;
+  virtual QTableWidget *getDataTable() const = 0;
+  virtual bool isMultipleDataTabSelected() const = 0;
+  virtual bool isResolutionHidden() const = 0;
+  virtual void setResolutionHidden(bool hide) = 0;
+  virtual void disableMultipleDataTab() = 0;
 
-				virtual std::string getSelectedSample() const = 0;
-				virtual std::string getSelectedResolution() const = 0;
+  virtual std::string getSelectedSample() const = 0;
+  virtual std::string getSelectedResolution() const = 0;
 
-				virtual QStringList getSampleWSSuffices() const = 0;
-				virtual QStringList getSampleFBSuffices() const = 0;
-				virtual QStringList getResolutionWSSuffices() const = 0;
-				virtual QStringList getResolutionFBSuffices() const = 0;
+  virtual QStringList getSampleWSSuffices() const = 0;
+  virtual QStringList getSampleFBSuffices() const = 0;
+  virtual QStringList getResolutionWSSuffices() const = 0;
+  virtual QStringList getResolutionFBSuffices() const = 0;
 
-				virtual void setSampleWSSuffices(QStringList const &suffices) = 0;
-				virtual void setSampleFBSuffices(QStringList const &suffices) = 0;
-				virtual void setResolutionWSSuffices(QStringList const &suffices) = 0;
-				virtual void setResolutionFBSuffices(QStringList const &suffices) = 0;
+  virtual void setSampleWSSuffices(QStringList const &suffices) = 0;
+  virtual void setSampleFBSuffices(QStringList const &suffices) = 0;
+  virtual void setResolutionWSSuffices(QStringList const &suffices) = 0;
+  virtual void setResolutionFBSuffices(QStringList const &suffices) = 0;
 
-				virtual void readSettings(QSettings const &settings) = 0;
-				virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
+  virtual void readSettings(QSettings const &settings) = 0;
+  virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
 
-				public slots:
-				virtual void displayWarning(std::string const &warning) = 0;
+public slots:
+  virtual void displayWarning(std::string const &warning) = 0;
 
-			signals:
-				void sampleLoaded(QString const &);
-				void resolutionLoaded(QString const &);
-				void addClicked();
-				void removeClicked();
-				void multipleDataViewSelected();
-				void singleDataViewSelected();
-
-			};
-		} // namespace IDA
-	} // namespace CustomInterfaces
+signals:
+  void sampleLoaded(QString const &);
+  void resolutionLoaded(QString const &);
+  void addClicked();
+  void removeClicked();
+  void multipleDataViewSelected();
+  void singleDataViewSelected();
+};
+} // namespace IDA
+} // namespace CustomInterfaces
 } // namespace MantidQt
 
 #endif

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -1,0 +1,66 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
+#define MANTIDQTCUSTOMINTERFACESIDA_IINDIRECTFITDATAVIEW_H_
+
+#include "DllConfig.h"
+#include "../General/UserInputValidator.h"
+
+#include <QObject>
+#include <QTabWidget>
+#include <QTableWidget>
+
+namespace MantidQt {
+	namespace CustomInterfaces {
+		namespace IDA {
+
+			class MANTIDQT_INDIRECT_DLL IIndirectFitDataView : public QTabWidget {
+				Q_OBJECT
+
+			public:
+				IIndirectFitDataView(QWidget *parent = nullptr) : QTabWidget(parent) {};
+				virtual ~IIndirectFitDataView() {};
+
+				virtual QTableWidget *getDataTable() const = 0;
+				virtual bool isMultipleDataTabSelected() const = 0;
+				virtual bool isResolutionHidden() const = 0;
+				virtual void setResolutionHidden(bool hide) = 0;
+				virtual void disableMultipleDataTab() = 0;
+
+				virtual std::string getSelectedSample() const = 0;
+				virtual std::string getSelectedResolution() const = 0;
+
+				virtual QStringList getSampleWSSuffices() const = 0;
+				virtual QStringList getSampleFBSuffices() const = 0;
+				virtual QStringList getResolutionWSSuffices() const = 0;
+				virtual QStringList getResolutionFBSuffices() const = 0;
+
+				virtual void setSampleWSSuffices(QStringList const &suffices) = 0;
+				virtual void setSampleFBSuffices(QStringList const &suffices) = 0;
+				virtual void setResolutionWSSuffices(QStringList const &suffices) = 0;
+				virtual void setResolutionFBSuffices(QStringList const &suffices) = 0;
+
+				virtual void readSettings(QSettings const &settings) = 0;
+				virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
+
+				public slots:
+				virtual void displayWarning(std::string const &warning) = 0;
+
+			signals:
+				void sampleLoaded(QString const &);
+				void resolutionLoaded(QString const &);
+				void addClicked();
+				void removeClicked();
+				void multipleDataViewSelected();
+				void singleDataViewSelected();
+
+			};
+		} // namespace IDA
+	} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
@@ -21,7 +21,7 @@ namespace IDA {
 /**
   Presenter for a table of indirect fitting data.
 */
-class DLLExport IndirectDataTablePresenter : public QObject {
+class MANTIDQT_INDIRECT_DLL IndirectDataTablePresenter : public QObject {
   Q_OBJECT
 public:
   IndirectDataTablePresenter(IndirectFittingModel *model,

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -14,14 +14,14 @@ namespace CustomInterfaces {
 namespace IDA {
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(IndirectFittingModel *model,
-                                                   IndirectFitDataView *view)
+                                                   IIndirectFitDataView *view)
     : IndirectFitDataPresenter(
           model, view,
           Mantid::Kernel::make_unique<IndirectDataTablePresenter>(
               model, view->getDataTable())) {}
 
 IndirectFitDataPresenter::IndirectFitDataPresenter(
-    IndirectFittingModel *model, IndirectFitDataView *view,
+    IndirectFittingModel *model, IIndirectFitDataView *view,
     std::unique_ptr<IndirectDataTablePresenter> tablePresenter)
     : m_model(model), m_view(view),
       m_tablePresenter(std::move(tablePresenter)) {
@@ -65,7 +65,7 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
                                       std::size_t)));
 }
 
-IndirectFitDataView const *IndirectFitDataPresenter::getView() const {
+IIndirectFitDataView const *IndirectFitDataPresenter::getView() const {
   return m_view;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -8,8 +8,8 @@
 #define MANTIDQTCUSTOMINTERFACESIDA_INDIRECTFITDATAPRESENTER_H_
 
 #include "IAddWorkspaceDialog.h"
-#include "IndirectDataTablePresenter.h"
 #include "IIndirectFitDataView.h"
+#include "IndirectDataTablePresenter.h"
 #include "IndirectFittingModel.h"
 
 #include "DllConfig.h"

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -12,6 +12,7 @@
 #include "IndirectFitDataView.h"
 #include "IndirectFittingModel.h"
 
+#include "DllConfig.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <QObject>
@@ -20,10 +21,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-/**
-  A presenter.
-*/
-class DLLExport IndirectFitDataPresenter : public QObject {
+class MANTIDQT_INDIRECT_DLL IndirectFitDataPresenter : public QObject {
   Q_OBJECT
 public:
   IndirectFitDataPresenter(IndirectFittingModel *model,

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -9,7 +9,7 @@
 
 #include "IAddWorkspaceDialog.h"
 #include "IndirectDataTablePresenter.h"
-#include "IndirectFitDataView.h"
+#include "IIndirectFitDataView.h"
 #include "IndirectFittingModel.h"
 
 #include "DllConfig.h"
@@ -25,10 +25,10 @@ class MANTIDQT_INDIRECT_DLL IndirectFitDataPresenter : public QObject {
   Q_OBJECT
 public:
   IndirectFitDataPresenter(IndirectFittingModel *model,
-                           IndirectFitDataView *view);
+                           IIndirectFitDataView *view);
 
   IndirectFitDataPresenter(
-      IndirectFittingModel *model, IndirectFitDataView *view,
+      IndirectFittingModel *model, IIndirectFitDataView *view,
       std::unique_ptr<IndirectDataTablePresenter> tablePresenter);
 
   void setSampleWSSuffices(const QStringList &suffices);
@@ -67,7 +67,7 @@ signals:
   void requestedAddWorkspaceDialog();
 
 protected:
-  IndirectFitDataView const *getView() const;
+  IIndirectFitDataView const *getView() const;
   void addData(IAddWorkspaceDialog const *dialog);
   virtual void addDataToModel(IAddWorkspaceDialog const *dialog);
   void setSingleModelData(const std::string &name);
@@ -85,7 +85,7 @@ private:
   IndirectFittingModel *m_model;
   PrivateFittingData m_singleData;
   PrivateFittingData m_multipleData;
-  IndirectFitDataView *m_view;
+  IIndirectFitDataView *m_view;
   std::unique_ptr<IndirectDataTablePresenter> m_tablePresenter;
 };
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -21,7 +21,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 IndirectFitDataView::IndirectFitDataView(QWidget *parent)
-    : QTabWidget(parent), m_dataForm(new Ui::IndirectFitDataForm) {
+    : IIndirectFitDataView(parent), m_dataForm(new Ui::IndirectFitDataForm) {
   m_dataForm->setupUi(this);
   m_dataForm->dsResolution->hide();
   m_dataForm->lbResolution->hide();

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -9,6 +9,8 @@
 
 #include "ui_IndirectFitDataView.h"
 
+#include "IIndirectFitDataView.h"
+
 #include "../General/UserInputValidator.h"
 #include "DllConfig.h"
 
@@ -18,44 +20,36 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INDIRECT_DLL IndirectFitDataView : public QTabWidget {
+class MANTIDQT_INDIRECT_DLL IndirectFitDataView : public IIndirectFitDataView {
   Q_OBJECT
 public:
   IndirectFitDataView(QWidget *parent = nullptr);
   ~IndirectFitDataView() override = default;
 
-  QTableWidget *getDataTable() const;
-  virtual bool isMultipleDataTabSelected() const;
-  bool isResolutionHidden() const;
-  void setResolutionHidden(bool hide);
-  void disableMultipleDataTab();
+  QTableWidget *getDataTable() const override;
+  virtual bool isMultipleDataTabSelected() const override;
+  bool isResolutionHidden() const override;
+  void setResolutionHidden(bool hide) override;
+  void disableMultipleDataTab() override;
 
-  virtual std::string getSelectedSample() const;
-  std::string getSelectedResolution() const;
+  virtual std::string getSelectedSample() const override;
+  std::string getSelectedResolution() const override;
 
-  virtual QStringList getSampleWSSuffices() const;
-  virtual QStringList getSampleFBSuffices() const;
-  QStringList getResolutionWSSuffices() const;
-  QStringList getResolutionFBSuffices() const;
+  virtual QStringList getSampleWSSuffices() const override;
+  virtual QStringList getSampleFBSuffices() const override;
+  QStringList getResolutionWSSuffices() const override;
+  QStringList getResolutionFBSuffices() const override;
 
-  virtual void setSampleWSSuffices(const QStringList &suffices);
-  virtual void setSampleFBSuffices(const QStringList &suffices);
-  virtual void setResolutionWSSuffices(const QStringList &suffices);
-  virtual void setResolutionFBSuffices(const QStringList &suffices);
+  virtual void setSampleWSSuffices(const QStringList &suffices) override;
+  virtual void setSampleFBSuffices(const QStringList &suffices) override;
+  virtual void setResolutionWSSuffices(const QStringList &suffices) override;
+  virtual void setResolutionFBSuffices(const QStringList &suffices) override;
 
-  void readSettings(const QSettings &settings);
-  UserInputValidator &validate(UserInputValidator &validator);
+  void readSettings(const QSettings &settings) override;
+  UserInputValidator &validate(UserInputValidator &validator) override;
 
 public slots:
-  void displayWarning(const std::string &warning);
-
-signals:
-  void sampleLoaded(const QString &);
-  void resolutionLoaded(const QString &);
-  void addClicked();
-  void removeClicked();
-  void multipleDataViewSelected();
-  void singleDataViewSelected();
+  void displayWarning(const std::string &warning) override;
 
 protected slots:
   void emitViewSelected(int index);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -33,15 +33,15 @@ public:
   virtual std::string getSelectedSample() const;
   std::string getSelectedResolution() const;
 
-  QStringList getSampleWSSuffices() const;
-  QStringList getSampleFBSuffices() const;
+  virtual QStringList getSampleWSSuffices() const;
+  virtual QStringList getSampleFBSuffices() const;
   QStringList getResolutionWSSuffices() const;
   QStringList getResolutionFBSuffices() const;
 
-  void setSampleWSSuffices(const QStringList &suffices);
-  void setSampleFBSuffices(const QStringList &suffices);
-  void setResolutionWSSuffices(const QStringList &suffices);
-  void setResolutionFBSuffices(const QStringList &suffices);
+  virtual void setSampleWSSuffices(const QStringList &suffices);
+  virtual void setSampleFBSuffices(const QStringList &suffices);
+  virtual void setResolutionWSSuffices(const QStringList &suffices);
+  virtual void setResolutionFBSuffices(const QStringList &suffices);
 
   void readSettings(const QSettings &settings);
   UserInputValidator &validate(UserInputValidator &validator);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -10,6 +10,7 @@
 #include "ui_IndirectFitDataView.h"
 
 #include "../General/UserInputValidator.h"
+#include "DllConfig.h"
 
 #include <QTabWidget>
 
@@ -17,7 +18,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class DLLExport IndirectFitDataView : public QTabWidget {
+class MANTIDQT_INDIRECT_DLL IndirectFitDataView : public QTabWidget {
   Q_OBJECT
 public:
   IndirectFitDataView(QWidget *parent);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -21,16 +21,16 @@ namespace IDA {
 class MANTIDQT_INDIRECT_DLL IndirectFitDataView : public QTabWidget {
   Q_OBJECT
 public:
-  IndirectFitDataView(QWidget *parent);
+  IndirectFitDataView(QWidget *parent = nullptr);
   ~IndirectFitDataView() override = default;
 
   QTableWidget *getDataTable() const;
-  bool isMultipleDataTabSelected() const;
+  virtual bool isMultipleDataTabSelected() const;
   bool isResolutionHidden() const;
   void setResolutionHidden(bool hide);
   void disableMultipleDataTab();
 
-  std::string getSelectedSample() const;
+  virtual std::string getSelectedSample() const;
   std::string getSelectedResolution() const;
 
   QStringList getSampleWSSuffices() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -209,7 +209,7 @@ private:
 template <typename F>
 void IndirectFittingModel::applySpectra(std::size_t index,
                                         const F &functor) const {
-	if (m_fittingData.size() > 0)
+  if (m_fittingData.size() > 0)
     m_fittingData[index]->applySpectra(functor);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -101,7 +101,7 @@ public:
   template <typename F>
   void applySpectra(std::size_t index, const F &functor) const;
 
-  FittingMode getFittingMode() const;
+  virtual FittingMode getFittingMode() const;
   std::unordered_map<std::string, ParameterValue>
   getParameterValues(std::size_t dataIndex, std::size_t spectrum) const;
   std::unordered_map<std::string, ParameterValue>

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -82,14 +82,14 @@ public:
   virtual void setExcludeRegion(const std::string &exclude,
                                 std::size_t dataIndex, std::size_t spectrum);
 
-  void addWorkspace(const std::string &workspaceName);
+  virtual void addWorkspace(const std::string &workspaceName);
   void addWorkspace(const std::string &workspaceName,
                     const std::string &spectra);
   void addWorkspace(const std::string &workspaceName, const Spectra &spectra);
   virtual void addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
                             const Spectra &spectra);
   virtual void removeWorkspace(std::size_t index);
-  PrivateFittingData clearWorkspaces();
+  virtual PrivateFittingData clearWorkspaces();
   void setFittingMode(FittingMode mode);
   virtual void setFitFunction(Mantid::API::IFunction_sptr function);
   virtual void setDefaultParameterValue(const std::string &name, double value,
@@ -209,7 +209,8 @@ private:
 template <typename F>
 void IndirectFittingModel::applySpectra(std::size_t index,
                                         const F &functor) const {
-  m_fittingData[index]->applySpectra(functor);
+	if (m_fittingData.size() > 0)
+    m_fittingData[index]->applySpectra(functor);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -79,8 +79,8 @@ public:
                          std::size_t spectrum);
   virtual void setEndX(double endX, std::size_t dataIndex,
                        std::size_t spectrum);
-  virtual void setExcludeRegion(const std::string &exclude, std::size_t dataIndex,
-                        std::size_t spectrum);
+  virtual void setExcludeRegion(const std::string &exclude,
+                                std::size_t dataIndex, std::size_t spectrum);
 
   void addWorkspace(const std::string &workspaceName);
   void addWorkspace(const std::string &workspaceName,

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -101,7 +101,7 @@ public:
   template <typename F>
   void applySpectra(std::size_t index, const F &functor) const;
 
-  virtual FittingMode getFittingMode() const;
+  FittingMode getFittingMode() const;
   std::unordered_map<std::string, ParameterValue>
   getParameterValues(std::size_t dataIndex, std::size_t spectrum) const;
   std::unordered_map<std::string, ParameterValue>

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -79,7 +79,7 @@ public:
                          std::size_t spectrum);
   virtual void setEndX(double endX, std::size_t dataIndex,
                        std::size_t spectrum);
-  void setExcludeRegion(const std::string &exclude, std::size_t dataIndex,
+  virtual void setExcludeRegion(const std::string &exclude, std::size_t dataIndex,
                         std::size_t spectrum);
 
   void addWorkspace(const std::string &workspaceName);

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -16,7 +16,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 JumpFitDataPresenter::JumpFitDataPresenter(
-    JumpFitModel *model, IndirectFitDataView *view, QComboBox *cbParameterType,
+    JumpFitModel *model, IIndirectFitDataView *view, QComboBox *cbParameterType,
     QComboBox *cbParameter, QLabel *lbParameterType, QLabel *lbParameter)
     : IndirectFitDataPresenter(
           model, view,

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -24,7 +24,7 @@ namespace IDA {
 class DLLExport JumpFitDataPresenter : public IndirectFitDataPresenter {
   Q_OBJECT
 public:
-  JumpFitDataPresenter(JumpFitModel *model, IndirectFitDataView *view,
+  JumpFitDataPresenter(JumpFitModel *model, IIndirectFitDataView *view,
                        QComboBox *cbParameterType, QComboBox *cbParameter,
                        QLabel *lbParameterType, QLabel *lbParameter);
 

--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.h
@@ -18,10 +18,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-/**
-  A presenter.
-*/
-class DLLExport JumpFitDataPresenter : public IndirectFitDataPresenter {
+class MANTIDQT_INDIRECT_DLL JumpFitDataPresenter
+    : public IndirectFitDataPresenter {
   Q_OBJECT
 public:
   JumpFitDataPresenter(JumpFitModel *model, IIndirectFitDataView *view,

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -22,6 +22,8 @@ struct JumpFitParameters {
 
 class DLLExport JumpFitModel : public IndirectFittingModel {
 public:
+  using IndirectFittingModel::addWorkspace;
+
   void addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
                     const Spectra &) override;
   void removeWorkspace(std::size_t index) override;

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -3,6 +3,7 @@
 ###########################################################################
 set ( TEST_FILES
   IndirectDataTablePresenterTest.h
+  IndirectFitDataPresenterTest.h
   IndirectFitDataTest.h
   IndirectFitOutputTest.h
   IndirectFitPlotModelTest.h

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Testing
 ###########################################################################
 set ( TEST_FILES
+  IndirectDataTablePresenterTest.h
   IndirectFitDataTest.h
   IndirectFitOutputTest.h
   IndirectFitPlotModelTest.h

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set ( TEST_FILES
   IndirectFitPlotPresenterTest.h
   IndirectFittingModelTest.h
   IndirectSpectrumSelectionPresenterTest.h
+  JumpFitDataPresenterTest.h
 )
 
 mtd_add_qt_tests (TARGET_NAME MantidQtInterfacesIndirectTest

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Testing
 ###########################################################################
 set ( TEST_FILES
+  ConvFitDataPresenterTest.h
   IndirectDataTablePresenterTest.h
   IndirectFitDataPresenterTest.h
   IndirectFitDataTest.h

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -41,6 +41,11 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 /// Mock object to mock the view
 class MockConvFitDataView : public IIndirectFitDataView {
 public:
+  /// Signals
+  void emitResolutionLoaded(QString const &workspaceName) {
+    emit resolutionLoaded(workspaceName);
+  }
+
   /// Public Methods
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
@@ -69,10 +74,7 @@ public:
 };
 
 /// Mock object to mock the model
-class MockConvFitModel : public ConvFitModel {
-public:
-  /// Public Methods - None currently
-};
+class MockConvFitModel : public ConvFitModel {};
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
@@ -117,7 +119,25 @@ public:
   /// Unit tests to check for successful mock object instantiation
   ///----------------------------------------------------------------------
 
-  void test_test() {}
+  void test_that_the_presenter_and_mock_objects_have_been_created() {
+    TS_ASSERT(m_presenter);
+    TS_ASSERT(m_model);
+    TS_ASSERT(m_view);
+  }
+
+  void test_that_the_data_table_is_the_size_specified() {
+    TS_ASSERT_EQUALS(m_dataTable->rowCount(), 6);
+    TS_ASSERT_EQUALS(m_dataTable->columnCount(), 6);
+  }
+
+  void
+  test_that_the_model_contains_the_correct_number_of_workspace_after_instantiation() {
+    TS_ASSERT_EQUALS(m_model->numberOfWorkspaces(), 1);
+  }
+
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the signals, methods and slots of the presenter
+  ///----------------------------------------------------------------------
 
 private:
   std::unique_ptr<QTableWidget> m_dataTable;

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -1,0 +1,129 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_CONVFITDATAPRESENTERTEST_H_
+#define MANTIDQT_CONVFITDATAPRESENTERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "ConvFitDataPresenter.h"
+#include "ConvFitModel.h"
+#include "IIndirectFitDataView.h"
+
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
+
+using namespace Mantid::API;
+using namespace Mantid::IndirectFitDataCreationHelper;
+using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::IDA;
+using namespace testing;
+
+namespace {
+
+std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+  auto table = std::make_unique<QTableWidget>(columns, rows);
+  for (auto column = 0; column < columns; ++column)
+    for (auto row = 0; row < rows; ++row)
+      table->setItem(row, column, new QTableWidgetItem("item"));
+  return table;
+}
+
+} // namespace
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+/// Mock object to mock the view
+class MockConvFitDataView : public IIndirectFitDataView {
+public:
+  /// Public Methods
+  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
+  MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
+  MOCK_CONST_METHOD0(isResolutionHidden, bool());
+  MOCK_METHOD1(setResolutionHidden, void(bool hide));
+  MOCK_METHOD0(disableMultipleDataTab, void());
+
+  MOCK_CONST_METHOD0(getSelectedSample, std::string());
+  MOCK_CONST_METHOD0(getSelectedResolution, std::string());
+
+  MOCK_CONST_METHOD0(getSampleWSSuffices, QStringList());
+  MOCK_CONST_METHOD0(getSampleFBSuffices, QStringList());
+  MOCK_CONST_METHOD0(getResolutionWSSuffices, QStringList());
+  MOCK_CONST_METHOD0(getResolutionFBSuffices, QStringList());
+
+  MOCK_METHOD1(setSampleWSSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setSampleFBSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
+
+  MOCK_METHOD1(readSettings, void(QSettings const &settings));
+  MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
+
+  /// Public slots
+  MOCK_METHOD1(displayWarning, void(std::string const &warning));
+};
+
+/// Mock object to mock the model
+class MockConvFitModel : public ConvFitModel {
+public:
+  /// Public Methods - None currently
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+class ConvFitDataPresenterTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  ConvFitDataPresenterTest() { FrameworkManager::Instance(); }
+
+  static ConvFitDataPresenterTest *createSuite() {
+    return new ConvFitDataPresenterTest();
+  }
+
+  static void destroySuite(ConvFitDataPresenterTest *suite) { delete suite; }
+
+  void setUp() override {
+    m_view = std::make_unique<NiceMock<MockConvFitDataView>>();
+    m_model = std::make_unique<NiceMock<MockConvFitModel>>();
+
+    m_dataTable = createEmptyTableWidget(6, 5);
+    ON_CALL(*m_view, getDataTable()).WillByDefault(Return(m_dataTable.get()));
+
+    m_presenter = std::make_unique<ConvFitDataPresenter>(
+        std::move(m_model.get()), std::move(m_view.get()));
+
+    SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(6));
+    m_model->addWorkspace("WorkspaceName");
+  }
+
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
+
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+
+    m_presenter.reset();
+    m_model.reset();
+    m_view.reset();
+    m_dataTable.reset();
+  }
+
+  ///----------------------------------------------------------------------
+  /// Unit tests to check for successful mock object instantiation
+  ///----------------------------------------------------------------------
+
+  void test_test() {}
+
+private:
+  std::unique_ptr<QTableWidget> m_dataTable;
+
+  std::unique_ptr<MockConvFitDataView> m_view;
+  std::unique_ptr<MockConvFitModel> m_model;
+  std::unique_ptr<ConvFitDataPresenter> m_presenter;
+};
+#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -57,9 +57,9 @@ public:
 	}
 
 	void setUp() override {
-		m_model = new NiceMock<MockIndirectFittingModel>();
-		m_table = new QTableWidget();
-		m_presenter = new IndirectDataTablePresenter(m_model, m_table);
+		m_model = std::make_unique<NiceMock<MockIndirectFittingModel>>();
+		m_table = std::make_unique<QTableWidget>();
+		m_presenter = std::make_unique<IndirectDataTablePresenter>(std::move(m_model.get()), std::move(m_table.get()));
 
 		//SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(10));
 		//m_fittingModel->addWorkspace("WorkspaceName");
@@ -68,20 +68,20 @@ public:
 	void tearDown() override {
 		//AnalysisDataService::Instance().clear();
 
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_table));
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model));
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_table.get()));
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
 
-		delete m_presenter;
-		delete m_model;
-		delete m_table;
+		m_presenter.reset();
+		m_model.reset();
+		m_table.reset();
 	}
 
 	void test_test() {}
 
 private:
-	QTableWidget *m_table;
-	MockIndirectFittingModel *m_model;
-	IndirectDataTablePresenter *m_presenter;
+	std::unique_ptr<QTableWidget> m_table;
+	std::unique_ptr<MockIndirectFittingModel> m_model;
+	std::unique_ptr<IndirectDataTablePresenter> m_presenter;
 
 	//SetUpADSWithWorkspace *m_ads;
 };

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -25,6 +25,8 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 /// Mock object to mock the view
 class MockIndirectFittingModel : public IndirectFittingModel {
 public:
+	MOCK_CONST_METHOD0(isMultiFit, bool());
+	MOCK_CONST_METHOD0(getFittingMode, FittingMode());
 
 private:
 	std::string sequentialFitOutputName() const override { return ""; };
@@ -58,7 +60,8 @@ public:
 
 	void setUp() override {
 		m_model = std::make_unique<NiceMock<MockIndirectFittingModel>>();
-		m_table = std::make_unique<QTableWidget>();
+		m_table = std::make_unique<QTableWidget>(10, 10);
+		//m_table->item(0, 0)->setText("test");
 		m_presenter = std::make_unique<IndirectDataTablePresenter>(std::move(m_model.get()), std::move(m_table.get()));
 
 		//SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(10));
@@ -74,6 +77,34 @@ public:
 		m_presenter.reset();
 		m_model.reset();
 		m_table.reset();
+	}
+
+	///----------------------------------------------------------------------
+	/// Unit tests to check for successful presenter instantiation
+	///----------------------------------------------------------------------
+
+	void test_that_the_model_has_been_instantiated_correctly() {
+		std::size_t const selectedSpectrum(3);
+		ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
+
+		EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
+
+		m_model->isMultiFit();
+	}
+
+	void
+		test_that_invoking_a_presenter_method_will_call_the_relevant_methods_in_the_model_and_view() {
+		//ON_CALL(*m_model, getFittingMode())
+		//	.WillByDefault(Return(FittingMode::SEQUENTIAL));
+
+		//EXPECT_CALL(*m_model, getFittingMode())
+		//	.Times(1)
+		//	.WillOnce(Return(FittingMode::SEQUENTIAL));
+		//EXPECT_CALL(*m_view, setMaskString(excludeRegion)).Times(1).After(getMask);
+		m_presenter->setStartX(2.0, 0, 0);
+		auto ggg = m_table->size();
+
+
 	}
 
 	void test_test() {}

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -24,10 +24,24 @@ using namespace testing;
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
-/// Mock object to mock the view
+/// Mock object to mock the model
 class MockIndirectDataTableModel : public IndirectFittingModel {
 public:
+	/// Public methods
+	MOCK_CONST_METHOD2(getFittingRange,
+		std::pair<double, double>(std::size_t dataIndex,
+			std::size_t spectrum));
+	MOCK_CONST_METHOD2(getExcludeRegion, std::string(std::size_t dataIndex,
+		std::size_t index));
 	MOCK_CONST_METHOD0(isMultiFit, bool());
+	MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
+
+	MOCK_METHOD3(setStartX, void(double startX, std::size_t dataIndex,
+		std::size_t spectrum));
+	MOCK_METHOD3(setEndX,
+		void(double endX, std::size_t dataIndex, std::size_t spectrum));
+	MOCK_METHOD3(setExcludeRegion,
+		void(std::string const &exclude, std::size_t dataIndex, std::size_t spectrum));
 
 private:
 	std::string sequentialFitOutputName() const override { return ""; };
@@ -68,13 +82,6 @@ public:
 		m_model->addWorkspace("WorkspaceName");
 	}
 
-	void createEmptyTableWidget(int const &columns, int const &rows) {
-		m_table = std::make_unique<QTableWidget>(columns, rows);
-		for (auto i = 0; i < columns; ++i)
-			for (auto j = 0; j < rows; ++j)
-				m_table->setItem(j, i, new QTableWidgetItem("test"));
-	}
-
 	void tearDown() override {
 		AnalysisDataService::Instance().clear();
 
@@ -100,28 +107,229 @@ public:
 	}
 
 	void
-	test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
+		test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
 		int const startXColumn(2);
 
 		m_presenter->setStartX(2.2, 0, 0);
 
-		for (auto i = 0; i < m_table->rowCount(); ++i)
-			TS_ASSERT_EQUALS(m_table->item(i, startXColumn)->text().toStdString(), "2.2")
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "2.2")
 	}
 
 	///----------------------------------------------------------------------
-	/// Unit Tests that test the signals (only the view emits signals here)
+	/// Unit Tests that test the signals call the correct methods
 	///----------------------------------------------------------------------
 
-	void test_test() {}
+	void test_that_the_cellChanged_signal_will_set_the_models_startX_when_the_relevant_column_is_changed() {
+		int const startXColumn(2);
+
+		EXPECT_CALL(*m_model, setStartX(2.0, 0, 0)).Times(1);
+
+		m_table->item(0, startXColumn)->setText("2.0");
+	}
+
+	void test_that_the_cellChanged_signal_will_set_the_models_endX_when_the_relevant_column_is_changed() {
+		int const endXColumn(3);
+
+		EXPECT_CALL(*m_model, setEndX(2.0, 0, 0)).Times(1);
+
+		m_table->item(0, endXColumn)->setText("2.0");
+	}
+
+	void test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_when_the_relevant_column_is_changed() {
+		int const excludeRegionColumn(4);
+
+		EXPECT_CALL(*m_model, setExcludeRegion("0-4", 0, 0)).Times(1);
+
+		m_table->item(0, excludeRegionColumn)->setText("0-4");
+	}
+
+	void test_that_the_cellChanged_signal_will_set_the_models_startX_in_every_row_when_the_relevant_column_is_changed() {
+		int const startXColumn(2);
+
+		m_table->item(0, startXColumn)->setText("1.5");
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.5")
+	}
+
+	void test_that_the_cellChanged_signal_will_set_the_models_endX_in_every_row_when_the_relevant_column_is_changed() {
+		int const endXColumn(3);
+
+		m_table->item(0, endXColumn)->setText("2.5");
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(), "2.5")
+	}
+
+	void test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_in_every_row_when_the_relevant_column_is_changed() {
+		int const excludeRegionColumn(4);
+
+		m_table->item(0, excludeRegionColumn)->setText("2-4");
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-4")
+	}
 
 	///----------------------------------------------------------------------
-	/// Unit Tests that test the methods and slots of the view
+	/// Unit Tests that test the methods and slots of the presenter
 	///----------------------------------------------------------------------
 
-	void test_test2() {}
+	void test_that_tableDatasetsMatchModel_returns_false_if_the_number_of_data_positions_is_not_equal_to_the_numberOfWorkspaces() {
+		std::size_t const numberOfWorkspaces(2);
+		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(numberOfWorkspaces));
+
+		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).WillOnce(Return(numberOfWorkspaces));
+
+		TS_ASSERT(!m_presenter->tableDatasetsMatchModel());
+	}
+
+	void test_that_tableDatasetsMatchModel_returns_true_if_the_table_datasets_match_the_model() {
+		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).WillOnce(Return(0));
+		TS_ASSERT(m_presenter->tableDatasetsMatchModel());
+	}
+
+	void test_that_addData_will_add_new_data_if_the_index_is_smaller_than_the_number_of_data_positions() {
+		std::size_t const index(0);
+
+		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
+
+		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1);
+
+		ExpectationSet getRanges = EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
+		for (auto spectrum = 1; spectrum < m_table->rowCount(); ++spectrum)
+			getRanges += EXPECT_CALL(*m_model, getFittingRange(index, spectrum)).Times(1).After(getRanges);
+
+		m_presenter->addData(index);
+	}
+
+	void
+		test_that_the_setStartX_slot_will_alter_the_relevant_startX_column_in_the_table() {
+		int const startXColumn(2);
+
+		m_presenter->setStartX(1.1, 0);
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.1")
+	}
+
+	void
+		test_that_the_setEndX_slot_will_alter_the_relevant_endX_column_in_the_table() {
+		int const endXColumn(3);
+
+		m_presenter->setEndX(1.1, 0);
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(), "1.1")
+	}
+
+	void
+		test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
+		int const excludeRegionColumn(4);
+
+		m_presenter->setExcludeRegion("2-3", 0);
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-3")
+
+	}
+
+	void test_that_setGlobalFittingRange_will_set_the_startX_and_endX_taken_from_the_fitting_range() {
+		std::size_t const index(0);
+		int const startXColumn(2);
+		int const endXColumn(3);
+		auto const range = std::make_pair(1.0, 2.0);
+
+		ON_CALL(*m_model, getFittingRange(index, 0))
+			.WillByDefault(Return(range));
+
+		EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
+
+		m_presenter->setGlobalFittingRange(true);
+
+		for (auto row = 0; row < m_table->rowCount(); ++row) {
+			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toDouble(), 1.0)
+				TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toDouble(), 2.0)
+		}
+	}
+
+	void test_that_setGlobalFittingRange_will_set_the_excludeRegion_when_passed_true() {
+		std::size_t const index(0);
+		int const excludeRegionColumn(4);
+
+		ON_CALL(*m_model, getExcludeRegion(index, 0))
+			.WillByDefault(Return("1-2"));
+
+		EXPECT_CALL(*m_model, getExcludeRegion(index, 0)).Times(1);
+
+		m_presenter->setGlobalFittingRange(true);
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "1-2");
+	}
+
+	void test_that_setGlobalFittingRange_will_connect_the_cellChanged_signal_to_updateAllFittingRangeFrom_when_passed_true() {
+		int const startXColumn(2);
+
+		m_presenter->setGlobalFittingRange(true);
+		m_table->item(0, startXColumn)->setText("1.5");
+
+		for (auto row = 0; row < m_table->rowCount(); ++row)
+			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.5")
+	}
+
+	void test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_startX_is_not_global() {
+		int const startXColumn(2);
+		std::string const startX("2.5");
+
+		m_presenter->setGlobalFittingRange(false);
+		m_table->item(0, startXColumn)->setText(QString::fromStdString(startX));
+
+		TS_ASSERT_EQUALS(m_table->item(0, startXColumn)->text().toStdString(), startX);
+		for (auto row = 1; row < m_table->rowCount(); ++row)
+			TS_ASSERT_DIFFERS(m_table->item(row, startXColumn)->text().toStdString(), startX)
+	}
+
+	void test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_endX_is_not_global() {
+		int const endXColumn(3);
+		std::string const endX("2.5");
+
+		m_presenter->setGlobalFittingRange(false);
+		m_table->item(0, endXColumn)->setText(QString::fromStdString(endX));
+
+		TS_ASSERT_EQUALS(m_table->item(0, endXColumn)->text().toStdString(), endX);
+		for (auto row = 1; row < m_table->rowCount(); ++row)
+			TS_ASSERT_DIFFERS(m_table->item(row, endXColumn)->text().toStdString(), endX)
+	}
+
+	void test_the_enableTable_slot_will_enable_the_table() {
+		m_presenter->disableTable();
+		m_presenter->enableTable();
+
+		TS_ASSERT(m_table->isEnabled());
+	}
+
+	void test_the_disableTable_slot_will_enable_the_table() {
+		m_presenter->enableTable();
+		m_presenter->disableTable();
+
+		TS_ASSERT(!m_table->isEnabled());
+	}
+
+	void test_that_clearTable_will_clear_the_data_table() {
+		m_presenter->clearTable();
+		TS_ASSERT_EQUALS(m_table->rowCount(), 0);
+	}
 
 private:
+	/// Used in setup
+	void createEmptyTableWidget(int columns, int rows) {
+		m_table = std::make_unique<QTableWidget>(columns, rows);
+		for (auto column = 0; column < columns; ++column)
+			for (auto row = 0; row < rows; ++row)
+				m_table->setItem(row, column, new QTableWidgetItem("item"));
+	}
+
 	std::unique_ptr<QTableWidget> m_table;
 	std::unique_ptr<MockIndirectDataTableModel> m_model;
 	std::unique_ptr<IndirectDataTablePresenter> m_presenter;

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -1,0 +1,89 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_INDIRECTDATATABLEPRESENTERTEST_H_
+#define MANTIDQT_INDIRECTDATATABLEPRESENTERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "IndirectFittingModel.h"
+#include "IndirectDataTablePresenter.h"
+
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidAPI/FrameworkManager.h"
+
+using namespace Mantid::API;
+using namespace MantidQt::CustomInterfaces::IDA;
+using namespace testing;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+/// Mock object to mock the view
+class MockIndirectFittingModel : public IndirectFittingModel {
+public:
+
+private:
+	std::string sequentialFitOutputName() const override { return ""; };
+	std::string simultaneousFitOutputName() const override { return ""; };
+	std::string singleFitOutputName(std::size_t index,
+		std::size_t spectrum) const override {
+		UNUSED_ARG(index);
+		UNUSED_ARG(spectrum);
+		return "";
+	};
+
+	std::vector<std::string> getSpectrumDependentAttributes() const override {
+		return{};
+	};
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+class IndirectDataTablePresenterTest : public CxxTest::TestSuite {
+public:
+	/// Needed to make sure everything is initialized
+	IndirectDataTablePresenterTest() { FrameworkManager::Instance(); }
+
+	static IndirectDataTablePresenterTest *createSuite() {
+		return new IndirectDataTablePresenterTest();
+	}
+
+	static void destroySuite(IndirectDataTablePresenterTest *suite) {
+		delete suite;
+	}
+
+	void setUp() override {
+		m_model = new NiceMock<MockIndirectFittingModel>();
+		m_table = new QTableWidget();
+		m_presenter = new IndirectDataTablePresenter(m_model, m_table);
+
+		//SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(10));
+		//m_fittingModel->addWorkspace("WorkspaceName");
+	}
+
+	void tearDown() override {
+		//AnalysisDataService::Instance().clear();
+
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_table));
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model));
+
+		delete m_presenter;
+		delete m_model;
+		delete m_table;
+	}
+
+	void test_test() {}
+
+private:
+	QTableWidget *m_table;
+	MockIndirectFittingModel *m_model;
+	IndirectDataTablePresenter *m_presenter;
+
+	//SetUpADSWithWorkspace *m_ads;
+};
+
+#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -10,11 +10,11 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
-#include "IndirectFittingModel.h"
 #include "IndirectDataTablePresenter.h"
+#include "IndirectFittingModel.h"
 
-#include "MantidKernel/WarningSuppressions.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
@@ -27,314 +27,345 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 /// Mock object to mock the model
 class MockIndirectDataTableModel : public IndirectFittingModel {
 public:
-	/// Public methods
-	MOCK_CONST_METHOD2(getFittingRange,
-		std::pair<double, double>(std::size_t dataIndex,
-			std::size_t spectrum));
-	MOCK_CONST_METHOD2(getExcludeRegion, std::string(std::size_t dataIndex,
-		std::size_t index));
-	MOCK_CONST_METHOD0(isMultiFit, bool());
-	MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
+  /// Public methods
+  MOCK_CONST_METHOD2(getFittingRange,
+                     std::pair<double, double>(std::size_t dataIndex,
+                                               std::size_t spectrum));
+  MOCK_CONST_METHOD2(getExcludeRegion,
+                     std::string(std::size_t dataIndex, std::size_t index));
+  MOCK_CONST_METHOD0(isMultiFit, bool());
+  MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
 
-	MOCK_METHOD3(setStartX, void(double startX, std::size_t dataIndex,
-		std::size_t spectrum));
-	MOCK_METHOD3(setEndX,
-		void(double endX, std::size_t dataIndex, std::size_t spectrum));
-	MOCK_METHOD3(setExcludeRegion,
-		void(std::string const &exclude, std::size_t dataIndex, std::size_t spectrum));
+  MOCK_METHOD3(setStartX, void(double startX, std::size_t dataIndex,
+                               std::size_t spectrum));
+  MOCK_METHOD3(setEndX,
+               void(double endX, std::size_t dataIndex, std::size_t spectrum));
+  MOCK_METHOD3(setExcludeRegion,
+               void(std::string const &exclude, std::size_t dataIndex,
+                    std::size_t spectrum));
 
 private:
-	std::string sequentialFitOutputName() const override { return ""; };
-	std::string simultaneousFitOutputName() const override { return ""; };
-	std::string singleFitOutputName(std::size_t index,
-		std::size_t spectrum) const override {
-		UNUSED_ARG(index);
-		UNUSED_ARG(spectrum);
-		return "";
-	};
+  std::string sequentialFitOutputName() const override { return ""; };
+  std::string simultaneousFitOutputName() const override { return ""; };
+  std::string singleFitOutputName(std::size_t index,
+                                  std::size_t spectrum) const override {
+    UNUSED_ARG(index);
+    UNUSED_ARG(spectrum);
+    return "";
+  };
 
-	std::vector<std::string> getSpectrumDependentAttributes() const override {
-		return{};
-	};
+  std::vector<std::string> getSpectrumDependentAttributes() const override {
+    return {};
+  };
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class IndirectDataTablePresenterTest : public CxxTest::TestSuite {
 public:
-	/// Needed to make sure everything is initialized
-	IndirectDataTablePresenterTest() { FrameworkManager::Instance(); }
+  /// Needed to make sure everything is initialized
+  IndirectDataTablePresenterTest() { FrameworkManager::Instance(); }
 
-	static IndirectDataTablePresenterTest *createSuite() {
-		return new IndirectDataTablePresenterTest();
-	}
+  static IndirectDataTablePresenterTest *createSuite() {
+    return new IndirectDataTablePresenterTest();
+  }
 
-	static void destroySuite(IndirectDataTablePresenterTest *suite) {
-		delete suite;
-	}
+  static void destroySuite(IndirectDataTablePresenterTest *suite) {
+    delete suite;
+  }
 
-	void setUp() override {
-		m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
-		createEmptyTableWidget(5, 5);
-		m_presenter = std::make_unique<IndirectDataTablePresenter>(std::move(m_model.get()), std::move(m_table.get()));
+  void setUp() override {
+    m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
+    createEmptyTableWidget(5, 5);
+    m_presenter = std::make_unique<IndirectDataTablePresenter>(
+        std::move(m_model.get()), std::move(m_table.get()));
 
-		SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
-		m_model->addWorkspace("WorkspaceName");
-	}
+    SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+    m_model->addWorkspace("WorkspaceName");
+  }
 
-	void tearDown() override {
-		AnalysisDataService::Instance().clear();
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
 
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_table.get()));
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_table.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
 
-		m_presenter.reset();
-		m_model.reset();
-		m_table.reset();
-	}
+    m_presenter.reset();
+    m_model.reset();
+    m_table.reset();
+  }
 
-	///----------------------------------------------------------------------
-	/// Unit tests to check for successful presenter instantiation
-	///----------------------------------------------------------------------
+  ///----------------------------------------------------------------------
+  /// Unit tests to check for successful presenter instantiation
+  ///----------------------------------------------------------------------
 
-	void test_that_the_model_has_been_instantiated_correctly() {
-		std::size_t const selectedSpectrum(3);
-		ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
+  void test_that_the_model_has_been_instantiated_correctly() {
+    std::size_t const selectedSpectrum(3);
+    ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
 
-		EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
 
-		m_model->isMultiFit();
-	}
+    m_model->isMultiFit();
+  }
 
-	void
-		test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
-		int const startXColumn(2);
+  void
+  test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
+    int const startXColumn(2);
 
-		m_presenter->setStartX(2.2, 0, 0);
+    m_presenter->setStartX(2.2, 0, 0);
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "2.2")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(),
+                       "2.2")
+  }
 
-	///----------------------------------------------------------------------
-	/// Unit Tests that test the signals call the correct methods
-	///----------------------------------------------------------------------
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the signals call the correct methods
+  ///----------------------------------------------------------------------
 
-	void test_that_the_cellChanged_signal_will_set_the_models_startX_when_the_relevant_column_is_changed() {
-		int const startXColumn(2);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_startX_when_the_relevant_column_is_changed() {
+    int const startXColumn(2);
 
-		EXPECT_CALL(*m_model, setStartX(2.0, 0, 0)).Times(1);
+    EXPECT_CALL(*m_model, setStartX(2.0, 0, 0)).Times(1);
 
-		m_table->item(0, startXColumn)->setText("2.0");
-	}
+    m_table->item(0, startXColumn)->setText("2.0");
+  }
 
-	void test_that_the_cellChanged_signal_will_set_the_models_endX_when_the_relevant_column_is_changed() {
-		int const endXColumn(3);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_endX_when_the_relevant_column_is_changed() {
+    int const endXColumn(3);
 
-		EXPECT_CALL(*m_model, setEndX(2.0, 0, 0)).Times(1);
+    EXPECT_CALL(*m_model, setEndX(2.0, 0, 0)).Times(1);
 
-		m_table->item(0, endXColumn)->setText("2.0");
-	}
+    m_table->item(0, endXColumn)->setText("2.0");
+  }
 
-	void test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_when_the_relevant_column_is_changed() {
-		int const excludeRegionColumn(4);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_when_the_relevant_column_is_changed() {
+    int const excludeRegionColumn(4);
 
-		EXPECT_CALL(*m_model, setExcludeRegion("0-4", 0, 0)).Times(1);
+    EXPECT_CALL(*m_model, setExcludeRegion("0-4", 0, 0)).Times(1);
 
-		m_table->item(0, excludeRegionColumn)->setText("0-4");
-	}
+    m_table->item(0, excludeRegionColumn)->setText("0-4");
+  }
 
-	void test_that_the_cellChanged_signal_will_set_the_models_startX_in_every_row_when_the_relevant_column_is_changed() {
-		int const startXColumn(2);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_startX_in_every_row_when_the_relevant_column_is_changed() {
+    int const startXColumn(2);
 
-		m_table->item(0, startXColumn)->setText("1.5");
+    m_table->item(0, startXColumn)->setText("1.5");
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.5")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(),
+                       "1.5")
+  }
 
-	void test_that_the_cellChanged_signal_will_set_the_models_endX_in_every_row_when_the_relevant_column_is_changed() {
-		int const endXColumn(3);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_endX_in_every_row_when_the_relevant_column_is_changed() {
+    int const endXColumn(3);
 
-		m_table->item(0, endXColumn)->setText("2.5");
+    m_table->item(0, endXColumn)->setText("2.5");
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(), "2.5")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(),
+                       "2.5")
+  }
 
-	void test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_in_every_row_when_the_relevant_column_is_changed() {
-		int const excludeRegionColumn(4);
+  void
+  test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_in_every_row_when_the_relevant_column_is_changed() {
+    int const excludeRegionColumn(4);
 
-		m_table->item(0, excludeRegionColumn)->setText("2-4");
+    m_table->item(0, excludeRegionColumn)->setText("2-4");
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-4")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(
+          m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-4")
+  }
 
-	///----------------------------------------------------------------------
-	/// Unit Tests that test the methods and slots of the presenter
-	///----------------------------------------------------------------------
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the methods and slots of the presenter
+  ///----------------------------------------------------------------------
 
-	void test_that_tableDatasetsMatchModel_returns_false_if_the_number_of_data_positions_is_not_equal_to_the_numberOfWorkspaces() {
-		std::size_t const numberOfWorkspaces(2);
-		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(numberOfWorkspaces));
+  void
+  test_that_tableDatasetsMatchModel_returns_false_if_the_number_of_data_positions_is_not_equal_to_the_numberOfWorkspaces() {
+    std::size_t const numberOfWorkspaces(2);
+    ON_CALL(*m_model, numberOfWorkspaces())
+        .WillByDefault(Return(numberOfWorkspaces));
 
-		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).WillOnce(Return(numberOfWorkspaces));
+    EXPECT_CALL(*m_model, numberOfWorkspaces())
+        .Times(1)
+        .WillOnce(Return(numberOfWorkspaces));
 
-		TS_ASSERT(!m_presenter->tableDatasetsMatchModel());
-	}
+    TS_ASSERT(!m_presenter->tableDatasetsMatchModel());
+  }
 
-	void test_that_tableDatasetsMatchModel_returns_true_if_the_table_datasets_match_the_model() {
-		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).WillOnce(Return(0));
-		TS_ASSERT(m_presenter->tableDatasetsMatchModel());
-	}
+  void
+  test_that_tableDatasetsMatchModel_returns_true_if_the_table_datasets_match_the_model() {
+    EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).WillOnce(Return(0));
+    TS_ASSERT(m_presenter->tableDatasetsMatchModel());
+  }
 
-	void test_that_addData_will_add_new_data_if_the_index_is_smaller_than_the_number_of_data_positions() {
-		std::size_t const index(0);
+  void
+  test_that_addData_will_add_new_data_if_the_index_is_smaller_than_the_number_of_data_positions() {
+    std::size_t const index(0);
 
-		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
+    ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
 
-		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1);
+    EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1);
 
-		ExpectationSet getRanges = EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
-		for (auto spectrum = 1; spectrum < m_table->rowCount(); ++spectrum)
-			getRanges += EXPECT_CALL(*m_model, getFittingRange(index, spectrum)).Times(1).After(getRanges);
+    ExpectationSet getRanges =
+        EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
+    for (auto spectrum = 1; spectrum < m_table->rowCount(); ++spectrum)
+      getRanges += EXPECT_CALL(*m_model, getFittingRange(index, spectrum))
+                       .Times(1)
+                       .After(getRanges);
 
-		m_presenter->addData(index);
-	}
+    m_presenter->addData(index);
+  }
 
-	void
-		test_that_the_setStartX_slot_will_alter_the_relevant_startX_column_in_the_table() {
-		int const startXColumn(2);
+  void
+  test_that_the_setStartX_slot_will_alter_the_relevant_startX_column_in_the_table() {
+    int const startXColumn(2);
 
-		m_presenter->setStartX(1.1, 0);
+    m_presenter->setStartX(1.1, 0);
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.1")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(),
+                       "1.1")
+  }
 
-	void
-		test_that_the_setEndX_slot_will_alter_the_relevant_endX_column_in_the_table() {
-		int const endXColumn(3);
+  void
+  test_that_the_setEndX_slot_will_alter_the_relevant_endX_column_in_the_table() {
+    int const endXColumn(3);
 
-		m_presenter->setEndX(1.1, 0);
+    m_presenter->setEndX(1.1, 0);
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(), "1.1")
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toStdString(),
+                       "1.1")
+  }
 
-	void
-		test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
-		int const excludeRegionColumn(4);
+  void
+  test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
+    int const excludeRegionColumn(4);
 
-		m_presenter->setExcludeRegion("2-3", 0);
+    m_presenter->setExcludeRegion("2-3", 0);
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-3")
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(
+          m_table->item(row, excludeRegionColumn)->text().toStdString(), "2-3")
+  }
 
-	}
+  void
+  test_that_setGlobalFittingRange_will_set_the_startX_and_endX_taken_from_the_fitting_range() {
+    std::size_t const index(0);
+    int const startXColumn(2);
+    int const endXColumn(3);
+    auto const range = std::make_pair(1.0, 2.0);
 
-	void test_that_setGlobalFittingRange_will_set_the_startX_and_endX_taken_from_the_fitting_range() {
-		std::size_t const index(0);
-		int const startXColumn(2);
-		int const endXColumn(3);
-		auto const range = std::make_pair(1.0, 2.0);
+    ON_CALL(*m_model, getFittingRange(index, 0)).WillByDefault(Return(range));
 
-		ON_CALL(*m_model, getFittingRange(index, 0))
-			.WillByDefault(Return(range));
+    EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
 
-		EXPECT_CALL(*m_model, getFittingRange(index, 0)).Times(1);
+    m_presenter->setGlobalFittingRange(true);
 
-		m_presenter->setGlobalFittingRange(true);
+    for (auto row = 0; row < m_table->rowCount(); ++row) {
+      TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toDouble(), 1.0)
+      TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toDouble(), 2.0)
+    }
+  }
 
-		for (auto row = 0; row < m_table->rowCount(); ++row) {
-			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toDouble(), 1.0)
-				TS_ASSERT_EQUALS(m_table->item(row, endXColumn)->text().toDouble(), 2.0)
-		}
-	}
+  void
+  test_that_setGlobalFittingRange_will_set_the_excludeRegion_when_passed_true() {
+    std::size_t const index(0);
+    int const excludeRegionColumn(4);
 
-	void test_that_setGlobalFittingRange_will_set_the_excludeRegion_when_passed_true() {
-		std::size_t const index(0);
-		int const excludeRegionColumn(4);
+    ON_CALL(*m_model, getExcludeRegion(index, 0)).WillByDefault(Return("1-2"));
 
-		ON_CALL(*m_model, getExcludeRegion(index, 0))
-			.WillByDefault(Return("1-2"));
+    EXPECT_CALL(*m_model, getExcludeRegion(index, 0)).Times(1);
 
-		EXPECT_CALL(*m_model, getExcludeRegion(index, 0)).Times(1);
+    m_presenter->setGlobalFittingRange(true);
 
-		m_presenter->setGlobalFittingRange(true);
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(
+          m_table->item(row, excludeRegionColumn)->text().toStdString(), "1-2");
+  }
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, excludeRegionColumn)->text().toStdString(), "1-2");
-	}
+  void
+  test_that_setGlobalFittingRange_will_connect_the_cellChanged_signal_to_updateAllFittingRangeFrom_when_passed_true() {
+    int const startXColumn(2);
 
-	void test_that_setGlobalFittingRange_will_connect_the_cellChanged_signal_to_updateAllFittingRangeFrom_when_passed_true() {
-		int const startXColumn(2);
+    m_presenter->setGlobalFittingRange(true);
+    m_table->item(0, startXColumn)->setText("1.5");
 
-		m_presenter->setGlobalFittingRange(true);
-		m_table->item(0, startXColumn)->setText("1.5");
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(),
+                       "1.5")
+  }
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(m_table->item(row, startXColumn)->text().toStdString(), "1.5")
-	}
+  void
+  test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_startX_is_not_global() {
+    int const startXColumn(2);
+    std::string const startX("2.5");
 
-	void test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_startX_is_not_global() {
-		int const startXColumn(2);
-		std::string const startX("2.5");
+    m_presenter->setGlobalFittingRange(false);
+    m_table->item(0, startXColumn)->setText(QString::fromStdString(startX));
 
-		m_presenter->setGlobalFittingRange(false);
-		m_table->item(0, startXColumn)->setText(QString::fromStdString(startX));
+    TS_ASSERT_EQUALS(m_table->item(0, startXColumn)->text().toStdString(),
+                     startX);
+    for (auto row = 1; row < m_table->rowCount(); ++row)
+      TS_ASSERT_DIFFERS(m_table->item(row, startXColumn)->text().toStdString(),
+                        startX)
+  }
 
-		TS_ASSERT_EQUALS(m_table->item(0, startXColumn)->text().toStdString(), startX);
-		for (auto row = 1; row < m_table->rowCount(); ++row)
-			TS_ASSERT_DIFFERS(m_table->item(row, startXColumn)->text().toStdString(), startX)
-	}
+  void
+  test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_endX_is_not_global() {
+    int const endXColumn(3);
+    std::string const endX("2.5");
 
-	void test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_endX_is_not_global() {
-		int const endXColumn(3);
-		std::string const endX("2.5");
+    m_presenter->setGlobalFittingRange(false);
+    m_table->item(0, endXColumn)->setText(QString::fromStdString(endX));
 
-		m_presenter->setGlobalFittingRange(false);
-		m_table->item(0, endXColumn)->setText(QString::fromStdString(endX));
+    TS_ASSERT_EQUALS(m_table->item(0, endXColumn)->text().toStdString(), endX);
+    for (auto row = 1; row < m_table->rowCount(); ++row)
+      TS_ASSERT_DIFFERS(m_table->item(row, endXColumn)->text().toStdString(),
+                        endX)
+  }
 
-		TS_ASSERT_EQUALS(m_table->item(0, endXColumn)->text().toStdString(), endX);
-		for (auto row = 1; row < m_table->rowCount(); ++row)
-			TS_ASSERT_DIFFERS(m_table->item(row, endXColumn)->text().toStdString(), endX)
-	}
+  void test_the_enableTable_slot_will_enable_the_table() {
+    m_presenter->disableTable();
+    m_presenter->enableTable();
 
-	void test_the_enableTable_slot_will_enable_the_table() {
-		m_presenter->disableTable();
-		m_presenter->enableTable();
+    TS_ASSERT(m_table->isEnabled());
+  }
 
-		TS_ASSERT(m_table->isEnabled());
-	}
+  void test_the_disableTable_slot_will_enable_the_table() {
+    m_presenter->enableTable();
+    m_presenter->disableTable();
 
-	void test_the_disableTable_slot_will_enable_the_table() {
-		m_presenter->enableTable();
-		m_presenter->disableTable();
+    TS_ASSERT(!m_table->isEnabled());
+  }
 
-		TS_ASSERT(!m_table->isEnabled());
-	}
-
-	void test_that_clearTable_will_clear_the_data_table() {
-		m_presenter->clearTable();
-		TS_ASSERT_EQUALS(m_table->rowCount(), 0);
-	}
+  void test_that_clearTable_will_clear_the_data_table() {
+    m_presenter->clearTable();
+    TS_ASSERT_EQUALS(m_table->rowCount(), 0);
+  }
 
 private:
-	/// Used in setup
-	void createEmptyTableWidget(int columns, int rows) {
-		m_table = std::make_unique<QTableWidget>(columns, rows);
-		for (auto column = 0; column < columns; ++column)
-			for (auto row = 0; row < rows; ++row)
-				m_table->setItem(row, column, new QTableWidgetItem("item"));
-	}
+  /// Used in setup
+  void createEmptyTableWidget(int columns, int rows) {
+    m_table = std::make_unique<QTableWidget>(columns, rows);
+    for (auto column = 0; column < columns; ++column)
+      for (auto row = 0; row < rows; ++row)
+        m_table->setItem(row, column, new QTableWidgetItem("item"));
+  }
 
-	std::unique_ptr<QTableWidget> m_table;
-	std::unique_ptr<MockIndirectDataTableModel> m_model;
-	std::unique_ptr<IndirectDataTablePresenter> m_presenter;
+  std::unique_ptr<QTableWidget> m_table;
+  std::unique_ptr<MockIndirectDataTableModel> m_model;
+  std::unique_ptr<IndirectDataTablePresenter> m_presenter;
 
-	SetUpADSWithWorkspace *m_ads;
+  SetUpADSWithWorkspace *m_ads;
 };
 
 #endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -80,7 +80,7 @@ public:
     m_presenter = std::make_unique<IndirectDataTablePresenter>(
         std::move(m_model.get()), std::move(m_table.get()));
 
-    SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+    SetUpADSWithWorkspace ads("WorkspaceName", createWorkspace(5));
     m_model->addWorkspace("WorkspaceName");
   }
 
@@ -100,7 +100,6 @@ public:
   ///----------------------------------------------------------------------
 
   void test_that_the_model_has_been_instantiated_correctly() {
-    std::size_t const selectedSpectrum(3);
     ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
 
     EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
@@ -364,8 +363,6 @@ private:
   std::unique_ptr<QTableWidget> m_table;
   std::unique_ptr<MockIndirectDataTableModel> m_model;
   std::unique_ptr<IndirectDataTablePresenter> m_presenter;
-
-  SetUpADSWithWorkspace *m_ads;
 };
 
 #endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -24,6 +24,14 @@ using namespace testing;
 
 namespace {
 
+std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+  auto table = std::make_unique<QTableWidget>(columns, rows);
+  for (auto column = 0; column < columns; ++column)
+    for (auto row = 0; row < rows; ++row)
+      table->setItem(row, column, new QTableWidgetItem("item"));
+  return table;
+}
+
 struct TableItem {
   TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
   TableItem(double const &value)
@@ -340,15 +348,6 @@ public:
   }
 
 private:
-  /// Used in setup
-  std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
-    auto table = std::make_unique<QTableWidget>(columns, rows);
-    for (auto column = 0; column < columns; ++column)
-      for (auto row = 0; row < rows; ++row)
-        table->setItem(row, column, new QTableWidgetItem("item"));
-    return table;
-  }
-
   void assertValueIsGlobal(int column, TableItem const &value) const {
     for (auto row = 0; row < m_table->rowCount(); ++row)
       TS_ASSERT_EQUALS(value, getTableItem(row, column));

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -131,12 +131,11 @@ public:
 
   void
   test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
-    int const startXColumn(2);
     TableItem const startX(2.2);
 
     m_presenter->setStartX(startX.asDouble(), 0, 0);
 
-    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
   }
 
   ///----------------------------------------------------------------------
@@ -163,32 +162,29 @@ public:
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_startX_in_every_row_when_the_relevant_column_is_changed() {
-    int const startXColumn(2);
     TableItem const startX(1.5);
 
-    m_table->item(0, startXColumn)->setText(startX.asQString());
+    m_table->item(0, START_X_COLUMN)->setText(startX.asQString());
 
-    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_endX_in_every_row_when_the_relevant_column_is_changed() {
-    int const endXColumn(3);
     TableItem const endX(2.5);
 
-    m_table->item(0, endXColumn)->setText(endX.asQString());
+    m_table->item(0, END_X_COLUMN)->setText(endX.asQString());
 
-    assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(END_X_COLUMN, endX);
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_in_every_row_when_the_relevant_column_is_changed() {
-    int const excludeRegionColumn(4);
     TableItem const excludeRegion("2-4");
 
-    m_table->item(0, excludeRegionColumn)->setText(excludeRegion.asQString());
+    m_table->item(0, EXCLUDE_REGION_COLUMN)->setText(excludeRegion.asQString());
 
-    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(EXCLUDE_REGION_COLUMN, excludeRegion);
   }
 
   ///----------------------------------------------------------------------
@@ -234,39 +230,34 @@ public:
 
   void
   test_that_the_setStartX_slot_will_alter_the_relevant_startX_column_in_the_table() {
-    int const startXColumn(2);
     TableItem const startX(1.1);
 
     m_presenter->setStartX(startX.asDouble(), 0);
 
-    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
   }
 
   void
   test_that_the_setEndX_slot_will_alter_the_relevant_endX_column_in_the_table() {
-    int const endXColumn(3);
     TableItem const endX(1.1);
 
     m_presenter->setEndX(endX.asDouble(), 0);
 
-    assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(END_X_COLUMN, endX);
   }
 
   void
   test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
-    int const excludeRegionColumn(4);
     TableItem const excludeRegion("2-3");
 
     m_presenter->setExcludeRegion(excludeRegion.asString(), 0);
 
-    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(EXCLUDE_REGION_COLUMN, excludeRegion);
   }
 
   void
   test_that_setGlobalFittingRange_will_set_the_startX_and_endX_taken_from_the_fitting_range() {
     std::size_t const index(0);
-    int const startXColumn(2);
-    int const endXColumn(3);
     TableItem const startX(1.0);
     TableItem const endX(2.0);
     auto const range = std::make_pair(startX.asDouble(), endX.asDouble());
@@ -277,14 +268,13 @@ public:
 
     m_presenter->setGlobalFittingRange(true);
 
-    assertValueIsGlobal(startXColumn, startX);
-    assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
+    assertValueIsGlobal(END_X_COLUMN, endX);
   }
 
   void
   test_that_setGlobalFittingRange_will_set_the_excludeRegion_when_passed_true() {
     std::size_t const index(0);
-    int const excludeRegionColumn(4);
     TableItem const excludeRegion("1-2");
 
     ON_CALL(*m_model, getExcludeRegion(index, 0)).WillByDefault(Return("1-2"));
@@ -293,42 +283,39 @@ public:
 
     m_presenter->setGlobalFittingRange(true);
 
-    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(EXCLUDE_REGION_COLUMN, excludeRegion);
   }
 
   void
   test_that_setGlobalFittingRange_will_connect_the_cellChanged_signal_to_updateAllFittingRangeFrom_when_passed_true() {
-    int const startXColumn(2);
     TableItem const startX(1.0);
 
     m_presenter->setGlobalFittingRange(true);
-    m_table->item(0, startXColumn)->setText(startX.asQString());
+    m_table->item(0, START_X_COLUMN)->setText(startX.asQString());
 
-    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
   }
 
   void
   test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_startX_is_not_global() {
     int const row(1);
-    int const startXColumn(2);
     TableItem const startX(2.5);
 
     m_presenter->setGlobalFittingRange(false);
-    m_table->item(row, startXColumn)->setText(startX.asQString());
+    m_table->item(row, START_X_COLUMN)->setText(startX.asQString());
 
-    assertValueIsNotGlobal(row, startXColumn, startX);
+    assertValueIsNotGlobal(row, START_X_COLUMN, startX);
   }
 
   void
   test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_endX_is_not_global() {
     int const row(0);
-    int const endXColumn(3);
     TableItem const endX(3.5);
 
     m_presenter->setGlobalFittingRange(false);
-    m_table->item(row, endXColumn)->setText(endX.asQString());
+    m_table->item(row, END_X_COLUMN)->setText(endX.asQString());
 
-    assertValueIsNotGlobal(row, endXColumn, endX);
+    assertValueIsNotGlobal(row, END_X_COLUMN, endX);
   }
 
   void test_the_enableTable_slot_will_enable_the_table() {

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -98,7 +98,7 @@ public:
 
   void setUp() override {
     m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
-    createEmptyTableWidget(5, 5);
+    m_table = createEmptyTableWidget(5, 5);
     m_presenter = std::make_unique<IndirectDataTablePresenter>(
         std::move(m_model.get()), std::move(m_table.get()));
 
@@ -145,29 +145,20 @@ public:
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_startX_when_the_relevant_column_is_changed() {
-    int const startXColumn(2);
-
     EXPECT_CALL(*m_model, setStartX(2.0, 0, 0)).Times(1);
-
-    m_table->item(0, startXColumn)->setText("2.0");
+    m_table->item(0, START_X_COLUMN)->setText("2.0");
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_endX_when_the_relevant_column_is_changed() {
-    int const endXColumn(3);
-
     EXPECT_CALL(*m_model, setEndX(2.0, 0, 0)).Times(1);
-
-    m_table->item(0, endXColumn)->setText("2.0");
+    m_table->item(0, END_X_COLUMN)->setText("2.0");
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_when_the_relevant_column_is_changed() {
-    int const excludeRegionColumn(4);
-
     EXPECT_CALL(*m_model, setExcludeRegion("0-4", 0, 0)).Times(1);
-
-    m_table->item(0, excludeRegionColumn)->setText("0-4");
+    m_table->item(0, EXCLUDE_REGION_COLUMN)->setText("0-4");
   }
 
   void
@@ -342,15 +333,17 @@ public:
 
   void test_the_enableTable_slot_will_enable_the_table() {
     m_presenter->disableTable();
-    m_presenter->enableTable();
+    TS_ASSERT(!m_table->isEnabled());
 
+    m_presenter->enableTable();
     TS_ASSERT(m_table->isEnabled());
   }
 
   void test_the_disableTable_slot_will_enable_the_table() {
     m_presenter->enableTable();
-    m_presenter->disableTable();
+    TS_ASSERT(m_table->isEnabled());
 
+    m_presenter->disableTable();
     TS_ASSERT(!m_table->isEnabled());
   }
 
@@ -361,11 +354,12 @@ public:
 
 private:
   /// Used in setup
-  void createEmptyTableWidget(int columns, int rows) {
-    m_table = std::make_unique<QTableWidget>(columns, rows);
+  std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+    auto table = std::make_unique<QTableWidget>(columns, rows);
     for (auto column = 0; column < columns; ++column)
       for (auto row = 0; row < rows; ++row)
-        m_table->setItem(row, column, new QTableWidgetItem("item"));
+        table->setItem(row, column, new QTableWidgetItem("item"));
+    return table;
   }
 
   void assertValueIsGlobal(int column, TableItem const &value) const {

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataTablePresenterTest.h
@@ -24,23 +24,23 @@ using namespace testing;
 
 namespace {
 
-	struct TableItem {
-		TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
-		TableItem(double const &value)
-			: m_str(QString::number(value, 'g', 16).toStdString()), m_dbl(value) {}
+struct TableItem {
+  TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
+  TableItem(double const &value)
+      : m_str(QString::number(value, 'g', 16).toStdString()), m_dbl(value) {}
 
-		std::string const &asString() const { return m_str; }
-		QString asQString() const { return QString::fromStdString(m_str); }
-		double const &asDouble() const { return m_dbl; }
+  std::string const &asString() const { return m_str; }
+  QString asQString() const { return QString::fromStdString(m_str); }
+  double const &asDouble() const { return m_dbl; }
 
-		bool operator==(std::string const &value) const {
-			return this->asString() == value;
-		}
+  bool operator==(std::string const &value) const {
+    return this->asString() == value;
+  }
 
-	private:
-		std::string m_str;
-		double m_dbl;
-	};
+private:
+  std::string m_str;
+  double m_dbl;
+};
 
 } // namespace
 
@@ -132,11 +132,11 @@ public:
   void
   test_that_invoking_setStartX_will_alter_the_relevant_column_in_the_table() {
     int const startXColumn(2);
-		TableItem const startX(2.2);
+    TableItem const startX(2.2);
 
     m_presenter->setStartX(startX.asDouble(), 0, 0);
 
-		assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(startXColumn, startX);
   }
 
   ///----------------------------------------------------------------------
@@ -173,31 +173,31 @@ public:
   void
   test_that_the_cellChanged_signal_will_set_the_models_startX_in_every_row_when_the_relevant_column_is_changed() {
     int const startXColumn(2);
-		TableItem const startX(1.5);
+    TableItem const startX(1.5);
 
     m_table->item(0, startXColumn)->setText(startX.asQString());
 
-		assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(startXColumn, startX);
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_endX_in_every_row_when_the_relevant_column_is_changed() {
     int const endXColumn(3);
-		TableItem const endX(2.5);
+    TableItem const endX(2.5);
 
     m_table->item(0, endXColumn)->setText(endX.asQString());
 
-		assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(endXColumn, endX);
   }
 
   void
   test_that_the_cellChanged_signal_will_set_the_models_excludeRegion_in_every_row_when_the_relevant_column_is_changed() {
     int const excludeRegionColumn(4);
-		TableItem const excludeRegion("2-4");
+    TableItem const excludeRegion("2-4");
 
-		m_table->item(0, excludeRegionColumn)->setText(excludeRegion.asQString());
+    m_table->item(0, excludeRegionColumn)->setText(excludeRegion.asQString());
 
-		assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
   }
 
   ///----------------------------------------------------------------------
@@ -244,31 +244,31 @@ public:
   void
   test_that_the_setStartX_slot_will_alter_the_relevant_startX_column_in_the_table() {
     int const startXColumn(2);
-		TableItem const startX(1.1);
+    TableItem const startX(1.1);
 
     m_presenter->setStartX(startX.asDouble(), 0);
 
-		assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(startXColumn, startX);
   }
 
   void
   test_that_the_setEndX_slot_will_alter_the_relevant_endX_column_in_the_table() {
     int const endXColumn(3);
-		TableItem const endX(1.1);
+    TableItem const endX(1.1);
 
     m_presenter->setEndX(endX.asDouble(), 0);
 
-		assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(endXColumn, endX);
   }
 
   void
   test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
     int const excludeRegionColumn(4);
-		TableItem const excludeRegion("2-3");
+    TableItem const excludeRegion("2-3");
 
     m_presenter->setExcludeRegion(excludeRegion.asString(), 0);
 
-		assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
   }
 
   void
@@ -276,8 +276,8 @@ public:
     std::size_t const index(0);
     int const startXColumn(2);
     int const endXColumn(3);
-		TableItem const startX(1.0);
-		TableItem const endX(2.0);
+    TableItem const startX(1.0);
+    TableItem const endX(2.0);
     auto const range = std::make_pair(startX.asDouble(), endX.asDouble());
 
     ON_CALL(*m_model, getFittingRange(index, 0)).WillByDefault(Return(range));
@@ -286,15 +286,15 @@ public:
 
     m_presenter->setGlobalFittingRange(true);
 
-		assertValueIsGlobal(startXColumn, startX);
-		assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(endXColumn, endX);
   }
 
   void
   test_that_setGlobalFittingRange_will_set_the_excludeRegion_when_passed_true() {
     std::size_t const index(0);
     int const excludeRegionColumn(4);
-		TableItem const excludeRegion("1-2");
+    TableItem const excludeRegion("1-2");
 
     ON_CALL(*m_model, getExcludeRegion(index, 0)).WillByDefault(Return("1-2"));
 
@@ -302,42 +302,42 @@ public:
 
     m_presenter->setGlobalFittingRange(true);
 
-		assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
   }
 
   void
   test_that_setGlobalFittingRange_will_connect_the_cellChanged_signal_to_updateAllFittingRangeFrom_when_passed_true() {
     int const startXColumn(2);
-		TableItem const startX(1.0);
+    TableItem const startX(1.0);
 
     m_presenter->setGlobalFittingRange(true);
     m_table->item(0, startXColumn)->setText(startX.asQString());
 
-		assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(startXColumn, startX);
   }
 
   void
   test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_startX_is_not_global() {
-		int const row(1);
+    int const row(1);
     int const startXColumn(2);
-		TableItem const startX(2.5);
+    TableItem const startX(2.5);
 
     m_presenter->setGlobalFittingRange(false);
     m_table->item(row, startXColumn)->setText(startX.asQString());
 
-		assertValueIsNotGlobal(row, startXColumn, startX);
+    assertValueIsNotGlobal(row, startXColumn, startX);
   }
 
   void
   test_that_setGlobalFittingRange_will_disconnect_the_cellChanged_signal_when_passed_false_so_that_endX_is_not_global() {
-		int const row(0);
+    int const row(0);
     int const endXColumn(3);
-		TableItem const endX(3.5);
+    TableItem const endX(3.5);
 
     m_presenter->setGlobalFittingRange(false);
     m_table->item(row, endXColumn)->setText(endX.asQString());
 
-		assertValueIsNotGlobal(row, endXColumn, endX);
+    assertValueIsNotGlobal(row, endXColumn, endX);
   }
 
   void test_the_enableTable_slot_will_enable_the_table() {
@@ -368,22 +368,23 @@ private:
         m_table->setItem(row, column, new QTableWidgetItem("item"));
   }
 
-	void assertValueIsGlobal(int column, TableItem const &value) const {
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(value, getTableItem(row, column));
-	}
+  void assertValueIsGlobal(int column, TableItem const &value) const {
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(value, getTableItem(row, column));
+  }
 
-	void assertValueIsNotGlobal(int valueRow, int column, TableItem const &value) const {
-		TS_ASSERT_EQUALS(value.asString(), getTableItem(valueRow, column));
+  void assertValueIsNotGlobal(int valueRow, int column,
+                              TableItem const &value) const {
+    TS_ASSERT_EQUALS(value.asString(), getTableItem(valueRow, column));
 
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			if (row != valueRow)
-			  TS_ASSERT_DIFFERS(value, getTableItem(row, column));
-	}
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      if (row != valueRow)
+        TS_ASSERT_DIFFERS(value, getTableItem(row, column));
+  }
 
-	std::string getTableItem(int row, int column) const {
-		return m_table->item(row, column)->text().toStdString();
-	}
+  std::string getTableItem(int row, int column) const {
+    return m_table->item(row, column)->text().toStdString();
+  }
 
   std::unique_ptr<QTableWidget> m_table;
   std::unique_ptr<MockIndirectDataTableModel> m_model;

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -1,0 +1,73 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_INDIRECTFITDATAPRESENTERTEST_H_
+#define MANTIDQT_INDIRECTFITDATAPRESENTERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "IndirectFitDataPresenter.h"
+#include "IndirectFitDataView.h"
+#include "IndirectFittingModel.h"
+
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidKernel/WarningSuppressions.h"
+
+using namespace Mantid::API;
+using namespace MantidQt::CustomInterfaces::IDA;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockIndirectFitDataView : public IndirectFitDataView {
+public:
+};
+
+class MockIndirectFitDataModel : public IndirectFittingModel {
+public:
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+class IndirectFitDataPresenterTest : public CxxTest::TestSuite {
+public:
+	/// Needed to make sure everything is initialized
+	IndirectFitDataPresenterTest() { FrameworkManager::Instance(); }
+
+	static IndirectFitDataPresenterTest *createSuite() {
+		return new IndirectFitDataPresenterTest();
+	}
+
+	static void destroySuite(IndirectFitDataPresenterTest *suite) {
+		delete suite;
+	}
+
+	void setUp() override {
+		//m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
+		//createEmptyTableWidget(5, 5);
+		//m_presenter = std::make_unique<IndirectDataTablePresenter>(
+		//	std::move(m_model.get()), std::move(m_table.get()));
+
+		//SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+		//m_model->addWorkspace("WorkspaceName");
+	}
+
+	void tearDown() override {
+		//AnalysisDataService::Instance().clear();
+
+		//TS_ASSERT(Mock::VerifyAndClearExpectations(m_table.get()));
+		//TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+
+		//m_presenter.reset();
+		//m_model.reset();
+		//m_table.reset();
+	}
+
+	void test_test() {}
+
+};
+
+#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -84,7 +84,7 @@ public:
 /// Mock object to mock the model
 class MockIndirectFitDataModel : public IndirectFittingModel {
 public:
-	using IndirectFittingModel::addWorkspace;
+  using IndirectFittingModel::addWorkspace;
 
   /// Public Methods
   MOCK_CONST_METHOD0(isMultiFit, bool());

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -271,13 +271,13 @@ public:
 
 private:
   /// Used in setup
-	std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
-		auto table = std::make_unique<QTableWidget>(columns, rows);
-		for (auto column = 0; column < columns; ++column)
-			for (auto row = 0; row < rows; ++row)
-				table->setItem(row, column, new QTableWidgetItem("item"));
-		return table;
-	}
+  std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+    auto table = std::make_unique<QTableWidget>(columns, rows);
+    for (auto column = 0; column < columns; ++column)
+      for (auto row = 0; row < rows; ++row)
+        table->setItem(row, column, new QTableWidgetItem("item"));
+    return table;
+  }
 
   void deleteSetup() {
     m_presenter.reset();

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -37,17 +37,17 @@ public:
 	//	emit resolutionLoaded(name);
 	//}
 
-	void emitAddClicked() {
-		emit addClicked();
-	}
+	//void emitAddClicked() {
+	//	emit addClicked();
+	//}
 
-	void emitRemoveClicked() {
-		emit removeClicked();
-	}
+	//void emitRemoveClicked() {
+	//	emit removeClicked();
+	//}
 
-	void emitMultipleDataViewSelected() {
-		emit multipleDataViewSelected();
-	}
+	//void emitMultipleDataViewSelected() {
+	//	emit multipleDataViewSelected();
+	//}
 
 	void emitSingleDataViewSelected() {
 		emit singleDataViewSelected();
@@ -56,6 +56,14 @@ public:
 	/// Public Methods
 	MOCK_CONST_METHOD0(getSelectedSample, std::string());
 	MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
+
+	MOCK_CONST_METHOD0(getSampleWSSuffices, QStringList());
+	MOCK_CONST_METHOD0(getSampleFBSuffices, QStringList());
+
+	MOCK_METHOD1(setSampleWSSuffices, void(QStringList const &suffices));
+	MOCK_METHOD1(setSampleFBSuffices, void(QStringList const &suffices));
+	MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
+	MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
 
 	/// Public Slots
 
@@ -152,7 +160,7 @@ public:
 	}
 
 	///----------------------------------------------------------------------
-	/// Unit Tests that test the signals call the correct methods
+	/// Unit Tests that test the signals, methods and slots of the presenter
 	///----------------------------------------------------------------------
 
 	void test_that_the_sampleLoaded_signal_will_add_the_loaded_workspace_to_the_model() {
@@ -163,6 +171,49 @@ public:
 		
 		m_view->emitSampleLoaded(QString::fromStdString(workspaceName));
 	}
+
+	void test_that_setSampleWSSuffices_will_set_the_sample_workspace_suffices_in_the_view() {
+		QStringList const suffices{"suffix1", "suffix2"};
+		
+		EXPECT_CALL(*m_view, setSampleWSSuffices(suffices)).Times(1);
+
+		m_presenter->setSampleWSSuffices(suffices);
+	}
+
+	void test_that_setSampleFBSuffices_will_set_the_sample_file_browser_suffices_in_the_view() {
+		QStringList const suffices{ "suffix1", "suffix2" };
+
+		EXPECT_CALL(*m_view, setSampleFBSuffices(suffices)).Times(1);
+
+		m_presenter->setSampleFBSuffices(suffices);
+	}
+
+	void test_that_setResolutionWSSuffices_will_set_the_resolution_workspace_suffices_in_the_view() {
+		QStringList const suffices{ "suffix1", "suffix2" };
+
+		EXPECT_CALL(*m_view, setResolutionWSSuffices(suffices)).Times(1);
+
+		m_presenter->setResolutionWSSuffices(suffices);
+	}
+
+	void test_that_setSampleFBSuffices_will_set_the_resolution_file_browser_suffices_in_the_view() {
+		QStringList const suffices{ "suffix1", "suffix2" };
+
+		EXPECT_CALL(*m_view, setResolutionFBSuffices(suffices)).Times(1);
+
+		m_presenter->setResolutionFBSuffices(suffices);
+	}
+
+
+	//void test_that_the_addClicked_signal_will_get_the_allowed_workspace_suffixes_from_the_view() {
+	//
+	//	EXPECT_CALL(*m_view, getSampleWSSuffices()).Times(1);
+	//	EXPECT_CALL(*m_view, getSampleFBSuffices()).Times(1);
+
+	//	m_view->emitAddClicked();
+	//}
+
+
 
 	void test_test() {}
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -10,10 +10,10 @@
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
-#include "IndirectFitDataPresenter.h"
 #include "IIndirectFitDataView.h"
-#include "IndirectFittingModel.h"
 #include "IndirectDataTablePresenter.h"
+#include "IndirectFitDataPresenter.h"
+#include "IndirectFittingModel.h"
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -27,274 +27,284 @@ using namespace testing;
 
 namespace {
 
-	struct TableItem {
-		TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
-		TableItem(double const &value) : m_str(QString::number(value, 'g', 16).toStdString()), m_dbl(value) {}
+struct TableItem {
+  TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
+  TableItem(double const &value)
+      : m_str(QString::number(value, 'g', 16).toStdString()), m_dbl(value) {}
 
-		std::string const &asString() const { return m_str; }
-		double const &asDouble() const { return m_dbl; }
+  std::string const &asString() const { return m_str; }
+  double const &asDouble() const { return m_dbl; }
 
-		bool operator==(std::string const &value) const {
-			return this->asString() == value;
-		}
+  bool operator==(std::string const &value) const {
+    return this->asString() == value;
+  }
 
-	private:
-		std::string m_str;
-		double m_dbl;
-	};
+private:
+  std::string m_str;
+  double m_dbl;
+};
 
-}
+} // namespace
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the view
 class MockIIndirectFitDataView : public IIndirectFitDataView {
 public:
-	/// Signals
-	void emitSampleLoaded(QString const &name) {
-		emit sampleLoaded(name);
-	}
+  /// Signals
+  void emitSampleLoaded(QString const &name) { emit sampleLoaded(name); }
 
-	/// Public Methods
-	MOCK_CONST_METHOD0(getDataTable, QTableWidget*());
-	MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
-	MOCK_CONST_METHOD0(isResolutionHidden, bool());
-	MOCK_METHOD1(setResolutionHidden, void(bool hide));
-	MOCK_METHOD0(disableMultipleDataTab, void());
+  /// Public Methods
+  MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
+  MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
+  MOCK_CONST_METHOD0(isResolutionHidden, bool());
+  MOCK_METHOD1(setResolutionHidden, void(bool hide));
+  MOCK_METHOD0(disableMultipleDataTab, void());
 
-	MOCK_CONST_METHOD0(getSelectedSample, std::string());
-	MOCK_CONST_METHOD0(getSelectedResolution, std::string());
+  MOCK_CONST_METHOD0(getSelectedSample, std::string());
+  MOCK_CONST_METHOD0(getSelectedResolution, std::string());
 
-	MOCK_CONST_METHOD0(getSampleWSSuffices, QStringList());
-	MOCK_CONST_METHOD0(getSampleFBSuffices, QStringList());
-	MOCK_CONST_METHOD0(getResolutionWSSuffices, QStringList());
-	MOCK_CONST_METHOD0(getResolutionFBSuffices, QStringList());
+  MOCK_CONST_METHOD0(getSampleWSSuffices, QStringList());
+  MOCK_CONST_METHOD0(getSampleFBSuffices, QStringList());
+  MOCK_CONST_METHOD0(getResolutionWSSuffices, QStringList());
+  MOCK_CONST_METHOD0(getResolutionFBSuffices, QStringList());
 
-	MOCK_METHOD1(setSampleWSSuffices, void(QStringList const &suffices));
-	MOCK_METHOD1(setSampleFBSuffices, void(QStringList const &suffices));
-	MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
-	MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setSampleWSSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setSampleFBSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
+  MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
 
-	MOCK_METHOD1(readSettings, void(QSettings const &settings));
-	MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
+  MOCK_METHOD1(readSettings, void(QSettings const &settings));
+  MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
 
-	/// Public slots
-	MOCK_METHOD1(displayWarning, void(std::string const &warning));
+  /// Public slots
+  MOCK_METHOD1(displayWarning, void(std::string const &warning));
 };
 
 /// Mock object to mock the model
 class MockIndirectFitDataModel : public IndirectFittingModel {
 public:
-	/// Public Methods
-	MOCK_CONST_METHOD0(isMultiFit, bool());
-	MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
+  /// Public Methods
+  MOCK_CONST_METHOD0(isMultiFit, bool());
+  MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
 
-	MOCK_METHOD1(addWorkspace, void(std::string const &workspaceName));
+  MOCK_METHOD1(addWorkspace, void(std::string const &workspaceName));
 
 private:
-	std::string sequentialFitOutputName() const override { return ""; };
-	std::string simultaneousFitOutputName() const override { return ""; };
-	std::string singleFitOutputName(std::size_t index,
-		std::size_t spectrum) const override {
-		UNUSED_ARG(index);
-		UNUSED_ARG(spectrum);
-		return "";
-	};
+  std::string sequentialFitOutputName() const override { return ""; };
+  std::string simultaneousFitOutputName() const override { return ""; };
+  std::string singleFitOutputName(std::size_t index,
+                                  std::size_t spectrum) const override {
+    UNUSED_ARG(index);
+    UNUSED_ARG(spectrum);
+    return "";
+  };
 
-	std::vector<std::string> getSpectrumDependentAttributes() const override {
-		return{};
-	};
+  std::vector<std::string> getSpectrumDependentAttributes() const override {
+    return {};
+  };
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 
 class IndirectFitDataPresenterTest : public CxxTest::TestSuite {
 public:
-	/// Needed to make sure everything is initialized
-	IndirectFitDataPresenterTest() { FrameworkManager::Instance(); }
+  /// Needed to make sure everything is initialized
+  IndirectFitDataPresenterTest() { FrameworkManager::Instance(); }
 
-	static IndirectFitDataPresenterTest *createSuite() {
-		return new IndirectFitDataPresenterTest();
-	}
+  static IndirectFitDataPresenterTest *createSuite() {
+    return new IndirectFitDataPresenterTest();
+  }
 
-	static void destroySuite(IndirectFitDataPresenterTest *suite) {
-		delete suite;
-	}
+  static void destroySuite(IndirectFitDataPresenterTest *suite) {
+    delete suite;
+  }
 
-	void setUp() override {
-		m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
-		m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
-		createEmptyTableWidget(5, 5);
+  void setUp() override {
+    m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
+    m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
+    createEmptyTableWidget(5, 5);
 
-		m_dataTablePresenter = std::make_unique<IndirectDataTablePresenter>(
-			std::move(m_model.get()), std::move(m_table.get()));
-		m_presenter = std::make_unique<IndirectFitDataPresenter>(
-			std::move(m_model.get()), std::move(m_view.get()), std::move(m_dataTablePresenter));
+    m_dataTablePresenter = std::make_unique<IndirectDataTablePresenter>(
+        std::move(m_model.get()), std::move(m_table.get()));
+    m_presenter = std::make_unique<IndirectFitDataPresenter>(
+        std::move(m_model.get()), std::move(m_view.get()),
+        std::move(m_dataTablePresenter));
 
-		SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
-		m_model->addWorkspace("WorkspaceName");
-	}
+    SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+    m_model->addWorkspace("WorkspaceName");
+  }
 
-	void tearDown() override {
-		AnalysisDataService::Instance().clear();
+  void tearDown() override {
+    AnalysisDataService::Instance().clear();
 
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
-		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
 
-		deleteSetup();
-	}
+    deleteSetup();
+  }
 
-	///----------------------------------------------------------------------
-	/// Unit tests to check for successful mock object instantiation
-	///----------------------------------------------------------------------
+  ///----------------------------------------------------------------------
+  /// Unit tests to check for successful mock object instantiation
+  ///----------------------------------------------------------------------
 
-	void test_that_the_model_has_been_instantiated_correctly() {
-		ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
+  void test_that_the_model_has_been_instantiated_correctly() {
+    ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
 
-		EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
 
-		m_model->isMultiFit();
-	}
+    m_model->isMultiFit();
+  }
 
-	void test_that_the_view_has_been_instantiated_correctly() {
-		std::string const sampleName("SampleName_red");
-		ON_CALL(*m_view, getSelectedSample()).WillByDefault(Return(sampleName));
+  void test_that_the_view_has_been_instantiated_correctly() {
+    std::string const sampleName("SampleName_red");
+    ON_CALL(*m_view, getSelectedSample()).WillByDefault(Return(sampleName));
 
-		EXPECT_CALL(*m_view, getSelectedSample()).Times(1).WillOnce(Return(sampleName));
+    EXPECT_CALL(*m_view, getSelectedSample())
+        .Times(1)
+        .WillOnce(Return(sampleName));
 
-		m_view->getSelectedSample();
-	}
+    m_view->getSelectedSample();
+  }
 
-	void
-		test_that_invoking_a_presenter_method_will_call_the_relevant_methods_in_the_view_and_model() {
-		ON_CALL(*m_view, isMultipleDataTabSelected()).WillByDefault(Return(true));
-		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
+  void
+  test_that_invoking_a_presenter_method_will_call_the_relevant_methods_in_the_view_and_model() {
+    ON_CALL(*m_view, isMultipleDataTabSelected()).WillByDefault(Return(true));
+    ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
 
-		Expectation isMultipleData = EXPECT_CALL(*m_view, isMultipleDataTabSelected()).Times(1).WillOnce(Return(true));
-		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).After(isMultipleData);
+    Expectation isMultipleData =
+        EXPECT_CALL(*m_view, isMultipleDataTabSelected())
+            .Times(1)
+            .WillOnce(Return(true));
+    EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).After(isMultipleData);
 
-		m_presenter->updateSpectraInTable(0);
-	}
+    m_presenter->updateSpectraInTable(0);
+  }
 
-	///----------------------------------------------------------------------
-	/// Unit Tests that test the signals, methods and slots of the presenter
-	///----------------------------------------------------------------------
+  ///----------------------------------------------------------------------
+  /// Unit Tests that test the signals, methods and slots of the presenter
+  ///----------------------------------------------------------------------
 
-	void test_that_the_sampleLoaded_signal_will_add_the_loaded_workspace_to_the_model() {
-		std::string const workspaceName("WorkspaceName2");
-		m_ads->addOrReplace(workspaceName, createWorkspace(5));
+  void
+  test_that_the_sampleLoaded_signal_will_add_the_loaded_workspace_to_the_model() {
+    std::string const workspaceName("WorkspaceName2");
+    m_ads->addOrReplace(workspaceName, createWorkspace(5));
 
-		EXPECT_CALL(*m_model, addWorkspace(workspaceName)).Times(Exactly(1));
+    EXPECT_CALL(*m_model, addWorkspace(workspaceName)).Times(Exactly(1));
 
-		m_view->emitSampleLoaded(QString::fromStdString(workspaceName));
-	}
+    m_view->emitSampleLoaded(QString::fromStdString(workspaceName));
+  }
 
-	void test_that_setSampleWSSuffices_will_set_the_sample_workspace_suffices_in_the_view() {
-		QStringList const suffices{ "suffix1", "suffix2" };
+  void
+  test_that_setSampleWSSuffices_will_set_the_sample_workspace_suffices_in_the_view() {
+    QStringList const suffices{"suffix1", "suffix2"};
 
-		EXPECT_CALL(*m_view, setSampleWSSuffices(suffices)).Times(Exactly(1));
+    EXPECT_CALL(*m_view, setSampleWSSuffices(suffices)).Times(Exactly(1));
 
-		m_presenter->setSampleWSSuffices(suffices);
-	}
+    m_presenter->setSampleWSSuffices(suffices);
+  }
 
-	void test_that_setSampleFBSuffices_will_set_the_sample_file_browser_suffices_in_the_view() {
-		QStringList const suffices{ "suffix1", "suffix2" };
+  void
+  test_that_setSampleFBSuffices_will_set_the_sample_file_browser_suffices_in_the_view() {
+    QStringList const suffices{"suffix1", "suffix2"};
 
-		EXPECT_CALL(*m_view, setSampleFBSuffices(suffices)).Times(Exactly(1));
+    EXPECT_CALL(*m_view, setSampleFBSuffices(suffices)).Times(Exactly(1));
 
-		m_presenter->setSampleFBSuffices(suffices);
-	}
+    m_presenter->setSampleFBSuffices(suffices);
+  }
 
-	void test_that_setResolutionWSSuffices_will_set_the_resolution_workspace_suffices_in_the_view() {
-		QStringList const suffices{ "suffix1", "suffix2" };
+  void
+  test_that_setResolutionWSSuffices_will_set_the_resolution_workspace_suffices_in_the_view() {
+    QStringList const suffices{"suffix1", "suffix2"};
 
-		EXPECT_CALL(*m_view, setResolutionWSSuffices(suffices)).Times(Exactly(1));
+    EXPECT_CALL(*m_view, setResolutionWSSuffices(suffices)).Times(Exactly(1));
 
-		m_presenter->setResolutionWSSuffices(suffices);
-	}
+    m_presenter->setResolutionWSSuffices(suffices);
+  }
 
-	void test_that_setResolutionFBSuffices_will_set_the_resolution_file_browser_suffices_in_the_view() {
-		QStringList const suffices{ "suffix1", "suffix2" };
+  void
+  test_that_setResolutionFBSuffices_will_set_the_resolution_file_browser_suffices_in_the_view() {
+    QStringList const suffices{"suffix1", "suffix2"};
 
-		EXPECT_CALL(*m_view, setResolutionFBSuffices(suffices)).Times(Exactly(1));
+    EXPECT_CALL(*m_view, setResolutionFBSuffices(suffices)).Times(Exactly(1));
 
-		m_presenter->setResolutionFBSuffices(suffices);
-	}
+    m_presenter->setResolutionFBSuffices(suffices);
+  }
 
-	void
-		test_that_setStartX_will_alter_the_relevant_startX_column_in_the_data_table() {
-		int const startXColumn(2);
-		TableItem const startX(2.3);
+  void
+  test_that_setStartX_will_alter_the_relevant_startX_column_in_the_data_table() {
+    int const startXColumn(2);
+    TableItem const startX(2.3);
 
-		m_presenter->setStartX(startX.asDouble(), 0, 0);
+    m_presenter->setStartX(startX.asDouble(), 0, 0);
 
-		assertValueIsGlobal(startXColumn, startX);
-	}
+    assertValueIsGlobal(startXColumn, startX);
+  }
 
-	void
-		test_that_setEndX_will_alter_the_relevant_endX_column_in_the_data_table() {
-		int const endXColumn(3);
-		TableItem const endX(5.5);
+  void
+  test_that_setEndX_will_alter_the_relevant_endX_column_in_the_data_table() {
+    int const endXColumn(3);
+    TableItem const endX(5.5);
 
-		m_presenter->setEndX(endX.asDouble(), 0, 0);
+    m_presenter->setEndX(endX.asDouble(), 0, 0);
 
-		assertValueIsGlobal(endXColumn, endX);
-	}
+    assertValueIsGlobal(endXColumn, endX);
+  }
 
-	void
-		test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
-		int const excludeRegionColumn(4);
-		TableItem const excludeRegion("2-3");
+  void
+  test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
+    int const excludeRegionColumn(4);
+    TableItem const excludeRegion("2-3");
 
-		m_presenter->setExclude(excludeRegion.asString(), 0, 0);
+    m_presenter->setExclude(excludeRegion.asString(), 0, 0);
 
-		assertValueIsGlobal(excludeRegionColumn, excludeRegion);
-	}
+    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+  }
 
-	void test_that_loadSettings_will_read_the_settings_from_the_view() {
-		QSettings settings;
-		settings.beginGroup("/ISettings");
+  void test_that_loadSettings_will_read_the_settings_from_the_view() {
+    QSettings settings;
+    settings.beginGroup("/ISettings");
 
-		EXPECT_CALL(*m_view, readSettings(_)).Times(Exactly(1));
+    EXPECT_CALL(*m_view, readSettings(_)).Times(Exactly(1));
 
-		m_presenter->loadSettings(settings);
-	}
+    m_presenter->loadSettings(settings);
+  }
 
 private:
-	/// Used in setup
-	void createEmptyTableWidget(int rows, int columns) {
-		m_table = std::make_unique<QTableWidget>(rows, columns);
-		for (auto column = 0; column < rows; ++column)
-			for (auto row = 0; row < columns; ++row)
-				m_table->setItem(row, column, new QTableWidgetItem("item"));
-	}
+  /// Used in setup
+  void createEmptyTableWidget(int rows, int columns) {
+    m_table = std::make_unique<QTableWidget>(rows, columns);
+    for (auto column = 0; column < rows; ++column)
+      for (auto row = 0; row < columns; ++row)
+        m_table->setItem(row, column, new QTableWidgetItem("item"));
+  }
 
-	void deleteSetup() {
-		m_presenter.reset();
-		m_model.reset();
-		m_view.reset();
+  void deleteSetup() {
+    m_presenter.reset();
+    m_model.reset();
+    m_view.reset();
 
-		m_dataTablePresenter.reset();
-		m_table.reset();
-	}
+    m_dataTablePresenter.reset();
+    m_table.reset();
+  }
 
-	void assertValueIsGlobal(int column, TableItem const &value) const {
-		for (auto row = 0; row < m_table->rowCount(); ++row)
-			TS_ASSERT_EQUALS(value, getTableItem(row, column));
-	}
+  void assertValueIsGlobal(int column, TableItem const &value) const {
+    for (auto row = 0; row < m_table->rowCount(); ++row)
+      TS_ASSERT_EQUALS(value, getTableItem(row, column));
+  }
 
-	std::string getTableItem(int row, int column) const {
-		return m_table->item(row, column)->text().toStdString();
-	}
+  std::string getTableItem(int row, int column) const {
+    return m_table->item(row, column)->text().toStdString();
+  }
 
-	std::unique_ptr<QTableWidget> m_table;
-	std::unique_ptr<IndirectDataTablePresenter> m_dataTablePresenter;
+  std::unique_ptr<QTableWidget> m_table;
+  std::unique_ptr<IndirectDataTablePresenter> m_dataTablePresenter;
 
-	std::unique_ptr<MockIIndirectFitDataView> m_view;
-	std::unique_ptr<MockIndirectFitDataModel> m_model;
-	std::unique_ptr<IndirectFitDataPresenter> m_presenter;
+  std::unique_ptr<MockIIndirectFitDataView> m_view;
+  std::unique_ptr<MockIndirectFitDataModel> m_model;
+  std::unique_ptr<IndirectFitDataPresenter> m_presenter;
 
-	SetUpADSWithWorkspace *m_ads;
+  SetUpADSWithWorkspace *m_ads;
 };
 
 #endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -125,7 +125,7 @@ public:
   void setUp() override {
     m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
     m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
-    createEmptyTableWidget(5, 5);
+    m_table = createEmptyTableWidget(5, 5);
 
     m_dataTablePresenter = std::make_unique<IndirectDataTablePresenter>(
         std::move(m_model.get()), std::move(m_table.get()));
@@ -235,32 +235,29 @@ public:
 
   void
   test_that_setStartX_will_alter_the_relevant_startX_column_in_the_data_table() {
-    int const startXColumn(2);
     TableItem const startX(2.3);
 
     m_presenter->setStartX(startX.asDouble(), 0, 0);
 
-    assertValueIsGlobal(startXColumn, startX);
+    assertValueIsGlobal(START_X_COLUMN, startX);
   }
 
   void
   test_that_setEndX_will_alter_the_relevant_endX_column_in_the_data_table() {
-    int const endXColumn(3);
     TableItem const endX(5.5);
 
     m_presenter->setEndX(endX.asDouble(), 0, 0);
 
-    assertValueIsGlobal(endXColumn, endX);
+    assertValueIsGlobal(END_X_COLUMN, endX);
   }
 
   void
   test_that_the_setExcludeRegion_slot_will_alter_the_relevant_excludeRegion_column_in_the_table() {
-    int const excludeRegionColumn(4);
     TableItem const excludeRegion("2-3");
 
     m_presenter->setExclude(excludeRegion.asString(), 0, 0);
 
-    assertValueIsGlobal(excludeRegionColumn, excludeRegion);
+    assertValueIsGlobal(EXCLUDE_REGION_COLUMN, excludeRegion);
   }
 
   void test_that_loadSettings_will_read_the_settings_from_the_view() {
@@ -274,12 +271,13 @@ public:
 
 private:
   /// Used in setup
-  void createEmptyTableWidget(int rows, int columns) {
-    m_table = std::make_unique<QTableWidget>(rows, columns);
-    for (auto column = 0; column < rows; ++column)
-      for (auto row = 0; row < columns; ++row)
-        m_table->setItem(row, column, new QTableWidgetItem("item"));
-  }
+	std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+		auto table = std::make_unique<QTableWidget>(columns, rows);
+		for (auto column = 0; column < columns; ++column)
+			for (auto row = 0; row < rows; ++row)
+				table->setItem(row, column, new QTableWidgetItem("item"));
+		return table;
+	}
 
   void deleteSetup() {
     m_presenter.reset();

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -84,6 +84,8 @@ public:
 /// Mock object to mock the model
 class MockIndirectFitDataModel : public IndirectFittingModel {
 public:
+	using IndirectFittingModel::addWorkspace;
+
   /// Public Methods
   MOCK_CONST_METHOD0(isMultiFit, bool());
   MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -19,36 +19,12 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
-#include <QObject>
-
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace testing;
 
-class SignalCatcher : public QObject{
-Q_OBJECT
-public:
-	SignalCatcher(IndirectFitDataPresenter *presenter) {
-		connect(presenter, SIGNAL(singleSampleLoaded()), this,
-			SLOT(singleSampleLoadedSlot()));
-		connect(presenter, SIGNAL(dataChanged()), this,
-			SLOT(dataChanged()));
-	}
-
-public slots:
- void singleSampleLoadedSlot() {}
- void dataChangedSlot() {}
-};
-
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
-
-class MockSignalCatcher : public SignalCatcher {
-public:
-	/// Public slots
-	MOCK_METHOD0(singleSampleLoadedSlot, void());
-	MOCK_METHOD0(dataChangedSlot, void());
-};
 
 class MockIndirectFitDataView : public IndirectFitDataView {
 public:
@@ -57,9 +33,9 @@ public:
 		emit sampleLoaded(name);
 	}
 
-	void emitResolutionLoaded(QString const &name) {
-		emit resolutionLoaded(name);
-	}
+	//void emitResolutionLoaded(QString const &name) {
+	//	emit resolutionLoaded(name);
+	//}
 
 	void emitAddClicked() {
 		emit addClicked();
@@ -128,8 +104,6 @@ public:
 		m_presenter = std::make_unique<IndirectFitDataPresenter>(
 			std::move(m_model.get()), std::move(m_view.get()));
 
-		m_signalCatcher = std::make_unique<NiceMock<MockSignalCatcher>>(std::move(m_presenter.get()));
-
 		SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
 		m_model->addWorkspace("WorkspaceName");
 	}
@@ -196,8 +170,6 @@ private:
 	std::unique_ptr<MockIndirectFitDataView> m_view;
 	std::unique_ptr<MockIndirectFitDataModel> m_model;
 	std::unique_ptr<IndirectFitDataPresenter> m_presenter;
-
-	std::unique_ptr<MockSignalCatcher> m_signalCatcher;
 
 	SetUpADSWithWorkspace *m_ads;
 };

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -16,18 +16,46 @@
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
+using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces::IDA;
+using namespace testing;
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockIndirectFitDataView : public IndirectFitDataView {
 public:
+	/// Signals
+
+	/// Public Methods
+	MOCK_CONST_METHOD0(getSelectedSample, std::string());
+	MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
+
+	/// Public Slots
+
 };
 
 class MockIndirectFitDataModel : public IndirectFittingModel {
 public:
+	MOCK_CONST_METHOD0(isMultiFit, bool());
+	MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
+
+
+private:
+	std::string sequentialFitOutputName() const override { return ""; };
+	std::string simultaneousFitOutputName() const override { return ""; };
+	std::string singleFitOutputName(std::size_t index,
+		std::size_t spectrum) const override {
+		UNUSED_ARG(index);
+		UNUSED_ARG(spectrum);
+		return "";
+	};
+
+	std::vector<std::string> getSpectrumDependentAttributes() const override {
+		return{};
+	};
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
@@ -46,27 +74,68 @@ public:
 	}
 
 	void setUp() override {
-		//m_model = std::make_unique<NiceMock<MockIndirectDataTableModel>>();
-		//createEmptyTableWidget(5, 5);
-		//m_presenter = std::make_unique<IndirectDataTablePresenter>(
-		//	std::move(m_model.get()), std::move(m_table.get()));
+		m_view = std::make_unique<NiceMock<MockIndirectFitDataView>>();
+		m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
+		m_presenter = std::make_unique<IndirectFitDataPresenter>(
+			std::move(m_model.get()), std::move(m_view.get()));
 
-		//SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
-		//m_model->addWorkspace("WorkspaceName");
+		SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+		m_model->addWorkspace("WorkspaceName");
 	}
 
 	void tearDown() override {
-		//AnalysisDataService::Instance().clear();
+		AnalysisDataService::Instance().clear();
 
-		//TS_ASSERT(Mock::VerifyAndClearExpectations(m_table.get()));
-		//TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+		TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
 
-		//m_presenter.reset();
-		//m_model.reset();
-		//m_table.reset();
+		m_presenter.reset();
+		m_model.reset();
+		m_view.reset();
 	}
 
+	///----------------------------------------------------------------------
+	/// Unit tests to check for successful mock object instantiation
+	///----------------------------------------------------------------------
+
+	void test_that_the_model_has_been_instantiated_correctly() {
+		ON_CALL(*m_model, isMultiFit()).WillByDefault(Return(false));
+
+		EXPECT_CALL(*m_model, isMultiFit()).Times(1).WillOnce(Return(false));
+
+		m_model->isMultiFit();
+	}
+
+	void test_that_the_view_has_been_instantiated_correctly() {
+	  std::string const sampleName("SampleName_red");
+		ON_CALL(*m_view, getSelectedSample()).WillByDefault(Return(sampleName));
+
+		EXPECT_CALL(*m_view, getSelectedSample()).Times(1).WillOnce(Return(sampleName));
+
+		m_view->getSelectedSample();
+	}
+
+	void
+	test_that_invoking_a_presenter_method_will_call_the_relevant_methods_in_the_view_and_model() {
+		ON_CALL(*m_view, isMultipleDataTabSelected()).WillByDefault(Return(true));
+		ON_CALL(*m_model, numberOfWorkspaces()).WillByDefault(Return(2));
+
+		Expectation isMultipleData = EXPECT_CALL(*m_view, isMultipleDataTabSelected()).Times(1).WillOnce(Return(true));
+		EXPECT_CALL(*m_model, numberOfWorkspaces()).Times(1).After(isMultipleData);
+
+		m_presenter->updateSpectraInTable(0);
+	}
+
+	///----------------------------------------------------------------------
+	/// Unit Tests that test the signals call the correct methods
+	///----------------------------------------------------------------------
+
 	void test_test() {}
+
+private:
+	std::unique_ptr<MockIndirectFitDataView> m_view;
+	std::unique_ptr<MockIndirectFitDataModel> m_model;
+	std::unique_ptr<IndirectFitDataPresenter> m_presenter;
 
 };
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -27,6 +27,14 @@ using namespace testing;
 
 namespace {
 
+std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
+  auto table = std::make_unique<QTableWidget>(columns, rows);
+  for (auto column = 0; column < columns; ++column)
+    for (auto row = 0; row < rows; ++row)
+      table->setItem(row, column, new QTableWidgetItem("item"));
+  return table;
+}
+
 struct TableItem {
   TableItem(std::string const &value) : m_str(value), m_dbl(0.0) {}
   TableItem(double const &value)
@@ -270,15 +278,6 @@ public:
   }
 
 private:
-  /// Used in setup
-  std::unique_ptr<QTableWidget> createEmptyTableWidget(int columns, int rows) {
-    auto table = std::make_unique<QTableWidget>(columns, rows);
-    for (auto column = 0; column < columns; ++column)
-      for (auto row = 0; row < rows; ++row)
-        table->setItem(row, column, new QTableWidgetItem("item"));
-    return table;
-  }
-
   void deleteSetup() {
     m_presenter.reset();
     m_model.reset();

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -27,14 +27,14 @@ using namespace testing;
 
 namespace {
 
-QStringList const &getJumpParameters() {
+QStringList getJumpParameters() {
   QStringList parameters;
   parameters << "f1.f1.FWHM"
              << "f2.f1.FWHM";
   return parameters;
 }
 
-QStringList const &getJumpParameterTypes() {
+QStringList getJumpParameterTypes() {
   QStringList parameterTypes;
   parameterTypes << "Width"
                  << "EISF";
@@ -124,9 +124,9 @@ public:
         std::move(m_ParameterTypeLabel.get()),
         std::move(m_ParameterLabel.get()));
 
-    SetUpADSWithWorkspace m_ads(
-        "WorkspaceName", createWorkspaceWithTextAxis(6, getTextAxisLabels()));
-    m_model->addWorkspace("WorkspaceName");
+    //SetUpADSWithWorkspace m_ads(
+    //    "WorkspaceName", createWorkspaceWithTextAxis(6, getTextAxisLabels()));
+    //m_model->addWorkspace("WorkspaceName");
   }
 
   void tearDown() override {
@@ -138,6 +138,12 @@ public:
     m_presenter.reset();
     m_model.reset();
     m_view.reset();
+
+    m_dataTable.reset();
+    m_ParameterTypeCombo.reset();
+    m_ParameterCombo.reset();
+    m_ParameterTypeLabel.reset();
+    m_ParameterLabel.reset();
   }
 
   ///----------------------------------------------------------------------
@@ -148,6 +154,19 @@ public:
     TS_ASSERT(m_presenter);
     TS_ASSERT(m_model);
     TS_ASSERT(m_view);
+  }
+
+  void test_that_the_comboboxes_contain_the_items_specified_during_the_setup() {
+    TS_ASSERT_EQUALS(m_ParameterTypeCombo->itemData(0), "Width");
+    TS_ASSERT_EQUALS(m_ParameterTypeCombo->itemData(1), "EISF");
+
+    TS_ASSERT_EQUALS(m_ParameterCombo->itemData(0), "f1.f1.FWHM");
+    TS_ASSERT_EQUALS(m_ParameterCombo->itemData(1), "f2.f1.FWHM");
+  }
+
+  void test_that_the_labels_have_the_correct_text_after_setup() {
+    TS_ASSERT_EQUALS(m_ParameterTypeLabel->text(), "Fit Parameter:");
+    TS_ASSERT_EQUALS(m_ParameterLabel->text(), "Width:");
   }
 
   void

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -15,7 +15,6 @@
 #include "JumpFitModel.h"
 
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidAPI/TextAxis.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
@@ -73,9 +72,6 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 /// Mock object to mock the view
 class MockJumpFitDataView : public IIndirectFitDataView {
 public:
-  /// Signals
-  void emitSampleLoaded(QString const &name) { emit sampleLoaded(name); }
-
   /// Public Methods
   MOCK_CONST_METHOD0(getDataTable, QTableWidget *());
   MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -15,9 +15,12 @@
 #include "JumpFitModel.h"
 
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
+using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace testing;
@@ -26,8 +29,8 @@ namespace {
 
 QStringList const &getJumpParameters() {
   QStringList parameters;
-  parameters << "1"
-             << "2";
+  parameters << "f1.f1.FWHM"
+             << "f2.f1.FWHM";
   return parameters;
 }
 
@@ -36,6 +39,10 @@ QStringList const &getJumpParameterTypes() {
   parameterTypes << "Width"
                  << "EISF";
   return parameterTypes;
+}
+
+std::vector<std::string> getTextAxisLabels() {
+  return {"f0.Width", "f1.Width", "f2.Width", "f0.EISF", "f1.EISF", "f2.EISF"};
 }
 
 } // namespace
@@ -117,12 +124,13 @@ public:
         std::move(m_ParameterTypeLabel.get()),
         std::move(m_ParameterLabel.get()));
 
-    // SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
-    // m_model->addWorkspace("WorkspaceName");
+    SetUpADSWithWorkspace m_ads(
+        "WorkspaceName", createWorkspaceWithTextAxis(6, getTextAxisLabels()));
+    m_model->addWorkspace("WorkspaceName");
   }
 
   void tearDown() override {
-    // AnalysisDataService::Instance().clear();
+    AnalysisDataService::Instance().clear();
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
     TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
@@ -130,6 +138,21 @@ public:
     m_presenter.reset();
     m_model.reset();
     m_view.reset();
+  }
+
+  ///----------------------------------------------------------------------
+  /// Unit tests to check for successful mock object instantiation
+  ///----------------------------------------------------------------------
+
+  void test_that_the_presenter_and_mock_objects_have_been_created() {
+    TS_ASSERT(m_presenter);
+    TS_ASSERT(m_model);
+    TS_ASSERT(m_view);
+  }
+
+  void
+  test_that_the_model_contains_the_correct_number_of_workspace_after_instantiation() {
+    TS_ASSERT_EQUALS(m_model->numberOfWorkspaces(), 1);
   }
 
   void test_test() {}

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -1,0 +1,56 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_JUMPFITDATAPRESENTERTEST_H_
+#define MANTIDQT_JUMPFITDATAPRESENTERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "MantidAPI/FrameworkManager.h"
+
+using namespace Mantid::API;
+
+class JumpFitDataPresenterTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  JumpFitDataPresenterTest() { FrameworkManager::Instance(); }
+
+  static JumpFitDataPresenterTest *createSuite() {
+    return new JumpFitDataPresenterTest();
+  }
+
+  static void destroySuite(JumpFitDataPresenterTest *suite) {
+    delete suite;
+  }
+
+  // void setUp() override {
+  //  m_view = std::make_unique<NiceMock<MockIIndirectFitDataView>>();
+  //  m_model = std::make_unique<NiceMock<MockIndirectFitDataModel>>();
+  //  m_table = createEmptyTableWidget(5, 5);
+
+  //  m_dataTablePresenter = std::make_unique<IndirectDataTablePresenter>(
+  //      std::move(m_model.get()), std::move(m_table.get()));
+  //  m_presenter = std::make_unique<IndirectFitDataPresenter>(
+  //      std::move(m_model.get()), std::move(m_view.get()),
+  //      std::move(m_dataTablePresenter));
+
+  //  SetUpADSWithWorkspace m_ads("WorkspaceName", createWorkspace(5));
+  //  m_model->addWorkspace("WorkspaceName");
+  //}
+
+  // void tearDown() override {
+  //  AnalysisDataService::Instance().clear();
+
+  //  TS_ASSERT(Mock::VerifyAndClearExpectations(m_view.get()));
+  //  TS_ASSERT(Mock::VerifyAndClearExpectations(m_model.get()));
+
+  //  deleteSetup();
+  //}
+
+  void test_test() {}
+};
+#endif

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -100,10 +100,7 @@ public:
 };
 
 /// Mock object to mock the model
-class MockJumpFitModel : public JumpFitModel {
-public:
-  /// Public Methods - None currently
-};
+class MockJumpFitModel : public JumpFitModel {};
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
 


### PR DESCRIPTION
**Description of work.**
This PR introduces unit tests for the ConvFitDataPresenter and JumpFitDataPresenter. These presenters have very little to test (the bulk of the testing has already been done in the IndirectFitDataPresenterTest #24149), and so these test files are quite short. However it is still important these tests are created in case of new additions to the ConvFitDataPresenter and JumpFitDataPresenter in the future which need to be tested.

**To test:**
Make sure the tests pass.

Fixes #24298 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
