### PR TITLE
LoadDiffCal error message

### DIFF
--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -419,6 +419,7 @@ void LoadDiffCal::exec() {
 #else
     e.printError(stderr);
 #endif
+    file.close();
     throw FileError("Did not find group \"/calibration\"", m_filename);
   }
 

--- a/Framework/DataHandling/src/LoadDiffCal.cpp
+++ b/Framework/DataHandling/src/LoadDiffCal.cpp
@@ -18,6 +18,7 @@
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/Diffraction.h"
+#include "MantidKernel/Exception.h"
 #include "MantidKernel/OptionalBool.h"
 
 #include <H5Cpp.h>
@@ -36,6 +37,7 @@ using Mantid::DataObjects::GroupingWorkspace_sptr;
 using Mantid::DataObjects::MaskWorkspace_sptr;
 using Mantid::DataObjects::Workspace2D;
 using Mantid::Kernel::Direction;
+using Mantid::Kernel::Exception::FileError;
 using Mantid::Kernel::PropertyWithValue;
 
 using namespace H5;
@@ -397,8 +399,13 @@ void LoadDiffCal::exec() {
   }
 
   // read in everything from the file
-  H5File file(m_filename, H5F_ACC_RDONLY);
   H5::Exception::dontPrint();
+  H5File file;
+  try {
+    file = H5File(m_filename, H5F_ACC_RDONLY);
+  } catch (FileIException &) {
+    throw FileError("Failed to open file using HDF5", m_filename);
+  }
   getInstrument(file);
 
   Progress progress(this, 0.1, 0.4, 8);
@@ -412,7 +419,7 @@ void LoadDiffCal::exec() {
 #else
     e.printError(stderr);
 #endif
-    throw std::runtime_error("Did not find group \"/calibration\"");
+    throw FileError("Did not find group \"/calibration\"", m_filename);
   }
 
   progress.report("Reading detid");

--- a/Framework/DataHandling/test/LoadDetectorsGroupingFileTest.h
+++ b/Framework/DataHandling/test/LoadDetectorsGroupingFileTest.h
@@ -372,8 +372,8 @@ public:
     TS_ASSERT(load.setProperty("InputFile", file.getFileName()));
     TS_ASSERT(load.setProperty("OutputWorkspace", ws));
 
-    std::string errorMsg =
-        "Bad number of spectra list in " + file.getFileName() + " on line 4";
+    std::string errorMsg = "Bad number of spectra list in \"" +
+                           file.getFileName() + "\" on line 4";
 
     TS_ASSERT_THROWS_EQUALS(load.execute(), const Exception::ParseError &e,
                             e.what(), errorMsg);
@@ -398,8 +398,9 @@ public:
     TS_ASSERT(load.setProperty("InputFile", file.getFileName()));
     TS_ASSERT(load.setProperty("OutputWorkspace", ws));
 
-    std::string errorMsg = "Premature end of file, expecting spectra list in " +
-                           file.getFileName() + " on line 4";
+    std::string errorMsg =
+        "Premature end of file, expecting spectra list in \"" +
+        file.getFileName() + "\" on line 4";
 
     TS_ASSERT_THROWS_EQUALS(load.execute(), const Exception::ParseError &e,
                             e.what(), errorMsg);
@@ -426,8 +427,8 @@ public:
     TS_ASSERT(load.setProperty("OutputWorkspace", ws));
 
     std::string errorMsg =
-        "Expected a single int for the number of group spectra in " +
-        file.getFileName() + " on line 3";
+        "Expected a single int for the number of group spectra in \"" +
+        file.getFileName() + "\" on line 3";
 
     TS_ASSERT_THROWS_EQUALS(load.execute(), const Exception::ParseError &e,
                             e.what(), errorMsg);

--- a/Framework/DataHandling/test/LoadInstrumentTest.h
+++ b/Framework/DataHandling/test/LoadInstrumentTest.h
@@ -665,7 +665,7 @@ public:
         instLoader.execute(), Kernel::Exception::FileError & e,
         std::string(e.what()),
         "Either the InstrumentName or Filename property of LoadInstrument "
-        "must be specified to load an instrument in ");
+        "must be specified to load an instrument in \"\"");
     TS_ASSERT(!instLoader.isExecuted());
     TS_ASSERT_EQUALS(instLoader.getPropertyValue("Filename"), "");
   }

--- a/Framework/Kernel/src/Exception.cpp
+++ b/Framework/Kernel/src/Exception.cpp
@@ -19,7 +19,8 @@ namespace Exception {
 */
 FileError::FileError(const std::string &Desc, const std::string &FName)
     : std::runtime_error(Desc), fileName(FName) {
-  outMessage = std::string(std::runtime_error::what()) + " in " + fileName;
+  outMessage =
+      std::string(std::runtime_error::what()) + " in \"" + fileName + "\"";
 }
 
 /// Copy constructor


### PR DESCRIPTION
Rather than just generating a nonsense error message on failure, catch and throw a `FileError` with a clear message of what went wrong.

**To test:**

Run `LoadDiffCal` on any text file that doesn't end in `.cal` and you will see an error message better describing what you did wrong.

*There is no associated issue.*

*This does not require release notes* because this is only a change in what error message is generated.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
