### PR TITLE
Increased logging level of creating geometry cache because of slow creation

### DIFF
--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -2610,7 +2610,7 @@ InstrumentDefinitionParser::writeAndApplyCache(
   IDFObject_const_sptr usedCache = firstChoiceCache;
   auto cachingOption = WroteGeomCache;
 
-  g_log.information("Geometry cache is not available");
+  g_log.notice("Geometry cache is not available");
   try {
     Poco::File dir = usedCache->getParentDirectory();
     if (dir.path().empty() || !dir.exists() || !dir.canWrite()) {
@@ -2627,7 +2627,7 @@ InstrumentDefinitionParser::writeAndApplyCache(
                              "attempting to write cache.\n");
   }
   const std::string cacheFullPath = usedCache->getFileFullPathStr();
-  g_log.information() << "Creating cache in " << cacheFullPath << "\n";
+  g_log.notice() << "Creating cache in " << cacheFullPath << "\n";
   // create a vtk writer
   std::map<std::string, boost::shared_ptr<Geometry::IObject>>::iterator objItr;
   boost::shared_ptr<Mantid::Geometry::vtkGeometryCacheWriter> writer(

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -101,3 +101,11 @@ Changes
  - The miniplot on the pick tab of the instrument view now shows the HKL values for peaks when viewing a summed collection of detectors.
 
 :ref:`Release 3.14.0 <v3.14.0>`
+
+Logging
+-------
+
+changes
+#######
+
+ - Increased the debug level of messages when creating an instrument geometry.

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -104,9 +104,9 @@ Changes
 Logging
 -------
 
-changes
+Changes
 #######
 
- - Increased the log level from information to notice when creating an instrument geometry
+ - Increased the log level from information to notice when creating an instrument geometry.
 
 :ref:`Release 3.14.0 <v3.14.0>`

--- a/docs/source/release/v3.14.0/ui.rst
+++ b/docs/source/release/v3.14.0/ui.rst
@@ -100,7 +100,6 @@ Changes
 #######
  - The miniplot on the pick tab of the instrument view now shows the HKL values for peaks when viewing a summed collection of detectors.
 
-:ref:`Release 3.14.0 <v3.14.0>`
 
 Logging
 -------
@@ -108,4 +107,6 @@ Logging
 changes
 #######
 
- - Increased the debug level of messages when creating an instrument geometry.
+ - Increased the log level from information to notice when creating an instrument geometry
+
+:ref:`Release 3.14.0 <v3.14.0>`


### PR DESCRIPTION
**Description of work.**
changed toe debug level to notice so that its clear that something is happening and mantid hasn't just hung when creating slow caches e.g. POLARIS.



**To test:**
Follow the instructions for reproducing the issue, with the log-level set to notice, the following messages should appear.
`Geometry cache is not available`
`Creating cache in /home/sjenkins/.mantid/instrument/geometryCache/POLARIS9fbf7121b4274c833043ae8933ec643ff7b9313d.vtp`
but with the path correct to your geometry cache.

Fixes #24085 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
