### PR TITLE
Make Tooltips Readable on Ubuntu18

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -11648,7 +11648,7 @@ void ApplicationWindow::patchPaletteForLinux(QPalette &palette) const {
 bool ApplicationWindow::isUnityDesktop() const {
   return QString::fromLocal8Bit(qgetenv("XDG_SESSION_DESKTOP")) == "Unity" ||
          QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP")) == "Unity" ||
-         QString::fromLocal8Bit(ggetenv("XDG_SESSION_DESKTOP")) ==
+         QString::fromLocal8Bit(qgetenv("XDG_SESSION_DESKTOP")) ==
              "ubuntu:GNOME" ||
          QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP")) ==
              "ubuntu:GNOME";

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -11647,7 +11647,11 @@ void ApplicationWindow::patchPaletteForLinux(QPalette &palette) const {
 
 bool ApplicationWindow::isUnityDesktop() const {
   return QString::fromLocal8Bit(qgetenv("XDG_SESSION_DESKTOP")) == "Unity" ||
-         QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP")) == "Unity";
+         QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP")) == "Unity" ||
+         QString::fromLocal8Bit(ggetenv("XDG_SESSION_DESKTOP")) ==
+             "ubuntu:GNOME" ||
+         QString::fromLocal8Bit(qgetenv("XDG_CURRENT_DESKTOP")) ==
+             "ubuntu:GNOME";
 }
 
 void ApplicationWindow::setAppColors(const QColor &wc, const QColor &pc,


### PR DESCRIPTION
**Description of work.**
Includes a check for ubuntu 18. When this is met the tooltip colour is changed to a readable format.
Directly linked to PRs #21930 and #21832

**Report to:** Nobody

**To test:**
1. Interfaces -> SANS -> SANS v2
2. In the options column in the table, begin to type something
3. A readable tooltip should appear

Tooltips should appear readable everywhere else on MantidPlot as well

Fixes #24347 

*This does not require release notes* because **small change not raised by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
