### PR TITLE
MR: use simple background average

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -90,6 +90,8 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                              "TOF/wavelength range to use with detector binning")
         self.declareProperty("UseWLTimeAxis", False,
                              doc="For const-Q, if true, wavelength will be used as the time axis, otherwise TOF is used")
+        self.declareProperty("ErrorWeightedBackground", True,
+                             doc="If true, use an error weighted average for the background estimate")
         self.declareProperty("CutTimeAxis", True,
                              doc="If true, the TOF/wavelength dimension will be cropped according to the TimeAxisRange property")
         self.declareProperty("RoundUpPixel", True, doc="If True, round up pixel position of the specular reflectivity")
@@ -696,6 +698,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         """
         logger.warning("Processing %s" % str(workspace))
         use_wl_cut = self.getProperty("UseWLTimeAxis").value
+        error_weighted_bck = self.getProperty("ErrorWeightedBackground").value
         constant_q_binning = self.getProperty("ConstantQBinning").value
         tof_step = self.getProperty("TimeAxisStep").value
 
@@ -753,7 +756,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                              XPixelMax=int(background_range[1]),
                              YPixelMin=low_res_min,
                              YPixelMax=low_res_max,
-                             ErrorWeighting = False,
+                             ErrorWeighting = error_weighted_bck,
                              SumPixels=True, NormalizeSum=True)
 
             signal = RefRoi(InputWorkspace=workspace, IntegrateY=True,

--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -753,7 +753,7 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
                              XPixelMax=int(background_range[1]),
                              YPixelMin=low_res_min,
                              YPixelMax=low_res_max,
-                             ErrorWeighting = True,
+                             ErrorWeighting = False,
                              SumPixels=True, NormalizeSum=True)
 
             signal = RefRoi(InputWorkspace=workspace, IntegrateY=True,


### PR DESCRIPTION
**Description of work.**

The reflectivity background for MR has been estimated by taking the weighted average of the background counts, which move the estimate slightly at low counts and produces results that are a tiny bit different than reference results. It would be best to use a simple sum and take care of the uncertainty separately.

**Report to:** nobody

**To test:**
- inspect code
- make sure tests pass


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
