### PR TITLE
Indirect Data Analysis - Error bars for results

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -433,8 +433,8 @@ Output
 
 The results of the fit may be plotted and saved under the 'Output' section of the fitting interfaces.
 
-Next to the 'Plot Output' label, you can select a parameter to plot and then click 'Plot' to plot it across the
-fit spectra (if multiple data-sets have been used, a separate plot will be produced for each data-set). 
+Next to the 'Plot Output' label, you can select a parameter to plot and then click 'Plot' to plot it with error 
+bars across the fit spectra (if multiple data-sets have been used, a separate plot will be produced for each data-set). 
 The 'Plot Output' options will be disabled after a fit if there is only one data point for the parameters.
 
 Clicking the 'Save Result' button will save the result of the fit to your default save location.

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -48,6 +48,7 @@ Improvements
 - Fit and Fit Sequential in the Fit combobox above the FitPropertyBrowser are now disabled while fitting is taking place.
 - The option to choose which workspace index to Plot Spectrum for and from which output workspace is now given in Elwin.
 - ConvFit now allows the loading of Dave ASCII files which end with '_sqw.dave'.
+- The results of a fit in MSDFit, IqtFit, ConvFit and F(Q)Fit are now plotted with error bars.
 
 
 Bugfixes

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -946,7 +946,7 @@ void IndirectFitAnalysisTab::plotSpectrum(
     if (boost::contains(parameter, parameterToPlot)) {
       auto it = labels.find(parameter);
       if (it != labels.end())
-        IndirectTab::plotSpectrum(name, static_cast<int>(it->second));
+        IndirectTab::plotSpectrum(name, static_cast<int>(it->second), true);
     }
   }
 }
@@ -955,7 +955,7 @@ void IndirectFitAnalysisTab::plotSpectrum(
     Mantid::API::MatrixWorkspace_sptr workspace) {
   const auto name = QString::fromStdString(workspace->getName());
   for (auto i = 0u; i < workspace->getNumberHistograms(); ++i)
-    IndirectTab::plotSpectrum(name, static_cast<int>(i));
+    IndirectTab::plotSpectrum(name, static_cast<int>(i), true);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -264,7 +264,7 @@ void IndirectTab::plotMultipleSpectra(
  * @param spectraIndex Index of spectrum from each workspace to plot
  */
 void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
-                               int spectraIndex, bool errorBars) {
+                               const int &spectraIndex, const bool &errorBars) {
   if (!workspaceNames.isEmpty()) {
     const QString errors = errorBars ? "True" : "False";
 
@@ -287,8 +287,8 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
  * @param spectraIndex Workspace Index of spectrum to plot
  * @param errorBars Is true if you want to plot the error bars
  */
-void IndirectTab::plotSpectrum(const QString &workspaceName, int spectraIndex,
-                               bool errorBars) {
+void IndirectTab::plotSpectrum(const QString &workspaceName,
+                               const int &spectraIndex, const bool &errorBars) {
   if (!workspaceName.isEmpty()) {
     QStringList workspaceNames;
     workspaceNames << workspaceName;

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -264,19 +264,19 @@ void IndirectTab::plotMultipleSpectra(
  * @param spectraIndex Index of spectrum from each workspace to plot
  */
 void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
-                               int spectraIndex) {
-  if (workspaceNames.isEmpty())
-    return;
+                               int spectraIndex, bool errorBars) {
+  if (!workspaceNames.isEmpty()) {
+    const QString errors = errorBars ? "True" : "False";
 
-  QString pyInput = "from mantidplot import plotSpectrum\n";
+    QString pyInput = "from mantidplot import plotSpectrum\n";
+    pyInput += "plotSpectrum(['";
+    pyInput += workspaceNames.join("','");
+    pyInput += "'], ";
+    pyInput += QString::number(spectraIndex);
+    pyInput += ", error_bars=" + errors + ")\n";
 
-  pyInput += "plotSpectrum(['";
-  pyInput += workspaceNames.join("','");
-  pyInput += "'], ";
-  pyInput += QString::number(spectraIndex);
-  pyInput += ")\n";
-
-  m_pythonRunner.runPythonCode(pyInput);
+    m_pythonRunner.runPythonCode(pyInput);
+  }
 }
 
 /**
@@ -285,14 +285,15 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
  *
  * @param workspaceName Names of workspace to plot
  * @param spectraIndex Workspace Index of spectrum to plot
+ * @param errorBars Is true if you want to plot the error bars
  */
-void IndirectTab::plotSpectrum(const QString &workspaceName, int spectraIndex) {
-  if (workspaceName.isEmpty())
-    return;
-
-  QStringList workspaceNames;
-  workspaceNames << workspaceName;
-  plotSpectrum(workspaceNames, spectraIndex);
+void IndirectTab::plotSpectrum(const QString &workspaceName, int spectraIndex,
+                               bool errorBars) {
+  if (!workspaceName.isEmpty()) {
+    QStringList workspaceNames;
+    workspaceNames << workspaceName;
+    plotSpectrum(workspaceNames, spectraIndex, errorBars);
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -94,9 +94,11 @@ protected:
   void plotMultipleSpectra(const QStringList &workspaceNames,
                            const std::vector<int> &workspaceIndices);
   /// Plot a spectrum plot with a given ws index
-  void plotSpectrum(const QStringList &workspaceNames, int spectraIndex = 0);
+  void plotSpectrum(const QStringList &workspaceNames, int spectraIndex = 0,
+                    bool errorBars = false);
   /// Plot a spectrum plot of a given workspace
-  void plotSpectrum(const QString &workspaceName, int spectraIndex = 0);
+  void plotSpectrum(const QString &workspaceName, int spectraIndex = 0,
+                    bool errorBars = false);
 
   /// Plot a spectrum plot with a given spectra range
   void plotSpectrum(const QStringList &workspaceNames, int specStart,

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -94,11 +94,11 @@ protected:
   void plotMultipleSpectra(const QStringList &workspaceNames,
                            const std::vector<int> &workspaceIndices);
   /// Plot a spectrum plot with a given ws index
-  void plotSpectrum(const QStringList &workspaceNames, int spectraIndex = 0,
-                    bool errorBars = false);
+  void plotSpectrum(const QStringList &workspaceNames,
+                    const int &spectraIndex = 0, const bool &errorBars = false);
   /// Plot a spectrum plot of a given workspace
-  void plotSpectrum(const QString &workspaceName, int spectraIndex = 0,
-                    bool errorBars = false);
+  void plotSpectrum(const QString &workspaceName, const int &spectraIndex = 0,
+                    const bool &errorBars = false);
 
   /// Plot a spectrum plot with a given spectra range
   void plotSpectrum(const QStringList &workspaceNames, int specStart,


### PR DESCRIPTION
**Description of work.**
This PR ensures error bars are plotted for the graphs plotted when you Plot the data in the Result workspaces in Indirect Data Analysis.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`MSDFit` tab
2. Load the data below
3. Select Gaussian as FitType
4. Click Run and wait
5. Select a parameter in the output options combo box, and click `Plot`.
6. The graph plotted should have error bars

**Data Files**
[osi104367-104371_graphite002_red_elwin_eq.zip](https://github.com/mantidproject/mantid/files/2733355/osi104367-104371_graphite002_red_elwin_eq.zip)

Fixes #24421 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
