### PR TITLE
Remove Unecessary calls to ISIS Data Archive

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
@@ -30,12 +30,13 @@ public:
   std::string
   getArchivePath(const std::set<std::string> &filenames,
                  const std::vector<std::string> &exts) const override;
+  /// Public and virtual for testing purposes
+  virtual std::string getCorrectExtension(const std::string &path,
+                                  const std::vector<std::string> &exts) const;
 
 private:
   /// Queries the archive & returns the path to a single file.
   std::string getPath(const std::string &fName) const;
-  std::string getCorrectExtension(const std::string &path,
-                                  const std::vector<std::string> &exts) const;
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
@@ -41,6 +41,7 @@ public:
 protected:
   /// Queries the archive & returns the path to a single file.
   virtual std::ostringstream sendRequest(const std::string &fName) const;
+  virtual bool fileExists(const std::string &path) const;
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
@@ -34,6 +34,8 @@ public:
 private:
   /// Queries the archive & returns the path to a single file.
   std::string getPath(const std::string &fName) const;
+  std::string getCorrectExtension(const std::string &path,
+                                  const std::vector<std::string> &exts) const;
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
@@ -31,8 +31,9 @@ public:
   getArchivePath(const std::set<std::string> &filenames,
                  const std::vector<std::string> &exts) const override;
   /// Public and virtual for testing purposes
-  virtual std::string getCorrectExtension(const std::string &path,
-                                  const std::vector<std::string> &exts) const;
+  virtual std::string
+  getCorrectExtension(const std::string &path,
+                      const std::vector<std::string> &exts) const;
 
 private:
   /// Queries the archive & returns the path to a single file.

--- a/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ISISDataArchive.h
@@ -13,6 +13,7 @@
 #include "MantidAPI/IArchiveSearch.h"
 #include "MantidKernel/System.h"
 
+#include <sstream>
 #include <string>
 
 namespace Mantid {
@@ -30,14 +31,16 @@ public:
   std::string
   getArchivePath(const std::set<std::string> &filenames,
                  const std::vector<std::string> &exts) const override;
+
   /// Public and virtual for testing purposes
   virtual std::string
   getCorrectExtension(const std::string &path,
                       const std::vector<std::string> &exts) const;
-
-private:
-  /// Queries the archive & returns the path to a single file.
   std::string getPath(const std::string &fName) const;
+
+protected:
+  /// Queries the archive & returns the path to a single file.
+  virtual std::ostringstream sendRequest(const std::string &fName) const;
 };
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -114,13 +114,26 @@ std::string ISISDataArchive::getCorrectExtension(
     const std::string &path, const std::vector<std::string> &exts) const {
   for (const auto &ext : exts) {
     std::string temp_path = path + ext;
-    try {
-      if (Poco::File(temp_path).exists())
-        return temp_path;
-    } catch (Poco::Exception &) {
-    }
+    if (fileExists(temp_path))
+      return temp_path;
   }
   return "";
+}
+
+/**
+ * Checks if the given file path exists or not.
+ * This code is in a separate function so it
+ * can be mocked out in testing.
+ * @param path :: The path to the file (including extension)
+ * @return A bool. Whether or not the file exists.
+ */
+bool ISISDataArchive::fileExists(const std::string &path) const {
+  try {
+    if (Poco::File(path).exists())
+      return true;
+  } catch (Poco::Exception &) {
+  }
+  return false;
 }
 
 } // namespace DataHandling

--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -17,8 +17,6 @@
 #include <Poco/File.h>
 #include <Poco/Path.h>
 
-#include <sstream>
-
 namespace Mantid {
 namespace DataHandling {
 namespace {
@@ -47,11 +45,13 @@ const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
 std::string
 ISISDataArchive::getArchivePath(const std::set<std::string> &filenames,
                                 const std::vector<std::string> &exts) const {
-  for (const auto &filename : filenames) {
-    g_log.debug() << filename << ")\n";
-  }
-  for (const auto &ext : exts) {
-    g_log.debug() << ext << ")\n";
+  if (g_log.is(Kernel::Logger::Priority::PRIO_DEBUG)) {
+    for (const auto &filename : filenames) {
+      g_log.debug() << filename << ")\n";
+    }
+    for (const auto &ext : exts) {
+      g_log.debug() << ext << ")\n";
+    }
   }
 
   for (const auto &filename : filenames) {
@@ -66,32 +66,39 @@ ISISDataArchive::getArchivePath(const std::set<std::string> &filenames,
 }
 
 /**
- * Calls a web service to get a path to a file.
- * Only returns a path string if the file exists.
- * The ISIS web service return a path independent of the file extension of the
- * file provided. Thus the call to web service uses a file WITHOUT an extension.
+ * Gets the path to the file, or most recent set of files.
  * @param fName :: The file name.
- * @return The path to the file or an empty string in case of error/non-existing
- * file.
+ * @return The path to the file or an empty string in case of empty filename
  */
 std::string ISISDataArchive::getPath(const std::string &fName) const {
   g_log.debug() << "ISISDataArchive::getPath() - fName=" << fName << "\n";
   if (fName.empty())
     return ""; // Avoid pointless call to service
 
+  std::ostringstream os = sendRequest(fName);
+  os << Poco::Path::separator() << fName;
+  const std::string expectedPath = os.str();
+  return expectedPath;
+}
+
+/** Calls a web service to get a path to a file.
+ * If the file does not exist, returns path to most recent run.
+ * The ISIS web service return a path independent of the file extension of the
+ * file provided. Thus the call to web service uses a file WITHOUT an extension.
+ * @param fName :: The file name.
+ * @return ostringstream object containing path to file (without filename
+ * itself)
+ */
+std::ostringstream
+ISISDataArchive::sendRequest(const std::string &fName) const {
   Kernel::InternetHelper inetHelper;
   std::ostringstream os;
   try {
     inetHelper.sendRequest(URL_PREFIX + fName, os);
-
-    os << Poco::Path::separator() << fName;
-    const std::string expectedPath = os.str();
-    return expectedPath;
   } catch (Kernel::Exception::InternetError &ie) {
-    g_log.warning() << "Could not access archive index " << ie.what();
+    g_log.warning() << "Could not access archive index." << ie.what();
   }
-
-  return "";
+  return os;
 }
 
 /**
@@ -105,7 +112,7 @@ std::string ISISDataArchive::getPath(const std::string &fName) const {
  */
 std::string ISISDataArchive::getCorrectExtension(
     const std::string &path, const std::vector<std::string> &exts) const {
-  for (auto ext : exts) {
+  for (const auto &ext : exts) {
     std::string temp_path = path + ext;
     try {
       if (Poco::File(temp_path).exists())

--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -37,12 +37,11 @@ const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
 }
 
 /**
- * Query the ISIS archive for a set of filenames & extensions. The method goes
- * through each extension
- * and checks whether it can find a match with each filename in the filenames
- * list. The first match is returned.
+ * Query the ISIS archive for a set of filenames and vector of extensions. The
+ * method gets a path to each of the filenames, and then loops over the
+ * extensions to find the correct file.
  * @param filenames :: A set of filenames without extensions
- * @param exts :: A list of extensions to try in order with each filename
+ * @param exts :: A vector of file extensions to search over.
  * @returns The full path to the first found
  */
 std::string
@@ -55,19 +54,22 @@ ISISDataArchive::getArchivePath(const std::set<std::string> &filenames,
     g_log.debug() << ext << ")\n";
   }
 
-  for (const auto &ext : exts) {
-    for (const auto &filename : filenames) {
-      const std::string fullPath = getPath(filename + ext);
+  for (const auto &filename : filenames) {
+    const std::string path_without_extension = getPath(filename);
+    if (!path_without_extension.empty()) {
+      std::string fullPath = getCorrectExtension(path_without_extension, exts);
       if (!fullPath.empty())
         return fullPath;
-    } // it
-  }   // ext
+    }
+  }
   return "";
 }
 
 /**
- * Calls a web service to get a full path to a file.
- * Only returns a full path string if the file exists
+ * Calls a web service to get a path to a file.
+ * Only returns a path string if the file exists.
+ * The ISIS web service return a path independent of the file extension of the
+ * file provided. Thus the call to web service uses a file WITHOUT an extension.
  * @param fName :: The file name.
  * @return The path to the file or an empty string in case of error/non-existing
  * file.
@@ -83,16 +85,34 @@ std::string ISISDataArchive::getPath(const std::string &fName) const {
     inetHelper.sendRequest(URL_PREFIX + fName, os);
 
     os << Poco::Path::separator() << fName;
-    try {
-      const std::string expectedPath = os.str();
-      if (Poco::File(expectedPath).exists())
-        return expectedPath;
-    } catch (Poco::Exception &) {
-    }
+    const std::string expectedPath = os.str();
+    return expectedPath;
   } catch (Kernel::Exception::InternetError &ie) {
     g_log.warning() << "Could not access archive index " << ie.what();
   }
 
+  return "";
+}
+
+/**
+ * Given a path to a file, this searches over possible
+ * extensions to find the full path.
+ * Only returns a full path string if the file exists.
+ * @param path :: The path to the file without an extension.
+ * @param exts :: vector of possible file extensions to search over.
+ * @return The full path to the file or an empty string in case of
+ * error/non-existing file.
+ */
+std::string ISISDataArchive::getCorrectExtension(
+    const std::string &path, const std::vector<std::string> &exts) const {
+  for (auto ext : exts) {
+    std::string temp_path = path + ext;
+    try {
+      if (Poco::File(temp_path).exists())
+        return temp_path;
+    } catch (Poco::Exception &) {
+    }
+  }
   return "";
 }
 

--- a/Framework/DataHandling/test/ISISDataArchiveTest.h
+++ b/Framework/DataHandling/test/ISISDataArchiveTest.h
@@ -26,11 +26,12 @@ const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
 
 class MockgetCorrectExtension : public ISISDataArchive {
 public:
-    std::string getCorrectExtension(const std::string &path,
-                                  const std::vector<std::string> &exts) const override {
-      (void)exts;
-      return path;
-    }
+  std::string
+  getCorrectExtension(const std::string &path,
+                      const std::vector<std::string> &exts) const override {
+    (void)exts;
+    return path;
+  }
 };
 
 class ISISDataArchiveTest : public CxxTest::TestSuite {
@@ -51,7 +52,7 @@ public:
     if (path.empty()) {
       TS_FAIL("Returned path was empty.");
     } else {
-    TS_ASSERT_EQUALS(path.substr(path.size() - 18, 10), "cycle_98_0");
+      TS_ASSERT_EQUALS(path.substr(path.size() - 18, 10), "cycle_98_0");
     }
   }
 
@@ -62,19 +63,23 @@ public:
    */
   void xtestgetCorrectExtension() {
     std::string path;
-    if (strcmp(URL_PREFIX,"http://data.isis.rl.ac.uk/where.py/windir?name=")==0) {
-      path = "\\isis.cclrc.ac.uk\\inst$\\ndxhrpd\\instrument\\data\\cycle_98_0\\HRP00273";
+    if (strcmp(URL_PREFIX, "http://data.isis.rl.ac.uk/where.py/windir?name=") ==
+        0) {
+      path = "\\isis.cclrc.ac.uk\\inst$\\ndxhrpd\\instrument\\data\\cycle_98_"
+             "0\\HRP00273";
     } else {
       path = "/archive/ndxhrpd/Instrument/data/cycle_98_0/HRP00273";
     }
     ISISDataArchive arch;
 
     const std::vector<std::string> correct_exts = {".RAW"};
-    const std::string rawExtension = arch.getCorrectExtension(path, correct_exts);
+    const std::string rawExtension =
+        arch.getCorrectExtension(path, correct_exts);
     TS_ASSERT_EQUALS(rawExtension, path + ".RAW");
 
     const std::vector<std::string> incorrect_exts = {".so", ".txt"};
-    const std::string emptyString = arch.getCorrectExtension(path, incorrect_exts);
+    const std::string emptyString =
+        arch.getCorrectExtension(path, incorrect_exts);
     TS_ASSERT_EQUALS(emptyString, "");
   }
 

--- a/Framework/DataHandling/test/ISISDataArchiveTest.h
+++ b/Framework/DataHandling/test/ISISDataArchiveTest.h
@@ -16,22 +16,66 @@
 using namespace Mantid::DataHandling;
 using namespace Mantid::API;
 
+namespace {
+#ifdef _WIN32
+const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/windir?name=";
+#else
+const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
+#endif
+}
+
+class MockgetCorrectExtension : public ISISDataArchive {
+public:
+    std::string getCorrectExtension(const std::string &path,
+                                  const std::vector<std::string> &exts) const override {
+      (void)exts;
+      return path;
+    }
+};
+
 class ISISDataArchiveTest : public CxxTest::TestSuite {
 public:
-  void xtestSearch() {
-    ISISDataArchive arch;
+  /**
+   * Un-'x' this test name to test locally.
+   * This tests the filename loop part of `getArchivePath`
+   * i.e. for each of the filenames in the set, it makes a call to the archive
+   * and `getCorrectExtension` is mocked out.
+   */
+  void xtestFilenameLoop() {
+    MockgetCorrectExtension arch;
 
     std::set<std::string> filename;
     filename.insert("hrpd273");
-    std::vector<std::string> extension = std::vector<std::string>(1, "");
-    std::string path = arch.getArchivePath(filename, extension);
-    std::cout << "(hrpd273)= " << path << '\n';
+    const std::vector<std::string> extension = std::vector<std::string>(1, "");
+    const std::string path = arch.getArchivePath(filename, extension);
+    if (path.empty()) {
+      TS_FAIL("Returned path was empty.");
+    } else {
     TS_ASSERT_EQUALS(path.substr(path.size() - 18, 10), "cycle_98_0");
+    }
+  }
 
-    filename.clear();
-    filename.insert("hrpds70");
-    path = arch.getArchivePath(filename, extension);
-    TS_ASSERT(path.empty());
+  /**
+   * Un-'x' this test name to test locally.
+   * This tests the file extensions loop.
+   * To run, this tests requires that the ISIS archive is on your local machine.
+   */
+  void xtestgetCorrectExtension() {
+    std::string path;
+    if (strcmp(URL_PREFIX,"http://data.isis.rl.ac.uk/where.py/windir?name=")==0) {
+      path = "\\isis.cclrc.ac.uk\\inst$\\ndxhrpd\\instrument\\data\\cycle_98_0\\HRP00273";
+    } else {
+      path = "/archive/ndxhrpd/Instrument/data/cycle_98_0/HRP00273";
+    }
+    ISISDataArchive arch;
+
+    const std::vector<std::string> correct_exts = {".RAW"};
+    const std::string rawExtension = arch.getCorrectExtension(path, correct_exts);
+    TS_ASSERT_EQUALS(rawExtension, path + ".RAW");
+
+    const std::vector<std::string> incorrect_exts = {".so", ".txt"};
+    const std::string emptyString = arch.getCorrectExtension(path, incorrect_exts);
+    TS_ASSERT_EQUALS(emptyString, "");
   }
 
   void testFactory() {


### PR DESCRIPTION
**Description of work.**
This PR changes the loop in ISISDataArchive through all possible filenames and extensions so that the call to the ISIS archive (e.g. `http://data.isis.rl.ac.uk/where.py/unixdir?name=hrpd273`) only occurs once for each file, rather than calling once for each file + extension combination.

**Report to:** @martyngigg 

**To test:**
In `ISISDataArchiveTest.h`, un-'x' the two tests `testFilenameLoop` and `testgetCorrectExtension`. (These tests are 'x' as they involve a web request, so we don't want them in Jenkins unit tests)
Your local machine must have access to the ISIS data archive for these tests to work.

Then run `ctest --output-on-failure -R ISISDataArchiveTest`. Tests should pass.

Additionally, in Mantidplot, click `Load` -> `File`, type `hrpd273` in the File box and run. This should successfully load workspace HRP00273. 
Try this for other files, which both do (workspace can be loaded) and do not exist.

Fixes #24408 

*This does not require release notes* because **internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
