### PR TITLE
move libMantidCatalog.so to lib/

### DIFF
--- a/Framework/Catalog/CMakeLists.txt
+++ b/Framework/Catalog/CMakeLists.txt
@@ -41,7 +41,7 @@ set_target_properties ( Catalog PROPERTIES OUTPUT_NAME MantidCatalog
 )
 
 if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(Catalog PROPERTIES INSTALL_RPATH "@loader_path/../Contents/MacOS")
+  set_target_properties(Catalog PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
 elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
   set_target_properties(Catalog PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
 endif ()

--- a/Framework/Catalog/CMakeLists.txt
+++ b/Framework/Catalog/CMakeLists.txt
@@ -60,4 +60,4 @@ add_subdirectory ( test )
 # Installation settings
 ###########################################################################
 
-install ( TARGETS Catalog ${SYSTEM_PACKAGE_TARGET} DESTINATION ${PLUGINS_DIR} )
+install ( TARGETS Catalog ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR} )


### PR DESCRIPTION
**Description of work.**

libMantidCatalog.so seems to be a library used by libMantidDataHandling. Right now it is installed as a plugin. This PR moves it to `$PREFIX/lib`. Without this change the conda build of mantid-framework does not work.

**To test:**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
