### PR TITLE
Fix fit browser workspace index bug

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -536,6 +536,8 @@ private:
   QString getStringPropertyValue(QtProperty *prop) const;
   /// Check that the properties match the function
   void checkFunction();
+  /// Return the nearest allowed workspace index.
+  int getAllowedIndex(int currentIndex) const;
 
   void setCurrentFunction(Mantid::API::IFunction_const_sptr f) const;
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -111,7 +111,7 @@ FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject *mantidui)
           Mantid::Kernel::ConfigService::Instance().getString(
               "curvefitting.autoBackground"))),
       m_autoBackground(nullptr), m_decimals(-1), m_mantidui(mantidui),
-      m_shouldBeNormalised(false), m_oldWorkspaceIndex(0) {
+      m_shouldBeNormalised(false), m_oldWorkspaceIndex(-1) {
   Mantid::API::FrameworkManager::Instance().loadPlugins();
 
   // Try to create a Gaussian. Failing will mean that CurveFitting dll is not
@@ -1158,7 +1158,7 @@ void FitPropertyBrowser::setWorkspaceName(const QString &wsName) {
       }
     }
   }
-  setWorkspaceIndex(-1);
+  setWorkspaceIndex(0);
 }
 
 /// Get workspace index
@@ -1375,7 +1375,7 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
       setWorkspaceIndex(allowedIndex);
       emit workspaceIndexChanged(allowedIndex);
     }
-    m_oldWorkspaceIndex = currentIndex;
+    m_oldWorkspaceIndex = allowedIndex;
   } else if (prop->propertyName() == "Workspace Index") {
     PropertyHandler *h = getHandler()->findHandler(prop);
     if (!h)
@@ -1766,7 +1766,7 @@ void FitPropertyBrowser::populateWorkspaceNames() {
     }
   }
   m_enumManager->setEnumNames(m_workspace, m_workspaceNames);
-  setWorkspaceIndex(-1);
+  setWorkspaceIndex(0);
 }
 
 /**
@@ -2450,7 +2450,7 @@ int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {
   }
 
   if (currentIndex == m_oldWorkspaceIndex) {
-    return currentIndex;
+    return currentIndex < 0 ? 0 : currentIndex;
   }
 
   auto const allowedIndices =

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2454,14 +2454,13 @@ int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {
   }
 
   auto const allowedIndices =
-    m_allowedSpectra.empty()
-        ? QList<int>()
-        : m_allowedSpectra[QString::fromStdString(workspaceName())];
-  auto const firstIndex =
-      m_allowedSpectra.empty() ? 0 : allowedIndices.front();
+      m_allowedSpectra.empty()
+          ? QList<int>()
+          : m_allowedSpectra[QString::fromStdString(workspaceName())];
+  auto const firstIndex = m_allowedSpectra.empty() ? 0 : allowedIndices.front();
   auto const lastIndex = m_allowedSpectra.empty()
-                              ? getNumberOfSpectra(workspace) - 1
-                              : allowedIndices.back();
+                             ? getNumberOfSpectra(workspace) - 1
+                             : allowedIndices.back();
 
   auto allowedIndex = currentIndex;
   if (currentIndex < firstIndex) {
@@ -2469,7 +2468,7 @@ int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {
   } else if (currentIndex > lastIndex) {
     allowedIndex = lastIndex;
   } else if (!m_allowedSpectra.empty() &&
-              !allowedIndices.contains(currentIndex)) {
+             !allowedIndices.contains(currentIndex)) {
     allowedIndex = m_oldWorkspaceIndex;
     auto i = allowedIndices.indexOf(m_oldWorkspaceIndex);
     if (i >= 0) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2438,7 +2438,7 @@ Mantid::API::IFunction_const_sptr FitPropertyBrowser::theFunction() const {
 void FitPropertyBrowser::checkFunction() {}
 
 /**
- * If the current wrkspace index is set to a disallowed value this fuunction
+ * If the current workspace index is set to a disallowed value this function
  * returns the nearest allowed index. Otherwise the current index is returned.
  */
 int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {


### PR DESCRIPTION
**Description of work.**
Set checks ensuring that workspace index cannot be < 0.

**To test:**
1. Indirect->Data Analysis->ConvFit tab
2. Load data
3. Select TeixeiraWater as the fit function
4. Look at the TeixeiraWater parameters. The Q Value and workspaceIndex are very large. The Q value should be around 0.4.

Fixes #24457 

*This does not require release notes* because the bug is fresh and wasn't in any release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
