### PR TITLE
Indirect Data Analysis - Elwin plot spectrum options

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -1,4 +1,4 @@
-Indirect Data Analysis
+﻿Indirect Data Analysis
 ======================
 
 .. contents:: Table of Contents
@@ -93,8 +93,10 @@ SE log value
   specified value in the instrument parameters file, and in the absence of such
   specification, defaults to "last value")
 
-Plot Result
-  If enabled will plot the result as a spectra plot.
+Plot Spectrum
+  If enabled it will plot the spectrum represented by the workspace index in the 
+  neighbouring spin box. This workspace index is the index of the spectrum within the 
+  workspace selected in the combobox.
 
 Save Result
   If enabled the result will be saved as a NeXus file in the default save
@@ -178,11 +180,16 @@ Save Result
   directory.
   
 Tiled Plot
-  Produces a tiled plot of the output workspaces generated.
+  Produces a tiled plot of spectra included within the range for the output workspaces 
+  generated. There is a maximum of 18 spectra allowed for a tiled plot. 
 
 Monte Carlo Error Calculation - Number Of Iterations
-  The number of iterations to perform in the Monte Carlo routine for error
-  calculation in I(Q,t)
+  The number of iterations to perform in the Monte Carlo routine for error calculation 
+  in I(Q,t). 
+
+Monte Carlo Error Calculation - Calculate Errors
+  The calculation of errors using a Monte Carlo implementation can be skipped by ticking 
+  the Calculate Errors checkbox.
 
 A note on Binning
 ~~~~~~~~~~~~~~~~~
@@ -424,10 +431,11 @@ The 'Plot Guess' check-box can be used to enable/disable the guess curve in the 
 Output
 ~~~~~~
 
-The results of the fit may be plot and saved under the 'Output' section of the fitting interfaces.
+The results of the fit may be plotted and saved under the 'Output' section of the fitting interfaces.
 
 Next to the 'Plot Output' label, you can select a parameter to plot and then click 'Plot' to plot it across the
-fit spectra (if multiple data-sets have been used, a separate plot will be produced for each data-set).
+fit spectra (if multiple data-sets have been used, a separate plot will be produced for each data-set). 
+The 'Plot Output' options will be disabled after a fit if there is only one data point for the parameters.
 
 Clicking the 'Save Result' button will save the result of the fit to your default save location.
 
@@ -481,9 +489,9 @@ input workspace, using the fitted values from the previous spectrum as input
 values for fitting the next. This is done by means of the
 :ref:`IqtFitSequential <algm-IqtFitSequential>` algorithm.
 
-A sequential fit is run by clicking the Run button at the bottom of the tab, a
-single fit can be done using the Fit Single Spectrum button underneath the
-preview plot.
+A sequential fit is run by clicking the Run button seen just above the output 
+options, a single fit can be done using the Fit Single Spectrum button underneath 
+the preview plot.
 
 Spectrum Selection
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -46,6 +46,7 @@ Improvements
 - The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed.
   This improvement can be seen in ConvFit when functions which depend on Q value are selected.
 - Fit and Fit Sequential in the Fit combobox above the FitPropertyBrowser are now disabled while fitting is taking place.
+- The option to choose which workspace index to Plot Spectrum for and from which output workspace is now given in Elwin.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -510,48 +510,22 @@ void Elwin::runClicked() { runTab(); }
 void Elwin::plotClicked() {
   setPlotResultIsPlotting(true);
 
-  auto const workspaceBaseName = getOutputBasename();
-
-  plotResult(workspaceBaseName + "_eq");
-  plotResult(workspaceBaseName + "_eq2");
-  plotResult(workspaceBaseName + "_elf");
-  plotResult(workspaceBaseName + "_elt");
+  auto const workspaceName = m_uiForm.cbPlotWorkspace->currentText();
+  auto const workspaceIndex = m_uiForm.spPlotSpectrum->text().toInt();
+  plotSpectrum(workspaceName, workspaceIndex);
 
   setPlotResultIsPlotting(false);
-}
-
-void Elwin::plotResult(QString const &workspaceName) {
-  auto const name = workspaceName.toStdString();
-  if (checkADSForPlotSaveWorkspace(name, true)) {
-    if (canPlotWorkspace(name))
-      plotSpectrum(workspaceName);
-    else
-      showMessageBox("Plotting a spectrum of the workspace " + workspaceName +
-                     " failed : Workspace only has one data point");
-  }
 }
 
 /**
  * Handles saving of workspaces
  */
 void Elwin::saveClicked() {
-  auto workspaceBaseName = getOutputBasename();
+  auto const workspaceBaseName = getOutputBasename().toStdString();
 
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq").toStdString(),
-                                   false))
-    addSaveWorkspaceToQueue(workspaceBaseName + "_eq");
-
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_eq2").toStdString(),
-                                   false))
-    addSaveWorkspaceToQueue(workspaceBaseName + "_eq2");
-
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elf").toStdString(),
-                                   false))
-    addSaveWorkspaceToQueue(workspaceBaseName + "_elf");
-
-  if (checkADSForPlotSaveWorkspace((workspaceBaseName + "_elt").toStdString(),
-                                   false, false))
-    addSaveWorkspaceToQueue(workspaceBaseName + "_elt");
+  for (auto const &suffix : getOutputWorkspaceSuffices())
+    if (checkADSForPlotSaveWorkspace(workspaceBaseName + suffix, false))
+      addSaveWorkspaceToQueue(workspaceBaseName + suffix);
 
   m_batchAlgoRunner->executeBatchAsync();
 }

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -315,6 +315,10 @@ void Elwin::updateAvailablePlotWorkspaces() {
   }
 }
 
+QString Elwin::getPlotWorkspaceName() const {
+  return m_uiForm.cbPlotWorkspace->currentText();
+}
+
 void Elwin::setPlotSpectrumValue(int value) {
   MantidQt::API::SignalBlocker<QObject> blocker(m_uiForm.spPlotSpectrum);
   m_uiForm.spPlotSpectrum->setValue(value);
@@ -330,6 +334,10 @@ void Elwin::updateAvailablePlotSpectra() {
 void Elwin::setPlotSpectrumMinMax(int minimum, int maximum) {
   m_uiForm.spPlotSpectrum->setMinimum(minimum);
   m_uiForm.spPlotSpectrum->setMaximum(maximum);
+}
+
+int Elwin::getPlotSpectrumIndex() const {
+  return m_uiForm.spPlotSpectrum->text().toInt();
 }
 
 bool Elwin::validate() {
@@ -541,11 +549,7 @@ void Elwin::runClicked() { runTab(); }
  */
 void Elwin::plotClicked() {
   setPlotResultIsPlotting(true);
-
-  auto const workspaceName = m_uiForm.cbPlotWorkspace->currentText();
-  auto const workspaceIndex = m_uiForm.spPlotSpectrum->text().toInt();
-  plotSpectrum(workspaceName, workspaceIndex);
-
+  plotSpectrum(getPlotWorkspaceName(), getPlotSpectrumIndex());
   setPlotResultIsPlotting(false);
 }
 
@@ -566,31 +570,33 @@ QString Elwin::getOutputBasename() {
   return getWorkspaceBasename(QString::fromStdString(m_pythonExportWsName));
 }
 
-void Elwin::setRunIsRunning(bool running) {
+void Elwin::setRunIsRunning(const bool &running) {
   m_uiForm.pbRun->setText(running ? "Running..." : "Run");
   setButtonsEnabled(!running);
 }
 
-void Elwin::setPlotResultIsPlotting(bool plotting) {
+void Elwin::setPlotResultIsPlotting(const bool &plotting) {
   m_uiForm.pbPlot->setText(plotting ? "Plotting..." : "Plot Spectrum");
   setButtonsEnabled(!plotting);
 }
 
-void Elwin::setButtonsEnabled(bool enabled) {
+void Elwin::setButtonsEnabled(const bool &enabled) {
   setRunEnabled(enabled);
   setPlotResultEnabled(enabled);
   setSaveResultEnabled(enabled);
 }
 
-void Elwin::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+void Elwin::setRunEnabled(const bool &enabled) {
+  m_uiForm.pbRun->setEnabled(enabled);
+}
 
-void Elwin::setPlotResultEnabled(bool enabled) {
+void Elwin::setPlotResultEnabled(const bool &enabled) {
   m_uiForm.pbPlot->setEnabled(enabled);
   m_uiForm.cbPlotWorkspace->setEnabled(enabled);
   m_uiForm.spPlotSpectrum->setEnabled(enabled);
 }
 
-void Elwin::setSaveResultEnabled(bool enabled) {
+void Elwin::setSaveResultEnabled(const bool &enabled) {
   m_uiForm.pbSave->setEnabled(enabled);
 }
 

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -146,7 +146,7 @@ void Elwin::setup() {
           SLOT(plotCurrentPreview()));
 
   connect(m_uiForm.cbPlotWorkspace, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(setPlotSpectrumMinMax()));
+          SLOT(updateAvailablePlotSpectra()));
 
   // Set any default values
   m_dblManager->setValue(m_properties["IntegrationStart"], -0.02);
@@ -289,16 +289,20 @@ void Elwin::unGroupInput(bool error) {
       ungroupAlg->execute();
     }
 
-    updateAvailablePlotWorkspaces();
-    if (m_uiForm.cbPlotWorkspace->size().isEmpty())
-      setPlotResultEnabled(false);
-    else
-      setPlotSpectrumMinMax();
+    updatePlotSpectrumOptions();
 
   } else {
     setPlotResultEnabled(false);
     setSaveResultEnabled(false);
   }
+}
+
+void Elwin::updatePlotSpectrumOptions() {
+  updateAvailablePlotWorkspaces();
+  if (m_uiForm.cbPlotWorkspace->size().isEmpty())
+    setPlotResultEnabled(false);
+  else
+    updateAvailablePlotSpectra();
 }
 
 void Elwin::updateAvailablePlotWorkspaces() {
@@ -316,7 +320,7 @@ void Elwin::setPlotSpectrumValue(int value) {
   m_uiForm.spPlotSpectrum->setValue(value);
 }
 
-void Elwin::setPlotSpectrumMinMax() {
+void Elwin::updateAvailablePlotSpectra() {
   auto const name = m_uiForm.cbPlotWorkspace->currentText().toStdString();
   auto const maximumValue = getNumberOfSpectra(name) - 1;
   setPlotSpectrumMinMax(0, maximumValue);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -43,14 +43,17 @@ private:
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
 
+  QString getOutputBasename();
+
+  void updateAvailablePlotWorkspaces();
   void plotResult(QString const &workspaceName);
 
+  void setRunIsRunning(bool running);
+  void setPlotResultIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setPlotResultEnabled(bool enabled);
   void setSaveResultEnabled(bool enabled);
-  void setButtonsEnabled(bool enabled);
-  void setRunIsRunning(bool running);
-  void setPlotResultIsPlotting(bool plotting);
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -46,7 +46,6 @@ private:
   QString getOutputBasename();
 
   void updateAvailablePlotWorkspaces();
-  void plotResult(QString const &workspaceName);
 
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -29,6 +29,7 @@ private slots:
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);
   void unGroupInput(bool error);
+  void setPlotSpectrumMinMax();
   void runClicked();
   void saveClicked();
   void plotClicked();
@@ -46,6 +47,8 @@ private:
   QString getOutputBasename();
 
   void updateAvailablePlotWorkspaces();
+  void setPlotSpectrumValue(int value);
+  void setPlotSpectrumMinMax(int minimum, int maximum);
 
   void setRunIsRunning(bool running);
   void setPlotResultIsPlotting(bool plotting);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -29,7 +29,7 @@ private slots:
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);
   void unGroupInput(bool error);
-  void setPlotSpectrumMinMax();
+  void updateAvailablePlotSpectra();
   void runClicked();
   void saveClicked();
   void plotClicked();
@@ -46,6 +46,7 @@ private:
 
   QString getOutputBasename();
 
+  void updatePlotSpectrumOptions();
   void updateAvailablePlotWorkspaces();
   void setPlotSpectrumValue(int value);
   void setPlotSpectrumMinMax(int minimum, int maximum);

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -48,15 +48,17 @@ private:
 
   void updatePlotSpectrumOptions();
   void updateAvailablePlotWorkspaces();
+  QString getPlotWorkspaceName() const;
   void setPlotSpectrumValue(int value);
   void setPlotSpectrumMinMax(int minimum, int maximum);
+  int getPlotSpectrumIndex() const;
 
-  void setRunIsRunning(bool running);
-  void setPlotResultIsPlotting(bool plotting);
-  void setButtonsEnabled(bool enabled);
-  void setRunEnabled(bool enabled);
-  void setPlotResultEnabled(bool enabled);
-  void setSaveResultEnabled(bool enabled);
+  void setRunIsRunning(const bool &running);
+  void setPlotResultIsPlotting(const bool &plotting);
+  void setButtonsEnabled(const bool &enabled);
+  void setRunEnabled(const bool &enabled);
+  void setPlotResultEnabled(const bool &enabled);
+  void setSaveResultEnabled(const bool &enabled);
 
   Ui::Elwin m_uiForm;
   QtTreePropertyBrowser *m_elwTree;

--- a/qt/scientific_interfaces/Indirect/Elwin.ui
+++ b/qt/scientific_interfaces/Indirect/Elwin.ui
@@ -269,12 +269,39 @@
         </property>
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Workspace:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cbPlotWorkspace">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>200</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="spPlotSpectrum">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QPushButton" name="pbPlot">
            <property name="enabled">
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Plot Result</string>
+            <string>Plot Spectrum</string>
            </property>
           </widget>
          </item>

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -167,19 +167,23 @@ bool IndirectTab::loadFile(const QString &filename, const QString &outputName,
  */
 void IndirectTab::addSaveWorkspaceToQueue(const QString &wsName,
                                           const QString &filename) {
+  addSaveWorkspaceToQueue(wsName.toStdString(), filename.toStdString());
+}
+
+void IndirectTab::addSaveWorkspaceToQueue(const std::string &wsName,
+                                          const std::string &filename) {
   // Setup the input workspace property
   API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
-  saveProps["InputWorkspace"] = wsName.toStdString();
+  saveProps["InputWorkspace"] = wsName;
 
   // Setup the algorithm
-  IAlgorithm_sptr saveAlgo =
-      AlgorithmManager::Instance().create("SaveNexusProcessed");
+  auto saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
   saveAlgo->initialize();
 
-  if (filename.isEmpty())
-    saveAlgo->setProperty("Filename", wsName.toStdString() + ".nxs");
+  if (filename.empty())
+    saveAlgo->setProperty("Filename", wsName + ".nxs");
   else
-    saveAlgo->setProperty("Filename", filename.toStdString());
+    saveAlgo->setProperty("Filename", filename);
 
   // Add the save algorithm to the batch
   m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -81,6 +81,8 @@ protected:
                 const int specMin = -1, const int specMax = -1);
 
   /// Add a SaveNexusProcessed step to the batch queue
+  void addSaveWorkspaceToQueue(const std::string &wsName,
+                               const std::string &filename = "");
   void addSaveWorkspaceToQueue(const QString &wsName,
                                const QString &filename = "");
 


### PR DESCRIPTION
**Description of work.**
This PR introduces options to allow the user to select which workspaceIndex should be plotted and from which workspace when clicking `Plot Spectrum`.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`Elwin` tab
2. Load the data below
3. Click `Run` and wait
4. The workspace names `irs26176_graphite002_elwin_eq` and `irs26176_graphite002_elwin_eq2` should appear in the Output options combo box.
5. Try changing the spinbox next to the combobox. This should stay at zero for both workspaces as they both have only 1 spectrum.
6. Click `Plot Spectrum` in turn for each workspace. Make sure the workspace name is correct for the plot

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2690299/irs26176_graphite002_red.zip)

Fixes #24354 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
