### PR TITLE
Fix failing system test: IRISIqtAndIqtFitTest

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectInelastic.py
@@ -85,6 +85,11 @@ import platform
 from six import with_metaclass
 
 
+def currentOSHasGSLv2():
+    """ Check whether the current OS should be running GSLv2 """
+    return platform.linux_distribution()[0] == "ubuntu" or platform.mac_ver()[0] != ''
+
+
 class ISISIndirectInelasticBase(with_metaclass(ABCMeta, systemtesting.MantidSystemTest)):
     '''
     A common base class for the ISISIndirectInelastic* base classes.
@@ -857,7 +862,7 @@ class IRISIqtAndIqtFit(ISISIndirectInelasticIqtAndIqtFit):
         ref_files = ['II.IRISFury.nxs']
         # gsl v2 gives a slightly different result than v1
         # we could do with a better check than this
-        if platform.linux_distribution()[0] == "Ubuntu":
+        if currentOSHasGSLv2():
             ref_files += ['II.IRISFuryFitSeq_gslv2.nxs']
         else:
             ref_files += ['II.IRISFuryFitSeq_gslv1.nxs']


### PR DESCRIPTION

**Description of work.**
This test was broken when the build servers moved from GSL v1 to v2.

This test has a different tolerance for the fit depending on the GSL
library used. As OSX is now on v2, the test needed to be changed to
match the corresponding library tolerance.

**To test:**

 - Check the system tests now pass for all operating systems.

*There is no associated issue.*

*This does not require release notes* because it is only a change to fix the system tests.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
