### PR TITLE
JobTreeView Identical Behaviour for Enter and Return Keypresses

### DIFF
--- a/qt/widgets/common/src/Batch/CellDelegate.cpp
+++ b/qt/widgets/common/src/Batch/CellDelegate.cpp
@@ -58,6 +58,7 @@ bool CellDelegate::eventFilter(QObject *object, QEvent *event) {
   }
   return QStyledItemDelegate::eventFilter(editor, event);
 }
+
 } // namespace Batch
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/Batch/CellDelegate.cpp
+++ b/qt/widgets/common/src/Batch/CellDelegate.cpp
@@ -58,7 +58,6 @@ bool CellDelegate::eventFilter(QObject *object, QEvent *event) {
   }
   return QStyledItemDelegate::eventFilter(editor, event);
 }
-
 } // namespace Batch
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/Batch/CellDelegate.cpp
+++ b/qt/widgets/common/src/Batch/CellDelegate.cpp
@@ -51,7 +51,7 @@ bool CellDelegate::eventFilter(QObject *object, QEvent *event) {
     return false;
   if (event->type() == QEvent::KeyPress) {
     QKeyEvent *keyPress = static_cast<QKeyEvent *>(event);
-    if (keyPress->key() == Qt::Key_Return) {
+    if (keyPress->key() == Qt::Key_Return || keyPress->key() == Qt::Key_Enter) {
       emit commitData(editor);
       return false;
     }

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -461,13 +461,15 @@ void JobTreeView::appendAndEditAtChildRow() {
 
 void JobTreeView::appendAndEditAtRowBelow() {
   auto current = currentIndex();
-  auto const below = findOrMakeCellBelow(fromFilteredModel(current));
-  auto index = below.first;
-  auto isNew = below.second;
+  if (current != m_mainModel.index(-1,-1)) {
+    auto const below = findOrMakeCellBelow(fromFilteredModel(current));
+    auto index = below.first;
+    auto isNew = below.second;
 
-  if (isNew)
-    m_notifyee->notifyRowInserted(rowLocation().atIndex(mapToMainModel(index)));
-  editAt(index);
+    if (isNew)
+      m_notifyee->notifyRowInserted(rowLocation().atIndex(mapToMainModel(index)));
+    editAt(index);
+  }
 }
 
 void JobTreeView::editAtRowAbove() {
@@ -483,7 +485,7 @@ void JobTreeView::enableFiltering() {
 
 void JobTreeView::keyPressEvent(QKeyEvent *event) {
   switch (event->key()) {
-  case Qt::Key_Return: {
+  case Qt::Key_Return: case Qt::Key_Enter: {
     if (event->modifiers() & Qt::ControlModifier) {
       appendAndEditAtChildRow();
     } else if (event->modifiers() & Qt::ShiftModifier) {

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -461,13 +461,14 @@ void JobTreeView::appendAndEditAtChildRow() {
 
 void JobTreeView::appendAndEditAtRowBelow() {
   auto current = currentIndex();
-  if (current != m_mainModel.index(-1,-1)) {
+  if (current != m_mainModel.index(-1, -1)) {
     auto const below = findOrMakeCellBelow(fromFilteredModel(current));
     auto index = below.first;
     auto isNew = below.second;
 
     if (isNew)
-      m_notifyee->notifyRowInserted(rowLocation().atIndex(mapToMainModel(index)));
+      m_notifyee->notifyRowInserted(
+          rowLocation().atIndex(mapToMainModel(index)));
     editAt(index);
   }
 }
@@ -485,7 +486,8 @@ void JobTreeView::enableFiltering() {
 
 void JobTreeView::keyPressEvent(QKeyEvent *event) {
   switch (event->key()) {
-  case Qt::Key_Return: case Qt::Key_Enter: {
+  case Qt::Key_Return:
+  case Qt::Key_Enter: {
     if (event->modifiers() & Qt::ControlModifier) {
       appendAndEditAtChildRow();
     } else if (event->modifiers() & Qt::ShiftModifier) {


### PR DESCRIPTION
**Description of work.**
This PR is related to PR #24328 
This PR fixes two small issues related to JobTreeView:
1. Stops a hard crash which only occurs if you have selected the table but not yet selected a particular cell, and try to append rows onto the current cell. This was fixed by checking if the current cell is real before trying to append onto it.
2. Return ("enter" key next to the letters) and enter (next to the numbers) now both append rows. Previously, enter did nothing.

**Report to:** Nobody

**To test:**
1. Interfaces -> SANS -> SANS v2
2. Click on the table but NOT onto a specific row i.e. click below the empty row.
3. Pressing the enter key or the return key will not cause a hard crash
4. Double click on any cell in the table and type some text
5. Clicking enter or return should set the text you typed and begin editing at the row below. If there was not previously a row below, it will be added.
6. Clicking shift + enter or return will begin editing at the row above. This will just stop editing if you are currently on the uppermost row
7. Click ctrl+enter or return will stop editing.

Fixes #24509 

*This does not require release notes* because **small change to how input is handled internal to fix issues not raised by any users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
