### PR TITLE
Stop crash when writing too many errors to stderr wituout an external console to write to

### DIFF
--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -9,14 +9,12 @@
 #
 from __future__ import (absolute_import)
 
-# std imports
 import unittest
 
-# 3rdparty
+import sys
 from mock import patch
 from qtpy.QtCore import QCoreApplication, QObject
 
-# local imports
 from mantidqt.utils.qt.test import GuiTest
 from mantidqt.utils.writetosignal import WriteToSignal
 

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -11,9 +11,9 @@ from __future__ import (absolute_import)
 
 # std imports
 import unittest
-import sys
 
 # 3rdparty
+from mock import patch
 from qtpy.QtCore import QCoreApplication, QObject
 
 # local imports
@@ -31,13 +31,20 @@ class Receiver(QObject):
 class WriteToSignalTest(GuiTest):
 
     def test_connected_receiver_receives_text(self):
-        recv = Receiver()
-        writer = WriteToSignal(sys.stdout)
-        writer.sig_write_received.connect(recv.capture_text)
-        txt = "I expect to see this"
-        writer.write(txt)
-        QCoreApplication.processEvents()
-        self.assertEqual(txt, recv.captured_txt)
+        import sys
+        sys.path.append("c:\\users\\qbr77747\\apps\\miniconda3\\lib\\site-packages")
+        import pydevd
+        pydevd.settrace('localhost', port=44444, stdoutToServer=True, stderrToServer=True)
+
+        with patch("sys.stdout.fileno") as mock_fileno:
+            recv = Receiver()
+            writer = WriteToSignal(sys.stdout)
+            writer.sig_write_received.connect(recv.capture_text)
+            txt = "I expect to see this"
+            writer.write(txt)
+            QCoreApplication.processEvents()
+            self.assertEqual(txt, recv.captured_txt)
+            mock_fileno.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -31,11 +31,6 @@ class Receiver(QObject):
 class WriteToSignalTest(GuiTest):
 
     def test_connected_receiver_receives_text(self):
-        import sys
-        sys.path.append("c:\\users\\qbr77747\\apps\\miniconda3\\lib\\site-packages")
-        import pydevd
-        pydevd.settrace('localhost', port=44444, stdoutToServer=True, stderrToServer=True)
-
         with patch("sys.stdout.fileno") as mock_fileno:
             recv = Receiver()
             writer = WriteToSignal(sys.stdout)

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -47,7 +47,7 @@ class WriteToSignalTest(GuiTest):
             self.assertEqual(writer._original_out, None)
 
     def test_connected_receiver_receives_text(self):
-        with patch("sys.stdout.fileno") as mock_fileno:
+        with patch("sys.stdout.fileno", return_value=1) as mock_fileno:
             recv = Receiver()
             writer = WriteToSignal(sys.stdout)
             writer.sig_write_received.connect(recv.capture_text)

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -27,6 +27,24 @@ class Receiver(QObject):
 
 
 class WriteToSignalTest(GuiTest):
+    @classmethod
+    def setUpClass(cls):
+        if not hasattr(sys.stdout, "fileno"):
+            # if not present in the test stdout, then add it as an
+            # attribute so that mock can replace it later.
+            sys.stdout.fileno = None
+
+    def test_run_with_output_present(self):
+        with patch("sys.stdout.fileno", return_value=10) as mock_fileno:
+            writer = WriteToSignal(sys.stdout)
+            mock_fileno.assert_called_once_with()
+            self.assertEqual(writer._original_out, sys.stdout)
+
+    def test_run_without_output_present(self):
+        with patch("sys.stdout.fileno", return_value=-1) as mock_fileno:
+            writer = WriteToSignal(sys.stdout)
+            mock_fileno.assert_called_once_with()
+            self.assertEqual(writer._original_out, None)
 
     def test_connected_receiver_receives_text(self):
         with patch("sys.stdout.fileno") as mock_fileno:

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -9,12 +9,7 @@
 #
 from __future__ import (absolute_import)
 
-# 3rdparty imports
-import sys
 from qtpy.QtCore import QObject, Signal
-
-
-# std imports
 
 
 class WriteToSignal(QObject):
@@ -25,8 +20,8 @@ class WriteToSignal(QObject):
 
     def __init__(self, original_out):
         QObject.__init__(self)
-        # If the file descriptor of the stream is -2 then we are running in a no-external-console mode
-        if self.__original_out.fileno() == -2:
+        # If the file descriptor of the stream is < 0 then we are running in a no-external-console mode
+        if self.__original_out.fileno() < 0:
             self.__original_out = None
         else:
             self.__original_out = original_out
@@ -44,7 +39,6 @@ class WriteToSignal(QObject):
 
     def write(self, txt):
         if self.__original_out:
-            # write to the console
             try:
                 self.__original_out.write(txt)
             except IOError:

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -18,15 +18,15 @@ class WriteToSignal(QObject):
     Qt-signals. Mainly used to communicate
     stdout/stderr across threads"""
 
+    sig_write_received = Signal(str)
+
     def __init__(self, original_out):
         QObject.__init__(self)
         # If the file descriptor of the stream is < 0 then we are running in a no-external-console mode
         if original_out.fileno() < 0:
-            self.__original_out = None
+            self._original_out = None
         else:
-            self.__original_out = original_out
-
-    sig_write_received = Signal(str)
+            self._original_out = original_out
 
     def closed(self):
         return False
@@ -38,9 +38,9 @@ class WriteToSignal(QObject):
         return False
 
     def write(self, txt):
-        if self.__original_out:
+        if self._original_out:
             try:
-                self.__original_out.write(txt)
+                self._original_out.write(txt)
             except IOError as e:
                 self.sig_write_received.emit("Error: Unable to write to the console of the process.\n"
                                              "This error is not related to your script's execution.\n"

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -41,9 +41,10 @@ class WriteToSignal(QObject):
         if self.__original_out:
             try:
                 self.__original_out.write(txt)
-            except IOError:
+            except IOError as e:
                 self.sig_write_received.emit("Error: Unable to write to the console of the process.\n"
-                                             "This error is not related to your script's execution.\n\n")
+                                             "This error is not related to your script's execution.\n"
+                                             "Original error: {}\n\n".format(str(e)))
 
         # always write to the message log
         self.sig_write_received.emit(txt)

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -9,10 +9,12 @@
 #
 from __future__ import (absolute_import)
 
-# std imports
-
 # 3rdparty imports
+import sys
 from qtpy.QtCore import QObject, Signal
+
+
+# std imports
 
 
 class WriteToSignal(QObject):
@@ -20,9 +22,14 @@ class WriteToSignal(QObject):
     used to transform write requests to
     Qt-signals. Mainly used to communicate
     stdout/stderr across threads"""
+
     def __init__(self, original_out):
         QObject.__init__(self)
-        self.__original_out = original_out
+        # If the file descriptor of the stream is -2 then we are running in a no-external-console mode
+        if self.__original_out.fileno() == -2:
+            self.__original_out = None
+        else:
+            self.__original_out = original_out
 
     sig_write_received = Signal(str)
 
@@ -36,7 +43,13 @@ class WriteToSignal(QObject):
         return False
 
     def write(self, txt):
-        # write to the console
-        self.__original_out.write(txt)
-        # emit the signal which will write to logging
+        if self.__original_out:
+            # write to the console
+            try:
+                self.__original_out.write(txt)
+            except IOError:
+                self.sig_write_received.emit("Error: Unable to write to the console of the process.\n"
+                                             "This error is not related to your script's execution.\n\n")
+
+        # always write to the message log
         self.sig_write_received.emit(txt)

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -21,7 +21,7 @@ class WriteToSignal(QObject):
     def __init__(self, original_out):
         QObject.__init__(self)
         # If the file descriptor of the stream is < 0 then we are running in a no-external-console mode
-        if self.__original_out.fileno() < 0:
+        if original_out.fileno() < 0:
             self.__original_out = None
         else:
             self.__original_out = original_out

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -249,7 +249,7 @@ class PythonFileInterpreterPresenter(QObject):
             lineno = exc_stack[-1][1] + self._code_start_offset
         else:
             lineno = -1
-        sys.stderr.write(self._error_formatter.format(exc_type, exc_value, exc_stack) + '\n')
+        sys.stderr.write(self._error_formatter.format(exc_type, exc_value, exc_stack) + os.linesep)
         self.view.editor.updateProgressMarker(lineno, True)
         self._finish(success=False, elapsed_time=task_error.elapsed_time)
 


### PR DESCRIPTION
**Description of work.**

Adds a check for whether an external console exists - if `stderr.fileno() < 0` then there is no external console, and we are likely running through `pythonw.exe`.

If the Workbench is ran with `python.exe` instead, the external console will be initialised, and written to correctly.

A try/except has been added around the external write code, so that any surprising `IOErrors` don't hard-crash the Workbench, but instead write out an error message to the user.

**To test:**

Run the Workbench, and print many errors - type something that produces an error and hold Ctrl+Return for 5-10 seconds. The Workbench shouldn't crash, nor should you see the new error messages introduced in this PR.

Fixes #24439 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
