### PR TITLE
Improve default output names in RROA

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -75,12 +75,10 @@ private:
   void applyFloodCorrections();
   double getPropertyOrDefault(const std::string &propertyName,
                               const double defaultValue);
-  void setOutputWorkspaces(std::vector<std::string> &IvsLamGroup,
-                           std::string const &outputIvsLam,
+  void setOutputWorkspaces(WorkspaceNames const &outputGroupNames,
+                           std::vector<std::string> &IvsLamGroup,
                            std::vector<std::string> &IvsQBinnedGroup,
-                           std::string const &outputIvsQBinned,
-                           std::vector<std::string> &IvsQGroup,
-                           std::string const &outputIvsQ);
+                           std::vector<std::string> &IvsQGroup);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -35,9 +35,18 @@ public:
   bool processGroups() override;
 
 private:
+  // Utility class to store output workspace names
+  struct WorkspaceNames {
+    std::string iVsQ;
+    std::string iVsQBinned;
+    std::string iVsLam;
+  };
+
   void init() override;
   void exec() override;
-  // Set default names for output workspaces
+  std::string
+  getRunNumberForWorkspaceGroup(WorkspaceGroup_const_sptr workspace);
+  WorkspaceNames getOutputWorkspaceNames();
   void setDefaultOutputWorkspaceNames();
   /// Get the name of the detectors of interest based on processing instructions
   std::vector<std::string>

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -77,9 +77,9 @@ private:
                               const double defaultValue);
   void setOutputWorkspaces(std::vector<std::string> &IvsLamGroup,
                            std::string const &outputIvsLam,
-                           std::vector<std::string> &IvsQGroup,
+                           std::vector<std::string> &IvsQBinnedGroup,
                            std::string const &outputIvsQBinned,
-                           std::vector<std::string> &IvsQUnbinnedGroup,
+                           std::vector<std::string> &IvsQGroup,
                            std::string const &outputIvsQ);
 };
 

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -763,8 +763,8 @@ bool ReflectometryReductionOneAuto2::checkGroups() {
 
 void ReflectometryReductionOneAuto2::setOutputWorkspaces(
     std::vector<std::string> &IvsLamGroup, std::string const &outputIvsLam,
-    std::vector<std::string> &IvsQGroup, std::string const &outputIvsQBinned,
-    std::vector<std::string> &IvsQUnbinnedGroup,
+    std::vector<std::string> &IvsQBinnedGroup,
+    std::string const &outputIvsQBinned, std::vector<std::string> &IvsQGroup,
     std::string const &outputIvsQ) {
   // Group the IvsQ and IvsLam workspaces
   Algorithm_sptr groupAlg = createChildAlgorithm("GroupWorkspaces");
@@ -775,11 +775,11 @@ void ReflectometryReductionOneAuto2::setOutputWorkspaces(
     groupAlg->setProperty("OutputWorkspace", outputIvsLam);
     groupAlg->execute();
   }
+  groupAlg->setProperty("InputWorkspaces", IvsQBinnedGroup);
+  groupAlg->setProperty("OutputWorkspace", outputIvsQBinned);
+  groupAlg->execute();
   groupAlg->setProperty("InputWorkspaces", IvsQGroup);
   groupAlg->setProperty("OutputWorkspace", outputIvsQ);
-  groupAlg->execute();
-  groupAlg->setProperty("InputWorkspaces", IvsQUnbinnedGroup);
-  groupAlg->setProperty("OutputWorkspace", outputIvsQBinned);
   groupAlg->execute();
 
   setPropertyValue("OutputWorkspace", outputIvsQ);
@@ -883,7 +883,7 @@ bool ReflectometryReductionOneAuto2::processGroups() {
     alg->execute();
 
     IvsQGroup.push_back(IvsQName);
-    IvsQUnbinnedGroup.push_back(IvsQBinnedName);
+    IvsQBinnedGroup.push_back(IvsQBinnedName);
     if (AnalysisDataService::Instance().doesExist(IvsLamName)) {
       IvsLamGroup.push_back(IvsLamName);
     }
@@ -898,11 +898,11 @@ bool ReflectometryReductionOneAuto2::processGroups() {
     groupAlg->setProperty("OutputWorkspace", output.iVsLam);
     groupAlg->execute();
   }
+  groupAlg->setProperty("InputWorkspaces", IvsQBinnedGroup);
+  groupAlg->setProperty("OutputWorkspace", output.iVsQBinned);
+  groupAlg->execute();
   groupAlg->setProperty("InputWorkspaces", IvsQGroup);
   groupAlg->setProperty("OutputWorkspace", output.iVsQ);
-  groupAlg->execute();
-  groupAlg->setProperty("InputWorkspaces", IvsQUnbinnedGroup);
-  groupAlg->setProperty("OutputWorkspace", output.iVsQBinned);
   groupAlg->execute();
 
   // Set other properties so they can be updated in the Reflectometry interface
@@ -915,8 +915,8 @@ bool ReflectometryReductionOneAuto2::processGroups() {
                    alg->getPropertyValue("MomentumTransferStep"));
   setPropertyValue("ScaleFactor", alg->getPropertyValue("ScaleFactor"));
 
-  setOutputWorkspaces(IvsLamGroup, output.iVsLam, IvsQGroup, output.iVsQBinned,
-                      IvsQUnbinnedGroup, output.iVsQ);
+  setOutputWorkspaces(IvsLamGroup, output.iVsLam, IvsQBinnedGroup,
+                      output.iVsQBinned, IvsQGroup, output.iVsQ);
 
   if (!polarizationAnalysisOn) {
     // No polarization analysis. Reduction stops here
@@ -928,8 +928,8 @@ bool ReflectometryReductionOneAuto2::processGroups() {
   // Polarization correction may have changed the number of workspaces in the
   // groups
   IvsLamGroup.clear();
+  IvsQBinnedGroup.clear();
   IvsQGroup.clear();
-  IvsQUnbinnedGroup.clear();
 
   // Now we've overwritten the IvsLam workspaces, we'll need to recalculate
   // the IvsQ ones
@@ -954,15 +954,15 @@ bool ReflectometryReductionOneAuto2::processGroups() {
     alg->setProperty("OutputWorkspaceBinned", IvsQBinnedName);
     alg->setProperty("OutputWorkspaceWavelength", IvsLamName);
     alg->execute();
+    IvsQBinnedGroup.push_back(IvsQBinnedName);
     IvsQGroup.push_back(IvsQName);
-    IvsQUnbinnedGroup.push_back(IvsQBinnedName);
     if (AnalysisDataService::Instance().doesExist(IvsLamName)) {
       IvsLamGroup.push_back(IvsLamName);
     }
   }
 
-  setOutputWorkspaces(IvsLamGroup, output.iVsLam, IvsQGroup, output.iVsQBinned,
-                      IvsQUnbinnedGroup, output.iVsQ);
+  setOutputWorkspaces(IvsLamGroup, output.iVsLam, IvsQBinnedGroup,
+                      output.iVsQBinned, IvsQGroup, output.iVsQ);
 
   return true;
 }

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
@@ -876,6 +876,85 @@ public:
     ADS.clear();
   }
 
+  void test_input_workspace_group_with_default_output_workspaces() {
+    ReflectometryReductionOneAuto2 alg;
+    setup_alg_on_input_workspace_group_with_run_number(alg);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Mandatory workspaces should exist
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsQ_1234"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsQ_binned_1234"), true);
+    // IvsLam is currently always output for group workspaces
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsLam_1234"), true);
+
+    auto outQGroup = retrieveOutWS("IvsQ_1234");
+    auto outQGroupBinned = retrieveOutWS("IvsQ_binned_1234");
+    TS_ASSERT_EQUALS(outQGroup.size(), 4);
+    TS_ASSERT_EQUALS(outQGroupBinned.size(), 4);
+
+    ADS.clear();
+  }
+
+  void
+  test_input_workspace_group_with_default_output_workspaces_and_debug_on() {
+    ReflectometryReductionOneAuto2 alg;
+    setup_alg_on_input_workspace_group_with_run_number(alg);
+    alg.setProperty("Debug", true);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Mandatory workspaces should exist
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsQ_1234"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsQ_binned_1234"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("IvsLam_1234"), true);
+
+    auto outLamGroup = retrieveOutWS("IvsLam_1234");
+    TS_ASSERT_EQUALS(outLamGroup.size(), 4);
+
+    ADS.clear();
+  }
+
+  void test_input_workspace_group_with_named_output_workspaces() {
+    ReflectometryReductionOneAuto2 alg;
+    setup_alg_on_input_workspace_group_with_run_number(alg);
+    alg.setPropertyValue("OutputWorkspace", "testIvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "testIvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "testIvsLam");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Mandatory workspaces should exist
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsQ"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsQ_binned"), true);
+    // IvsLam is currently always output for group workspaces
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsLam"), true);
+
+    auto outQGroup = retrieveOutWS("testIvsQ");
+    auto outQGroupBinned = retrieveOutWS("testIvsQ_binned");
+    TS_ASSERT_EQUALS(outQGroup.size(), 4);
+    TS_ASSERT_EQUALS(outQGroupBinned.size(), 4);
+
+    ADS.clear();
+  }
+
+  void test_input_workspace_group_with_named_output_workspaces_and_debug_on() {
+    ReflectometryReductionOneAuto2 alg;
+    setup_alg_on_input_workspace_group_with_run_number(alg);
+    alg.setPropertyValue("OutputWorkspace", "testIvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "testIvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "testIvsLam");
+    alg.setProperty("Debug", true);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Mandatory workspaces should exist
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsQ"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsQ_binned"), true);
+    TS_ASSERT_EQUALS(ADS.doesExist("testIvsLam"), true);
+
+    auto outLamGroup = retrieveOutWS("testIvsLam");
+    TS_ASSERT_EQUALS(outLamGroup.size(), 4);
+
+    ADS.clear();
+  }
+
   void test_one_transmissionrun() {
     const double startX = 1000;
     const int nBins = 3;
@@ -916,6 +995,7 @@ public:
     alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
     alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.setPropertyValue("FirstTransmissionRun", "transWSGroup");
+    alg.setProperty("Debug", true);
     TS_ASSERT_THROWS_NOTHING(alg.execute());
 
     auto outQGroup = retrieveOutWS("IvsQ");
@@ -1055,6 +1135,7 @@ public:
     alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.setPropertyValue("FirstTransmissionRun", "transWSGroup");
     alg.setPropertyValue("SecondTransmissionRun", "transWSGroup2");
+    alg.setProperty("Debug", true);
     TS_ASSERT_THROWS_NOTHING(alg.execute());
 
     auto outQGroup = retrieveOutWS("IvsQ");
@@ -1562,6 +1643,25 @@ private:
     }
     flood->getAxis(0)->setUnit("TOF");
     return flood;
+  }
+
+  void setup_alg_on_input_workspace_group_with_run_number(
+      ReflectometryReductionOneAuto2 &alg) {
+    std::string const name = "input";
+    prepareInputGroup(name);
+    WorkspaceGroup_sptr group = ADS.retrieveWS<WorkspaceGroup>("input");
+    MatrixWorkspace_sptr ws =
+        ADS.retrieveWS<MatrixWorkspace>(group->getNames()[0]);
+    ws->mutableRun().addProperty<std::string>("run_number", "1234");
+
+    alg.initialize();
+    alg.setChild(true);
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("WavelengthMin", 0.0000000001);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
   }
 };
 

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
@@ -53,10 +53,9 @@ std::vector<MatrixWorkspace_sptr> retrieveOutWS(std::string const &name);
 // original.
 void applyPolarizationEfficiencies(std::string const &name);
 
-MatrixWorkspace_sptr
-createWorkspaceSingle(const double startX = 1, const int nBins = 3,
-                      const double deltaX = 1,
-                      const std::vector<double> &yValues = {1, 2, 3});
+MatrixWorkspace_sptr createWorkspaceSingle(const double startX, const int nBins,
+                                           const double deltaX,
+                                           const std::vector<double> &yValues);
 
 MatrixWorkspace_sptr createWorkspaceSingle(const double startX = 1,
                                            const int nBins = 3,


### PR DESCRIPTION
**Description of work.**
This PR adds the following changes:
- Fix a bug where default output names are not set correctly when the input is a group workspace.
- Minor refactoring to improve on some confusing variable naming (use "binned" consistently, rather than sometimes "unbinned")

**Report to:** nobody

**To test:**
This script runs examples on group workspace input with/without debug and with/without polarization correction, plus examples on matrix workspaces with/without debug.
```
from __future__ import print_function

def checkOutputs(title, exist, notExist = []):
    print(title)
    ok = True
    for name in exist:
        if not AnalysisDataService.doesExist(name):
            ok = False
            print('  FAILED: ' + name + ' should exist')
    for name in notExist:
        if AnalysisDataService.doesExist(name):
            ok = False
            print('  FAILED: ' + name + ' should NOT exist')
    if ok:
        print('  PASSED')
        
#
# WorkspaceGroup as input
#

# Run RROA on a group - outputs IvsQ and IvsQ_binned groups
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02)
checkOutputs('Group input with default names', ['IvsQ_44956', 'IvsQ_binned_44956','IvsLam_44956'])

# With Debug - also outputs IvsLam group
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02,Debug=1)
checkOutputs('Group input with default names and debug', ['IvsQ_44956', 'IvsQ_binned_44956', 'IvsLam_44956'])

# Check we can override output names
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02,OutputWorkspace='testIvsQ', OutputWorkspaceBinned='testIvsQBin', OutputWorkspaceWavelength='testIvsLam')
checkOutputs('Group input with user names', ['testIvsQ', 'testIvsQBin','testIvsLam'])

# And again with debug
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02,OSee the linked issueutputWorkspace='testIvsQ', OutputWorkspaceBinned='testIvsQBin', OutputWorkspaceWavelength='testIvsLam',Debug=1)
checkOutputs('Group input with user names and debug', ['testIvsQ', 'testIvsQBin', 'testIvsLam'])


# With pol Cor should always output IvsLam group, even without Debug, so this should output IvsQ_44956, IvsQ_binned_44956 and IvsLam_44956 groups
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02,PolarizationAnalysis='ParameterFile')
checkOutputs('Pol cor with default names', ['IvsQ_44956', 'IvsQ_binned_44956', 'IvsLam_44956'])

# Check pol cor with override names - should output testIvsQ, testIvsQBin and testIvsLam groups
AnalysisDataService.clear()
LoadISISNexus(Filename='OFFSPEC44956', OutputWorkspace='offspec44956')
ReflectometryReductionOneAuto(InputWorkspace='offspec44956', AnalysisMode='MultiDetectorAnalysis', ProcessingInstructions='390-410', ThetaIn=0.5, MomentumTransferStep=0.02,PolarizationAnalysis='ParameterFile',OutputWorkspace='testIvsQ', OutputWorkspaceBinned='testIvsQBin', OutputWorkspaceWavelength='testIvsLam')
checkOutputs('Pol cor with user names', ['testIvsQ', 'testIvsQBin', 'testIvsLam'])



#
# MatrixWorkspace as input
#

# Check RROA on a matrix workspace - outputs IvsQ, IvsQ binned matrix workspaces
AnalysisDataService.clear()
LoadISISNexus(Filename='INTER13460', OutputWorkspace='INTER13460')
ReflectometryReductionOneAuto(InputWorkspace='INTER13460')
checkOutputs('Single input with default names', ['IvsQ_13460', 'IvsQ_binned_13460'], ['IvsLam_13460'])

# With Debug also outputs IvsLam matrix workspace
AnalysisDataService.clear()
LoadISISNexus(Filename='INTER13460', OutputWorkspace='INTER13460')
ReflectometryReductionOneAuto(InputWorkspace='INTER13460',Debug=1)
checkOutputs('Single input with default names and debug', ['IvsQ_13460', 'IvsQ_binned_13460', 'IvsLam_13460'])

# check override names
AnalysisDataService.clear()
LoadISISNexus(Filename='INTER13460', OutputWorkspace='INTER13460')
ReflectometryReductionOneAuto(InputWorkspace='INTER13460',Debug=1,OutputWorkspace='testIvsQ', OutputWorkspaceBinned='testIvsQBin')
checkOutputs('Single input with user names', ['testIvsQ', 'testIvsQBin'], ['testIvsLam'])

# and again with debug
AnalysisDataService.clear()
LoadISISNexus(Filename='INTER13460', OutputWorkspace='INTER13460')
ReflectometryReductionOneAuto(InputWorkspace='INTER13460',Debug=1,OutputWorkspace='testIvsQ', OutputWorkspaceBinned='testIvsQBin', OutputWorkspaceWavelength='testIvsLam')
checkOutputs('Single input with user names and debug', ['testIvsQ', 'testIvsQBin', 'testIvsLam'])
```

Fixes #24564 

Release notes are not required because the debug output is new functionality since v3.13 and this just makes it work more as users would expect

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
