### PR TITLE
Update colorfill plot check to ignore final bin.

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -81,4 +81,14 @@ BugFixes
 - Fixed issue where an open set of data from ITableWorkspace wouldn't update if the data was changed via python
 - Fixed an issue where MantidPlot would crash when renaming workspaces.
 
+MantidWorkbench
+---------------
+
+Changes
+#######
+- Colorfill plots with uniform bin widths were made more responsive by resampling to 4K resolution and using :func:`~mantid.plots.MantidAxes.imshow`.
+
+BugFixes
+########
+
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -202,12 +202,12 @@ def use_imshow(ws):
 
     x = ws.dataX(0)
     difference = np.diff(x)
-    if not np.all(np.isclose(difference, difference[0])):
+    if not np.all(np.isclose(difference[:-1], difference[0])):
         return False
 
     y = ws.getAxis(1).extractValues()
     difference = np.diff(y)
-    if not np.all(np.isclose(difference, difference[0])):
+    if not np.all(np.isclose(difference[:-1], difference[0])):
         return False
 
     return True


### PR DESCRIPTION
**Description of work.**

Updates the imshow check on colorfill plots to ignore the last bin. `Rebin` often makes the bin smaller, which was breaking the original test.

**To test:**

<!-- Instructions for testing. -->

See #24205.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
