### PR TITLE
Fix not showing last bin boundary in X values

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -99,7 +99,7 @@ endif ()
 
     mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_model.py
     mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_presenter.py
-    mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_tableviewmodel.py
+    mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_table_view_model.py
 
     mantidqt/widgets/tableworkspacedisplay/test/test_tableworkspacedisplay_error_column.py
     mantidqt/widgets/tableworkspacedisplay/test/test_tableworkspacedisplay_marked_columns.py

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/table_view_model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/table_view_model.py
@@ -67,6 +67,12 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
         self.type = model_type
         if self.type == MatrixWorkspaceTableViewModelType.x:
             self.relevant_data = self.ws.readX
+
+            # add another column if the workspace is histogram data
+            # this will contain the right boundary for the last bin
+            if self.ws.isHistogramData():
+                self.column_count += 1
+
         elif self.type == MatrixWorkspaceTableViewModelType.y:
             self.relevant_data = self.ws.readY
         elif self.type == MatrixWorkspaceTableViewModelType.e:

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/test/test_matrixworkspacedisplay_table_view_model.py
@@ -24,8 +24,6 @@ from mantidqt.widgets.matrixworkspacedisplay.test_helpers.matrixworkspacedisplay
 
 
 class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
-    WORKSPACE = r"C:\Users\qbr77747\dev\m\workbench_matrixworkspace\test_masked_bins.nxs"
-
     def test_correct_model_type(self):
         ws = MockWorkspace()
         model = MatrixWorkspaceTableViewModel(ws, MatrixWorkspaceTableViewModelType.x)
@@ -482,6 +480,31 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
         output = model.headerData(mock_section, Qt.Horizontal, Qt.ToolTipRole)
 
         self.assertEqual(MatrixWorkspaceTableViewModel.HORIZONTAL_BINS_VARY_TOOLTIP_STRING.format(mock_section), output)
+
+    def test_histogram_data_has_one_extra_x_column(self):
+        """
+        Test that an extra column is added if the workspace is HistogramData. This is the column that
+        contains the right boundary for the last bin.
+        """
+        mock_data = [1, 2, 3, 4, 5, 6, 7]
+        data_len = len(mock_data)
+        ws = MockWorkspace(read_return=mock_data, isHistogramData=True)
+
+        model_type = MatrixWorkspaceTableViewModelType.x
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+
+        self.assertEqual(data_len + 1, model.columnCount())
+
+        # test that it is not added to Y and E
+        model_type = MatrixWorkspaceTableViewModelType.y
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+
+        self.assertEqual(data_len, model.columnCount())
+
+        model_type = MatrixWorkspaceTableViewModelType.e
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+
+        self.assertEqual(data_len, model.columnCount())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

If the workspace is HistogramData, increase X cols by 1. Test added that covers the case.

Renamed the `test_matrixworkspacedisplay_table_view_model` test to match the filename `table_view_model`.

**To test:**
Run `ws = CreateSampleWorkspace()`. Open the workspace. Y and E column numbers should be in range 0-99 (inclusive), and X columns should be 0-100.

Fixes #24493

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
