### PR TITLE
Allow FileFinder findRuns to Search for Vector of Provided Extensions

### DIFF
--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -51,11 +51,11 @@ public:
   std::string
   findRun(const std::string &hintstr,
           const std::vector<std::string> &exts = std::vector<std::string>(),
-          const bool overwriteExts = false) const;
+          const bool useExtsOnly = false) const;
   std::vector<std::string>
   findRuns(const std::string &hintstr,
            const std::vector<std::string> &exts = std::vector<std::string>(),
-           const bool overwriteExts = false) const;
+           const bool useExtsOnly = false) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   const Kernel::InstrumentInfo getInstrument(const std::string &hint) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -49,7 +49,7 @@ public:
   std::vector<IArchiveSearch_sptr>
   getArchiveSearch(const Kernel::FacilityInfo &facility) const;
   std::string findRun(const std::string &hintstr,
-                      const std::vector<std::string> &exts,
+                      const std::vector<std::string> &exts = {},
                       const bool useExtsOnly = false) const;
   std::vector<std::string> findRuns(const std::string &hintstr,
                                     const std::vector<std::string> &exts = {},

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -58,8 +58,6 @@ public:
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   std::string getExtension(const std::string &filename,
                            const std::vector<std::string> &exts) const;
-  void getUniqueExtensions(const std::vector<std::string> &exts,
-                           std::set<std::string> &uniqueExts) const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FileFinderImpl>;
@@ -79,6 +77,8 @@ private:
                              const std::set<std::string> &filenames,
                              const std::vector<std::string> &exts) const;
   std::string toUpper(const std::string &src) const;
+  void getUniqueExtensions(const std::vector<std::string> &exts,
+                           std::set<std::string> &uniqueExts) const;
   /// glob option - set to case sensitive or insensitive
   int m_globOption;
 };

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -48,14 +48,12 @@ public:
   bool getCaseSensitive() const;
   std::vector<IArchiveSearch_sptr>
   getArchiveSearch(const Kernel::FacilityInfo &facility) const;
-  std::string
-  findRun(const std::string &hintstr,
-          const std::vector<std::string> &exts = std::vector<std::string>(),
-          const bool useExtsOnly = false) const;
-  std::vector<std::string>
-  findRuns(const std::string &hintstr,
-           const std::vector<std::string> &exts = std::vector<std::string>(),
-           const bool useExtsOnly = false) const;
+  std::string findRun(const std::string &hintstr,
+                      const std::vector<std::string> &exts,
+                      const bool useExtsOnly = false) const;
+  std::vector<std::string> findRuns(const std::string &hintstr,
+                                    const std::vector<std::string> &exts = {},
+                                    const bool useExtsOnly = false) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   const Kernel::InstrumentInfo getInstrument(const std::string &hint) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -58,6 +58,8 @@ public:
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   std::string getExtension(const std::string &filename,
                            const std::vector<std::string> &exts) const;
+  void getUniqueExtensions(const std::vector<std::string> &exts,
+                           std::set<std::string> &uniqueExts) const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FileFinderImpl>;

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -48,12 +48,11 @@ public:
   bool getCaseSensitive() const;
   std::vector<IArchiveSearch_sptr>
   getArchiveSearch(const Kernel::FacilityInfo &facility) const;
-  std::string findRun(const std::string &hintstr,
-                      const std::set<std::string> &exts) const;
   std::string findRun(
       const std::string &hintstr,
       const std::vector<std::string> &exts = std::vector<std::string>()) const;
-  std::vector<std::string> findRuns(const std::string &hintstr) const;
+  std::vector<std::string> findRuns(const std::string &hintstr,
+                                    const std::vector<std::string> &exts = std::vector<std::string>()) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   const Kernel::InstrumentInfo getInstrument(const std::string &hint) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.

--- a/Framework/API/inc/MantidAPI/FileFinder.h
+++ b/Framework/API/inc/MantidAPI/FileFinder.h
@@ -48,16 +48,21 @@ public:
   bool getCaseSensitive() const;
   std::vector<IArchiveSearch_sptr>
   getArchiveSearch(const Kernel::FacilityInfo &facility) const;
-  std::string findRun(
-      const std::string &hintstr,
-      const std::vector<std::string> &exts = std::vector<std::string>()) const;
-  std::vector<std::string> findRuns(const std::string &hintstr,
-                                    const std::vector<std::string> &exts = std::vector<std::string>()) const;
+  std::string
+  findRun(const std::string &hintstr,
+          const std::vector<std::string> &exts = std::vector<std::string>(),
+          const bool overwriteExts = false) const;
+  std::vector<std::string>
+  findRuns(const std::string &hintstr,
+           const std::vector<std::string> &exts = std::vector<std::string>(),
+           const bool overwriteExts = false) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   const Kernel::InstrumentInfo getInstrument(const std::string &hint) const;
   /// DO NOT USE! MADE PUBLIC FOR TESTING ONLY.
   std::string getExtension(const std::string &filename,
                            const std::vector<std::string> &exts) const;
+  void getUniqueExtensions(const std::vector<std::string> &extensionsToAdd,
+                           std::vector<std::string> &uniqueExts) const;
 
 private:
   friend struct Mantid::Kernel::CreateUsingNew<FileFinderImpl>;
@@ -77,8 +82,6 @@ private:
                              const std::set<std::string> &filenames,
                              const std::vector<std::string> &exts) const;
   std::string toUpper(const std::string &src) const;
-  void getUniqueExtensions(const std::vector<std::string> &exts,
-                           std::set<std::string> &uniqueExts) const;
   /// glob option - set to case sensitive or insensitive
   int m_globOption;
 };

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -400,7 +400,7 @@ FileFinderImpl::getArchiveSearch(const Kernel::FacilityInfo &facility) const {
 
 std::string FileFinderImpl::findRun(const std::string &hintstr,
                                     const std::vector<std::string> &exts,
-                                    const bool overwriteExts) const {
+                                    const bool useExtsOnly) const {
   std::string hint = Kernel::Strings::strip(hintstr);
   g_log.debug() << "vector findRun(\'" << hint << "\', exts[" << exts.size()
                 << "])\n";
@@ -487,12 +487,12 @@ std::string FileFinderImpl::findRun(const std::string &hintstr,
   if (!extension.empty())
     uniqueExts.push_back(extension);
 
-  // If provided exts are empty, or overwriteExts is false,
+  // If provided exts are empty, or useExtsOnly is false,
   // we want to include facility exts as well
-  if (exts.empty() || !overwriteExts) {
+  getUniqueExtensions(exts, uniqueExts);
+  if (exts.empty() || !useExtsOnly) {
     getUniqueExtensions(extensions, uniqueExts);
   }
-  getUniqueExtensions(exts, uniqueExts);
 
   // determine which archive search facilities to use
   std::vector<IArchiveSearch_sptr> archs = getArchiveSearch(facility);
@@ -543,7 +543,7 @@ void FileFinderImpl::getUniqueExtensions(
  * @param exts :: Vector of allowed file extensions. Optional.
  *                If provided, this provides the only extensions searched for.
  *                If not provided, facility extensions used.
- * @param overwriteExts :: Optional bool. If it's true (and exts is not empty),
+ * @param useExtsOnly :: Optional bool. If it's true (and exts is not empty),
                            search the for the file using exts only.
                            If it's false, use exts AND facility extensions.
  * @return A vector of full paths or empty vector
@@ -553,7 +553,7 @@ void FileFinderImpl::getUniqueExtensions(
 std::vector<std::string>
 FileFinderImpl::findRuns(const std::string &hintstr,
                          const std::vector<std::string> &exts,
-                         const bool overwriteExts) const {
+                         const bool useExtsOnly) const {
   std::string hint = Kernel::Strings::strip(hintstr);
   g_log.debug() << "findRuns hint = " << hint << "\n";
   std::vector<std::string> res;
@@ -611,7 +611,7 @@ FileFinderImpl::findRuns(const std::string &hintstr,
         run = std::to_string(irun);
         while (run.size() < nZero)
           run.insert(0, "0");
-        std::string path = findRun(p1.first + run, exts, overwriteExts);
+        std::string path = findRun(p1.first + run, exts, useExtsOnly);
         if (!path.empty()) {
           res.push_back(path);
         } else {
@@ -619,7 +619,7 @@ FileFinderImpl::findRuns(const std::string &hintstr,
         }
       }
     } else {
-      std::string path = findRun(*h, exts, overwriteExts);
+      std::string path = findRun(*h, exts, useExtsOnly);
       if (!path.empty()) {
         res.push_back(path);
       } else {

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -309,32 +309,6 @@ FileFinderImpl::makeFileName(const std::string &hint,
 }
 
 /**
- * Find the file given a hint. If the name contains a dot(.) then it is assumed
- * that it is already a file stem
- * otherwise calls makeFileName internally.
- * @param hintstr :: The name hint, format: [INSTR]1234[.ext]
- * @param exts :: Optional list of allowed extensions. Only those extensions
- * found in both
- *  facilities extension list and exts will be used in the search. If an
- * extension is given in hint
- *  this argument is ignored.
- * @return The full path to the file or empty string if not found
- */
-std::string FileFinderImpl::findRun(const std::string &hintstr,
-                                    const std::set<std::string> &exts) const {
-  std::string hint = Kernel::Strings::strip(hintstr);
-  g_log.debug() << "set findRun(\'" << hintstr << "\', exts[" << exts.size()
-                << "])\n";
-  if (hint.empty())
-    return "";
-  std::vector<std::string> exts_v;
-  if (!exts.empty())
-    exts_v.assign(exts.begin(), exts.end());
-
-  return this->findRun(hint, exts_v);
-}
-
-/**
  * Determine the extension from a filename.
  *
  * @param filename The filename to get the extension from.
@@ -575,12 +549,13 @@ FileFinderImpl::findRun(const std::string &hintstr,
  * @param hintstr :: Comma separated list of hints to findRun method.
  *  Can also include ranges of runs, e.g. 123-135 or equivalently 123-35.
  *  Only the beginning of a range can contain an instrument name.
+ * @param exts :: Vector of allowed file extensions.
  * @return A vector of full paths or empty vector
  * @throw std::invalid_argument if the argument is malformed
  * @throw Exception::NotFoundError if a file could not be found
  */
 std::vector<std::string>
-FileFinderImpl::findRuns(const std::string &hintstr) const {
+FileFinderImpl::findRuns(const std::string &hintstr, const std::vector<std::string> &exts) const {
   std::string hint = Kernel::Strings::strip(hintstr);
   g_log.debug() << "findRuns hint = " << hint << "\n";
   std::vector<std::string> res;
@@ -638,7 +613,7 @@ FileFinderImpl::findRuns(const std::string &hintstr) const {
         run = std::to_string(irun);
         while (run.size() < nZero)
           run.insert(0, "0");
-        std::string path = findRun(p1.first + run);
+        std::string path = findRun(p1.first + run, exts);
         if (!path.empty()) {
           res.push_back(path);
         } else {
@@ -646,7 +621,7 @@ FileFinderImpl::findRuns(const std::string &hintstr) const {
         }
       }
     } else {
-      std::string path = findRun(*h);
+      std::string path = findRun(*h, exts);
       if (!path.empty()) {
         res.push_back(path);
       } else {

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -512,6 +512,14 @@ FileFinderImpl::findRun(const std::string &hintstr,
   return "";
 }
 
+/**
+ * Given a set of already determined extensions and new extensions,
+ * create a set of all extensions.
+ * If not in an extension-is-case-sensitive environment, only add the
+ * lower case OR upper case version of the extension
+ * @param exts :: a vector of extensions to add
+ * @param uniqueExts :: a set of currently included extensions
+ */
 void FileFinderImpl::getUniqueExtensions(
     const std::vector<std::string> &exts,
     std::set<std::string> &uniqueExts) const {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -333,18 +333,84 @@ public:
         TS_ASSERT_DIFFERS(*it, *(it - 1));
       }
     }
-    std::cout << "\n Failing test \n";
-    // This file is .nxs
-    const std::vector<std::string> incorrect_extension = {".txt"};
-    files =
-        FileFinder::Instance().findRuns("MUSR15189-15193", incorrect_extension);
-    for (auto it = files.begin(); it != files.end(); ++it) {
-      std::cout << *it;
+  }
+
+  void testThatGetUniqueExtensionsPreservesOrder() {
+    auto &fileFinder = FileFinder::Instance();
+    fileFinder.setCaseSensitive(false);
+
+    const std::vector<std::string> extensions1 = {".RAW", ".b", ".txt"};
+    const std::vector<std::string> extensions2 = {".a", ".raw", ".txt"};
+
+    std::vector<std::string> uniqueExts = {".log"};
+    const std::vector<std::string> expectedExts1 = {".log", ".raw", ".b",
+                                                    ".txt"};
+    const std::vector<std::string> expectedExts2 = {".log", ".raw", ".b",
+                                                    ".txt", ".a"};
+
+    fileFinder.getUniqueExtensions(extensions1, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts.size(), expectedExts1.size());
+
+    fileFinder.getUniqueExtensions(extensions2, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts.size(),
+                     expectedExts2.size()); // Contain same number of elements
+    auto itVec = expectedExts2.begin();
+    auto itSet = uniqueExts.begin();
+    for (; itVec != expectedExts2.end(); ++itVec, ++itSet) {
+      // Elements are in the same order
+      TS_ASSERT_EQUALS(*itVec, *itSet);
     }
-    /*TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns(
-                         "MUSR15189-15193", incorrect_extension),
-                     Exception::NotFoundError); */
-    std::cout << "\n end of test \n";
+  }
+
+  void testThatGetUniqueExtensionsPreservesOrderWithCaseSensitivity() {
+    auto &fileFinder = FileFinder::Instance();
+    fileFinder.setCaseSensitive(true);
+
+    const std::vector<std::string> extensions1 = {".RAW", ".b", ".txt"};
+    const std::vector<std::string> extensions2 = {".a", ".raw", ".txt"};
+
+    std::vector<std::string> uniqueExts = {".log"};
+    const std::vector<std::string> expectedExts1 = {".log", ".RAW", ".b",
+                                                    ".txt"};
+    const std::vector<std::string> expectedExts2 = {".log", ".RAW", ".b",
+                                                    ".txt", ".a",   ".raw"};
+
+    fileFinder.getUniqueExtensions(extensions1, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts.size(), expectedExts1.size());
+
+    fileFinder.getUniqueExtensions(extensions2, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts.size(),
+                     expectedExts2.size()); // Contain same number of elements
+    auto itVec = expectedExts2.begin();
+    auto itSet = uniqueExts.begin();
+    for (; itVec != expectedExts2.end(); ++itVec, ++itSet) {
+      // Elements are in the same order
+      TS_ASSERT_EQUALS(*itVec, *itSet);
+    }
+  }
+
+  void testFindRunWithOverwriteExtensionsAndIncorrectExtensions() {
+    std::string path;
+
+    // This file is .nxs or .RAW
+    const std::vector<std::string> incorrect_extension = {".txt"};
+    path =
+        FileFinder::Instance().findRun("MUSR15189", incorrect_extension, true);
+    TS_ASSERT_EQUALS(path, "");
+  }
+
+  void testFindRunWithOverwriteExtensionsAndOneCorrectExtension() {
+    std::string path;
+
+    // This file is .nxs or .RAW
+    // returns a .nxs if no extensions passed in
+    const std::vector<std::string> extensions = {".a", ".txt", ".RAW"};
+    path = FileFinder::Instance().findRun("MUSR15189", extensions, true);
+    std::string actualExtension = "";
+    if (!path.empty()) {
+      actualExtension = path.substr(path.size() - 4, 4);
+    }
+    TS_ASSERT_EQUALS(actualExtension, ".RAW");
   }
 
   void testFindAddFiles() {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -333,11 +333,34 @@ public:
         TS_ASSERT_DIFFERS(*it, *(it - 1));
       }
     }
-
+    std::cout << "\n Failing test \n";
+    // This file is .nxs
     const std::vector<std::string> incorrect_extension = {".txt"};
-    TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns(
+    files =
+        FileFinder::Instance().findRuns("MUSR15189-15193", incorrect_extension);
+    for (auto it = files.begin(); it != files.end(); ++it) {
+      std::cout << *it;
+    }
+    /*TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns(
                          "MUSR15189-15193", incorrect_extension),
-                     Exception::NotFoundError);
+                     Exception::NotFoundError); */
+    std::cout << "\n end of test \n";
+  }
+
+  void testGetUniqueExtensions() {
+    std::set<std::string> uniqueExts;
+    std::vector<std::string> firstExtsToAdd = {".RAW", ".log"};
+    std::vector<std::string> secondExtsToAdd = {".so", ".txt", ".RAW"};
+
+    std::set<std::string> expectedFirstExtensions = {".RAW", ".log"};
+    std::set<std::string> expectedSecondExtensions = {".RAW", ".log", ".so",
+                                                      ".txt"};
+
+    FileFinder::Instance().getUniqueExtensions(firstExtsToAdd, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts, expectedFirstExtensions);
+
+    FileFinder::Instance().getUniqueExtensions(secondExtsToAdd, uniqueExts);
+    TS_ASSERT_EQUALS(uniqueExts, expectedSecondExtensions);
   }
 
   void testFindAddFiles() {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -333,6 +333,11 @@ public:
         TS_ASSERT_DIFFERS(*it, *(it - 1));
       }
     }
+
+    const std::vector<std::string> incorrect_extension = {".txt"};
+    TS_ASSERT_THROWS(files = FileFinder::Instance().findRuns(
+                         "MUSR15189-15193", incorrect_extension),
+                     Exception::NotFoundError);
   }
 
   void testFindAddFiles() {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -404,13 +404,13 @@ public:
 
     // This file is .nxs or .RAW
     // returns a .nxs if no extensions passed in
-    const std::vector<std::string> extensions = {".a", ".txt", ".RAW"};
+    const std::vector<std::string> extensions = {".a", ".txt", ".nxs"};
     path = FileFinder::Instance().findRun("MUSR15189", extensions, true);
     std::string actualExtension = "";
     if (!path.empty()) {
       actualExtension = path.substr(path.size() - 4, 4);
     }
-    TS_ASSERT_EQUALS(actualExtension, ".RAW");
+    TS_ASSERT_EQUALS(actualExtension, ".nxs");
   }
 
   void testFindAddFiles() {

--- a/Framework/API/test/FileFinderTest.h
+++ b/Framework/API/test/FileFinderTest.h
@@ -347,22 +347,6 @@ public:
     std::cout << "\n end of test \n";
   }
 
-  void testGetUniqueExtensions() {
-    std::set<std::string> uniqueExts;
-    std::vector<std::string> firstExtsToAdd = {".RAW", ".log"};
-    std::vector<std::string> secondExtsToAdd = {".so", ".txt", ".RAW"};
-
-    std::set<std::string> expectedFirstExtensions = {".RAW", ".log"};
-    std::set<std::string> expectedSecondExtensions = {".RAW", ".log", ".so",
-                                                      ".txt"};
-
-    FileFinder::Instance().getUniqueExtensions(firstExtsToAdd, uniqueExts);
-    TS_ASSERT_EQUALS(uniqueExts, expectedFirstExtensions);
-
-    FileFinder::Instance().getUniqueExtensions(secondExtsToAdd, uniqueExts);
-    TS_ASSERT_EQUALS(uniqueExts, expectedSecondExtensions);
-  }
-
   void testFindAddFiles() {
     // create a test file to find
     Poco::File file("LOQ00111-add.raw");

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -38,7 +38,8 @@ GNU_DIAG_ON("unused-local-typedef")
 std::vector<std::string> runFinderProxy(FileFinderImpl &self,
                                         std::string hintstr,
                                         list exts_list) {
-  std::vector<std::string> exts;  // Convert python list to c++ vector
+  // Convert python list to c++ vector
+  std::vector<std::string> exts;
   for (int i = 0; i < len(exts_list); ++i)
     exts.push_back(extract<std::string>(exts_list[i]));
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -35,12 +35,12 @@ GNU_DIAG_ON("unused-local-typedef")
  * to search for
  * @param exts_list :: A python list containing strings of file extensions to
  * search
- * @param overwriteExts :: bool. If true, use exts_list only. If false, use
+ * @param useExtsOnly :: bool. If true, use exts_list only. If false, use
  * combination of exts_list and facility_exts.
  */
 std::vector<std::string> runFinderProxy(FileFinderImpl &self,
                                         std::string hintstr, list exts_list,
-                                        const bool overwriteExts) {
+                                        const bool useExtsOnly) {
   // Convert python list to c++ vector
   std::vector<std::string> exts;
   for (int i = 0; i < len(exts_list); ++i)
@@ -52,7 +52,7 @@ std::vector<std::string> runFinderProxy(FileFinderImpl &self,
   //   ReleaseGlobalInterpreter does this for us
   Mantid::PythonInterface::ReleaseGlobalInterpreterLock
       releaseGlobalInterpreterLock;
-  return self.findRuns(hintstr, exts, overwriteExts);
+  return self.findRuns(hintstr, exts, useExtsOnly);
 }
 
 void export_FileFinder() {
@@ -65,14 +65,14 @@ void export_FileFinder() {
                "ignoreDirs=True. An empty string is returned otherwise."))
       .def("findRuns", &runFinderProxy,
            (arg("self"), arg("hintstr"), arg("exts_list") = list(),
-            arg("overwriteExts") = false),
+            arg("useExtsOnly") = false),
            "Find a list of files file given a hint. "
            "The hint can be a comma separated list of run numbers and can also "
            "include ranges of runs, e.g. 123-135 or equivalently 123-35"
            "If no instrument prefix is given then the current default is used."
            "exts_list is an optional list containing strings of file "
            "extensions to search."
-           "overwriteExts is an optional bool. If it's true then don't use "
+           "useExtsOnly is an optional bool. If it's true then don't use "
            "facility exts.")
       .def("getCaseSensitive", &FileFinderImpl::getCaseSensitive, (arg("self")),
            "Option to get if file finder should be case sensitive.")

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -33,11 +33,14 @@ GNU_DIAG_ON("unused-local-typedef")
  * @param self :: A reference to the calling object
  * @param hintstr :: A string containing the run number and possibly instrument
  * to search for
- * @param exts_list :: A python list containing strings of file extensions to search
+ * @param exts_list :: A python list containing strings of file extensions to
+ * search
+ * @param overwriteExts :: bool. If true, use exts_list only. If false, use
+ * combination of exts_list and facility_exts.
  */
 std::vector<std::string> runFinderProxy(FileFinderImpl &self,
-                                        std::string hintstr,
-                                        list exts_list) {
+                                        std::string hintstr, list exts_list,
+                                        const bool overwriteExts) {
   // Convert python list to c++ vector
   std::vector<std::string> exts;
   for (int i = 0; i < len(exts_list); ++i)
@@ -49,7 +52,7 @@ std::vector<std::string> runFinderProxy(FileFinderImpl &self,
   //   ReleaseGlobalInterpreter does this for us
   Mantid::PythonInterface::ReleaseGlobalInterpreterLock
       releaseGlobalInterpreterLock;
-  return self.findRuns(hintstr, exts);
+  return self.findRuns(hintstr, exts, overwriteExts);
 }
 
 void export_FileFinder() {
@@ -60,12 +63,17 @@ void export_FileFinder() {
                "Return a full path to the given file if it can be found within "
                "datasearch.directories paths. Directories can be ignored with "
                "ignoreDirs=True. An empty string is returned otherwise."))
-      .def("findRuns", &runFinderProxy, (arg("self"), arg("hintstr"), arg("exts_list")=list()),
+      .def("findRuns", &runFinderProxy,
+           (arg("self"), arg("hintstr"), arg("exts_list") = list(),
+            arg("overwriteExts") = false),
            "Find a list of files file given a hint. "
            "The hint can be a comma separated list of run numbers and can also "
            "include ranges of runs, e.g. 123-135 or equivalently 123-35"
            "If no instrument prefix is given then the current default is used."
-           "exts_list is an optional list containing strings of file extensions to search.")
+           "exts_list is an optional list containing strings of file "
+           "extensions to search."
+           "overwriteExts is an optional bool. If it's true then don't use "
+           "facility exts.")
       .def("getCaseSensitive", &FileFinderImpl::getCaseSensitive, (arg("self")),
            "Option to get if file finder should be case sensitive.")
       .def("setCaseSensitive", &FileFinderImpl::setCaseSensitive,

--- a/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
@@ -26,12 +26,14 @@ class FileFinderTest(unittest.TestCase):
         # We can't be sure what the full path is in general but it should certainly exist!
         self.assertTrue(os.path.exists(runs[0]))
 
-    def test_that_find_runs_accepts_a_list_of_strings(self):
+    def test_that_find_runs_accepts_a_list_of_string_and_a_bool(self):
         try:
-            runs = FileFinder.findRuns("CNCS7860", [".nxs", ".txt"])
+            runs = FileFinder.findRuns("CNCS7860", overwriteExts=True)
+            FileFinder.findRuns("CNCS7860", [".nxs", ".txt"], overwriteExts=True)
         except Exception as e:
-            self.assertFalse(True, "Expected findRuns to accept list of strings as input. {} error was raised "
-                                    "with message {}".format(type(e).__name__, str(e)))
+            if type(e).__name__ == "ArgumentError":
+                self.assertFalse(True, "Expected findRuns to accept a list of strings and a bool as input."
+                                       " {} error was raised with message {}".format(type(e).__name__, str(e)))
         else:
             # Confirm that it works as above
             self.assertTrue(len(runs) == 1)

--- a/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
@@ -28,8 +28,8 @@ class FileFinderTest(unittest.TestCase):
 
     def test_that_find_runs_accepts_a_list_of_string_and_a_bool(self):
         try:
-            runs = FileFinder.findRuns("CNCS7860", overwriteExts=True)
-            FileFinder.findRuns("CNCS7860", [".nxs", ".txt"], overwriteExts=True)
+            runs = FileFinder.findRuns("CNCS7860", useExtsOnly=True)
+            FileFinder.findRuns("CNCS7860", [".nxs", ".txt"], useExtsOnly=True)
         except Exception as e:
             if type(e).__name__ == "ArgumentError":
                 self.assertFalse(True, "Expected findRuns to accept a list of strings and a bool as input."

--- a/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/FileFinderTest.py
@@ -6,9 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 
-import unittest
-from mantid.api import FileFinder
 import os
+import unittest
+
+from mantid.api import FileFinder
+
 
 class FileFinderTest(unittest.TestCase):
 
@@ -24,4 +26,17 @@ class FileFinderTest(unittest.TestCase):
         # We can't be sure what the full path is in general but it should certainly exist!
         self.assertTrue(os.path.exists(runs[0]))
 
-if __name__ == '__main__': unittest.main()
+    def test_that_find_runs_accepts_a_list_of_strings(self):
+        try:
+            runs = FileFinder.findRuns("CNCS7860", [".nxs", ".txt"])
+        except Exception as e:
+            self.assertFalse(True, "Expected findRuns to accept list of strings as input. {} error was raised "
+                                    "with message {}".format(type(e).__name__, str(e)))
+        else:
+            # Confirm that it works as above
+            self.assertTrue(len(runs) == 1)
+            self.assertTrue(os.path.exists(runs[0]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -132,6 +132,7 @@ New
    UsageService.setApplicationName('myapp')
    FrameworkManager.Instance()
 
+- `FileFinder.findRuns` now optionally accepts a list of file extensions to search, called **exts**, and an boolean flag **useExtsOnly**. If this flag is True, FileFinder will search for the passed in extensions ONLY. If it is False, it will search for passed in extensions and then facility extensions.
 
 Improvements
 ############


### PR DESCRIPTION
**Description of work.**
Provides `FileFinder::findRuns` with optional parameters of a vector of file extensions to search for, and a bool. If this bool is true then search for provided extensions ONLY. If this bool is false search for provided extensions in addition to facility extensions. (default is false).

This is exposed to Python. 

**Report to:** @Mantid-Matthew 

**To test:**


Fixes #21231 


*This does not require release notes* because **internal**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
