### PR TITLE
Set sample position in OptimizeCrystalPlacement

### DIFF
--- a/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -118,7 +118,7 @@ void OptimizeCrystalPlacement::init() {
   declareProperty("MaxAngularChange", 5.0,
                   "Max offset in degrees from current settings(def=5)");
 
-  declareProperty("MaxIndexingError", .25,
+  declareProperty("MaxIndexingError", 0.15,
                   "Use only peaks whose fractional "
                   "hkl values are below this "
                   "tolerance(def=.25)");

--- a/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -449,8 +449,9 @@ void OptimizeCrystalPlacement::exec() {
   UBinv.Invert();
   UBinv /= (2 * M_PI);
   for (int i = 0; i < outPeaks->getNumberPeaks(); ++i) {
-    outPeaks->getPeak(i).setSamplePos(newSampPos);
-    int RunNum = outPeaks->getPeak(i).getRunNumber();
+    auto peak = outPeaks->getPeak(i);
+    peak.setSamplePos(peak.getSamplePos() + newSampPos);
+    int RunNum = peak.getRunNumber();
     std::string RunNumStr = std::to_string(RunNum);
     Matrix<double> GonMatrix;
     if (RunNum == prevRunNum ||
@@ -472,12 +473,12 @@ void OptimizeCrystalPlacement::exec() {
       GonMatrix = GonTilt * uniGonio.getR();
       MapRunNum2GonMat[RunNum] = GonMatrix;
     } else {
-      GonMatrix = GonTilt * outPeaks->getPeak(i).getGoniometerMatrix();
+      GonMatrix = GonTilt * peak.getGoniometerMatrix();
       MapRunNum2GonMat[RunNum] = GonMatrix;
     }
 
-    outPeaks->getPeak(i).setGoniometerMatrix(GonMatrix);
-    V3D hkl = UBinv * outPeaks->getPeak(i).getQSampleFrame();
+    peak.setGoniometerMatrix(GonMatrix);
+    V3D hkl = UBinv * peak.getQSampleFrame();
     if (Geometry::IndexingUtils::ValidIndex(hkl, HKLintOffsetMax))
       nIndexed++;
 

--- a/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
+++ b/Framework/Crystal/src/OptimizeCrystalPlacement.cpp
@@ -121,7 +121,7 @@ void OptimizeCrystalPlacement::init() {
   declareProperty("MaxIndexingError", 0.15,
                   "Use only peaks whose fractional "
                   "hkl values are below this "
-                  "tolerance(def=.25)");
+                  "tolerance(def=0.15)");
 
   declareProperty("MaxHKLPeaks2Use", -1.0,
                   "If less than 0 all peaks are used, "

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -208,7 +208,7 @@ PeakHKLErrors::getNewInstrument(PeaksWorkspace_sptr Peaks) const {
   } else // catch(... )
   {
     auto P1 = boost::make_shared<Geometry::Instrument>(
-        instSave->baseInstrument(), pmap);
+        instSave->baseInstrument(), instSave->makeLegacyParameterMap());
     instChange = P1;
   }
 
@@ -394,6 +394,10 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
     } else {
       peak.setGoniometerMatrix(GonRot * peak.getGoniometerMatrix());
     }
+    V3D sampOffsets(getParameter("SampleXOffset"), getParameter("SampleYOffset"),
+                  getParameter("SampleZOffset"));
+    peak.setSamplePos(sampOffsets);
+
 
     V3D hkl = UBinv * peak.getQSampleFrame();
 
@@ -513,6 +517,9 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
       chiParamNum = phiParamNum = omegaParamNum = nParams() + 10;
       peak.setGoniometerMatrix(GonRot * peak.getGoniometerMatrix());
     }
+    V3D sampOffsets(getParameter("SampleXOffset"), getParameter("SampleYOffset"),
+                  getParameter("SampleZOffset"));
+    peak.setSamplePos(sampOffsets);
     // NOTE:Use getQLabFrame except for below.
     // For parameters the getGoniometerMatrix should remove GonRot, for derivs
     // wrt GonRot*, wrt chi*,phi*,etc.

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -397,7 +397,7 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
     V3D sampOffsets(getParameter("SampleXOffset"),
                     getParameter("SampleYOffset"),
                     getParameter("SampleZOffset"));
-    peak.setSamplePos(sampOffsets);
+    peak.setSamplePos(peak.getSamplePos() + sampOffsets);
 
     V3D hkl = UBinv * peak.getQSampleFrame();
 
@@ -520,7 +520,7 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
     V3D sampOffsets(getParameter("SampleXOffset"),
                     getParameter("SampleYOffset"),
                     getParameter("SampleZOffset"));
-    peak.setSamplePos(sampOffsets);
+    peak.setSamplePos(peak.getSamplePos() + sampOffsets);
     // NOTE:Use getQLabFrame except for below.
     // For parameters the getGoniometerMatrix should remove GonRot, for derivs
     // wrt GonRot*, wrt chi*,phi*,etc.

--- a/Framework/Crystal/src/PeakHKLErrors.cpp
+++ b/Framework/Crystal/src/PeakHKLErrors.cpp
@@ -394,10 +394,10 @@ void PeakHKLErrors::function1D(double *out, const double *xValues,
     } else {
       peak.setGoniometerMatrix(GonRot * peak.getGoniometerMatrix());
     }
-    V3D sampOffsets(getParameter("SampleXOffset"), getParameter("SampleYOffset"),
-                  getParameter("SampleZOffset"));
+    V3D sampOffsets(getParameter("SampleXOffset"),
+                    getParameter("SampleYOffset"),
+                    getParameter("SampleZOffset"));
     peak.setSamplePos(sampOffsets);
-
 
     V3D hkl = UBinv * peak.getQSampleFrame();
 
@@ -517,8 +517,9 @@ void PeakHKLErrors::functionDeriv1D(Jacobian *out, const double *xValues,
       chiParamNum = phiParamNum = omegaParamNum = nParams() + 10;
       peak.setGoniometerMatrix(GonRot * peak.getGoniometerMatrix());
     }
-    V3D sampOffsets(getParameter("SampleXOffset"), getParameter("SampleYOffset"),
-                  getParameter("SampleZOffset"));
+    V3D sampOffsets(getParameter("SampleXOffset"),
+                    getParameter("SampleYOffset"),
+                    getParameter("SampleZOffset"));
     peak.setSamplePos(sampOffsets);
     // NOTE:Use getQLabFrame except for below.
     // For parameters the getGoniometerMatrix should remove GonRot, for derivs

--- a/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
+++ b/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
@@ -187,9 +187,10 @@ public:
 
   void test_SamplePosition() {
     auto modPeaksNoFix = calculateBasicPlacement();
-    const auto &peak = modPeaksNoFix->getPeak(0);
+    auto peak = modPeaksNoFix->getPeak(0);
     auto inst = peak.getInstrument();
     const V3D sampPos(.0003, -.00025, .00015);
+    peak.setSamplePos(sampPos);
 
     auto pmap = inst->getParameterMap();
     auto sample = inst->getSample();
@@ -208,9 +209,9 @@ public:
         modPeaksNoFix, {{"KeepGoniometerFixedfor", "5637, 5638"},
                         {"AdjustSampleOffsets", "1"}});
     const auto table = resultsSamplePos.second;
-    TS_ASSERT_DELTA(table->Double(0, 1), 0, 0.0003378);
-    TS_ASSERT_DELTA(table->Double(1, 1), 0, 0.00008976);
-    TS_ASSERT_DELTA(table->Double(2, 1), 0, 0.00026796);
+    TS_ASSERT_DELTA(table->Double(0, 1), 0, 0.0000773);
+    TS_ASSERT_DELTA(table->Double(1, 1), 0, 0.00004575);
+    TS_ASSERT_DELTA(table->Double(2, 1), 0, 0.00006745);
   }
 
 private:

--- a/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
+++ b/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
@@ -208,9 +208,9 @@ public:
         modPeaksNoFix, {{"KeepGoniometerFixedfor", "5637, 5638"},
                         {"AdjustSampleOffsets", "1"}});
     const auto table = resultsSamplePos.second;
-    TS_ASSERT_DELTA(table->Double(0, 1), 0, .0004);
-    TS_ASSERT_DELTA(table->Double(1, 1), 0, .00024);
-    TS_ASSERT_DELTA(table->Double(2, 1), 0, .0003);
+    TS_ASSERT_DELTA(table->Double(0, 1), 0, 0.0000649);
+    TS_ASSERT_DELTA(table->Double(1, 1), 0, 0.00000146);
+    TS_ASSERT_DELTA(table->Double(2, 1), 0, 0.00006745);
   }
 
 private:

--- a/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
+++ b/Framework/Crystal/test/OptimizeCrystalPlacementTest.h
@@ -208,9 +208,9 @@ public:
         modPeaksNoFix, {{"KeepGoniometerFixedfor", "5637, 5638"},
                         {"AdjustSampleOffsets", "1"}});
     const auto table = resultsSamplePos.second;
-    TS_ASSERT_DELTA(table->Double(0, 1), 0, 0.0000649);
-    TS_ASSERT_DELTA(table->Double(1, 1), 0, 0.00000146);
-    TS_ASSERT_DELTA(table->Double(2, 1), 0, 0.00006745);
+    TS_ASSERT_DELTA(table->Double(0, 1), 0, 0.0003378);
+    TS_ASSERT_DELTA(table->Double(1, 1), 0, 0.00008976);
+    TS_ASSERT_DELTA(table->Double(2, 1), 0, 0.00026796);
   }
 
 private:

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -64,7 +64,7 @@ public:
     TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.2);
     TS_ASSERT_DELTA(0.0, results->cell<double>(4, 1), 1.1);
     TS_ASSERT_DELTA(0.1133, results->cell<double>(5, 1), 0.36);
-    TS_ASSERT_DELTA(0.9953, results->cell<double>(6, 1), 8e-3);
+    TS_ASSERT_DELTA(0.9953, results->cell<double>(6, 1), 1e-2);
     TS_ASSERT_DELTA(0.9986, results->cell<double>(7, 1), 1e-2);
     TS_ASSERT_DELTA(0.2710, results->cell<double>(9, 1), 0.2);
     ITableWorkspace_sptr resultsL1 =

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -64,7 +64,7 @@ public:
     TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.2);
     TS_ASSERT_DELTA(0.0, results->cell<double>(4, 1), 1.1);
     TS_ASSERT_DELTA(0.1133, results->cell<double>(5, 1), 0.36);
-    TS_ASSERT_DELTA(0.9953, results->cell<double>(6, 1), 5e-3);
+    TS_ASSERT_DELTA(0.9953, results->cell<double>(6, 1), 8e-3);
     TS_ASSERT_DELTA(0.9986, results->cell<double>(7, 1), 1e-2);
     TS_ASSERT_DELTA(0.2710, results->cell<double>(9, 1), 0.2);
     ITableWorkspace_sptr resultsL1 =

--- a/Framework/Crystal/test/SCDCalibratePanelsTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanelsTest.h
@@ -64,7 +64,7 @@ public:
     TS_ASSERT_DELTA(0.0, results->cell<double>(3, 1), 1.2);
     TS_ASSERT_DELTA(0.0, results->cell<double>(4, 1), 1.1);
     TS_ASSERT_DELTA(0.1133, results->cell<double>(5, 1), 0.36);
-    TS_ASSERT_DELTA(1.0024, results->cell<double>(6, 1), 5e-3);
+    TS_ASSERT_DELTA(0.9953, results->cell<double>(6, 1), 5e-3);
     TS_ASSERT_DELTA(0.9986, results->cell<double>(7, 1), 1e-2);
     TS_ASSERT_DELTA(0.2710, results->cell<double>(9, 1), 0.2);
     ITableWorkspace_sptr resultsL1 =

--- a/docs/source/algorithms/OptimizeCrystalPlacement-v1.rst
+++ b/docs/source/algorithms/OptimizeCrystalPlacement-v1.rst
@@ -54,16 +54,16 @@ Usage
 .. testcode:: ExOptimizeCrystalPlacement
 
     ws=LoadIsawPeaks("TOPAZ_3007.peaks")
-    LoadIsawUB(ws,"ls5637.mat")
+    LoadIsawUB(ws,"TOPAZ_3007.mat")
     wsd = OptimizeCrystalPlacement(ws)
-    (wsPeakOut,fitInfoTable,chi2overDoF,nPeaks,nParams,nIndexed,covrianceInfoTable) = OptimizeCrystalPlacement(ws)
+    (wsPeakOut,fitInfoTable,chi2overDoF,nPeaks,nParams,nIndexed,covrianceInfoTable) = OptimizeCrystalPlacement(ws,AdjustSampleOffsets=True)
     print("Chi2: {:.4f}".format(chi2overDoF))
 
 Output:
 
 .. testoutput:: ExOptimizeCrystalPlacement
 
-    Chi2: 0.0203
+    Chi2: 0.0003
 
 .. categories::
 

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -50,7 +50,7 @@ Bugfixes
 - :ref:`SaveIsawPeaks <algm-SaveIsawPeaks>` does not have duplicate peak numbers when saving PeaksWorkspaces with more than one RunNumber.
 - :ref:`LoadIsawPeaks <algm-LoadIsawPeaks>` now loads the calibration from the peaks file correctly.
 
-- :ref:`OptimizeCrystalPlacement <algm-OptimizeCrystalPlacement>` now updates the sample location used by peaks.  Previously, the sample was effectively left unmoved.
+- :ref:`OptimizeCrystalPlacement <algm-OptimizeCrystalPlacement>` now updates the sample location used by peaks.  Previously, the sample was effectively left unmoved. Default for indexing tolerance was lowered to 0.15.
 
 Powder Diffraction
 ------------------


### PR DESCRIPTION
**Description of work.**
Function for fitting was not changing sample position for peaks.  Also parameters were not being copied to cloned instrument.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
````python
LoadIsawPeaks(Filename='/SNS/users/vel/SCDcalib_demo/natrolite_Niggli.integrate', OutputWorkspace='ws')
LoadIsawUB(InputWorkspace='ws', Filename='/SNS/users/vel/SCDcalib_demo/natrolite_Niggli.mat')
IndexPeaks(PeaksWorkspace='ws',Tolerance=0.15)
OptimizeCrystalPlacement(PeaksWorkspace='ws', ModifiedPeaksWorkspace='wsd', AdjustSampleOffsets=True, MaxSamplePositionChangeMeters=0.05,MaxIndexingError=0.15)
IndexPeaks(PeaksWorkspace='wsd',Tolerance=0.15)


from mantid.simpleapi import *
LoadIsawPeaks(Filename='tmp.integrate', OutputWorkspace='peaks_ws')
LoadIsawUB(InputWorkspace='peaks_ws', Filename='beta_lac_july2018_secondxtal.mat', CheckUMatrix=False)
IndexPeaks(PeaksWorkspace='peaks_ws',Tolerance=0.15)
OptimizeCrystalPlacement(PeaksWorkspace='peaks_ws', ModifiedPeaksWorkspace='test', AdjustSampleOffsets=True, MaxSamplePositionChangeMeters=0.005,MaxIndexingError=0.15)
#FindUBUsingFFT(PeaksWorkspace='test',MinD=70, MaxD=105)
IndexPeaks(PeaksWorkspace='test',Tolerance=0.15)
print('Original peak(0) QLabFrame: %s\n'%(str(mtd['peaks_ws'].getPeak(0).getQLabFrame())))
print('Optimized peak(0) QLabFrame: %s\n'%(str(mtd['test'].getPeak(0).getQLabFrame())))
print('Original peak(0) sample position: %s\n'%str(mtd['peaks_ws'].getPeak(0).getSamplePos()))
print('Optimized peak(0) sample position: %s\n'%str(mtd['test'].getPeak(0).getSamplePos()))

samplePosNew = mtd['test'].getPeak(0).getSamplePos()
print('Setting sample position to [1,1,1]:')
mtd['test'].getPeak(0).setSamplePos(1,1,1)
print('Optimized peak(0) sample position: %s\n'%str(mtd['test'].getPeak(0).getSamplePos()))
print('Resetting sample position to %s\n'%str(samplePosNew))
mtd['test'].getPeak(0).setSamplePos(samplePosNew[0], samplePosNew[1], samplePosNew[2])
print('Optimized peak(0) sample position: %s\n'%str(mtd['test'].getPeak(0).getSamplePos()))
````

<!-- Instructions for testing. -->

Fixes #24376 
<!-- alternative
*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
