### PR TITLE
Cleanup Histogram usage

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/RadiusSum.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RadiusSum.h
@@ -62,7 +62,7 @@ private:
   double getMaxDistance(const Kernel::V3D &centre,
                         const std::vector<double> &boundary_limits);
 
-  void setUpOutputWorkspace(std::vector<double> &values);
+  void setUpOutputWorkspace(const std::vector<double> &values);
 
   int getBinForPixelPos(const Kernel::V3D &pos);
 

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -331,7 +331,7 @@ void ConjoinXRuns::joinSpectrum(int64_t wsIndex) {
     }
   }
   if (!xerrors.empty())
-    m_outWS->setPointStandardDeviations(index, xerrors);
+    m_outWS->setPointStandardDeviations(index, std::move(xerrors));
   m_outWS->mutableY(index) = std::move(spectrum);
   m_outWS->mutableE(index) = std::move(errors);
   m_outWS->mutableX(index) = std::move(axis);

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -153,7 +153,9 @@ std::map<std::string, std::string> ConjoinXRuns::validateInputs() {
       issues[INPUT_WORKSPACE_PROPERTY] +=
           "Workspace " + ws->getName() + " is not a point-data\n";
     } else {
-      if (!ws->isCommonBins()) {
+      try {
+        ws->blocksize();
+      } catch (std::length_error &) {
         issues[INPUT_WORKSPACE_PROPERTY] +=
             "Workspace " + ws->getName() +
             " has different number of points per histogram\n";

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -333,9 +333,9 @@ void ConjoinXRuns::joinSpectrum(int64_t wsIndex) {
   }
   if (!xerrors.empty())
     m_outWS->setPointStandardDeviations(index, xerrors);
-  m_outWS->mutableY(index) = spectrum;
-  m_outWS->mutableE(index) = errors;
-  m_outWS->mutableX(index) = axis;
+  m_outWS->mutableY(index) = std::move(spectrum);
+  m_outWS->mutableE(index) = std::move(errors);
+  m_outWS->mutableX(index) = std::move(axis);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -175,12 +175,14 @@ void CrossCorrelate::exec() {
   // Now copy the other spectra
   bool is_distrib = inputWS->isDistribution();
 
-  std::vector<double> XX(npoints);
-  for (int i = 0; i < npoints; ++i) {
-    XX[i] = static_cast<double>(i - nY + 2);
+  {
+    std::vector<double> XX(npoints);
+    for (int i = 0; i < npoints; ++i) {
+      XX[i] = static_cast<double>(i - nY + 2);
+    }
+    out->mutableX(0) = std::move(XX);
   }
   // Initialise the progress reporting object
-  out->mutableX(0) = XX;
   m_progress = make_unique<Progress>(this, 0.0, 1.0, nspecs);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *out))
   for (int i = 0; i < nspecs; ++i) // Now loop on all spectra

--- a/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
@@ -215,8 +215,8 @@ void DetectorEfficiencyCor::correctForEfficiency(
   auto &yout = m_outputWS->mutableY(spectraIn);
   auto &eout = m_outputWS->mutableE(spectraIn);
   // Need the original values so this is not a reference
-  auto yValues = m_inputWS->y(spectraIn);
-  auto eValues = m_inputWS->e(spectraIn);
+  const auto yValues = m_inputWS->y(spectraIn);
+  const auto eValues = m_inputWS->e(spectraIn);
 
   // Storage for the reciprocal wave vectors that are calculated as the
   // correction proceeds

--- a/Framework/Algorithms/src/FitPeak.cpp
+++ b/Framework/Algorithms/src/FitPeak.cpp
@@ -501,7 +501,7 @@ void FitOneSinglePeak::highBkgdFit() {
     size_t numpts = i_maxFitX - i_minFitX;
     size_t shift = static_cast<size_t>(static_cast<double>(numpts) / 6.);
     i_minPeakX += shift;
-    auto Xdata = m_dataWS->x(m_wsIndex);
+    const auto &Xdata = m_dataWS->x(m_wsIndex);
     if (i_minPeakX >= Xdata.size())
       i_minPeakX = Xdata.size() - 1;
     m_minPeakX = Xdata[i_minPeakX];

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -2011,17 +2011,8 @@ void FitPeaks::generateCalculatedPeaksWS() {
     return;
   }
 
-  // create a wokspace with same number of input matrix workspace
+  // create a wokspace with same size as in the input matrix workspace
   m_fittedPeakWS = create<Workspace2D>(*m_inputMatrixWS);
-  for (size_t iws = 0; iws < m_fittedPeakWS->getNumberHistograms(); ++iws) {
-    auto &out_vecx = m_fittedPeakWS->mutableX(iws);
-    const auto &in_vecx = m_inputMatrixWS->x(iws);
-    for (size_t j = 0; j < out_vecx.size(); ++j) {
-      out_vecx[j] = in_vecx[j];
-    }
-  }
-
-  return;
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -708,16 +708,17 @@ void FitPeaks::processInputFitRanges() {
               << " with the number of peaks " << m_numPeaksToFit << " to fit.";
         throw std::invalid_argument(errss.str());
       }
+      const auto &peakWindowX = m_peakWindowWorkspace->x(wi);
 
       // check window range against peak center
       size_t window_index = window_index_start + wi;
       size_t center_index = window_index - center_index_start;
+      const auto &peakCenterX = m_peakCenterWorkspace->x(center_index);
 
       for (size_t ipeak = 0; ipeak < m_numPeaksToFit; ++ipeak) {
-        double left_w_bound =
-            m_peakWindowWorkspace->x(wi)[ipeak * 2]; // TODO getting on y
-        double right_w_bound = m_peakWindowWorkspace->x(wi)[ipeak * 2 + 1];
-        double center = m_peakCenterWorkspace->x(center_index)[ipeak];
+        double left_w_bound = peakWindowX[ipeak * 2]; // TODO getting on y
+        double right_w_bound = peakWindowX[ipeak * 2 + 1];
+        double center = peakCenterX[ipeak];
         if (!(left_w_bound < center && center < right_w_bound)) {
           std::stringstream errss;
           errss << "Workspace index " << wi
@@ -1289,7 +1290,7 @@ void FitPeaks::calculateFittedPeaks(
 
       // use domain and function to calcualte
       // get the range of start and stop to construct a function domain
-      auto vec_x = m_fittedPeakWS->x(static_cast<size_t>(iws));
+      const auto &vec_x = m_fittedPeakWS->x(static_cast<size_t>(iws));
       std::pair<double, double> peakwindow =
           getPeakFitWindow(static_cast<size_t>(iws), ipeak);
       std::vector<double>::const_iterator start_x_iter =
@@ -2013,10 +2014,10 @@ void FitPeaks::generateCalculatedPeaksWS() {
   // create a wokspace with same number of input matrix workspace
   m_fittedPeakWS = create<Workspace2D>(*m_inputMatrixWS);
   for (size_t iws = 0; iws < m_fittedPeakWS->getNumberHistograms(); ++iws) {
-    auto out_vecx = m_fittedPeakWS->histogram(iws).x();
-    auto in_vecx = m_inputMatrixWS->histogram(iws).x();
+    auto &out_vecx = m_fittedPeakWS->mutableX(iws);
+    const auto &in_vecx = m_inputMatrixWS->x(iws);
     for (size_t j = 0; j < out_vecx.size(); ++j) {
-      m_fittedPeakWS->dataX(iws)[j] = in_vecx[j];
+      out_vecx[j] = in_vecx[j];
     }
   }
 

--- a/Framework/Algorithms/src/Qhelper.cpp
+++ b/Framework/Algorithms/src/Qhelper.cpp
@@ -174,7 +174,7 @@ size_t Qhelper::waveLengthCutOff(API::MatrixWorkspace_const_sptr dataWS,
   R = std::sqrt(R);
 
   const double WMin = l_WCutOver * (l_RCut - R);
-  auto Xs = dataWS->x(wsInd);
+  const auto &Xs = dataWS->x(wsInd);
   return std::lower_bound(Xs.begin(), Xs.end(), WMin) - Xs.begin();
 }
 

--- a/Framework/Algorithms/src/RadiusSum.cpp
+++ b/Framework/Algorithms/src/RadiusSum.cpp
@@ -603,7 +603,7 @@ double RadiusSum::getMaxDistance(const V3D &centre,
   return max_distance;
 }
 
-void RadiusSum::setUpOutputWorkspace(std::vector<double> &values) {
+void RadiusSum::setUpOutputWorkspace(const std::vector<double> &values) {
 
   g_log.debug() << "Output calculated, setting up the output workspace\n";
 

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -837,7 +837,7 @@ double ReflectometryReductionOne2::findIvsLamRangeMin(
   const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
 
   // For bLambda, use the average bin size for this spectrum
-  auto xValues = detectorWS->x(spIdx);
+  const auto &xValues = detectorWS->x(spIdx);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
                    static_cast<int>(xValues.size());
   double dummy = 0.0;
@@ -856,7 +856,7 @@ double ReflectometryReductionOne2::findIvsLamRangeMax(
   const double bTwoTheta = getDetectorTwoThetaRange(spIdx);
 
   // For bLambda, use the average bin size for this spectrum
-  auto xValues = detectorWS->x(spIdx);
+  const auto &xValues = detectorWS->x(spIdx);
   double bLambda = (xValues[xValues.size() - 1] - xValues[0]) /
                    static_cast<int>(xValues.size());
 

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -469,7 +469,7 @@ bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr &ws) {
     PARALLEL_START_INTERUPT_REGION
     if (!hasNonZeroErrors) // Keep checking
     {
-      auto e = ws->e(i);
+      const auto &e = ws->e(i);
       auto it = std::find_if(e.begin(), e.end(), isNonzero);
       if (it != e.end()) {
         PARALLEL_CRITICAL(has_non_zero) {

--- a/Framework/Algorithms/src/StripVanadiumPeaks.cpp
+++ b/Framework/Algorithms/src/StripVanadiumPeaks.cpp
@@ -176,8 +176,6 @@ void StripVanadiumPeaks::exec() {
         }
       }
 
-      // Save the output
-      outputWS->mutableY(k) = outY;
     } // if the spectrum is to be changed.
     progress.report();
   } // each spectrum

--- a/Framework/Algorithms/test/CalculateIqtTest.h
+++ b/Framework/Algorithms/test/CalculateIqtTest.h
@@ -110,8 +110,8 @@ public:
     algorithm->execute();
     MatrixWorkspace_sptr outWorkspace =
         algorithm->getProperty("OutputWorkspace");
-    auto yValues = outWorkspace->y(0);
-    auto eValues = outWorkspace->e(0);
+    const auto &yValues = outWorkspace->y(0);
+    const auto &eValues = outWorkspace->e(0);
     TS_ASSERT_DELTA(yValues[0], 1, 0.0001);
     TS_ASSERT_DELTA(yValues[1], 0, 0.0001);
     TS_ASSERT_DELTA(yValues[4], 0.4831171, 0.0001);

--- a/Framework/Algorithms/test/GeneralisedSecondDifferenceTest.h
+++ b/Framework/Algorithms/test/GeneralisedSecondDifferenceTest.h
@@ -60,11 +60,11 @@ public:
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 1);
     TS_ASSERT_EQUALS(outWs->blocksize(), 4);
 
-    auto x1 = outWs->x(0);
+    const auto &x1 = outWs->x(0);
     TS_ASSERT_EQUALS(x1[0], 3);
     TS_ASSERT_EQUALS(x1[3], 6);
 
-    auto y1 = outWs->y(0);
+    const auto &y1 = outWs->y(0);
     TS_ASSERT_DELTA(y1[1], -7.0300, 0.0001);
     TS_ASSERT_DELTA(y1[2], -20.0000, 0.0001);
 

--- a/Framework/Algorithms/test/GeneratePeaksTest.h
+++ b/Framework/Algorithms/test/GeneratePeaksTest.h
@@ -237,8 +237,8 @@ public:
     TS_ASSERT_EQUALS(peaksws->getNumberHistograms(), 2);
 
     // peak 0:
-    auto p0_x = peaksws->x(0);
-    auto p0_y = peaksws->y(0);
+    const auto &p0_x = peaksws->x(0);
+    const auto &p0_y = peaksws->y(0);
     TS_ASSERT_DELTA(p0_x[200], 2.0, 1.0E-8);
     TS_ASSERT_DELTA(p0_y[200], 5.0, 1.0E-4);
 
@@ -250,8 +250,8 @@ public:
     TS_ASSERT_DELTA(p0_y[800], 10.0, 1.0E-4);
 
     // peak 2:
-    auto p1_x = peaksws->x(1);
-    auto p1_y = peaksws->y(1);
+    const auto &p1_x = peaksws->x(1);
+    const auto &p1_y = peaksws->y(1);
     TS_ASSERT_DELTA(p1_x[400], 4.0, 1.0E-8);
     TS_ASSERT_DELTA(p1_y[400], 20.0, 1.0E-4);
 
@@ -311,8 +311,8 @@ public:
     TS_ASSERT_EQUALS(peaksws->getNumberHistograms(), 5);
 
     // Peak 0:
-    auto p0_x = peaksws->x(0);
-    auto p0_y = peaksws->y(0);
+    const auto &p0_x = peaksws->x(0);
+    const auto &p0_y = peaksws->y(0);
     TS_ASSERT_DELTA(p0_x[50], 2.0, 1.0E-8);
     TS_ASSERT_DELTA(p0_y[50], 5.0, 1.0E-4);
 
@@ -324,8 +324,8 @@ public:
     TS_ASSERT_DELTA(p0_y[350], 10.0, 1.0E-4);
 
     // Peak 2:
-    auto p1_x = peaksws->x(2);
-    auto p1_y = peaksws->y(2);
+    const auto &p1_x = peaksws->x(2);
+    const auto &p1_y = peaksws->y(2);
     TS_ASSERT_DELTA(p1_x[150], 4.0, 1.0E-8);
     TS_ASSERT_DELTA(p1_y[150], 20.0, 1.0E-4);
 
@@ -385,8 +385,8 @@ public:
     TS_ASSERT_EQUALS(peaksws->getNumberHistograms(), 2);
 
     // peak 0:
-    auto p0_x = peaksws->x(0);
-    auto p0_y = peaksws->y(0);
+    const auto &p0_x = peaksws->x(0);
+    const auto &p0_y = peaksws->y(0);
     TS_ASSERT_DELTA(p0_x[200], 2.0, 1.0E-8);
     TS_ASSERT_DELTA(p0_y[200], 10.0, 1.0E-4);
 
@@ -395,8 +395,8 @@ public:
     TS_ASSERT_DELTA(p0_y[800], 20.0, 1.0E-4);
 
     // peak 2:
-    auto p1_x = peaksws->x(1);
-    auto p1_y = peaksws->y(1);
+    const auto &p1_x = peaksws->x(1);
+    const auto &p1_y = peaksws->y(1);
     TS_ASSERT_DELTA(p1_x[400], 4.0, 1.0E-8);
     TS_ASSERT_DELTA(p1_y[400], 24.0, 1.0E-4);
 
@@ -455,8 +455,8 @@ public:
     TS_ASSERT_EQUALS(peaksws->getNumberHistograms(), 1);
 
     // peak 0:
-    auto p0_x = peaksws->x(0);
-    auto p0_y = peaksws->y(0);
+    const auto &p0_x = peaksws->x(0);
+    const auto &p0_y = peaksws->y(0);
     TS_ASSERT_DELTA(p0_x[200], 2.0, 1.0E-8);
     TS_ASSERT_DELTA(p0_y[200], 5.0, 1.0E-4);
 
@@ -514,8 +514,8 @@ public:
     TS_ASSERT_EQUALS(peaksws->getNumberHistograms(), 1);
 
     // peak 0:
-    auto p0_x = peaksws->x(0);
-    auto p0_y = peaksws->y(0);
+    const auto &p0_x = peaksws->x(0);
+    const auto &p0_y = peaksws->y(0);
     TS_ASSERT_DELTA(p0_x[200], 2.0, 1.0E-8);
     TS_ASSERT_DELTA(p0_y[200], 5.0, 1.0E-4);
 

--- a/Framework/Algorithms/test/HyspecScharpfCorrectionTest.h
+++ b/Framework/Algorithms/test/HyspecScharpfCorrectionTest.h
@@ -53,7 +53,7 @@ public:
     TS_ASSERT(outputWS);
     auto histo = outputWS->histogram(0);
     auto x = histo.points();
-    auto y = histo.y();
+    const auto &y = histo.y();
     for (size_t i = 0; i < x.size(); ++i) {
       if (x[i] < 4) {
         TS_ASSERT_LESS_THAN(y[i], 0);

--- a/Framework/Algorithms/test/IntegrateEPPTest.h
+++ b/Framework/Algorithms/test/IntegrateEPPTest.h
@@ -58,8 +58,8 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), nHist)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     for (size_t i = 0; i < outputWS->getNumberHistograms(); ++i) {
-      const auto ys = outputWS->y(i);
-      const auto xs = outputWS->x(i);
+      const auto &ys = outputWS->y(i);
+      const auto &xs = outputWS->x(i);
       TS_ASSERT_EQUALS(ys[0], 2.0 * static_cast<double>(i))
       TS_ASSERT_EQUALS(xs[0], 2.5)
       TS_ASSERT_EQUALS(xs[1], 4.5)

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -121,9 +121,9 @@ public:
 
     auto outHisto = mscat.getCorrectedHisto();
 
-    auto tof = outHisto.x();
-    auto signal = outHisto.y();
-    auto error = outHisto.e();
+    const auto &tof = outHisto.x();
+    const auto &signal = outHisto.y();
+    const auto &error = outHisto.e();
 
     // Check some values
     const double delta(1e-06);
@@ -147,9 +147,9 @@ public:
     MayersSampleCorrectionStrategy mscat(corrPars, histo);
 
     const auto outHisto = mscat.getCorrectedHisto();
-    const auto tof = outHisto.x();
-    const auto signal = outHisto.y();
-    const auto error = outHisto.e();
+    const auto &tof = outHisto.x();
+    const auto &signal = outHisto.y();
+    const auto &error = outHisto.e();
 
     // Check some values
     // Check some values
@@ -174,9 +174,9 @@ public:
     MayersSampleCorrectionStrategy mscat(corrPars, histo);
 
     const auto outHisto = mscat.getCorrectedHisto();
-    const auto tof = outHisto.x();
-    const auto signal = outHisto.y();
-    const auto error = outHisto.e();
+    const auto &tof = outHisto.x();
+    const auto &signal = outHisto.y();
+    const auto &error = outHisto.e();
 
     // Check some values
     // Check some values

--- a/Framework/Algorithms/test/PDFFourierTransformTest.h
+++ b/Framework/Algorithms/test/PDFFourierTransformTest.h
@@ -121,8 +121,8 @@ public:
     DataObjects::Workspace2D_sptr pdfws =
         boost::dynamic_pointer_cast<DataObjects::Workspace2D>(
             API::AnalysisDataService::Instance().retrieve("PDFGofR"));
-    const auto R = pdfws->x(0);
-    const auto GofR = pdfws->y(0);
+    const auto &R = pdfws->x(0);
+    const auto &GofR = pdfws->y(0);
 
     TS_ASSERT_DELTA(R[0], 0.01, 0.0001);
     TS_ASSERT_DELTA(R[249], 2.5, 0.0001);
@@ -155,8 +155,8 @@ public:
     DataObjects::Workspace2D_sptr pdfws =
         boost::dynamic_pointer_cast<DataObjects::Workspace2D>(
             API::AnalysisDataService::Instance().retrieve("PDFGofR"));
-    const auto R = pdfws->x(0);
-    const auto GofR = pdfws->y(0);
+    const auto &R = pdfws->x(0);
+    const auto &GofR = pdfws->y(0);
 
     TS_ASSERT_DELTA(R[0], 0.01, 0.0001);
     TS_ASSERT_DELTA(R[249], 2.5, 0.0001);

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
@@ -1180,8 +1180,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.1, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0, 0.0001);
@@ -1205,8 +1205,8 @@ public:
 
     MatrixWorkspace_sptr outQbinned = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQbinned->x(0);
-    auto outY = outQbinned->y(0);
+    const auto &outX = outQbinned->x(0);
+    const auto &outY = outQbinned->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.1, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0, 0.0001);
@@ -1229,8 +1229,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.009, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0006, 0.0001);
@@ -1255,8 +1255,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.1, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0, 0.0001);
@@ -1280,8 +1280,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.009, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0021, 0.0001);
@@ -1306,8 +1306,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.1, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0, 0.0001);
@@ -1331,8 +1331,8 @@ public:
 
     MatrixWorkspace_sptr outQBin = alg.getProperty("OutputWorkspaceBinned");
 
-    auto outX = outQBin->x(0);
-    auto outY = outQBin->y(0);
+    const auto &outX = outQBin->x(0);
+    const auto &outY = outQBin->y(0);
 
     TS_ASSERT_DELTA(outX[0], 0.009, 0.0001);
     TS_ASSERT_DELTA(outY[0], 0.0021, 0.0001);

--- a/Framework/Algorithms/test/SassenaFFTTest.h
+++ b/Framework/Algorithms/test/SassenaFFTTest.h
@@ -245,19 +245,20 @@ private:
 
     const double dt = 0.01; // time unit, in picoseconds
     MantidVec xv;
+    xv.reserve(nbins);
     for (size_t i = 0; i < nbins; i++) {
       int j = -static_cast<int>(nbins / 2) + static_cast<int>(i);
-      xv.push_back(dt * static_cast<double>(j));
+      xv.emplace_back(dt * static_cast<double>(j));
     }
 
     double sigma;
     MantidVec yv(nbins);
     // each spectra is a gaussian of same Height but different stdev
     for (size_t i = 0; i < nspectra; i++) {
-      ws->dataX(i) = xv;
+      ws->mutableX(i) = xv;
       sigma = sigma0 / (1 + static_cast<double>(i));
       this->Gaussian(xv, yv, Heigth, sigma);
-      ws->dataY(i) = yv;
+      ws->mutableY(i) = yv;
     }
 
     API::AnalysisDataService::Instance().add(wsName, ws);

--- a/Framework/Algorithms/test/SetUncertaintiesTest.h
+++ b/Framework/Algorithms/test/SetUncertaintiesTest.h
@@ -90,7 +90,7 @@ public:
   void test_zero() {
     const auto outWS = runAlg("zero");
 
-    const auto E = outWS->e(0);
+    const auto &E = outWS->e(0);
     for (const auto item : E) {
       TS_ASSERT_EQUALS(item, 0.);
     }
@@ -101,8 +101,8 @@ public:
   void test_sqrt() {
     const auto outWS = runAlg("sqrt");
 
-    const auto E = outWS->e(0);
-    const auto Y = outWS->y(0);
+    const auto &E = outWS->e(0);
+    const auto &Y = outWS->y(0);
     for (size_t i = 0; i < E.size(); ++i) {
       TS_ASSERT_DELTA(Y[i], E[i] * E[i], .001);
     }
@@ -113,7 +113,7 @@ public:
   void test_oneIfZero() {
     const auto outWS = runAlg("oneIfZero");
 
-    const auto E = outWS->e(0);
+    const auto &E = outWS->e(0);
     for (const auto item : E) {
       TS_ASSERT(item > 0.);
     }

--- a/Framework/Algorithms/test/SortXAxisTest.h
+++ b/Framework/Algorithms/test/SortXAxisTest.h
@@ -23,9 +23,9 @@ using namespace Mantid::DataObjects;
 using namespace Mantid::HistogramData;
 
 namespace {
-MatrixWorkspace_sptr createWorkspaceE(const std::vector<double> xData,
-                                      const std::vector<double> yData,
-                                      const std::vector<double> eData,
+MatrixWorkspace_sptr createWorkspaceE(const std::vector<double> &xData,
+                                      const std::vector<double> &yData,
+                                      const std::vector<double> &eData,
                                       const int nSpec = 1) {
 
   Workspace2D_sptr outputWorkspace = create<DataObjects::Workspace2D>(
@@ -39,9 +39,9 @@ MatrixWorkspace_sptr createWorkspaceE(const std::vector<double> xData,
   return outputWorkspace;
 }
 
-MatrixWorkspace_sptr createHistoWorkspaceE(const std::vector<double> xData,
-                                           const std::vector<double> yData,
-                                           const std::vector<double> eData,
+MatrixWorkspace_sptr createHistoWorkspaceE(const std::vector<double> &xData,
+                                           const std::vector<double> &yData,
+                                           const std::vector<double> &eData,
                                            const int nSpec = 1) {
 
   Workspace2D_sptr outputWorkspace = create<DataObjects::Workspace2D>(
@@ -55,9 +55,9 @@ MatrixWorkspace_sptr createHistoWorkspaceE(const std::vector<double> xData,
   return outputWorkspace;
 }
 
-MatrixWorkspace_sptr createWorkspaceDx(const std::vector<double> xData,
-                                       const std::vector<double> yData,
-                                       const std::vector<double> dxData,
+MatrixWorkspace_sptr createWorkspaceDx(const std::vector<double> &xData,
+                                       const std::vector<double> &yData,
+                                       const std::vector<double> &dxData,
                                        const int nSpec = 1) {
 
   Workspace2D_sptr outputWorkspace = create<DataObjects::Workspace2D>(
@@ -71,9 +71,9 @@ MatrixWorkspace_sptr createWorkspaceDx(const std::vector<double> xData,
   return outputWorkspace;
 }
 
-MatrixWorkspace_sptr createHistoWorkspaceDx(const std::vector<double> xData,
-                                            const std::vector<double> yData,
-                                            const std::vector<double> dxData,
+MatrixWorkspace_sptr createHistoWorkspaceDx(const std::vector<double> &xData,
+                                            const std::vector<double> &yData,
+                                            const std::vector<double> &dxData,
                                             const int nSpec = 1) {
 
   Workspace2D_sptr outputWorkspace = create<DataObjects::Workspace2D>(
@@ -87,8 +87,8 @@ MatrixWorkspace_sptr createHistoWorkspaceDx(const std::vector<double> xData,
   return outputWorkspace;
 }
 
-MatrixWorkspace_sptr createHistoWorkspace(const std::vector<double> xData,
-                                          const std::vector<double> yData,
+MatrixWorkspace_sptr createHistoWorkspace(const std::vector<double> &xData,
+                                          const std::vector<double> &yData,
                                           const int nSpec = 1) {
 
   Workspace2D_sptr outputWorkspace = create<DataObjects::Workspace2D>(

--- a/Framework/Algorithms/test/SumSpectraTest.h
+++ b/Framework/Algorithms/test/SumSpectraTest.h
@@ -622,7 +622,7 @@ public:
     Workspace2D_const_sptr output2D =
         boost::dynamic_pointer_cast<const Workspace2D>(output);
 
-    auto outYVals = output2D->y(0);
+    const auto &outYVals = output2D->y(0);
     // We expect one less because of inf and NaN
     TS_ASSERT_EQUALS(outYVals[0], 2.);
     TS_ASSERT_EQUALS(outYVals[1], 2.);
@@ -659,7 +659,7 @@ public:
     Workspace2D_const_sptr output2D =
         boost::dynamic_pointer_cast<const Workspace2D>(output);
 
-    auto outYVals = output2D->y(0);
+    const auto &outYVals = output2D->y(0);
     // We expect a NaN and an Inf to propagate here
     TS_ASSERT_EQUALS(std::isnormal(outYVals[0]), false);
     TS_ASSERT_EQUALS(std::isnormal(outYVals[1]), false);

--- a/Framework/Algorithms/test/WienerSmoothTest.h
+++ b/Framework/Algorithms/test/WienerSmoothTest.h
@@ -610,8 +610,8 @@ private:
 
     for (size_t i = 0; i < ws->getNumberHistograms(); ++i) {
 
-      auto outX = ws->x(i);
-      auto outE = ws->e(i);
+      const auto &outX = ws->x(i);
+      const auto &outE = ws->e(i);
 
       TS_ASSERT(std::equal(outX.begin(), outX.end(), inX.begin()));
       TS_ASSERT(std::equal(outE.begin(), outE.end(), inE.begin()));

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -93,7 +93,7 @@ public:
     // GIVEN
     auto workspace = WorkspaceCreationHelper::create1DWorkspaceConstant(
         10 /*size*/, 1.5 /*value*/, 1. /*error*/, true /*isHisto*/);
-    const auto y = workspace->y(0);
+    const auto &y = workspace->y(0);
 
     // WHEN
     auto backgroundStrategy = AbsoluteBackgroundStrategy(2.);
@@ -109,7 +109,7 @@ public:
     // GIVEN
     auto workspace = WorkspaceCreationHelper::create1DWorkspaceConstant(
         10 /*size*/, 1.5 /*value*/, 1. /*error*/, true /*isHisto*/);
-    const auto y = workspace->y(0);
+    const auto &y = workspace->y(0);
 
     // WHEN
     auto backgroundStrategy = PerSpectrumBackgroundStrategy(1.);

--- a/Framework/Crystal/test/IntegratePeakTimeSlicesTest.h
+++ b/Framework/Crystal/test/IntegratePeakTimeSlicesTest.h
@@ -160,8 +160,8 @@ public:
           }
         }
 
-        wsPtr->mutableY(wsIndex) = dataY;
-        wsPtr->mutableE(wsIndex) = dataE;
+        wsPtr->mutableY(wsIndex) = std::move(dataY);
+        wsPtr->mutableE(wsIndex) = std::move(dataE);
       }
 
     PeaksWorkspace_sptr pks(new PeaksWorkspace());

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -482,7 +482,7 @@ void LeBailFit::execPatternCalculation() {
   bool resultphysical = calculateDiffractionPattern(
       m_dataWS->x(m_wsIndex), m_dataWS->y(m_wsIndex), true, true, emptyvec,
       vecY, rfactor);
-  m_outputWS->mutableY(CALDATAINDEX) = vecY;
+  m_outputWS->mutableY(CALDATAINDEX) = std::move(vecY);
 
   // Calculate background
   m_outputWS->mutableY(INPUTBKGDINDEX) =
@@ -659,8 +659,8 @@ void LeBailFit::execRefineBackground() {
 
   //   (3: peak without background, 4: input background)
   // m_backgroundFunction->function(domain, values);
-  m_outputWS->mutableY(CALBKGDINDEX) = backgroundvalues;
-  m_outputWS->mutableY(CALPUREPEAKINDEX) = valueVec;
+  m_outputWS->mutableY(CALBKGDINDEX) = std::move(backgroundvalues);
+  m_outputWS->mutableY(CALPUREPEAKINDEX) = std::move(valueVec);
 
   // 5. Output background to table workspace
   auto outtablews = boost::make_shared<TableWorkspace>();

--- a/Framework/CurveFitting/src/Algorithms/NormaliseByPeakArea.cpp
+++ b/Framework/CurveFitting/src/Algorithms/NormaliseByPeakArea.cpp
@@ -168,14 +168,14 @@ void NormaliseByPeakArea::createOutputWorkspaces(
   if (m_sumResults) {
     // Copy over xvalues & assign "high" initial error values to simplify
     // symmetrisation calculation
-    double high(1e6);
+    constexpr double high(1e6);
 
     m_yspaceWS->setSharedX(0, yspaceIn->sharedX(0));
     m_fittedWS->setSharedX(0, yspaceIn->sharedX(0));
     m_symmetrisedWS->setSharedX(0, yspaceIn->sharedX(0));
     m_yspaceWS->mutableE(0) = high;
-    m_fittedWS->mutableE(0) = high;
-    m_symmetrisedWS->mutableE(0) = high;
+    m_fittedWS->setSharedE(0, m_yspaceWS->sharedE(0));
+    m_symmetrisedWS->setSharedE(0, m_yspaceWS->sharedE(0));
   }
 
   setUnitsToMomentum(m_yspaceWS);

--- a/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
+++ b/Framework/CurveFitting/src/Algorithms/RefinePowderInstrumentParameters.cpp
@@ -366,12 +366,14 @@ void RefinePowderInstrumentParameters::fitInstrumentParameters() {
   stringstream zss;
   zss << setw(20) << "d_h" << setw(20) << "Z DataY" << setw(20) << "Z ModelY"
       << setw(20) << "Z DiffY" << setw(20) << "DiffY\n";
+  const auto &X = m_dataWS->x(0);
+  const auto &Y = m_dataWS->y(2);
   for (size_t i = 0; i < z0.size(); ++i) {
-    double d_h = m_dataWS->x(0)[i];
+    double d_h = X[i];
     double zdatay = z0[i];
     double zmodely = z1[i];
     double zdiffy = z2[i];
-    double diffy = m_dataWS->y(2)[i];
+    double diffy = Y[i];
     zss << setw(20) << d_h << setw(20) << zdatay << setw(20) << zmodely
         << setw(20) << zdiffy << setw(20) << diffy << '\n';
   }

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -2047,7 +2047,7 @@ public:
     auto ws =
         WorkspaceFactory::Instance().create("Workspace2D", 1, nbins, nbins);
     FunctionDomain1DVector x(-10, 10, nbins);
-    ws->dataX(0) = x.toVector();
+    ws->mutableX(0) = x.toVector();
     {
       Fit fit;
       fit.initialize();
@@ -2058,7 +2058,7 @@ public:
       fit.execute();
       auto res = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
           "out_Workspace");
-      auto y = res->y(1);
+      const auto &y = res->y(1);
       TS_ASSERT_DIFFERS(y.front(), 0.0);
       TS_ASSERT_DIFFERS(y.back(), 0.0);
     }
@@ -2073,7 +2073,7 @@ public:
       fit.execute();
       auto res = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
           "out_Workspace");
-      auto y = res->y(1);
+      const auto &y = res->y(1);
       for (size_t i = 0; i < 25; ++i) {
         TS_ASSERT_EQUALS(y[i], 0.0);
         TS_ASSERT_EQUALS(y[nbins - i - 1], 0.0);

--- a/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
@@ -248,14 +248,13 @@ private:
 
     FunctionDomain1DVector xValues(xMin, xMax, n);
     FunctionValues yValues(xValues);
-    std::vector<double> eValues(n, 1.0);
 
     siFn->function(xValues, yValues);
 
     ws->mutableX(0) = xValues.toVector();
     ws->mutableY(0) = yValues.toVector();
     ws->mutableY(0) += bg;
-    ws->mutableE(0) = eValues;
+    ws->mutableE(0) = std::vector<double>(n, 1.0);
     WorkspaceCreationHelper::addNoise(ws, 0, -0.5, 0.5);
 
     ws->getAxis(0)->setUnit(unit);

--- a/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
@@ -254,7 +254,7 @@ private:
     ws->mutableX(0) = xValues.toVector();
     ws->mutableY(0) = yValues.toVector();
     ws->mutableY(0) += bg;
-    ws->mutableE(0) = std::vector<double>(n, 1.0);
+    ws->mutableE(0) = 1.0;
     WorkspaceCreationHelper::addNoise(ws, 0, -0.5, 0.5);
 
     ws->getAxis(0)->setUnit(unit);

--- a/Framework/CurveFitting/test/FuncMinimizers/ErrorMessagesTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/ErrorMessagesTest.h
@@ -277,8 +277,8 @@ private:
     size_t nbins = x.size();
     auto ws =
         WorkspaceFactory::Instance().create("Workspace2D", 1, nbins, nbins);
-    ws->dataX(0) = x;
-    ws->dataY(0) = y;
+    ws->mutableX(0) = x;
+    ws->mutableY(0) = y;
     return ws;
   }
 };

--- a/Framework/CurveFitting/test/Functions/CrystalFieldMultiSpectrumTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldMultiSpectrumTest.h
@@ -557,10 +557,10 @@ private:
     fun.function(domain, y);
     for (size_t i = 0; i < nSpec; ++i) {
       auto x = static_cast<const FunctionDomain1DVector &>(domain.getDomain(i));
-      ws->dataX(i) = x.toVector();
+      ws->mutableX(i) = x.toVector();
       auto n = x.size();
       auto from = y.getPointerToCalculated(i * n);
-      ws->dataY(i).assign(from, from + n);
+      ws->mutableY(i).assign(from, from + n);
     }
     return ws;
   }

--- a/Framework/CurveFitting/test/Functions/CrystalFieldSpectrumTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldSpectrumTest.h
@@ -874,8 +874,8 @@ private:
     FunctionDomain1DVector x(x0, x1, nbins);
     FunctionValues y(x);
     fun.function(x, y);
-    ws->dataX(0) = x.toVector();
-    ws->dataY(0) = y.toVector();
+    ws->mutableX(0) = x.toVector();
+    ws->mutableY(0) = y.toVector();
     return ws;
   }
 };

--- a/Framework/DataHandling/src/JoinISISPolarizationEfficiencies.cpp
+++ b/Framework/DataHandling/src/JoinISISPolarizationEfficiencies.cpp
@@ -134,9 +134,9 @@ MatrixWorkspace_sptr JoinISISPolarizationEfficiencies::createEfficiencies(
 
   for (size_t i = 0; i < interpolatedWorkspaces.size(); ++i) {
     auto &ws = interpolatedWorkspaces[i];
-    outWS->mutableX(i) = ws->x(0);
-    outWS->mutableY(i) = ws->y(0);
-    outWS->mutableE(i) = ws->e(0);
+    outWS->setSharedX(i, ws->sharedX(0));
+    outWS->setSharedY(i, ws->sharedY(0));
+    outWS->setSharedE(i, ws->sharedE(0));
     axis1->setLabel(i, labels[i]);
   }
 

--- a/Framework/DataHandling/src/JoinISISPolarizationEfficiencies.cpp
+++ b/Framework/DataHandling/src/JoinISISPolarizationEfficiencies.cpp
@@ -134,9 +134,7 @@ MatrixWorkspace_sptr JoinISISPolarizationEfficiencies::createEfficiencies(
 
   for (size_t i = 0; i < interpolatedWorkspaces.size(); ++i) {
     auto &ws = interpolatedWorkspaces[i];
-    outWS->setSharedX(i, ws->sharedX(0));
-    outWS->setSharedY(i, ws->sharedY(0));
-    outWS->setSharedE(i, ws->sharedE(0));
+    outWS->setHistogram(i, ws->histogram(0));
     axis1->setLabel(i, labels[i]);
   }
 

--- a/Framework/DataHandling/src/LoadDaveGrp.cpp
+++ b/Framework/DataHandling/src/LoadDaveGrp.cpp
@@ -181,8 +181,9 @@ void LoadDaveGrp::setWorkspaceAxes(API::MatrixWorkspace_sptr workspace,
                                    const std::vector<double> &yAxis) const {
 
   auto verticalAxis = workspace->getAxis(1);
+  auto sharedX = Kernel::make_cow<HistogramData::HistogramX>(xAxis);
   for (size_t i = 0; i < nGroups; i++) {
-    workspace->mutableX(i) = xAxis;
+    workspace->setSharedX(i, sharedX);
     verticalAxis->setValue(i, yAxis.at(i));
   }
 }

--- a/Framework/DataHandling/src/LoadILLDiffraction.cpp
+++ b/Framework/DataHandling/src/LoadILLDiffraction.cpp
@@ -514,8 +514,8 @@ void LoadILLDiffraction::fillStaticInstrumentScan(const NXUInt &data,
                                                   const NXDouble &scan,
                                                   const NXFloat &twoTheta0) {
 
-  std::vector<double> axis = getAxis(scan);
-  std::vector<double> monitor = getMonitor(scan);
+  const std::vector<double> axis = getAxis(scan);
+  const std::vector<double> monitor = getMonitor(scan);
 
   // Assign monitor counts
   m_outWorkspace->mutableX(0) = axis;

--- a/Framework/DataHandling/src/LoadILLIndirect2.cpp
+++ b/Framework/DataHandling/src/LoadILLIndirect2.cpp
@@ -289,7 +289,7 @@ void LoadILLIndirect2::loadDataIntoTheWorkSpace(
   for (size_t im = 0; im < m_numberOfMonitors; im++) {
 
     if (im > 0) {
-      m_localWorkspace->dataX(im) = m_localWorkspace->readX(0);
+      m_localWorkspace->setSharedX(im, m_localWorkspace->sharedX(0));
     }
 
     // Assign Y

--- a/Framework/DataHandling/src/LoadMcStasNexus.cpp
+++ b/Framework/DataHandling/src/LoadMcStasNexus.cpp
@@ -155,7 +155,7 @@ void LoadMcStasNexus::exec() {
       ws->setYUnit(axis2Name);
       ws->replaceAxis(1, axis2);
 
-      ws->mutableX(0) = axis1Values;
+      ws->mutableX(0) = std::move(axis1Values);
 
       for (size_t wsIndex = 0; wsIndex < axis2Length; ++wsIndex) {
         auto &dataY = ws->mutableY(wsIndex);

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -701,7 +701,7 @@ void addTransmission(H5::Group &group,
 
   //-----------------------------------------
   // Add Tdev with units
-  const auto transmissionErrors = workspace->e(0);
+  const auto &transmissionErrors = workspace->e(0);
   std::map<std::string, std::string> transmissionErrorAttributes;
   transmissionErrorAttributes.emplace(sasUnitAttr, unit);
 
@@ -711,7 +711,7 @@ void addTransmission(H5::Group &group,
 
   //-----------------------------------------
   // Add lambda with units
-  const auto lambda = workspace->x(0);
+  const auto &lambda = workspace->x(0);
   std::map<std::string, std::string> lambdaAttributes;
   auto lambdaUnit = getUnitFromMDDimension(workspace->getDimension(0));
   if (lambdaUnit.empty() || lambdaUnit == "Angstrom") {

--- a/Framework/DataHandling/test/GroupDetectors2Test.h
+++ b/Framework/DataHandling/test/GroupDetectors2Test.h
@@ -1209,7 +1209,7 @@ public:
     for (size_t pix = 0; pix < inputEventWs->getNumberHistograms(); pix++) {
       size_t xAxisSize = inputEventWs->x(pix).size();
       Mantid::HistogramData::HistogramX axisVals(xAxisSize, 1.0);
-      inputEventWs->mutableX(pix) = axisVals;
+      inputEventWs->mutableX(pix) = std::move(axisVals);
       inputEventWs->getSpectrum(pix).addEventQuickly(TofEvent(1000.0));
     }
     setupGroupWS(numGroups);

--- a/Framework/DataHandling/test/LoadQKKTest.h
+++ b/Framework/DataHandling/test/LoadQKKTest.h
@@ -61,15 +61,15 @@ public:
     for (size_t i = 0; i < data->getNumberHistograms(); ++i) {
       TS_ASSERT_THROWS_NOTHING(spectrumInfo.detector(i));
 
-      auto x = data->x(i);
+      const auto &x = data->x(i);
       TS_ASSERT_EQUALS(x.size(), 2);
       TS_ASSERT_DELTA(x[0], 4.9639999139, 1e-8);
       TS_ASSERT_DELTA(x[1], 5.1039999245, 1e-8);
 
-      auto y = data->y(i);
+      const auto &y = data->y(i);
       TS_ASSERT_DIFFERS(y[0], 0.0);
 
-      auto e = data->e(i);
+      const auto &e = data->e(i);
       TS_ASSERT_DIFFERS(e[0], 0.0);
     }
   }

--- a/Framework/DataHandling/test/SaveANSTOAsciiTest.h
+++ b/Framework/DataHandling/test/SaveANSTOAsciiTest.h
@@ -8,16 +8,19 @@
 #define SAVEANSTOASCIITEST_H_
 
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataHandling/SaveANSTOAscii.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include <Poco/File.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cxxtest/TestSuite.h>
 #include <fstream>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling;
+using namespace Mantid::HistogramData;
 using namespace Mantid::DataObjects;
 
 class SaveANSTOAsciiTest : public CxxTest::TestSuite {
@@ -64,9 +67,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
     in.close();
 
@@ -95,9 +98,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
     in.close();
 
@@ -126,9 +129,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
     in.close();
 
@@ -157,9 +160,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
     in.close();
 
@@ -189,9 +192,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of(","),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
     in.close();
 
@@ -214,27 +217,14 @@ public:
 
 private:
   void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
-    MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    AnalysisDataService::Instance().addOrReplace(m_name, ws);
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    if (zeroX) {
-      ws->dataX(0) = m_data0;
-    } else {
-      ws->dataX(0) = m_dataX;
-    }
-
-    if (zeroY) {
-      ws->dataY(0) = m_data0;
-    } else {
-      ws->dataY(0) = m_dataY;
-    }
-
-    if (zeroE) {
-      ws->dataE(0) = m_data0;
-    } else {
-      ws->dataE(0) = m_dataE;
-    }
+    Points points(zeroX ? m_data0 : m_dataX);
+    Counts counts(zeroY ? m_data0 : m_dataY);
+    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    MatrixWorkspace_sptr ws =
+        create<Workspace2D>(1, Histogram(points, counts, stddev));
+    AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
     Poco::File(m_long_filename).remove();

--- a/Framework/DataHandling/test/SaveANSTOAsciiTest.h
+++ b/Framework/DataHandling/test/SaveANSTOAsciiTest.h
@@ -33,16 +33,12 @@ public:
     m_filename = "SaveANSTOAsciiTestFile.txt";
     m_name = "SaveANSTOAsciiWS";
     for (int i = 1; i < 11; ++i) {
-      // X, Y and E get [1,2,3,4,5,6,7,8,9,10]
-      // 0 gets [0,0,0,0,0,0,0,0,0,0] and is used to make sure there is no
-      // problem with divide by zero
-      m_dataX.push_back(i);
-      m_dataY.push_back(i);
-      m_dataE.push_back(i);
-      m_data0.push_back(0);
+      m_dataX.emplace_back(i);
+      m_dataY.emplace_back(i);
+      m_dataE.emplace_back(i);
     }
+    m_dataX.emplace_back(11);
   }
-  ~SaveANSTOAsciiTest() override {}
 
   void testExec() {
     // create a new workspace and then delete it later on
@@ -67,7 +63,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
@@ -129,7 +125,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
@@ -160,7 +156,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
@@ -192,7 +188,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of(","),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(0)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_EQUALS(columns.at(3), "0.000000000000000e+00");
@@ -219,11 +215,12 @@ private:
   void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    Points points(zeroX ? m_data0 : m_dataX);
-    Counts counts(zeroY ? m_data0 : m_dataY);
-    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    BinEdges edges = zeroX ? BinEdges(11, 0.) : BinEdges(m_dataX);
+    Counts counts = zeroY ? Counts(10, 0.) : Counts(m_dataY);
+    CountStandardDeviations stddev = zeroE ? CountStandardDeviations(10, 0.)
+                                           : CountStandardDeviations(m_dataE);
     MatrixWorkspace_sptr ws =
-        create<Workspace2D>(1, Histogram(points, counts, stddev));
+        create<Workspace2D>(1, Histogram(edges, counts, stddev));
     AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
@@ -231,7 +228,7 @@ private:
     AnalysisDataService::Instance().remove(m_name);
   }
   std::string m_filename, m_name, m_long_filename;
-  std::vector<double> m_dataX, m_dataY, m_dataE, m_data0;
+  std::vector<double> m_dataX, m_dataY, m_dataE;
 };
 
 #endif /*SAVEANSTOTEST_H_*/

--- a/Framework/DataHandling/test/SaveReflCustomAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflCustomAsciiTest.h
@@ -36,16 +36,12 @@ public:
     m_filename = "SaveReflCustomAsciiFile.txt";
     m_name = "SaveReflCustomAsciiWS";
     for (int i = 1; i < 11; ++i) {
-      // X, Y and E get [1,2,3,4,5,6,7,8,9,10]
-      // 0 gets [0,0,0,0,0,0,0,0,0,0] and is used to make sure there is no
-      // problem with divide by zero
-      m_dataX.push_back(i);
-      m_dataY.push_back(i);
-      m_dataE.push_back(i);
-      m_data0.push_back(0);
+      m_dataX.emplace_back(i);
+      m_dataY.emplace_back(i);
+      m_dataE.emplace_back(i);
     }
+    m_dataX.emplace_back(11.);
   }
-  ~SaveReflCustomAsciiTest() override {}
 
   void testExec() {
     // create a new workspace and then delete it later on
@@ -75,7 +71,7 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2., 0.01);
     in.close();
@@ -141,7 +137,7 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2., 0.01);
     in.close();
@@ -174,7 +170,7 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0., 0.01);
     in.close();
@@ -210,7 +206,7 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
@@ -244,12 +240,12 @@ private:
   void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    Points points(zeroX ? m_data0 : m_dataX);
-    Counts counts(zeroY ? m_data0 : m_dataY);
-    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    BinEdges edges = zeroX ? BinEdges(11, 0.) : BinEdges(m_dataX);
+    Counts counts = zeroY ? Counts(10, 0.) : Counts(m_dataY);
+    CountStandardDeviations stddev = zeroE ? CountStandardDeviations(10, 0.)
+                                           : CountStandardDeviations(m_dataE);
     MatrixWorkspace_sptr ws =
-        create<Workspace2D>(1, Histogram(points, counts, stddev));
-    AnalysisDataService::Instance().addOrReplace(m_name, ws);
+        create<Workspace2D>(1, Histogram(edges, counts, stddev));
     AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
@@ -257,6 +253,6 @@ private:
     AnalysisDataService::Instance().remove(m_name);
   }
   std::string m_filename, m_name, m_long_filename;
-  std::vector<double> m_dataX, m_dataY, m_dataE, m_data0;
+  std::vector<double> m_dataX, m_dataY, m_dataE;
 };
 #endif /*SAVEREFLCUSTOMASCIITEST_H_*/

--- a/Framework/DataHandling/test/SaveReflCustomAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflCustomAsciiTest.h
@@ -8,16 +8,20 @@
 #define SAVEREFLCUSTOMASCIITEST_H_
 
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataHandling/SaveReflCustomAscii.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidHistogramData/Points.h"
 #include <Poco/File.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cxxtest/TestSuite.h>
 #include <fstream>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling;
+using namespace Mantid::HistogramData;
 using namespace Mantid::DataObjects;
 
 class SaveReflCustomAsciiTest : public CxxTest::TestSuite {
@@ -62,6 +66,7 @@ public:
     std::ifstream in(m_long_filename.c_str());
     std::string fullline;
     headingsTests(in, fullline);
+
     getline(in, fullline);
 
     std::vector<std::string> columns;
@@ -70,9 +75,9 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -103,9 +108,9 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -136,9 +141,9 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 2., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -169,16 +174,16 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 2., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0., 0.01);
     in.close();
 
     cleanupafterwards();
   }
   void testParameters() {
     // create a new workspace and then delete it later on
-    createWS(false, false, false, true);
+    createWS(false, false, false);
 
     Mantid::API::IAlgorithm_sptr alg =
         Mantid::API::AlgorithmManager::Instance().create("SaveReflCustomAscii");
@@ -205,9 +210,9 @@ public:
     TS_ASSERT_EQUALS(columns.size(), 4);
     // the first is black due to the leading separator
     TS_ASSERT(columns.at(0) == "");
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -236,33 +241,16 @@ private:
     } else {
     };
   }
-  void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false,
-                bool createLogs = false) {
-    createLogs = false;
-    MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    AnalysisDataService::Instance().addOrReplace(m_name, ws);
+  void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    if (zeroX) {
-      ws->dataX(0) = m_data0;
-    } else {
-      ws->dataX(0) = m_dataX;
-    }
-
-    if (zeroY) {
-      ws->dataY(0) = m_data0;
-    } else {
-      ws->dataY(0) = m_dataY;
-    }
-
-    if (zeroE) {
-      ws->dataE(0) = m_data0;
-    } else {
-      ws->dataE(0) = m_dataE;
-    }
-    if (createLogs) {
-    } else {
-    }
+    Points points(zeroX ? m_data0 : m_dataX);
+    Counts counts(zeroY ? m_data0 : m_dataY);
+    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    MatrixWorkspace_sptr ws =
+        create<Workspace2D>(1, Histogram(points, counts, stddev));
+    AnalysisDataService::Instance().addOrReplace(m_name, ws);
+    AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
     Poco::File(m_long_filename).remove();

--- a/Framework/DataHandling/test/SaveReflThreeColumnAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflThreeColumnAsciiTest.h
@@ -37,14 +37,11 @@ public:
     m_filename = "SaveReflThreeColumnAsciiTestFile.txt";
     m_name = "SaveReflThreeColumnAsciiWS";
     for (int i = 1; i < 11; ++i) {
-      // X, Y and E get [1,2,3,4,5,6,7,8,9,10]
-      // 0 gets [0,0,0,0,0,0,0,0,0,0] and is used to make sure there is no
-      // problem with divide by zero
-      m_dataX.push_back(i);
-      m_dataY.push_back(i);
-      m_dataE.push_back(i);
-      m_data0.push_back(0);
+      m_dataX.emplace_back(i);
+      m_dataY.emplace_back(i);
+      m_dataE.emplace_back(i);
     }
+    m_dataX.emplace_back(11);
   }
   ~SaveReflThreeColumnAsciiTest() override {}
 
@@ -72,7 +69,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
@@ -134,7 +131,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
@@ -165,7 +162,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0., 0.01);
     in.close();
@@ -197,7 +194,7 @@ public:
     boost::split(columns, fullline, boost::is_any_of(","),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
@@ -224,11 +221,12 @@ private:
   void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    Points points(zeroX ? m_data0 : m_dataX);
-    Counts counts(zeroY ? m_data0 : m_dataY);
-    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    BinEdges edges = zeroX ? BinEdges(11, 0.) : BinEdges(m_dataX);
+    Counts counts = zeroY ? Counts(10, 0.) : Counts(m_dataY);
+    CountStandardDeviations stddev = zeroE ? CountStandardDeviations(10, 0.)
+                                           : CountStandardDeviations(m_dataE);
     MatrixWorkspace_sptr ws =
-        create<Workspace2D>(1, Histogram(points, counts, stddev));
+        create<Workspace2D>(1, Histogram(edges, counts, stddev));
     AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
@@ -236,7 +234,7 @@ private:
     AnalysisDataService::Instance().remove(m_name);
   }
   std::string m_filename, m_name, m_long_filename;
-  std::vector<double> m_dataX, m_dataY, m_dataE, m_data0;
+  std::vector<double> m_dataX, m_dataY, m_dataE;
 };
 
 #endif /*SAVEREFLTHREECOLUMNASCIITEST_H_*/

--- a/Framework/DataHandling/test/SaveReflThreeColumnAsciiTest.h
+++ b/Framework/DataHandling/test/SaveReflThreeColumnAsciiTest.h
@@ -8,16 +8,19 @@
 #define SAVEREFLTHREECOLUMNASCIITEST_H_
 
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
 #include "MantidDataHandling/SaveReflThreeColumnAscii.h"
 #include "MantidDataObjects/Workspace2D.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
 #include <Poco/File.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
 #include <cxxtest/TestSuite.h>
 #include <fstream>
 
 using namespace Mantid::API;
 using namespace Mantid::DataHandling;
+using namespace Mantid::HistogramData;
 using namespace Mantid::DataObjects;
 
 class SaveReflThreeColumnAsciiTest : public CxxTest::TestSuite {
@@ -69,9 +72,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -100,8 +103,8 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
     // TS_ASSERT((columns.at(3) == "nan") || (columns.at(3) == "inf"));
     in.close();
 
@@ -131,9 +134,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 0., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -162,9 +165,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of("\t"),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 0., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -194,9 +197,9 @@ public:
     boost::split(columns, fullline, boost::is_any_of(","),
                  boost::token_compress_on);
     TS_ASSERT_EQUALS(columns.size(), 4); // first blank
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1.5, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1, 0.01);
-    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1, 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(1)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(2)), 1., 0.01);
+    TS_ASSERT_DELTA(boost::lexical_cast<double>(columns.at(3)), 1., 0.01);
     in.close();
 
     cleanupafterwards();
@@ -219,27 +222,14 @@ public:
 
 private:
   void createWS(bool zeroX = false, bool zeroY = false, bool zeroE = false) {
-    MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(1, 10);
-    AnalysisDataService::Instance().addOrReplace(m_name, ws);
     // Check if any of X, Y or E should be zeroed to check for divide by zero or
     // similiar
-    if (zeroX) {
-      ws->dataX(0) = m_data0;
-    } else {
-      ws->dataX(0) = m_dataX;
-    }
-
-    if (zeroY) {
-      ws->dataY(0) = m_data0;
-    } else {
-      ws->dataY(0) = m_dataY;
-    }
-
-    if (zeroE) {
-      ws->dataE(0) = m_data0;
-    } else {
-      ws->dataE(0) = m_dataE;
-    }
+    Points points(zeroX ? m_data0 : m_dataX);
+    Counts counts(zeroY ? m_data0 : m_dataY);
+    CountStandardDeviations stddev(zeroE ? m_data0 : m_dataE);
+    MatrixWorkspace_sptr ws =
+        create<Workspace2D>(1, Histogram(points, counts, stddev));
+    AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   void cleanupafterwards() {
     Poco::File(m_long_filename).remove();

--- a/Framework/DataHandling/test/SaveSESANSTest.h
+++ b/Framework/DataHandling/test/SaveSESANSTest.h
@@ -96,9 +96,9 @@ public:
 
     // Check (a small sample of) the values we wrote are correct
     TS_ASSERT_EQUALS(static_cast<int>(data->getNumberHistograms()), 1);
-    auto xValues = data->x(0);
-    auto yValues = data->y(0);
-    auto eValues = data->e(0);
+    const auto &xValues = data->x(0);
+    const auto &yValues = data->y(0);
+    const auto &eValues = data->e(0);
 
     TS_ASSERT_EQUALS(static_cast<int>(xValues.size()), 10);
     TS_ASSERT_EQUALS(static_cast<int>(yValues.size()), 10);

--- a/Framework/DataObjects/test/RefAxisTest.h
+++ b/Framework/DataObjects/test/RefAxisTest.h
@@ -38,8 +38,8 @@ public:
 
     // Fill them
     Mantid::MantidVec a(25);
-    for (int i = 0; i < a.size(); ++i) {
-      a[i] = i + 0.1;
+    for (size_t i = 0; i < a.size(); ++i) {
+      a[i] = static_cast<double>(i) + 0.1;
     }
     for (int j = 0; j < 5; ++j) {
       m_space->mutableX(j) =

--- a/Framework/DataObjects/test/RefAxisTest.h
+++ b/Framework/DataObjects/test/RefAxisTest.h
@@ -31,95 +31,85 @@ public:
 
   RefAxisTest() {
     // Set up two small workspaces for these tests
-    space = new Mantid::DataObjects::Workspace2D;
-    space->initialize(5, 25, 25);
-    space2 = new Mantid::DataObjects::Workspace2D;
-    space2->initialize(1, 5, 5);
+    m_space.reset(new Mantid::DataObjects::Workspace2D);
+    m_space->initialize(5, 5, 5);
+    m_space2.reset(new Mantid::DataObjects::Workspace2D);
+    m_space2->initialize(1, 5, 5);
 
     // Fill them
-    double *a = new double[25];
-    double *b = new double[25];
-    for (int i = 0; i < 25; ++i) {
+    Mantid::MantidVec a(25);
+    for (int i = 0; i < a.size(); ++i) {
       a[i] = i + 0.1;
     }
     for (int j = 0; j < 5; ++j) {
-      space->dataX(j) = Mantid::MantidVec(a + (5 * j), a + (5 * j) + 5);
+      m_space->mutableX(j) =
+          Mantid::MantidVec(a.cbegin() + (5 * j), a.cbegin() + (5 * j) + 5);
     }
-    delete[] a;
-    delete[] b;
 
     // Create the axis that the tests will be performed on
-    refAxis = new RefAxis(space);
-    refAxis->title() = "test axis";
-    refAxis->unit() = UnitFactory::Instance().create("TOF");
-  }
-
-  ~RefAxisTest() override {
-    delete refAxis;
-    delete space;
-    delete space2;
+    m_refAxis.reset(new RefAxis(m_space.get()));
+    m_refAxis->title() = "test axis";
+    m_refAxis->unit() = UnitFactory::Instance().create("TOF");
   }
 
   void testConstructor() {
-    TS_ASSERT_EQUALS(refAxis->title(), "test axis")
-    TS_ASSERT(refAxis->isNumeric())
-    TS_ASSERT(!refAxis->isSpectra())
-    TS_ASSERT_EQUALS(refAxis->unit()->unitID(), "TOF")
-    TS_ASSERT_THROWS(refAxis->spectraNo(0), std::domain_error)
+    TS_ASSERT_EQUALS(m_refAxis->title(), "test axis")
+    TS_ASSERT(m_refAxis->isNumeric())
+    TS_ASSERT(!m_refAxis->isSpectra())
+    TS_ASSERT_EQUALS(m_refAxis->unit()->unitID(), "TOF")
+    TS_ASSERT_THROWS(m_refAxis->spectraNo(0), std::domain_error)
   }
 
   void testClone() {
-    Axis *clonedAxis = refAxis->clone(space2);
-    TS_ASSERT_DIFFERS(clonedAxis, refAxis)
-    TS_ASSERT(dynamic_cast<RefAxis *>(clonedAxis))
+    std::unique_ptr<Axis> clonedAxis(m_refAxis->clone(m_space2.get()));
+    TS_ASSERT_DIFFERS(clonedAxis.get(), m_refAxis.get())
+    TS_ASSERT(clonedAxis)
     TS_ASSERT_EQUALS(clonedAxis->title(), "test axis")
     TS_ASSERT_EQUALS(clonedAxis->unit()->unitID(), "TOF")
     TS_ASSERT(clonedAxis->isNumeric())
     TS_ASSERT_EQUALS((*clonedAxis)(0, 0), 1.0)
     TS_ASSERT_THROWS((*clonedAxis)(0, 1), std::range_error)
-    delete clonedAxis;
   }
 
   void testCloneDifferentLength() {
-    Axis *newRefAxis = refAxis->clone(5, space2);
-    TS_ASSERT_DIFFERS(newRefAxis, refAxis);
+    std::unique_ptr<Axis> newRefAxis(m_refAxis->clone(5, m_space2.get()));
+    TS_ASSERT_DIFFERS(newRefAxis.get(), m_refAxis.get());
     TS_ASSERT(newRefAxis->isNumeric());
     TS_ASSERT_EQUALS(newRefAxis->title(), "test axis");
     TS_ASSERT_EQUALS(newRefAxis->unit()->unitID(), "TOF");
     TS_ASSERT_EQUALS(newRefAxis->length(), 5);
-    space2->dataX(0)[1] = 9.9;
+    m_space2->dataX(0)[1] = 9.9;
     TS_ASSERT_EQUALS((*newRefAxis)(1), 9.9);
-    delete newRefAxis;
   }
 
   void testOperatorBrackets() {
-    TS_ASSERT_EQUALS((*refAxis)(4, 4), 24.1)
-    TS_ASSERT_EQUALS((*refAxis)(0, 2), 10.1)
-    TS_ASSERT_EQUALS((*refAxis)(2, 0), 2.1)
+    TS_ASSERT_EQUALS((*m_refAxis)(4, 4), 24.1)
+    TS_ASSERT_EQUALS((*m_refAxis)(0, 2), 10.1)
+    TS_ASSERT_EQUALS((*m_refAxis)(2, 0), 2.1)
 
-    TS_ASSERT_THROWS((*refAxis)(-1, 0), Exception::IndexError)
-    TS_ASSERT_THROWS((*refAxis)(5, 0), Exception::IndexError)
-    TS_ASSERT_THROWS((*refAxis)(0, -1), std::range_error)
-    TS_ASSERT_THROWS((*refAxis)(0, 5), std::range_error)
+    TS_ASSERT_THROWS((*m_refAxis)(-1, 0), Exception::IndexError)
+    TS_ASSERT_THROWS((*m_refAxis)(5, 0), Exception::IndexError)
+    TS_ASSERT_THROWS((*m_refAxis)(0, -1), std::range_error)
+    TS_ASSERT_THROWS((*m_refAxis)(0, 5), std::range_error)
   }
 
   void testSetValue() {
-    TS_ASSERT_THROWS(refAxis->setValue(0, 9.9), std::domain_error)
+    TS_ASSERT_THROWS(m_refAxis->setValue(0, 9.9), std::domain_error)
   }
 
   void testGetMin() {
-    std::unique_ptr<Axis> newRefAxis(refAxis->clone(5, space2));
+    std::unique_ptr<Axis> newRefAxis(m_refAxis->clone(5, m_space2.get()));
     TS_ASSERT_THROWS(newRefAxis->getMin(), std::runtime_error)
   }
 
   void testGetMax() {
-    std::unique_ptr<Axis> newRefAxis(refAxis->clone(5, space2));
+    std::unique_ptr<Axis> newRefAxis(m_refAxis->clone(5, m_space2.get()));
     TS_ASSERT_THROWS(newRefAxis->getMax(), std::runtime_error)
   }
 
 private:
-  MatrixWorkspace *space, *space2;
-  RefAxis *refAxis;
+  std::unique_ptr<MatrixWorkspace> m_space, m_space2;
+  std::unique_ptr<RefAxis> m_refAxis;
 };
 
 #endif /*REFAXISTEST_H_*/

--- a/Framework/DataObjects/test/WorkspaceSingleValueTest.h
+++ b/Framework/DataObjects/test/WorkspaceSingleValueTest.h
@@ -24,44 +24,44 @@ class WorkspaceSingleValueTest : public CxxTest::TestSuite {
 public:
   void testConstructorDefaults() {
     WorkspaceSingleValue ws;
-    TS_ASSERT_DELTA(0.0, ws.dataX(0)[0], 1e-6);
-    TS_ASSERT_DELTA(0.0, ws.dataY(0)[0], 1e-6);
-    TS_ASSERT_DELTA(0.0, ws.dataE(0)[0], 1e-6);
+    TS_ASSERT_DELTA(0.0, ws.x(0)[0], 1e-6);
+    TS_ASSERT_DELTA(0.0, ws.y(0)[0], 1e-6);
+    TS_ASSERT_DELTA(0.0, ws.e(0)[0], 1e-6);
   }
   void testConstructor() {
     WorkspaceSingleValue ws(1, 2);
-    TS_ASSERT_DELTA(0.0, ws.dataX(0)[0], 1e-6);
-    TS_ASSERT_DELTA(1, ws.dataY(0)[0], 1e-6);
-    TS_ASSERT_DELTA(2, ws.dataE(0)[0], 1e-6);
+    TS_ASSERT_DELTA(0.0, ws.x(0)[0], 1e-6);
+    TS_ASSERT_DELTA(1, ws.y(0)[0], 1e-6);
+    TS_ASSERT_DELTA(2, ws.e(0)[0], 1e-6);
   }
 
   void testClone() {
     WorkspaceSingleValue ws(2.0, 0.1);
     auto cloned = ws.clone();
 
-    TS_ASSERT_EQUALS(ws.dataX(0)[0], cloned->dataX(0)[0]);
-    TS_ASSERT_EQUALS(ws.dataY(0)[0], cloned->dataY(0)[0]);
-    TS_ASSERT_EQUALS(ws.dataE(0)[0], cloned->dataE(0)[0]);
+    TS_ASSERT_EQUALS(ws.x(0)[0], cloned->x(0)[0]);
+    TS_ASSERT_EQUALS(ws.y(0)[0], cloned->y(0)[0]);
+    TS_ASSERT_EQUALS(ws.e(0)[0], cloned->e(0)[0]);
   }
 
   void testsetgetXvector() {
     WorkspaceSingleValue ws;
     Mantid::MantidVec v1(1, 1.1);
-    ws.dataX(0) = v1;
-    TS_ASSERT_EQUALS(v1, ws.dataX(0));
+    ws.mutableX(0) = v1;
+    TS_ASSERT_EQUALS(v1, ws.x(0).rawData());
   }
   void testsetgetYvector() {
     WorkspaceSingleValue ws;
     Mantid::MantidVec v1(1, 1.1);
-    ws.dataY(0) = v1;
-    TS_ASSERT_EQUALS(v1, ws.dataY(0));
+    ws.mutableY(0) = v1;
+    TS_ASSERT_EQUALS(v1, ws.y(0).rawData());
   }
 
   void testsetgetEvector() {
     WorkspaceSingleValue ws;
     Mantid::MantidVec v1(1, 1.1);
-    ws.dataE(0) = v1;
-    TS_ASSERT_EQUALS(v1, ws.dataE(0));
+    ws.mutableE(0) = v1;
+    TS_ASSERT_EQUALS(v1, ws.e(0).rawData());
   }
 
   void testgetNumDims() {

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD.cpp
@@ -542,7 +542,7 @@ void IntegratePeaksMD::integrate(typename MDEventWorkspace<MDE, nd>::sptr ws) {
             FunctionFactory::Instance().createInitialized(fun_str.str());
         boost::shared_ptr<const CompositeFunction> fun =
             boost::dynamic_pointer_cast<const CompositeFunction>(ifun);
-        const auto x = wsProfile2D->x(i);
+        const auto &x = wsProfile2D->x(i);
         wsFit2D->setSharedX(i, wsProfile2D->sharedX(i));
         wsDiff2D->setSharedX(i, wsProfile2D->sharedX(i));
 

--- a/Framework/Muon/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Muon/src/CalMuonDetectorPhases.cpp
@@ -173,7 +173,7 @@ void CalMuonDetectorPhases::fitWorkspace(const API::MatrixWorkspace_sptr &ws,
   const static std::string success = "success";
   for (int wsIndex = 0; wsIndex < nhist; wsIndex++) {
     reportProgress(wsIndex, nhist);
-    auto yValues = ws->y(wsIndex);
+    const auto &yValues = ws->y(wsIndex);
     auto emptySpectrum = std::all_of(yValues.begin(), yValues.end(),
                                      [](double value) { return value == 0.; });
     if (emptySpectrum) {

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -197,7 +197,7 @@ void EstimateMuonAsymmetryFromCounts::exec() {
     outputWS->setHistogram(
         specNum, normaliseCounts(inputWS->histogram(specNum), numGoodFrames));
     if (extraData) {
-      unnormWS->mutableX(specNum) = outputWS->x(specNum);
+      unnormWS->setSharedX(specNum, outputWS->sharedX(specNum));
       unnormWS->mutableY(specNum) = outputWS->y(specNum);
       unnormWS->mutableE(specNum) = outputWS->e(specNum);
     }

--- a/Framework/Muon/src/RRFMuon.cpp
+++ b/Framework/Muon/src/RRFMuon.cpp
@@ -95,10 +95,10 @@ void RRFMuon::exec() {
   // Put results into output workspace
   // Real RRF polarization
   outputWs->setSharedX(0, inputWs->sharedX(0));
-  outputWs->mutableY(0) = rrfRe;
+  outputWs->mutableY(0) = std::move(rrfRe);
   // Imaginary RRF polarization
   outputWs->setSharedX(1, inputWs->sharedX(1));
-  outputWs->mutableY(1) = rrfIm;
+  outputWs->mutableY(1) = std::move(rrfIm);
 
   // Set output workspace
   setProperty("OutputWorkspace", outputWs);

--- a/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
+++ b/Framework/Muon/test/PlotAsymmetryByLogValueTest.h
@@ -142,7 +142,7 @@ public:
     TS_ASSERT(outWS);
     TS_ASSERT_EQUALS(outWS->blocksize(), 2);
     TS_ASSERT_EQUALS(outWS->getNumberHistograms(), 4);
-    const auto Y = outWS->y(0);
+    const auto &Y = outWS->y(0);
     TS_ASSERT_DELTA(Y[0], 0.0128845, 0.001);
     TS_ASSERT_DELTA(Y[1], 0.0224898, 0.00001);
 
@@ -178,7 +178,7 @@ public:
     TS_ASSERT(outWS);
     TS_ASSERT_EQUALS(outWS->blocksize(), 2);
     TS_ASSERT_EQUALS(outWS->getNumberHistograms(), 4);
-    const auto Y = outWS->y(0);
+    const auto &Y = outWS->y(0);
     TS_ASSERT_DELTA(Y[0], -0.01236, 0.001);
     TS_ASSERT_DELTA(Y[1], 0.019186, 0.00001);
   }
@@ -286,7 +286,7 @@ public:
     TS_ASSERT_EQUALS(outWs->blocksize(), 2);
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 1);
 
-    const auto Y = outWs->y(0);
+    const auto &Y = outWs->y(0);
 
     TS_ASSERT_DELTA(Y[0], 0.15214, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.14492, 0.00001);
@@ -319,7 +319,7 @@ public:
     TS_ASSERT_EQUALS(outWs->blocksize(), 2);
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 1);
 
-    const auto Y = outWs->y(0);
+    const auto &Y = outWs->y(0);
 
     TS_ASSERT_DELTA(Y[0], 0.151202, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.144008, 0.00001);
@@ -354,10 +354,10 @@ public:
     TS_ASSERT_EQUALS(outWs->blocksize(), 2);
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 4);
 
-    const auto YDiff = outWs->y(0);
-    const auto EDiff = outWs->e(0);
-    const auto YSum = outWs->y(3);
-    const auto ESum = outWs->e(3);
+    const auto &YDiff = outWs->y(0);
+    const auto &EDiff = outWs->e(0);
+    const auto &YSum = outWs->y(3);
+    const auto &ESum = outWs->e(3);
 
     TS_ASSERT_DELTA(YDiff[0], 0.001135, 0.000001);
     TS_ASSERT_DELTA(EDiff[0], 0.001805, 0.000001);
@@ -394,7 +394,7 @@ public:
     TS_ASSERT_EQUALS(outWs->blocksize(), 2);
     TS_ASSERT_EQUALS(outWs->getNumberHistograms(), 1);
 
-    const auto Y = outWs->y(0);
+    const auto &Y = outWs->y(0);
     TS_ASSERT_DELTA(Y[0], 0.14700, 0.00001);
     TS_ASSERT_DELTA(Y[1], 0.13042, 0.00001);
   }
@@ -428,7 +428,7 @@ public:
 
     // Now we want to test X values (log values) in the output workspace
     // rather than asymmetry (Y values)
-    const auto X = outWs->x(0);
+    const auto &X = outWs->x(0);
 
     TS_ASSERT_DELTA(X[0], 178.740476, 0.00001);
     TS_ASSERT_DELTA(X[1], 178.849998, 0.00001);

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1133,7 +1133,7 @@ createProcessedInelasticWS(const std::vector<double> &L2,
     for (size_t i = 0; i <= numBins; i++) {
       E_transfer.push_back(Emin + static_cast<double>(i) * dE);
     }
-    ws->mutableX(j) = E_transfer;
+    ws->mutableX(j) = std::move(E_transfer);
   }
 
   // set axis, correspondent to the X-values

--- a/qt/scientific_interfaces/DynamicPDF/DPDFFourierTransform.cpp
+++ b/qt/scientific_interfaces/DynamicPDF/DPDFFourierTransform.cpp
@@ -101,11 +101,11 @@ void FourierTransform::extractResidualsHistogram(
     // use modelWorkspace as template for the residuals workspace
     auto residualsWorkspace =
         Mantid::API::WorkspaceFactory::Instance().create(modelWorkspace, 1);
-    residualsWorkspace->dataX(0) = modelWorkspace->dataX(0);
-    residualsWorkspace->dataY(0) =
-        modelWorkspace->dataY(2); // residuals is the third spectrum
-    residualsWorkspace->dataE(0) =
-        modelWorkspace->dataE(0); // errors are coming from experiment
+    residualsWorkspace->setSharedX(0, modelWorkspace->sharedX(0));
+    // residuals is the third spectrum
+    residualsWorkspace->setSharedY(0, modelWorkspace->sharedY(2));
+    // errors are coming from experiment
+    residualsWorkspace->setSharedE(0, modelWorkspace->sharedE(0));
     Mantid::API::AnalysisDataService::Instance().addOrReplace(
         m_residualsName, residualsWorkspace);
   } catch (std::exception &e) {

--- a/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
@@ -54,8 +54,8 @@ bool CorrectionsTab::checkWorkspaceBinningMatches(
     MatrixWorkspace_const_sptr left, MatrixWorkspace_const_sptr right) {
   if (left && right) // check the workspaces actually point to something first
   {
-    const auto leftX = left->x(0);
-    const auto rightX = right->x(0);
+    const auto &leftX = left->x(0);
+    const auto &rightX = right->x(0);
     return leftX.size() == rightX.size() &&
            std::equal(leftX.begin(), leftX.end(), rightX.begin());
   } else {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -236,8 +236,8 @@ bool ISISEnergyTransfer::validate() {
     if (m_uiForm.ckBackgroundRemoval->isChecked()) {
       MatrixWorkspace_sptr tempWs =
           AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
-      const double minBack = tempWs->x(0)[0];
-      const double maxBack = tempWs->x(0)[tempWs->blocksize()];
+      const double minBack = tempWs->x(0).front();
+      const double maxBack = tempWs->x(0).back();
 
       if (m_uiForm.spBackgroundStart->value() < minBack) {
         uiv.addErrorMessage("The Start of Background Removal is less than the "
@@ -691,8 +691,8 @@ void ISISEnergyTransfer::plotRaw() {
     MatrixWorkspace_sptr tempWs =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
 
-    const double minBack = tempWs->x(0)[0];
-    const double maxBack = tempWs->x(0)[tempWs->blocksize()];
+    const double minBack = tempWs->x(0).front();
+    const double maxBack = tempWs->x(0).back();
 
     if (startBack < minBack) {
       emit showMessageBox("The Start of Background Removal is less than the "

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -226,7 +226,7 @@ std::map<std::string, double> IndirectDataReductionTab::getRangesFromInstrument(
   convUnitsAlg->execute();
   MatrixWorkspace_sptr tofWs = convUnitsAlg->getProperty("OutputWorkspace");
 
-  const auto tofData = tofWs->x(0);
+  const auto &tofData = tofWs->x(0);
   ranges["peak-start-tof"] = tofData[0];
   ranges["peak-end-tof"] = tofData[2];
   ranges["back-start-tof"] = tofData[3];

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
@@ -108,8 +108,8 @@ bool hasConstrainableIntensities(IFunction_sptr function) {
 }
 
 double computeTauApproximation(MatrixWorkspace_sptr workspace) {
-  const auto x = workspace->x(0);
-  const auto y = workspace->y(0);
+  const auto &x = workspace->x(0);
+  const auto &y = workspace->y(0);
 
   if (x.size() > 4)
     return -x[4] / log(y[4]);

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingPresenter.cpp
@@ -106,7 +106,7 @@ void ALCPeakFittingPresenter::onFittedPeaksChanged() {
   IFunction_const_sptr fittedPeaks = m_model->fittedPeaks();
   auto dataWS = m_model->data();
   if (fittedPeaks && dataWS) {
-    auto x = dataWS->x(0);
+    const auto &x = dataWS->x(0);
     m_view->setFittedCurve(
         *(QwtHelper::curveDataFromFunction(fittedPeaks, x.rawData())));
     m_view->setFunction(fittedPeaks);
@@ -154,7 +154,7 @@ bool ALCPeakFittingPresenter::plotGuessOnGraph() {
   auto func = m_view->function("");
   auto dataWS = m_model->data();
   if (func && dataWS) {
-    auto xdata = dataWS->x(0);
+    const auto &xdata = dataWS->x(0);
     m_view->setFittedCurve(
         *(QwtHelper::curveDataFromFunction(func, xdata.rawData())));
     plotted = true;

--- a/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
+++ b/qt/scientific_interfaces/test/MuonAnalysisDataLoaderTest.h
@@ -271,7 +271,7 @@ public:
     TS_ASSERT(outputWS);
     const auto &data = outputWS->y(0);
     TS_ASSERT_EQUALS(data.size(), 1958);
-    auto xData = outputWS->x(0);
+    const auto &xData = outputWS->x(0);
     auto offset = std::distance(xData.begin(),
                                 std::lower_bound(xData.begin(), xData.end(),
                                                  options.timeLimits.first)) +


### PR DESCRIPTION
This PR is a cleanup to some usages of `Histogram` data.

- Replace copies by references to x, y and e data.
- Use `setSharedX`, `setSharedY`, `setSharedE` instead of manually copying the
values
- Use `std::move` where appropriate
- Fix off-by-one errors in `SaveReflThreeColumnAsciiTest`,
`SaveReflCustomAsciiTest`, `SaveANSTOAsciiTest` and `ISISEnergyTransfer`
- Fix issues in `RefAxisTest`

**Report to:** [nobody].

**To test:**

Careful code review.

Fixes #24462. 


*This does not require release notes* because this is an internal change which should not affect the users.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
