### PR TITLE
DownloadInstrument segfault in docker and conda

### DIFF
--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -91,6 +91,12 @@ void DownloadInstrument::init() {
 void DownloadInstrument::exec() {
   StringToStringMap fileMap;
   setProperty("FileDownloadCount", 0);
+
+  // to aid in general debugging, always ask github for what the rate limit
+  // status is. This doesn't count against rate limit.
+  GitHubApiHelper inetHelper;
+  g_log.information(inetHelper.getRateLimitDescription());
+
   try {
     fileMap = processRepository();
   } catch (Mantid::Kernel::Exception::InternetError &ex) {

--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -117,15 +117,33 @@ void DownloadInstrument::exec() {
 
   for (auto &itMap : fileMap) {
     // download a file
-    doDownloadFile(itMap.first, itMap.second);
     if (boost::algorithm::ends_with(itMap.second, "Facilities.xml")) {
       g_log.notice("A new Facilities.xml file has been downloaded, this will "
                    "take effect next time Mantid is started.");
+    } else {
+      g_log.information() << "Downloading \"" << itMap.second << "\" from \""
+                          << itMap.first << "\"\n";
     }
+    doDownloadFile(itMap.first, itMap.second);
   }
 
   setProperty("FileDownloadCount", static_cast<int>(fileMap.size()));
 }
+
+namespace {
+// Converts a json chunk to a url for the raw file contents.
+std::string getDownloadUrl(Json::Value &contents) {
+  std::string url = contents.get("download_url", "").asString();
+  if (url.empty()) { // guess it from html url
+    url = contents.get("html_url", "").asString();
+    if (url.empty())
+      throw std::runtime_error("Failed to find download link");
+    url = url + "?raw=1";
+  }
+
+  return url;
+}
+} // namespace
 
 DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
   // get the instrument directories
@@ -198,8 +216,7 @@ DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
     if (filePath.getExtension() != "xml")
       continue;
     std::string sha = serverElement.get("sha", "").asString();
-    std::string htmlUrl =
-        getDownloadableRepoUrl(serverElement.get("html_url", "").asString());
+    std::string downloadUrl = getDownloadUrl(serverElement);
 
     // Find shas
     std::string localSha = getValueOrDefault(localShas, name, "");
@@ -208,14 +225,14 @@ DownloadInstrument::StringToStringMap DownloadInstrument::processRepository() {
     // this will also catch when file is only present on github (as local sha
     // will be "")
     if ((sha != installSha) && (sha != localSha)) {
-      fileMap.emplace(htmlUrl,
+      fileMap.emplace(downloadUrl,
                       filePath.toString()); // ACTION - DOWNLOAD to localPath
     } else if ((!localSha.empty()) && (sha == installSha) &&
                (sha != localSha)) // matches install, but different local
     {
-      fileMap.emplace(
-          htmlUrl,
-          filePath.toString()); // ACTION - DOWNLOAD to localPath and overwrite
+      fileMap.emplace(downloadUrl, filePath.toString()); // ACTION - DOWNLOAD to
+                                                         // localPath and
+                                                         // overwrite
     }
   }
 
@@ -331,15 +348,6 @@ size_t DownloadInstrument::removeOrphanedFiles(
   g_log.debug() << filesToDelete.size() << " Files deleted.\n";
 
   return filesToDelete.size();
-}
-
-/** Converts a github file page to a downloadable url for the file.
- * @param filename a github file page url
- * @returns a downloadable url for the file
- **/
-const std::string
-DownloadInstrument::getDownloadableRepoUrl(const std::string &filename) const {
-  return filename + "?raw=1";
 }
 
 /** Download a url and fetch it inside the local path given.

--- a/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
+++ b/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
@@ -24,6 +24,14 @@ public:
 
   void reset() override;
   bool isAuthenticated();
+  /**
+   * String describing the rate limit status. This uses a url that github claims
+   * will never cout against your REST API limit.
+   * https://developer.github.com/v3/rate_limit/
+   *
+   * @return description of the status or an empty string
+   */
+  std::string getRateLimitDescription();
 
 protected:
   virtual void processResponseHeaders(const Poco::Net::HTTPResponse &res) override;

--- a/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
+++ b/Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h.in
@@ -26,7 +26,7 @@ public:
   bool isAuthenticated();
   /**
    * String describing the rate limit status. This uses a url that github claims
-   * will never cout against your REST API limit.
+   * will never count against your REST API limit.
    * https://developer.github.com/v3/rate_limit/
    *
    * @return description of the status or an empty string

--- a/Framework/Kernel/src/GitHubApiHelper.cpp
+++ b/Framework/Kernel/src/GitHubApiHelper.cpp
@@ -110,7 +110,10 @@ int GitHubApiHelper::sendRequestAndProcess(HTTPClientSession &session,
   if (retStatus == HTTP_OK ||
       (retStatus == HTTP_CREATED && m_method == HTTPRequest::HTTP_POST)) {
     Poco::StreamCopier::copyStream(rs, responseStream);
-    processResponseHeaders(*m_response);
+    if (m_response)
+      processResponseHeaders(*m_response);
+    else
+      g_log.warning("Response is null pointer");
     return retStatus;
   } else if ((retStatus == HTTP_FORBIDDEN && isAuthenticated()) ||
              (retStatus == HTTP_UNAUTHORIZED) ||

--- a/Framework/Kernel/src/GitHubApiHelper.cpp
+++ b/Framework/Kernel/src/GitHubApiHelper.cpp
@@ -14,7 +14,7 @@
 #include <Poco/URI.h>
 
 #include <boost/lexical_cast.hpp>
-
+#include <json/json.h>
 #include <map>
 #include <ostream>
 #include <string>
@@ -32,7 +32,21 @@ using std::string;
 namespace {
 // anonymous namespace for some utility functions
 /// static Logger object
-Logger g_log("InternetHelper");
+Logger g_log("GitHubApiHelper");
+
+const std::string RATE_LIMIT_URL("https://api.github.com/rate_limit");
+
+std::string formatRateLimit(const int rateLimit, const int remaining,
+                            const int expires) {
+  DateAndTime expiresDateAndTime;
+  expiresDateAndTime.set_from_time_t(expires);
+
+  std::stringstream msg;
+  msg << "GitHub API limited to " << remaining << " of " << rateLimit
+      << " calls left. Resets at " << expiresDateAndTime.toISO8601String()
+      << "Z";
+  return msg.str();
+}
 } // namespace
 
 //----------------------------------------------------------------------------------------------
@@ -64,28 +78,47 @@ void GitHubApiHelper::processResponseHeaders(
   // get github api rate limit information if available;
   int rateLimitRemaining = 0;
   int rateLimitLimit;
-  DateAndTime rateLimitReset;
+  int rateLimitReset;
   try {
     rateLimitLimit =
         boost::lexical_cast<int>(res.get("X-RateLimit-Limit", "-1"));
     rateLimitRemaining =
         boost::lexical_cast<int>(res.get("X-RateLimit-Remaining", "-1"));
-    rateLimitReset.set_from_time_t(
-        boost::lexical_cast<int>(res.get("X-RateLimit-Reset", "0")));
+    rateLimitReset =
+        boost::lexical_cast<int>(res.get("X-RateLimit-Reset", "0"));
   } catch (boost::bad_lexical_cast const &) {
     rateLimitLimit = -1;
   }
   if (rateLimitLimit > -1) {
-    g_log.debug() << "GitHub API " << rateLimitRemaining << " of "
-                  << rateLimitLimit << " calls left. Resets at "
-                  << rateLimitReset.toSimpleString() << " GMT\n";
+    g_log.debug(
+        formatRateLimit(rateLimitLimit, rateLimitRemaining, rateLimitReset));
   }
+}
+
+std::string GitHubApiHelper::getRateLimitDescription() {
+  std::stringstream responseStream;
+  this->sendRequest(RATE_LIMIT_URL, responseStream);
+  Json::Reader reader;
+  Json::Value root;
+  if (!reader.parse(responseStream, root)) {
+    return "Failed to parse json document from \"" + RATE_LIMIT_URL + "\"";
+  }
+
+  const auto &rateInfo = root.get("rate", "");
+  if (rateInfo.empty())
+    return std::string();
+
+  const int limit = rateInfo.get("limit", -1).asInt();
+  const int remaining = rateInfo.get("remaining", -1).asInt();
+  const int expires = rateInfo.get("reset", 0).asInt();
+
+  return formatRateLimit(limit, remaining, expires);
 }
 
 int GitHubApiHelper::processAnonymousRequest(
     const Poco::Net::HTTPResponse &response, Poco::URI &uri,
     std::ostream &responseStream) {
-  if (isAuthenticated()) {
+  if (!isAuthenticated()) {
     g_log.debug("Repeating API call anonymously\n");
     removeHeader("Authorization");
     return this->sendRequest(uri.toString(), responseStream);

--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -160,7 +160,10 @@ int InternetHelper::sendRequestAndProcess(HTTPClientSession &session,
   if (retStatus == HTTP_OK ||
       (retStatus == HTTP_CREATED && m_method == HTTPRequest::HTTP_POST)) {
     Poco::StreamCopier::copyStream(rs, responseStream);
-    processResponseHeaders(*m_response);
+    if (m_response)
+      processResponseHeaders(*m_response);
+    else
+      g_log.warning("Response is null pointer");
     return retStatus;
   } else if (isRelocated(retStatus)) {
     return this->processRelocation(*m_response, responseStream);
@@ -174,7 +177,7 @@ int InternetHelper::processRelocation(const HTTPResponse &response,
                                       std::ostream &responseStream) {
   std::string newLocation = response.get("location", "");
   if (!newLocation.empty()) {
-    g_log.information() << "url relocated to " << newLocation;
+    g_log.information() << "url relocated to " << newLocation << "\n";
     return this->sendRequest(newLocation, responseStream);
   } else {
     g_log.warning("Apparent relocation did not give new location\n");
@@ -413,8 +416,8 @@ behaviour.
 int InternetHelper::downloadFile(const std::string &urlFile,
                                  const std::string &localFilePath) {
   int retStatus = 0;
-  g_log.debug() << "DownloadFile : " << urlFile << " to file: " << localFilePath
-                << '\n';
+  g_log.debug() << "DownloadFile from \"" << urlFile << "\" to file: \""
+                << localFilePath << "\"\n";
 
   Poco::TemporaryFile tempFile;
   Poco::FileStream tempFileStream(tempFile.path());


### PR DESCRIPTION
This changeset is to improve logging around the issue so we can better determine what is actually going on. There is an additional `nullptr` check, but it is uncertain if that will help with what was reported.

**To test:**

`DownloadInstrument(ForceUpdate=True)` should continue to work. With logging at `information`, you'll also see how many requests are left against the github REST api.

Refs #24339. This may actually fix the issue, but it needs to be merged into `master` so the docker/conda builds can have improved logging.

*This does not require release notes* because it is only an improvement in logging.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
