### PR TITLE
Indirect Elwin - Load without history option

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -69,6 +69,12 @@ Input File
   Specify a range of input files that are either reduced (*_red.nxs*) or
   :math:`S(Q, \omega)`.
 
+Group Input
+  Provides an option to group or ungroup the input data.
+
+Load History
+  If unchecked the input workspace will be loaded without it's history.
+
 Integration Range
   The energy range over which to integrate the values.
 

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -51,6 +51,7 @@ Improvements
 - The results of a fit in MSDFit, IqtFit, ConvFit and F(Q)Fit are now plotted with error bars.
 - The AddWorkspace windows (opened from the Multiple Input tab) now stay open after adding a workspace to the data table. This 
   is found on the MSDFit, I(Q,t)Fit, ConvFit and F(Q)Fit interfaces.
+- It is now possible to load a Nexus file without it's history on the Elwin interface by unchecking the Load History checkbox.
 
 
 Bugfixes

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -423,7 +423,7 @@ void Elwin::setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws) {
 /**
  * Handles a new set of input files being entered.
  *
- * Updates preview seletcion combo box.
+ * Updates preview selection combo box.
  */
 void Elwin::newInputFiles() {
   // Clear the existing list of files
@@ -456,24 +456,22 @@ void Elwin::newInputFiles() {
  * @param index Index of the new selected file
  */
 void Elwin::newPreviewFileSelected(int index) {
-  QString wsName = m_uiForm.cbPreviewFile->itemText(index);
-  QString filename = m_uiForm.cbPreviewFile->itemData(index).toString();
+  auto const workspaceName = m_uiForm.cbPreviewFile->itemText(index);
+  auto const filename = m_uiForm.cbPreviewFile->itemData(index).toString();
 
-  // Ignore empty filenames (can happen when new files are loaded and the widget
-  // is being populated)
-  if (filename.isEmpty())
-    return;
+  if (!filename.isEmpty()) {
+    auto const loadHistory = m_uiForm.ckLoadHistory->isChecked();
 
-  if (!loadFile(filename, wsName)) {
-    g_log.error("Failed to load input workspace.");
-    return;
+    if (loadFile(filename, workspaceName, -1, -1, loadHistory)) {
+      auto const workspace = getADSMatrixWorkspace(workspaceName.toStdString());
+      int const numHist =
+          static_cast<int>(workspace->getNumberHistograms()) - 1;
+
+      m_uiForm.spPreviewSpec->setMaximum(numHist);
+      m_uiForm.spPreviewSpec->setValue(0);
+    } else
+      g_log.error("Failed to load input workspace.");
   }
-
-  auto const ws = getADSMatrixWorkspace(wsName.toStdString());
-  int const numHist = static_cast<int>(ws->getNumberHistograms()) - 1;
-
-  m_uiForm.spPreviewSpec->setMaximum(numHist);
-  m_uiForm.spPreviewSpec->setValue(0);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/Elwin.ui
+++ b/qt/scientific_interfaces/Indirect/Elwin.ui
@@ -47,18 +47,6 @@
       </item>
       <item>
        <widget class="QFrame" name="frame">
-        <property name="maximumSize">
-         <size>
-          <width>90</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::StyledPanel</enum>
-        </property>
-        <property name="frameShadow">
-         <enum>QFrame::Raised</enum>
-        </property>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <property name="spacing">
           <number>3</number>

--- a/qt/scientific_interfaces/Indirect/Elwin.ui
+++ b/qt/scientific_interfaces/Indirect/Elwin.ui
@@ -46,13 +46,56 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="ckGroupInput">
-        <property name="text">
-         <string>Group Input</string>
+       <widget class="QFrame" name="frame">
+        <property name="maximumSize">
+         <size>
+          <width>90</width>
+          <height>16777215</height>
+         </size>
         </property>
-        <property name="checked">
-         <bool>true</bool>
+        <property name="frameShape">
+         <enum>QFrame::StyledPanel</enum>
         </property>
+        <property name="frameShadow">
+         <enum>QFrame::Raised</enum>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="ckGroupInput">
+           <property name="text">
+            <string>Group Input</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="ckLoadHistory">
+           <property name="text">
+            <string>Load History</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
      </layout>

--- a/qt/scientific_interfaces/Indirect/Elwin.ui
+++ b/qt/scientific_interfaces/Indirect/Elwin.ui
@@ -90,9 +90,6 @@
            <property name="text">
             <string>Load History</string>
            </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
           </widget>
          </item>
         </layout>

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -136,21 +136,21 @@ void IndirectTab::exportPythonScript() {
  * @return If the algorithm was successful
  */
 bool IndirectTab::loadFile(const QString &filename, const QString &outputName,
-                           const int specMin, const int specMax) {
-  Algorithm_sptr load =
-      AlgorithmManager::Instance().createUnmanaged("Load", -1);
+                           const int specMin, const int specMax,
+                           bool loadHistory) {
+  auto load = AlgorithmManager::Instance().createUnmanaged("Load", -1);
   load->initialize();
-
   load->setProperty("Filename", filename.toStdString());
   load->setProperty("OutputWorkspace", outputName.toStdString());
 
   if (specMin != -1)
     load->setPropertyValue("SpectrumMin",
                            boost::lexical_cast<std::string>(specMin));
-
   if (specMax != -1)
     load->setPropertyValue("SpectrumMax",
                            boost::lexical_cast<std::string>(specMax));
+  if (!loadHistory)
+    load->setProperty("LoadHistory", loadHistory);
 
   load->execute();
 

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -75,8 +75,7 @@ protected slots:
   virtual void algorithmFinished(bool error);
 
 protected:
-  /// Run the load algorithm with the given file name, output name and spectrum
-  /// range
+  /// Run the load algorithms
   bool loadFile(const QString &filename, const QString &outputName,
                 const int specMin = -1, const int specMax = -1,
                 bool loadHistory = true);

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -78,7 +78,8 @@ protected:
   /// Run the load algorithm with the given file name, output name and spectrum
   /// range
   bool loadFile(const QString &filename, const QString &outputName,
-                const int specMin = -1, const int specMax = -1);
+                const int specMin = -1, const int specMax = -1,
+                bool loadHistory = true);
 
   /// Add a SaveNexusProcessed step to the batch queue
   void addSaveWorkspaceToQueue(const std::string &wsName,


### PR DESCRIPTION
**Description of work.**
This PR introduces the option to load a reduced workspace without loading its history. 

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`Elwin` tab
2. Check the `Load History` checkbox 
3. Load the data below. Make sure it has history (Load, Scale, Minus, SaveNexusProcessed, Load).
4. Now uncheck the `Load History` checkbox and reload the data. There should be no history (apart from Load) 

**Data Files**
[irs26176_withhistory_red.zip](https://github.com/mantidproject/mantid/files/2755453/irs26176_withhistory_red.zip)

Fixes #24487 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
