### PR TITLE
Indirect BayesQuasi - Prob workspace needs values for all 3 peaks

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -359,8 +359,11 @@ class BayesQuasi(PythonAlgorithm):
             yProb = np.append(yProb, yPr1)
             yProb = np.append(yProb, yPr2)
             yProb = np.append(yProb, yPr3)
+
+            prob_axis_names = '0 Peak, 1 Peak, 2 Peak, 3 Peak'
             s_api.CreateWorkspace(OutputWorkspace=probWS, DataX=xProb, DataY=yProb, DataE=eProb,
-                                  Nspec=4, UnitX='MomentumTransfer')
+                                  Nspec=4, UnitX='MomentumTransfer', VerticalAxisUnit='Text',
+                                  VerticalAxisValues=prob_axis_names)
             outWS = self.C2Fw(fname)
         elif self._program == 'QSe':
             comp_prog.report('Running C2Se')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -1,3 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name,too-many-instance-attributes,too-many-branches,no-init,redefined-builtin
 from __future__ import (absolute_import, division, print_function)
 from six.moves import range
@@ -261,15 +267,13 @@ class BayesQuasi(PythonAlgorithm):
                 nd, xout, yout, eout, yfit, yprob = QLr.qlres(numb, Xv, Yv, Ev, reals, fitOp,
                                                               Xdat, Xb, Yb, Wy, We, dtn, xsc,
                                                               wrks, wrkr, lwrk)
-                logger.information(' Log(prob) : %f %f %f %f' % 
-                                   (yprob[0], yprob[1], yprob[2], yprob[3]))
+                logger.information(' Log(prob) : %f %f %f %f' % (yprob[0], yprob[1], yprob[2], yprob[3]))
             elif prog == 'QLd':
                 workflow_prog.report('Processing Sample number %i' % spectrum)
                 nd, xout, yout, eout, yfit, yprob = QLd.qldata(numb, Xv, Yv, Ev, reals, fitOp,
                                                                Xdat, Xb, Yb, Eb, Wy, We,
                                                                wrks, wrkr, lwrk)
-                logger.information(' Log(prob) : %f %f %f %f' % 
-                                   (yprob[0], yprob[1], yprob[2], yprob[3]))
+                logger.information(' Log(prob) : %f %f %f %f' % (yprob[0], yprob[1], yprob[2], yprob[3]))
             elif prog == 'QSe':
                 workflow_prog.report('Processing Sample number %i as Stretched Exp' % spectrum)
                 nd, xout, yout, eout, yfit, yprob = Qse.qlstexp(numb, Xv, Yv, Ev, reals, fitOp,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/BayesQuasi.py
@@ -211,9 +211,9 @@ class BayesQuasi(PythonAlgorithm):
             else:
                 raise ValueError('Stretched Exp ONLY works with RES file')
 
-        logger.information('Version is %s ' % prog)
-        logger.information(' Number of spectra = %i ' % (nsam))
-        logger.information(' Erange : %f  to %f ' % (erange[0], erange[1]))
+        logger.information('Version is {0}'.format(prog))
+        logger.information(' Number of spectra = {0} '.format(nsam))
+        logger.information(' Erange : {0}  to {1} '.format(erange[0], erange[1]))
 
         setup_prog.report('Reading files')
         Wy, We = self._read_width_file(self._width, self._wfile, totalNoSam)
@@ -246,7 +246,7 @@ class BayesQuasi(PythonAlgorithm):
         group = ''
         workflow_prog = Progress(self, start=0.3, end=0.7, nreports=nsam * 3)
         for spectrum in range(0, nsam):
-            logger.information('Group %i at angle %f ' % (spectrum, theta[spectrum]))
+            logger.information('Group {0} at angle {1} '.format(spectrum, theta[spectrum]))
             nsp = spectrum + 1
 
             nout, bnorm, Xdat, Xv, Yv, Ev = CalcErange(self._samWS, spectrum, erange, nbin)
@@ -263,19 +263,19 @@ class BayesQuasi(PythonAlgorithm):
             reals = [efix, theta[spectrum], rscl, bnorm]
 
             if prog == 'QLr':
-                workflow_prog.report('Processing Sample number %i as Lorentzian' % spectrum)
+                workflow_prog.report('Processing Sample number {0} as Lorentzian'.format(spectrum))
                 nd, xout, yout, eout, yfit, yprob = QLr.qlres(numb, Xv, Yv, Ev, reals, fitOp,
                                                               Xdat, Xb, Yb, Wy, We, dtn, xsc,
                                                               wrks, wrkr, lwrk)
-                logger.information(' Log(prob) : %f %f %f %f' % (yprob[0], yprob[1], yprob[2], yprob[3]))
+                logger.information(' Log(prob) : {0} {1} {2} {3}'.format(yprob[0], yprob[1], yprob[2], yprob[3]))
             elif prog == 'QLd':
-                workflow_prog.report('Processing Sample number %i' % spectrum)
+                workflow_prog.report('Processing Sample number {0}'.format(spectrum))
                 nd, xout, yout, eout, yfit, yprob = QLd.qldata(numb, Xv, Yv, Ev, reals, fitOp,
                                                                Xdat, Xb, Yb, Eb, Wy, We,
                                                                wrks, wrkr, lwrk)
-                logger.information(' Log(prob) : %f %f %f %f' % (yprob[0], yprob[1], yprob[2], yprob[3]))
+                logger.information(' Log(prob) : {0} {1} {2} {3}'.format(yprob[0], yprob[1], yprob[2], yprob[3]))
             elif prog == 'QSe':
-                workflow_prog.report('Processing Sample number %i as Stretched Exp' % spectrum)
+                workflow_prog.report('Processing Sample number {0} as Stretched Exp'.format(spectrum))
                 nd, xout, yout, eout, yfit, yprob = Qse.qlstexp(numb, Xv, Yv, Ev, reals, fitOp,
                                                                 Xdat, Xb, Yb, Wy, We, dtn, xsc,
                                                                 wrks, wrkr, lwrk)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -140,7 +140,7 @@ if platform.system() == "Windows":
 
             # Test size/shape of probability
             self.assertTrue(isinstance(probability, MatrixWorkspace))
-            self.assertEquals(probability.getNumberHistograms(), 3)
+            self.assertEquals(probability.getNumberHistograms(), 4)
             self.assertEquals(probability.blocksize(), self._num_hists)
             self.assertEquals(result.getAxis(0).getUnit().unitID(), 'MomentumTransfer')
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesQuasiTest.py
@@ -152,7 +152,7 @@ if platform.system() == "Windows":
             for i in range (group.getNumberOfEntries()):
                 sub_ws = group.getItem(i)
                 self.assertTrue(isinstance(sub_ws, MatrixWorkspace))
-                self.assertEqual(sub_ws.getNumberHistograms(), 5)
+                self.assertEqual(sub_ws.getNumberHistograms(), 7)
                 self.assertEquals(sub_ws.getAxis(0).getUnit().unitID(), 'DeltaE')
 
 

--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -119,6 +119,8 @@ Improvements
   Plot Current Preview.
 - The sample logs are now copied over properly for the result workspace in the ResNorm tab.
 - Sqw files can now be loaded as Vanadium in the ResNorm interface.
+- In the Quasi interface, fit. 3 and diff. 3 are now stored in the fit workspaces. The probabilities for 3 peaks is now 
+  available in the probability workspace.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Review on windows only**
--------------------------------
**Description of work.**
BayesQuasi does a 3 peak fit but only gives the GUI output for 2. The parameter & fit workspaces (and the text file output) do have the 3 peak fit, but the probability workspace only has the 2 peak values. This workspace should have all three.

**To test:**
1.`Interfaces`->`Indirect`->`Bayes`->`Quasi` interface
2. Load the data below
3. Click Run.
4. Click `Yes` if a pop-up box appears.
5. When the fit is finished:
- Open up the _workspaces group and look at one of their workspaces. There should be a `fit. 3` and `diff. 3` at the bottom of the workspace
- Open up the probability workspace. There should be a `3 Peak` row at the bottom

**Data files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2763451/irs26176_graphite002_red.zip)
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2763452/irs26173_graphite002_res.zip)

Fixes #24510 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
