### PR TITLE
Indirect Data Analysis - Result workspace names are wrong

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -302,6 +302,7 @@ runParameterProcessingWithGrouping(IAlgorithm &processingAlgorithm,
   }
   return createGroup(results);
 }
+
 } // namespace
 
 namespace Mantid {
@@ -514,15 +515,15 @@ void QENSFitSequential::exec() {
   const auto groupWs =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
           outputBaseName + "_Workspaces");
-  auto hhh = getPropertyValue("OutputWorkspace");
   AnalysisDataService::Instance().addOrReplace(
       getPropertyValue("OutputWorkspace"), resultWs);
 
-  //if (containsMultipleData(workspaces))
-  //  renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace",
-  //                   inputWorkspaces);
-  //else
-  //  renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace");
+  if (containsMultipleData(workspaces))
+    renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace",
+                     inputWorkspaces);
+  else
+    renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace");
+
   copyLogs(resultWs, workspaces);
 
   const bool doExtractMembers = getProperty("ExtractMembers");
@@ -691,9 +692,9 @@ void QENSFitSequential::renameGroupWorkspace(
     std::string const &currentName, std::vector<std::string> const &spectra,
     std::string const &outputBaseName, std::string const &endOfSuffix) {
   if (AnalysisDataService::Instance().doesExist(currentName)) {
-    auto const pdfGroup =
+    auto const group =
         AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(currentName);
-    renameWorkspaces(pdfGroup, spectra, outputBaseName, endOfSuffix);
+    renameWorkspaces(group, spectra, outputBaseName, endOfSuffix);
   }
 }
 

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -514,14 +514,15 @@ void QENSFitSequential::exec() {
   const auto groupWs =
       AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
           outputBaseName + "_Workspaces");
+  auto hhh = getPropertyValue("OutputWorkspace");
   AnalysisDataService::Instance().addOrReplace(
       getPropertyValue("OutputWorkspace"), resultWs);
 
-  if (containsMultipleData(workspaces))
-    renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace",
-                     inputWorkspaces);
-  else
-    renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace");
+  //if (containsMultipleData(workspaces))
+  //  renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace",
+  //                   inputWorkspaces);
+  //else
+  //  renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace");
   copyLogs(resultWs, workspaces);
 
   const bool doExtractMembers = getProperty("ExtractMembers");

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -29,6 +29,16 @@ namespace {
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 
+WorkspaceGroup_sptr getADSGroupWorkspace(const std::string &workspaceName) {
+  return AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
+      workspaceName);
+}
+
+MatrixWorkspace_sptr getADSMatrixWorkspace(const std::string &workspaceName) {
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      workspaceName);
+}
+
 MatrixWorkspace_sptr convertSpectrumAxis(MatrixWorkspace_sptr inputWorkspace,
                                          const std::string &outputName) {
   auto convSpec = AlgorithmManager::Instance().create("ConvertSpectrumAxis");
@@ -40,8 +50,7 @@ MatrixWorkspace_sptr convertSpectrumAxis(MatrixWorkspace_sptr inputWorkspace,
   convSpec->execute();
   // Attempting to use getProperty("OutputWorkspace") on algorithm results in a
   // nullptr being returned
-  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-      outputName);
+  return getADSMatrixWorkspace(outputName);
 }
 
 MatrixWorkspace_sptr cloneWorkspace(MatrixWorkspace_sptr inputWorkspace,
@@ -150,8 +159,7 @@ std::vector<MatrixWorkspace_sptr> extractWorkspaces(const std::string &input) {
   std::vector<MatrixWorkspace_sptr> workspaces;
 
   auto extractWorkspace = [&](const std::string &name) {
-    workspaces.emplace_back(
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name));
+    workspaces.emplace_back(getADSMatrixWorkspace(name));
   };
 
   boost::regex reg("([^,;]+),");
@@ -512,9 +520,7 @@ void QENSFitSequential::exec() {
       processParameterTable(performFit(inputString, outputBaseName));
   const auto resultWs =
       processIndirectFitParameters(parameterWs, getDatasetGrouping(workspaces));
-  const auto groupWs =
-      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(
-          outputBaseName + "_Workspaces");
+  const auto groupWs = getADSGroupWorkspace(outputBaseName + "_Workspaces");
   AnalysisDataService::Instance().addOrReplace(
       getPropertyValue("OutputWorkspace"), resultWs);
 
@@ -692,9 +698,9 @@ void QENSFitSequential::renameGroupWorkspace(
     std::string const &currentName, std::vector<std::string> const &spectra,
     std::string const &outputBaseName, std::string const &endOfSuffix) {
   if (AnalysisDataService::Instance().doesExist(currentName)) {
-    auto const group =
-        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(currentName);
-    renameWorkspaces(group, spectra, outputBaseName, endOfSuffix);
+    auto const group = getADSGroupWorkspace(currentName);
+    if (group)
+      renameWorkspaces(group, spectra, outputBaseName, endOfSuffix);
   }
 }
 

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -612,7 +612,7 @@ std::vector<MatrixWorkspace_sptr> QENSFitSimultaneous::convertInputToElasticQ(
 
 std::string QENSFitSimultaneous::getOutputBaseName() const {
   const auto base = getPropertyValue("OutputWorkspace");
-  auto position = base.rfind("_Results");
+  auto position = base.rfind("_Result");
   if (position != std::string::npos)
     return base.substr(0, position);
   return base;

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -612,7 +612,7 @@ std::vector<MatrixWorkspace_sptr> QENSFitSimultaneous::convertInputToElasticQ(
 
 std::string QENSFitSimultaneous::getOutputBaseName() const {
   const auto base = getPropertyValue("OutputWorkspace");
-  auto position = base.rfind("_Result");
+  auto position = base.rfind("_Results");
   if (position != std::string::npos)
     return base.substr(0, position);
   return base;

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -70,6 +70,7 @@ Bugfixes
 - The x-axis labels in the output plots for MSDFit are now correct.
 - An unexpected error is now prevented when clicking Plot Guess from the Display combo box in ConvFit without first loading
   a reduced file.
+- The output workspace ending with _Results now contains workspaces with corrected names which detail the fit functions used.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -66,7 +66,7 @@ void ConvFit::setupFitTab() {
   m_fitStrings["ElasticDiffSphere"] = "EDS";
   m_fitStrings["ElasticDiffRotDiscreteCircle"] = "EDC";
   m_fitStrings["StretchedExpFT"] = "SFT";
-  m_fitStrings["Teixeira Water"] = "Teixeria1L";
+  m_fitStrings["Teixeira Water"] = "TxWater";
 
   auto &functionFactory = FunctionFactory::Instance();
   auto lorentzian = functionFactory.createFunction("Lorentzian");

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -66,7 +66,7 @@ void ConvFit::setupFitTab() {
   m_fitStrings["ElasticDiffSphere"] = "EDS";
   m_fitStrings["ElasticDiffRotDiscreteCircle"] = "EDC";
   m_fitStrings["StretchedExpFT"] = "SFT";
-  m_fitStrings["TeixeiraWaterSQE"] = "Teixeria1L";
+  m_fitStrings["Teixeira Water"] = "Teixeria1L";
 
   auto &functionFactory = FunctionFactory::Instance();
   auto lorentzian = functionFactory.createFunction("Lorentzian");

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -450,7 +450,7 @@ IAlgorithm_sptr ConvFitModel::simultaneousFitAlgorithm() const {
 
 std::string ConvFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
-    return "MultiConvFit_" + m_fitType + m_backgroundString + "_Result";
+    return "MultiConvFit_" + m_fitType + m_backgroundString + "_Results";
   return createOutputName(
       "%1%_conv_" + m_fitType + m_backgroundString + "_s%2%", "_to_", 0);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -276,7 +276,7 @@ IndirectFitData::IndirectFitData(MatrixWorkspace_sptr workspace,
 std::string
 IndirectFitData::displayName(const std::string &formatString,
                              const std::string &rangeDelimiter) const {
-  const auto workspaceName = getInputBasename();
+  const auto workspaceName = getBasename();
   const auto spectraString =
       boost::apply_visitor(SpectraToString(rangeDelimiter), m_spectra);
 
@@ -291,7 +291,7 @@ IndirectFitData::displayName(const std::string &formatString,
 
 std::string IndirectFitData::displayName(const std::string &formatString,
                                          std::size_t spectrum) const {
-  const auto workspaceName = getInputBasename();
+  const auto workspaceName = getBasename();
 
   auto formatted = boost::format(formatString);
   formatted = tryPassFormatArgument(formatted, workspaceName);
@@ -299,7 +299,7 @@ std::string IndirectFitData::displayName(const std::string &formatString,
   return formatted.str();
 }
 
-std::string IndirectFitData::getInputBasename() const {
+std::string IndirectFitData::getBasename() const {
   return cutLastOf(workspace()->getName(), "_red");
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -276,7 +276,7 @@ IndirectFitData::IndirectFitData(MatrixWorkspace_sptr workspace,
 std::string
 IndirectFitData::displayName(const std::string &formatString,
                              const std::string &rangeDelimiter) const {
-  const auto workspaceName = cutLastOf(workspace()->getName(), "_red");
+  const auto workspaceName = getInputBasename();
   const auto spectraString =
       boost::apply_visitor(SpectraToString(rangeDelimiter), m_spectra);
 
@@ -291,12 +291,16 @@ IndirectFitData::displayName(const std::string &formatString,
 
 std::string IndirectFitData::displayName(const std::string &formatString,
                                          std::size_t spectrum) const {
-  const auto workspaceName = cutLastOf(workspace()->getName(), "_red");
+  const auto workspaceName = getInputBasename();
 
   auto formatted = boost::format(formatString);
   formatted = tryPassFormatArgument(formatted, workspaceName);
   formatted = tryPassFormatArgument(formatted, std::to_string(spectrum));
   return formatted.str();
+}
+
+std::string IndirectFitData::getInputBasename() const {
+  return cutLastOf(workspace()->getName(), "_red");
 }
 
 Mantid::API::MatrixWorkspace_sptr IndirectFitData::workspace() const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.h
@@ -150,6 +150,7 @@ public:
                           const std::string &rangeDelimiter) const;
   std::string displayName(const std::string &formatString,
                           std::size_t spectrum) const;
+  std::string getInputBasename() const;
 
   Mantid::API::MatrixWorkspace_sptr workspace() const;
   const Spectra &spectra() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.h
@@ -150,7 +150,7 @@ public:
                           const std::string &rangeDelimiter) const;
   std::string displayName(const std::string &formatString,
                           std::size_t spectrum) const;
-  std::string getInputBasename() const;
+  std::string getBasename() const;
 
   Mantid::API::MatrixWorkspace_sptr workspace() const;
   const Spectra &spectra() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -136,6 +136,33 @@ std::vector<std::string> getAxisLabels(MatrixWorkspace_sptr workspace,
   return std::vector<std::string>();
 }
 
+std::string cutFirstOf(const std::string &str, const std::string &delimiter) {
+  const auto cutIndex = str.find(delimiter);
+  if (cutIndex != std::string::npos)
+    return str.substr(delimiter.size() + cutIndex, str.size() - cutIndex);
+  return str;
+}
+
+std::string cutLastOf(const std::string &str, const std::string &delimiter) {
+  const auto cutIndex = str.rfind(delimiter);
+  if (cutIndex != std::string::npos)
+    return str.substr(0, cutIndex);
+  return str;
+}
+
+bool containsMultipleData(const std::string &name) {
+  return name.substr(0, 5) == "Multi";
+}
+
+std::string constructResultName(const std::string &name,
+                                IndirectFitData const *fitData) {
+  if (containsMultipleData(name)) {
+    const auto nameEnd = cutFirstOf(cutLastOf(name, "s_"), "Multi");
+    return fitData->getInputBasename() + "_" + nameEnd;
+  } else
+    return cutLastOf(name, "s_1");
+}
+
 void renameWorkspace(std::string const &name, std::string const &newName) {
   auto renamer = AlgorithmManager::Instance().create("RenameWorkspace");
   renamer->setProperty("InputWorkspace", name);
@@ -151,7 +178,7 @@ void renameResult(Workspace_sptr resultWorkspace,
 void renameResult(Workspace_sptr resultWorkspace,
                   IndirectFitData const *fitData) {
   const auto name = resultWorkspace->getName();
-  const auto newName = fitData->displayName("%1%_s%2%_Result", "_to_");
+  const auto newName = constructResultName(name, fitData);
   renameWorkspace(name, newName);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -179,7 +179,8 @@ void renameResult(Workspace_sptr resultWorkspace,
                   IndirectFitData const *fitData) {
   const auto name = resultWorkspace->getName();
   const auto newName = constructResultName(name, fitData);
-  renameWorkspace(name, newName);
+  if (newName != name)
+    renameWorkspace(name, newName);
 }
 
 void renameResultWithoutSpectra(WorkspaceGroup_sptr resultWorkspace,

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -158,7 +158,7 @@ std::string constructResultName(const std::string &name,
                                 IndirectFitData const *fitData) {
   if (containsMultipleData(name)) {
     const auto nameEnd = cutFirstOf(cutLastOf(name, "s_"), "Multi");
-    return fitData->getInputBasename() + "_" + nameEnd;
+    return fitData->getBasename() + "_" + nameEnd;
   } else
     return cutLastOf(name, "s_1");
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -136,13 +136,6 @@ std::vector<std::string> getAxisLabels(MatrixWorkspace_sptr workspace,
   return std::vector<std::string>();
 }
 
-std::string cutFirstOf(const std::string &str, const std::string &delimiter) {
-  const auto cutIndex = str.find(delimiter);
-  if (cutIndex != std::string::npos)
-    return str.substr(delimiter.size() + cutIndex, str.size() - cutIndex);
-  return str;
-}
-
 std::string cutLastOf(const std::string &str, const std::string &delimiter) {
   const auto cutIndex = str.rfind(delimiter);
   if (cutIndex != std::string::npos)
@@ -157,8 +150,8 @@ bool containsMultipleData(const std::string &name) {
 std::string constructResultName(const std::string &name,
                                 IndirectFitData const *fitData) {
   if (containsMultipleData(name)) {
-    const auto nameEnd = cutFirstOf(cutLastOf(name, "s_"), "Multi");
-    return fitData->getBasename() + "_" + nameEnd;
+    const auto formatString = cutLastOf(name, "_Results") + "_%1%_s%2%_Result";
+    return fitData->displayName(formatString, "_to_");
   } else
     return cutLastOf(name, "s_1");
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -384,7 +384,8 @@ std::string
 IndirectFittingModel::createOutputName(const std::string &formatString,
                                        const std::string &rangeDelimiter,
                                        std::size_t dataIndex) const {
-  return createDisplayName(formatString, rangeDelimiter, dataIndex) + "_Result";
+  return createDisplayName(formatString, rangeDelimiter, dataIndex) +
+         "_Results";
 }
 
 bool IndirectFittingModel::isMultiFit() const {

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
@@ -217,7 +217,7 @@ IAlgorithm_sptr IqtFitModel::simultaneousFitAlgorithm() const {
 
 std::string IqtFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
-    return "MultiIqtFit_" + m_fitType + "_Result";
+    return "MultiIqtFit_" + m_fitType + "_Results";
   auto const fitString = getFitString(getWorkspace(0));
   return createOutputName("%1%" + fitString + "_" + m_fitType + "_s%2%", "_to_",
                           0);
@@ -225,7 +225,7 @@ std::string IqtFitModel::sequentialFitOutputName() const {
 
 std::string IqtFitModel::simultaneousFitOutputName() const {
   if (isMultiFit())
-    return "MultiSimultaneousIqtFit_" + m_fitType + "_Result";
+    return "MultiSimultaneousIqtFit_" + m_fitType + "_Results";
   auto const fitString = getFitString(getWorkspace(0));
   return createOutputName("%1%" + fitString + "_mult" + m_fitType + "_s%2%",
                           "_to_", 0);

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -340,7 +340,7 @@ JumpFitModel::getEISFSpectrum(std::size_t eisfIndex,
 
 std::string JumpFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
-    return "MultiFofQFit_" + m_fitType + "_Result";
+    return "MultiFofQFit_" + m_fitType + "_Results";
   return constructOutputName();
 }
 
@@ -356,7 +356,7 @@ std::string JumpFitModel::getResultXAxisUnit() const { return ""; }
 
 std::string JumpFitModel::constructOutputName() const {
   auto const name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
-  auto const position = name.find("_Result");
+  auto const position = name.find("_Results");
   if (position != std::string::npos)
     return name.substr(0, position) + name.substr(position + 7, name.size());
   return name;

--- a/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/MSDFitModel.cpp
@@ -18,7 +18,7 @@ void MSDFitModel::setFitType(const std::string &fitType) {
 
 std::string MSDFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
-    return "MultiMSDFit_" + m_fitType + "_Result";
+    return "MultiMSDFit_" + m_fitType + "_Results";
   return createOutputName("%1%_MSDFit_" + m_fitType + "_s%2%", "_to_", 0);
 }
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
@@ -347,7 +347,7 @@ public:
   void
   test_that_the_resultworkspace_is_renamed_to_have_the_correct_name_after_a_fit_is_executed_with_multiple_data() {
     (void)getFitOutputData();
-    TS_ASSERT(m_ads->doesExist("_ConvFit_1L_Result"));
+    TS_ASSERT(m_ads->doesExist("MultiConvFit_1L__s0_to_4_Result"));
   }
 
 private:

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
@@ -35,7 +35,7 @@ createPopulatedworkspace(std::vector<double> const &xValues,
   createWorkspaceAlgorithm->setProperty("VerticalAxisUnit", "Text");
   createWorkspaceAlgorithm->setProperty("VerticalAxisValues",
                                         verticalAxisNames);
-  createWorkspaceAlgorithm->setProperty("OutputWorkspace", "workspace");
+  createWorkspaceAlgorithm->setProperty("OutputWorkspace", "OutputResults");
   createWorkspaceAlgorithm->execute();
   return createWorkspaceAlgorithm->getProperty("OutputWorkspace");
 }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputTest.h
@@ -81,14 +81,6 @@ WorkspaceGroup_sptr getPopulatedGroup(std::size_t const &size) {
   return group;
 }
 
-/// Store workspaces in ADS and won't destruct the ADS when leaving scope
-void storeWorkspacesInADS(WorkspaceGroup_sptr group,
-                          ITableWorkspace_sptr table) {
-  SetUpADSWithWorkspace ads("ResultGroup", group);
-  ads.addOrReplace("ResultWorkspaces", group);
-  ads.addOrReplace("ParameterTable", table);
-}
-
 std::unique_ptr<IndirectFitOutput>
 createFitOutput(WorkspaceGroup_sptr resultGroup,
                 ITableWorkspace_sptr parameterTable,
@@ -96,17 +88,6 @@ createFitOutput(WorkspaceGroup_sptr resultGroup,
                 std::size_t spectrum) {
   return std::make_unique<IndirectFitOutput>(
       resultGroup, parameterTable, resultWorkspace, fitData, spectrum);
-}
-
-/// This will return fit output with workspaces still stored in the ADS
-std::unique_ptr<IndirectFitOutput> getFitOutputData() {
-  auto const group = getPopulatedGroup(2);
-  auto const table = getPopulatedTable(2);
-  IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
-
-  storeWorkspacesInADS(group, table);
-
-  return createFitOutput(group, table, group, data, 0);
 }
 
 std::unordered_map<std::string, std::string>
@@ -147,10 +128,10 @@ public:
   test_that_the_group_workspaces_stored_are_equal_to_the_workspaces_inputed() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
     TS_ASSERT_EQUALS(output->getLastResultGroup(), group);
     TS_ASSERT_EQUALS(output->getLastResultWorkspace(), group);
@@ -160,48 +141,48 @@ public:
   test_that_isSpectrumFit_returns_false_if_the_spectrum_has_not_been_previously_fit() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    TS_ASSERT(!output->isSpectrumFit(data, 7));
+    TS_ASSERT(!output->isSpectrumFit(data.get(), 7));
   }
 
   void
   test_that_isSpectrumFit_returns_true_if_the_spectrum_has_been_previously_fit() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    TS_ASSERT(output->isSpectrumFit(data, 0));
+    TS_ASSERT(output->isSpectrumFit(data.get(), 0));
   }
 
   void
   test_that_getParameters_returns_an_empty_map_when_the_spectrum_number_provided_is_out_of_range() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    TS_ASSERT(output->getParameters(data, 7).empty());
+    TS_ASSERT(output->getParameters(data.get(), 7).empty());
   }
 
   void
   test_that_getParameters_returns_the_correct_parameter_values_when_the_spectrum_number_and_IndirectFitData_provided_is_valid() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    auto const parameters = output->getParameters(data, 0);
+    auto const parameters = output->getParameters(data.get(), 0);
     TS_ASSERT_EQUALS(parameters.size(), 2);
     TS_ASSERT_EQUALS(parameters.at("Height_Err").value, 0.047);
     TS_ASSERT_EQUALS(parameters.at("Msd_Err").value, 0.514);
@@ -211,24 +192,24 @@ public:
   test_that_getResultLocation_returns_none_when_the_spectrum_number_provided_is_out_of_range() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    TS_ASSERT(!output->getResultLocation(data, 7));
+    TS_ASSERT(!output->getResultLocation(data.get(), 7));
   }
 
   void
   test_that_getResultLocation_returns_the_ResultLocation_when_the_spectrum_number_and_IndirectFitData_provided_is_valid() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
 
-    auto const resultLocation = output->getResultLocation(data, 0);
+    auto const resultLocation = output->getResultLocation(data.get(), 0);
     TS_ASSERT(resultLocation);
     TS_ASSERT_EQUALS(resultLocation->result.lock(), group);
   }
@@ -237,10 +218,10 @@ public:
   test_that_getResultParameterNames_gets_the_parameter_names_which_were_provided_as_input_data() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
     std::vector<std::string> const expectedParameters{
         "Height", "Height_Err", "Msd", "Msd_Err", "Chi_squared"};
     auto const parameters = output->getResultParameterNames();
@@ -265,15 +246,15 @@ public:
   test_that_mapParameterNames_will_remap_the_parameters_to_correspond_to_the_provided_parameter_names() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
     auto const newParameterNames =
         getNewParameterNames({"Height_Err", "Msd_Err"});
-    output->mapParameterNames(newParameterNames, data);
+    output->mapParameterNames(newParameterNames, data.get());
 
-    auto const parameters = output->getParameters(data, 0);
+    auto const parameters = output->getParameters(data.get(), 0);
     TS_ASSERT_EQUALS(parameters.size(), 2);
     TS_ASSERT_EQUALS(parameters.at("Width_Err").value, 0.047);
     TS_ASSERT_EQUALS(parameters.at("MSD_Err").value, 0.514);
@@ -283,14 +264,14 @@ public:
   test_that_mapParameterNames_will_not_remap_the_parameters_when_the_provided_old_parameter_names_do_not_exist() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
     auto const newParameterNames = getNewParameterNames({"None1", "None2"});
-    output->mapParameterNames(newParameterNames, data);
+    output->mapParameterNames(newParameterNames, data.get());
 
-    auto const parameters = output->getParameters(data, 0);
+    auto const parameters = output->getParameters(data.get(), 0);
     TS_ASSERT(parameters.at("Height_Err").value);
     TS_ASSERT(parameters.at("Msd_Err").value);
   }
@@ -299,57 +280,99 @@ public:
   test_that_addOutput_will_add_new_fitData_without_overwriting_existing_data() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data1 = new IndirectFitData(getIndirectFitData(5));
+    auto const data1 = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data1, 0);
-    IndirectFitData const *data2 = new IndirectFitData(getIndirectFitData(2));
-    output->addOutput(group, table, group, data2, 0);
+    auto const output = createFitOutput(group, table, group, data1.get(), 0);
+    auto const data2 = std::make_unique<IndirectFitData>(getIndirectFitData(2));
+    output->addOutput(group, table, group, data2.get(), 0);
 
-    TS_ASSERT(!output->getParameters(data1, 0).empty());
-    TS_ASSERT(!output->getParameters(data2, 0).empty());
+    TS_ASSERT(!output->getParameters(data1.get(), 0).empty());
+    TS_ASSERT(!output->getParameters(data2.get(), 0).empty());
   }
 
   void test_that_removeOutput_will_erase_the_provided_fitData() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data = new IndirectFitData(getIndirectFitData(5));
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data, 0);
-    output->removeOutput(data);
+    auto const output = createFitOutput(group, table, group, data.get(), 0);
+    output->removeOutput(data.get());
 
-    TS_ASSERT(output->getParameters(data, 0).empty());
-    TS_ASSERT(!output->getResultLocation(data, 0));
+    TS_ASSERT(output->getParameters(data.get(), 0).empty());
+    TS_ASSERT(!output->getResultLocation(data.get(), 0));
   }
 
   void test_that_removeOutput_will_not_delete_fitData_which_is_not_specified() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data1 = new IndirectFitData(getIndirectFitData(5));
+    auto const data1 = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data1, 0);
-    IndirectFitData const *data2 = new IndirectFitData(getIndirectFitData(2));
-    output->addOutput(group, table, group, data2, 0);
-    output->removeOutput(data2);
+    auto const output = createFitOutput(group, table, group, data1.get(), 0);
+    auto const data2 = std::make_unique<IndirectFitData>(getIndirectFitData(2));
+    output->addOutput(group, table, group, data2.get(), 0);
+    output->removeOutput(data2.get());
 
-    TS_ASSERT(!output->getParameters(data1, 0).empty());
-    TS_ASSERT(output->getParameters(data2, 0).empty());
+    TS_ASSERT(!output->getParameters(data1.get(), 0).empty());
+    TS_ASSERT(output->getParameters(data2.get(), 0).empty());
   }
 
   void
   test_that_removeOutput_does_not_throw_when_provided_fitData_which_does_not_exist() {
     auto const group = getPopulatedGroup(2);
     auto const table = getPopulatedTable(2);
-    IndirectFitData *data1 = new IndirectFitData(getIndirectFitData(5));
+    auto const data1 = std::make_unique<IndirectFitData>(getIndirectFitData(5));
     storeWorkspacesInADS(group, table);
 
-    auto const output = createFitOutput(group, table, group, data1, 0);
-    IndirectFitData const *data2 = new IndirectFitData(getIndirectFitData(2));
+    auto const output = createFitOutput(group, table, group, data1.get(), 0);
+    auto const data2 = std::make_unique<IndirectFitData>(getIndirectFitData(2));
 
-    TS_ASSERT_THROWS_NOTHING(output->removeOutput(data2));
+    TS_ASSERT_THROWS_NOTHING(output->removeOutput(data2.get()));
   }
+
+  void
+  test_that_the_resultworkspace_is_renamed_to_have_the_correct_name_after_a_fit_is_executed() {
+    auto const group = getPopulatedGroup(1);
+    auto const table = getPopulatedTable(2);
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
+    storeWorkspacesInADS(group, table);
+
+    (void)createFitOutput(group, table, group, data.get(), 0);
+
+    TS_ASSERT(m_ads->doesExist("ConvFit_1L_Result"));
+  }
+
+  void
+  test_that_the_resultworkspace_is_renamed_to_have_the_correct_name_after_a_fit_is_executed_with_multiple_data() {
+    (void)getFitOutputData();
+    TS_ASSERT(m_ads->doesExist("_ConvFit_1L_Result"));
+  }
+
+private:
+  /// This will return fit output with workspaces still stored in the ADS
+  std::unique_ptr<IndirectFitOutput> getFitOutputData() {
+    auto const group = getPopulatedGroup(2);
+    auto const table = getPopulatedTable(2);
+    auto const data = std::make_unique<IndirectFitData>(getIndirectFitData(5));
+
+    storeWorkspacesInADS(group, table);
+
+    return createFitOutput(group, table, group, data.get(), 0);
+  }
+
+  /// Store workspaces in ADS and won't destruct the ADS when leaving scope
+  void storeWorkspacesInADS(WorkspaceGroup_sptr group,
+                            ITableWorkspace_sptr table) {
+    std::string const nameStart = group->size() > 1 ? "Multi" : "";
+    m_ads = std::make_unique<SetUpADSWithWorkspace>(
+        nameStart + "ConvFit_1L_Workspaces", group);
+    m_ads->addOrReplace(nameStart + "ConvFit_1L_Results_1", group);
+    m_ads->addOrReplace(nameStart + "ConvFit_1L_Parameters", table);
+  }
+
+  std::unique_ptr<SetUpADSWithWorkspace> m_ads;
 };
 
 #endif // MANTID_INDIRECTFITOUTPUTTEST_H

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
@@ -129,7 +129,7 @@ IAlgorithm_sptr setupFitAlgorithm(MatrixWorkspace_sptr workspace,
   alg->setProperty("ConvolveMembers", true);
   alg->setProperty("Minimizer", "Levenberg-Marquardt");
   alg->setProperty("MaxIterations", 500);
-  alg->setProperty("OutputWorkspace", "output");
+  alg->setProperty("OutputWorkspace", "OutputResults");
   alg->setLogging(false);
   return alg;
 }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -335,7 +335,7 @@ public:
     std::string const rangeDelimiter = "_to_";
 
     TS_ASSERT_EQUALS(model->createOutputName(formatString, rangeDelimiter, 0),
-                     "WorkspaceName_s0_Gaussian_Result");
+                     "WorkspaceName_s0_Gaussian_Results");
   }
 
   void
@@ -346,7 +346,7 @@ public:
     std::string const rangeDelimiter = "_to_";
 
     TS_ASSERT_EQUALS(model->createOutputName(formatString, rangeDelimiter, 0),
-                     "Workspace_3456_s0_Gaussian_Result");
+                     "Workspace_3456_s0_Gaussian_Results");
   }
 
   void
@@ -359,13 +359,13 @@ public:
 
     TS_ASSERT_EQUALS(
         model->createOutputName(formatStrings[0], rangeDelimiter, 0),
-        "Workspace_3456_s0_Gaussian_Result");
+        "Workspace_3456_s0_Gaussian_Results");
     TS_ASSERT_EQUALS(
         model->createOutputName(formatStrings[1], rangeDelimiter, 0),
-        "Workspace_3456_f0+s0_MSD_Result");
+        "Workspace_3456_f0+s0_MSD_Results");
     TS_ASSERT_EQUALS(
         model->createOutputName(formatStrings[2], rangeDelimiter, 0),
-        "Workspace_3456_s0_TeixeiraWater_Result");
+        "Workspace_3456_s0_TeixeiraWater_Results");
   }
 
   void


### PR DESCRIPTION
**Description of work.**
This PR ensures that the TeixeiraWater Fit type is displayed in the name of the result workspaces as `TxWater`.
It also makes sure that the workspaces in the _Results group have the correct name.

**To test:**
**A.**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` interface
2. Load the single input data below
3. Select the One Lorentzian fit type.
4. Click Run and wait. Expand the _Results group. The name inside should be `irs26176_graphite002_conv_1L_s0_to_9_Result`.
5. Select the Multile Input tab and load in the workspaces below by clicking `Add Workspaces` and checking All Spectra.
6. Click Run and wait. The names inside the _Results group should be:
![image](https://user-images.githubusercontent.com/40830825/50093404-75bfaa80-0208-11e9-91a6-16f90b80444d.png)

**B.**
1. Now go back to single input and load the data below.
2. Select TeixeiraWater as the Fit type
3. Click Run and wait. The names of the output workspaces should contain `TxWater`.

**Data Files**
Single Input: 
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2686430/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2686431/irs26173_graphite002_res.zip)

Multiple Input:
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2686430/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2686431/irs26173_graphite002_res.zip)

[irs26173_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2686432/irs26173_graphite002_red.zip)
Same resolution file as for the first workspace.

No release notes required as I believe this was introduced in #23221 

Fixes #24346 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
