### PR TITLE
Columns in Matrix and Table workspace displays are now adjustable

### DIFF
--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
@@ -28,7 +28,7 @@ class MatrixWorkspaceTableView(QTableView):
         header = self.horizontalHeader()
         header.sectionDoubleClicked.connect(self.handle_double_click)
 
-    def resizeEvent(self, event):
+    def resizeEvent(self, _):
         header = self.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.Interactive)
 

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
@@ -20,6 +20,22 @@ import mantidqt.icons
 from mantidqt.widgets.matrixworkspacedisplay.table_view_model import MatrixWorkspaceTableViewModelType
 
 
+class MatrixWorkspaceTableView(QTableView):
+    def __init__(self, parent):
+        super(MatrixWorkspaceTableView, self).__init__(parent)
+        self.setSelectionBehavior(QAbstractItemView.SelectItems)
+
+        header = self.horizontalHeader()
+        header.sectionDoubleClicked.connect(self.handle_double_click)
+
+    def resizeEvent(self, event):
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Interactive)
+
+    def handle_double_click(self, section):
+        header = self.horizontalHeader()
+        header.resizeSection(section, header.defaultSectionSize())
+
 class MatrixWorkspaceDisplayView(QTabWidget):
     def __init__(self, presenter, parent=None, name=''):
         super(MatrixWorkspaceDisplayView, self).__init__(parent)
@@ -51,8 +67,8 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         self.show()
 
     def add_table(self, label):
-        tab = QTableView()
-        tab.setSelectionBehavior(QAbstractItemView.SelectItems)
+        tab = MatrixWorkspaceTableView(self)
+
         self.addTab(tab, label)
         self.tabs.append(tab)
         return tab

--- a/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/matrixworkspacedisplay/view.py
@@ -36,6 +36,7 @@ class MatrixWorkspaceTableView(QTableView):
         header = self.horizontalHeader()
         header.resizeSection(section, header.defaultSectionSize())
 
+
 class MatrixWorkspaceDisplayView(QTabWidget):
     def __init__(self, presenter, parent=None, name=''):
         super(MatrixWorkspaceDisplayView, self).__init__(parent)

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
@@ -57,6 +57,17 @@ class TableWorkspaceDisplayView(QTableWidget):
         self.resize(600, 400)
         self.show()
 
+        header = self.horizontalHeader()
+        header.sectionDoubleClicked.connect(self.handle_double_click)
+
+    def resizeEvent(self, _):
+        header = self.horizontalHeader()
+        header.setSectionResizeMode(QHeaderView.Interactive)
+
+    def handle_double_click(self, section):
+        header = self.horizontalHeader()
+        header.resizeSection(section, header.defaultSectionSize())
+
     def keyPressEvent(self, event):
         if event.matches(QKeySequence.Copy):
             self.presenter.action_keypress_copy()


### PR DESCRIPTION
**Description of work.**
Columns in the MWD and TWD are now adjustable. Additionally a double click was added to revert to original column width (is this feature desirable?)

**To test:**
Show data for a workspace (either right click show data, or double click)
Resize the columns
Double click to reset their width
<!-- Instructions for testing. -->

Fixes #24388
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
