### PR TITLE
Show error and stop CMake configuration if .NET 2 is not available

### DIFF
--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -166,7 +166,7 @@ if ( ENABLE_WORKBENCH AND PACKAGE_WORKBENCH )
     execute_process(COMMAND powershell.exe -version 2.0 -noprofile -windowstyle hidden -ExecutionPolicy Bypass ${THIRD_PARTY_DIR}/bin/ps2exe.ps1 -inputFile ${CMAKE_CURRENT_SOURCE_DIR}/buildconfig/CMake/Packaging/${_workbench_base_name}.ps1 -outputFile ${CMAKE_CURRENT_BINARY_DIR}/${_workbench_executable_install_name} -x64 -runtime2 -noconsole RESULT_VARIABLE _workbench_powershell_return_code OUTPUT_VARIABLE _workbench_powershell_output)
 
     # If the EXE generation failed then display an error and stop the CMAKE generation
-    if ( _workbench_powershell_return_code GREATER 0 )
+    if ( NOT _workbench_powershell_return_code EQUAL 0 )
       message(STATUS ${_workbench_powershell_output})
       message(FATAL_ERROR "Generating the Workbench executable encountered an error.")
     endif ()


### PR DESCRIPTION
**Description of work.**
Changes the check to require EXIT CODE to be 0. Turns out if .NET 2 is not available the return code is `-65536` and the previous check was `GREATER 0`, so it never showed an error, nor it created the executable.

I also want to discuss here whether to fallback (but really fall-forward) if .NET 2 is missing, and then run the same PS command but without the `-version 2.0` and `-runtime2` restrictions - meaning PS will use whatever version is available on the user's system (which is guaranteed to be >= 2).

The reason this was not done before: the Nightly targets the lowest possible common version between Windows 7 and 10.

**To test:**

`ENABLE_CPACK` must be enabled - otherwise the attempt to generate the executable is never run.

Configure Mantid on Windows with .NET disabled. When `launch_workbench` is being created an error will be shown that stops the configuration.

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
