### PR TITLE
LoadIsawPeaks loads calibration correctly

### DIFF
--- a/Framework/Crystal/test/LoadIsawPeaksTest.h
+++ b/Framework/Crystal/test/LoadIsawPeaksTest.h
@@ -139,6 +139,47 @@ public:
     TS_ASSERT_EQUALS(G.getAxis(1).name, "chi");
     TS_ASSERT_EQUALS(G.getAxis(0).name, "omega");
   }
+
+  /* Test for the calibrated geometry */
+  void test_exec_calibrated() {
+    LoadIsawPeaks alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setPropertyValue("Filename", "calibrated.peaks");
+    alg.setPropertyValue("OutputWorkspace", "calibrated");
+
+    TS_ASSERT(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    PeaksWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = boost::dynamic_pointer_cast<PeaksWorkspace>(
+            AnalysisDataService::Instance().retrieve("calibrated")));
+    TS_ASSERT(ws);
+    if (!ws)
+      return;
+    TS_ASSERT_EQUALS(ws->getNumberPeaks(), 14);
+
+    Peak p = ws->getPeaks()[0];
+    TS_ASSERT_EQUALS(p.getRunNumber(), 71907)
+    TS_ASSERT_DELTA(p.getH(), 0, 1e-4);
+    TS_ASSERT_DELTA(p.getK(), 0, 1e-4);
+    TS_ASSERT_DELTA(p.getL(), 0, 1e-4);
+    TS_ASSERT_EQUALS(p.getBankName(), "bank22");
+    TS_ASSERT_DELTA(p.getCol(), 5, 1e-4);
+    TS_ASSERT_DELTA(p.getRow(), 154, 1e-4);
+    TS_ASSERT_DELTA(p.getIntensity(), 0, 0.01);
+    TS_ASSERT_DELTA(p.getSigmaIntensity(), 0, 0.01);
+    TS_ASSERT_DELTA(p.getBinCount(), 8, 53);
+    TS_ASSERT_DELTA(p.getWavelength(), 0.893676, 0.001);
+    TS_ASSERT_DELTA(p.getL1(), 20.0, 1e-3);
+    TS_ASSERT_DELTA(p.getL2(), 2.51, 1e-3);
+    TS_ASSERT_DELTA(p.getTOF(), 5085.05, 0.1); // channel number is about TOF
+
+    TS_ASSERT_DELTA(p.getDSpacing(), 2.0360, 0.001);
+    TS_ASSERT_DELTA(ws->getPeaks()[1].getDSpacing(), 2.3261, 0.001);
+    TS_ASSERT_DELTA(ws->getPeaks()[2].getDSpacing(), 2.3329, 0.001);
+  }
 };
 
 #endif /* MANTID_CRYSTAL_LOADPEAKSFILETEST_H_ */

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -59,7 +59,7 @@ void LoadIsawDetCal::init() {
 
   declareProperty(
       Kernel::make_unique<API::FileProperty>(
-          "Filename2", "", API::FileProperty::OptionalLoad, ".DetCal"),
+          "Filename2", "", API::FileProperty::OptionalLoad, exts),
       "The input filename of the second ISAW DetCal file (West "
       "banks for SNAP) ");
 

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -50,7 +50,8 @@ void LoadIsawDetCal::init() {
                       boost::make_shared<InstrumentValidator>()),
                   "The workspace containing the geometry to be calibrated.");
 
-  const auto exts = std::vector<std::string>({".DetCal", ".detcal", ".peaks", ".integrate"});
+  const auto exts =
+      std::vector<std::string>({".DetCal", ".detcal", ".peaks", ".integrate"});
   declareProperty(
       Kernel::make_unique<API::MultipleFileProperty>("Filename", exts),
       "The input filename of the ISAW DetCal file (Two files "

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -50,7 +50,7 @@ void LoadIsawDetCal::init() {
                       boost::make_shared<InstrumentValidator>()),
                   "The workspace containing the geometry to be calibrated.");
 
-  const auto exts = std::vector<std::string>({".DetCal"});
+  const auto exts = std::vector<std::string>({".DetCal", ".detcal", ".peaks", ".integrate"});
   declareProperty(
       Kernel::make_unique<API::MultipleFileProperty>("Filename", exts),
       "The input filename of the ISAW DetCal file (Two files "

--- a/Framework/DataHandling/src/LoadIsawDetCal.cpp
+++ b/Framework/DataHandling/src/LoadIsawDetCal.cpp
@@ -57,11 +57,10 @@ void LoadIsawDetCal::init() {
       "The input filename of the ISAW DetCal file (Two files "
       "allowed for SNAP) ");
 
-  declareProperty(
-      Kernel::make_unique<API::FileProperty>(
-          "Filename2", "", API::FileProperty::OptionalLoad, exts),
-      "The input filename of the second ISAW DetCal file (West "
-      "banks for SNAP) ");
+  declareProperty(Kernel::make_unique<API::FileProperty>(
+                      "Filename2", "", API::FileProperty::OptionalLoad, exts),
+                  "The input filename of the second ISAW DetCal file (West "
+                  "banks for SNAP) ");
 
   declareProperty("TimeOffset", 0.0, "Time Offset", Direction::Output);
 }

--- a/Testing/Data/UnitTest/calibrated.peaks.md5
+++ b/Testing/Data/UnitTest/calibrated.peaks.md5
@@ -1,0 +1,1 @@
+baeef5e84e6c12ef0e8ad19d9e05fffb

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -48,6 +48,7 @@ Bugfixes
 
 - :ref:`FindPeaksMD <algm-FindPeaksMD>` now finds peaks correctly with the crystallography convention setting and reduction with crystallography convention is tested with a system test.
 - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` does not have duplicate peak numbers when saving PeaksWorkspaces with more than one RunNumber.
+- :ref:`LoadIsawPeaks <algm-LoadIsawPeaks>` now loads the calibration from the peaks file correctly.
 
 Powder Diffraction
 ------------------


### PR DESCRIPTION
**Description of work.**
LoadIsawDetCal was not loading the DetCal file correctly because LoadIsawDetCal only allowed files with DetCal extension.



[1.peaks.txt](https://github.com/mantidproject/mantid/files/2676662/1.peaks.txt)

**Report to:** [Yaohua Liu]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
LoadIsawPeaks(Filename='1.peaks', OutputWorkspace='reload_peaks')
SaveIsawDetCal(Filename='1.DetCal', InputWorkspace='reload_peaks')
````
Fixes #2432



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
