### PR TITLE
Restrict the Details window to only 1 instance

### DIFF
--- a/qt/python/mantidqt/widgets/algorithmprogress/dialog_presenter.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/dialog_presenter.py
@@ -19,7 +19,7 @@ class AlgorithmProgressDialogPresenter(AlgorithmProgressPresenterBase):
         # connect the close button to the closeEvent of the window
         # so that pressing the X button, and pressing `Close` go through
         # the same routine, and properly call the presenter's close()
-        view.close_button.clicked.connect(view.closeEvent)
+        view.close_button.clicked.connect(view.close)
         self.view = view
         self.model = model
         self.model.add_presenter(self)
@@ -64,7 +64,7 @@ class AlgorithmProgressDialogPresenter(AlgorithmProgressPresenterBase):
         """
         self.model.remove_presenter(self)
         self.progress_bars.clear()
-        self.view.parent.clear_dialog()
+        self.view.parent().clear_dialog()
 
     def cancel_algorithm(self, algorithm_id):
         """

--- a/qt/python/mantidqt/widgets/algorithmprogress/dialog_presenter.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/dialog_presenter.py
@@ -13,9 +13,13 @@ class AlgorithmProgressDialogPresenter(AlgorithmProgressPresenterBase):
     """
     Presents progress reports on algorithms.
     """
+
     def __init__(self, view, model):
         super(AlgorithmProgressDialogPresenter, self).__init__()
-        view.close_button.clicked.connect(self.close)
+        # connect the close button to the closeEvent of the window
+        # so that pressing the X button, and pressing `Close` go through
+        # the same routine, and properly call the presenter's close()
+        view.close_button.clicked.connect(view.closeEvent)
         self.view = view
         self.model = model
         self.model.add_presenter(self)
@@ -60,7 +64,7 @@ class AlgorithmProgressDialogPresenter(AlgorithmProgressPresenterBase):
         """
         self.model.remove_presenter(self)
         self.progress_bars.clear()
-        self.view.close()
+        self.view.parent.clear_dialog()
 
     def cancel_algorithm(self, algorithm_id):
         """

--- a/qt/python/mantidqt/widgets/algorithmprogress/dialog_widget.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/dialog_widget.py
@@ -42,7 +42,6 @@ class AlgorithmMonitorDialog(QDialog):
 
     def __init__(self, parent, model):
         super(AlgorithmMonitorDialog, self).__init__(parent)
-        self.parent = parent
         self.tree = QTreeWidget(self)
         self.tree.setColumnCount(3)
         self.tree.setSelectionMode(QTreeWidget.NoSelection)
@@ -70,7 +69,7 @@ class AlgorithmMonitorDialog(QDialog):
         self.presenter = AlgorithmProgressDialogPresenter(self, model)
         self.presenter.update_gui()
 
-    def closeEvent(self, *args):
+    def closeEvent(self, event):
         """
         Funnel the closeEvent, triggered when the user presses X,
         through the same routine as the `Close` button
@@ -79,6 +78,7 @@ class AlgorithmMonitorDialog(QDialog):
         """
         self.presenter.close()
         self.deleteLater()
+        event.accept()
 
     def update(self, data):
         """

--- a/qt/python/mantidqt/widgets/algorithmprogress/dialog_widget.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/dialog_widget.py
@@ -19,6 +19,7 @@ class CancelButton(QPushButton):
     """
     Button that cancels an algorithm
     """
+
     def __init__(self, presenter, algorithm_id):
         """
         Init an instance
@@ -38,8 +39,10 @@ class AlgorithmMonitorDialog(QDialog):
     """
     Displays progress of all running algorithms.
     """
+
     def __init__(self, parent, model):
         super(AlgorithmMonitorDialog, self).__init__(parent)
+        self.parent = parent
         self.tree = QTreeWidget(self)
         self.tree.setColumnCount(3)
         self.tree.setSelectionMode(QTreeWidget.NoSelection)
@@ -66,6 +69,16 @@ class AlgorithmMonitorDialog(QDialog):
 
         self.presenter = AlgorithmProgressDialogPresenter(self, model)
         self.presenter.update_gui()
+
+    def closeEvent(self, *args):
+        """
+        Funnel the closeEvent, triggered when the user presses X,
+        through the same routine as the `Close` button
+        :param args:
+        :return:
+        """
+        self.presenter.close()
+        self.deleteLater()
 
     def update(self, data):
         """

--- a/qt/python/mantidqt/widgets/algorithmprogress/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmprogress/widget.py
@@ -17,6 +17,7 @@ class AlgorithmProgressWidget(QWidget):
     """
     Widget consisting of a progress bar and a button.
     """
+
     def __init__(self, parent=None):
         super(AlgorithmProgressWidget, self).__init__(parent)
         self.progress_bar = None
@@ -27,6 +28,7 @@ class AlgorithmProgressWidget(QWidget):
         self.layout.addWidget(self.details_button)
         self.setLayout(self.layout)
         self.presenter = AlgorithmProgressPresenter(self)
+        self.algorithm_monitor_dialog = None
 
     def show_progress_bar(self):
         if self.progress_bar is None:
@@ -43,5 +45,11 @@ class AlgorithmProgressWidget(QWidget):
             self.progress_bar = None
 
     def show_dialog(self):
-        dialog = AlgorithmMonitorDialog(self, self.presenter.model)
-        dialog.show()
+        if not self.algorithm_monitor_dialog:
+            self.algorithm_monitor_dialog = AlgorithmMonitorDialog(self, self.presenter.model)
+            self.algorithm_monitor_dialog.show()
+        else:
+            self.algorithm_monitor_dialog.setFocus()
+
+    def clear_dialog(self):
+        self.algorithm_monitor_dialog = None


### PR DESCRIPTION
**Description of work.**
Allows the user to only have 1 `Details` window. Additionally fixes a memory 'leak' where the presenter's close function wouldn't be called when the `Details` window is closed from the `X` - this triggers closeEvent that previously wasn't overriden to call the presenter's method. This is done by funnelling both the `X` and clicking the `Close` button events through the view's `closeEvent`, which then calls the presenter's `close`.

**To test:**
Click `Details` a bunch of times. Only 1 window should open at all times. Try closing via both the `X` and via the `Close` button.

<!-- Instructions for testing. -->

Fixes #24445 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
