### PR TITLE
Clarification of geometry and material documents

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/CreateSampleShape.h
@@ -35,7 +35,8 @@ public:
   /// Algorithm's version
   int version() const override { return (1); }
   const std::vector<std::string> seeAlso() const override {
-    return {"AbsorptionCorrection", "SetSampleMaterial", "CopySample"};
+    return {"SetSample", "AbsorptionCorrection", "SetSampleMaterial",
+            "CopySample"};
   }
   /// Algorithm's category for identification
   const std::string category() const override { return "Sample;"; }

--- a/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
@@ -26,7 +26,7 @@ public:
   const std::string name() const override final;
   int version() const override final;
   const std::vector<std::string> seeAlso() const override {
-    return {"SetSampleMaterial", "CopySample", "SetBeam"};
+    return {"SetSampleMaterial", "CreateSampleShape", "CopySample", "SetBeam"};
   }
   const std::string category() const override final;
   const std::string summary() const override final;

--- a/Framework/DataHandling/inc/MantidDataHandling/SetSampleMaterial.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SetSampleMaterial.h
@@ -33,7 +33,7 @@ public:
   /// Algorithm's version
   int version() const override;
   const std::vector<std::string> seeAlso() const override {
-    return {"AbsorptionCorrection", "CreateSampleShape",
+    return {"SetSample", "AbsorptionCorrection", "CreateSampleShape",
             "CalculateSampleTransmission"};
   }
   /// Algorithm's category for identification

--- a/docs/source/algorithms/CreateSampleShape-v1.rst
+++ b/docs/source/algorithms/CreateSampleShape-v1.rst
@@ -13,10 +13,12 @@ Creates a shape object that defines the sample and sets the sample for
 the given workspace. Shapes are defined using XML descriptions that can
 be found :ref:`here <HowToDefineGeometricShape>`.
 
+.. note:: It is recommended that you use :ref:`SetSample <algm-SetSample>` instead.
+
 Usage
 -----
 
-**Example - A Sphere**  
+**Example - A Sphere**
 
 .. testcode:: Sphere
 
@@ -28,7 +30,7 @@ Usage
       </sphere>'''
     CreateSampleShape(ws,shape_xml)
 
-**Example - A ball with a cylinder carved out of the middle**  
+**Example - A ball with a cylinder carved out of the middle**
 
 .. testcode:: BallwithHole
 

--- a/docs/source/algorithms/SetSample-v1.rst
+++ b/docs/source/algorithms/SetSample-v1.rst
@@ -22,6 +22,10 @@ The 3 arguments to this algorithm ``Environment``, ``Geometry`` and
 dictionaries specifying multiple parameters that relate to the
 respective argument.
 
+.. note:: Contrary to the :ref:`xml forms of defining the geometry
+          <HowToDefineGeometricShape>` which are in metres,
+          :py:obj:`dict` versions are in centimetres.
+
 Environment
 ###########
 

--- a/docs/source/algorithms/SetSampleMaterial-v1.rst
+++ b/docs/source/algorithms/SetSampleMaterial-v1.rst
@@ -10,109 +10,17 @@ Description
 -----------
 
 Sets the neutrons information in the sample. You can either enter
-details about the chemical formula or atomic number, or you can provide
-specific values for the attenuation and scattering cross sections and
-the sample number density. If you decide to provide specific values you
-must give values for all three (attenuation and scattering cross
-sections and the sample number density), and any formula information
-will be ignored. If you miss any of the three specific values then the
-other will be ignored.
+details about the chemical formula or atomic number, or you can
+provide specific values for the attenuation and scattering cross
+sections and the sample number density. If you decide to provide
+specific values you must give values for all three (attenuation and
+scattering cross sections and the sample number density), and any
+formula information will be ignored. If you miss any of the three
+specific values then the other will be ignored. For details of how the
+various quantities are calculated, refer to the :ref:`Materials`
+concept page.
 
-Neutron scattering lengths and cross sections of the elements and their
-isotopes have been taken from
-`NIST <http://www.ncnr.nist.gov/resources/n-lengths/list.html>`__.
-
-Chemical Composition with Examples
-##################################
-- ``H2 O`` - Isotopically averaged Hydrogen
-- ``(H2)2 O`` - Heavy water
-- ``D2 O`` - Another way to specify heavy water
-
-Enter a composition as a molecular formula of elements or isotopes.
-For example, basic elements might be ``H``, ``Fe`` or ``Si``, etc.
-A molecular formula of elements might be ``H4-N2-C3``, which
-corresponds to a molecule with 4 Hydrogen atoms, 2 Nitrogen atoms and
-3 Carbon atoms.  Each element in a molecular formula is followed by
-the number of the atoms for that element, specified **without a hyphen**,
-because each element is separated from other elements using a hyphen.
-
-The number of atoms can be integer or float, but must start with a
-digit, e.g. 0.6 is fine but .6 is not. This can be used to set elemental ratios
-within a chemical composition. For example 95.1% Vanadium 4.9% Niobium can be
-expressed as ``V0.951 Nb0.049``. *Warning: Using this representation will
-calculate all properties except for SampleNumberDensity which must be
-set manually if required*
-
-Isotopes may also be included in a :py:obj:`material
-<mantid.kernel.Material>` composition, and can be specified alone (as
-in ``Li7``), or in a molecular formula (as in ``(Li7)2-C-H4-N-Cl6``).
-Note, however, that No Spaces or Hyphens are allowed in an isotope
-symbol specification. Also Note that for isotopes specified in a
-molecular expression, the isotope must be enclosed by parenthesis,
-except for two special cases, ``D`` and ``T``, which stand for ``H2``
-and ``H3``, respectively.
-
-Cross Section Calculations
-##########################
-
-Each of the cross sections (:math:`\sigma`) are calculated according to
-
-.. math:: \sigma = \frac{1}{N_{atoms}}\sum_{i}\sigma_{i}n_{i}
-
-where :math:`N_{atoms} = \sum_{i}n_{i}`. A concrete example for the total
-cross section of ``D2 O``
-
-.. math:: \sigma = \frac{1}{2+1}\left( 7.64*2 + 4.232*1\right) = 6.504\ barns
-
-Number Density
-##############
-
-The number density is defined as
-
-.. math:: \rho_n = \frac{N_{atoms}ZParameter}{UnitCellVolume}
-
-It can can be generated in one of three ways:
-
-1. Specifying it directly with ``SampleNumberDensity``.
-2. Specifying the ``ZParameter`` and the ``UnitCellVolume`` (or letting
-   the algorithm calculate it from the OrientedLattice on the
-   ``InputWorkspace``).
-3. Specifying the mass density. In this case the number density is calculated as
-
-.. math:: \rho_n = \frac{N_{atoms} \rho_m N_A}{M_r}
-
-where :math:`\rho_m` is the mass density, :math:`N_A` is the Avogadro constant, and :math:`M_r` the relative molecular mass.
-
-Linear Absorption Coefficients
-##############################
-
-.. math:: \mu_s = \rho_n \frac{1}{N_{atoms}}\sum_{i}s_{i}n_{i} \text{ units of 1/cm}
-.. math:: s = \sigma_{total scattering}
-.. math:: \mu_a = \rho_n \frac{1}{N_{atoms}}\sum_{i}a_{i}n_{i} \text{ units of 1/cm}
-.. math:: a = \sigma_{absorption} (\lambda=1.8)
-
-A detailed version of this is found in [2].
-
-Normalized Laue
-###############
-
-The low-:math:`Q` limit of :math:`S(Q)` is :math:`-L` where :math:`L` is called the normalized Laue term
-
-.. math:: bAverage = <b_{coh}> = \frac{1}{N_{atoms}}\sum_{i}b_{coh,i}
-.. math:: bSquaredAverage = <b_{tot}^2> = \frac{1}{N_{atoms}}\sum_{i}b_{tot,i}^2
-.. math:: L = \frac{<b_{tot}^2>-<b_{coh}>^2}{<b_{coh}>^2}
-
-References
-----------
-
-The data used in this algorithm comes from the following paper.
-
-#. Varley F. Sears, *Neutron scattering lengths and cross sections*, Neutron News **3:3** (1992) 26
-   `doi: 10.1080/10448639208218770 <http://dx.doi.org/10.1080/10448639208218770>`_
-#. J. A. K. Howard, O. Johnson, A. J. Schultz and A. M. Stringer, *Determination of the neutron
-   absorption cross section for hydrogen as a function of wavelength with a pulsed neutron
-   source*, J. Appl. Cryst. (1987). 20, 120-122
-   `doi: 10.1107/S0021889887087028 <http://dx.doi.org/10.1107/S0021889887087028>`_
+.. note:: It is recommended that you use :ref:`SetSample <algm-SetSample>` instead.
 
 .. categories::
 

--- a/docs/source/concepts/Materials.rst
+++ b/docs/source/concepts/Materials.rst
@@ -1,0 +1,104 @@
+.. _Materials:
+
+Materials
+=========
+
+.. contents::
+
+Neutron scattering lengths and cross sections of the elements and their
+isotopes have been taken from
+`NIST <http://www.ncnr.nist.gov/resources/n-lengths/list.html>`__.
+
+Chemical Composition with Examples
+##################################
+- ``H2 O`` - Isotopically averaged Hydrogen
+- ``(H2)2 O`` - Heavy water
+- ``D2 O`` - Another way to specify heavy water
+
+Enter a composition as a molecular formula of elements or isotopes.
+For example, basic elements might be ``H``, ``Fe`` or ``Si``, etc.
+A molecular formula of elements might be ``H4-N2-C3``, which
+corresponds to a molecule with 4 Hydrogen atoms, 2 Nitrogen atoms and
+3 Carbon atoms.  Each element in a molecular formula is followed by
+the number of the atoms for that element, specified **without a hyphen**,
+because each element is separated from other elements using a hyphen.
+
+The number of atoms can be integer or float, but must start with a
+digit, e.g. 0.6 is fine but .6 is not. This can be used to set elemental ratios
+within a chemical composition. For example 95.1% Vanadium 4.9% Niobium can be
+expressed as ``V0.951 Nb0.049``. *Warning: Using this representation will
+calculate all properties except for SampleNumberDensity which must be
+set manually if required*
+
+Isotopes may also be included in a :py:obj:`material
+<mantid.kernel.Material>` composition, and can be specified alone (as
+in ``(Li7)``), or in a molecular formula (as in ``(Li7)2-C-H4-N-Cl6``).
+Note, however, that No Spaces or Hyphens are allowed in an isotope
+symbol specification. Also Note that for isotopes specified in a
+molecular expression, the isotope must be enclosed by parenthesis,
+except for two special cases, ``D`` and ``T``, which stand for ``H2``
+and ``H3``, respectively.
+
+Cross Section Calculations
+##########################
+
+Each of the cross sections (:math:`\sigma`) are calculated according to
+
+.. math:: \sigma = \frac{1}{N_{atoms}}\sum_{i}\sigma_{i}n_{i}
+
+where :math:`N_{atoms} = \sum_{i}n_{i}`. A concrete example for the total
+cross section of ``D2 O``
+
+.. math:: \sigma = \frac{1}{2+1}\left( 7.64*2 + 4.232*1\right) = 6.504\ barns
+
+Number Density
+##############
+
+The number density is defined as
+
+.. math:: \rho_n = \frac{N_{atoms}ZParameter}{UnitCellVolume}
+
+It can can be generated in one of three ways:
+
+1. Specifying it directly with ``SampleNumberDensity``.
+2. Specifying the ``ZParameter`` and the ``UnitCellVolume`` (or letting
+   the algorithm calculate it from the OrientedLattice on the
+   ``InputWorkspace``).
+3. Specifying the mass density. In this case the number density is calculated as
+
+.. math:: \rho_n = \frac{N_{atoms} \rho_m N_A}{M_r}
+
+where :math:`\rho_m` is the mass density, :math:`N_A` is the Avogadro constant, and :math:`M_r` the relative molecular mass.
+
+Linear Absorption Coefficients
+##############################
+
+.. math:: \mu_s = \rho_n \frac{1}{N_{atoms}}\sum_{i}s_{i}n_{i} \text{ units of 1/cm}
+.. math:: s = \sigma_{total scattering}
+.. math:: \mu_a = \rho_n \frac{1}{N_{atoms}}\sum_{i}a_{i}n_{i} \text{ units of 1/cm}
+.. math:: a = \sigma_{absorption} (\lambda=1.8)
+
+A detailed version of this is found in [2].
+
+Normalized Laue
+###############
+
+The low-:math:`Q` limit of :math:`S(Q)` is :math:`-L` where :math:`L` is called the normalized Laue term
+
+.. math:: bAverage = <b_{coh}> = \frac{1}{N_{atoms}}\sum_{i}b_{coh,i}
+.. math:: bSquaredAverage = <b_{tot}^2> = \frac{1}{N_{atoms}}\sum_{i}b_{tot,i}^2
+.. math:: L = \frac{<b_{tot}^2>-<b_{coh}>^2}{<b_{coh}>^2}
+
+References
+----------
+
+The data used in this algorithm comes from the following paper.
+
+#. Varley F. Sears, *Neutron scattering lengths and cross sections*, Neutron News **3:3** (1992) 26
+   `doi: 10.1080/10448639208218770 <http://dx.doi.org/10.1080/10448639208218770>`_
+#. J. A. K. Howard, O. Johnson, A. J. Schultz and A. M. Stringer, *Determination of the neutron
+   absorption cross section for hydrogen as a function of wavelength with a pulsed neutron
+   source*, J. Appl. Cryst. (1987). 20, 120-122
+   `doi: 10.1107/S0021889887087028 <http://dx.doi.org/10.1107/S0021889887087028>`_
+
+.. categories:: Concepts

--- a/docs/source/concepts/SampleEnvironment.rst
+++ b/docs/source/concepts/SampleEnvironment.rst
@@ -16,9 +16,11 @@ Specification
 
 A sample environment is defined by:
 
-- one or more available containers, each with a defined geometry & composition
-- optional additional components that will be in the beam, each with their own
-  geometry and composition.
+- one or more available containers, each with a defined :ref:`geometry
+  <HowToDefineGeometricShape>` and :ref:`composition <Materials>`
+- optional additional components that will be in the beam, each with
+  their own :ref:`geometry <HowToDefineGeometricShape>` and
+  :ref:`composition <Materials>`
 
 At a minimum a sample environment is expected to define a container with both its
 geometry and composition.
@@ -71,17 +73,17 @@ is used to reference the material when defining a container or component.
 The other attributes define the properties of the material. The allowed attributes
 map to the arguments of a similar name on the :ref:`SetSampleMaterial <algm-SetSampleMaterial>` algorithm
 
-- formula
-- atomicnumber
-- massnumber
-- numberdensity
-- zparameter
-- unitcellvol
-- massdensity
-- totalscatterxsec
-- cohscatterxsec
-- incohscatterxsec
-- absorptionxsec
+- ``formula``
+- ``atomicnumber``
+- ``massnumber``
+- ``numberdensity``
+- ``zparameter``
+- ``unitcellvol``
+- ``massdensity``
+- ``totalscatterxsec``
+- ``cohscatterxsec``
+- ``incohscatterxsec``
+- ``absorptionxsec``
 
 Non-container Components
 ------------------------

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -86,6 +86,7 @@ Improvements
 - :ref:`FitPeaks <algm-FitPeaks>` can output parameters' uncertainty (fitting error) in an optional workspace.
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
 - All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``).
+- Various clarifications and additional links in the geometry and material documentation pages
 
 Bugfixes
 ########


### PR DESCRIPTION
This split out the material information into a new concept page, added additional links between the various docs, and added a big note at the top of `SetSample` that the dict definitions are in cm.

**To test:**

Build the docs and decide that they are better than they were. 

Fixes #21467

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
