### PR TITLE
Do not double declare properties

### DIFF
--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -545,10 +545,12 @@ void FilterEvents::groupOutputWorkspace() {
   }
 
   // set the group workspace as output workspace
-  declareProperty(
-      make_unique<WorkspaceProperty<WorkspaceGroup>>(
-          "OutputWorkspace", groupname, Direction::Output),
-      "Name of the workspace to be created as the output of grouping ");
+  if (!this->existsProperty("OutputWorkspace")) {
+    declareProperty(
+        make_unique<WorkspaceProperty<WorkspaceGroup>>(
+            "OutputWorkspace", groupname, Direction::Output),
+        "Name of the workspace to be created as the output of grouping ");
+  }
 
   AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
   API::WorkspaceGroup_sptr workspace_group =
@@ -1171,11 +1173,13 @@ void FilterEvents::createOutputWorkspaces() {
 
       // create these output properties
       if (!this->m_toGroupWS) {
-        declareProperty(
-            Kernel::make_unique<
-                API::WorkspaceProperty<DataObjects::EventWorkspace>>(
-                propertynamess.str(), wsname.str(), Direction::Output),
-            "Output");
+        if (!this->existsProperty(propertynamess.str())) {
+          declareProperty(
+              Kernel::make_unique<
+                  API::WorkspaceProperty<DataObjects::EventWorkspace>>(
+                  propertynamess.str(), wsname.str(), Direction::Output),
+              "Output");
+        }
         setProperty(propertynamess.str(), optws);
       }
 
@@ -1264,11 +1268,13 @@ void FilterEvents::createOutputWorkspacesMatrixCase() {
 
     // Set (property) to output workspace and set to ADS
     if (m_toGroupWS) {
-      declareProperty(
-          Kernel::make_unique<
-              API::WorkspaceProperty<DataObjects::EventWorkspace>>(
-              propertynamess.str(), wsname.str(), Direction::Output),
-          "Output");
+      if (!this->existsProperty(propertynamess.str())) {
+        declareProperty(
+            Kernel::make_unique<
+                API::WorkspaceProperty<DataObjects::EventWorkspace>>(
+                propertynamess.str(), wsname.str(), Direction::Output),
+            "Output");
+      }
       setProperty(propertynamess.str(), optws);
 
       g_log.debug() << "  Property Name = " << propertynamess.str() << "\n";
@@ -1355,11 +1361,13 @@ void FilterEvents::createOutputWorkspacesTableSplitterCase() {
       } else {
         propertynamess << "OutputWorkspace_" << wsgroup;
       }
-      declareProperty(
-          Kernel::make_unique<
-              API::WorkspaceProperty<DataObjects::EventWorkspace>>(
-              propertynamess.str(), wsname.str(), Direction::Output),
-          "Output");
+      if (!this->existsProperty(propertynamess.str())) {
+        declareProperty(
+            Kernel::make_unique<
+                API::WorkspaceProperty<DataObjects::EventWorkspace>>(
+                propertynamess.str(), wsname.str(), Direction::Output),
+            "Output");
+      }
       setProperty(propertynamess.str(), optws);
 
       g_log.debug() << "  Property Name = " << propertynamess.str() << "\n";


### PR DESCRIPTION
Since there are lots of output workspaces declared on the fly, make sure they are not declared before declaring. The main time this happens is when the "keep dialog open" box is checked in the algorithm dialog.

**To test:**

Follow the instructions described in the issue.

Fixes #24461

*This does not require release notes* because it is a bug only seen when "Keep Open" is checked.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
