### PR TITLE
Updated reporting and download urls to https

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -216,7 +216,7 @@ UploaderWebServer = @MANTIDPUBLISHER@
 # Local system path for the script repository.
 ScriptLocalRepository =
 # Base Url for the remote script repository. Not necessarily accessible, it is used to construct longer URLs
-ScriptRepository = https://download.mantidproject.org/scriptrepository/
+ScriptRepository = http://download.mantidproject.org/scriptrepository/
 # Pattern given to ScriptRepository that is used to hide entries from repository to the users. It is a csv string separated with ';'
 ScriptRepositoryIgnore = *pyc;
 

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -50,12 +50,12 @@ UpdateInstrumentDefinitions.URL = https://api.github.com/repos/mantidproject/man
 # Whether to check for newer mantid versions on startup
 CheckMantidVersion.OnStartup = @CHECK_FOR_NEW_MANTID_VERSION@
 CheckMantidVersion.GitHubReleaseURL = https://api.github.com/repos/mantidproject/mantid/releases/latest
-CheckMantidVersion.DownloadURL = http://download.mantidproject.org
+CheckMantidVersion.DownloadURL = https://download.mantidproject.org
 
 # Whether to report usage statistics back to central server
 usagereports.enabled = @ENABLE_USAGE_REPORTS@
-errorreports.rooturl = http://errorreports.mantidproject.org
-usagereports.rooturl = http://reports.mantidproject.org
+errorreports.rooturl = https://errorreports.mantidproject.org
+usagereports.rooturl = https://reports.mantidproject.org
 
 # Where to load Grouping files (that are shipped with Mantid) from
 groupingFiles.directory = @MANTID_ROOT@/instrument/Grouping
@@ -216,7 +216,7 @@ UploaderWebServer = @MANTIDPUBLISHER@
 # Local system path for the script repository.
 ScriptLocalRepository =
 # Base Url for the remote script repository. Not necessarily accessible, it is used to construct longer URLs
-ScriptRepository = http://download.mantidproject.org/scriptrepository/
+ScriptRepository = https://download.mantidproject.org/scriptrepository/
 # Pattern given to ScriptRepository that is used to hide entries from repository to the users. It is a csv string separated with ';'
 ScriptRepositoryIgnore = *pyc;
 


### PR DESCRIPTION
**Description of work.**

This updates several of the url's in the properties templates file to use https rather than http.

**To test:**

To test need to check that all the relevant url's can be reached. To do this:
 * Start up mantid, and turn on usage reporting then restart mantid.
 * Check that a usage report has been sent to the server and registered. Do do this you can set the logs to debug mode before startup and check that a 201 https response is received or log into the reporting system and check that a start-up report has been generated, contact me if you want me to explain how to do this.
 * In the script interpreter run `CheckMantidVersion()` and ensure that it works.
 * Run the errorreport system test `systemtest -R ErrorReporter` and ensure that it passes.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because * it is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
