### PR TITLE
Indirect F(Q)Fit - Plot Spectrum spinbox updating to wrong value when Fit type is changed

### DIFF
--- a/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataPresenter.cpp
@@ -38,7 +38,7 @@ JumpFitDataPresenter::JumpFitDataPresenter(
           SLOT(setParameterLabel(const QString &)));
   connect(cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
           SLOT(updateAvailableParameters(QString const &)));
-  connect(cbParameterType, SIGNAL(currentIndexChanged(int)), this,
+  connect(cbParameterType, SIGNAL(currentIndexChanged(const QString &)), this,
           SIGNAL(dataChanged()));
   connect(cbParameter, SIGNAL(currentIndexChanged(int)), this,
           SLOT(setSingleModelSpectrum(int)));


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where the connect statements were being 'called' in the wrong order causing the spectrum in the Plot Spectrum spin box to update to the old spectrum rather than the new one.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`F(Q)Fit` interface
2. Load the data below
3. See the `Fit Parameter` combo box (above the mini-plot)
4. Change this combobox to say EISF
5. The Plot Spectrum spin box (under the mini-plots) should change to 3. The plot looks like:
![image](https://user-images.githubusercontent.com/40830825/50002389-e3b16b00-ff97-11e8-8046-9b9fe3838c7a.png)
6. Change the combobox to say Width
7. The Plot Spectrum spin box (under the mini-plots) should change to 2. The plot looks like:
![image](https://user-images.githubusercontent.com/40830825/50002422-fe83df80-ff97-11e8-888d-4b897d759e70.png)

**Data Files**
Input File: [IN16B_125878_QLd_Result.zip](https://github.com/mantidproject/mantid/files/2679985/IN16B_125878_QLd_Result.zip)

No release notes required as I believe this was introduced in #23221 

Fixes #24337

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
