### PR TITLE
SEQ map detector name to number

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -100,6 +100,7 @@ set ( TEST_PY_FILES
       test/DirectReductionHelpersTest.py
       test/ErrorReportPresenterTest.py
       test/IndirectCommonTests.py
+      test/InelasticDirectDetpackmapTest.py
       test/ISISDirecInelasticConfigTest.py
       test/PyChopTest.py
       test/pythonTSVTest.py

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,9 +1,10 @@
 def sequoia(name):
     name = name.strip().upper()
-    packs = ['B%s' % i for i in range(1, 37+1)] \
-                + ['C%s' % i for i in range(1, 24+1)] \
-                + ['C25T', 'C26T', 'C25B', 'C26B'] \
-                + ['C%s' % i for i in range(27, 37+1)] \
-                + ['D%s' % i for i in range(1, 37+1)]
+    packs = (['B%s' % i for i in range(1, 37+1)]
+             + ['C%s' % i for i in range(1, 24+1)]
+             + ['C25T', 'C26T', 'C25B', 'C26B']
+             + ['C%s' % i for i in range(27, 37+1)]
+             + ['D%s' % i for i in range(1, 37+1)]
+             )
     start_index = 38
     return start_index + packs.index(name)

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,0 +1,36 @@
+def sequoia(name):
+    rows = 'BCD'
+    startindexes = dict(B=37, C=74, D=113)
+    name = name.strip().upper()
+    row = name[0]
+    assert row in rows, "Invalid pack name %r" % name
+    start = startindexes[row]
+    col = int(name[1:3])
+    # C25T, ...
+    extra = 0
+    if row == 'C':
+        if len(name) == 4:
+            assert name[-1] in 'TB', "Invalid pack name %r" % name
+            if name[3] == 'B': extra = 2
+        if col>26: extra = 2
+    return start + col + extra
+
+
+import unittest
+class TestCase(unittest.TestCase):
+    def test_sequoia(self):
+        assert sequoia('B1') == 38
+        assert sequoia('B37') == 74
+        assert sequoia('C1') == 75
+        assert sequoia('C25T') == 99
+        assert sequoia('C26T') == 100
+        assert sequoia('C25B') == 101
+        assert sequoia('C26B') == 102
+        assert sequoia('D1') == 114
+        assert sequoia('D37') == 150
+        return
+
+
+if __name__ == '__main__': unittest.main()
+
+    

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,10 +1,10 @@
 def sequoia(name):
     name = name.strip().upper()
-    packs = (['B%s' % i for i in range(1, 37+1)]
-             + ['C%s' % i for i in range(1, 24+1)]
+    packs = (['B{}'.format(i) for i in range(1, 37+1)]
+             + ['C{}'.format(i) for i in range(1, 24+1)]
              + ['C25T', 'C26T', 'C25B', 'C26B']
-             + ['C%s' % i for i in range(27, 37+1)]
-             + ['D%s' % i for i in range(1, 37+1)]
+             + ['C{}'.format(i) for i in range(27, 37+1)]
+             + ['D{}'.format(i) for i in range(1, 37+1)]
              )
     start_index = 38
     return start_index + packs.index(name)

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -4,5 +4,7 @@ sequoia_packs = ['B%s' % i for i in range(1, 37+1)] \
                 + ['C%s' % i for i in range(27, 37+1)] \
                 + ['D%s' % i for i in range(1, 37+1)]
 sequoia_start_index = 38
+
+
 def sequoia(name):
     return sequoia_start_index + sequoia_packs.index(name)

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,40 +1,8 @@
-
+sequoia_packs = ['B%s' % i for i in range(1, 37+1)] \
+                + ['C%s' % i for i in range(1, 24+1)] \
+                + ['C25T', 'C26T', 'C25B', 'C26B'] \
+                + ['C%s' % i for i in range(27, 37+1)] \
+                + ['D%s' % i for i in range(1, 37+1)]
+sequoia_start_index = 38
 def sequoia(name):
-    rows = 'BCD'
-    startindexes = dict(B=37, C=74, D=113)
-    name = name.strip().upper()
-    row = name[0]
-    assert row in rows, "Invalid pack name %r" % name
-    start = startindexes[row]
-    col = int(name[1:3])
-    # C25T, ...
-    extra = 0
-    if row == 'C':
-        if len(name) == 4:
-            assert name[-1] in 'TB', "Invalid pack name %r" % name
-            if name[3] == 'B':
-                extra = 2
-        if col>26:
-            extra = 2
-    return start + col + extra
-
-
-import unittest # noqa: E402
-
-
-class TestCase(unittest.TestCase):
-    def test_sequoia(self):
-        assert sequoia('B1') == 38
-        assert sequoia('B37') == 74
-        assert sequoia('C1') == 75
-        assert sequoia('C25T') == 99
-        assert sequoia('C26T') == 100
-        assert sequoia('C25B') == 101
-        assert sequoia('C26B') == 102
-        assert sequoia('D1') == 114
-        assert sequoia('D37') == 150
-        return
-
-
-if __name__ == '__main__':
-    unittest.main()
+    return sequoia_start_index + sequoia_packs.index(name)

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,10 +1,9 @@
-sequoia_packs = ['B%s' % i for i in range(1, 37+1)] \
+def sequoia(name):
+    name = name.strip().upper()
+    packs = ['B%s' % i for i in range(1, 37+1)] \
                 + ['C%s' % i for i in range(1, 24+1)] \
                 + ['C25T', 'C26T', 'C25B', 'C26B'] \
                 + ['C%s' % i for i in range(27, 37+1)] \
                 + ['D%s' % i for i in range(1, 37+1)]
-sequoia_start_index = 38
-
-
-def sequoia(name):
-    return sequoia_start_index + sequoia_packs.index(name)
+    start_index = 38
+    return start_index + packs.index(name)

--- a/scripts/Inelastic/Direct/detpackmap.py
+++ b/scripts/Inelastic/Direct/detpackmap.py
@@ -1,3 +1,4 @@
+
 def sequoia(name):
     rows = 'BCD'
     startindexes = dict(B=37, C=74, D=113)
@@ -11,12 +12,16 @@ def sequoia(name):
     if row == 'C':
         if len(name) == 4:
             assert name[-1] in 'TB', "Invalid pack name %r" % name
-            if name[3] == 'B': extra = 2
-        if col>26: extra = 2
+            if name[3] == 'B':
+                extra = 2
+        if col>26:
+            extra = 2
     return start + col + extra
 
 
-import unittest
+import unittest # noqa: E402
+
+
 class TestCase(unittest.TestCase):
     def test_sequoia(self):
         assert sequoia('B1') == 38
@@ -31,6 +36,5 @@ class TestCase(unittest.TestCase):
         return
 
 
-if __name__ == '__main__': unittest.main()
-
-    
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/InelasticDirectDetpackmapTest.py
+++ b/scripts/test/InelasticDirectDetpackmapTest.py
@@ -2,7 +2,7 @@ from Direct.detpackmap import sequoia
 import unittest
 
 
-class TestCase(unittest.TestCase):
+class InelasticDirectDetpackmapTest(unittest.TestCase):
 
     def test_sequoia(self):
         self.assertEqual(sequoia('B1'),  38)
@@ -15,7 +15,8 @@ class TestCase(unittest.TestCase):
         self.assertEqual(sequoia('C37'),  113)
         self.assertEqual(sequoia('D1'),  114)
         self.assertEqual(sequoia('D37'),  150)
-
+        with self.assertRaises(ValueError):
+            sequoia('M38')
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/InelasticDirect_detpackmap_Test.py
+++ b/scripts/test/InelasticDirect_detpackmap_Test.py
@@ -5,18 +5,16 @@ import unittest
 class TestCase(unittest.TestCase):
 
     def test_sequoia(self):
-        asserteq = self.assertEqual
-        asserteq(sequoia('B1'),  38)
-        asserteq(sequoia('B37'),  74)
-        asserteq(sequoia('C1'),  75)
-        asserteq(sequoia('C25T'),  99)
-        asserteq(sequoia('C26T'),  100)
-        asserteq(sequoia('C25B'),  101)
-        asserteq(sequoia('C26B'),  102)
-        asserteq(sequoia('C37'),  113)
-        asserteq(sequoia('D1'),  114)
-        asserteq(sequoia('D37'),  150)
-        return
+        self.assertEqual(sequoia('B1'),  38)
+        self.assertEqual(sequoia('B37'),  74)
+        self.assertEqual(sequoia('C1'),  75)
+        self.assertEqual(sequoia('C25T'),  99)
+        self.assertEqual(sequoia('C26T'),  100)
+        self.assertEqual(sequoia('C25B'),  101)
+        self.assertEqual(sequoia('C26B'),  102)
+        self.assertEqual(sequoia('C37'),  113)
+        self.assertEqual(sequoia('D1'),  114)
+        self.assertEqual(sequoia('D37'),  150)
 
 
 if __name__ == '__main__':

--- a/scripts/test/InelasticDirect_detpackmap_Test.py
+++ b/scripts/test/InelasticDirect_detpackmap_Test.py
@@ -1,0 +1,20 @@
+from Direct.detpackmap import sequoia
+import unittest
+
+
+class TestCase(unittest.TestCase):
+    def test_sequoia(self):
+        assert sequoia('B1') == 38
+        assert sequoia('B37') == 74
+        assert sequoia('C1') == 75
+        assert sequoia('C25T') == 99
+        assert sequoia('C26T') == 100
+        assert sequoia('C25B') == 101
+        assert sequoia('C26B') == 102
+        assert sequoia('D1') == 114
+        assert sequoia('D37') == 150
+        return
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/InelasticDirect_detpackmap_Test.py
+++ b/scripts/test/InelasticDirect_detpackmap_Test.py
@@ -3,6 +3,7 @@ import unittest
 
 
 class TestCase(unittest.TestCase):
+
     def test_sequoia(self):
         assert sequoia('B1') == 38
         assert sequoia('B37') == 74

--- a/scripts/test/InelasticDirect_detpackmap_Test.py
+++ b/scripts/test/InelasticDirect_detpackmap_Test.py
@@ -5,16 +5,17 @@ import unittest
 class TestCase(unittest.TestCase):
 
     def test_sequoia(self):
-        assert sequoia('B1') == 38
-        assert sequoia('B37') == 74
-        assert sequoia('C1') == 75
-        assert sequoia('C25T') == 99
-        assert sequoia('C26T') == 100
-        assert sequoia('C25B') == 101
-        assert sequoia('C26B') == 102
-        assert sequoia('C37') == 113
-        assert sequoia('D1') == 114
-        assert sequoia('D37') == 150
+        asserteq = self.assertEqual
+        asserteq(sequoia('B1'),  38)
+        asserteq(sequoia('B37'),  74)
+        asserteq(sequoia('C1'),  75)
+        asserteq(sequoia('C25T'),  99)
+        asserteq(sequoia('C26T'),  100)
+        asserteq(sequoia('C25B'),  101)
+        asserteq(sequoia('C26B'),  102)
+        asserteq(sequoia('C37'),  113)
+        asserteq(sequoia('D1'),  114)
+        asserteq(sequoia('D37'),  150)
         return
 
 

--- a/scripts/test/InelasticDirect_detpackmap_Test.py
+++ b/scripts/test/InelasticDirect_detpackmap_Test.py
@@ -11,6 +11,7 @@ class TestCase(unittest.TestCase):
         assert sequoia('C26T') == 100
         assert sequoia('C25B') == 101
         assert sequoia('C26B') == 102
+        assert sequoia('C37') == 113
         assert sequoia('D1') == 114
         assert sequoia('D37') == 150
         return


### PR DESCRIPTION
**Description of work.**
Add a function to map SEQ pack name to number. For details, see #24330 

**To test:**
`python scripts/Inelastic/Direct/detpackmap.py`

Fixes #24330 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
