### PR TITLE
Add Ctrl+Enter shortcut to execute code in the CodeEditor

### DIFF
--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -9,6 +9,7 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 
+# system imports
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
@@ -18,7 +19,6 @@ from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInte
 # local package imports
 from workbench.plugins.base import PluginWidget
 
-# system imports
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
@@ -53,9 +53,8 @@ class MultiFileEditor(PluginWidget):
         # attributes
         self.run_action = create_action(self, "Run",
                                         on_triggered=self.editors.execute_current,
-                                        shortcut=["Ctrl+Return", "Ctrl+Enter"],
+                                        shortcut=("Ctrl+Return", "Ctrl+Enter"),
                                         shortcut_context=Qt.ApplicationShortcut)
-        # shortcut=["Ctrl+Return", "Ctrl+Enter"],
         self.abort_action = create_action(self, "Abort",
                                           on_triggered=self.editors.abort_current)
 

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -9,16 +9,16 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 
-# system imports
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QVBoxLayout
 
 # third-party library imports
 from mantidqt.utils.qt import add_actions, create_action
 from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import QVBoxLayout
-
 # local package imports
 from workbench.plugins.base import PluginWidget
+
+# system imports
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 
@@ -53,8 +53,9 @@ class MultiFileEditor(PluginWidget):
         # attributes
         self.run_action = create_action(self, "Run",
                                         on_triggered=self.editors.execute_current,
-                                        shortcut="Ctrl+Return",
+                                        shortcut=["Ctrl+Return", "Ctrl+Enter"],
                                         shortcut_context=Qt.ApplicationShortcut)
+        # shortcut=["Ctrl+Return", "Ctrl+Enter"],
         self.abort_action = create_action(self, "Abort",
                                           on_triggered=self.editors.abort_current)
 

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -11,8 +11,8 @@
 """
 from __future__ import absolute_import
 
-import os.path as osp
 # stdlib modules
+import os.path as osp
 from contextlib import contextmanager
 from importlib import import_module
 
@@ -22,7 +22,6 @@ from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import QAction, QMenu
 from qtpy.uic import loadUi, loadUiType
 
-# local modules
 from ...icons import get_icon
 
 LIB_SUFFIX = 'qt' + QT_VERSION[0]
@@ -131,7 +130,7 @@ def create_action(parent, text, on_triggered=None, shortcut=None,
     if on_triggered is not None:
         action.triggered.connect(on_triggered)
     if shortcut is not None:
-        if isinstance(shortcut, list):
+        if isinstance(shortcut, tuple) or isinstance(shortcut, list):
             qshortcuts = [QKeySequence(s) for s in shortcut]
             action.setShortcuts(qshortcuts)
         else:

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -11,15 +11,16 @@
 """
 from __future__ import absolute_import
 
+import os.path as osp
 # stdlib modules
 from contextlib import contextmanager
 from importlib import import_module
-import os.path as osp
 
 # 3rd-party modules
 from qtpy import QT_VERSION
-from qtpy.uic import loadUi, loadUiType
+from qtpy.QtGui import QKeySequence
 from qtpy.QtWidgets import QAction, QMenu
+from qtpy.uic import loadUi, loadUiType
 
 # local modules
 from ...icons import get_icon
@@ -130,7 +131,12 @@ def create_action(parent, text, on_triggered=None, shortcut=None,
     if on_triggered is not None:
         action.triggered.connect(on_triggered)
     if shortcut is not None:
-        action.setShortcut(shortcut)
+        if isinstance(shortcut, list):
+            qshortcuts = [QKeySequence(s) for s in shortcut]
+            action.setShortcuts(qshortcuts)
+        else:
+            action.setShortcut(shortcut)
+
         if shortcut_context is not None:
             action.setShortcutContext(shortcut_context)
     if icon_name is not None:

--- a/qt/python/mantidqt/utils/test/test_qt_utils.py
+++ b/qt/python/mantidqt/utils/test/test_qt_utils.py
@@ -14,8 +14,10 @@ import unittest
 
 from qtpy.QtCore import QObject, Qt, Slot
 from qtpy.QtWidgets import QAction, QMenu, QToolBar
+
 try:
     from qtpy.QtCore import SIGNAL
+
     NEW_STYLE_SIGNAL = False
 except ImportError:
     NEW_STYLE_SIGNAL = True
@@ -29,6 +31,7 @@ class CreateActionTest(GuiTest):
     def test_parent_and_name_only_required(self):
         class Parent(QObject):
             pass
+
         parent = Parent()
         action = create_action(parent, "Test Action")
         self.assertTrue(isinstance(action, QAction))
@@ -44,6 +47,7 @@ class CreateActionTest(GuiTest):
             @Slot()
             def test_slot(self):
                 pass
+
         recv = Receiver()
         action = create_action(None, "Test Action", on_triggered=recv.test_slot)
         if NEW_STYLE_SIGNAL:
@@ -54,6 +58,12 @@ class CreateActionTest(GuiTest):
     def test_shortcut_is_set_if_given(self):
         action = create_action(None, "Test Action", shortcut="Ctrl+S")
         self.assertEqual("Ctrl+S", action.shortcut())
+
+    def test_multiple_shortcuts_are_set_if_given(self):
+        expected_shortcuts = ["Ctrl+S", "Ctrl+W"]
+        action = create_action(None, "Test Action", shortcut=expected_shortcuts)
+        for expected, actual in zip(expected_shortcuts, action.shortcuts()):
+            self.assertEqual(expected, actual.toString())
 
     def test_shortcut_context_used_if_shortcut_given(self):
         action = create_action(None, "Test Action", shortcut="Ctrl+S",

--- a/qt/python/mantidqt/utils/test/test_qt_utils.py
+++ b/qt/python/mantidqt/utils/test/test_qt_utils.py
@@ -60,7 +60,7 @@ class CreateActionTest(GuiTest):
         self.assertEqual("Ctrl+S", action.shortcut())
 
     def test_multiple_shortcuts_are_set_if_given(self):
-        expected_shortcuts = ["Ctrl+S", "Ctrl+W"]
+        expected_shortcuts = ("Ctrl+S", "Ctrl+W")
         action = create_action(None, "Test Action", shortcut=expected_shortcuts)
         for expected, actual in zip(expected_shortcuts, action.shortcuts()):
             self.assertEqual(expected, actual.toString())


### PR DESCRIPTION
**Description of work**
This brings it in line with the behaviour in MantidPlot - Ctrl + Return (big enter) and Ctrl + Enter (Enter in Numpad keys) both run the code.

Behaviour of the run should be unchanged, i.e. both shortcuts will run the selection if there is one, otherwise execute all code.

**To test:**
Run the Code Editor using Ctrl + Return (big Enter), and Ctrl + Enter (numpad Enter)

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
