### PR TITLE
Indirect Data Analysis - Multiple input Unexpected error

### DIFF
--- a/docs/source/release/v3.14.0/indirect_inelastic.rst
+++ b/docs/source/release/v3.14.0/indirect_inelastic.rst
@@ -72,6 +72,8 @@ Bugfixes
 - An unexpected error is now prevented when clicking Plot Guess from the Display combo box in ConvFit without first loading
   a reduced file.
 - The output workspace ending with _Results now contains workspaces with corrected names which detail the fit functions used.
+- Selecting multiple data using the All Spectra checkbox without first selected a sample file used to cause an unexpected error.
+  This is now prevented. Meaningful error messages are also displayed when a sample or resolution file are not selected.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.cpp
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <boost/optional.hpp>
 
@@ -16,6 +17,14 @@ using namespace Mantid::API;
 
 MatrixWorkspace_sptr getWorkspace(const std::string &name) {
   return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+}
+
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
+bool validWorkspace(std::string const &name) {
+  return !name.empty() && doesExistInADS(name);
 }
 
 boost::optional<std::size_t> maximumIndex(MatrixWorkspace_sptr workspace) {
@@ -115,8 +124,9 @@ void ConvFitAddWorkspaceDialog::setResolutionFBSuffices(
 }
 
 void ConvFitAddWorkspaceDialog::selectAllSpectra(int state) {
-  if (state == Qt::Checked) {
-    m_uiForm.leWorkspaceIndices->setText(getIndexString(workspaceName()));
+  auto const name = workspaceName();
+  if (validWorkspace(name) && state == Qt::Checked) {
+    m_uiForm.leWorkspaceIndices->setText(getIndexString(name));
     m_uiForm.leWorkspaceIndices->setEnabled(false);
   } else
     m_uiForm.leWorkspaceIndices->setEnabled(true);
@@ -133,8 +143,10 @@ void ConvFitAddWorkspaceDialog::workspaceChanged(const QString &workspaceName) {
 
 void ConvFitAddWorkspaceDialog::setWorkspace(const std::string &workspace) {
   setAllSpectraSelectionEnabled(true);
-  if (m_uiForm.ckAllSpectra->isChecked())
+  if (m_uiForm.ckAllSpectra->isChecked()) {
     m_uiForm.leWorkspaceIndices->setText(getIndexString(workspace));
+    m_uiForm.leWorkspaceIndices->setEnabled(false);
+  }
 }
 
 void ConvFitAddWorkspaceDialog::setAllSpectraSelectionEnabled(bool doEnable) {

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -24,6 +24,10 @@ MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
       workspaceName);
 }
 
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
 boost::optional<std::size_t>
 getFirstInCategory(CompositeFunction_const_sptr composite,
                    const std::string &category) {
@@ -553,7 +557,10 @@ void ConvFitModel::removeWorkspace(std::size_t index) {
 }
 
 void ConvFitModel::setResolution(const std::string &name, std::size_t index) {
-  setResolution(getADSMatrixWorkspace(name), index);
+  if (!name.empty() && doesExistInADS(name))
+    setResolution(getADSMatrixWorkspace(name), index);
+  else
+    throw std::runtime_error("A valid resolution file needs to be selected.");
 }
 
 void ConvFitModel::setResolution(MatrixWorkspace_sptr resolution,

--- a/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.cpp
@@ -18,6 +18,14 @@ MatrixWorkspace_sptr getWorkspace(const std::string &name) {
   return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
 }
 
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
+bool validWorkspace(std::string const &name) {
+  return !name.empty() && doesExistInADS(name);
+}
+
 boost::optional<std::size_t> maximumIndex(MatrixWorkspace_sptr workspace) {
   if (workspace) {
     const auto numberOfHistograms = workspace->getNumberHistograms();
@@ -102,8 +110,9 @@ void AddWorkspaceDialog::setFBSuffices(const QStringList &suffices) {
 }
 
 void AddWorkspaceDialog::selectAllSpectra(int state) {
-  if (state == Qt::Checked) {
-    m_uiForm.leWorkspaceIndices->setText(getIndexString(workspaceName()));
+  auto const name = workspaceName();
+  if (validWorkspace(name) && state == Qt::Checked) {
+    m_uiForm.leWorkspaceIndices->setText(getIndexString(name));
     m_uiForm.leWorkspaceIndices->setEnabled(false);
   } else
     m_uiForm.leWorkspaceIndices->setEnabled(true);
@@ -120,8 +129,10 @@ void AddWorkspaceDialog::workspaceChanged(const QString &workspaceName) {
 
 void AddWorkspaceDialog::setWorkspace(const std::string &workspace) {
   setAllSpectraSelectionEnabled(true);
-  if (m_uiForm.ckAllSpectra->isChecked())
+  if (m_uiForm.ckAllSpectra->isChecked()) {
     m_uiForm.leWorkspaceIndices->setText(getIndexString(workspace));
+    m_uiForm.leWorkspaceIndices->setEnabled(false);
+  }
 }
 
 void AddWorkspaceDialog::setAllSpectraSelectionEnabled(bool doEnable) {

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -25,6 +25,10 @@ using namespace Mantid::API;
 namespace {
 using namespace MantidQt::CustomInterfaces::IDA;
 
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
 bool equivalentWorkspaces(MatrixWorkspace_const_sptr lhs,
                           MatrixWorkspace_const_sptr rhs) {
   if (!lhs || !rhs)
@@ -497,6 +501,9 @@ void IndirectFittingModel::addWorkspace(const std::string &workspaceName,
   if (spectra.empty())
     throw std::runtime_error(
         "Fitting Data must consist of one or more spectra.");
+  if (workspaceName.empty() || !doesExistInADS(workspaceName))
+    throw std::runtime_error("A valid sample file needs to be selected.");
+
   addWorkspace(workspaceName, DiscontinuousSpectra<std::size_t>(spectra));
 }
 


### PR DESCRIPTION
**Description of work.**
This PR fixes an unexpected error cause when checking All Spectra without a sample file selected.
It also ensures more meaningful error messages are given when you click Add and there is no sample or resolution file selected.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` interface
2. Select the Multiple Input tab
3. Load a reduced (_red) file 
4. Remove the _red file 
5. Check `All Spectra`

An unexpected error should not pop up!

Clearing the Sample or Resolution boxs before clicking `Add` should also result in a meaningful error message.

Fixes #24528 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
