### PR TITLE
Correct sourcelink in AbsorptionCorrection docs

### DIFF
--- a/docs/source/algorithms/AbsorptionCorrection-v1.rst
+++ b/docs/source/algorithms/AbsorptionCorrection-v1.rst
@@ -112,3 +112,4 @@ Output:
 .. categories::
 
 .. sourcelink::
+   :filename: AnyShapeAbsorption


### PR DESCRIPTION
The documentation pointed to the wrong source files.

**To test:**

Build the docs and see that they now point to the correct source code.

*There is no associated issue.*

*This does not require release notes* because it is a very minor change to the docs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
