### PR TITLE
Follow changes in plotly

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -155,8 +155,8 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
                 (traces, xlabel, ylabel) = self.toScatterAndLabels(wksp, spectraNames)
                 for spectrum in traces:
                     fig.append_trace(spectrum, i+1, 1)
-                fig['layout']['xaxis%d' % (i+1)].update(title=xlabel)
-                fig['layout']['yaxis%d' % (i+1)].update(title=ylabel)
+                fig['layout']['xaxis%d' % (i+1)].update(title={'text':xlabel})
+                fig['layout']['yaxis%d' % (i+1)].update(title={'text':ylabel})
                 if len(spectraNames) > 0:  # remove the used spectra names
                     spectraNames = spectraNames[len(traces):]
             fig['layout'].update(margin={'r':0,'t':0})
@@ -164,8 +164,8 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
             (traces, xlabel, ylabel) = self.toScatterAndLabels(self._wksp,
                                                                spectraNames)
 
-            layout = go.Layout(yaxis={'title': ylabel},
-                               xaxis={'title': xlabel},
+            layout = go.Layout(yaxis={'title': {'text':ylabel}},
+                               xaxis={'title': {'text':xlabel}},
                                margin={'l':40,'r':0,'t':0,'b':40})
 
             fig = go.Figure(data=traces, layout=layout)
@@ -201,7 +201,7 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
 
             data.append(go.Scatter(x=x, y=y, name=label, visible=visible))
 
-        (xlabel, ylabel) = self.getAxesLabels(wksp, utf8=True)
+        (xlabel, ylabel) = self.getAxesLabels(wksp, utf8=False)
 
         return (data, xlabel, ylabel)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
@@ -8,6 +8,23 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest, os
 from mantid import AnalysisDataServiceImpl, config, simpleapi
+try:
+    import plotly
+    havePlotly = True
+except ImportError:
+    havePlotly = False
+# check if matplotlib is available and a new enough version
+matplotlibissue = None  # indicates there are no issues
+try:
+    import matplotlib
+    from distutils.version import LooseVersion
+
+    if LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0"):
+        matplotlibissue = 'Wrong version of matplotlib. Required >= 1.2.0'
+    matplotlib.use("agg")
+    import matplotlib.pyplot as plt
+except:
+    matplotlibissue = 'Problem importing matplotlib'
 
 
 class SavePlot1DTest(unittest.TestCase):
@@ -29,22 +46,34 @@ class SavePlot1DTest(unittest.TestCase):
         if os.path.exists(self.plotfile):
             os.remove(self.plotfile)
 
-    def testPlot(self):
+    @unittest.skipIf(matplotlibissue is not None, matplotlibissue)
+    def testPlotSingle(self):
         self.makeWs()
-        ok2run = ''
-        try:
-            import matplotlib
-            from distutils.version import LooseVersion
-            if LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0"):
-                ok2run = 'Wrong version of matplotlib. Required >= 1.2.0'
-            matplotlib.use("agg")
-            import matplotlib.pyplot as plt
-        except:
-            ok2run = 'Problem importing matplotlib'
-        if ok2run == '':
-            simpleapi.SavePlot1D("group", self.plotfile)
-            self.assertGreater(os.path.getsize(self.plotfile), 1e4)
+        simpleapi.SavePlot1D('test1', self.plotfile)
+        self.assertGreater(os.path.getsize(self.plotfile), 1e4)
         self.cleanup()
+
+    @unittest.skipIf(matplotlibissue is not None, matplotlibissue)
+    def testPlotGroup(self):
+        self.makeWs()
+        simpleapi.SavePlot1D('group', self.plotfile)
+        self.assertGreater(os.path.getsize(self.plotfile), 1e4)
+        self.cleanup()
+
+    @unittest.skipIf(not havePlotly, 'Do not have plotly installed')
+    def testPlotlySingle(self):
+        self.makeWs()
+        div = simpleapi.SavePlot1D(InputWorkspace='test1', OutputType='plotly')
+        self.cleanup()
+        self.assertTrue(len(div) > 0)  # confirm result is non-empty
+
+
+    @unittest.skipIf(not havePlotly, 'Do not have plotly installed')
+    def testPlotlyGroup(self):
+        self.makeWs()
+        div = simpleapi.SavePlot1D(InputWorkspace='group', OutputType='plotly')
+        self.cleanup()
+        self.assertTrue(len(div) > 0)  # confirm result is non-empty
 
 
 if __name__ == "__main__":

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -64,6 +64,7 @@ Bugfixes
 - Project recovery will now successfully recover live data, it will however be unable to recover any data that was up at the time, but will start the live data streams again from scratch.
 - If an empty group workspace is present in the ADS it will no longer crash the save thread of project recovery and instead will delete it from the ADS and ignore it.
 - A bug has been fixed in Indirect I(Q,t) interface when analyzing IN16B reduced data.
+- :ref:`SavePlot1D <algm-SavePlot1D>` has been updated to follow changes to the plotly api.
 
 MantidPlot
 ----------


### PR DESCRIPTION
They appear to change the API in the javascript layer without fully
reflecting it in the documentation. This even affects the older python
API mantid uses.

**To test:**

Ideally, try `SavePlot1D` using different plotly API versions. These changes appear to work on rhel7 with plotly 1.12.12.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
