### PR TITLE
All AllTests target to Framework-only builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,12 +203,13 @@ if ( MSVC )
   add_definitions ( -DQWT_DLL )
 endif ()
 
+add_custom_target ( AllTests )
+add_dependencies( AllTests FrameworkTests )
 if ( ENABLE_MANTIDPLOT OR ENABLE_WORKBENCH )
   add_custom_target ( GUITests )
   add_dependencies ( check GUITests )
   # Collect all tests together
-  add_custom_target ( AllTests )
-  add_dependencies ( AllTests FrameworkTests GUITests )
+  add_dependencies ( AllTests GUITests )
   add_subdirectory ( qt )
 endif()
 

--- a/Framework/DataHandling/test/ReadMaterialTest.h
+++ b/Framework/DataHandling/test/ReadMaterialTest.h
@@ -34,7 +34,7 @@ public:
   }
 
   void testSuccessfullValidateInputsAtomicNumber() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -64,7 +64,7 @@ public:
   }
 
   void testFailureValidateInputsNoMaterial() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 0;
       setMaterial.massNumber = 0;
@@ -78,7 +78,7 @@ public:
   }
 
   void testSuccessfullValidateInputsSampleNumber() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -93,7 +93,7 @@ public:
   }
 
   void testSuccessfullValidateInputsZParam() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -109,7 +109,7 @@ public:
   }
 
   void testSuccessfullValidateInputsSampleMass() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -124,7 +124,7 @@ public:
   }
 
   void testFailureValidateInputsSampleNumberAndZParam() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -142,7 +142,7 @@ public:
   }
 
   void testFailureValidateInputsZParamWithSampleMass() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -160,7 +160,7 @@ public:
   }
 
   void testFailureValidateInputsZParamWithoutUnitCell() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;
@@ -176,7 +176,7 @@ public:
   }
 
   void testFailureValidateInputsSampleNumWithSampleMass() {
-    const ReadMaterial::MaterialParameters params = [this]() -> auto {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 1;
       setMaterial.massNumber = 1;


### PR DESCRIPTION
**Description of work.**

Add the AllTests target to framework-only builds. Should be no changes with `ENABLE_WORKBENCH=ON` and/or `ENABLE_MANTIDPLOT=ON`

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Code review
* Verify build servers run the same number of tests
* build with `ENABLE_MANTIDPLOT=OFF`, verify `ninja && ninja AllTests` builds Framework and FrameworkTests.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because developer detail.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
