### PR TITLE
Try both arg lists for Layout

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -164,9 +164,16 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
             (traces, xlabel, ylabel) = self.toScatterAndLabels(self._wksp,
                                                                spectraNames)
 
-            layout = go.Layout(yaxis={'title': {'text':ylabel}},
-                               xaxis={'title': {'text':xlabel}},
-                               margin={'l':40,'r':0,'t':0,'b':40})
+            # plotly seems to change the way to set the axes labels
+            # randomly and within a version. Just give up and try both.
+            try:
+                layout = go.Layout(yaxis={'title': ylabel},
+                                   xaxis={'title': xlabel},
+                                   margin={'l': 40, 'r': 0, 't': 0, 'b': 40})
+            except RuntimeError:
+                layout = go.Layout(yaxis={'title': {'text': ylabel}},
+                                   xaxis={'title': {'text': xlabel}},
+                                   margin={'l': 40, 'r': 0, 't': 0, 'b': 40})
 
             fig = go.Figure(data=traces, layout=layout)
 
@@ -201,7 +208,7 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
 
             data.append(go.Scatter(x=x, y=y, name=label, visible=visible))
 
-        (xlabel, ylabel) = self.getAxesLabels(wksp, utf8=False)
+        (xlabel, ylabel) = self.getAxesLabels(wksp, utf8=True)
 
         return (data, xlabel, ylabel)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
@@ -30,7 +30,7 @@ except:
 class SavePlot1DTest(unittest.TestCase):
     def makeWs(self):
         simpleapi.CreateWorkspace(OutputWorkspace='test1', DataX='1,2,3,4,5,1,2,3,4,5', DataY='1,2,3,4,2,3,4,5',
-                                  DataE='1,2,3,4,2,3,4,5', NSpec='2', UnitX='TOF', Distribution='1', YUnitlabel="S(q)")
+                                  DataE='1,2,3,4,2,3,4,5', NSpec='2', UnitX='dSpacing', Distribution='1', YUnitlabel="S(q)")
         simpleapi.CreateWorkspace(OutputWorkspace='test2', DataX='1,2,3,4,5,1,2,3,4,5', DataY='1,2,3,4,2,3,4,5',
                                   DataE='1,2,3,4,2,3,4,5', NSpec='2',
                                   UnitX='Momentum', VerticalAxisUnit='TOF', VerticalAxisValues='1,2', Distribution='1',


### PR DESCRIPTION
Different versions of plotly appear to have different arguments lists for `Layout`. This just gives up and tries both.

**To test:**

Try to `SavePlot1D` with something that has an angstrom symbol. It should work everywhere.

*There is no associated issue,* but it is intended to follow-on and fix (universally) #24513.

*This does not require release notes* because the previous PR had them.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
