### PR TITLE
Fix error reporter when recovery directory does not exist

### DIFF
--- a/scripts/ErrorReporter/retrieve_recovery_files.py
+++ b/scripts/ErrorReporter/retrieve_recovery_files.py
@@ -10,31 +10,23 @@ def get_properties_directory():
 
 
 def get_recovery_files_path():
-    recovery_files_path = ''
     properties_directory = get_properties_directory()
     if 'recovery' not in os.listdir(properties_directory):
-        return recovery_files_path
+        return None
 
-    recovery_dir_contents = os.listdir(properties_directory + 'recovery')
-    if not recovery_dir_contents:
+    recovery_files_path = os.path.join(properties_directory, 'recovery')
+    if len(os.listdir(recovery_files_path)) > 0:
         return recovery_files_path
-
-    recovery_files_path = properties_directory + 'recovery'
-    return recovery_files_path
+    else:
+        return None
 
 
 def zip_recovery_directory():
     path = get_recovery_files_path()
+    if path is None:
+        return "", ""
     directory = get_properties_directory()
     hash_value = hashlib.md5(str.encode(directory + str(datetime.datetime.now())))
-    zip_file = os.path.join(directory, hash_value.hexdigest())
-    if path:
-        shutil.make_archive(zip_file, 'zip', path)
-        return zip_file, hash_value.hexdigest()
-    return ''
-
-
-def remove_recovery_file(file):
-    directory = get_properties_directory()
-    zip_file = os.path.join(directory, file)
-    os.remove(zip_file + '.zip')
+    base_name = os.path.join(directory, hash_value.hexdigest())
+    zip_file = shutil.make_archive(base_name, 'zip', path)
+    return zip_file, hash_value.hexdigest()

--- a/scripts/test/ErrorReportPresenterTest.py
+++ b/scripts/test/ErrorReportPresenterTest.py
@@ -26,10 +26,6 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.zip_recovery_mock = zip_recovery_patcher.start()
         self.zip_recovery_mock.return_value = ('zipped_file', 'file_hash')
 
-        file_removal_patcher = mock.patch('ErrorReporter.error_report_presenter.remove_recovery_file')
-        self.addCleanup(file_removal_patcher.stop)
-        self.file_removal_mock = file_removal_patcher.start()
-
         self.view = mock.MagicMock()
         self.exit_code = 255
         self.error_report_presenter = ErrorReporterPresenter(self.view, self.exit_code)
@@ -97,7 +93,7 @@ class ErrorReportPresenterTest(unittest.TestCase):
         self.error_report_presenter._send_report_to_server = mock.MagicMock(return_value=201)
         self.error_report_presenter._upload_recovery_file = mock.MagicMock()
         self.error_report_presenter._handle_exit = mock.MagicMock()
-        
+
         self.error_report_presenter.error_handler(continue_working, share, name, email, text_box)
 
         self.error_report_presenter._send_report_to_server.called_once_with(share_identifiable=True, name=name, email=email,


### PR DESCRIPTION
**Description of work.**

The error reporter currently fails if it can't [find the recovery directory](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-rhel7/807/testReport/SystemTests/ErrorReporterServerTest/ErrorReportServerTests/):

```
ConfigService-[Information] Unable to locate directory at: /etc/mantid/instrument
ConfigService-[Information] This is Mantid version 3.13.20181231.1446 revision g9c3e884
ConfigService-[Information] running on ndw1457.isis.cclrc.ac.uk starting 2019-01-01T02:17Z
ConfigService-[Information] Properties file(s) loaded: /opt/mantidnightly/bin/Mantid.properties, /home/builder/.mantid/Mantid.user.properties
ConfigService-[Information] Unable to locate directory at: /etc/mantid/instrument
FrameworkManager-[Notice] Welcome to Mantid 3.13.20181231.1446
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
FrameworkManager-[Information] Instrument updates disabled - cannot update instrument definitions.
FrameworkManager-[Information] Version check disabled.
error-[Notice] No information shared
error-[Error] Continue working.
error-[Notice] Sent non-identifiable information
error-[Error] Continue working.
Traceback (most recent call last):
  File "/tmp/tmpQc6kec", line 24, in <module>
    systest.execute()
  File "/home/builder/Jenkins/workspace/master_systemtests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 207, in execute
    self.runTest()
  File "/home/builder/Jenkins/workspace/master_systemtests-rhel7/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py", line 70, in runTest
    self.test_share_identifiable_works_for_empty_values()
  File "/home/builder/Jenkins/workspace/master_systemtests-rhel7/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py", line 32, in test_share_identifiable_works_for_empty_values
    status = self.error_report_presenter.error_handler(True, 0, '', '', '')
  File "/opt/mantidnightly/scripts/ErrorReporter/error_report_presenter.py", line 46, in error_handler
    status = self.share_all_information(continue_working, name, email, text_box)
  File "/opt/mantidnightly/scripts/ErrorReporter/error_report_presenter.py", line 34, in share_all_information
    zip_recovery_file, file_hash = zip_recovery_directory()
ValueError: need more than 0 values to unpack
```

These changes ensure that any error generating the recovery archive, including the case where recovery information is not found, does not stop the error reporter from continuing.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Remove the `recovery` directory in the `.mantid` directory
* Run the ErrorReporter system test and see it doesn't fail
* Produce some recovery information and run the test again.
* Make sure the data was uploaded.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **it was a change made this cycle**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
