### PR TITLE
Prevent a crash when property has no value attribute

### DIFF
--- a/qt/python/mantidqt/widgets/algorithmprogress/model.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/model.py
@@ -124,6 +124,6 @@ class AlgorithmProgressModel(AlgorithmObserver):
         for observer in self.progress_observers:
             properties = []
             for prop in observer.properties():
-                properties.append([prop.name, str(prop.value), 'Default' if prop.isDefault else ''])
+                properties.append([prop.name, str(prop.valueAsStr), 'Default' if prop.isDefault else ''])
             algorithm_data.append((observer.name(), observer.algorithm, properties))
         return algorithm_data


### PR DESCRIPTION
**Description of work.**
While loading a file the `Details` button is clicked, it iterates over the algorithms' properties to display them - turns out that the `mantid.kernel._kernel.Property` object doesn't have a `value` attribute. However, they all seem to have a `valueAsStr` attribute, so this PR just replaces the call from `value` to `valueAsStr`.

**To test:**
- Click the `Details` button to open the details dialog. 
- Load `POLARIS00098531.nxs` or any of the other POLARIS files from SampleData-ISIS. (The reason they are useful is that it takes the instrument a long time to load). 
- The workbench shouldn't crash.
- Load more things, no crashes should happen.

<!-- Instructions for testing. -->

Fixes #24444 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
