### PR TITLE
CodeEditor: Set executing state after the code has been retrieved

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -217,10 +217,10 @@ class PythonFileInterpreterPresenter(QObject):
     def req_execute_async(self):
         if self.is_executing:
             return
-        self.is_executing = True
         code_str, self._code_start_offset = self._get_code_for_execution()
         if not code_str:
             return
+        self.is_executing = True
         self.view.set_editor_readonly(True)
         self.view.set_status_message(RUNNING_STATUS_MSG)
         return self.model.execute_async(code_str, self.view.filename)


### PR DESCRIPTION
**Description of work.**
Moves the line that sets the `is_executing` flag to be done after the code has been retrieved. What used to happen is `is_executing` would be set, but then nothing would be retrieved (code invalid or empty). So nothing was ran, `_finish` was never called and `is_executing` never reset.

**To test:**
- Try [running this](https://github.com/mantidproject/mantid/issues/23634#issuecomment-454011793)
- Try deleting all code, run (ctrl+return), then type some code and try running again

<!-- Instructions for testing. -->

Fixes #23634 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
