### PR TITLE
Fix TableWorkspaceDisplay resize and add show data context

### DIFF
--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
@@ -60,7 +60,8 @@ class TableWorkspaceDisplayView(QTableWidget):
         header = self.horizontalHeader()
         header.sectionDoubleClicked.connect(self.handle_double_click)
 
-    def resizeEvent(self, _):
+    def resizeEvent(self, event):
+        QTableWidget.resizeEvent(self, event)
         header = self.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.Interactive)
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -106,6 +106,9 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           matrixWS->getInstrument() &&
           !matrixWS->getInstrument()->getName().empty());
       menu->addSeparator();
+    } else if (boost::dynamic_pointer_cast<ITableWorkspace>(workspace)) {
+      menu->addAction(m_showData);
+      menu->addSeparator();
     }
     menu->addAction(m_rename);
     menu->addAction(m_saveNexus);


### PR DESCRIPTION
**Description of work.**
Fixes the resize event for the `TableWorkspaceDisplay`, making it render properly after resize.

Adds the `Show Data` context menu when right clicking a Table or Peaks workspace.

**To test:**
Load a table workspace, right click should show `Show Data`. Click Show Data, then resize the window, it should resize normally.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
