### PR TITLE
EQSANS adjust detector bank position when loading the instrument

### DIFF
--- a/instrument/EQ-SANS_Definition.xml
+++ b/instrument/EQ-SANS_Definition.xml
@@ -36,7 +36,11 @@
     </component>
   </type>
   <component type="detector1" idlist="detector1">
-    <location/>
+    <location name="detector1">
+       <parameter name="z">
+         <logfile eq="0.0+0.001*value" id="detectorZ"/>
+       </parameter>
+    </location>
   </component>
   <type name="detector1">
     <component type="bank1_tube1">


### PR DESCRIPTION
- [x] Modified instrument definition file

**To test:**
The below script load an events file, applies the new instrument definition, and finally  shows the instrument. Be sure to update the value of variable `instrument_file` with the location of the instrument file in your cloned repository

```
instrument_file='my_absolute_path_to/mantid/instrument/EQ-SANS_Definition.xml'
w = Load(Filename='EQSANS_88888', OutputWorkspace='eqsans')
LoadInstrument(Workspace='eqsans', Filename=instrument_file, RewriteSpectraMap=False)
instrument_view = getInstrumentView('eqsans')
instrument_view.show()
````
In the instrument view window, verify that the detector bank does not contain the origin of coordinates anymore, but is displaced along the Z-axis (color blue)

Fixes #24290 

This does not require release notes  because it's an offshot of branch `ORNL_SANS`. Release notes will be incorporated when branch `ORNL_SANS` is merged onto master

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
