### PR TITLE
Allow powerusers to change default editor content

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -39,6 +39,7 @@ class MultiPythonFileInterpreter(QWidget):
 
         # attributes
         self.default_content = default_content
+        self.default_content_filepath = osp.expanduser("~/.mantid/default_editor_content.py")
 
         # widget setup
         self._tabs = self.create_tabwidget()
@@ -56,13 +57,10 @@ class MultiPythonFileInterpreter(QWidget):
 
     def append_new_editor(self, content=None, filename=None):
         if content is None:
-            filepath = osp.expanduser("~/.mantid/default_editor_content.py")
-            if osp.isfile(filepath):
-                with open(filepath, 'r') as f:
-                    content = "".join(f.readlines())
+            if osp.isfile(self.default_content_filepath):
+                with open(self.default_content_filepath, 'r') as f:
+                    content = f.read()
             else:
-                with open(filepath, 'w') as f:
-                    f.write(self.default_content)
                 content = self.default_content
 
         interpreter = PythonFileInterpreter(content, filename=filename,

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -10,6 +10,7 @@
 from __future__ import (absolute_import, unicode_literals)
 
 # std imports
+import os
 import os.path as osp
 
 # 3rd party imports
@@ -56,7 +57,15 @@ class MultiPythonFileInterpreter(QWidget):
 
     def append_new_editor(self, content=None, filename=None):
         if content is None:
-            content = self.default_content
+            filepath = os.path.expanduser("~/.mantid/default_editor_content.py")
+            if os.path.isfile(filepath):
+                with open(filepath, 'r') as f:
+                    content = "".join(f.readlines())
+            else:
+                with open(filepath, 'w') as f:
+                    f.write(self.default_content)
+                content = self.default_content
+
         interpreter = PythonFileInterpreter(content, filename=filename,
                                             parent=self._tabs)
         # monitor future modifications
@@ -102,7 +111,7 @@ class MultiPythonFileInterpreter(QWidget):
 
         # we never want an empty widget
         if self.editor_count == 0:
-            self.append_new_editor(content=self.default_content)
+            self.append_new_editor()
 
         return True
 

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -10,7 +10,6 @@
 from __future__ import (absolute_import, unicode_literals)
 
 # std imports
-import os
 import os.path as osp
 
 # 3rd party imports
@@ -57,8 +56,8 @@ class MultiPythonFileInterpreter(QWidget):
 
     def append_new_editor(self, content=None, filename=None):
         if content is None:
-            filepath = os.path.expanduser("~/.mantid/default_editor_content.py")
-            if os.path.isfile(filepath):
+            filepath = osp.expanduser("~/.mantid/default_editor_content.py")
+            if osp.isfile(filepath):
                 with open(filepath, 'r') as f:
                     content = "".join(f.readlines())
             else:


### PR DESCRIPTION
**Description of work.**
This allows powerusers to change the default editor content that is loaded each time a new editor is made. Changes to the file will be reflected when a new editor is found (no need to restart Workbench)

**To test:**
- Open Workbench, this should create the `~/.mantid/default_editor_content.py` file. 
- Change the file, make a new editor (from `+`), it should now contain it

To consider: 
- I find this very useful for testing that requires me to load data, as I can have the script ready on startup without copy pasting. I want an opinion if other would find it useful.
- Is `~/.mantid/default_editor_content.py` the correct place for this file?
- If in the future the default content is changed, this PR might prevent this on already existing installation: should versioning be considered?

If this is found useful, future improvements are:
- Add options in context menu
  - Save current editor content as default, which will immediately replace the default with the current editor's content. 
  - Restore default editor content

<!-- Instructions for testing. -->

Fixes #24565 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
