### PR TITLE
Indirect Simulations - Move and disable the Run button

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -118,6 +118,16 @@ Bugfixes
 - An unwanted 'Fit' plot is no longer plotted in ResNorm when you click `Plot` in the output options.
 
 
+Simulations Interface
+---------------------
+
+Improvements
+############
+
+- The Run button is now above the output options.
+- The Run, Plot and Save buttons are now disabled while running and plotting is taking place.
+
+
 Diffraction Interface
 ---------------------
 

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.cpp
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.cpp
@@ -28,9 +28,10 @@ DensityOfStates::DensityOfStates(QWidget *parent)
 
   connect(m_uiForm.mwInputFile, SIGNAL(filesFound()), this,
           SLOT(handleFileChange()));
-  // Handle plot and save
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 
   m_uiForm.lwIons->setSelectionMode(QAbstractItemView::MultiSelection);
 }
@@ -246,6 +247,8 @@ void DensityOfStates::ionLoadComplete(bool error) {
 void DensityOfStates::loadSettings(const QSettings &settings) {
   m_uiForm.mwInputFile->readSettings(settings.group());
 }
+
+void DensityOfStates::runClicked() { runTab(); }
 
 /**
  * Handle mantid plotting of workspace

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.h
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.h
@@ -36,6 +36,13 @@ private slots:
   void saveClicked();
 
 private:
+  void setRunIsRunning(bool running);
+  void setPlotIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+
   /// The ui form
   Ui::DensityOfStates m_uiForm;
   /// Name of output workspace

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.h
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.h
@@ -31,7 +31,7 @@ private slots:
   void dosAlgoComplete(bool error);
   void handleFileChange();
   void ionLoadComplete(bool error);
-  /// Handle plotting and saving
+  void runClicked();
   void plotClicked();
   void saveClicked();
 

--- a/qt/scientific_interfaces/Indirect/DensityOfStates.ui
+++ b/qt/scientific_interfaces/Indirect/DensityOfStates.ui
@@ -56,7 +56,7 @@
         <x>0</x>
         <y>0</y>
         <width>480</width>
-        <height>379</height>
+        <height>328</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -242,7 +242,16 @@
          </property>
          <widget class="QWidget" name="pgDOS">
           <layout class="QGridLayout" name="gridLayout_2">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item row="0" column="0">
@@ -413,14 +422,32 @@
            </sizepolicy>
           </property>
           <layout class="QGridLayout" name="gridLayout_3">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
           </layout>
          </widget>
          <widget class="QWidget" name="pgRaman">
           <layout class="QGridLayout" name="gridLayout_4">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item row="0" column="0">
@@ -483,6 +510,60 @@
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>194</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>193</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp
@@ -24,6 +24,13 @@ IndirectLoadILL::IndirectLoadILL(QWidget *parent) : IndirectToolsTab(parent) {
   connect(m_uiForm.mwRun, SIGNAL(filesFound()), this, SLOT(handleFilesFound()));
   connect(m_uiForm.chkUseMap, SIGNAL(toggled(bool)), m_uiForm.mwMapFile,
           SLOT(setEnabled(bool)));
+
+  connect(this,
+          SIGNAL(updateRunButton(bool, std::string const &, QString const &,
+                                 QString const &)),
+          this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &,
+                               QString const &)));
 }
 
 /**
@@ -56,24 +63,29 @@ bool IndirectLoadILL::validate() {
  * script that runs IndirectLoadILL
  */
 void IndirectLoadILL::run() {
+  setRunIsRunning(true);
+
   QString plot("False");
   QString save("None");
 
   QString useMap("False");
   QString rejectZero("False");
 
-  QString filename = m_uiForm.mwRun->getFirstFilename();
-  QFileInfo finfo(filename);
+  QString const filename = m_uiForm.mwRun->getFirstFilename();
+  QFileInfo const finfo(filename);
   QString ext = finfo.suffix().toLower();
 
-  QString instrument = m_uiForm.iicInstrumentConfiguration->getInstrumentName();
-  QString analyser = m_uiForm.iicInstrumentConfiguration->getAnalyserName();
-  QString reflection = m_uiForm.iicInstrumentConfiguration->getReflectionName();
+  QString const instrument =
+      m_uiForm.iicInstrumentConfiguration->getInstrumentName();
+  QString const analyser =
+      m_uiForm.iicInstrumentConfiguration->getAnalyserName();
+  QString const reflection =
+      m_uiForm.iicInstrumentConfiguration->getReflectionName();
 
   if (m_uiForm.chkUseMap->isChecked()) {
     useMap = "True";
   }
-  QString mapPath = m_uiForm.mwMapFile->getFirstFilename();
+  QString const mapPath = m_uiForm.mwMapFile->getFirstFilename();
 
   if (m_uiForm.chkRejectZero->isChecked()) {
     rejectZero = "True";
@@ -107,6 +119,7 @@ void IndirectLoadILL::run() {
     {
       pyFunc += "InxStart";
     } else {
+      setRunIsRunning(false);
       emit showMessageBox("Could not find appropriate loading routine for " +
                           filename);
       return;
@@ -121,6 +134,8 @@ void IndirectLoadILL::run() {
                plot + "'," + save + ")";
   }
   runPythonScript(pyInput);
+
+  setRunIsRunning(false);
 }
 
 /**
@@ -152,6 +167,20 @@ void IndirectLoadILL::handleFilesFound() {
 }
 
 void IndirectLoadILL::runClicked() { runTab(); }
+
+void IndirectLoadILL::setRunIsRunning(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setRunEnabled(!running);
+  setPlotOptionsEnabled(!running);
+}
+
+void IndirectLoadILL::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectLoadILL::setPlotOptionsEnabled(bool enabled) {
+  m_uiForm.cbPlot->setEnabled(enabled);
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
+++ b/qt/scientific_interfaces/Indirect/IndirectLoadILL.h
@@ -37,6 +37,10 @@ private slots:
   void runClicked();
 
 private:
+  void setRunIsRunning(bool running);
+  void setRunEnabled(bool enabled);
+  void setPlotOptionsEnabled(bool enabled);
+
   /// Map to store instrument analysers and reflections for this instrument
   QMap<QString, QStringList> m_paramMap;
   /// The ui form

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
@@ -14,6 +14,15 @@
 
 using namespace Mantid::API;
 
+namespace {
+
+WorkspaceGroup_sptr getADSWorkspaceGroup(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+      workspaceName);
+}
+
+} // namespace
+
 namespace MantidQt {
 namespace CustomInterfaces {
 IndirectMolDyn::IndirectMolDyn(QWidget *parent)
@@ -141,28 +150,28 @@ void IndirectMolDyn::runClicked() { runTab(); }
  * Handle plotting of mantid workspace
  */
 void IndirectMolDyn::plotClicked() {
+  setPlotIsPlotting(true);
 
-  QString filename = m_uiForm.mwRun->getFirstFilename();
-  QFileInfo fi(filename);
-  QString baseName = fi.baseName();
+  QString const filename = m_uiForm.mwRun->getFirstFilename();
+  QString const baseName = QFileInfo(filename).baseName();
 
   if (checkADSForPlotSaveWorkspace(baseName.toStdString(), true)) {
 
-    WorkspaceGroup_sptr diffResultsGroup =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-            baseName.toStdString());
+    auto const diffResultsGroup = getADSWorkspaceGroup(baseName.toStdString());
 
-    auto names = diffResultsGroup->getNames();
-    auto plotType = m_uiForm.cbPlot->currentText();
+    auto const names = diffResultsGroup->getNames();
+    auto const plotType = m_uiForm.cbPlot->currentText();
 
-    for (const auto &wsName : names) {
+    for (auto const &name : names) {
       if (plotType == "Spectra" || plotType == "Both")
-        plotSpectrum(QString::fromStdString(wsName));
+        plotSpectrum(QString::fromStdString(name));
 
       if (plotType == "Contour" || plotType == "Both")
-        plot2D(QString::fromStdString(wsName));
+        plot2D(QString::fromStdString(name));
     }
   }
+
+  setPlotIsPlotting(false);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
@@ -158,7 +158,6 @@ void IndirectMolDyn::plotClicked() {
   if (checkADSForPlotSaveWorkspace(baseName.toStdString(), true)) {
 
     auto const diffResultsGroup = getADSWorkspaceGroup(baseName.toStdString());
-
     auto const names = diffResultsGroup->getNames();
     auto const plotType = m_uiForm.cbPlot->currentText();
 
@@ -194,7 +193,7 @@ void IndirectMolDyn::setRunIsRunning(bool running) {
 }
 
 void IndirectMolDyn::setPlotIsPlotting(bool running) {
-  m_uiForm.pbRun->setText(running ? "Plotting..." : "Plot");
+  m_uiForm.pbPlot->setText(running ? "Plotting..." : "Plot");
   setButtonsEnabled(!running);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
@@ -26,7 +26,8 @@ IndirectMolDyn::IndirectMolDyn(QWidget *parent)
           SLOT(setEnabled(bool)));
   connect(m_uiForm.cbVersion, SIGNAL(currentIndexChanged(const QString &)),
           this, SLOT(versionSelected(const QString &)));
-  // Handle plotting and saving
+
+	connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
@@ -124,6 +125,9 @@ void IndirectMolDyn::versionSelected(const QString &version) {
   bool version4(version == "4");
   m_uiForm.mwRun->isForDirectory(version4);
 }
+
+void IndirectMolDyn::runClicked() { runTab(); }
+
 /**
  * Handle plotting of mantid workspace
  */

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
@@ -28,7 +28,7 @@ public:
 
 private slots:
   void versionSelected(const QString &);
-  // Handle plotting and saving
+  void runClicked();
   void plotClicked();
   void saveClicked();
 

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
@@ -31,8 +31,16 @@ private slots:
   void runClicked();
   void plotClicked();
   void saveClicked();
+  void algorithmComplete(bool error);
 
 private:
+  void setRunIsRunning(bool running);
+  void setPlotIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+
   // The ui form
   Ui::IndirectMolDyn m_uiForm;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.ui
@@ -270,6 +270,60 @@
     </spacer>
    </item>
    <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>194</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>193</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Fixed">

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.cpp
@@ -6,6 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectSassena.h"
 
+#include "../General/UserInputValidator.h"
+
 #include <QFileInfo>
 #include <QString>
 
@@ -30,9 +32,14 @@ void IndirectSassena::setup() {}
  * @return Whether the form was valid
  */
 bool IndirectSassena::validate() {
-  // There is very little to actually be invalid here
-  // that was not already done via restrictions on input
-  return true;
+  UserInputValidator uiv;
+
+  auto const inputFileName = m_uiForm.mwInputFile->getFirstFilename();
+  if (inputFileName.isEmpty())
+    uiv.addErrorMessage("Incorrect input file provided.");
+
+  emit showMessageBox(uiv.generateErrorMessage());
+  return uiv.isAllInputValid();
 }
 
 /**
@@ -42,18 +49,17 @@ void IndirectSassena::run() {
   using namespace Mantid::API;
   using MantidQt::API::BatchAlgorithmRunner;
 
-  QString inputFileName = m_uiForm.mwInputFile->getFirstFilename();
-  QFileInfo inputFileInfo(inputFileName);
-  m_outWsName = inputFileInfo.baseName();
+  setRunIsRunning(true);
+
+  QString const inputFileName = m_uiForm.mwInputFile->getFirstFilename();
+  m_outWsName = QFileInfo(inputFileName).baseName();
 
   // If the workspace group already exists then remove it
   if (AnalysisDataService::Instance().doesExist(m_outWsName.toStdString()))
     AnalysisDataService::Instance().deepRemoveGroup(m_outWsName.toStdString());
 
-  IAlgorithm_sptr sassenaAlg =
-      AlgorithmManager::Instance().create("LoadSassena");
+  auto sassenaAlg = AlgorithmManager::Instance().create("LoadSassena");
   sassenaAlg->initialize();
-
   sassenaAlg->setProperty("Filename", inputFileName.toStdString());
   sassenaAlg->setProperty("SortByQVectors", m_uiForm.cbSortQ->isChecked());
   sassenaAlg->setProperty("TimeUnit", m_uiForm.sbTimeUnit->value());
@@ -73,14 +79,11 @@ void IndirectSassena::run() {
  * @param error If the batch was stopped due to error
  */
 void IndirectSassena::handleAlgorithmFinish(bool error) {
-
-  // Nothing to do if the algorithm failed
-  if (error)
-    return;
-
-  // Enable plot and save
-  m_uiForm.pbPlot->setEnabled(true);
-  m_uiForm.pbSave->setEnabled(true);
+  setRunIsRunning(false);
+  if (error) {
+    setPlotEnabled(false);
+    setSaveEnabled(false);
+  }
 }
 
 /**
@@ -99,8 +102,10 @@ void IndirectSassena::runClicked() { runTab(); }
  * Handle mantid plotting of workspace
  */
 void IndirectSassena::plotClicked() {
+  setPlotIsPlotting(true);
   if (checkADSForPlotSaveWorkspace(m_outWsName.toStdString(), true))
     plotSpectrum(m_outWsName);
+  setPlotIsPlotting(false);
 }
 
 /**
@@ -110,6 +115,34 @@ void IndirectSassena::saveClicked() {
   if (checkADSForPlotSaveWorkspace(m_outWsName.toStdString(), false))
     addSaveWorkspaceToQueue(m_outWsName);
   m_batchAlgoRunner->executeBatchAsync();
+}
+
+void IndirectSassena::setRunIsRunning(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  setButtonsEnabled(!running);
+}
+
+void IndirectSassena::setPlotIsPlotting(bool running) {
+  m_uiForm.pbPlot->setText(running ? "Plotting..." : "Plot Result");
+  setButtonsEnabled(!running);
+}
+
+void IndirectSassena::setButtonsEnabled(bool enabled) {
+  setRunEnabled(enabled);
+  setPlotEnabled(enabled);
+  setSaveEnabled(enabled);
+}
+
+void IndirectSassena::setRunEnabled(bool enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
+
+void IndirectSassena::setPlotEnabled(bool enabled) {
+  m_uiForm.pbPlot->setEnabled(enabled);
+}
+
+void IndirectSassena::setSaveEnabled(bool enabled) {
+  m_uiForm.pbSave->setEnabled(enabled);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.cpp
@@ -16,9 +16,10 @@ IndirectSassena::IndirectSassena(QWidget *parent)
   m_uiForm.setupUi(parent);
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(handleAlgorithmFinish(bool)));
-  // Handle plotting and saving
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
+
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
 }
 
 void IndirectSassena::setup() {}
@@ -91,6 +92,8 @@ void IndirectSassena::handleAlgorithmFinish(bool error) {
 void IndirectSassena::loadSettings(const QSettings &settings) {
   m_uiForm.mwInputFile->readSettings(settings.group());
 }
+
+void IndirectSassena::runClicked() { runTab(); }
 
 /**
  * Handle mantid plotting of workspace

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.h
@@ -33,6 +33,13 @@ private slots:
   void saveClicked();
 
 private:
+  void setRunIsRunning(bool running);
+  void setPlotIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
+  void setRunEnabled(bool enabled);
+  void setPlotEnabled(bool enabled);
+  void setSaveEnabled(bool enabled);
+
   /// The ui form
   Ui::IndirectSassena m_uiForm;
   /// Name of the output workspace group

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.h
@@ -28,7 +28,7 @@ public:
 private slots:
   /// Handle completion of the algorithm batch
   void handleAlgorithmFinish(bool error);
-  /// Handle plotting and saving
+  void runClicked();
   void plotClicked();
   void saveClicked();
 

--- a/qt/scientific_interfaces/Indirect/IndirectSassena.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSassena.ui
@@ -20,7 +20,16 @@
       <string>Input File</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>6</number>
+      </property>
+      <property name="topMargin">
+       <number>6</number>
+      </property>
+      <property name="rightMargin">
+       <number>6</number>
+      </property>
+      <property name="bottomMargin">
        <number>6</number>
       </property>
       <item row="0" column="1">
@@ -103,6 +112,60 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>194</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>193</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="gbOutput">

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
@@ -57,7 +57,6 @@ void IndirectSimulation::initLayout() {
 
   // Connect statements for the buttons shared between all tabs on the Indirect
   // Bayes interface
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(helpClicked()));
   connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
           SLOT(manageUserDirectories()));
@@ -108,18 +107,6 @@ void IndirectSimulation::loadSettings() {
   }
 
   settings.endGroup();
-}
-
-/**
- * Slot to run the underlying algorithm code based on the currently selected
- * tab.
- *
- * This method checks the tabs validate method is passing before calling
- * the run method.
- */
-void IndirectSimulation::runClicked() {
-  int tabIndex = m_uiForm.IndirectSimulationTabs->currentIndex();
-  m_simulationTabs[tabIndex]->runTab();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.h
@@ -47,8 +47,6 @@ public: // public constructor, destructor and functions
   void initLayout() override;
 
 private slots:
-  /// Slot for clicking on the run button
-  void runClicked();
   /// Slot for clicking on the help button
   void helpClicked();
   /// Slot for clicking on the manage directories button

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.ui
@@ -14,102 +14,82 @@
    <string>Indirect Simulation</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QTabWidget" name="IndirectSimulationTabs">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="molDyn">
-      <attribute name="title">
-       <string>MolDyn</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="sassena">
-      <attribute name="title">
-       <string>Sassena</string>
-      </attribute>
-     </widget>
-     <widget class="QWidget" name="dos">
-      <attribute name="title">
-       <string>DensityOfStates</string>
-      </attribute>
-     </widget>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="layout_bottom">
-     <item>
-      <widget class="QPushButton" name="pbHelp">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>20</width>
-         <height>20</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>?</string>
-       </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="IndirectSimulationTabs">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="molDyn">
+       <attribute name="title">
+        <string>MolDyn</string>
+       </attribute>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_14">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pbRun">
-       <property name="text">
-        <string>Run</string>
-       </property>
+      <widget class="QWidget" name="sassena">
+       <attribute name="title">
+        <string>Sassena</string>
+       </attribute>
       </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_11">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="pbManageDirs">
-       <property name="text">
-        <string>Manage Directories</string>
-       </property>
+      <widget class="QWidget" name="dos">
+       <attribute name="title">
+        <string>DensityOfStates</string>
+       </attribute>
       </widget>
-     </item>
-    </layout>
-   </item>
-  </layout>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layout_bottom">
+      <item>
+       <widget class="QPushButton" name="pbHelp">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>?</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_14">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbManageDirs">
+        <property name="text">
+         <string>Manage Directories</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
   </widget>
  </widget>
  <resources/>


### PR DESCRIPTION
**Description of work.**
This PR moves the run button on the Indirect Simulations interfaces to allow it to be disabled while processing is being done. the output options are also disable while running is taking place.

**To test:**
1. `Interfaces`->`Indirect`->`Simulations`
2. Load the data below for the relevant tabs
3. Click `Run` and ensure it is disabled and then re-enabled after running is finished.
4. Click `Plot` in the output options and make sure the Run and output options are disabled while plotting is taking place.

**Data Files**
**DensitiesOfStates:**
Input File: [csd_benzen11_PhonDisp.zip](https://github.com/mantidproject/mantid/files/2675281/csd_benzen11_PhonDisp.zip)

**Sassena:**
No data could be found as this is a largely unused interface. The run and plotting however does work, and an additional validation check was added to prevent an error when clicking Run without loading any data.

**MolDyn:**
Input File: [NaF_DISF.zip](https://github.com/mantidproject/mantid/files/2672564/NaF_DISF.zip)
FunctionNames: `Sqw-Na`

Fixes #24063 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
