### PR TITLE
Plot HKL in summed miniplot on instrument view

### DIFF
--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -92,4 +92,11 @@ Changes
 BugFixes
 ########
 
+Instrument View
+---------------
+
+Changes
+#######
+ - The miniplot on the pick tab of the instrument view now shows the HKL values for peaks when viewing a summed collection of detectors.
+
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -273,6 +273,7 @@ private:
   static double getOutOfPlaneAngle(const Mantid::Kernel::V3D &pos,
                                    const Mantid::Kernel::V3D &origin,
                                    const Mantid::Kernel::V3D &normal);
+  void addPeakLabels(const std::vector<size_t> &detIndices);
 
   InstrumentWidgetPickTab *m_tab;
   InstrumentWidget *m_instrWidget;

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1160,6 +1160,27 @@ void DetectorPlotController::setPlotData(
                         actor.getWorkspace()->getAxis(0)->unit()->unitID()),
                     "multiple");
   }
+
+  addPeakLabels(detIndices);
+}
+
+/**
+ * Add peak labels to plot for each detector shown
+ * @param detIndices :: A list of detector inidices.
+ */
+void DetectorPlotController::addPeakLabels(
+    const std::vector<size_t> &detIndices) {
+  auto surface = m_tab->getSurface();
+  if (surface) {
+    const auto &actor = m_instrWidget->getInstrumentActor();
+    auto detIds = actor.getDetIDs(detIndices);
+    for (const auto &detId : detIds) {
+      auto markers = surface->getMarkersWithID(static_cast<int>(detId));
+      for (const auto &marker : markers) {
+        m_plot->addPeakLabel(marker);
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

Previously the HKL values would only show when when viewing a single detector. Now when plotting with a collection of detectors the HKL values will also be plotted in the miniplot.

**Report to:** Pascal

**To test:**
- Load some data and look at it in the instrument view.
- Add a peak anywhere you on the instrument.
- Hover over the detector where you placed the peak. It should show the HKL value (probably 000 in the miniplot)
-  Now click on the ellipse tool.
- Draw an ellipse over the peak.
- The miniplot should now show the sum of all detectors in the shape. It should also show the HKL value.
 - Check this works with multiple peaks.

Below is a screenshot of how the plot should look with the shape overlaid.

![screen shot 2019-01-07 at 13 50 22](https://user-images.githubusercontent.com/2487781/50771678-345c7100-1283-11e9-8690-948b9bb7004e.png)


Fixes #24360 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
