### PR TITLE
Remove GUI state files before each build on builders

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -363,6 +363,16 @@ fi
 # Prevent race conditions when creating the user config directory
 userconfig_dir=$HOME/.mantid
 rm -fr $userconfig_dir
+# Remove GUI qsettings files
+if [[ ${ON_MACOS} == true ]] ; then
+  rm -f $HOME/Library/Preferences/com.mantid.MantidPlot.plist
+  rm -f $HOME/Library/Preferences/org.mantidproject.MantidPlot.plist
+  rm -f "$HOME/Library/Saved Application State/org.mantidproject.MantidPlot.savedState/windows.plist"
+else
+  rm -f ~/.config/Mantid/MantidPlot.conf
+fi
+rm -f ~/.config/mantidproject/mantidworkbench.ini
+
 mkdir -p $userconfig_dir
 # use a fixed number of openmp threads to avoid overloading the system
 userprops_file=$userconfig_dir/Mantid.user.properties

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -201,9 +201,10 @@ if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 :: This prevents race conditions when creating the user config directory
 set USERPROPS=bin\%BUILD_CONFIG%\Mantid.user.properties
 del %USERPROPS%
-set CONFIGDIR=%APPDATA%\mantidproject\mantid
+set CONFIGDIR=%APPDATA%\mantidproject
 rmdir /S /Q %CONFIGDIR%
-mkdir %CONFIGDIR%
+:: Create the directory to avoid any race conditions
+mkdir %CONFIGDIR%\mantid
 :: use a fixed number of openmp threads to avoid overloading the system
 echo MultiThreaded.MaxCores=2 > %USERPROPS%
 

--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -74,15 +74,25 @@ ${CMAKE_EXE} --build . -- SystemTestData
 ###############################################################################
 # Run the tests
 ###############################################################################
-# Remove any Mantid.user.properties file
-userprops=~/.mantid/Mantid.user.properties
-rm -f $userprops
+# Remove any user settings
+userconfig_dir=$HOME/.mantid
+rm -fr $userconfig_dir
+# Remove GUI qsettings files
+if [[ ${ON_MACOS} == true ]] ; then
+  rm -f $HOME/Library/Preferences/com.mantid.MantidPlot.plist
+  rm -f $HOME/Library/Preferences/org.mantidproject.MantidPlot.plist
+  rm -f "$HOME/Library/Saved Application State/org.mantidproject.MantidPlot.savedState/windows.plist"
+else
+  rm -f ~/.config/Mantid/MantidPlot.conf
+fi
+rm -f ~/.config/mantidproject/mantidworkbench.ini
+
 # Turn off any auto updating on startup
+mkdir -p $userconfig_dir
+userprops=$userconfig_dir/Mantid.user.properties
 echo "UpdateInstrumentDefinitions.OnStartup = 0" > $userprops
 echo "usagereports.enabled = 0" >> $userprops
 echo "CheckMantidVersion.OnStartup = 0" >> $userprops
-# Remove user instrument directory
-rm -fr ~/.mantid/instrument
 
 # Remove mismatch files which have not been cleaned up yet
 default_save_directory=${WORKSPACE}/build/Testing/SystemTests/scripts/

--- a/buildconfig/Jenkins/systemtests.bat
+++ b/buildconfig/Jenkins/systemtests.bat
@@ -67,6 +67,12 @@ if ERRORLEVEL 1 exit /b %ERRORLEVEL%
 set USERPROPS_RELEASE=C:\MantidInstall\bin\Mantid.user.properties
 set USERPROPS_NIGHTLY=C:\MantidNightlyInstall\bin\Mantid.user.properties
 del /Q %USERPROPS_RELEASE% %USERPROPS_NIGHTLY%
+:: Remove user settings
+set CONFIGDIR=%APPDATA%\mantidproject
+rmdir /S /Q %CONFIGDIR%
+:: Create the directory to avoid any race conditions
+mkdir %CONFIGDIR%\mantid
+
 :: Turn off any auto updating on startup
 echo UpdateInstrumentDefinitions.OnStartup = 0 > %USERPROPS_RELEASE%
 echo usagereports.enabled = 0 >> %USERPROPS_RELEASE%
@@ -75,9 +81,6 @@ echo CheckMantidVersion.OnStartup = 0 >> %USERPROPS_RELEASE%
 echo UpdateInstrumentDefinitions.OnStartup = 0 > %USERPROPS_NIGHTLY%
 echo usagereports.enabled = 0 >> %USERPROPS_NIGHTLY%
 echo CheckMantidVersion.OnStartup = 0 >> %USERPROPS_NIGHTLY%
-:: Remove user instrument directory
-rmdir /S /Q %APPDATA%\mantidproject\mantid\instrument
-
 
 :: Run
 set PKGDIR=%WORKSPACE%\build


### PR DESCRIPTION
**Description of work.**

Removes all GUI state before running any tests. This is required particularly for the workbench on a machine building for Python 2 & 3 as the files are not compatible.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* All builds should pass.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **they are buildscript changes and not user facing**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
