### PR TITLE
Restore full workspace history on WorkspaceGroups

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -293,7 +293,8 @@ public:
   using WorkspaceVector = std::vector<boost::shared_ptr<Workspace>>;
 
   void findWorkspaceProperties(WorkspaceVector &inputWorkspaces,
-                               WorkspaceVector &outputWorkspaces) const;
+                               WorkspaceVector &outputWorkspaces,
+                               bool checkADSForOutputs = false) const;
 
   // ------------------ For WorkspaceGroups ------------------------------------
   virtual bool checkGroups();
@@ -419,6 +420,9 @@ private:
 
   bool doCallProcessGroups(Mantid::Types::Core::DateAndTime &start_time);
 
+  void fillHistory(const std::vector<Workspace_sptr> &inputWorkspaces,
+                   const std::vector<Workspace_sptr> &outputWorkspaces);
+
   // Report that the algorithm has completed.
   void reportCompleted(const double &duration,
                        const bool groupProcessing = false);
@@ -431,13 +435,6 @@ private:
   void setupSkipValidationMasterOnly();
 
   bool isCompoundProperty(const std::string &name) const;
-
-  bool hasAnADSValidator(const Mantid::Kernel::IValidator_sptr propProp) const;
-
-  void constructWorkspaceVectorForHistoryHelper(
-      std::vector<Workspace_sptr> &inputWorkspaces,
-      std::vector<Workspace_sptr> &outputWorkspaces,
-      const unsigned int direction, std::string &currentWS) const;
 
   // --------------------- Private Members -----------------------------------
   /// Poco::ActiveMethod used to implement asynchronous execution.

--- a/Framework/API/src/MultiPeriodGroupWorker.cpp
+++ b/Framework/API/src/MultiPeriodGroupWorker.cpp
@@ -93,9 +93,7 @@ MultiPeriodGroupWorker::findMultiPeriodGroups(
   } else {
     using WorkspaceVector = std::vector<boost::shared_ptr<Workspace>>;
     WorkspaceVector inWorkspaces;
-    WorkspaceVector outWorkspaces;
-    sourceAlg->findWorkspaceProperties(inWorkspaces, outWorkspaces);
-    UNUSED_ARG(outWorkspaces);
+    sourceAlg->findWorkspaces(inWorkspaces, Direction::Input);
     for (auto &inWorkspace : inWorkspaces) {
       tryAddInputWorkspaceToInputGroups(
           inWorkspace, vecMultiPeriodWorkspaceGroups, vecWorkspaceGroups);

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -51,8 +51,8 @@ const std::string WorkspaceGroup::toString() const {
  * Turn on/off observing delete and rename notifications to update the group
  * accordingly
  * It can be useful to turn them off when constructing the group.
- * @param observeADS :: If true observe the ADS notifications, otherwise disable
- * them
+ * @param observeADS :: If true observe the ADS notifications, otherwise
+ * disable them
  */
 void WorkspaceGroup::observeADSNotifications(const bool observeADS) {
   if (observeADS) {
@@ -105,9 +105,10 @@ void WorkspaceGroup::sortMembersByName() {
 }
 
 /**
- * Adds a workspace to the group. The workspace does not have to be in the ADS
- * @param workspace :: A shared pointer to a workspace to add. If the workspace
- * already exists give a warning.
+ * Adds a workspace to the group. The workspace does not have to be in the
+ * ADS
+ * @param workspace :: A shared pointer to a workspace to add. If the
+ * workspace already exists give a warning.
  */
 void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
@@ -188,8 +189,8 @@ Workspace_sptr WorkspaceGroup::getItem(const size_t index) const {
 /**
  * Return the workspace by name
  * @param wsName The name of the workspace
- * @throws an out_of_range error if the workspace's name not contained in the
- * group's list of workspace names
+ * @throws an out_of_range error if the workspace's name not contained in
+ * the group's list of workspace names
  */
 Workspace_sptr WorkspaceGroup::getItem(const std::string &wsName) const {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
@@ -228,8 +229,8 @@ void WorkspaceGroup::removeByADS(const std::string &wsName) {
   }
 }
 
-/// Print the names of all the workspaces in this group to the logger (at debug
-/// level)
+/// Print the names of all the workspaces in this group to the logger (at
+/// debug level)
 void WorkspaceGroup::print() const {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   for (const auto &workspace : m_workspaces) {
@@ -268,7 +269,8 @@ std::vector<Workspace_sptr>::iterator WorkspaceGroup::end() {
   return m_workspaces.end();
 }
 
-/** Returns a const iterator pointing to the past-the-end element in the group.
+/** Returns a const iterator pointing to the past-the-end element in the
+ * group.
  *
  * @return  A const iterator pointing to the last workspace in this
  *          workspace group.
@@ -278,8 +280,8 @@ std::vector<Workspace_sptr>::const_iterator WorkspaceGroup::end() const {
 }
 
 /**
- * Remove a workspace pointed to by an index. The workspace remains in the ADS
- * if it was there
+ * Remove a workspace pointed to by an index. The workspace remains in the
+ * ADS if it was there
  *
  * @param index :: Index of a workspace to delete.
  */
@@ -287,8 +289,8 @@ void WorkspaceGroup::removeItem(const size_t index) {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   // do not allow this way of removing for groups in the ADS
   if (!this->getName().empty()) {
-    throw std::runtime_error(
-        "AnalysisDataService must be used to remove a workspace from group.");
+    throw std::runtime_error("AnalysisDataService must be used to remove a "
+                             "workspace from group.");
   }
   if (index >= this->size()) {
     std::ostringstream os;
@@ -334,7 +336,8 @@ void WorkspaceGroup::workspaceDeleteHandle(
  * Callback when a before-replace notification is received
  * Replaces a member if it was replaced in the ADS and checks
  * for duplicate members within the group
- * @param notice :: A pointer to a workspace before-replace notification object
+ * @param notice :: A pointer to a workspace before-replace notification
+ * object
  */
 void WorkspaceGroup::workspaceBeforeReplaceHandle(
     Mantid::API::WorkspaceBeforeReplaceNotification_ptr notice) {
@@ -446,10 +449,10 @@ bool WorkspaceGroup::isMultiperiod() const {
 
 /**
  * @param workspaceToCheck :: A workspace to check.
- * @param level :: The current nesting level. Intended for internal use only by
- * WorkspaceGroup.
- * @return :: True if the worspace is found in any of the nested groups in this
- * group.
+ * @param level :: The current nesting level. Intended for internal use only
+ * by WorkspaceGroup.
+ * @return :: True if the worspace is found in any of the nested groups in
+ * this group.
  */
 bool WorkspaceGroup::isInGroup(const Workspace &workspaceToCheck,
                                size_t level) const {

--- a/Framework/API/src/WorkspaceHistory.cpp
+++ b/Framework/API/src/WorkspaceHistory.cpp
@@ -93,13 +93,21 @@ void WorkspaceHistory::addHistory(const WorkspaceHistory &otherHistory) {
     this->addHistory(algHistory);
   }
 
-  std::unordered_set<AlgorithmHistory_sptr, AlgorithmHistoryHasher,
-                     AlgorithmHistoryComparator>
-      set;
-  for (auto i : m_algorithms)
-    set.insert(i);
-  m_algorithms.assign(set.begin(), set.end());
-  std::sort(m_algorithms.begin(), m_algorithms.end(), AlgorithmHistorySearch());
+  using UniqueAlgorithmHistories =
+      std::unordered_set<AlgorithmHistory_sptr, AlgorithmHistoryHasher,
+                         AlgorithmHistoryComparator>;
+  // It is faster to default construct a set/unordered_set and insert the
+  // elements than use the range-based constructor directly.
+  // See https://stackoverflow.com/a/24477023:
+  //   "the constructor actually construct a new node for every element, before
+  //   checking its value to determine if it should actually be inserted."
+  UniqueAlgorithmHistories uniqueHistories;
+  for (const auto &algorithmHistory : m_algorithms) {
+    uniqueHistories.insert(algorithmHistory);
+  }
+  m_algorithms.assign(std::begin(uniqueHistories), std::end(uniqueHistories));
+  std::sort(std::begin(m_algorithms), std::end(m_algorithms),
+            AlgorithmHistorySearch());
 }
 
 /// Append an AlgorithmHistory to this WorkspaceHistory

--- a/Framework/API/test/AlgorithmTest.h
+++ b/Framework/API/test/AlgorithmTest.h
@@ -837,10 +837,12 @@ public:
 
   void doHistoryCopyOnGroupsTest(const std::string &inputWSName,
                                  const std::string &outputWSName) {
+    using Mantid::Types::Core::DateAndTime;
     const auto group =
         boost::dynamic_pointer_cast<WorkspaceGroup>(makeWorkspaceGroup(
             inputWSName, inputWSName + "_1," + inputWSName + "_2"));
-    const auto execDate{Mantid::Types::Core::DateAndTime::getCurrentTime()};
+    const DateAndTime execDate{
+        Mantid::Types::Core::DateAndTime::getCurrentTime()};
     for (auto &item : *group) {
       item->history().addHistory(boost::make_shared<AlgorithmHistory>(
           "Load", 1, "49ea7cb9-6172-4e5c-acf5-c3edccd0bb27", execDate));

--- a/Framework/API/test/AlgorithmTest.h
+++ b/Framework/API/test/AlgorithmTest.h
@@ -12,10 +12,12 @@
 #include "FakeAlgorithms.h"
 #include "MantidAPI/Algorithm.tcc"
 #include "MantidAPI/AlgorithmFactory.h"
+#include "MantidAPI/AlgorithmHistory.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/HistogramValidator.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceHistory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/Property.h"
@@ -58,21 +60,20 @@ public:
   }
 
   void exec() override {
-    boost::shared_ptr<WorkspaceTester> out1 =
-        boost::make_shared<WorkspaceTester>();
+    const std::string outName = getPropertyValue("InputWorkspace1") + "+" +
+                                getPropertyValue("InputWorkspace2") + "+" +
+                                getPropertyValue("InOutWorkspace");
+    auto out1 = boost::make_shared<WorkspaceTester>();
     out1->initialize(10, 10, 10);
-    boost::shared_ptr<WorkspaceTester> out2 =
-        boost::make_shared<WorkspaceTester>();
-    out2->initialize(10, 10, 10);
-    std::string outName = getPropertyValue("InputWorkspace1") + "+" +
-                          getPropertyValue("InputWorkspace2") + "+" +
-                          getPropertyValue("InOutWorkspace");
     out1->setTitle(outName);
-    out2->setTitle(outName);
-    double val = getProperty("Number");
-    out1->dataY(0)[0] = val;
+    out1->dataY(0)[0] = getProperty("Number");
     setProperty("OutputWorkspace1", out1);
-    setProperty("OutputWorkspace2", out2);
+    if (!getPropertyValue("OutputWorkspace2").empty()) {
+      auto out2 = boost::make_shared<WorkspaceTester>();
+      out2->initialize(10, 10, 10);
+      out2->setTitle(outName);
+      setProperty("OutputWorkspace2", out2);
+    }
   }
 };
 DECLARE_ALGORITHM(StubbedWorkspaceAlgorithm)
@@ -213,6 +214,8 @@ public:
     Mantid::API::AlgorithmFactory::Instance().unsubscribe("ToyAlgorithm", 1);
     Mantid::API::AlgorithmFactory::Instance().unsubscribe("ToyAlgorithmTwo", 1);
   }
+
+  void setUp() override { AnalysisDataService::Instance().clear(); }
 
   void testAlgorithm() {
     std::string theName = alg.name();
@@ -572,32 +575,33 @@ public:
    * @param group1 :: name of the group. Do nothing if blank.
    * @param contents1 :: comma-sep names of fake workspaces in the group
    *        Make no group if blank, just 1 workspace
+   * @return The new WorkspaceGroup object
    */
-  void makeWorkspaceGroup(std::string group1, std::string contents1) {
+  Workspace_sptr makeWorkspaceGroup(std::string group1, std::string contents1) {
+    auto &ads = AnalysisDataService::Instance();
     if (contents1.empty()) {
       if (group1.empty())
-        return;
-      boost::shared_ptr<WorkspaceTester> ws =
-          boost::make_shared<WorkspaceTester>();
-      AnalysisDataService::Instance().addOrReplace(group1, ws);
-      return;
+        return Workspace_sptr();
+      auto ws = boost::make_shared<WorkspaceTester>();
+      ads.addOrReplace(group1, ws);
+      return ws;
     }
 
     std::vector<std::string> names;
     boost::split(names, contents1,
                  boost::algorithm::detail::is_any_ofF<char>(","));
     if (names.size() >= 1) {
-      WorkspaceGroup_sptr wsGroup = WorkspaceGroup_sptr(new WorkspaceGroup());
-      AnalysisDataService::Instance().addOrReplace(group1, wsGroup);
-      std::vector<std::string>::iterator it = names.begin();
-      for (; it != names.end(); it++) {
-        boost::shared_ptr<WorkspaceTester> ws =
-            boost::make_shared<WorkspaceTester>();
+      auto wsGroup = WorkspaceGroup_sptr(new WorkspaceGroup());
+      ads.addOrReplace(group1, wsGroup);
+      for (const auto &name : names) {
+        auto ws = boost::make_shared<WorkspaceTester>();
         ws->initialize(10, 10, 10);
-        AnalysisDataService::Instance().addOrReplace(*it, ws);
-        wsGroup->add(*it);
+        ads.addOrReplace(name, ws);
+        wsGroup->add(name);
       }
+      return wsGroup;
     }
+    return Workspace_sptr();
   }
 
   //------------------------------------------------------------------------
@@ -650,7 +654,6 @@ public:
 
   /// All groups are the same size
   void test_processGroups_allSameSize() {
-    Mantid::API::AnalysisDataService::Instance().clear();
     WorkspaceGroup_sptr group = do_test_groups(
         "A", "A_1,A_2,A_3", "B", "B_1,B_2,B_3", "C", "C_1,C_2,C_3");
 
@@ -762,7 +765,6 @@ public:
 
   /// Rewrite first input group
   void test_processGroups_rewriteFirstGroup() {
-    Mantid::API::AnalysisDataService::Instance().clear();
     WorkspaceGroup_sptr group =
         do_test_groups("D", "D1,D2,D3", "B", "B1,B2,B3", "C", "C1,C2,C3");
 
@@ -777,7 +779,6 @@ public:
 
   /// Rewrite second group
   void test_processGroups_rewriteSecondGroup() {
-    Mantid::API::AnalysisDataService::Instance().clear();
     WorkspaceGroup_sptr group =
         do_test_groups("A", "A1,A2,A3", "D", "D1,D2,D3", "C", "C1,C2,C3");
 
@@ -792,7 +793,6 @@ public:
 
   /// Rewrite multiple group
   void test_processGroups_rewriteMultipleGroup() {
-    Mantid::API::AnalysisDataService::Instance().clear();
     WorkspaceGroup_sptr group =
         do_test_groups("A", "A1,A2,A3", "D", "D1,D2,D3", "D", "D1,D2,D3");
 
@@ -803,6 +803,72 @@ public:
     TS_ASSERT_EQUALS(ws2->getTitle(), "A2+D2+D2");
     TS_ASSERT_EQUALS(ws3->getName(), "D3");
     TS_ASSERT_EQUALS(ws3->getTitle(), "A3+D3+D3");
+  }
+
+  void doHistoryCopyTest(const std::string &inputWSName,
+                         const std::string &outputWSName) {
+    auto inputWS = boost::make_shared<WorkspaceTester>();
+    inputWS->history().addHistory(boost::make_shared<AlgorithmHistory>(
+        "Load", 1, "b5b65a94-e656-468e-987c-644288fac655"));
+    auto &ads = AnalysisDataService::Instance();
+    ads.addOrReplace(inputWSName, inputWS);
+
+    StubbedWorkspaceAlgorithm nextStep;
+    nextStep.initialize();
+    nextStep.setPropertyValue("InputWorkspace1", inputWSName);
+    nextStep.setPropertyValue("OutputWorkspace1", outputWSName);
+    nextStep.execute();
+
+    auto outputWS = ads.retrieve(outputWSName);
+    const auto &outputHistory = outputWS->history();
+    TS_ASSERT_EQUALS(2, outputHistory.size());
+    TS_ASSERT_EQUALS("Load", outputHistory.getAlgorithmHistory(0)->name());
+    TS_ASSERT_EQUALS("StubbedWorkspaceAlgorithm",
+                     outputHistory.getAlgorithmHistory(1)->name());
+  }
+
+  void test_singleInputWorkspaceHistoryCopiedToOutputWorkspace() {
+    doHistoryCopyTest("copyHistoryIn", "copyHistoryOut");
+  }
+
+  void test_singleInputWorkspaceHistoryCopiedToReplacedOutputWorkspace() {
+    doHistoryCopyTest("copyHistoryInOut", "copyHistoryInOut");
+  }
+
+  void doHistoryCopyOnGroupsTest(const std::string &inputWSName,
+                                 const std::string &outputWSName) {
+    const auto group =
+        boost::dynamic_pointer_cast<WorkspaceGroup>(makeWorkspaceGroup(
+            inputWSName, inputWSName + "_1," + inputWSName + "_2"));
+    const auto execDate{Mantid::Types::Core::DateAndTime::getCurrentTime()};
+    for (auto &item : *group) {
+      item->history().addHistory(boost::make_shared<AlgorithmHistory>(
+          "Load", 1, "49ea7cb9-6172-4e5c-acf5-c3edccd0bb27", execDate));
+    }
+    auto &ads = AnalysisDataService::Instance();
+    StubbedWorkspaceAlgorithm nextStep;
+    nextStep.initialize();
+    nextStep.setPropertyValue("InputWorkspace1", inputWSName);
+    nextStep.setPropertyValue("OutputWorkspace1", outputWSName);
+    nextStep.execute();
+
+    auto outputGroup = ads.retrieveWS<WorkspaceGroup>(outputWSName);
+    TS_ASSERT(outputGroup);
+    for (auto &item : *outputGroup) {
+      const auto &outputHistory = item->history();
+      TS_ASSERT_EQUALS(2, outputHistory.size());
+      TS_ASSERT_EQUALS("Load", outputHistory.getAlgorithmHistory(0)->name());
+      TS_ASSERT_EQUALS("StubbedWorkspaceAlgorithm",
+                       outputHistory.getAlgorithmHistory(1)->name());
+    }
+  }
+
+  void test_InputWorkspaceGroupHistoryCopiedToOutputWorkspaceGroup() {
+    doHistoryCopyOnGroupsTest("copyHistoryGroupIn", "copyHistoryGroupOut");
+  }
+
+  void test_InputWorkspaceGroupHistoryCopiedToReplacedOutputWorkspaceGroup() {
+    doHistoryCopyOnGroupsTest("copyHistoryGroupInOut", "copyHistoryGroupInOut");
   }
 
   /**

--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
@@ -49,6 +49,8 @@ public:
 private:
   /// Overwrites Algorithm method.
   void init() override;
+  /// Pass groups in as they are to this algorithm
+  bool checkGroups() override { return false; }
   /// Overwrites Algorithm method.
   void exec() override;
 

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -520,16 +520,16 @@ bool SaveNexusProcessed::processGroups() {
     }
   }
 
-  // Only the input workspace property can take group workspaces. Therefore
-  // index = 0.
-  std::vector<Workspace_sptr> &thisGroup = m_groups[0];
-  if (!thisGroup.empty()) {
-    for (size_t entry = 0; entry < m_groupSize; entry++) {
-      Workspace_sptr ws = thisGroup[entry];
+  // If we have arrived here then a WorkspaceGroup was passed to the
+  // InputWorkspace property. Pull out the unrolled workspaces and append an
+  // entry for each one. We only have a single input workspace property declared
+  // so there will only be a single list of unrolled workspaces
+  const auto &workspaces = m_unrolledInputWorkspaces[0];
+  if (!workspaces.empty()) {
+    for (size_t entry = 0; entry < workspaces.size(); entry++) {
+      const Workspace_sptr ws = workspaces[entry];
       this->doExec(ws, nexusFile, true /*keepFile*/, entry);
-      std::stringstream buffer;
-      buffer << "Saving group index " << entry;
-      m_log.information(buffer.str());
+      g_log.information() << "Saving group index " << entry << "\n";
     }
   }
 

--- a/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/CompositeValidator.h
@@ -52,7 +52,18 @@ public:
   template <typename T, typename U> void add(const U &arg) {
     this->add(boost::make_shared<T>(arg));
   }
-  std::list<IValidator_sptr> getChildren() const { return m_children; };
+  /// Returns true if the child list contains a validator of the specified
+  /// template type
+  template <typename T> bool contains() {
+    for (const auto &validator : m_children) {
+      // avoid boost::dynamic_pointer cast to avoid constructing
+      // a temporary shared_ptr type
+      if (dynamic_cast<T *>(validator.get())) {
+        return true;
+      }
+    }
+    return false;
+  }
 
 private:
   /// Verify the value with the child validators

--- a/Framework/Kernel/test/CompositeValidatorTest.h
+++ b/Framework/Kernel/test/CompositeValidatorTest.h
@@ -89,6 +89,27 @@ public:
     TS_ASSERT_EQUALS(comp.isValid(70), "");  // In range of val2
     TS_ASSERT_DIFFERS(comp.isValid(55), ""); // Not in range
   }
+
+  void test_ContainsReturnsTrueIfListContainsType() {
+    CompositeValidator comp;
+    auto val1 = boost::make_shared<BoundedValidator<int>>(1, 50);
+    auto val2 = boost::make_shared<BoundedValidator<double>>(60, 100);
+    comp.add(val1);
+    comp.add(val2);
+
+    TS_ASSERT(comp.contains<BoundedValidator<int>>());
+    TS_ASSERT(comp.contains<BoundedValidator<double>>());
+  }
+
+  void test_ContainsReturnsFalseIfListDoesNotContainType() {
+    CompositeValidator comp;
+    auto val1 = boost::make_shared<BoundedValidator<int>>(1, 50);
+    auto val2 = boost::make_shared<BoundedValidator<double>>(60, 100);
+    comp.add(val1);
+    comp.add(val2);
+
+    TS_ASSERT_EQUALS(false, comp.contains<StringListValidator>());
+  }
 };
 
 #endif /* MANTID_KERNEL_COMPOSITEVALIDATORTEST_H_ */

--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -255,6 +255,8 @@ def getBinsBoundariesFromWorkspace(ws_reference):
 
 def getFilePathFromWorkspace(ws):
     ws_pointer = getWorkspaceReference(ws)
+    if isinstance(ws_pointer, WorkspaceGroup):
+        ws_pointer = ws_pointer[0]
     file_path = None
 
     try:

--- a/scripts/SANS/isis_reduction_steps.py
+++ b/scripts/SANS/isis_reduction_steps.py
@@ -219,8 +219,12 @@ class LoadRun(object):
                                                          monitor_appendix=appendix)
 
         loader_name = ''
+        if isinstance(outWs, WorkspaceGroup):
+            historyWs = outWs[0]
+        else:
+            historyWs = outWs
         try:
-            last_algorithm = outWs.getHistory().lastAlgorithm()
+            last_algorithm = historyWs.getHistory().lastAlgorithm()
             loader_name = last_algorithm.getProperty('LoaderName').value
         except RuntimeError as details:
             sanslog.warning(


### PR DESCRIPTION
**Description of work.**

In #23914 the workspace history recording for groups was changed so that the group call was captured and not the individual child algorithms however the original history from the input groups was not copied over so creating a new workspace in an algorithm would result in missing history entries on the output workspace.

**Report to:** Rob Dalgleish. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Check the script in the original issue shows the correct history. 

Fixes #24372 

*This does not require release notes* because **regression in this development cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
