### PR TITLE
Enable materials with unknown chemical compositions

### DIFF
--- a/Framework/API/inc/MantidAPI/Sample.h
+++ b/Framework/API/inc/MantidAPI/Sample.h
@@ -13,7 +13,6 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidKernel/V3D.h"
-#include <vector>
 
 namespace Mantid {
 //-----------------------------------------------------------------------------

--- a/Framework/DataHandling/inc/MantidDataHandling/ReadMaterial.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ReadMaterial.h
@@ -59,14 +59,14 @@ public:
    * @param params A struct containing all the parameters to be set.
    * @returns A map containing the relevent failure messages, if any.
    */
-  static ValidationErrors validateInputs(MaterialParameters params);
+  static ValidationErrors validateInputs(const MaterialParameters &params);
   /**
    * Set the parameters to build the material to the builder,
    * taking into account which values were and weren't set.
    *
    * @param params A struct containing all the parameters to be set.
    */
-  void setMaterialParameters(MaterialParameters params);
+  void setMaterialParameters(const MaterialParameters &params);
   /**
    * Construct the material,
    *

--- a/Framework/DataHandling/src/ReadMaterial.cpp
+++ b/Framework/DataHandling/src/ReadMaterial.cpp
@@ -20,16 +20,39 @@ namespace DataHandling {
  * @param params A struct containing all the parameters to be set.
  * @returns A map containing the relevent failure messages, if any.
  */
-ValidationErrors ReadMaterial::validateInputs(const MaterialParameters params) {
+ValidationErrors
+ReadMaterial::validateInputs(const MaterialParameters &params) {
   ValidationErrors result;
-  if (params.chemicalSymbol.empty()) {
-    if (params.atomicNumber <= 0) {
-      result["ChemicalFormula"] = "Need to specify the material";
+  const bool chemicalSymbol{!params.chemicalSymbol.empty()};
+  const bool atomicNumber{params.atomicNumber != 0};
+  if (!chemicalSymbol && !atomicNumber) {
+    if (isEmpty(params.coherentXSection)) {
+      result["CoherentXSection"] = "The cross section must be specified when "
+                                   "no ChemicalFormula or AtomicNumber is "
+                                   "given.";
     }
-  } else {
-    if (params.atomicNumber > 0)
-      result["AtomicNumber"] =
-          "Cannot specify both ChemicalFormula and AtomicNumber";
+    if (isEmpty(params.incoherentXSection)) {
+      result["IncoherentXSection"] = "The cross section must be specified when "
+                                     "no ChemicalFormula or AtomicNumber is "
+                                     "given.";
+    }
+    if (isEmpty(params.attenuationXSection)) {
+      result["AttenuationXSection"] = "The cross section must be specified "
+                                      "when no ChemicalFormula or AtomicNumber "
+                                      "is given.";
+    }
+    if (isEmpty(params.scatteringXSection)) {
+      result["ScatteringXSection"] = "The cross section must be specified when "
+                                     "no ChemicalFormula or AtomicNumber is "
+                                     "given.";
+    }
+    if (isEmpty(params.sampleNumberDensity)) {
+      result["SampleNumberDensity"] =
+          "The number density must be specified with a use-defined material.";
+    }
+  } else if (chemicalSymbol && atomicNumber) {
+    result["AtomicNumber"] =
+        "Cannot specify both ChemicalFormula and AtomicNumber";
   }
 
   if (params.massNumber > 0 && params.atomicNumber <= 0)
@@ -42,16 +65,16 @@ ValidationErrors ReadMaterial::validateInputs(const MaterialParameters params) {
     }
     if (!isEmpty(params.sampleNumberDensity)) {
       result["ZParameter"] =
-          "Can not give ZParameter with SampleNumberDensity set";
+          "Cannot give ZParameter with SampleNumberDensity set";
     }
     if (!isEmpty(params.sampleMassDensity)) {
       result["SampleMassDensity"] =
-          "Can not give SampleMassDensity with ZParameter set";
+          "Cannot give SampleMassDensity with ZParameter set";
     }
   } else if (!isEmpty(params.sampleNumberDensity)) {
     if (!isEmpty(params.sampleMassDensity)) {
       result["SampleMassDensity"] =
-          "Can not give SampleMassDensity with SampleNumberDensity set";
+          "Cannot give SampleMassDensity with SampleNumberDensity set";
     }
   }
   return result;
@@ -63,7 +86,7 @@ ValidationErrors ReadMaterial::validateInputs(const MaterialParameters params) {
  *
  * @param params A struct containing all the parameters to be set.
  */
-void ReadMaterial::setMaterialParameters(MaterialParameters params) {
+void ReadMaterial::setMaterialParameters(const MaterialParameters &params) {
   setMaterial(params.chemicalSymbol, params.atomicNumber, params.massNumber);
   setNumberDensity(params.sampleMassDensity, params.sampleNumberDensity,
                    params.zParameter, params.unitCellVolume);
@@ -83,9 +106,8 @@ std::unique_ptr<Kernel::Material> ReadMaterial::buildMaterial() {
 void ReadMaterial::setMaterial(const std::string chemicalSymbol,
                                const int atomicNumber, const int massNumber) {
   if (!chemicalSymbol.empty()) {
-    std::cout << "CHEM: " << chemicalSymbol << std::endl;
     builder.setFormula(chemicalSymbol);
-  } else {
+  } else if (atomicNumber != 0) {
     builder.setAtomicNumber(atomicNumber);
     builder.setMassNumber(massNumber);
   }

--- a/Framework/DataHandling/src/SetSampleMaterial.cpp
+++ b/Framework/DataHandling/src/SetSampleMaterial.cpp
@@ -49,7 +49,7 @@ void SetSampleMaterial::init() {
                   "The chemical formula, see examples in documentation");
   declareProperty("AtomicNumber", 0, "The atomic number");
   declareProperty("MassNumber", 0,
-                  "Mass number if ion (use 0 for default mass sensity)");
+                  "Mass number if ion (use 0 for default mass number)");
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
   declareProperty("SampleNumberDensity", EMPTY_DBL(), mustBePositive,
@@ -62,13 +62,13 @@ void SetSampleMaterial::init() {
                   "Unit cell volume in Angstoms^3. Will be calculated from the "
                   "OrientedLattice if not supplied.");
   declareProperty("CoherentXSection", EMPTY_DBL(), mustBePositive,
-                  "Optional:  This coherent cross-section for the sample "
+                  "This coherent cross-section for the sample "
                   "material in barns will be used instead of tabulated");
   declareProperty("IncoherentXSection", EMPTY_DBL(), mustBePositive,
-                  "Optional:  This incoherent cross-section for the sample "
+                  "This incoherent cross-section for the sample "
                   "material in barns will be used instead of tabulated");
   declareProperty("AttenuationXSection", EMPTY_DBL(), mustBePositive,
-                  "Optional:  This absorption cross-section for the sample "
+                  "This absorption cross-section for the sample "
                   "material in barns will be used instead of tabulated");
   declareProperty("ScatteringXSection", EMPTY_DBL(), mustBePositive,
                   "Optional:  This total scattering cross-section (coherent + "
@@ -115,6 +115,10 @@ std::map<std::string, std::string> SetSampleMaterial::validateInputs() {
   params.zParameter = getProperty("ZParameter");
   params.unitCellVolume = getProperty("UnitCellVolume");
   params.sampleMassDensity = getProperty("SampleMassDensity");
+  params.coherentXSection = getProperty("CoherentXSection");
+  params.incoherentXSection = getProperty("IncoherentXSection");
+  params.attenuationXSection = getProperty("AttenuationXSection");
+  params.scatteringXSection = getProperty("ScatteringXSection");
   auto result = ReadMaterial::validateInputs(params);
 
   return result;
@@ -152,18 +156,15 @@ void SetSampleMaterial::exec() {
   // an ExperimentInfo object has a sample
   ExperimentInfo_sptr expInfo =
       boost::dynamic_pointer_cast<ExperimentInfo>(workspace);
-  if (!bool(expInfo)) {
+  if (!expInfo) {
     throw std::runtime_error("InputWorkspace does not have a sample object");
   }
 
   ReadMaterial reader;
-  params.coherentXSection = getProperty("CoherentXSection");
-  params.incoherentXSection = getProperty("IncoherentXSection");
-  params.attenuationXSection = getProperty("AttenuationXSection");
-  params.scatteringXSection = getProperty("ScatteringXSection");
   reader.setMaterialParameters(params);
 
-  double rho = getProperty("SampleNumberDensity"); // in atoms / Angstroms^3
+  const double rho =
+      getProperty("SampleNumberDensity"); // in atoms / Angstroms^3
 
   // get the scattering information - this will override table values
   // create the material

--- a/Framework/DataHandling/test/ReadMaterialTest.h
+++ b/Framework/DataHandling/test/ReadMaterialTest.h
@@ -63,18 +63,105 @@ public:
                      "Cannot specify both ChemicalFormula and AtomicNumber")
   }
 
-  void testFailureValidateInputsNoMaterial() {
+  void testFailureValidateInputsNoCoherentXSection() {
     const ReadMaterial::MaterialParameters params = []() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.atomicNumber = 0;
       setMaterial.massNumber = 0;
+      setMaterial.incoherentXSection = 1.;
+      setMaterial.attenuationXSection = 1.;
+      setMaterial.scatteringXSection = 1.;
+      setMaterial.sampleNumberDensity = 1.;
       return setMaterial;
     }
     ();
 
     auto result = ReadMaterial::validateInputs(params);
+    TS_ASSERT_EQUALS(result.size(), 1)
+    TS_ASSERT_EQUALS(result["CoherentXSection"],
+                     "The cross section must be specified when "
+                     "no ChemicalFormula or AtomicNumber is "
+                     "given.")
+  }
 
-    TS_ASSERT_EQUALS(result["ChemicalFormula"], "Need to specify the material")
+  void testFailureValidateInputsNoIncoherentXSection() {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.atomicNumber = 0;
+      setMaterial.massNumber = 0;
+      setMaterial.coherentXSection = 1.;
+      setMaterial.attenuationXSection = 1.;
+      setMaterial.scatteringXSection = 1.;
+      setMaterial.sampleNumberDensity = 1.;
+      return setMaterial;
+    }
+    ();
+
+    auto result = ReadMaterial::validateInputs(params);
+    TS_ASSERT_EQUALS(result.size(), 1)
+    TS_ASSERT_EQUALS(result["IncoherentXSection"],
+                     "The cross section must be specified when "
+                     "no ChemicalFormula or AtomicNumber is "
+                     "given.")
+  }
+  void testFailureValidateInputsNoAttenuationXSection() {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.atomicNumber = 0;
+      setMaterial.massNumber = 0;
+      setMaterial.coherentXSection = 1.;
+      setMaterial.incoherentXSection = 1.;
+      setMaterial.scatteringXSection = 1.;
+      setMaterial.sampleNumberDensity = 1.;
+      return setMaterial;
+    }
+    ();
+
+    auto result = ReadMaterial::validateInputs(params);
+    TS_ASSERT_EQUALS(result.size(), 1)
+    TS_ASSERT_EQUALS(result["AttenuationXSection"],
+                     "The cross section must be specified when "
+                     "no ChemicalFormula or AtomicNumber is "
+                     "given.")
+  }
+  void testFailureValidateInputsNoScatteringXSection() {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.atomicNumber = 0;
+      setMaterial.massNumber = 0;
+      setMaterial.coherentXSection = 1.;
+      setMaterial.incoherentXSection = 1.;
+      setMaterial.attenuationXSection = 1.;
+      setMaterial.sampleNumberDensity = 1.;
+      return setMaterial;
+    }
+    ();
+
+    auto result = ReadMaterial::validateInputs(params);
+    TS_ASSERT_EQUALS(result.size(), 1)
+    TS_ASSERT_EQUALS(result["ScatteringXSection"],
+                     "The cross section must be specified when "
+                     "no ChemicalFormula or AtomicNumber is "
+                     "given.")
+  }
+  void testFailureValidateInputsNoSampleNumberDensity() {
+    const ReadMaterial::MaterialParameters params = []() -> auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.atomicNumber = 0;
+      setMaterial.massNumber = 0;
+      setMaterial.coherentXSection = 1.;
+      setMaterial.incoherentXSection = 1.;
+      setMaterial.attenuationXSection = 1.;
+      setMaterial.scatteringXSection = 1.;
+      return setMaterial;
+    }
+    ();
+
+    auto result = ReadMaterial::validateInputs(params);
+    TS_ASSERT_EQUALS(result.size(), 1)
+    TS_ASSERT_EQUALS(
+        result["SampleNumberDensity"],
+        "The number density must be specified with a use-defined material.")
   }
 
   void testSuccessfullValidateInputsSampleNumber() {
@@ -138,7 +225,7 @@ public:
     auto result = ReadMaterial::validateInputs(params);
 
     TS_ASSERT_EQUALS(result["ZParameter"],
-                     "Can not give ZParameter with SampleNumberDensity set")
+                     "Cannot give ZParameter with SampleNumberDensity set")
   }
 
   void testFailureValidateInputsZParamWithSampleMass() {
@@ -156,7 +243,7 @@ public:
     auto result = ReadMaterial::validateInputs(params);
 
     TS_ASSERT_EQUALS(result["SampleMassDensity"],
-                     "Can not give SampleMassDensity with ZParameter set")
+                     "Cannot give SampleMassDensity with ZParameter set")
   }
 
   void testFailureValidateInputsZParamWithoutUnitCell() {
@@ -190,7 +277,7 @@ public:
 
     TS_ASSERT_EQUALS(
         result["SampleMassDensity"],
-        "Can not give SampleMassDensity with SampleNumberDensity set")
+        "Cannot give SampleMassDensity with SampleNumberDensity set")
   }
 
   void testMaterialIsCorrect() {

--- a/Framework/Kernel/inc/MantidKernel/Atom.h
+++ b/Framework/Kernel/inc/MantidKernel/Atom.h
@@ -9,7 +9,6 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/NeutronAtom.h"
-#include <ostream>
 #include <string>
 
 namespace Mantid {

--- a/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
+++ b/Framework/Kernel/inc/MantidKernel/MaterialBuilder.h
@@ -10,8 +10,6 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/Material.h"
 #include <boost/optional/optional.hpp>
-#include <string>
-#include <tuple>
 
 namespace Mantid {
 // Forward declare
@@ -58,7 +56,7 @@ private:
   double getOrCalculateRho(const Material::ChemicalFormula &formula) const;
 
   std::string m_name;
-  std::unique_ptr<Material::ChemicalFormula> m_formula;
+  Material::ChemicalFormula m_formula;
   boost::optional<int> m_atomicNo;
   int m_massNo;
   boost::optional<double> m_numberDensity, m_zParam, m_cellVol, m_massDensity;

--- a/Framework/Kernel/inc/MantidKernel/NeutronAtom.h
+++ b/Framework/Kernel/inc/MantidKernel/NeutronAtom.h
@@ -109,7 +109,7 @@ MANTID_KERNEL_DLL NeutronAtom getNeutronNoExceptions(const uint16_t z_number,
 MANTID_KERNEL_DLL NeutronAtom getNeutronNoExceptions(const NeutronAtom &other);
 
 /// Utility function to calculate scattering lengths from cross-sections.
-MANTID_KERNEL_DLL void calculateScatteringLengths(NeutronAtom *atom);
+MANTID_KERNEL_DLL void calculateScatteringLengths(NeutronAtom &atom);
 
 } // Namespace PhysicalConstants
 } // Namespace Mantid

--- a/Framework/Kernel/src/Atom.cpp
+++ b/Framework/Kernel/src/Atom.cpp
@@ -9,10 +9,7 @@
 #include "MantidKernel/PhysicalConstants.h"
 
 #include <algorithm>
-#include <cmath>
 #include <sstream>
-#include <stdexcept>
-#include <string>
 
 namespace Mantid {
 namespace PhysicalConstants {
@@ -3214,7 +3211,10 @@ bool compareAtoms(const Atom &left, const Atom &right) {
  * @return The atom corresponding to the given Z and A
  */
 Atom getAtom(const uint16_t z_number, const uint16_t a_number) {
-  Atom temp("junk", z_number, a_number, NAN, NAN, NAN);
+  Atom temp("junk", z_number, a_number,
+            std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN(),
+            std::numeric_limits<double>::quiet_NaN());
 
   Atom *result =
       std::lower_bound(&(ATOMS[0]), &(ATOMS[NUM_ATOMS]), temp, compareAtoms);

--- a/Framework/Kernel/src/NeutronAtom.cpp
+++ b/Framework/Kernel/src/NeutronAtom.cpp
@@ -26,19 +26,19 @@ namespace {
 const double INV_FOUR_PI = 1. / (4. * M_PI);
 }
 
-void calculateScatteringLengths(NeutronAtom *atom) {
+void calculateScatteringLengths(NeutronAtom &atom) {
   // 1 barn = 100 fm
-  atom->tot_scatt_length = 10. * std::sqrt(atom->tot_scatt_xs * INV_FOUR_PI);
+  atom.tot_scatt_length = 10. * std::sqrt(atom.tot_scatt_xs * INV_FOUR_PI);
 
-  if (atom->coh_scatt_length_img == 0.)
-    atom->coh_scatt_length = fabs(atom->coh_scatt_length_real);
+  if (atom.coh_scatt_length_img == 0.)
+    atom.coh_scatt_length = fabs(atom.coh_scatt_length_real);
   else
-    atom->coh_scatt_length = 10. * std::sqrt(atom->coh_scatt_xs * INV_FOUR_PI);
+    atom.coh_scatt_length = 10. * std::sqrt(atom.coh_scatt_xs * INV_FOUR_PI);
 
-  if (atom->inc_scatt_length_img == 0.)
-    atom->inc_scatt_length = fabs(atom->inc_scatt_length_real);
+  if (atom.inc_scatt_length_img == 0.)
+    atom.inc_scatt_length = fabs(atom.inc_scatt_length_real);
   else
-    atom->inc_scatt_length = 10. * std::sqrt(atom->inc_scatt_xs * INV_FOUR_PI);
+    atom.inc_scatt_length = 10. * std::sqrt(atom.inc_scatt_xs * INV_FOUR_PI);
 }
 
 /**
@@ -59,7 +59,7 @@ NeutronAtom::NeutronAtom(const uint16_t z, const double coh_b_real,
       coh_scatt_length_img(0.), inc_scatt_length_real(inc_b_real),
       inc_scatt_length_img(0.), coh_scatt_xs(coh_xs), inc_scatt_xs(inc_xs),
       tot_scatt_xs(tot_xs), abs_scatt_xs(abs_xs) {
-  calculateScatteringLengths(this);
+  calculateScatteringLengths(*this);
 }
 /**
  * Atom constructor
@@ -80,7 +80,7 @@ NeutronAtom::NeutronAtom(const uint16_t z, const uint16_t a,
       coh_scatt_length_img(0.), inc_scatt_length_real(inc_b_real),
       inc_scatt_length_img(0.), coh_scatt_xs(coh_xs), inc_scatt_xs(inc_xs),
       tot_scatt_xs(tot_xs), abs_scatt_xs(abs_xs) {
-  calculateScatteringLengths(this);
+  calculateScatteringLengths(*this);
 }
 /**
  * Atom constructor
@@ -104,7 +104,7 @@ NeutronAtom::NeutronAtom(const uint16_t z, const uint16_t a,
       coh_scatt_length_img(coh_b_img), inc_scatt_length_real(inc_b_real),
       inc_scatt_length_img(inc_b_img), coh_scatt_xs(coh_xs),
       inc_scatt_xs(inc_xs), tot_scatt_xs(tot_xs), abs_scatt_xs(abs_xs) {
-  calculateScatteringLengths(this);
+  calculateScatteringLengths(*this);
 }
 
 NeutronAtom::NeutronAtom(const NeutronAtom &other)
@@ -115,7 +115,7 @@ NeutronAtom::NeutronAtom(const NeutronAtom &other)
       inc_scatt_length_img(other.inc_scatt_length_img),
       coh_scatt_xs(other.coh_scatt_xs), inc_scatt_xs(other.inc_scatt_xs),
       tot_scatt_xs(other.tot_scatt_xs), abs_scatt_xs(other.abs_scatt_xs) {
-  calculateScatteringLengths(this);
+  calculateScatteringLengths(*this);
 }
 
 NeutronAtom &NeutronAtom::operator=(const NeutronAtom &other) {
@@ -133,7 +133,7 @@ NeutronAtom &NeutronAtom::operator=(const NeutronAtom &other) {
   tot_scatt_xs = other.tot_scatt_xs;
   abs_scatt_xs = other.abs_scatt_xs;
 
-  calculateScatteringLengths(this);
+  calculateScatteringLengths(*this);
 
   return *this;
 }
@@ -144,11 +144,18 @@ NeutronAtom &NeutronAtom::operator=(const NeutronAtom &other) {
  * initialize them.
  */
 NeutronAtom::NeutronAtom()
-    : z_number(0), a_number(0), coh_scatt_length_real(NAN),
-      coh_scatt_length_img(NAN), inc_scatt_length_real(NAN),
-      inc_scatt_length_img(NAN), coh_scatt_xs(NAN), inc_scatt_xs(NAN),
-      tot_scatt_xs(NAN), abs_scatt_xs(NAN), tot_scatt_length(NAN),
-      coh_scatt_length(NAN), inc_scatt_length(NAN) {}
+    : z_number(0), a_number(0),
+      coh_scatt_length_real(std::numeric_limits<double>::quiet_NaN()),
+      coh_scatt_length_img(std::numeric_limits<double>::quiet_NaN()),
+      inc_scatt_length_real(std::numeric_limits<double>::quiet_NaN()),
+      inc_scatt_length_img(std::numeric_limits<double>::quiet_NaN()),
+      coh_scatt_xs(std::numeric_limits<double>::quiet_NaN()),
+      inc_scatt_xs(std::numeric_limits<double>::quiet_NaN()),
+      tot_scatt_xs(std::numeric_limits<double>::quiet_NaN()),
+      abs_scatt_xs(std::numeric_limits<double>::quiet_NaN()),
+      tot_scatt_length(std::numeric_limits<double>::quiet_NaN()),
+      coh_scatt_length(std::numeric_limits<double>::quiet_NaN()),
+      inc_scatt_length(std::numeric_limits<double>::quiet_NaN()) {}
 
 /// @cond
 static const NeutronAtom H(1, -3.7390, 0., 1.7568, 80.26, 82.02, 0.3326);

--- a/Framework/Kernel/test/MaterialBuilderTest.h
+++ b/Framework/Kernel/test/MaterialBuilderTest.h
@@ -9,6 +9,7 @@
 
 #include <cxxtest/TestSuite.h>
 
+#include "MantidKernel/Atom.h"
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/MaterialBuilder.h"
 #include "MantidKernel/NeutronAtom.h"
@@ -82,6 +83,23 @@ public:
     // Other isotop
     TS_ASSERT_DELTA(mat.totalScatterXSection(), 26.1, 0.0001);
     TS_ASSERT_DELTA(mat.absorbXSection(), 4.6, 0.0001);
+  }
+
+  void test_Build_From_Cross_Sections() {
+    MaterialBuilder builder;
+    Material mat = builder.setNumberDensity(0.1)
+                       .setTotalScatterXSection(2.3)
+                       .setCoherentXSection(0.5)
+                       .setIncoherentXSection(5.0)
+                       .setAbsorptionXSection(0.23)
+                       .build();
+    TS_ASSERT_EQUALS(mat.chemicalFormula().size(), 1)
+    TS_ASSERT_EQUALS(mat.chemicalFormula().front().atom->symbol, "user")
+    TS_ASSERT_EQUALS(mat.numberDensity(), 0.1)
+    TS_ASSERT_EQUALS(mat.totalScatterXSection(), 2.3)
+    TS_ASSERT_EQUALS(mat.cohScatterXSection(), 0.5)
+    TS_ASSERT_EQUALS(mat.incohScatterXSection(), 5.0)
+    TS_ASSERT_EQUALS(mat.absorbXSection(), 0.23)
   }
 
   void test_Number_Density_Set_By_Formula_ZParameter_And_Cell_Volume() {
@@ -172,6 +190,51 @@ public:
         "The number density could not be determined. Please "
         "provide the number density, ZParameter and unit "
         "cell volume or mass density.")
+  }
+
+  void test_User_Defined_Material_Without_NumberDensity_Throws() {
+    MaterialBuilder builder;
+    builder = builder.setTotalScatterXSection(2.3)
+                  .setCoherentXSection(0.5)
+                  .setIncoherentXSection(5.0)
+                  .setAbsorptionXSection(0.23);
+    TS_ASSERT_THROWS(builder.build(), std::runtime_error)
+  }
+
+  void test_User_Defined_Material_Without_TotalScatterXSection_Throws() {
+    MaterialBuilder builder;
+    builder = builder.setNumberDensity(0.1)
+                  .setCoherentXSection(0.5)
+                  .setIncoherentXSection(5.0)
+                  .setAbsorptionXSection(0.23);
+    TS_ASSERT_THROWS(builder.build(), std::runtime_error)
+  }
+
+  void test_User_Defined_Material_Without_CoherentXSection_Throws() {
+    MaterialBuilder builder;
+    builder = builder.setNumberDensity(0.1)
+                  .setTotalScatterXSection(2.3)
+                  .setIncoherentXSection(5.0)
+                  .setAbsorptionXSection(0.23);
+    TS_ASSERT_THROWS(builder.build(), std::runtime_error)
+  }
+
+  void test_User_Defined_Material_Without_IncoherentXSection_Throws() {
+    MaterialBuilder builder;
+    builder = builder.setNumberDensity(0.1)
+                  .setTotalScatterXSection(2.3)
+                  .setCoherentXSection(5.0)
+                  .setAbsorptionXSection(0.23);
+    TS_ASSERT_THROWS(builder.build(), std::runtime_error)
+  }
+
+  void test_User_Defined_Material_Without_AbsorptionXSection_Throws() {
+    MaterialBuilder builder;
+    builder = builder.setNumberDensity(0.1)
+                  .setTotalScatterXSection(2.3)
+                  .setCoherentXSection(5.0)
+                  .setIncoherentXSection(5.0);
+    TS_ASSERT_THROWS(builder.build(), std::runtime_error)
   }
 };
 

--- a/docs/source/algorithms/SetSampleMaterial-v1.rst
+++ b/docs/source/algorithms/SetSampleMaterial-v1.rst
@@ -9,16 +9,13 @@
 Description
 -----------
 
-Sets the neutrons information in the sample. You can either enter
-details about the chemical formula or atomic number, or you can
-provide specific values for the attenuation and scattering cross
-sections and the sample number density. If you decide to provide
-specific values you must give values for all three (attenuation and
-scattering cross sections and the sample number density), and any
-formula information will be ignored. If you miss any of the three
-specific values then the other will be ignored. For details of how the
-various quantities are calculated, refer to the :ref:`Materials`
-concept page.
+Sets the neutrons information in the sample. You can either enter details 
+about the chemical formula or atomic number, or you can provide specific 
+values for the attenuation and scattering cross sections and the sample number 
+density. If you provide a chemical formula or atomic number, the cross 
+sections will be calculated from a database. If you decide to provide specific 
+cross sections, they will override the tabulated ones. For details of how the 
+various quantities are calculated, refer to the :ref:`Materials` concept page.
 
 .. note:: It is recommended that you use :ref:`SetSample <algm-SetSample>` instead.
 

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -88,6 +88,7 @@ Improvements
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
 - All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``).
 - Various clarifications and additional links in the geometry and material documentation pages
+- :ref:`SetSample <algm-SetSample>` and :ref:`SetSampleMaterial <algm-SetSampleMaterial>` now accept materials without ``ChemicalFormula`` or ``AtomicNumber``. In this case, all cross sections and ``SampleNumberDensity`` have to be given.
 
 Bugfixes
 ########
@@ -145,7 +146,7 @@ Improvements
 - :ref:`ChudleyElliot <func-ChudleyElliot>` includes hbar in the definition
 - :ref:`Functions <FitFunctionsInPython>` may now have their constraint penalties for fitting set in python using ``function.setConstraintPenaltyFactor("parameterName", double)``.
 - :py:obj:`mantid.kernel.Logger` now handles unicode in python2
-
+- It is now possible to build custom materials with :class:`mantid.kernel.MaterialBuilder` without setting a formula or atomic number. In this case, all cross sections and number density have to be given.
 
 Bugfixes
 ########


### PR DESCRIPTION
Sometimes the chemical composition is too complex or simply unknown.  This PR enables specifying materials without a chemical formula or atomic number in `SetSampleMaterial` and `MaterialBuilder`. It is now enough to specify the cross sections and number density which is sufficient for, for example, `MonteCarloAbsorption`.

**Report to:** Björn Fåk/ILL

**To test:**

1. The following script exercises `SetSampleMaterial` via `SetSample` and then runs `MonteCarloAbsorption` within `DirectILLSelfShielding`. After making sure that the doc test data directory is in Mantid's Data search directories, the script should run without problems. Try giving the some bogus numbers/combination of parameter and see if what happens.

```python
DirectILLCollectData(
    Run='ILL/IN4/087294+087295.nxs',
    OutputWorkspace='sample',
)
geometry = {
    'Shape': 'FlatPlate',
    'Width': 4.0,
    'Height': 5.0,
    'Thick': 0.1,
    'Center': [0.0, 0.0, 0.0],
    'Angle': 45.0
}
material = {
    'SampleNumberDensity': 0.01,
    'CoherentXSection': 5.,
    'IncoherentXSection': 5.,
    'AttenuationXSection': 1.,
    'ScatteringXSection': 3.
}
SetSample(
    InputWorkspace='sample',
    Geometry=geometry,
    Material=material
)
DirectILLSelfShielding(
    InputWorkspace='sample',
    OutputWorkspace='corrections',
    NumberOfSimulatedWavelengths=10
)
```

2. The following script tests `MaterialBuilder` and should execute without assertion errors.

```python
builder = MaterialBuilder()
builder.setAbsorptionXSection(3.)
builder.setCoherentXSection(4.)
builder.setIncoherentXSection(5.)
builder.setTotalScatterXSection(6.)
builder.setNumberDensity(0.01)
material = builder.build()
assert(material.absorbXSection() == 3.)
assert(material.cohScatterXSection() == 4.)
assert(material.incohScatterXSection() == 5.)
assert(material.totalScatterXSection() == 6.)
assert(material.numberDensity == 0.01)
assert(material.chemicalFormula()[0][0].symbol == 'user')
```


Fixes #21466.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
