### PR TITLE
Throw an exception when fail to make volume

### DIFF
--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -138,6 +138,11 @@ void AbsorptionCorrection::exec() {
 
   // Calculate the cached values of L1 and element volumes.
   initialiseCachedDistances();
+  if (m_L1s.empty()) {
+    throw std::runtime_error(
+        "Failed to define any initial scattering gauge volume for geometry");
+  }
+
   // If sample not at origin, shift cached positions.
   const auto &spectrumInfo = m_inputWS->spectrumInfo();
   const V3D samplePos = spectrumInfo.samplePosition();

--- a/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
+++ b/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
@@ -127,8 +127,7 @@ public:
     TS_ASSERT(cyl.isExecuted());
 
     // Using the output of the CylinderAbsorption algorithm is convenient
-    // because
-    // it adds the sample object to the workspace
+    // because it adds the sample object to the workspace
     TS_ASSERT_THROWS_NOTHING(atten2.setPropertyValue("InputWorkspace", cylWS));
     std::string outputWS("factors");
     TS_ASSERT_THROWS_NOTHING(
@@ -197,6 +196,55 @@ public:
     Mantid::API::AnalysisDataService::Instance().remove(cylWS);
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);
     Mantid::API::AnalysisDataService::Instance().remove("gauge");
+  }
+
+  void testTinyVolume() {
+    if (!atten.isInitialized())
+      atten.initialize();
+
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
+    // Needs to have units of wavelength
+    testWS->getAxis(0)->unit() =
+        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
+
+    Mantid::Algorithms::FlatPlateAbsorption flat;
+    flat.initialize();
+    TS_ASSERT_THROWS_NOTHING(
+        flat.setProperty<MatrixWorkspace_sptr>("InputWorkspace", testWS));
+    std::string flatWS("flat");
+    TS_ASSERT_THROWS_NOTHING(flat.setPropertyValue("OutputWorkspace", flatWS));
+    TS_ASSERT_THROWS_NOTHING(
+        flat.setPropertyValue("AttenuationXSection", "5.08"));
+    TS_ASSERT_THROWS_NOTHING(
+        flat.setPropertyValue("ScatteringXSection", "5.1"));
+    TS_ASSERT_THROWS_NOTHING(
+        flat.setPropertyValue("SampleNumberDensity", "0.07192"));
+    TS_ASSERT_THROWS_NOTHING(flat.setPropertyValue("SampleHeight", "2.3"));
+    TS_ASSERT_THROWS_NOTHING(flat.setPropertyValue("SampleWidth", "1.8"));
+    // too thin to work in any shapes gauge volume creation
+    TS_ASSERT_THROWS_NOTHING(flat.setPropertyValue("SampleThickness", ".1"));
+    TS_ASSERT_THROWS_NOTHING(flat.execute());
+    TS_ASSERT(flat.isExecuted());
+
+    // Using the output of the FlatPlateAbsorption algorithm is convenient
+    // because it adds the sample object to the workspace
+    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("InputWorkspace", flatWS));
+    std::string outputWS("factors");
+    TS_ASSERT_THROWS_NOTHING(
+        atten.setPropertyValue("OutputWorkspace", outputWS));
+    TS_ASSERT_THROWS_NOTHING(
+        atten.setPropertyValue("AttenuationXSection", "5.08"));
+    TS_ASSERT_THROWS_NOTHING(
+        atten.setPropertyValue("ScatteringXSection", "5.1"));
+    TS_ASSERT_THROWS_NOTHING(
+        atten.setPropertyValue("SampleNumberDensity", "0.07192"));
+    atten.setRethrows(true); // needed for the next check to work
+    TS_ASSERT_THROWS(atten.execute(), std::runtime_error);
+    TS_ASSERT(!atten.isExecuted());
+
+    Mantid::API::AnalysisDataService::Instance().remove(flatWS);
   }
 
 private:

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -85,6 +85,7 @@ Improvements
 - :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>` and :ref:`LoadNexusProcessed <algm-LoadNexusProcessed>` can now save and load a ``MaskWorkspace``.
 - :ref:`FitPeaks <algm-FitPeaks>` can output parameters' uncertainty (fitting error) in an optional workspace.
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
+- All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``).
 
 Bugfixes
 ########


### PR DESCRIPTION
Previously the integration volume would be quietly undefined. This makes
it much more obvious to the user when something goes wrong. The
underlying issue is in the numerics of determining what is inside the
shape.

**To test:**

Since it is just adding a check and throwing an exception, a code review should be sufficient.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
