### PR TITLE
Print sample log's units, if present

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveReflectometryAscii.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveReflectometryAscii.h
@@ -62,6 +62,8 @@ private:
   void outputval(std::string val);
   /// Retrieve sample log information
   std::string sampleInfo(const std::string &logName);
+  /// Retrieve sample log unit
+  std::string sampleUnit(const std::string &logName);
   /// Write one header line
   void writeInfo(const std::string logName, const std::string logValue = "");
   /// Write header

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveReflectometryAscii.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveReflectometryAscii.h
@@ -60,12 +60,13 @@ private:
   bool writeString(bool write, std::string s);
   /// Print a string value to file
   void outputval(std::string val);
-  /// Retrieve sample log information
-  std::string sampleInfo(const std::string &logName);
+  /// Retrieve sample log value
+  std::string sampleLogValue(const std::string &logName);
   /// Retrieve sample log unit
-  std::string sampleUnit(const std::string &logName);
+  std::string sampleLogUnit(const std::string &logName);
   /// Write one header line
-  void writeInfo(const std::string logName, const std::string logValue = "");
+  void writeInfo(const std::string logName,
+                 const std::string logNameFixed = "");
   /// Write header
   void header();
   /// Determine the separator

--- a/Framework/DataHandling/src/SaveReflectometryAscii.cpp
+++ b/Framework/DataHandling/src/SaveReflectometryAscii.cpp
@@ -224,13 +224,16 @@ void SaveReflectometryAscii::header() {
   writeInfo("Theta 2 + dir + ref numbers");
   writeInfo("Theta 3 + dir + ref numbers");
   const std::vector<std::string> logList = getProperty("LogList");
+  int existingLogs = 0;
   for (const auto &log : logList) {
     if (find(logs.cbegin(), logs.cend(), log) ==
         logs.end()) { // do not repeat a log
       writeInfo(log);
+      ++existingLogs;
     }
   }
-  for (auto i = logList.size(); i < 9; ++i)
+  // Write "Parameter : Not defined" 9 times minus the number of new user logs
+  for (auto i = logList.size() - existingLogs; i < 9; ++i)
     writeInfo("Parameter ");
   m_file << "Number of file format : "
          << "40\n";

--- a/Framework/DataHandling/src/SaveReflectometryAscii.cpp
+++ b/Framework/DataHandling/src/SaveReflectometryAscii.cpp
@@ -212,8 +212,16 @@ void SaveReflectometryAscii::writeInfo(const std::string logName,
 void SaveReflectometryAscii::header() {
   m_file << std::setfill(' ');
   m_file << "MFT\n";
-  std::vector<std::string> logs{"instrument.name", "user.namelocalcontact",
-                                "title", "start_time", "end_time"};
+  std::map<std::string, std::string> logs;
+  logs["Instrument"] = "instrument.name";
+  logs["User-local contact"] = "user.namelocalcontact";
+  logs["Title"] = "title";
+  logs["Subtitle"] = "";
+  logs["Start date + time"] = "start_time";
+  logs["End date + time"] = "end_time";
+  logs["Theta 1 + dir + ref numbers"] = "";
+  logs["Theta 2 + dir + ref numbers"] = "";
+  logs["Theta 3 + dir + ref numbers"] = "";
   writeInfo("Instrument", "instrument.name");
   writeInfo("User-local contact", "user.namelocalcontact");
   writeInfo("Title", "title");
@@ -224,16 +232,15 @@ void SaveReflectometryAscii::header() {
   writeInfo("Theta 2 + dir + ref numbers");
   writeInfo("Theta 3 + dir + ref numbers");
   const std::vector<std::string> logList = getProperty("LogList");
-  int existingLogs = 0;
+  int nLogs = 0;
   for (const auto &log : logList) {
-    if (find(logs.cbegin(), logs.cend(), log) ==
-        logs.end()) { // do not repeat a log
+    if (logs.find(log) == logs.end()) { // do not repeat a log
       writeInfo(log);
-      ++existingLogs;
+      ++nLogs;
     }
   }
   // Write "Parameter : Not defined" 9 times minus the number of new user logs
-  for (auto i = logList.size() - existingLogs; i < 9; ++i)
+  for (auto i = nLogs; i < 9; ++i)
     writeInfo("Parameter ");
   m_file << "Number of file format : "
          << "40\n";

--- a/Framework/DataHandling/src/SaveReflectometryAscii.cpp
+++ b/Framework/DataHandling/src/SaveReflectometryAscii.cpp
@@ -204,41 +204,33 @@ void SaveReflectometryAscii::writeInfo(const std::string logName,
     m_file << logName << " : " << sampleInfo(logValue) << sampleUnit(logValue)
            << '\n';
   else
-    m_file << logName << " : " << sampleInfo(logName) << '\n';
+    m_file << logName << " : " << sampleInfo(logName) << sampleUnit(logName)
+           << '\n';
 }
 
 /// Write header lines
 void SaveReflectometryAscii::header() {
   m_file << std::setfill(' ');
   m_file << "MFT\n";
-  std::map<std::string, std::string> logs;
-  logs["Instrument"] = "instrument.name";
-  logs["User-local contact"] = "user.namelocalcontact";
-  logs["Title"] = "title";
-  logs["Subtitle"] = "";
-  logs["Start date + time"] = "start_time";
-  logs["End date + time"] = "end_time";
-  logs["Theta 1 + dir + ref numbers"] = "";
-  logs["Theta 2 + dir + ref numbers"] = "";
-  logs["Theta 3 + dir + ref numbers"] = "";
+  std::vector<std::string> logs{"instrument.name", "user.namelocalcontact",
+                                "title", "start_time", "end_time"};
   writeInfo("Instrument", "instrument.name");
   writeInfo("User-local contact", "user.namelocalcontact");
   writeInfo("Title", "title");
-  writeInfo("Subtitle", "");
+  writeInfo("Subtitle");
   writeInfo("Start date + time", "start_time");
   writeInfo("End date + time", "end_time");
-  writeInfo("Theta 1 + dir + ref numbers", "");
-  writeInfo("Theta 2 + dir + ref numbers", "");
-  writeInfo("Theta 3 + dir + ref numbers", "");
+  writeInfo("Theta 1 + dir + ref numbers");
+  writeInfo("Theta 2 + dir + ref numbers");
+  writeInfo("Theta 3 + dir + ref numbers");
   const std::vector<std::string> logList = getProperty("LogList");
-  int nlogs = 0;
   for (const auto &log : logList) {
-    if (logs.find(log) == logs.end()) {
+    if (find(logs.cbegin(), logs.cend(), log) ==
+        logs.end()) { // do not repeat a log
       writeInfo(log);
-      ++nlogs;
     }
   }
-  for (auto i = nlogs + 1; i < 10; ++i)
+  for (auto i = logList.size(); i < 9; ++i)
     writeInfo("Parameter ");
   m_file << "Number of file format : "
          << "40\n";

--- a/Framework/DataHandling/src/SaveReflectometryAscii.cpp
+++ b/Framework/DataHandling/src/SaveReflectometryAscii.cpp
@@ -176,72 +176,72 @@ void SaveReflectometryAscii::outputval(std::string val) {
   m_file << std::setw(28) << val;
 }
 
-/// Retrieve sample log information
-std::string SaveReflectometryAscii::sampleInfo(const std::string &logName) {
+/// Retrieve sample log value
+std::string SaveReflectometryAscii::sampleLogValue(const std::string &logName) {
   auto run = m_ws->run();
   try {
     return boost::lexical_cast<std::string>(run.getLogData(logName)->value());
   } catch (Exception::NotFoundError &) {
+    return "Not defined";
   }
-  return "Not defined";
 }
 
 /// Retrieve sample log unit
-std::string SaveReflectometryAscii::sampleUnit(const std::string &logName) {
+std::string SaveReflectometryAscii::sampleLogUnit(const std::string &logName) {
   auto run = m_ws->run();
   try {
     return " " +
            boost::lexical_cast<std::string>(run.getLogData(logName)->units());
   } catch (Exception::NotFoundError &) {
+    return "";
   }
-  return "";
 }
 
-/// Write one header line
+/** Write one header line
+ *  @param logName :: the name of a SampleLog entry to get its value from
+ *  @param logNameFixed :: the name of the SampleLog entry defined by the header
+ */
 void SaveReflectometryAscii::writeInfo(const std::string logName,
-                                       const std::string logValue) {
-  if (!logValue.empty())
-    m_file << logName << " : " << sampleInfo(logValue) << sampleUnit(logValue)
-           << '\n';
-  else
-    m_file << logName << " : " << sampleInfo(logName) << sampleUnit(logName)
-           << '\n';
+                                       const std::string logNameFixed) {
+  const std::string logValue = sampleLogValue(logName);
+  const std::string logUnit = sampleLogUnit(logName);
+  if (!logNameFixed.empty()) {
+    // The logName corresponds to an existing header line of given name
+    m_file << logNameFixed;
+  } else {
+    // The user provided a log name which is not part of the defined header
+    m_file << logName;
+  }
+  m_file << " : " << logValue << logUnit << '\n';
 }
 
 /// Write header lines
 void SaveReflectometryAscii::header() {
   m_file << std::setfill(' ');
   m_file << "MFT\n";
-  std::map<std::string, std::string> logs;
-  logs["Instrument"] = "instrument.name";
-  logs["User-local contact"] = "user.namelocalcontact";
-  logs["Title"] = "title";
-  logs["Subtitle"] = "";
-  logs["Start date + time"] = "start_time";
-  logs["End date + time"] = "end_time";
-  logs["Theta 1 + dir + ref numbers"] = "";
-  logs["Theta 2 + dir + ref numbers"] = "";
-  logs["Theta 3 + dir + ref numbers"] = "";
-  writeInfo("Instrument", "instrument.name");
-  writeInfo("User-local contact", "user.namelocalcontact");
-  writeInfo("Title", "title");
-  writeInfo("Subtitle");
-  writeInfo("Start date + time", "start_time");
-  writeInfo("End date + time", "end_time");
-  writeInfo("Theta 1 + dir + ref numbers");
-  writeInfo("Theta 2 + dir + ref numbers");
-  writeInfo("Theta 3 + dir + ref numbers");
+  std::vector<std::string> logs{"instrument.name", "user.namelocalcontact",
+                                "title", "start_time", "end_time"};
+  writeInfo("instrument.name", "Instrument");
+  writeInfo("user.namelocalcontact", "User-local contact");
+  writeInfo("title", "Title");
+  writeInfo("", "Subtitle");
+  writeInfo("start_time", "Start date + time");
+  writeInfo("end_time", "End date + time");
+  writeInfo("", "Theta 1 + dir + ref numbers");
+  writeInfo("", "Theta 2 + dir + ref numbers");
+  writeInfo("", "Theta 3 + dir + ref numbers");
   const std::vector<std::string> logList = getProperty("LogList");
   int nLogs = 0;
   for (const auto &log : logList) {
-    if (logs.find(log) == logs.end()) { // do not repeat a log
+    if (find(logs.cbegin(), logs.cend(), log) ==
+        logs.end()) { // do not repeat a log
       writeInfo(log);
       ++nLogs;
     }
   }
   // Write "Parameter : Not defined" 9 times minus the number of new user logs
   for (auto i = nLogs; i < 9; ++i)
-    writeInfo("Parameter ");
+    writeInfo("", "Parameter ");
   m_file << "Number of file format : "
          << "40\n";
   m_file << "Number of data points : " << m_ws->y(0).size() << '\n';

--- a/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
@@ -344,7 +344,7 @@ public:
     TS_ASSERT_EQUALS(line, "Number of data points : 2")
   }
 
-  void test_defined_log() {
+  void test_user_log() {
     const auto &x1 = Mantid::HistogramData::Points({0.33, 0.34});
     const auto &y1 = Mantid::HistogramData::Counts({3., 6.6});
     Mantid::HistogramData::Histogram histogram(x1, y1);
@@ -396,6 +396,122 @@ public:
     std::getline(in, line);
     TS_ASSERT_EQUALS(line, "b : 3.4382000000000001 MyUnit")
     for (int i = 0; i < 7; ++i) {
+      std::getline(in, line);
+      TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
+    }
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of file format : 40")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of data points : 2")
+  }
+
+  void test_user_log_overrides_fixed_log() {
+    const auto &x1 = Mantid::HistogramData::Points({0.33, 0.34});
+    const auto &y1 = Mantid::HistogramData::Counts({3., 6.6});
+    Mantid::HistogramData::Histogram histogram(x1, y1);
+    auto ws = boost::make_shared<Mantid::DataObjects::Workspace2D>();
+    ws->initialize(1, histogram);
+    // User wants to add the Instrument name header line
+    Mantid::Kernel::PropertyWithValue<std::string> *a =
+        new Mantid::Kernel::PropertyWithValue<std::string>("Instrument", "ABC");
+    ws->mutableRun().addLogData(a);
+    // The workspace has an entry already for the instrument name
+    Mantid::Kernel::PropertyWithValue<std::string> *b =
+        new Mantid::Kernel::PropertyWithValue<std::string>("instrument.name",
+                                                           "DEF");
+    ws->mutableRun().addLogData(b);
+    auto outputFileHandle = Poco::TemporaryFile();
+    const std::string file = outputFileHandle.path();
+    SaveReflectometryAscii alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", file))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty("LogList", "Instrument, instrument.name"))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename.append(".mft")).exists())
+    std::ifstream in(filename);
+    std::string line;
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "MFT")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Instrument : DEF ")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "User-local contact : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Title : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Subtitle : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Start date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "End date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 1 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 2 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Instrument : ABC ")
+    for (int i = 0; i < 8; ++i) {
+      std::getline(in, line);
+      TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
+    }
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of file format : 40")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of data points : 2")
+  }
+
+  void test_automatic_log_filling() {
+    const auto &x1 = Mantid::HistogramData::Points({0.33, 0.34});
+    const auto &y1 = Mantid::HistogramData::Counts({3., 6.6});
+    Mantid::HistogramData::Histogram histogram(x1, y1);
+    auto ws = boost::make_shared<Mantid::DataObjects::Workspace2D>();
+    ws->initialize(1, histogram);
+    // Should use this instrument name
+    Mantid::Kernel::PropertyWithValue<std::string> *a =
+        new Mantid::Kernel::PropertyWithValue<std::string>("instrument.name",
+                                                           "DEF");
+    ws->mutableRun().addLogData(a);
+    auto outputFileHandle = Poco::TemporaryFile();
+    const std::string file = outputFileHandle.path();
+    SaveReflectometryAscii alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", file))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename.append(".mft")).exists())
+    std::ifstream in(filename);
+    std::string line;
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "MFT")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Instrument : DEF ")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "User-local contact : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Title : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Subtitle : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Start date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "End date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 1 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 2 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
+    for (int i = 0; i < 9; ++i) {
       std::getline(in, line);
       TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
     }

--- a/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
@@ -353,6 +353,10 @@ public:
     Mantid::Kernel::PropertyWithValue<int> *a =
         new Mantid::Kernel::PropertyWithValue<int>("a", 5);
     ws->mutableRun().addLogData(a);
+    Mantid::Kernel::PropertyWithValue<double> *b =
+        new Mantid::Kernel::PropertyWithValue<double>("b", 3.4382);
+    ws->mutableRun().addLogData(b);
+    ws->mutableRun().getProperty("b")->setUnits("MyUnit");
     auto outputFileHandle = Poco::TemporaryFile();
     const std::string file = outputFileHandle.path();
     SaveReflectometryAscii alg;
@@ -390,64 +394,9 @@ public:
     TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
     std::getline(in, line);
     TS_ASSERT_EQUALS(line, "a : 5")
-    for (int i = 0; i < 8; ++i) {
-      std::getline(in, line);
-      TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
-    }
     std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Number of file format : 40")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Number of data points : 2")
-  }
-
-  void test_defined_log_with_unit() {
-    const auto &x1 = Mantid::HistogramData::Points({0.33, 0.34});
-    const auto &y1 = Mantid::HistogramData::Counts({3., 6.6});
-    Mantid::HistogramData::Histogram histogram(x1, y1);
-    auto ws = boost::make_shared<Mantid::DataObjects::Workspace2D>();
-    ws->initialize(1, histogram);
-    Mantid::Kernel::PropertyWithValue<int> *a =
-        new Mantid::Kernel::PropertyWithValue<int>("a", 5);
-    ws->mutableRun().addLogData(a);
-    ws->mutableRun().getProperty("a")->setUnits("MyUnit");
-    auto outputFileHandle = Poco::TemporaryFile();
-    const std::string file = outputFileHandle.path();
-    SaveReflectometryAscii alg;
-    alg.initialize();
-    alg.setRethrows(true);
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", file))
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("LogList", std::vector<std::string>{"a"}))
-    TS_ASSERT_THROWS_NOTHING(alg.execute())
-    TS_ASSERT(alg.isExecuted())
-    std::string filename = alg.getPropertyValue("Filename");
-    TS_ASSERT(Poco::File(filename.append(".mft")).exists())
-    std::ifstream in(filename);
-    std::string line;
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "MFT")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Instrument : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "User-local contact : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Title : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Subtitle : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Start date + time : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "End date + time : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Theta 1 + dir + ref numbers : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Theta 2 + dir + ref numbers : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
-    std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "a : 5 MyUnit")
-    for (int i = 0; i < 8; ++i) {
+    TS_ASSERT_EQUALS(line, "b : 3.4382 MyUnit")
+    for (int i = 0; i < 7; ++i) {
       std::getline(in, line);
       TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
     }

--- a/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
@@ -400,6 +400,63 @@ public:
     TS_ASSERT_EQUALS(line, "Number of data points : 2")
   }
 
+  void test_defined_log_with_unit() {
+    const auto &x1 = Mantid::HistogramData::Points({0.33, 0.34});
+    const auto &y1 = Mantid::HistogramData::Counts({3., 6.6});
+    Mantid::HistogramData::Histogram histogram(x1, y1);
+    auto ws = boost::make_shared<Mantid::DataObjects::Workspace2D>();
+    ws->initialize(1, histogram);
+    Mantid::Kernel::PropertyWithValue<int> *a =
+        new Mantid::Kernel::PropertyWithValue<int>("a", 5);
+    ws->mutableRun().addLogData(a);
+    ws->mutableRun().getProperty("a")->setUnits("MyUnit");
+    auto outputFileHandle = Poco::TemporaryFile();
+    const std::string file = outputFileHandle.path();
+    SaveReflectometryAscii alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", file))
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty("LogList", std::vector<std::string>{"a"}))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+    std::string filename = alg.getPropertyValue("Filename");
+    TS_ASSERT(Poco::File(filename.append(".mft")).exists())
+    std::ifstream in(filename);
+    std::string line;
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "MFT")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Instrument : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "User-local contact : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Title : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Subtitle : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Start date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "End date + time : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 1 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 2 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "a : 5 MyUnit")
+    for (int i = 0; i < 8; ++i) {
+      std::getline(in, line);
+      TS_ASSERT_EQUALS(line, "Parameter  : Not defined")
+    }
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of file format : 40")
+    std::getline(in, line);
+    TS_ASSERT_EQUALS(line, "Number of data points : 2")
+  }
+
   void test_group_workspaces() {
     const auto &x1 = Mantid::HistogramData::Points({4.36, 6.32});
     const auto &y1 = Mantid::HistogramData::Counts({4., 7.6});

--- a/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflectometryAsciiTest.h
@@ -364,8 +364,7 @@ public:
     alg.setRethrows(true);
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", ws))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("Filename", file))
-    TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("LogList", std::vector<std::string>{"a"}))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("LogList", "a, b"))
     TS_ASSERT_THROWS_NOTHING(alg.execute())
     TS_ASSERT(alg.isExecuted())
     std::string filename = alg.getPropertyValue("Filename");
@@ -393,9 +392,9 @@ public:
     std::getline(in, line);
     TS_ASSERT_EQUALS(line, "Theta 3 + dir + ref numbers : Not defined")
     std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "a : 5")
+    TS_ASSERT_EQUALS(line, "a : 5 ")
     std::getline(in, line);
-    TS_ASSERT_EQUALS(line, "b : 3.4382 MyUnit")
+    TS_ASSERT_EQUALS(line, "b : 3.4382000000000001 MyUnit")
     for (int i = 0; i < 7; ++i) {
       std::getline(in, line);
       TS_ASSERT_EQUALS(line, "Parameter  : Not defined")

--- a/docs/source/algorithms/SaveReflectometryAscii-v1.rst
+++ b/docs/source/algorithms/SaveReflectometryAscii-v1.rst
@@ -87,7 +87,7 @@ Usage
 
     # Save with mft extension and using the option LogList: Title will be added to a required header line and d will be additionally added
     # to the first parameter field.
-    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['title', 'd'])
+    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['Title', 'd'])
 
     if os.path.exists(file + ".mft"):
       myFile = open((file + ".mft"), 'r')

--- a/docs/source/algorithms/SaveReflectometryAscii-v1.rst
+++ b/docs/source/algorithms/SaveReflectometryAscii-v1.rst
@@ -17,6 +17,7 @@ In case of histogrammed input data, the resulting file will contain the bin cent
 It is especially useful for saving reflectometry reduction data.
 A file can be loaded back into Mantid by :ref:`algm-LoadAscii`, which will not have an instrument defined and `Sample Logs` are missing.
 This algorithm writes data in scientific exponential notation (E-notation) of double-precision.
+Please note that `SampleLog` entries are not case sensitive, editing fields `Title` and `title` both edit the field `title`.
 
 Computation of resolution values
 --------------------------------
@@ -34,6 +35,7 @@ The file contains minimum 21 header lines each separating its name and value by 
 The header lines contain the following information: `Instrument`, `User-local contact`, `Title`, `Subtitle`, `Start date + time`, `End date + time`, `Theta 1 + dir + ref numbers`, `Theta 2 + dir + ref numbers`, `Theta 3 + dir + ref numbers`, (foreseen potentially added angle(s),) followed by 9 user defined parameter lines, followed by potentially added user defined parameter lines, `Number of file format`, `Number of data points`.
 The version of the file format is set randomly to the high value 40 in order to exceed all ILL Cosmos versions.
 For the ILL instruments D17 and FIGARO, obligatory header lines will be automatically filled by using the workspaces `Sample Logs` information which can be modified as shown in the `Usage`_.
+The algorithm seeks to add the values for the following SampleLog entries: `instrument.name`, `user.namelocalcontact`, `title`, `start_time` and `end_time` which correspond to the header lines of names `Instrument`, `User-local contact`, `Title`, `Start date + time`, `End date + time`, respectively.
 The options `WriteHeader`, `WriteResolution` and `Separator` do not have any effect and are not visible in the user interface.
 
 TXT File Format
@@ -80,14 +82,14 @@ Usage
     file = os.path.join(os.path.expanduser("~"), "ws")
 
     # Add Sample Log entries
-    # Add a Title entry which will be automatically used
-    AddSampleLog(Workspace=ws, LogName='Title', LogText='MyTest', LogType='String')
+    # Add a Title entry:
+    AddSampleLog(Workspace=ws, LogName='title', LogText='MyTest', LogType='String')
     # Add an entry called d as a Parameter (then, only eight not defined parameter lines remain):
     AddSampleLog(Workspace=ws, LogName='d', LogText='0.3', LogType='Number', LogUnit='mm', NumberType='Double')
 
-    # Save with mft extension and using the option LogList: Title will be added to a required header line and d will be additionally added
+    # Save with mft extension and using the option LogList: title will be added to a required header line and d will be additionally added
     # to the first parameter field.
-    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['Title', 'd'])
+    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['title', 'd'])
 
     if os.path.exists(file + ".mft"):
       myFile = open((file + ".mft"), 'r')

--- a/docs/source/algorithms/SaveReflectometryAscii-v1.rst
+++ b/docs/source/algorithms/SaveReflectometryAscii-v1.rst
@@ -106,7 +106,7 @@ Usage
    Theta 1 + dir + ref numbers : Not defined
    Theta 2 + dir + ref numbers : Not defined
    Theta 3 + dir + ref numbers : Not defined
-   d : 0.29999999999999999
+   d : 0.29999999999999999 mm
    Parameter  : Not defined
    Parameter  : Not defined
    Parameter  : Not defined

--- a/docs/source/algorithms/SaveReflectometryAscii-v1.rst
+++ b/docs/source/algorithms/SaveReflectometryAscii-v1.rst
@@ -87,7 +87,7 @@ Usage
 
     # Save with mft extension and using the option LogList: Title will be added to a required header line and d will be additionally added
     # to the first parameter field.
-    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['Title', 'd'])
+    SaveReflectometryAscii(InputWorkspace=ws, Filename=file, LogList=['title', 'd'])
 
     if os.path.exists(file + ".mft"):
       myFile = open((file + ".mft"), 'r')


### PR DESCRIPTION
**Description of work.**

The algorithm  `SaveReflectometryAscii` saves as well SampleLog information to file. Now, units will be printed, if present.

**To test:**

- Consult the usage example of the documentation
- Create a workspace and SampleLogs with units
- Run the algorithm
- Check that the resulting file contains the units of log values

or
- Make sure that you trust the unit test
- Observe that the tests do not fail

Fixes #24312.

*This does not require release notes* : deprecated reflectometry save algorithms do not print units and nobody seem to care about it.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
