### PR TITLE
Fixes VSI crash for Pick Mode and threshold with no data

### DIFF
--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -82,6 +82,8 @@ SplatterPlotView::SplatterPlotView(
                    SIGNAL(setRotationToPoint(double, double, double)), this,
                    SLOT(onResetCenterToPoint(double, double, double)));
 
+  this->m_ui.thresholdButton->setToolTip(
+      "Set the threshold button to create a threshold filter on data");
   // Set the threshold button to create a threshold filter on data
   QObject::connect(this->m_ui.thresholdButton, SIGNAL(clicked()), this,
                    SLOT(onThresholdButtonClicked()));
@@ -177,7 +179,6 @@ void SplatterPlotView::render() {
     this->m_splatSource = builder->createFilter(
         "filters", MantidQt::API::MdConstants::MantidParaViewSplatterPlot,
         this->origSrc);
-    src = this->m_splatSource;
   } else {
     // We don't want to load the same peak workspace twice into the splatterplot
     // mode
@@ -292,6 +293,11 @@ void SplatterPlotView::checkPeaksCoordinates() {
 }
 
 void SplatterPlotView::onThresholdButtonClicked() {
+  if (!this->m_threshSource) {
+    // prevent trying to create a filter for empty data (nullptr)
+    // which causes VSI to crash
+    return;
+  }
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
   this->m_threshSource = builder->createFilter(
       "filters", MantidQt::API::MdConstants::Threshold, this->m_splatSource);
@@ -321,12 +327,16 @@ void SplatterPlotView::checkView(ModeControlWidget::Views initialView) {
  */
 void SplatterPlotView::onPickModeToggled(bool state) {
   pqObjectBuilder *builder = pqApplicationCore::instance()->getObjectBuilder();
+
   if (state) {
     pqPipelineSource *src = nullptr;
     if (this->m_threshSource) {
       src = this->m_threshSource;
-    } else {
+    } else if (this->m_splatSource) {
       src = this->m_splatSource;
+    } else {
+      // no sources are present in the view -> don't do anything
+      return;
     }
     this->m_probeSource = builder->createFilter(
         "filters", MantidQt::API::MdConstants::ProbePoint, src);

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/SplatterPlotView.cpp
@@ -83,7 +83,7 @@ SplatterPlotView::SplatterPlotView(
                    SLOT(onResetCenterToPoint(double, double, double)));
 
   this->m_ui.thresholdButton->setToolTip(
-      "Set the threshold button to create a threshold filter on data");
+      "Create a threshold filter on the data");
   // Set the threshold button to create a threshold filter on data
   QObject::connect(this->m_ui.thresholdButton, SIGNAL(clicked()), this,
                    SLOT(onThresholdButtonClicked()));


### PR DESCRIPTION
**Description of work.**

Adds checks to see if data _is present_ before trying to create filters for it. This fixes a crash from `Pick Mode`, and from clicking the `Threshold` button, while no data is loaded in the VSI.

Also adds a mouse hover tooltip for the Threshold button, to explain what it does, as the icon is not enough.

**Report to:** Gemma Guest

**To test:**
- Build Mantid with VSI (I advise against Windows unless you have built it, or have a day or so to spend building it)
  - Also on Windows, VSI only seems to work properly in `Release`. Both `Debug` and `RelWithDebInfo` cause crashes in the VSI (Raise separate issue?)
- Follow instructions from https://github.com/mantidproject/mantid/issues/24214
  - Save out the `QLab` workspace with `SaveMD` - makes the testing process much faster if you have to reload it.
- Open VSI on the MD workspace, click _all of the buttons repeatedly_, if we don't crash then this PR is 🥇 
<!-- Instructions for testing. -->

Fixes #24214 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
