### PR TITLE
Indirect ConvFit - Load Dave ASCII files

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -1,4 +1,4 @@
-Indirect Data Analysis
+﻿Indirect Data Analysis
 ======================
 
 .. contents:: Table of Contents
@@ -271,11 +271,11 @@ Options
 
 Sample
   Either a reduced file (*_red.nxs*) or workspace (*_red*) or an :math:`S(Q,
-  \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
+  \omega)` file (*_sqw.nxs*, *_sqw.dave*) or workspace (*_sqw*).
 
 Resolution
   Either a resolution file (_res.nxs) or workspace (_res) or an :math:`S(Q,
-  \omega)` file (*_sqw.nxs*) or workspace (*_sqw*).
+  \omega)` file (*_sqw.nxs*, *_sqw.dave*) or workspace (*_sqw*).
 
 Use Delta Function
   Found under 'Custom Function Groups'. Enables use of a delta function.

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -46,6 +46,7 @@ Improvements
 - The WorkspaceIndex and Q value in the FitPropertyBrowser are now updated when the Plot Spectrum number is changed.
   This improvement can be seen in ConvFit when functions which depend on Q value are selected.
 - Fit and Fit Sequential in the Fit combobox above the FitPropertyBrowser are now disabled while fitting is taking place.
+- ConvFit now allows the loading of Dave ASCII files which end with '_sqw.dave'.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -53,9 +53,9 @@ void ConvFit::setupFitTab() {
   setConvolveMembers(true);
 
   setSampleWSSuffices({"_red", "_sqw"});
-  setSampleFBSuffices({"_red.nxs", "_sqw.nxs"});
+  setSampleFBSuffices({"_red.nxs", "_sqw.nxs", "_sqw.dave"});
   setResolutionWSSuffices({"_res", "_red", "_sqw"});
-  setResolutionFBSuffices({"_res.nxs", "_red.nxs", "_sqw.nxs"});
+  setResolutionFBSuffices({"_res.nxs", "_red.nxs", "_sqw.nxs", "_sqw.dave"});
 
   // Initialise fitTypeStrings
   m_fitStrings["None"] = "";

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -17,6 +17,23 @@
 #include <QMimeData>
 #include <QUrl>
 
+namespace {
+
+std::string extractLastOf(const std::string &str,
+                          const std::string &delimiter) {
+  const auto cutIndex = str.rfind(delimiter);
+  if (cutIndex != std::string::npos)
+    return str.substr(cutIndex, str.size() - cutIndex);
+  return str;
+}
+
+std::string loadAlgName(const std::string &filePath) {
+  const auto suffix = extractLastOf(filePath, ".");
+  return suffix == ".dave" ? "LoadDaveGrp" : "Load";
+}
+
+} // namespace
+
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -125,8 +142,8 @@ bool DataSelector::isValid() {
         // don't use algorithm runner because we need to know instantly.
         const QString filepath =
             m_uiForm.rfFileInput->getUserInput().toString();
-        const Algorithm_sptr loadAlg =
-            AlgorithmManager::Instance().createUnmanaged("Load");
+        const auto loadAlg = AlgorithmManager::Instance().createUnmanaged(
+            loadAlgName(filepath.toStdString()));
         loadAlg->initialize();
         loadAlg->setProperty("Filename", filepath.toStdString());
         loadAlg->setProperty("OutputWorkspace", wsName.toStdString());
@@ -179,14 +196,14 @@ QString DataSelector::getProblem() const {
  */
 void DataSelector::autoLoadFile(const QString &filepath) {
   using namespace Mantid::API;
-  QString baseName = getWsNameFromFiles();
+  const auto baseName = getWsNameFromFiles().toStdString();
 
   // create instance of load algorithm
-  const Algorithm_sptr loadAlg =
-      AlgorithmManager::Instance().createUnmanaged("Load");
+  const auto loadAlg = AlgorithmManager::Instance().createUnmanaged(
+      loadAlgName(filepath.toStdString()));
   loadAlg->initialize();
   loadAlg->setProperty("Filename", filepath.toStdString());
-  loadAlg->setProperty("OutputWorkspace", baseName.toStdString());
+  loadAlg->setProperty("OutputWorkspace", baseName);
 
   m_algRunner.startAlgorithm(loadAlg);
 }


### PR DESCRIPTION
**Description of work.**
This PR introduces the ability to load Dave ASCII files with the ending `_sqw.dave` as the sample or resolution in ConvFit.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load the '_red.nxs' file below as the sample. The Results log should say Load Successful.
3. Load the '26176..._sqw.dave' file as the sample. The Results log should say LoadDaveGrp Successful.
4. Load the '26173..._sqw.dave' file as the resolution. The Results log should say LoadDaveGrp Successful.
5. Select the fit type to be `One Lorentzian'. Click `Run` and it should run without error.

**Data files:**
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2694216/iris26176_graphite002_red.zip)

Dave files:
[iris26176_graphite002_sqw.zip](https://github.com/mantidproject/mantid/files/2694210/iris26176_graphite002_sqw.zip)
[iris26173_graphite002_sqw.zip](https://github.com/mantidproject/mantid/files/2694212/iris26173_graphite002_sqw.zip)


Fixes #23849 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
