### PR TITLE
Automatically Add Batch File directory to Directory Manager

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -30,6 +30,7 @@ Improved
 * Added a "process all" and "process selected" button to the batch table in place of "process" button.
 * Added a load button to load selected workspaces without processing.
 * Added save_can option to output unsubtracted can and sample workspaces.
+* File path to batch file will be added to your directories automatically upon loading
 
 Bug fixes
 #########

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -459,6 +459,7 @@ void JobTreeView::appendAndEditAtChildRow() {
 
 void JobTreeView::appendAndEditAtRowBelow() {
   auto current = currentIndex();
+  try {
   auto const below = findOrMakeCellBelow(fromFilteredModel(current));
   auto index = below.first;
   auto isNew = below.second;
@@ -466,6 +467,8 @@ void JobTreeView::appendAndEditAtRowBelow() {
   editAt(index);
   if (isNew)
     m_notifyee->notifyRowInserted(rowLocation().atIndex(mapToMainModel(index)));
+  } catch (std::runtime_error e) {
+  }
 }
 
 void JobTreeView::editAtRowAbove() {

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -459,7 +459,6 @@ void JobTreeView::appendAndEditAtChildRow() {
 
 void JobTreeView::appendAndEditAtRowBelow() {
   auto current = currentIndex();
-  try {
   auto const below = findOrMakeCellBelow(fromFilteredModel(current));
   auto index = below.first;
   auto isNew = below.second;
@@ -467,8 +466,6 @@ void JobTreeView::appendAndEditAtRowBelow() {
   editAt(index);
   if (isNew)
     m_notifyee->notifyRowInserted(rowLocation().atIndex(mapToMainModel(index)));
-  } catch (std::runtime_error e) {
-  }
 }
 
 void JobTreeView::editAtRowAbove() {

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -4,7 +4,6 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.kernel import config
 from sans.common.enums import SANSInstrument, ISISReductionMode, DetectorType
 from qtpy.QtWidgets import (QFileDialog)  # noqa
 from qtpy.QtCore import (QSettings)  # noqa

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -4,6 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from mantid.kernel import config
 from sans.common.enums import SANSInstrument, ISISReductionMode, DetectorType
 from qtpy.QtWidgets import (QFileDialog)  # noqa
 from qtpy.QtCore import (QSettings)  # noqa
@@ -214,3 +215,23 @@ def open_file_dialog(line_edit, filter_text, directory):
     if isinstance(file_name, tuple):
         file_name = file_name[0]
     line_edit.setText(file_name)
+
+
+def get_batch_file_dir_from_path(batch_file_path):
+    path, file = os.path.split(batch_file_path)
+    if path != "" and path[-1] != "/":
+        # Make string inline with other ConfigService paths
+        path += "/"
+    return path
+
+
+def add_dir_to_datasearch(batch_file_path, current_directories):
+    batch_file_directory = get_batch_file_dir_from_path(batch_file_path)
+    if batch_file_directory != "" and batch_file_directory not in current_directories:
+        current_directories = ";".join([current_directories, batch_file_directory])
+    return batch_file_directory, current_directories
+
+
+def remove_dir_from_datasearch(batch_file_path, directories):
+    new_dirs = ";".join([path for path in directories.split(";") if path != batch_file_path])
+    return new_dirs

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -324,14 +324,14 @@ class RunTabPresenter(object):
             if not batch_file_path:
                 return
 
+            datasearch_dirs = ConfigService["datasearch.directories"]
+            batch_file_directory, datasearch_dirs = add_dir_to_datasearch(batch_file_path, datasearch_dirs)
+            ConfigService["datasearch.directories"] = datasearch_dirs
+
             if not os.path.exists(batch_file_path):
                 raise RuntimeError(
                     "The batch file path {} does not exist. Make sure a valid batch file path"
                     " has been specified.".format(batch_file_path))
-
-            datasearch_dirs = ConfigService["datasearch.directories"]
-            batch_file_directory, datasearch_dirs = add_dir_to_datasearch(batch_file_path, datasearch_dirs)
-            ConfigService["datasearch.directories"] = datasearch_dirs
 
             self._table_model.batch_file = batch_file_path
 

--- a/scripts/test/SANS/gui_logic/gui_common_test.py
+++ b/scripts/test/SANS/gui_logic/gui_common_test.py
@@ -9,10 +9,15 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 import mantid
+from mantid.kernel import config
 
 from sans.gui_logic.gui_common import (get_reduction_mode_strings_for_gui, get_reduction_selection,
-                                       get_string_for_gui_from_reduction_mode)
+                                       get_string_for_gui_from_reduction_mode,
+                                       get_batch_file_dir_from_path,
+                                       add_dir_to_datasearch,
+                                       remove_dir_from_datasearch)
 from sans.common.enums import (SANSInstrument, ISISReductionMode)
+import os
 
 
 class GuiCommonTest(unittest.TestCase):
@@ -66,6 +71,59 @@ class GuiCommonTest(unittest.TestCase):
         self.do_test_reduction_mode_string(SANSInstrument.LARMOR, ISISReductionMode.LAB, "DetectorBench")
         self.do_test_reduction_mode_string(SANSInstrument.NoInstrument, ISISReductionMode.LAB, "LAB")
         self.do_test_reduction_mode_string(SANSInstrument.NoInstrument, ISISReductionMode.HAB, "HAB")
+
+    def test_that_batch_file_dir_returns_none_if_no_forwardslash(self):
+        a_path = "test_batch_file_path.csv"
+        result = get_batch_file_dir_from_path(a_path)
+        self.assertEqual("", result, "Expected empty string. Returned value was {}".format(result))
+
+    def test_correct_batch_file_dir_returned(self):
+        a_path = "A/Test/Path/batch_file.csv"
+        result = get_batch_file_dir_from_path(a_path)
+
+        expected_result = "A/Test/Path/"
+        self.assertEqual(result, expected_result, "Expected path to be {}, was {} instead.".format(expected_result,
+                                                                                                   result))
+
+    def test_datasearch_directories_updated(self):
+        current_dirs = "A/Path/"
+        batch_file = "A/Path/To/Batch/File/batch_file.csv"
+        _, result = add_dir_to_datasearch(batch_file, current_dirs)
+
+        expected_result = "A/Path/;A/Path/To/Batch/File/"
+        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+
+    def test_empty_string_not_added_to_datasearch_directories(self):
+        current_dirs = "A/Path/"
+        batch_file = "batch_file.csv"
+        _, result = add_dir_to_datasearch(batch_file, current_dirs)
+
+        expected_result = "A/Path/"
+        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+
+    def test_existing_directory_not_added_to_datasearch_directories(self):
+        current_dirs = "A/Path/;A/Path/Already/Added/"
+        batch_file = "A/Path/Already/Added/batch_file.csv"
+        _, result = add_dir_to_datasearch(batch_file, current_dirs)
+
+        expected_result = "A/Path/;A/Path/Already/Added/"
+        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+
+    def test_directories_unchanged_when_removing_empty_string(self):
+        current_dirs = "A/Path/;Another/Path/"
+        file_to_remove = ""
+        result = remove_dir_from_datasearch(file_to_remove, current_dirs)
+
+        expected_result = "A/Path/;Another/Path/"
+        self.assertEqual(result, expected_result, "Expected {}, got {}".format(expected_result, result))
+
+    def test_correct_directory_removed(self):
+        current_dirs = "A/Path/;Another/Path/;A/Final/Path/"
+        file_to_remove = "Another/Path/"
+        result = remove_dir_from_datasearch(file_to_remove, current_dirs)
+
+        expected_result = "A/Path/;A/Final/Path/"
+        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/gui_logic/gui_common_test.py
+++ b/scripts/test/SANS/gui_logic/gui_common_test.py
@@ -82,8 +82,7 @@ class GuiCommonTest(unittest.TestCase):
         result = get_batch_file_dir_from_path(a_path)
 
         expected_result = "A/Test/Path/"
-        self.assertEqual(result, expected_result, "Expected path to be {}, was {} instead.".format(expected_result,
-                                                                                                   result))
+        self.assertEqual(result, expected_result)
 
     def test_datasearch_directories_updated(self):
         current_dirs = "A/Path/"
@@ -91,7 +90,7 @@ class GuiCommonTest(unittest.TestCase):
         _, result = add_dir_to_datasearch(batch_file, current_dirs)
 
         expected_result = "A/Path/;A/Path/To/Batch/File/"
-        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+        self.assertEqual(expected_result, result)
 
     def test_empty_string_not_added_to_datasearch_directories(self):
         current_dirs = "A/Path/"
@@ -99,7 +98,7 @@ class GuiCommonTest(unittest.TestCase):
         _, result = add_dir_to_datasearch(batch_file, current_dirs)
 
         expected_result = "A/Path/"
-        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+        self.assertEqual(expected_result, result)
 
     def test_existing_directory_not_added_to_datasearch_directories(self):
         current_dirs = "A/Path/;A/Path/Already/Added/"
@@ -107,7 +106,7 @@ class GuiCommonTest(unittest.TestCase):
         _, result = add_dir_to_datasearch(batch_file, current_dirs)
 
         expected_result = "A/Path/;A/Path/Already/Added/"
-        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+        self.assertEqual(expected_result, result)
 
     def test_directories_unchanged_when_removing_empty_string(self):
         current_dirs = "A/Path/;Another/Path/"
@@ -115,7 +114,7 @@ class GuiCommonTest(unittest.TestCase):
         result = remove_dir_from_datasearch(file_to_remove, current_dirs)
 
         expected_result = "A/Path/;Another/Path/"
-        self.assertEqual(result, expected_result, "Expected {}, got {}".format(expected_result, result))
+        self.assertEqual(result, expected_result)
 
     def test_correct_directory_removed(self):
         current_dirs = "A/Path/;Another/Path/;A/Final/Path/"
@@ -123,7 +122,7 @@ class GuiCommonTest(unittest.TestCase):
         result = remove_dir_from_datasearch(file_to_remove, current_dirs)
 
         expected_result = "A/Path/;A/Final/Path/"
-        self.assertEqual(expected_result, result, "Expected {}, got {}".format(expected_result, result))
+        self.assertEqual(expected_result, result)
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -75,7 +75,6 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.os_patcher = mock.patch('sans.gui_logic.presenter.run_tab_presenter.os')
         self.addCleanup(self.os_patcher.stop)
-        self.os_patcher.start()
         self.osMock = self.os_patcher.start()
 
         self.thickness_patcher = mock.patch('sans.gui_logic.models.table_model.create_file_information')
@@ -268,8 +267,7 @@ class RunTabPresenterTest(unittest.TestCase):
         self._remove_files(user_file_path=user_file_path)
         self.os_patcher.start()
 
-    def test_batch_file_dir_not_added_to_config(self):
-        self.os_patcher.stop()
+    def test_batch_file_dir_not_added_to_config_if_batch_file_load_fails(self):
         presenter = RunTabPresenter(SANSFacility.ISIS)
         user_file_path = create_user_file(sample_user_file)
         view, settings_diagnostic_tab, masking_table = create_mock_view(user_file_path, "A/Path/batch_file.csv")
@@ -281,8 +279,6 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.assertFalse(result, "We do not expect A/Path/ to be added to config, "
                                  "datasearch.directories is now {}".format(config_dirs))
-
-        self.os_patcher.start()
 
     def test_that_gets_states_from_view(self):
         # Arrange

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -75,6 +75,7 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.os_patcher = mock.patch('sans.gui_logic.presenter.run_tab_presenter.os')
         self.addCleanup(self.os_patcher.stop)
+        self.os_patcher.start()
         self.osMock = self.os_patcher.start()
 
         self.thickness_patcher = mock.patch('sans.gui_logic.models.table_model.create_file_information')
@@ -265,6 +266,22 @@ class RunTabPresenterTest(unittest.TestCase):
 
         # Clean up
         self._remove_files(user_file_path=user_file_path)
+        self.os_patcher.start()
+
+    def test_batch_file_dir_not_added_to_config(self):
+        self.os_patcher.stop()
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        user_file_path = create_user_file(sample_user_file)
+        view, settings_diagnostic_tab, masking_table = create_mock_view(user_file_path, "A/Path/batch_file.csv")
+        presenter.set_view(view)
+
+        presenter.on_batch_file_load()
+        config_dirs = config["datasearch.directories"]
+        result = "A/Path/" in config_dirs
+
+        self.assertFalse(result, "We do not expect A/Path/ to be added to config, "
+                                 "datasearch.directories is now {}".format(config_dirs))
+
         self.os_patcher.start()
 
     def test_that_gets_states_from_view(self):


### PR DESCRIPTION
**Description of work.**
If trying to load a batch file in SANS v2 from a directory which has not been added to directory manager, this PR will extract the path and add it automatically. If loading batch file fails, the new directory is removed (this avoids filling directory manager with directories accidentally clicked on).

**Report to:** nobody

**To test:**
1. Interfaces -> SANS -> SANS v2
2. Load a user file
3. Click manage directories, remove directories
4. Attempt to load a valid batch file
5. This should not cause any errors (table won't turn blue) and you should be able to process without errors
6. Click manage directories, you should see the batch file directory there
7. Attempt to load an invalid file (from a different directory)
8. There should be errors, and manage directories will not include that path

`ctest --output-on-failure -R gui_common_test`
and 
`ctest --output-on-failure -R run_tab_presenter_test`
should both pass

Fixes #24147 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
