### PR TITLE
Update PropertyWithValue to use pass-by-value idiom

### DIFF
--- a/Framework/API/test/FakeAlgorithms.h
+++ b/Framework/API/test/FakeAlgorithms.h
@@ -73,7 +73,8 @@ public:
     binning.push_back(0.1);
     binning.push_back(2.0);
     declareProperty(Mantid::Kernel::make_unique<ArrayProperty<double>>(
-        "Binning", binning, boost::make_shared<RebinParamsValidator>()));
+        "Binning", std::move(binning),
+        boost::make_shared<RebinParamsValidator>()));
   }
   void exec() override {}
 };

--- a/Framework/API/test/FakeAlgorithms.h
+++ b/Framework/API/test/FakeAlgorithms.h
@@ -68,10 +68,7 @@ public:
     declareProperty("prop1", "value");
     declareProperty("prop2", 1);
     declareProperty("prop3", 10.5);
-    std::vector<double> binning;
-    binning.push_back(1.0);
-    binning.push_back(0.1);
-    binning.push_back(2.0);
+    std::vector<double> binning{1.0, 0.1, 2.0};
     declareProperty(Mantid::Kernel::make_unique<ArrayProperty<double>>(
         "Binning", std::move(binning),
         boost::make_shared<RebinParamsValidator>()));

--- a/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
+++ b/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
@@ -153,13 +153,13 @@ void PDDetermineCharacterizations::init() {
   std::vector<std::string> defaultFrequencyNames{"SpeedRequest1", "Speed1",
                                                  "frequency", "skf1.speed"};
   declareProperty(Kernel::make_unique<Kernel::ArrayProperty<std::string>>(
-                      FREQ_PROP_NAME, defaultFrequencyNames),
+                      FREQ_PROP_NAME, std::move(defaultFrequencyNames)),
                   "Candidate log names for frequency");
 
   std::vector<std::string> defaultWavelengthNames{"LambdaRequest", "lambda",
                                                   "skf12.lambda"};
   declareProperty(Kernel::make_unique<Kernel::ArrayProperty<std::string>>(
-                      WL_PROP_NAME, defaultWavelengthNames),
+                      WL_PROP_NAME, std::move(defaultWavelengthNames)),
                   "Candidate log names for wave length");
 }
 

--- a/Framework/Algorithms/src/RadiusSum.cpp
+++ b/Framework/Algorithms/src/RadiusSum.cpp
@@ -58,7 +58,7 @@ void RadiusSum::init() {
       boost::make_shared<ArrayLengthValidator<double>>(2, 3);
   std::vector<double> myInput(3, 0);
   declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Centre", myInput, twoOrThreeElements),
+                      "Centre", std::move(myInput), twoOrThreeElements),
                   "Coordinate of the centre of the ring");
 
   auto nonNegative = boost::make_shared<BoundedValidator<double>>();

--- a/Framework/Algorithms/src/RadiusSum.cpp
+++ b/Framework/Algorithms/src/RadiusSum.cpp
@@ -57,22 +57,23 @@ void RadiusSum::init() {
   auto twoOrThreeElements =
       boost::make_shared<ArrayLengthValidator<double>>(2, 3);
   std::vector<double> myInput(3, 0);
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Centre", std::move(myInput), twoOrThreeElements),
-                  "Coordinate of the centre of the ring");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("Centre", std::move(myInput),
+                                                 std::move(twoOrThreeElements)),
+      "Coordinate of the centre of the ring");
 
   auto nonNegative = boost::make_shared<BoundedValidator<double>>();
   nonNegative->setLower(0);
-  declareProperty("MinRadius", 0.0, nonNegative,
+  declareProperty("MinRadius", 0.0, nonNegative->clone(),
                   "Length of the inner ring. Default=0");
-  declareProperty(
-      make_unique<PropertyWithValue<double>>(
-          "MaxRadius", std::numeric_limits<double>::max(), nonNegative),
-      "Length of the outer ring. Default=ImageSize.");
+  declareProperty(make_unique<PropertyWithValue<double>>(
+                      "MaxRadius", std::numeric_limits<double>::max(),
+                      std::move(nonNegative)),
+                  "Length of the outer ring. Default=ImageSize.");
 
   auto nonNegativeInt = boost::make_shared<BoundedValidator<int>>();
   nonNegativeInt->setLower(1);
-  declareProperty("NumBins", 100, nonNegativeInt,
+  declareProperty("NumBins", 100, std::move(nonNegativeInt),
                   "Number of slice bins for the output. Default=100");
 
   const char *normBy = "NormalizeByRadius";

--- a/Framework/Algorithms/src/RingProfile.cpp
+++ b/Framework/Algorithms/src/RingProfile.cpp
@@ -56,20 +56,20 @@ void RingProfile::init() {
       boost::make_shared<Kernel::ArrayLengthValidator<double>>(2, 3);
   std::vector<double> myInput(3, 0);
   declareProperty(Kernel::make_unique<Kernel::ArrayProperty<double>>(
-                      "Centre", std::move(myInput), twoOrThree),
+                      "Centre", std::move(myInput), std::move(twoOrThree)),
                   "Coordinate of the centre of the ring");
   auto nonNegative = boost::make_shared<Kernel::BoundedValidator<double>>();
   nonNegative->setLower(0);
 
-  declareProperty<double>("MinRadius", 0, nonNegative,
+  declareProperty<double>("MinRadius", 0, nonNegative->clone(),
                           "Radius of the inner ring(m)");
-  declareProperty(
-      Kernel::make_unique<Kernel::PropertyWithValue<double>>(
-          "MaxRadius", std::numeric_limits<double>::max(), nonNegative),
-      "Radius of the outer ring(m)");
+  declareProperty(Kernel::make_unique<Kernel::PropertyWithValue<double>>(
+                      "MaxRadius", std::numeric_limits<double>::max(),
+                      std::move(nonNegative)),
+                  "Radius of the outer ring(m)");
   auto nonNegativeInt = boost::make_shared<Kernel::BoundedValidator<int>>();
   nonNegativeInt->setLower(1);
-  declareProperty<int>("NumBins", 100, nonNegativeInt,
+  declareProperty<int>("NumBins", 100, std::move(nonNegativeInt),
                        "Number of slice bins for the output");
   auto degreesLimits = boost::make_shared<Kernel::BoundedValidator<double>>();
   degreesLimits->setLower(-360);

--- a/Framework/Algorithms/src/RingProfile.cpp
+++ b/Framework/Algorithms/src/RingProfile.cpp
@@ -56,7 +56,7 @@ void RingProfile::init() {
       boost::make_shared<Kernel::ArrayLengthValidator<double>>(2, 3);
   std::vector<double> myInput(3, 0);
   declareProperty(Kernel::make_unique<Kernel::ArrayProperty<double>>(
-                      "Centre", myInput, twoOrThree),
+                      "Centre", std::move(myInput), twoOrThree),
                   "Coordinate of the centre of the ring");
   auto nonNegative = boost::make_shared<Kernel::BoundedValidator<double>>();
   nonNegative->setLower(0);

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -28,14 +28,13 @@ void SmoothData::init() {
       make_unique<WorkspaceProperty<>>("OutputWorkspace", "",
                                        Direction::Output),
       "The name of the workspace to be created as the output of the algorithm");
-  std::vector<int> npts0;
-  npts0.push_back(3);
+  std::vector<int> npts0{3};
   auto min = boost::make_shared<Kernel::ArrayBoundedValidator<int>>();
   min->setLower(3);
   // The number of points to use in the smoothing.
   declareProperty(
-      Kernel::make_unique<ArrayProperty<int>>("NPoints", std::move(npts0), min,
-                                              Direction::Input),
+      Kernel::make_unique<ArrayProperty<int>>("NPoints", std::move(npts0),
+                                              std::move(min), Direction::Input),
       "The number of points to average over (minimum 3). If an even number is\n"
       "given, it will be incremented by 1 to make it odd (default value 3)");
   declareProperty(

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -34,7 +34,7 @@ void SmoothData::init() {
   min->setLower(3);
   // The number of points to use in the smoothing.
   declareProperty(
-      Kernel::make_unique<ArrayProperty<int>>("NPoints", npts0, min,
+      Kernel::make_unique<ArrayProperty<int>>("NPoints", std::move(npts0), min,
                                               Direction::Input),
       "The number of points to average over (minimum 3). If an even number is\n"
       "given, it will be incremented by 1 to make it odd (default value 3)");

--- a/Framework/Crystal/src/IndexSXPeaks.cpp
+++ b/Framework/Crystal/src/IndexSXPeaks.cpp
@@ -79,11 +79,11 @@ void IndexSXPeaks::init() {
   extents[3] = range;
   extents[4] = -range;
   extents[5] = range;
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<int>>("SearchExtents", extents),
-      "A comma separated list of min, max for each of H, K and L,\n"
-      "Specifies the search extents applied for H K L values "
-      "associated with the peaks.");
+  declareProperty(Kernel::make_unique<ArrayProperty<int>>("SearchExtents",
+                                                          std::move(extents)),
+                  "A comma separated list of min, max for each of H, K and L,\n"
+                  "Specifies the search extents applied for H K L values "
+                  "associated with the peaks.");
 }
 
 /**

--- a/Framework/Crystal/src/IndexSXPeaks.cpp
+++ b/Framework/Crystal/src/IndexSXPeaks.cpp
@@ -41,28 +41,31 @@ void IndexSXPeaks::init() {
       "Input Peaks Workspace");
 
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "a", -1.0, mustBePositive, Direction::Input),
+                      "a", -1.0, mustBePositive->clone(), Direction::Input),
                   "Lattice parameter a");
 
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "b", -1.0, mustBePositive, Direction::Input),
+                      "b", -1.0, mustBePositive->clone(), Direction::Input),
                   "Lattice parameter b");
 
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "c", -1.0, mustBePositive, Direction::Input),
+                      "c", -1.0, std::move(mustBePositive), Direction::Input),
                   "Lattice parameter c");
 
-  declareProperty(make_unique<PropertyWithValue<double>>(
-                      "alpha", -1.0, reasonable_angle, Direction::Input),
-                  "Lattice parameter alpha");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "alpha", -1.0, reasonable_angle->clone(), Direction::Input),
+      "Lattice parameter alpha");
 
-  declareProperty(make_unique<PropertyWithValue<double>>(
-                      "beta", -1.0, reasonable_angle, Direction::Input),
-                  "Lattice parameter beta");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "beta", -1.0, reasonable_angle->clone(), Direction::Input),
+      "Lattice parameter beta");
 
-  declareProperty(make_unique<PropertyWithValue<double>>(
-                      "gamma", -1.0, reasonable_angle, Direction::Input),
-                  "Lattice parameter gamma");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "gamma", -1.0, std::move(reasonable_angle), Direction::Input),
+      "Lattice parameter gamma");
 
   declareProperty(make_unique<ArrayProperty<int>>("PeakIndices"),
                   "Index of the peaks in the table workspace to be used. If no "

--- a/Framework/Crystal/src/PeaksInRegion.cpp
+++ b/Framework/Crystal/src/PeaksInRegion.cpp
@@ -49,7 +49,7 @@ void PeaksInRegion::init() {
   extents[1] = +50;
   declareProperty(
       Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents),
-                                                 mandatoryExtents),
+                                                 std::move(mandatoryExtents)),
       "A comma separated list of min, max for each dimension,\n"
       "specifying the extents of each dimension. Optional, default +-50 in "
       "each dimension.");

--- a/Framework/Crystal/src/PeaksInRegion.cpp
+++ b/Framework/Crystal/src/PeaksInRegion.cpp
@@ -48,7 +48,7 @@ void PeaksInRegion::init() {
   extents[0] = -50;
   extents[1] = +50;
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Extents", extents,
+      Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents),
                                                  mandatoryExtents),
       "A comma separated list of min, max for each dimension,\n"
       "specifying the extents of each dimension. Optional, default +-50 in "

--- a/Framework/Crystal/src/PeaksOnSurface.cpp
+++ b/Framework/Crystal/src/PeaksOnSurface.cpp
@@ -43,31 +43,33 @@ void PeaksOnSurface::init() {
   auto manditoryExtents = boost::make_shared<
       Mantid::Kernel::MandatoryValidator<std::vector<double>>>();
 
-  std::vector<double> vertexDefault;
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>(
+          "Vertex1", std::vector<double>(), manditoryExtents->clone()),
+      "A comma separated list of cartesian coordinates for the "
+      "lower left vertex of the surface. Values to be specified in "
+      "the CoordinateFrame choosen.");
 
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Vertex1", vertexDefault, manditoryExtents->clone()),
-                  "A comma separated list of cartesian coordinates for the "
-                  "lower left vertex of the surface. Values to be specified in "
-                  "the CoordinateFrame choosen.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>(
+          "Vertex2", std::vector<double>(), manditoryExtents->clone()),
+      "A comma separated list of cartesian coordinates for the "
+      "upper left vertex of the surface. Values to be specified in "
+      "the CoordinateFrame choosen.");
 
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Vertex2", vertexDefault, manditoryExtents->clone()),
-                  "A comma separated list of cartesian coordinates for the "
-                  "upper left vertex of the surface. Values to be specified in "
-                  "the CoordinateFrame choosen.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>(
+          "Vertex3", std::vector<double>(), manditoryExtents->clone()),
+      "A comma separated list of cartesian coordinates for the "
+      "upper right vertex of the surface. Values to be specified "
+      "in the CoordinateFrame choosen.");
 
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Vertex3", vertexDefault, manditoryExtents->clone()),
-                  "A comma separated list of cartesian coordinates for the "
-                  "upper right vertex of the surface. Values to be specified "
-                  "in the CoordinateFrame choosen.");
-
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Vertex4", vertexDefault, manditoryExtents->clone()),
-                  "A comma separated list of cartesian coordinates for the "
-                  "lower right vertex of the surface. Values to be specified "
-                  "in the CoordinateFrame choosen.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>(
+          "Vertex4", std::vector<double>(), manditoryExtents->clone()),
+      "A comma separated list of cartesian coordinates for the "
+      "lower right vertex of the surface. Values to be specified "
+      "in the CoordinateFrame choosen.");
 }
 
 void PeaksOnSurface::validateExtentsInput() const {

--- a/Framework/Crystal/src/PeaksOnSurface.cpp
+++ b/Framework/Crystal/src/PeaksOnSurface.cpp
@@ -66,7 +66,7 @@ void PeaksOnSurface::init() {
 
   declareProperty(
       Kernel::make_unique<ArrayProperty<double>>(
-          "Vertex4", std::vector<double>(), manditoryExtents->clone()),
+          "Vertex4", std::vector<double>(), std::move(manditoryExtents)),
       "A comma separated list of cartesian coordinates for the "
       "lower right vertex of the surface. Values to be specified "
       "in the CoordinateFrame choosen.");

--- a/Framework/Crystal/src/SetUB.cpp
+++ b/Framework/Crystal/src/SetUB.cpp
@@ -68,14 +68,14 @@ void SetUB::init() {
                             "gamma", 90.0, reasonableAngle, Direction::Input),
                         "Lattice parameter gamma(degrees) ");
   this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("u", u0, mustBe3D),
+      Kernel::make_unique<ArrayProperty<double>>("u", std::move(u0), mustBe3D),
       "Vector along k_i, when goniometer is at 0");
   this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("v", v0, mustBe3D),
+      Kernel::make_unique<ArrayProperty<double>>("v", std::move(v0), mustBe3D),
       "In plane vector perpendicular to k_i, when goniometer is at 0");
-  this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("UB", zeroes, threeVthree),
-      "UB Matrix");
+  this->declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                            "UB", std::move(zeroes), threeVthree),
+                        "UB Matrix");
   this->declareProperty(make_unique<PropertyWithValue<int>>(
                             "MDSampleNumber", EMPTY_INT(), Direction::Input),
                         "For an MD workspace, the sample number to wich to "

--- a/Framework/Crystal/src/SetUB.cpp
+++ b/Framework/Crystal/src/SetUB.cpp
@@ -49,29 +49,36 @@ void SetUB::init() {
   this->declareProperty(make_unique<WorkspaceProperty<Workspace>>(
                             "Workspace", "", Direction::InOut),
                         "An input workspace.");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "a", 1.0, mustBePositive, Direction::Input),
-                        "Lattice parameter a");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "b", 1.0, mustBePositive, Direction::Input),
-                        "Lattice parameter b");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "c", 1.0, mustBePositive, Direction::Input),
-                        "Lattice parameter c");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "alpha", 90.0, reasonableAngle, Direction::Input),
-                        "Lattice parameter alpha (degrees)");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "beta", 90.0, reasonableAngle, Direction::Input),
-                        "Lattice parameter beta (degrees)");
-  this->declareProperty(make_unique<PropertyWithValue<double>>(
-                            "gamma", 90.0, reasonableAngle, Direction::Input),
-                        "Lattice parameter gamma(degrees) ");
   this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("u", std::move(u0), mustBe3D),
-      "Vector along k_i, when goniometer is at 0");
+      make_unique<PropertyWithValue<double>>("a", 1.0, mustBePositive->clone(),
+                                             Direction::Input),
+      "Lattice parameter a");
   this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("v", std::move(v0), mustBe3D),
+      make_unique<PropertyWithValue<double>>("b", 1.0, mustBePositive->clone(),
+                                             Direction::Input),
+      "Lattice parameter b");
+  this->declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "c", 1.0, std::move(mustBePositive), Direction::Input),
+      "Lattice parameter c");
+  this->declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "alpha", 90.0, reasonableAngle->clone(), Direction::Input),
+      "Lattice parameter alpha (degrees)");
+  this->declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "beta", 90.0, reasonableAngle->clone(), Direction::Input),
+      "Lattice parameter beta (degrees)");
+  this->declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "gamma", 90.0, std::move(reasonableAngle), Direction::Input),
+      "Lattice parameter gamma(degrees) ");
+  this->declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                            "u", std::move(u0), mustBe3D->clone()),
+                        "Vector along k_i, when goniometer is at 0");
+  this->declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("v", std::move(v0),
+                                                 std::move(mustBe3D)),
       "In plane vector perpendicular to k_i, when goniometer is at 0");
   this->declareProperty(Kernel::make_unique<ArrayProperty<double>>(
                             "UB", std::move(zeroes), threeVthree),

--- a/Framework/Crystal/src/TransformHKL.cpp
+++ b/Framework/Crystal/src/TransformHKL.cpp
@@ -53,8 +53,8 @@ void TransformHKL::init() {
   auto threeBythree = boost::make_shared<ArrayLengthValidator<double> >(9);
   // clang-format on
   this->declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("HKLTransform",
-                                                 identity_matrix, threeBythree),
+      Kernel::make_unique<ArrayProperty<double>>(
+          "HKLTransform", std::move(identity_matrix), threeBythree),
       "Specify 3x3 HKL transform matrix as a comma separated list of 9 "
       "numbers");
 

--- a/Framework/Crystal/src/TransformHKL.cpp
+++ b/Framework/Crystal/src/TransformHKL.cpp
@@ -41,8 +41,8 @@ void TransformHKL::init() {
   mustBePositive->setLower(0.0);
 
   this->declareProperty(
-      make_unique<PropertyWithValue<double>>("Tolerance", 0.15, mustBePositive,
-                                             Direction::Input),
+      make_unique<PropertyWithValue<double>>(
+          "Tolerance", 0.15, std::move(mustBePositive), Direction::Input),
       "Indexing Tolerance (0.15)");
 
   std::vector<double> identity_matrix(9, 0.0);
@@ -54,7 +54,7 @@ void TransformHKL::init() {
   // clang-format on
   this->declareProperty(
       Kernel::make_unique<ArrayProperty<double>>(
-          "HKLTransform", std::move(identity_matrix), threeBythree),
+          "HKLTransform", std::move(identity_matrix), std::move(threeBythree)),
       "Specify 3x3 HKL transform matrix as a comma separated list of 9 "
       "numbers");
 

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -473,8 +473,8 @@ void LoadNexusLogs::loadNPeriods(
     API::Run &run = workspace->mutableRun();
     const std::string protonChargeByPeriodLabel = "proton_charge_by_period";
     if (!run.hasProperty(protonChargeByPeriodLabel)) {
-      run.addProperty(new ArrayProperty<double>(protonChargeByPeriodLabel,
-                                                protonChargeByPeriod));
+      run.addProperty(new ArrayProperty<double>(
+          protonChargeByPeriodLabel, std::move(protonChargeByPeriod)));
     }
     file.closeGroup();
   } catch (::NeXus::Exception &) {

--- a/Framework/DataHandling/src/LoadSpiceAscii.cpp
+++ b/Framework/DataHandling/src/LoadSpiceAscii.cpp
@@ -128,7 +128,7 @@ void LoadSpiceAscii::init() {
   defaultlogformat[2] = "time";
   defaultlogformat[3] = "HH:MM:SS AM";
   declareProperty(Kernel::make_unique<ArrayProperty<std::string>>(
-                      "DateAndTimeLog", defaultlogformat),
+                      "DateAndTimeLog", std::move(defaultlogformat)),
                   "Name and format for date and time");
 
   // Output

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -201,7 +201,8 @@ void SaveGSS::init() {
   std::vector<int> default_precision(3, 9);
   declareProperty(
       Kernel::make_unique<Kernel::ArrayProperty<int>>(
-          "SLOGXYEPrecision", default_precision, precision_validator),
+          "SLOGXYEPrecision", std::move(default_precision),
+          precision_validator),
       "Enter 3 integers as the precisions of output X, Y and E for SLOG data "
       "only."
       "Default is (9, 9, 9) if it is left empty.  Otherwise it is not "

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -202,7 +202,7 @@ void SaveGSS::init() {
   declareProperty(
       Kernel::make_unique<Kernel::ArrayProperty<int>>(
           "SLOGXYEPrecision", std::move(default_precision),
-          precision_validator),
+          std::move(precision_validator)),
       "Enter 3 integers as the precisions of output X, Y and E for SLOG data "
       "only."
       "Default is (9, 9, 9) if it is left empty.  Otherwise it is not "

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -520,8 +520,9 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<DoubleProperty>("Thick", 0.1), "");
     std::vector<double> center{1, 0, 0};
-    props->declareProperty(
-        Mantid::Kernel::make_unique<DoubleArrayProperty>("Center", center), "");
+    props->declareProperty(Mantid::Kernel::make_unique<DoubleArrayProperty>(
+                               "Center", std::move(center)),
+                           "");
     if (angle != 0.0) {
       props->declareProperty(
           Mantid::Kernel::make_unique<DoubleProperty>("Angle", angle), "");
@@ -543,8 +544,9 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<DoubleProperty>("Radius", 5), "");
     std::vector<double> center{0, 0, 1};
-    props->declareProperty(
-        Mantid::Kernel::make_unique<DoubleArrayProperty>("Center", center), "");
+    props->declareProperty(Mantid::Kernel::make_unique<DoubleArrayProperty>(
+                               "Center", std::move(center)),
+                           "");
 
     return props;
   }
@@ -566,8 +568,9 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<DoubleProperty>("OuterRadius", 4), "");
     std::vector<double> center{0, 0, 1};
-    props->declareProperty(
-        Mantid::Kernel::make_unique<DoubleArrayProperty>("Center", center), "");
+    props->declareProperty(Mantid::Kernel::make_unique<DoubleArrayProperty>(
+                               "Center", std::move(center)),
+                           "");
 
     return props;
   }

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -29,14 +29,14 @@ namespace Kernel {
 template <typename T>
 class DLLExport ArrayProperty : public PropertyWithValue<std::vector<T>> {
 public:
-  ArrayProperty(const std::string &name, std::vector<T> &&vec,
+  ArrayProperty(std::string name, std::vector<T> vec,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input);
-  ArrayProperty(const std::string &name, IValidator_sptr validator,
+  ArrayProperty(std::string name, IValidator_sptr validator,
                 const unsigned int direction = Direction::Input);
-  ArrayProperty(const std::string &name,
+  ArrayProperty(std::string name,
                 const unsigned int direction = Direction::Input);
-  ArrayProperty(const std::string &name, const std::string &values,
+  ArrayProperty(std::string name, const std::string &values,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input);
 

--- a/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayProperty.h
@@ -29,7 +29,7 @@ namespace Kernel {
 template <typename T>
 class DLLExport ArrayProperty : public PropertyWithValue<std::vector<T>> {
 public:
-  ArrayProperty(const std::string &name, const std::vector<T> &vec,
+  ArrayProperty(const std::string &name, std::vector<T> &&vec,
                 IValidator_sptr validator = IValidator_sptr(new NullValidator),
                 const unsigned int direction = Direction::Input);
   ArrayProperty(const std::string &name, IValidator_sptr validator,

--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -196,8 +196,8 @@ public:
 
 protected:
   /// Constructor
-  Property(const std::string &name, const std::type_info &type,
-           const unsigned int direction = Direction::Input);
+  Property(std::string name, const std::type_info &type,
+           unsigned int direction = Direction::Input);
   /// Copy constructor
   Property(const Property &right);
   /// The name of the property

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.h
@@ -38,13 +38,13 @@ namespace Kernel {
 template <typename TYPE> class DLLExport PropertyWithValue : public Property {
 public:
   PropertyWithValue(
-      const std::string &name, const TYPE &defaultValue,
+      std::string name, TYPE defaultValue,
       IValidator_sptr validator = IValidator_sptr(new NullValidator),
       const unsigned int direction = Direction::Input);
-  PropertyWithValue(const std::string &name, const TYPE &defaultValue,
+  PropertyWithValue(std::string name, TYPE defaultValue,
                     const unsigned int direction);
-  PropertyWithValue(const std::string &name, const TYPE &defaultValue,
-                    const std::string defaultValueStr,
+  PropertyWithValue(std::string name, TYPE defaultValue,
+                    const std::string &defaultValueStr,
                     IValidator_sptr validator, const unsigned int direction);
   PropertyWithValue(const PropertyWithValue &right);
   PropertyWithValue<TYPE> *clone() const override;

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
@@ -39,12 +39,12 @@ namespace Kernel {
  * or Direction::InOut (Input & Output) property
  */
 template <typename TYPE>
-PropertyWithValue<TYPE>::PropertyWithValue(const std::string &name,
-                                           const TYPE &defaultValue,
+PropertyWithValue<TYPE>::PropertyWithValue(std::string name,
+                                           TYPE defaultValue,
                                            IValidator_sptr validator,
-                                           const unsigned int direction)
-    : Property(name, typeid(TYPE), direction), m_value(defaultValue),
-      m_initialValue(defaultValue), m_validator(validator) {}
+                                           unsigned int direction)
+    : Property(std::move(name), typeid(TYPE), direction), m_value(defaultValue),
+      m_initialValue(std::move(defaultValue)), m_validator(std::move(validator)) {}
 
 /** Constructor
  *  @param name :: The name to assign to the property
@@ -53,11 +53,11 @@ PropertyWithValue<TYPE>::PropertyWithValue(const std::string &name,
  * or Direction::InOut (Input & Output) property
  */
 template <typename TYPE>
-PropertyWithValue<TYPE>::PropertyWithValue(const std::string &name,
-                                           const TYPE &defaultValue,
-                                           const unsigned int direction)
-    : Property(name, typeid(TYPE), direction), m_value(defaultValue),
-      m_initialValue(defaultValue),
+PropertyWithValue<TYPE>::PropertyWithValue(std::string name,
+                                           TYPE defaultValue,
+                                           unsigned int direction)
+    : Property(std::move(name), typeid(TYPE), direction), m_value(defaultValue),
+      m_initialValue(std::move(defaultValue)),
       m_validator(boost::make_shared<NullValidator>()) {}
 
 /*
@@ -75,15 +75,15 @@ PropertyWithValue<TYPE>::PropertyWithValue(const std::string &name,
   * or Direction::InOut (Input & Output) property
   */
 template <typename TYPE>
-PropertyWithValue<TYPE>::PropertyWithValue(const std::string &name,
-                                           const TYPE &defaultValue,
-                                           const std::string defaultValueStr,
+PropertyWithValue<TYPE>::PropertyWithValue(std::string name,
+                                           TYPE defaultValue,
+                                           const std::string &defaultValueStr,
                                            IValidator_sptr validator,
-                                           const unsigned int direction)
-    : Property(name, typeid(TYPE), direction),
+                                           unsigned int direction)
+    : Property(std::move(name), typeid(TYPE), direction),
       m_value(extractToValueVector<TYPE>(defaultValueStr)),
-      m_initialValue(extractToValueVector<TYPE>(defaultValueStr)),
-      m_validator(validator) {
+      m_initialValue(m_value),
+      m_validator(std::move(validator)) {
   UNUSED_ARG(defaultValue);
 }
 

--- a/Framework/Kernel/src/ArrayProperty.cpp
+++ b/Framework/Kernel/src/ArrayProperty.cpp
@@ -18,10 +18,11 @@ namespace Kernel {
  *  @param direction :: The direction (Input/Output/InOut) of this property
  */
 template <typename T>
-ArrayProperty<T>::ArrayProperty(const std::string &name, std::vector<T> &&vec,
+ArrayProperty<T>::ArrayProperty(std::string name, std::vector<T> vec,
                                 IValidator_sptr validator,
                                 const unsigned int direction)
-    : PropertyWithValue<std::vector<T>>(name, vec, validator, direction) {}
+    : PropertyWithValue<std::vector<T>>(std::move(name), std::move(vec),
+                                        std::move(validator), direction) {}
 
 /** Constructor
  *  Will lead to the property having a default-constructed (i.e. empty) vector
@@ -32,11 +33,10 @@ ArrayProperty<T>::ArrayProperty(const std::string &name, std::vector<T> &&vec,
  */
 
 template <typename T>
-ArrayProperty<T>::ArrayProperty(const std::string &name,
-                                IValidator_sptr validator,
+ArrayProperty<T>::ArrayProperty(std::string name, IValidator_sptr validator,
                                 const unsigned int direction)
-    : PropertyWithValue<std::vector<T>>(name, std::vector<T>(), validator,
-                                        direction) {}
+    : PropertyWithValue<std::vector<T>>(std::move(name), std::vector<T>(),
+                                        std::move(validator), direction) {}
 
 /** Constructor that's useful for output properties or inputs with an empty
  * default and no validator.
@@ -46,9 +46,8 @@ ArrayProperty<T>::ArrayProperty(const std::string &name,
  *  @param direction :: The direction (Input/Output/InOut) of this property
  */
 template <typename T>
-ArrayProperty<T>::ArrayProperty(const std::string &name,
-                                const unsigned int direction)
-    : PropertyWithValue<std::vector<T>>(name, std::vector<T>(),
+ArrayProperty<T>::ArrayProperty(std::string name, const unsigned int direction)
+    : PropertyWithValue<std::vector<T>>(std::move(name), std::vector<T>(),
                                         IValidator_sptr(new NullValidator),
                                         direction) {}
 
@@ -68,12 +67,12 @@ ArrayProperty<T>::ArrayProperty(const std::string &name,
  * the array type
  */
 template <typename T>
-ArrayProperty<T>::ArrayProperty(const std::string &name,
-                                const std::string &values,
+ArrayProperty<T>::ArrayProperty(std::string name, const std::string &values,
                                 IValidator_sptr validator,
                                 const unsigned int direction)
-    : PropertyWithValue<std::vector<T>>(name, std::vector<T>(), values,
-                                        validator, direction) {}
+    : PropertyWithValue<std::vector<T>>(std::move(name), std::vector<T>(),
+                                        values, std::move(validator),
+                                        direction) {}
 
 /// 'Virtual copy constructor'
 template <typename T> ArrayProperty<T> *ArrayProperty<T>::clone() const {

--- a/Framework/Kernel/src/ArrayProperty.cpp
+++ b/Framework/Kernel/src/ArrayProperty.cpp
@@ -18,8 +18,7 @@ namespace Kernel {
  *  @param direction :: The direction (Input/Output/InOut) of this property
  */
 template <typename T>
-ArrayProperty<T>::ArrayProperty(const std::string &name,
-                                const std::vector<T> &vec,
+ArrayProperty<T>::ArrayProperty(const std::string &name, std::vector<T> &&vec,
                                 IValidator_sptr validator,
                                 const unsigned int direction)
     : PropertyWithValue<std::vector<T>>(name, vec, validator, direction) {}

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -27,7 +27,7 @@ namespace Kernel {
  */
 Property::Property(std::string name, const std::type_info &type,
                    const unsigned int direction)
-    : m_name(name), m_documentation(""), m_typeinfo(&type),
+    : m_name(std::move(name)), m_documentation(""), m_typeinfo(&type),
       m_direction(direction), m_units(""), m_group(""), m_remember(true),
       m_autotrim(true) {
   // Make sure a random int hasn't been passed in for the direction

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -25,7 +25,7 @@ namespace Kernel {
  *  @param direction :: Whether this is a Direction::Input, Direction::Output or
  * Direction::InOut (Input & Output) property
  */
-Property::Property(const std::string &name, const std::type_info &type,
+Property::Property(std::string name, const std::type_info &type,
                    const unsigned int direction)
     : m_name(name), m_documentation(""), m_typeinfo(&type),
       m_direction(direction), m_units(""), m_group(""), m_remember(true),

--- a/Framework/Kernel/src/PropertyNexus.cpp
+++ b/Framework/Kernel/src/PropertyNexus.cpp
@@ -57,7 +57,8 @@ makeProperty(::NeXus::File *file, const std::string &name,
       return Mantid::Kernel::make_unique<PropertyWithValue<NumT>>(name,
                                                                   values[0]);
     } else {
-      return Mantid::Kernel::make_unique<ArrayProperty<NumT>>(name, values);
+      return Mantid::Kernel::make_unique<ArrayProperty<NumT>>(
+          name, std::move(values));
     }
   } else {
     auto prop = Mantid::Kernel::make_unique<TimeSeriesProperty<NumT>>(name);

--- a/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Framework/Kernel/test/ArrayPropertyTest.h
@@ -47,17 +47,17 @@ public:
     TS_ASSERT(sProp->operator()().empty())
 
     std::vector<int> i(5, 2);
-    ArrayProperty<int> ip("ip", i);
+    ArrayProperty<int> ip("ip", std::move(i));
     TS_ASSERT_EQUALS(ip.operator()().size(), 5)
     TS_ASSERT_EQUALS(ip.operator()()[3], 2)
 
     std::vector<double> d(4, 6.66);
-    ArrayProperty<double> dp("dp", d);
+    ArrayProperty<double> dp("dp", std::move(d));
     TS_ASSERT_EQUALS(dp.operator()().size(), 4)
     TS_ASSERT_EQUALS(dp.operator()()[1], 6.66)
 
     std::vector<std::string> s(3, "yyy");
-    ArrayProperty<std::string> sp("sp", s);
+    ArrayProperty<std::string> sp("sp", std::move(s));
     TS_ASSERT_EQUALS(sp.operator()().size(), 3)
     TS_ASSERT(!sp.operator()()[2].compare("yyy"))
   }
@@ -77,7 +77,8 @@ public:
     // should only be the size of the
     // parent vector that is counted.
     std::vector<std::vector<int>> input{{10}};
-    Property *b = new ArrayProperty<std::vector<int>>("vec_property", input);
+    Property *b =
+        new ArrayProperty<std::vector<int>>("vec_property", std::move(input));
     TS_ASSERT_EQUALS(1, b->size());
     delete b;
   }
@@ -185,15 +186,15 @@ public:
 
   void testValue() {
     std::vector<int> i(3, 3);
-    ArrayProperty<int> ip("ip", i);
+    ArrayProperty<int> ip("ip", std::move(i));
     TS_ASSERT(!ip.value().compare("3,3,3"))
 
     std::vector<double> d(4, 1.23);
-    ArrayProperty<double> dp("dp", d);
+    ArrayProperty<double> dp("dp", std::move(d));
     TS_ASSERT(!dp.value().compare("1.23,1.23,1.23,1.23"))
 
     std::vector<std::string> s(2, "yyy");
-    ArrayProperty<std::string> sp("sp", s);
+    ArrayProperty<std::string> sp("sp", std::move(s));
     TS_ASSERT(!sp.value().compare("yyy,yyy"))
   }
 

--- a/Framework/MDAlgorithms/src/BoxControllerSettingsAlgorithm.cpp
+++ b/Framework/MDAlgorithms/src/BoxControllerSettingsAlgorithm.cpp
@@ -41,7 +41,7 @@ void BoxControllerSettingsAlgorithm::initBoxControllerProps(
     valueVec.push_back(boost::lexical_cast<int>(value));
 
   declareProperty(
-      Kernel::make_unique<ArrayProperty<int>>("SplitInto", valueVec),
+      Kernel::make_unique<ArrayProperty<int>>("SplitInto", std::move(valueVec)),
       "A comma separated list of into how many sub-grid elements each "
       "dimension should split; "
       "or just one to split into the same number for all dimensions. Default " +

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -121,20 +121,20 @@ void CalculateCoverageDGS::init() {
   Q2[1] = 1.;
   Q3[2] = 1.;
   declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Q1Basis", std::move(Q1), mustBe3D),
+                      "Q1Basis", std::move(Q1), mustBe3D->clone()),
                   "Q1 projection direction in the x,y,z format. Q1, Q2, Q3 "
                   "must not be coplanar");
   declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Q2Basis", std::move(Q2), mustBe3D),
+                      "Q2Basis", std::move(Q2), mustBe3D->clone()),
                   "Q2 projection direction in the x,y,z format. Q1, Q2, Q3 "
                   "must not be coplanar");
   declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "Q3Basis", std::move(Q3), mustBe3D),
+                      "Q3Basis", std::move(Q3), std::move(mustBe3D)),
                   "Q3 projection direction in the x,y,z format. Q1, Q2, Q3 "
                   "must not be coplanar");
   declareProperty(
       make_unique<PropertyWithValue<double>>("IncidentEnergy", EMPTY_DBL(),
-                                             mustBePositive,
+                                             std::move(mustBePositive),
                                              Mantid::Kernel::Direction::Input),
       "Incident energy. If set, will override Ei in the input workspace");
 

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -120,18 +120,18 @@ void CalculateCoverageDGS::init() {
   Q1[0] = 1.;
   Q2[1] = 1.;
   Q3[2] = 1.;
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Q1Basis", Q1, mustBe3D),
-      "Q1 projection direction in the x,y,z format. Q1, Q2, Q3 "
-      "must not be coplanar");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Q2Basis", Q2, mustBe3D),
-      "Q2 projection direction in the x,y,z format. Q1, Q2, Q3 "
-      "must not be coplanar");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Q3Basis", Q3, mustBe3D),
-      "Q3 projection direction in the x,y,z format. Q1, Q2, Q3 "
-      "must not be coplanar");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "Q1Basis", std::move(Q1), mustBe3D),
+                  "Q1 projection direction in the x,y,z format. Q1, Q2, Q3 "
+                  "must not be coplanar");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "Q2Basis", std::move(Q2), mustBe3D),
+                  "Q2 projection direction in the x,y,z format. Q1, Q2, Q3 "
+                  "must not be coplanar");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "Q3Basis", std::move(Q3), mustBe3D),
+                  "Q3 projection direction in the x,y,z format. Q1, Q2, Q3 "
+                  "must not be coplanar");
   declareProperty(
       make_unique<PropertyWithValue<double>>("IncidentEnergy", EMPTY_DBL(),
                                              mustBePositive,

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -123,7 +123,7 @@ void ConvertToDiffractionMDWorkspace::init() {
 
   std::vector<double> extents{-50, +50};
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Extents", extents),
+      Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents)),
       "A comma separated list of min, max for each dimension,\n"
       "specifying the extents of each dimension. Optional, default "
       "+-50 in each dimension.");

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace2.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace2.cpp
@@ -43,7 +43,7 @@ void ConvertToDiffractionMDWorkspace2::init() {
 
   std::vector<double> extents = {-50.0, 50.0};
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Extents", extents),
+      Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents)),
       "A comma separated list of min, max for each dimension,\n"
       "specifying the extents of each dimension. Optional, default "
       "+- 50 in each dimension.");

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace3.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace3.cpp
@@ -43,7 +43,7 @@ void ConvertToDiffractionMDWorkspace3::init() {
 
   std::vector<double> extents;
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Extents", extents),
+      Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents)),
       "A comma separated list of min, max for each dimension,\n"
       "specifying the extents of each dimension. Optional, default "
       "will use ConvertToMDMinMaxLocal to calculate extents for each "

--- a/Framework/MDAlgorithms/src/ConvertToReflectometryQ.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToReflectometryQ.cpp
@@ -236,7 +236,7 @@ void ConvertToReflectometryQ::init() {
 
   std::vector<double> extents{-50, +50, -50, +50};
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Extents", extents),
+      Kernel::make_unique<ArrayProperty<double>>("Extents", std::move(extents)),
       "A comma separated list of min, max for each dimension. "
       "Takes four values in the form dim_0_min, dim_0_max, "
       "dim_1_min, dim_1_max,\n"

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -279,21 +279,22 @@ void IntegrateMDHistoWorkspace::init() {
                       "InputWorkspace", "", Direction::Input),
                   "An input workspace.");
 
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "P1Bin", std::vector<double>()),
-                  "Projection 1 binning.");
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "P2Bin", std::vector<double>()),
-                  "Projection 2 binning.");
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "P3Bin", std::vector<double>()),
-                  "Projection 3 binning.");
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "P4Bin", std::vector<double>()),
-                  "Projection 4 binning.");
-  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
-                      "P5Bin", std::vector<double>()),
-                  "Projection 5 binning.");
+  const std::vector<double> defaultBinning;
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("P1Bin", defaultBinning),
+      "Projection 1 binning.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("P2Bin", defaultBinning),
+      "Projection 2 binning.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("P3Bin", defaultBinning),
+      "Projection 3 binning.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("P4Bin", defaultBinning),
+      "Projection 4 binning.");
+  declareProperty(
+      Kernel::make_unique<ArrayProperty<double>>("P5Bin", defaultBinning),
+      "Projection 5 binning.");
 
   declareProperty(make_unique<WorkspaceProperty<IMDHistoWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -279,22 +279,21 @@ void IntegrateMDHistoWorkspace::init() {
                       "InputWorkspace", "", Direction::Input),
                   "An input workspace.");
 
-  const std::vector<double> defaultBinning;
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("P1Bin", defaultBinning),
-      "Projection 1 binning.");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("P2Bin", defaultBinning),
-      "Projection 2 binning.");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("P3Bin", defaultBinning),
-      "Projection 3 binning.");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("P4Bin", defaultBinning),
-      "Projection 4 binning.");
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("P5Bin", defaultBinning),
-      "Projection 5 binning.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "P1Bin", std::vector<double>()),
+                  "Projection 1 binning.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "P2Bin", std::vector<double>()),
+                  "Projection 2 binning.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "P3Bin", std::vector<double>()),
+                  "Projection 3 binning.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "P4Bin", std::vector<double>()),
+                  "Projection 4 binning.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "P5Bin", std::vector<double>()),
+                  "Projection 5 binning.");
 
   declareProperty(make_unique<WorkspaceProperty<IMDHistoWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),

--- a/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
+++ b/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
@@ -181,21 +181,23 @@ void LoadDNSSCD::init() {
                   "Angle in degrees between (HKL1) and the beam axis"
                   "if the goniometer is at zero.");
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("HKL1", u0, mustBe3D),
+      Kernel::make_unique<ArrayProperty<double>>("HKL1", std::move(u0),
+                                                 mustBe3D),
       "Indices of the vector in reciprocal space in the horizontal plane at "
       "angle Omegaoffset, "
       "if the goniometer is at zero.");
 
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("HKL2", v0, mustBe3D),
+      Kernel::make_unique<ArrayProperty<double>>("HKL2", std::move(v0),
+                                                 mustBe3D),
       "Indices of a second vector in reciprocal space in the horizontal plane "
       "not parallel to HKL1");
 
   std::vector<double> ttl(2, 0);
   ttl[1] = 180.0;
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("TwoThetaLimits", ttl,
-                                                 mustBe2D),
+      Kernel::make_unique<ArrayProperty<double>>("TwoThetaLimits",
+                                                 std::move(ttl), mustBe2D),
       "Range (min, max) of scattering angles (2theta, in degrees) to consider. "
       "Everything out of this range will be cut.");
 

--- a/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
+++ b/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
@@ -156,23 +156,25 @@ void LoadDNSSCD::init() {
   v0[2] = 1.;
 
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "a", 1.0, mustBePositive, Direction::Input),
+                      "a", 1.0, mustBePositive->clone(), Direction::Input),
                   "Lattice parameter a in Angstrom");
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "b", 1.0, mustBePositive, Direction::Input),
+                      "b", 1.0, mustBePositive->clone(), Direction::Input),
                   "Lattice parameter b in Angstrom");
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "c", 1.0, mustBePositive, Direction::Input),
+                      "c", 1.0, std::move(mustBePositive), Direction::Input),
                   "Lattice parameter c in Angstrom");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "alpha", 90.0, reasonableAngle->clone(), Direction::Input),
+      "Angle between b and c in degrees");
   declareProperty(make_unique<PropertyWithValue<double>>(
-                      "alpha", 90.0, reasonableAngle, Direction::Input),
-                  "Angle between b and c in degrees");
-  declareProperty(make_unique<PropertyWithValue<double>>(
-                      "beta", 90.0, reasonableAngle, Direction::Input),
+                      "beta", 90.0, reasonableAngle->clone(), Direction::Input),
                   "Angle between a and c in degrees");
-  declareProperty(make_unique<PropertyWithValue<double>>(
-                      "gamma", 90.0, reasonableAngle, Direction::Input),
-                  "Angle between a and b in degrees");
+  declareProperty(
+      make_unique<PropertyWithValue<double>>(
+          "gamma", 90.0, std::move(reasonableAngle), Direction::Input),
+      "Angle between a and b in degrees");
 
   declareProperty(make_unique<PropertyWithValue<double>>(
                       "OmegaOffset", 0.0,
@@ -182,22 +184,22 @@ void LoadDNSSCD::init() {
                   "if the goniometer is at zero.");
   declareProperty(
       Kernel::make_unique<ArrayProperty<double>>("HKL1", std::move(u0),
-                                                 mustBe3D),
+                                                 mustBe3D->clone()),
       "Indices of the vector in reciprocal space in the horizontal plane at "
       "angle Omegaoffset, "
       "if the goniometer is at zero.");
 
   declareProperty(
       Kernel::make_unique<ArrayProperty<double>>("HKL2", std::move(v0),
-                                                 mustBe3D),
+                                                 std::move(mustBe3D)),
       "Indices of a second vector in reciprocal space in the horizontal plane "
       "not parallel to HKL1");
 
   std::vector<double> ttl(2, 0);
   ttl[1] = 180.0;
   declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("TwoThetaLimits",
-                                                 std::move(ttl), mustBe2D),
+      Kernel::make_unique<ArrayProperty<double>>(
+          "TwoThetaLimits", std::move(ttl), std::move(mustBe2D)),
       "Range (min, max) of scattering angles (2theta, in degrees) to consider. "
       "Everything out of this range will be cut.");
 
@@ -214,15 +216,16 @@ void LoadDNSSCD::init() {
 
   auto mustBeIntPositive = boost::make_shared<BoundedValidator<int>>();
   mustBeIntPositive->setLower(0);
-  declareProperty(make_unique<PropertyWithValue<int>>(
-                      "ElasticChannel", 0, mustBeIntPositive, Direction::Input),
-                  "Elastic channel number. Only for TOF data.");
+  declareProperty(
+      make_unique<PropertyWithValue<int>>(
+          "ElasticChannel", 0, std::move(mustBeIntPositive), Direction::Input),
+      "Elastic channel number. Only for TOF data.");
 
   auto mustBeNegative = boost::make_shared<BoundedValidator<double>>();
   mustBeNegative->setUpper(0.0);
   declareProperty(
-      make_unique<PropertyWithValue<double>>("DeltaEmin", -10.0, mustBeNegative,
-                                             Direction::Input),
+      make_unique<PropertyWithValue<double>>(
+          "DeltaEmin", -10.0, std::move(mustBeNegative), Direction::Input),
       "Minimal energy transfer to consider. Should be <=0. Only for TOF data.");
 }
 

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -48,16 +48,16 @@ void TransformMD::init() {
                   "Any input MDWorkspace.");
 
   std::vector<double> defaultScaling(1, 1.0);
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Scaling", defaultScaling),
-      "Scaling value multiplying each coordinate. Default "
-      "1.\nEither a single value or a list for each dimension.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "Scaling", std::move(defaultScaling)),
+                  "Scaling value multiplying each coordinate. Default "
+                  "1.\nEither a single value or a list for each dimension.");
 
   std::vector<double> defaultOffset(1, 0.0);
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<double>>("Offset", defaultOffset),
-      "Offset value to add to each coordinate. Default 0.\nEither "
-      "a single value or a list for each dimension.");
+  declareProperty(Kernel::make_unique<ArrayProperty<double>>(
+                      "Offset", std::move(defaultOffset)),
+                  "Offset value to add to each coordinate. Default 0.\nEither "
+                  "a single value or a list for each dimension.");
 
   declareProperty(make_unique<WorkspaceProperty<IMDWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),

--- a/Framework/Muon/src/AlphaCalc.cpp
+++ b/Framework/Muon/src/AlphaCalc.cpp
@@ -32,13 +32,13 @@ void AlphaCalc::init() {
                   "Name of the input workspace");
 
   std::vector<int> forwardDefault{1};
-  declareProperty(
-      Kernel::make_unique<ArrayProperty<int>>("ForwardSpectra", forwardDefault),
-      "The spectra numbers of the forward group (default to 1)");
+  declareProperty(Kernel::make_unique<ArrayProperty<int>>(
+                      "ForwardSpectra", std::move(forwardDefault)),
+                  "The spectra numbers of the forward group (default to 1)");
 
   std::vector<int> backwardDefault{2};
-  declareProperty(Kernel::make_unique<ArrayProperty<int>>("BackwardSpectra",
-                                                          backwardDefault),
+  declareProperty(Kernel::make_unique<ArrayProperty<int>>(
+                      "BackwardSpectra", std::move(backwardDefault)),
                   "The spectra numbers of the backward group (default to 2)");
 
   declareProperty("FirstGoodValue", EMPTY_DBL(),

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -59,7 +59,8 @@ void EstimateMuonAsymmetryFromCounts::init() {
 
   std::vector<int> empty;
   declareProperty(
-      Kernel::make_unique<Kernel::ArrayProperty<int>>("Spectra", empty),
+      Kernel::make_unique<Kernel::ArrayProperty<int>>("Spectra",
+                                                      std::move(empty)),
       "The workspace indices to remove the exponential decay from.");
   declareProperty(
       "StartX", 0.1,

--- a/Framework/Muon/src/MuonGroupingAsymmetry.cpp
+++ b/Framework/Muon/src/MuonGroupingAsymmetry.cpp
@@ -138,8 +138,8 @@ DECLARE_ALGORITHM(MuonGroupingAsymmetry)
 
 void MuonGroupingAsymmetry::init() {
   const std::string emptyString("");
-  const std::vector<int> defaultGrouping = {1};
-  const std::vector<int> defaultPeriods = {1};
+  std::vector<int> defaultGrouping = {1};
+  std::vector<int> defaultPeriods = {1};
 
   declareProperty(
       Mantid::Kernel::make_unique<WorkspaceProperty<WorkspaceGroup>>(
@@ -160,7 +160,7 @@ void MuonGroupingAsymmetry::init() {
                   Direction::Input);
 
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "Grouping", defaultGrouping,
+                      "Grouping", std::move(defaultGrouping),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "The grouping of detectors, comma separated list of detector "
                   "IDs or hyphenated ranges of IDs.");
@@ -181,7 +181,7 @@ void MuonGroupingAsymmetry::init() {
                   Direction::Input);
 
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "SummedPeriods", defaultPeriods,
+                      "SummedPeriods", std::move(defaultPeriods),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "A list of periods to sum in multiperiod data.");
   declareProperty(

--- a/Framework/Muon/src/MuonGroupingCounts.cpp
+++ b/Framework/Muon/src/MuonGroupingCounts.cpp
@@ -88,13 +88,13 @@ void MuonGroupingCounts::init() {
                   "alphanumeric character.",
                   Direction::Input);
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "Grouping", defaultGrouping,
+                      "Grouping", std::move(defaultGrouping),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "The grouping of detectors, comma separated list of detector "
                   "IDs or hyphenated ranges of IDs.");
 
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "SummedPeriods", defaultGrouping,
+                      "SummedPeriods", std::vector<int>(1, 1),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "A list of periods to sum in multiperiod data.");
   declareProperty(

--- a/Framework/Muon/src/MuonPairingAsymmetry.cpp
+++ b/Framework/Muon/src/MuonPairingAsymmetry.cpp
@@ -105,8 +105,8 @@ DECLARE_ALGORITHM(MuonPairingAsymmetry)
 
 void MuonPairingAsymmetry::init() {
   std::string emptyString("");
-  const std::vector<int> defaultGrouping1 = {1};
-  const std::vector<int> defaultGrouping2 = {2};
+  std::vector<int> defaultGrouping1 = {1};
+  std::vector<int> defaultGrouping2 = {2};
 
   declareProperty(
       Mantid::Kernel::make_unique<WorkspaceProperty<MatrixWorkspace>>(
@@ -158,12 +158,12 @@ void MuonPairingAsymmetry::init() {
                       make_unique<Kernel::EnabledWhenProperty>(
                           "SpecifyGroupsManually", Kernel::IS_EQUAL_TO, "1"));
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "Group1", defaultGrouping1,
+                      "Group1", std::move(defaultGrouping1),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "The grouping of detectors, comma separated list of detector "
                   "IDs or hyphenated ranges of IDs.");
   declareProperty(make_unique<ArrayProperty<int>>(
-                      "Group2", defaultGrouping2,
+                      "Group2", std::move(defaultGrouping2),
                       IValidator_sptr(new NullValidator), Direction::Input),
                   "The grouping of detectors, comma separated list of detector "
                   "IDs or hyphenated ranges of IDs.");

--- a/Framework/Muon/src/RemoveExpDecay.cpp
+++ b/Framework/Muon/src/RemoveExpDecay.cpp
@@ -49,7 +49,8 @@ void MuonRemoveExpDecay::init() {
                   "The name of the output 2D workspace.");
   std::vector<int> empty;
   declareProperty(
-      Kernel::make_unique<Kernel::ArrayProperty<int>>("Spectra", empty),
+      Kernel::make_unique<Kernel::ArrayProperty<int>>("Spectra",
+                                                      std::move(empty)),
       "The workspace indices to remove the exponential decay from.");
 }
 

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/NDArrayToVector.h
@@ -26,7 +26,7 @@ template <typename DestElementType> struct DLLExport NDArrayToVector {
   /// Constructor
   NDArrayToVector(const NDArray &value);
   /// Create a new vector from the contents of the array
-  const TypedVector operator()();
+  TypedVector operator()();
   /// Fill the container with data from the array
   void copyTo(TypedVector &dest) const;
 

--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/Converters/PySequenceToVector.h
@@ -62,7 +62,7 @@ template <typename DestElementType> struct DLLExport PySequenceToVector {
    * @return A std::vector<ElementType> containing the values
    * from the Python sequence
    */
-  inline const TypedVector operator()() {
+  inline TypedVector operator()() {
     TypedVector cvector(srcSize());
     copyTo(cvector);
     return cvector;

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -133,7 +133,7 @@ NDArrayToVector<DestElementType>::NDArrayToVector(const NDArray &value)
  * @return A vector of the DestElementType created from the numpy array
  */
 template <typename DestElementType>
-const typename NDArrayToVector<DestElementType>::TypedVector
+typename NDArrayToVector<DestElementType>::TypedVector
 NDArrayToVector<DestElementType>::operator()() {
   std::vector<DestElementType> cvector(
       PyArray_SIZE((PyArrayObject *)m_arr.ptr()));


### PR DESCRIPTION
**Description of work.**

This uses the [pass-by-value idiom](https://clang.llvm.org/extra/clang-tidy/checks/modernize-pass-by-value.html) to reduce the number of copies of `std::string`, `std::vector` and `std::shared_ptr<IValidator>`.

Benefits require minor changes in algorithms. I made most changes that involve `ArrayProperty`, where any benefit should be the greatest.

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

How do we best communicate this change?

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
