### PR TITLE
Fixing Muon Testing Docs

### DIFF
--- a/dev-docs/source/Testing/MuonInterface/MuonTesting.rst
+++ b/dev-docs/source/Testing/MuonInterface/MuonTesting.rst
@@ -55,8 +55,8 @@ Ionic Diffusion test
 -  In the ``Results Table`` workspace
 
    -  Expected values (similar to within 50%) ..
-   -  f0.A0: 0.18235938124844153
-   -  f1.Asym: 0.0050597127151507
+   -  f0.A0: -0.083439833711330152
+   -  f1.Asym: 0.19125607982528858
    -  f1:Delta: 0.3301445010124604
    -  f1:Nu: 0.8574644977974730220884
 
@@ -67,11 +67,6 @@ Ionic Diffusion test
    -  Right-click each workspace
    -  Choose ``Plot spectrum``
    -  Choose ``1D plot`` and click ``Plot All``
-   -  The results should look like the image below:
-
-.. figure:: ../../images/CuResult.jpg
-   :alt: CuResult.png
-
 
 Possible problems
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
**Description of work.**

This PR fixes a mistaken set of expected values in the unscripted testing of the `Muon Analysis` interface.

**Report to:** Matthew Andrew/Anthony Lim

**To test:**

* Build the `dev-docs-html` target
* Open up `dev-docs/html/Testing/MuonInterface/MuonTesting.html`
* Run the `Ionic Diffusion test`
* Check that the expected values for `f0.A0`,`f1.Asym`, `f1:Delta`, `f1:Nu` are reasonably close to the values that you get

*There is no associated issue.*

*This does not require release notes* because it is not user-facing.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
