### PR TITLE
Set colorfill plot origin to match pcolormesh

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -398,7 +398,7 @@ class ScalingAxesImage(mimage.AxesImage):
         self.dx = None
         self.dy = None
         self.unsampled_data = None
-        super(mimage.AxesImage, self).__init__(
+        super(ScalingAxesImage, self).__init__(
             ax,
             cmap=cmap,
             norm=norm,
@@ -421,7 +421,7 @@ class ScalingAxesImage(mimage.AxesImage):
                 self.unsampled_data = resize(A, new_dims, mode='constant', cval=numpy.nan)
         else:
             self.unsampled_data = A
-        super(mimage.AxesImage, self).set_data(A)
+        super(ScalingAxesImage, self).set_data(A)
 
     def draw(self, renderer):
         ax = self.axes
@@ -440,7 +440,7 @@ class ScalingAxesImage(mimage.AxesImage):
                     sampled_data = resize(self.unsampled_data, new_dims, mode='constant', cval=numpy.nan)
                 self.dx = dx
                 self.dy = dy
-                super(mimage.AxesImage, self).set_data(sampled_data)
+                super(ScalingAxesImage, self).set_data(sampled_data)
         return super(ScalingAxesImage,self).draw(renderer)
 
 def _imshow(axes, z, cmap=None, norm=None, aspect=None,

--- a/qt/applications/workbench/workbench/plotting/functions.py
+++ b/qt/applications/workbench/workbench/plotting/functions.py
@@ -236,7 +236,7 @@ def pcolormesh(workspaces, fig=None):
             ws = workspaces[subplot_idx]
             ax.set_title(ws.name())
             if use_imshow(ws):
-                pcm = ax.imshow(ws, cmap=DEFAULT_CMAP, aspect='auto')
+                pcm = ax.imshow(ws, cmap=DEFAULT_CMAP, aspect='auto', origin='lower')
             else:
                 pcm = ax.pcolormesh(ws, cmap=DEFAULT_CMAP)
             for lbl in ax.get_xticklabels():


### PR DESCRIPTION
**Description of work.**

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

<!-- Instructions for testing. -->

Run script in Workbench
```python
# The following line helps with future compatibility with Python 3
# print must now be used as a function, e.g print('Hello','World')
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

LoadEventNexus(Filename="PG3_37861",OutputWorkspace="ws1")
ConvertUnits(InputWorkspace="ws1",OutputWorkspace="ws2",target="dSpacing")
Rebin(InputWorkspace="ws2", OutputWorkspace="ws3", Params='.2,0.01,2.5', PreserveEvents=False)
```

Right-click `ws3` and select `plot->colorfill`.

Verify orientation matches MantidPlot

*There is no associated issue.*

*This does not require release notes* because new feature in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
