### PR TITLE
Rebin2D: avoid NaNs by skipping bins of zero size

### DIFF
--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -77,7 +77,7 @@ void Rebin2D::init() {
 void Rebin2D::exec() {
   // Information to form input grid
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
-  NumericAxis *oldAxis2 = dynamic_cast<API::NumericAxis *>(inputWS->getAxis(1));
+  const NumericAxis *oldAxis2 = dynamic_cast<API::NumericAxis *>(inputWS->getAxis(1));
   if (!oldAxis2) {
     throw std::invalid_argument(
         "Vertical axis is not a numeric axis, cannot rebin. "
@@ -87,16 +87,9 @@ void Rebin2D::exec() {
   const auto &oldXEdges = inputWS->x(0);
   const size_t numXBins = inputWS->blocksize();
   const size_t numYBins = inputWS->getNumberHistograms();
-  std::vector<double> oldYEdges;
-  if (numYBins == oldAxis2->length()) {
-    // Pt data on axis 2, create bins
-    oldYEdges = oldAxis2->createBinBoundaries();
-  } else {
-    oldYEdges.resize(oldAxis2->length());
-    for (size_t i = 0; i < oldAxis2->length(); ++i) {
-      oldYEdges[i] = (*oldAxis2)(i);
-    }
-  }
+  // This will convert plain NumericAxis to bin edges while
+  // BinEdgeAxis will just return its edges.
+  const std::vector<double> oldYEdges = oldAxis2->createBinBoundaries();
 
   // Output grid and workspace. Fills in the new X and Y bin vectors
   // MantidVecPtr newXBins;

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -77,7 +77,8 @@ void Rebin2D::init() {
 void Rebin2D::exec() {
   // Information to form input grid
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
-  const NumericAxis *oldAxis2 = dynamic_cast<API::NumericAxis *>(inputWS->getAxis(1));
+  const NumericAxis *oldAxis2 =
+      dynamic_cast<API::NumericAxis *>(inputWS->getAxis(1));
   if (!oldAxis2) {
     throw std::invalid_argument(
         "Vertical axis is not a numeric axis, cannot rebin. "

--- a/Framework/Algorithms/test/Rebin2DTest.h
+++ b/Framework/Algorithms/test/Rebin2DTest.h
@@ -7,8 +7,8 @@
 #ifndef MANTID_ALGORITHMS_REBIN2DTEST_H_
 #define MANTID_ALGORITHMS_REBIN2DTEST_H_
 
-#include "MantidAPI/NumericAxis.h"
 #include "MantidAlgorithms/Rebin2D.h"
+#include "MantidAPI/BinEdgeAxis.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
@@ -49,7 +49,7 @@ MatrixWorkspace_sptr makeInputWS(const bool distribution,
       int(nhist), int(nbins), x0, deltax);
 
   // We need something other than a spectrum axis, call this one theta
-  NumericAxis *const thetaAxis = new NumericAxis(nhist + 1);
+  BinEdgeAxis *const thetaAxis = new BinEdgeAxis(nhist + 1);
   for (size_t i = 0; i < nhist + 1; ++i) {
     thetaAxis->setValue(i, -0.5 + static_cast<double>(i));
   }
@@ -259,19 +259,23 @@ public:
   static void destroySuite(Rebin2DTestPerformance *suite) { delete suite; }
 
   Rebin2DTestPerformance() {
+    constexpr bool distribution = false;
+    constexpr bool perf_test = true;
+    constexpr bool small_bins = false;
     m_inputWS = makeInputWS(distribution, perf_test, small_bins);
   }
 
   void test_On_Large_Workspace() {
-    runAlgorithm(m_inputWS, "100,200,41000", "-0.5,2,499.5");
+    runAlgorithm(m_inputWS, "100,10,41000", "-0.5,0.5,499.5");
+  }
+
+  void test_Use_Fractional_Area() {
+    constexpr bool useFractionalArea = true;
+    runAlgorithm(m_inputWS, "100,10,41000", "-0.5,0.5,499.5", useFractionalArea);
   }
 
 private:
   MatrixWorkspace_sptr m_inputWS;
-
-  const bool distribution = false;
-  const bool perf_test = true;
-  const bool small_bins = false;
 };
 
 #endif /* MANTID_ALGORITHMS_REBIN2DTEST_H_ */

--- a/Framework/Algorithms/test/Rebin2DTest.h
+++ b/Framework/Algorithms/test/Rebin2DTest.h
@@ -184,6 +184,42 @@ public:
     }
   }
 
+  void test_Zero_Area_Bins_NoFractionalBinning() {
+    MatrixWorkspace_sptr inputWS = makeInputWS(false);
+    const auto nhist = inputWS->getNumberHistograms();
+    // Set the vertical 'width' of a single histogram to zero
+    auto thetaAxis = inputWS->getAxis(1);
+    const auto middle = nhist / 2;
+    const auto midValue = thetaAxis->getValue(middle);
+    thetaAxis->setValue(middle - 1, midValue);
+    constexpr bool useFractionalBinning = false;
+    MatrixWorkspace_sptr outputWS =
+        runAlgorithm(inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
+    const auto &Ys = outputWS->y(0);
+    for (size_t j = 0; j < Ys.size(); ++j) {
+      TS_ASSERT(!std::isnan(Ys[j]))
+    }
+  }
+
+  void test_Zero_Area_Bins_FractionalBinning() {
+    MatrixWorkspace_sptr inputWS = makeInputWS(false);
+    const auto nhist = inputWS->getNumberHistograms();
+    // Set the vertical 'width' of a single histogram to zero
+    auto thetaAxis = inputWS->getAxis(1);
+    const auto middle = nhist / 2;
+    const auto midValue = thetaAxis->getValue(middle);
+    thetaAxis->setValue(middle - 1, midValue);
+    constexpr bool useFractionalBinning = true;
+    MatrixWorkspace_sptr outputWS =
+        runAlgorithm(inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
+    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
+    const auto &Ys = outputWS->y(0);
+    for (size_t j = 0; j < Ys.size(); ++j) {
+      TS_ASSERT(!std::isnan(Ys[j]))
+    }
+  }
+
 private:
   void checkData(MatrixWorkspace_const_sptr outputWS, const size_t nxvalues,
                  const size_t nhist, const bool dist, const bool onAxis1,
@@ -202,8 +238,6 @@ private:
       const auto &y = outputWS->y(i);
       const auto &e = outputWS->e(i);
       for (size_t j = 0; j < nxvalues - 1; ++j) {
-        std::ostringstream os;
-        os << "Bin " << i << "," << j;
         if (onAxis1) {
           if (small_bins) {
 
@@ -224,6 +258,8 @@ private:
           TS_ASSERT_DELTA(y[j], 1.0, epsilon);
           TS_ASSERT_DELTA(e[j], 0.5, epsilon);
         } else {
+          std::ostringstream os;
+          os << "Bin " << i << "," << j;
           TSM_ASSERT_DELTA(os.str(), y[j], 4.0, epsilon);
           TS_ASSERT_DELTA(e[j], 2.0, epsilon);
         }

--- a/Framework/Algorithms/test/Rebin2DTest.h
+++ b/Framework/Algorithms/test/Rebin2DTest.h
@@ -7,8 +7,9 @@
 #ifndef MANTID_ALGORITHMS_REBIN2DTEST_H_
 #define MANTID_ALGORITHMS_REBIN2DTEST_H_
 
-#include "MantidAlgorithms/Rebin2D.h"
 #include "MantidAPI/BinEdgeAxis.h"
+#include "MantidAlgorithms/Rebin2D.h"
+#include "MantidDataObjects/RebinnedOutput.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 
@@ -16,6 +17,7 @@
 
 using Mantid::Algorithms::Rebin2D;
 using namespace Mantid::API;
+using namespace Mantid::DataObjects;
 
 namespace {
 /**
@@ -193,12 +195,17 @@ public:
     const auto midValue = thetaAxis->getValue(middle);
     thetaAxis->setValue(middle - 1, midValue);
     constexpr bool useFractionalBinning = false;
-    MatrixWorkspace_sptr outputWS =
-        runAlgorithm(inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
+    MatrixWorkspace_sptr outputWS = runAlgorithm(
+        inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
+    const auto expectedY = 2. * 9. * 2.;
+    const auto expectedE = std::sqrt(expectedY);
     const auto &Ys = outputWS->y(0);
-    for (size_t j = 0; j < Ys.size(); ++j) {
-      TS_ASSERT(!std::isnan(Ys[j]))
+    const auto &Es = outputWS->e(0);
+    for (size_t i = 0; i < Ys.size(); ++i) {
+      TS_ASSERT(!std::isnan(Ys[i]))
+      TS_ASSERT_DELTA(Ys[i], expectedY, 1e-12)
+      TS_ASSERT_DELTA(Es[i], expectedE, 1e-12)
     }
   }
 
@@ -211,12 +218,19 @@ public:
     const auto midValue = thetaAxis->getValue(middle);
     thetaAxis->setValue(middle - 1, midValue);
     constexpr bool useFractionalBinning = true;
-    MatrixWorkspace_sptr outputWS =
-        runAlgorithm(inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
-    TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 1)
-    const auto &Ys = outputWS->y(0);
-    for (size_t j = 0; j < Ys.size(); ++j) {
-      TS_ASSERT(!std::isnan(Ys[j]))
+    MatrixWorkspace_sptr outputWS = runAlgorithm(
+        inputWS, "5.,2.,15.", "-0.5,10.,9.5", useFractionalBinning);
+    const auto &rebinned = *dynamic_cast<RebinnedOutput *>(outputWS.get());
+    TS_ASSERT_EQUALS(rebinned.getNumberHistograms(), 1)
+    const auto expectedY = 2. * 9. * 2.;
+    const auto expectedE = std::sqrt(expectedY);
+    const auto &Fs = rebinned.dataF(0);
+    const auto &Ys = rebinned.y(0);
+    const auto &Es = rebinned.e(0);
+    for (size_t i = 0; i < Ys.size(); ++i) {
+      TS_ASSERT(!std::isnan(Ys[i]))
+      TS_ASSERT_DELTA(Ys[i] * Fs[i], expectedY, 1e-12)
+      TS_ASSERT_DELTA(Es[i] * Fs[i], expectedE, 1e-12)
     }
   }
 
@@ -307,7 +321,8 @@ public:
 
   void test_Use_Fractional_Area() {
     constexpr bool useFractionalArea = true;
-    runAlgorithm(m_inputWS, "100,10,41000", "-0.5,0.5,499.5", useFractionalArea);
+    runAlgorithm(m_inputWS, "100,10,41000", "-0.5,0.5,499.5",
+                 useFractionalArea);
   }
 
 private:

--- a/Framework/Kernel/src/VectorHelper.cpp
+++ b/Framework/Kernel/src/VectorHelper.cpp
@@ -391,7 +391,7 @@ void convertToBinCentre(const std::vector<double> &bin_edges,
  */
 void convertToBinBoundary(const std::vector<double> &bin_centers,
                           std::vector<double> &bin_edges) {
-  const std::vector<double>::size_type n = bin_centers.size();
+  const auto n = bin_centers.size();
 
   // Special case empty input: output is also empty
   if (n == 0) {

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -95,7 +95,7 @@ Bugfixes
 - Bugfix in :ref:`ConvertToMatrixWorkspace <algm-ConvertToMatrixWorkspace>` with ``Workspace2D`` as the ``InputWorkspace`` not being cloned to the ``OutputWorkspace``. Added support for ragged workspaces.
 - :ref:`SolidAngle <algm-SolidAngle-v1>` Now properly accounts for a given StartWorkspaceIndex.
 - :ref:`FilterEvents <algm-FilterEvents-v1>` output workspaces now contain the goniometer.
-- Fixed an issue where if a workspace's history wouldn't update for some algorithms
+- Fixed an issue where a workspace's history wouldn't update for some algorithms
 - Fixed a ``std::bad_cast`` error in :ref:`algm-LoadLiveData` when the data size changes.
 - :ref:`Fit <algm-Fit>` now applies the ties in correct order independently on the order they are set. If any circular dependencies are found Fit will give an error.
 - Fixed a rare bug in :ref:`MaskDetectors <algm-MaskDetectors>` where a workspace could become invalidated in Python if it was a ``MaskWorkspace``.
@@ -108,6 +108,7 @@ Bugfixes
 - The input validator is fixed in :ref:`MostLikelyMean <algm-MostLikelyMean>` avoiding a segmentation fault.
 - Fixed a bug in `AlignAndFocusPowder <algm-AlignAndFocusPowder>` where a histogram input workspace did not clone propertly to the output workspace and properly masking a grouping workspace passed to `DiffractionFocussing <algm-DiffractionFocussing>`. Also adds initial unit tests for `AlignAndFocusPowder <algm-AlignAndFocusPowder>`.
 - Fixed a bug in :ref:`ExtractSpectra <algm-ExtractSpectra>` which was causing a wrong last value in the output's vertical axis if the axis type was ``BinEdgeAxis``.
+- Fixed an issue in :ref:`Rebin2D <algm-Rebin2D>` where `NaN` values would result if there were zero-area bins in the input workspace.
 
 Python
 ------


### PR DESCRIPTION
This PR fixes an issue in `Rebin2D` where `NaN` values would result if the input workspace contained 'zero area' bins. This can happen for example when the input workspace has vertical units of `Theta` and three or more detectors at the same scattering angle. In this case the bin area of one of the histograms would be zero for all bins, resulting in `0 / 0 = NaN`. We now skip bins which have an area of zero.

**Report to:** [nobody].

**To test:**

Run the following script:
```python
ws = CreateSampleWorkspace(NumBanks=1, XUnit='DeltaE', XMin=-12., XMax=12., BinWidth=0.2)
ws = ConvertSpectrumAxis(ws, 'Theta', 'Direct', 14.)
rebinned = Rebin2D(ws, [-10, 1., 10.], [0., 1., 1.], UseFractionalArea=False)
```
- Check that the histograms around workspace indices 22-25 have the same vertical axis coordinate (0.458356458)
- Check that `rebinned` does not contain `NaN`s
- Change `UseFractionalArea` to `True`
- Rerun
- Check the absence of `NaN`s in `rebinned` again

Fixes #24492.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
