### PR TITLE
Discard preservation of events for monitor counts

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -471,7 +471,8 @@ class BASISReduction(PythonAlgorithm):
                                       OutputWorkspace=mon_ws)
             sapi.Rebin(InputWorkspace=mon_ws,
                        OutputWorkspace=mon_ws,
-                       Params='10')
+                       Params='10',  # 10 microseconds TOF bin width
+                       PreserveEvents=False)
             sapi.ConvertUnits(InputWorkspace=mon_ws,
                               OutputWorkspace=mon_ws,
                               Target='Wavelength')


### PR DESCRIPTION
**Description of work.**
- discard preservation of events in monitor counts

**Report to:** Eugene Mamontov

**To test:**
Reduce the following run, check the execution time is no longer than about three minutes. Prior to this change it took more than half an hour.

```
BASISReduction(RunNumbers='90070',
               MonitorNorm=True,
               EnergyBins=[-330, 0.4, 330],
               MomentumTransferBins=[0.2, 1.8, 2.0])
```

Fixes #24521

*This does not require release notes* because there's no change in the functionality exposed to the user

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
