### PR TITLE
Corrected import in errorreport.py

### DIFF
--- a/docs/source/release/v3.14.0/error_reporter.rst
+++ b/docs/source/release/v3.14.0/error_reporter.rst
@@ -19,4 +19,4 @@ New Features
 Bugfixes
 ========
 
-* An issue causing the window to fail to display on python 3 was fixed
+* An issue causing the window to fail to display with python3 version of mantid was fixed

--- a/docs/source/release/v3.14.0/error_reporter.rst
+++ b/docs/source/release/v3.14.0/error_reporter.rst
@@ -15,3 +15,8 @@ New Features
 ============
 
 * The error reporter now accepts free text of up to 3200 characters in a free text box
+
+Bugfixes
+========
+
+* An issue causing the window to fail to display on python 3 was fixed

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -5,7 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from PyQt4 import QtGui, QtCore
-import ui_errorreport
+import ErrorReporter.ui_errorreport as ui_errorreport
 from PyQt4.QtCore import pyqtSignal
 from mantidqtpython import MantidQt
 

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -4,6 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, print_function)
 from PyQt4 import QtGui, QtCore
 import ErrorReporter.ui_errorreport as ui_errorreport
 from PyQt4.QtCore import pyqtSignal


### PR DESCRIPTION
**Description of work.**

In the python3 version of mantid the error report widget was failing to import a component and therefore not displaying when an unhandled exception was thrown. This PR updates the import statement so that the ui can be found correctly.

**To test:**
 * Run tests in python2 and python3 versions of mantid
 * In mantid ensure that usage reporting is turned on and restart mantid after doing so
 * Run the segfault algorithm and ensure error window comes up
 * In the script interpreter check that the following import statement works `from ErrorReporter.errorreport import CrashReportPage` This is checking that the import works from within mantid which is what is needed in the unhanded exception case.  

<!-- Instructions for testing. -->


*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
