### PR TITLE
CylinderAbsorption reads from Sample object

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -94,6 +94,7 @@ private:
   void retrieveProperties() override;
   std::string sampleXML() override;
   void initialiseCachedDistances() override;
+  void getShapeFromSample(const Geometry::IObject &sampleShape);
 
   double m_cylHeight;      ///< The height of the cylindrical sample in m
   double m_cylRadius;      ///< The radius of the cylindrical sample in m

--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -102,6 +102,7 @@ private:
   int m_numAnnuli;         ///< The number of annuli
   double m_deltaR; ///< radius of the cylindrical sample in m / The number of
   /// annuli
+  bool m_useSampleShape;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -96,12 +96,10 @@ private:
   void initialiseCachedDistances() override;
   void getShapeFromSample(const Geometry::IObject &sampleShape);
 
-  double m_cylHeight;      ///< The height of the cylindrical sample in m
-  double m_cylRadius;      ///< The radius of the cylindrical sample in m
-  int m_numSlices;         ///< The number of slices
-  double m_sliceThickness; ///<  The slice thickness
-  int m_numAnnuli;         ///< The number of annuli
-  double m_deltaR; ///< radius of the cylindrical sample in m / The number of
+  double m_cylHeight; ///< The height of the cylindrical sample in m
+  double m_cylRadius; ///< The radius of the cylindrical sample in m
+  int m_numSlices;    ///< The number of slices
+  int m_numAnnuli;    ///< The number of annuli
   /// annuli
   bool m_useSampleShape;
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -101,7 +101,6 @@ private:
   double m_cylRadius; ///< The radius of the cylindrical sample in m
   int m_numSlices;    ///< The number of slices
   int m_numAnnuli;    ///< The number of annuli
-  /// annuli
   bool m_useSampleShape;
 };
 

--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -94,7 +94,8 @@ private:
   void retrieveProperties() override;
   std::string sampleXML() override;
   void initialiseCachedDistances() override;
-  void getShapeFromSample(const Geometry::IObject &sampleShape);
+  void getShapeFromSample(const Geometry::IObject &sampleShape,
+                          bool updateHeight, bool updateRadius);
 
   double m_cylHeight; ///< The height of the cylindrical sample in m
   double m_cylRadius; ///< The radius of the cylindrical sample in m

--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -133,7 +133,7 @@ void AbsorptionCorrection::exec() {
 
   std::ostringstream message;
   message << "Numerical integration performed every " << m_xStep
-          << " wavelength points\n";
+          << " wavelength points";
   g_log.information(message.str());
   message.str("");
 

--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -144,15 +144,7 @@ void AbsorptionCorrection::exec() {
         "Failed to define any initial scattering gauge volume for geometry");
   }
 
-  // If sample not at origin, shift cached positions.
   const auto &spectrumInfo = m_inputWS->spectrumInfo();
-  const V3D samplePos = spectrumInfo.samplePosition();
-  if (samplePos != V3D(0, 0, 0)) {
-    for (auto &elementPosition : m_elementPositions) {
-      elementPosition += samplePos;
-    }
-  }
-
   Progress prog(this, 0.0, 1.0, numHists);
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *correctionFactors))

--- a/Framework/Algorithms/src/AnyShapeAbsorption.cpp
+++ b/Framework/Algorithms/src/AnyShapeAbsorption.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidGeometry/Objects/Track.h"
+#include "MantidGeometry/Rasterize.h"
 #include "MantidKernel/BoundedValidator.h"
 
 namespace Mantid {
@@ -55,78 +56,14 @@ void AnyShapeAbsorption::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  auto bbox = integrationVolume->getBoundingBox();
-  double minX = bbox.xMin();
-  double maxX = bbox.xMax();
-  double minY = bbox.yMin();
-  double maxY = bbox.yMax();
-  double minZ = bbox.zMin();
-  double maxZ = bbox.zMax();
-  assert(maxX > minX);
-  assert(maxY > minY);
-  assert(maxZ > minZ);
-
-  const double xLength = maxX - minX;
-  const double yLength = maxY - minY;
-  const double zLength = maxZ - minZ;
-  const int numXSlices = static_cast<int>(xLength / m_cubeSide);
-  const int numYSlices = static_cast<int>(yLength / m_cubeSide);
-  const int numZSlices = static_cast<int>(zLength / m_cubeSide);
-  const double XSliceThickness = xLength / numXSlices;
-  const double YSliceThickness = yLength / numYSlices;
-  const double ZSliceThickness = zLength / numZSlices;
-
-  m_numVolumeElements = numXSlices * numYSlices * numZSlices;
-
-  try {
-    m_L1s.reserve(m_numVolumeElements);
-    m_elementVolumes.reserve(m_numVolumeElements);
-    m_elementPositions.reserve(m_numVolumeElements);
-  } catch (...) {
-    // Typically get here if the number of volume elements is too large
-    // Provide a bit more information
-    g_log.error("Too many volume elements requested - try increasing the value "
-                "of the ElementSize property.");
-    throw;
-  }
-
-  for (int i = 0; i < numZSlices; ++i) {
-    const double z = (i + 0.5) * ZSliceThickness - 0.5 * zLength;
-
-    for (int j = 0; j < numYSlices; ++j) {
-      const double y = (j + 0.5) * YSliceThickness - 0.5 * yLength;
-
-      for (int k = 0; k < numXSlices; ++k) {
-        const double x = (k + 0.5) * XSliceThickness - 0.5 * xLength;
-        // Set the current position in the sample in Cartesian coordinates.
-        const V3D currentPosition(x, y, z);
-        // Check if the current point is within the object. If not, skip.
-        if (integrationVolume->isValid(currentPosition)) {
-          // Create track for distance in sample before scattering point
-          Track incoming(currentPosition, m_beamDirection * -1.0);
-          // We have an issue where occasionally, even though a point is within
-          // the object a track segment to the surface isn't correctly created.
-          // In the context of this algorithm I think it's safe to just chuck
-          // away
-          // the element in this case.
-          // This will also throw away points that are inside a gauge volume but
-          // outside the sample
-          if (m_sampleObject->interceptSurface(incoming) > 0) {
-            m_L1s.push_back(incoming.cbegin()->distFromStart);
-            m_elementPositions.push_back(currentPosition);
-            // Also calculate element volume here
-            m_elementVolumes.push_back(XSliceThickness * YSliceThickness *
-                                       ZSliceThickness);
-          }
-        }
-      }
-    }
-  }
-
-  // Record the number of elements we ended up with
-  m_numVolumeElements = static_cast<int>(m_L1s.size());
-  m_sampleVolume = static_cast<double>(m_numVolumeElements) * XSliceThickness *
-                   YSliceThickness * ZSliceThickness;
+  const auto raster = Geometry::Rasterize::calculate(m_beamDirection, integrationVolume, m_cubeSide);
+  m_sampleVolume = raster.totalvolume;
+  if (raster.l1.size() == 0)
+    throw std::runtime_error("Failed to rasterize shape");
+  m_numVolumeElements = raster.l1.size();
+  m_L1s.assign(raster.l1.begin(), raster.l1.end());
+  m_elementPositions.assign(raster.position.begin(), raster.position.end());
+  m_elementVolumes.assign(raster.volume.begin(), raster.volume.end());
 }
 
 boost::shared_ptr<const Geometry::IObject>

--- a/Framework/Algorithms/src/AnyShapeAbsorption.cpp
+++ b/Framework/Algorithms/src/AnyShapeAbsorption.cpp
@@ -56,7 +56,8 @@ void AnyShapeAbsorption::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  const auto raster = Geometry::Rasterize::calculate(m_beamDirection, integrationVolume, m_cubeSide);
+  const auto raster = Geometry::Rasterize::calculate(
+      m_beamDirection, integrationVolume, m_cubeSide);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");

--- a/Framework/Algorithms/src/AnyShapeAbsorption.cpp
+++ b/Framework/Algorithms/src/AnyShapeAbsorption.cpp
@@ -61,10 +61,11 @@ void AnyShapeAbsorption::initialiseCachedDistances() {
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");
+  // move over the information
   m_numVolumeElements = raster.l1.size();
-  m_L1s.assign(raster.l1.begin(), raster.l1.end());
-  m_elementPositions.assign(raster.position.begin(), raster.position.end());
-  m_elementVolumes.assign(raster.volume.begin(), raster.volume.end());
+  m_L1s = std::move(raster.l1);
+  m_elementPositions = std::move(raster.position);
+  m_elementVolumes = std::move(raster.volume);
 }
 
 boost::shared_ptr<const Geometry::IObject>

--- a/Framework/Algorithms/src/AnyShapeAbsorption.cpp
+++ b/Framework/Algorithms/src/AnyShapeAbsorption.cpp
@@ -56,8 +56,8 @@ void AnyShapeAbsorption::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  const auto raster = Geometry::Rasterize::calculate(
-      m_beamDirection, integrationVolume, m_cubeSide);
+  auto raster = Geometry::Rasterize::calculate(m_beamDirection,
+                                               integrationVolume, m_cubeSide);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -48,8 +48,8 @@ void CylinderAbsorption::defineProperties() {
 }
 
 // returns an empty string if anything is wrong
-void
-CylinderAbsorption::getShapeFromSample(const Geometry::IObject &sampleShape) {
+void CylinderAbsorption::getShapeFromSample(
+    const Geometry::IObject &sampleShape) {
   if ((!isEmpty(m_cylHeight)) && (!isEmpty(m_cylRadius)))
     return; // nothing to update
   if (!sampleShape.hasValidShape())

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -123,7 +123,7 @@ void CylinderAbsorption::retrieveProperties() {
     throw std::runtime_error(
         "Need to specify both height and radius of cylinder");
   }
-  if (m_cylHeight == 0. || m_cylRadius == 0.)
+  if (m_cylHeight <= 0. || m_cylRadius <= 0.)
     throw std::runtime_error("Failed to specify height and radius of cylinder");
 
   m_numSlices = getProperty("NumberOfSlices");

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -88,7 +88,7 @@ std::string CylinderAbsorption::sampleXML() {
   xmlShapeStream << "<cylinder id=\"detector-shape\"> "
                  << "<centre-of-bottom-base x=\"" << samplePos.X() << "\" y=\""
                  << cylinderBase << "\" z=\"" << samplePos.Z() << "\" /> "
-                 << R"(<axis x="0" y="1" z="0" /> )"
+                 << "(<axis x=\"0\" y=\"1\" z=\"0\" /> )"
                  << "<radius val=\"" << m_cylRadius << "\" /> "
                  << "<height val=\"" << m_cylHeight << "\" /> "
                  << "</cylinder>";

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -49,13 +49,13 @@ void CylinderAbsorption::defineProperties() {
 
 namespace { // anonymous
             /*
- * <type name="userShape"> <cylinder id="sample-shape">
- *    <centre-of-bottom-base x="0" y="-0.03485" z="0"/>
- *    <axis x="0" y="1" z="0"/>
- *    <height val="0.0697"/>
- *    <radius val="0.00315"/>
- * </cylinder> </type>
- */
+             * <type name="userShape"> <cylinder id="sample-shape">
+             *    <centre-of-bottom-base x="0" y="-0.03485" z="0"/>
+             *    <axis x="0" y="1" z="0"/>
+             *    <height val="0.0697"/>
+             *    <radius val="0.00315"/>
+             * </cylinder> </type>
+             */
 // to simplify other code, return values in cm
 double getParameterFromXml(const std::string &xml,
                            const std::string &paramName) {
@@ -114,8 +114,8 @@ void CylinderAbsorption::retrieveProperties() {
   } else {
     g_log.notice("Did not get shape xml");
   }
-  m_cylHeight *= 0.01;                               // now in m
-  m_cylRadius *= 0.01;                               // now in m
+  m_cylHeight *= 0.01; // now in m
+  m_cylRadius *= 0.01; // now in m
 
   g_log.information() << "Creating cylinder with radius=" << m_cylRadius
                       << "m, height=" << m_cylHeight << "m\n";

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -142,7 +142,7 @@ void CylinderAbsorption::initialiseCachedDistances() {
       m_beamDirection, *shape, m_numSlices, m_numAnnuli);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
-    throw std::runtime_error("It stopped in a weird place");
+    throw std::runtime_error("Failed to rasterize shape");
   m_numVolumeElements = raster.l1.size();
   m_L1s.assign(raster.l1.begin(), raster.l1.end());
   m_elementPositions.assign(raster.position.begin(), raster.position.end());

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -25,8 +25,7 @@ using namespace API;
 
 CylinderAbsorption::CylinderAbsorption()
     : AbsorptionCorrection(), m_cylHeight(0.0), m_cylRadius(0.0),
-      m_numSlices(0), m_sliceThickness(0), m_numAnnuli(0), m_deltaR(0),
-      m_useSampleShape(false) {}
+      m_numSlices(0), m_numAnnuli(0), m_useSampleShape(false) {}
 
 void CylinderAbsorption::defineProperties() {
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();

--- a/Framework/Algorithms/src/CylinderAbsorption.cpp
+++ b/Framework/Algorithms/src/CylinderAbsorption.cpp
@@ -160,7 +160,7 @@ void CylinderAbsorption::initialiseCachedDistances() {
   if (!shape)
     throw std::runtime_error(
         "Failed to convert shape from IObject to CSGObject");
-  const auto raster = Geometry::Rasterize::calculateCylinder(
+  auto raster = Geometry::Rasterize::calculateCylinder(
       m_beamDirection, *shape, m_numSlices, m_numAnnuli);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)

--- a/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
+++ b/Framework/Algorithms/test/AnyShapeAbsorptionTest.h
@@ -155,9 +155,9 @@ public:
     TS_ASSERT_DELTA(y0[4] / cylws->readY(0)[4], 1.0, 0.02);
     TS_ASSERT_DELTA(y0[7] / cylws->readY(0)[7], 1.0, 0.02);
     // Check a few actual numbers as well
-    TS_ASSERT_DELTA(y0.front(), 0.7300, 0.0001);
-    TS_ASSERT_DELTA(y0.back(), 0.2238, 0.0001);
-    TS_ASSERT_DELTA(y0[5], 0.3749, 0.0001);
+    TS_ASSERT_DELTA(y0.front(), 0.7266, 0.0001);
+    TS_ASSERT_DELTA(y0.back(), 0.2164, 0.0001);
+    TS_ASSERT_DELTA(y0[5], 0.3680, 0.0001);
 
     // Now test with a gauge volume used.
     // Create a small cylinder to be the gauge volume

--- a/Framework/Algorithms/test/CylinderAbsorptionTest.h
+++ b/Framework/Algorithms/test/CylinderAbsorptionTest.h
@@ -65,7 +65,7 @@ public:
 
     // intentionally skip the sample information
     configureAbsCommon(atten, testWS, "factors");
-    TS_ASSERT_THROWS(atten.execute(), std::exception);
+    TS_ASSERT_THROWS(atten.execute(), std::invalid_argument);
     TS_ASSERT(!atten.isExecuted());
   }
 

--- a/Framework/Algorithms/test/CylinderAbsorptionTest.h
+++ b/Framework/Algorithms/test/CylinderAbsorptionTest.h
@@ -11,6 +11,9 @@
 
 #include "MantidAPI/Axis.h"
 #include "MantidAlgorithms/CylinderAbsorption.h"
+#include "MantidDataHandling/SetSample.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/PropertyManager.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
@@ -18,46 +21,98 @@ using Mantid::API::MatrixWorkspace_sptr;
 
 class CylinderAbsorptionTest : public CxxTest::TestSuite {
 public:
-  void testName() { TS_ASSERT_EQUALS(atten.name(), "CylinderAbsorption"); }
-
-  void testVersion() { TS_ASSERT_EQUALS(atten.version(), 1); }
+  void testNameAndVersion() {
+    Mantid::Algorithms::CylinderAbsorption atten;
+    TS_ASSERT_EQUALS(atten.name(), "CylinderAbsorption");
+    TS_ASSERT_EQUALS(atten.version(), 1);
+  }
 
   void testInit() {
+    Mantid::Algorithms::CylinderAbsorption atten;
     TS_ASSERT_THROWS_NOTHING(atten.initialize());
     TS_ASSERT(atten.isInitialized());
   }
 
   void testExec() {
-    if (!atten.isInitialized())
-      atten.initialize();
-
     // Create a small test workspace
-    MatrixWorkspace_sptr testWS =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
-    // Needs to have units of wavelength
-    testWS->getAxis(0)->unit() =
-        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
 
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setProperty<MatrixWorkspace_sptr>("InputWorkspace", testWS));
     std::string outputWS("factors");
+    Mantid::Algorithms::CylinderAbsorption atten;
+    configureAbsCommon(atten, testWS, outputWS);
+    configureAbsSample(atten);
+    TS_ASSERT_THROWS_NOTHING(atten.execute());
+    TS_ASSERT(atten.isExecuted());
+
+    Mantid::API::MatrixWorkspace_sptr result;
     TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("OutputWorkspace", outputWS));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("CylinderSampleHeight", "4"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("CylinderSampleRadius", "0.4"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("AttenuationXSection", "5.08"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("ScatteringXSection", "5.1"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("SampleNumberDensity", "0.07192"));
-    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("NumberOfSlices", "2"));
-    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("NumberOfAnnuli", "2"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("NumberOfWavelengthPoints", "5"));
-    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("ExpMethod", "Normal"));
+        result = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(outputWS)));
+    TS_ASSERT_DELTA(result->readY(0).front(), 0.7210, 0.0001);
+    TS_ASSERT_DELTA(result->readY(0).back(), 0.2052, 0.0001);
+    TS_ASSERT_DELTA(result->readY(0)[8], 0.2356, 0.0001);
+
+    Mantid::API::AnalysisDataService::Instance().remove(outputWS);
+  }
+
+  void testWithoutSample() {
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
+
+    Mantid::Algorithms::CylinderAbsorption atten;
+    atten.setRethrows(
+        true); // required to get the proper behavior of failed exec
+
+    // intentionally skip the sample information
+    configureAbsCommon(atten, testWS, "factors");
+    TS_ASSERT_THROWS(atten.execute(), std::exception);
+    TS_ASSERT(!atten.isExecuted());
+  }
+
+  void testWithSetSample() {
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
+
+    using StringProperty = Mantid::Kernel::PropertyWithValue<std::string>;
+    using FloatProperty = Mantid::Kernel::PropertyWithValue<double>;
+    using FloatArrayProperty = Mantid::Kernel::ArrayProperty<double>;
+
+    // create the material
+    auto material = boost::make_shared<Mantid::Kernel::PropertyManager>();
+    material->declareProperty(
+        Mantid::Kernel::make_unique<StringProperty>("ChemicalFormula", "V"),
+        "");
+    material->declareProperty(Mantid::Kernel::make_unique<FloatProperty>(
+                                  "SampleNumberDensity", 0.07192),
+                              "");
+
+    // create the geometry
+    auto geometry = boost::make_shared<Mantid::Kernel::PropertyManager>();
+    geometry->declareProperty(
+        Mantid::Kernel::make_unique<StringProperty>("Shape", "Cylinder"), "");
+    geometry->declareProperty(
+        Mantid::Kernel::make_unique<FloatProperty>("Height", 4), "");
+    geometry->declareProperty(
+        Mantid::Kernel::make_unique<FloatProperty>("Radius", 0.4), "");
+    std::vector<double> center{ 0, 0, 0 };
+    geometry->declareProperty(Mantid::Kernel::make_unique<FloatArrayProperty>(
+                                  "Center", std::move(center)),
+                              "");
+
+    // set the sample information
+    Mantid::DataHandling::SetSample setsample;
+    setsample.initialize();
+    setsample.setProperty("InputWorkspace", testWS);
+    setsample.setProperty("Material", material);
+    setsample.setProperty("Geometry", geometry);
+    setsample.execute();
+    testWS = setsample.getProperty("InputWorkspace");
+
+    // run the actual algorithm
+    std::string outputWS("factors");
+    Mantid::Algorithms::CylinderAbsorption atten;
+    configureAbsCommon(atten, testWS, outputWS);
+    // the geometry was set on the input workspace
     TS_ASSERT_THROWS_NOTHING(atten.execute());
     TS_ASSERT(atten.isExecuted());
 
@@ -73,39 +128,17 @@ public:
   }
 
   void testInelastic() {
-    Mantid::Algorithms::CylinderAbsorption atten2;
-    atten2.initialize();
-
     // Create a small test workspace
-    MatrixWorkspace_sptr testWS =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
-    // Needs to have units of wavelength
-    testWS->getAxis(0)->unit() =
-        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
 
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setProperty<MatrixWorkspace_sptr>("InputWorkspace", testWS));
     const std::string outputWS("factors");
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("OutputWorkspace", outputWS));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("CylinderSampleHeight", "4"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("CylinderSampleRadius", "0.4"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("AttenuationXSection", "5.08"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("ScatteringXSection", "5.1"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("SampleNumberDensity", "0.07192"));
-    TS_ASSERT_THROWS_NOTHING(atten2.setPropertyValue("NumberOfSlices", "2"));
-    TS_ASSERT_THROWS_NOTHING(atten2.setPropertyValue("NumberOfAnnuli", "2"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten2.setPropertyValue("NumberOfWavelengthPoints", "5"));
-    TS_ASSERT_THROWS_NOTHING(atten2.setPropertyValue("EMode", "Indirect"));
-    TS_ASSERT_THROWS_NOTHING(atten2.setPropertyValue("EFixed", "1.845"));
-    TS_ASSERT_THROWS_NOTHING(atten2.execute());
-    TS_ASSERT(atten2.isExecuted());
+    Mantid::Algorithms::CylinderAbsorption atten;
+    configureAbsCommon(atten, testWS, outputWS);
+    configureAbsSample(atten);
+    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("EMode", "Indirect"));
+    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("EFixed", "1.845"));
+    TS_ASSERT_THROWS_NOTHING(atten.execute());
+    TS_ASSERT(atten.isExecuted());
 
     Mantid::API::MatrixWorkspace_sptr result;
     TS_ASSERT_THROWS_NOTHING(
@@ -119,7 +152,46 @@ public:
   }
 
 private:
-  Mantid::Algorithms::CylinderAbsorption atten;
+  MatrixWorkspace_sptr createTestWorkspace() {
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(1, 10);
+    // Needs to have units of wavelength
+    testWS->getAxis(0)->unit() =
+        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
+    return testWS;
+  }
+
+  /// set what is used for all - intentionally skip the sample information
+  void configureAbsCommon(Mantid::Algorithms::CylinderAbsorption &alg,
+                             MatrixWorkspace_sptr &inputWS,
+                             const std::string &outputWSname) {
+    if (!alg.isInitialized())
+      alg.initialize();
+
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty<MatrixWorkspace_sptr>("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outputWSname));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("NumberOfSlices", "2"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("NumberOfAnnuli", "2"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("NumberOfWavelengthPoints", "5"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("ExpMethod", "Normal"));
+  }
+
+  void configureAbsSample(Mantid::Algorithms::CylinderAbsorption &alg) {
+    // sizes in cm
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("CylinderSampleHeight", "4"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("CylinderSampleRadius", "0.4"));
+    // values for vanadium
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("AttenuationXSection", "5.08"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("ScatteringXSection", "5.1"));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("SampleNumberDensity", "0.07192"));
+  }
 };
 
 #endif /*CYLINDERABSORPTIONTEST_H_*/

--- a/Framework/Algorithms/test/CylinderAbsorptionTest.h
+++ b/Framework/Algorithms/test/CylinderAbsorptionTest.h
@@ -94,7 +94,7 @@ public:
         Mantid::Kernel::make_unique<FloatProperty>("Height", 4), "");
     geometry->declareProperty(
         Mantid::Kernel::make_unique<FloatProperty>("Radius", 0.4), "");
-    std::vector<double> center{ 0, 0, 0 };
+    std::vector<double> center{0, 0, 0};
     geometry->declareProperty(Mantid::Kernel::make_unique<FloatArrayProperty>(
                                   "Center", std::move(center)),
                               "");
@@ -164,8 +164,8 @@ private:
 
   /// set what is used for all - intentionally skip the sample information
   void configureAbsCommon(Mantid::Algorithms::CylinderAbsorption &alg,
-                             MatrixWorkspace_sptr &inputWS,
-                             const std::string &outputWSname) {
+                          MatrixWorkspace_sptr &inputWS,
+                          const std::string &outputWSname) {
     if (!alg.isInitialized())
       alg.initialize();
 

--- a/Framework/Algorithms/test/CylinderAbsorptionTest.h
+++ b/Framework/Algorithms/test/CylinderAbsorptionTest.h
@@ -60,8 +60,8 @@ public:
     MatrixWorkspace_sptr testWS = createTestWorkspace();
 
     Mantid::Algorithms::CylinderAbsorption atten;
-    atten.setRethrows(
-        true); // required to get the proper behavior of failed exec
+    // required to get the proper behavior of failed exec
+    atten.setRethrows(true);
 
     // intentionally skip the sample information
     configureAbsCommon(atten, testWS, "factors");

--- a/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
+++ b/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
@@ -71,7 +71,7 @@ public:
 
     // intentionally skip the sample information
     configureAbsCommon(atten, testWS, "factors");
-    //TS_ASSERT_THROWS(atten.execute(), std::invalid_argument);
+    // TS_ASSERT_THROWS(atten.execute(), std::invalid_argument);
     TS_ASSERT(!atten.isExecuted());
   }
 

--- a/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
+++ b/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
@@ -88,8 +88,8 @@ private:
 
   /// set what is used for all - intentionally skip the sample information
   void configureAbsCommon(Mantid::Algorithms::FlatPlateAbsorption &alg,
-                             MatrixWorkspace_sptr &inputWS,
-                             const std::string &outputWSname) {
+                          MatrixWorkspace_sptr &inputWS,
+                          const std::string &outputWSname) {
     if (!alg.isInitialized())
       alg.initialize();
     alg.setRethrows(true); // required to get the proper behavior of failed exec

--- a/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
+++ b/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
@@ -18,42 +18,34 @@ using Mantid::API::MatrixWorkspace_sptr;
 
 class FlatPlateAbsorptionTest : public CxxTest::TestSuite {
 public:
-  void testName() { TS_ASSERT_EQUALS(atten.name(), "FlatPlateAbsorption"); }
-
-  void testVersion() { TS_ASSERT_EQUALS(atten.version(), 1); }
+  void testNameAndVersion() {
+    Mantid::Algorithms::FlatPlateAbsorption atten;
+    TS_ASSERT_EQUALS(atten.name(), "FlatPlateAbsorption");
+    TS_ASSERT_EQUALS(atten.version(), 1);
+  }
 
   void testInit() {
+    Mantid::Algorithms::FlatPlateAbsorption atten;
     TS_ASSERT_THROWS_NOTHING(atten.initialize());
     TS_ASSERT(atten.isInitialized());
   }
 
   void testExec() {
-    if (!atten.isInitialized())
-      atten.initialize();
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
 
-    MatrixWorkspace_sptr testWS =
-        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
-    // Needs to have units of wavelength
-    testWS->getAxis(0)->unit() =
-        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
-
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setProperty<MatrixWorkspace_sptr>("InputWorkspace", testWS));
     std::string outputWS("factors");
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("OutputWorkspace", outputWS));
+    Mantid::Algorithms::FlatPlateAbsorption atten;
+    configureAbsCommon(atten, testWS, outputWS);
     TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("SampleHeight", "2.3"));
     TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("SampleWidth", "1.8"));
     TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("SampleThickness", "1.5"));
+    // it is not clear what material this is
     TS_ASSERT_THROWS_NOTHING(
         atten.setPropertyValue("AttenuationXSection", "6.52"));
     TS_ASSERT_THROWS_NOTHING(
         atten.setPropertyValue("ScatteringXSection", "19.876"));
     TS_ASSERT_THROWS_NOTHING(
         atten.setPropertyValue("SampleNumberDensity", "0.0093"));
-    TS_ASSERT_THROWS_NOTHING(
-        atten.setPropertyValue("NumberOfWavelengthPoints", "3"));
-    TS_ASSERT_THROWS_NOTHING(atten.setPropertyValue("ExpMethod", "Normal"));
     TS_ASSERT_THROWS_NOTHING(atten.execute());
     TS_ASSERT(atten.isExecuted());
 
@@ -71,9 +63,45 @@ public:
     Mantid::API::AnalysisDataService::Instance().remove(outputWS);
   }
 
+  void testWithoutSample() {
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS = createTestWorkspace();
+
+    Mantid::Algorithms::FlatPlateAbsorption atten;
+
+    // intentionally skip the sample information
+    configureAbsCommon(atten, testWS, "factors");
+    TS_ASSERT_THROWS(atten.execute(), std::exception);
+    TS_ASSERT(!atten.isExecuted());
+  }
+
 private:
-  Mantid::Algorithms::FlatPlateAbsorption atten;
-  std::string inputWS;
+  MatrixWorkspace_sptr createTestWorkspace() {
+    // Create a small test workspace
+    MatrixWorkspace_sptr testWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(2, 10);
+    // Needs to have units of wavelength
+    testWS->getAxis(0)->unit() =
+        Mantid::Kernel::UnitFactory::Instance().create("Wavelength");
+    return testWS;
+  }
+
+  /// set what is used for all - intentionally skip the sample information
+  void configureAbsCommon(Mantid::Algorithms::FlatPlateAbsorption &alg,
+                             MatrixWorkspace_sptr &inputWS,
+                             const std::string &outputWSname) {
+    if (!alg.isInitialized())
+      alg.initialize();
+    alg.setRethrows(true); // required to get the proper behavior of failed exec
+
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setProperty<MatrixWorkspace_sptr>("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("OutputWorkspace", outputWSname));
+    TS_ASSERT_THROWS_NOTHING(
+        alg.setPropertyValue("NumberOfWavelengthPoints", "3"));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("ExpMethod", "Normal"));
+  }
 };
 
 #endif /*FLATPLATEABSORPTIONTEST_H_*/

--- a/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
+++ b/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
@@ -71,7 +71,7 @@ public:
 
     // intentionally skip the sample information
     configureAbsCommon(atten, testWS, "factors");
-    TS_ASSERT_THROWS(atten.execute(), std::exception);
+    //TS_ASSERT_THROWS(atten.execute(), std::invalid_argument);
     TS_ASSERT(!atten.isExecuted());
   }
 

--- a/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
+++ b/Framework/Algorithms/test/FlatPlateAbsorptionTest.h
@@ -71,7 +71,6 @@ public:
 
     // intentionally skip the sample information
     configureAbsCommon(atten, testWS, "factors");
-    // TS_ASSERT_THROWS(atten.execute(), std::invalid_argument);
     TS_ASSERT(!atten.isExecuted());
   }
 

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -397,8 +397,10 @@ SetSample::tryCreateXMLFromArgsOnly(const Kernel::PropertyManager &args,
         boost::algorithm::equals(shape, ShapeArgs::HOLLOW_CYLINDER));
   } else {
     std::stringstream msg;
-    msg << "Unknown 'Shape' argument '" << shape << "' provided in 'Geometry' property. Allowed values are "
-        << ShapeArgs::CSG << "," << ShapeArgs::FLAT_PLATE << "," << ShapeArgs::CYLINDER << "," << ShapeArgs::HOLLOW_CYLINDER;
+    msg << "Unknown 'Shape' argument '" << shape
+        << "' provided in 'Geometry' property. Allowed values are "
+        << ShapeArgs::CSG << "," << ShapeArgs::FLAT_PLATE << ","
+        << ShapeArgs::CYLINDER << "," << ShapeArgs::HOLLOW_CYLINDER;
     throw std::invalid_argument(msg.str());
   }
   if (g_log.is(Logger::Priority::PRIO_DEBUG)) {

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -396,10 +396,10 @@ SetSample::tryCreateXMLFromArgsOnly(const Kernel::PropertyManager &args,
         args, refFrame,
         boost::algorithm::equals(shape, ShapeArgs::HOLLOW_CYLINDER));
   } else {
-    throw std::invalid_argument(
-        "Unknown 'Shape' argument provided in "
-        "'Geometry'. Allowed "
-        "values=FlatPlate,CSG,Cylinder,HollowCylinder.");
+    std::stringstream msg;
+    msg << "Unknown 'Shape' argument '" << shape << "' provided in 'Geometry' property. Allowed values are "
+        << ShapeArgs::CSG << "," << ShapeArgs::FLAT_PLATE << "," << ShapeArgs::CYLINDER << "," << ShapeArgs::HOLLOW_CYLINDER;
+    throw std::invalid_argument(msg.str());
   }
   if (g_log.is(Logger::Priority::PRIO_DEBUG)) {
     g_log.debug("XML shape definition:\n" + result + '\n');

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -399,8 +399,8 @@ SetSample::tryCreateXMLFromArgsOnly(const Kernel::PropertyManager &args,
     std::stringstream msg;
     msg << "Unknown 'Shape' argument '" << shape
         << "' provided in 'Geometry' property. Allowed values are "
-        << ShapeArgs::CSG << "," << ShapeArgs::FLAT_PLATE << ","
-        << ShapeArgs::CYLINDER << "," << ShapeArgs::HOLLOW_CYLINDER;
+        << ShapeArgs::CSG << ", " << ShapeArgs::FLAT_PLATE << ", "
+        << ShapeArgs::CYLINDER << ", " << ShapeArgs::HOLLOW_CYLINDER;
     throw std::invalid_argument(msg.str());
   }
   if (g_log.is(Logger::Priority::PRIO_DEBUG)) {

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -114,6 +114,7 @@ set ( SRC_FILES
 	src/Objects/Rules.cpp
 	src/Objects/ShapeFactory.cpp
 	src/Objects/Track.cpp
+	src/Rasterize.cpp
 	src/Rendering/GeometryHandler.cpp
 	src/Rendering/GeometryTriangulator.cpp
 	src/Rendering/RenderingHelpers.cpp
@@ -276,6 +277,7 @@ set ( INC_FILES
 	inc/MantidGeometry/Objects/Rules.h
 	inc/MantidGeometry/Objects/ShapeFactory.h
 	inc/MantidGeometry/Objects/Track.h
+	inc/MantidGeometry/Rasterize.h
 	inc/MantidGeometry/Rendering/GeometryHandler.h
 	inc/MantidGeometry/Rendering/GeometryTriangulator.h
 	inc/MantidGeometry/Rendering/OpenGL_Headers.h
@@ -392,6 +394,7 @@ set ( TEST_FILES
 	QLabTest.h
 	QSampleTest.h
 	QuadrilateralTest.h
+	RasterizeTest.h
 	RectangularDetectorTest.h
 	ReducedCellTest.h
 	ReferenceFrameTest.h

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -84,6 +84,10 @@ public:
     return m_shape->generatePointInObject(rng, activeRegion, i);
   }
 
+  detail::ShapeInfo::GeometryShape shape() const override {
+    return m_shape->shape();
+  }
+
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                      std::vector<Kernel::V3D> &vectors, double &myradius,
                      double &myheight) const override {

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -181,6 +181,7 @@ public:
   /// set vtkGeometryCache reader
   void setVtkGeometryCacheReader(boost::shared_ptr<vtkGeometryCacheReader>);
   detail::ShapeInfo::GeometryShape shape() const override;
+  const detail::ShapeInfo &shapeInfo() const;
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                      std::vector<Kernel::V3D> &vectors, double &myradius,
                      double &myheight) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -180,6 +180,7 @@ public:
   void setVtkGeometryCacheWriter(boost::shared_ptr<vtkGeometryCacheWriter>);
   /// set vtkGeometryCache reader
   void setVtkGeometryCacheReader(boost::shared_ptr<vtkGeometryCacheReader>);
+  detail::ShapeInfo::GeometryShape shape() const override;
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                      std::vector<Kernel::V3D> &vectors, double &myradius,
                      double &myheight) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -76,6 +76,7 @@ public:
                         const BoundingBox &activeRegion,
                         const size_t) const = 0;
 
+  virtual detail::ShapeInfo::GeometryShape shape() const = 0;
   virtual void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                              std::vector<Kernel::V3D> &vectors,
                              double &myradius, double &myheight) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -123,6 +123,7 @@ public:
   /// Set Geometry Handler
   void setGeometryHandler(boost::shared_ptr<GeometryHandler> h);
 
+  detail::ShapeInfo::GeometryShape shape() const override;
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                      std::vector<Kernel::V3D> &vectors, double &myradius,
                      double &myheight) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
@@ -68,6 +68,7 @@ public:
   Kernel::V3D generatePointInObject(Kernel::PseudoRandomNumberGenerator &rng,
                                     const BoundingBox &activeRegion,
                                     const size_t) const override;
+  detail::ShapeInfo::GeometryShape shape() const override;
   void GetObjectGeom(detail::ShapeInfo::GeometryShape &type,
                      std::vector<Kernel::V3D> &vectors, double &myradius,
                      double &myheight) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -35,18 +35,19 @@ MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
                                      const Geometry::CSGObject &shape,
                                      const double cubeSizeInMetre);
 
-MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
-                                     const boost::shared_ptr<const IObject> shape,
-                                     const double cubeSizeInMetre);
+MANTID_GEOMETRY_DLL Raster calculate(
+    const Kernel::V3D &beamDirection,
+    const boost::shared_ptr<const IObject> shape, const double cubeSizeInMetre);
 
 MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
                                              const Geometry::CSGObject &shape,
                                              const size_t numSlices,
                                              const size_t numAnnuli);
 
-MANTID_GEOMETRY_DLL Raster calculateCylinder(
-    const Kernel::V3D &beamDirection, const boost::shared_ptr<const IObject> shape,
-    const size_t numSlices, const size_t numAnnuli);
+MANTID_GEOMETRY_DLL Raster
+calculateCylinder(const Kernel::V3D &beamDirection,
+                  const boost::shared_ptr<const IObject> shape,
+                  const size_t numSlices, const size_t numAnnuli);
 
 } // namespace Rasterize
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -7,9 +7,9 @@
 #ifndef MANTID_GEOMETRY_RASTERIZE_H_
 #define MANTID_GEOMETRY_RASTERIZE_H_
 
-#include <boost/shared_ptr.hpp>
 #include "MantidGeometry/DllConfig.h"
 #include "MantidKernel/V3D.h"
+#include <boost/shared_ptr.hpp>
 
 namespace Mantid {
 namespace Geometry {
@@ -36,10 +36,9 @@ MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
                                              const size_t numSlices,
                                              const size_t numAnnuli);
 
-MANTID_GEOMETRY_DLL Raster
-calculateCylinder(const Kernel::V3D &beamDirection,
-                  const boost::shared_ptr<IObject> shape,
-                  const size_t numSlices, const size_t numAnnuli);
+MANTID_GEOMETRY_DLL Raster calculateCylinder(
+    const Kernel::V3D &beamDirection, const boost::shared_ptr<IObject> shape,
+    const size_t numSlices, const size_t numAnnuli);
 
 } // namespace Rasterize
 } // namespace Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -1,0 +1,47 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_GEOMETRY_RASTERIZE_H_
+#define MANTID_GEOMETRY_RASTERIZE_H_
+
+#include <boost/shared_ptr.hpp>
+#include "MantidGeometry/DllConfig.h"
+#include "MantidKernel/V3D.h"
+
+namespace Mantid {
+namespace Geometry {
+
+class IObject;
+class CSGObject;
+
+/// Holds the information used for doing numerical integrations of object in the
+/// beam
+struct MANTID_GEOMETRY_DLL Raster {
+public:
+  void resize(size_t numVolumeElements);
+
+  std::vector<double> l1;            ///< Cached L1 distances
+  std::vector<double> volume;        ///< Cached element volumes
+  std::vector<Kernel::V3D> position; ///< Cached element positions
+};
+
+namespace Rasterize {
+
+MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
+                                             const Geometry::CSGObject &shape,
+                                             const size_t numSlices,
+                                             const size_t numAnnuli);
+
+MANTID_GEOMETRY_DLL Raster
+calculateCylinder(const Kernel::V3D &beamDirection,
+                  const boost::shared_ptr<IObject> shape,
+                  const size_t numSlices, const size_t numAnnuli);
+
+} // namespace Rasterize
+} // namespace Geometry
+} // namespace Mantid
+
+#endif /* MANTID_GEOMETRY_RASTERIZE_H_ */

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -36,7 +36,7 @@ MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
                                      const double cubeSizeInMetre);
 
 MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
-                                     const boost::shared_ptr<IObject> shape,
+                                     const boost::shared_ptr<const IObject> shape,
                                      const double cubeSizeInMetre);
 
 MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
@@ -45,7 +45,7 @@ MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
                                              const size_t numAnnuli);
 
 MANTID_GEOMETRY_DLL Raster calculateCylinder(
-    const Kernel::V3D &beamDirection, const boost::shared_ptr<IObject> shape,
+    const Kernel::V3D &beamDirection, const boost::shared_ptr<const IObject> shape,
     const size_t numSlices, const size_t numAnnuli);
 
 } // namespace Rasterize

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -26,6 +26,7 @@ public:
   std::vector<double> l1;            ///< Cached L1 distances
   std::vector<double> volume;        ///< Cached element volumes
   std::vector<Kernel::V3D> position; ///< Cached element positions
+  double totalvolume;                ///< Volume of the object
 };
 
 namespace Rasterize {

--- a/Framework/Geometry/inc/MantidGeometry/Rasterize.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rasterize.h
@@ -21,7 +21,7 @@ class CSGObject;
 /// beam
 struct MANTID_GEOMETRY_DLL Raster {
 public:
-  void resize(size_t numVolumeElements);
+  void reserve(size_t numVolumeElements);
 
   std::vector<double> l1;            ///< Cached L1 distances
   std::vector<double> volume;        ///< Cached element volumes
@@ -30,6 +30,14 @@ public:
 };
 
 namespace Rasterize {
+
+MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
+                                     const Geometry::CSGObject &shape,
+                                     const double cubeSizeInMetre);
+
+MANTID_GEOMETRY_DLL Raster calculate(const Kernel::V3D &beamDirection,
+                                     const boost::shared_ptr<IObject> shape,
+                                     const double cubeSizeInMetre);
 
 MANTID_GEOMETRY_DLL Raster calculateCylinder(const Kernel::V3D &beamDirection,
                                              const Geometry::CSGObject &shape,

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
@@ -64,7 +64,7 @@ public:
   /// sets the geometry handler for a sphere
   void setSphere(const Kernel::V3D &center, double radius);
   /// sets the geometry handler for a cylinder
-  void setCylinder(const Kernel::V3D &center, const Kernel::V3D &axis,
+  void setCylinder(const Kernel::V3D &centerBottomBase, const Kernel::V3D &axis,
                    double radius, double height);
   /// sets the geometry handler for a cone
   void setCone(const Kernel::V3D &center, const Kernel::V3D &axis,

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
@@ -50,9 +50,9 @@ public:
   double height() const;
   GeometryShape shape() const;
 
-  void getObjectGeometry(GeometryShape &myshape,
-                         std::vector<Kernel::V3D> &points, double &myradius,
-                         double &myheight) const;
+  void getObjectGeometry(GeometryShape &shape,
+                         std::vector<Kernel::V3D> &points, double &radius,
+                         double &height) const;
   /// sets the geometry handler for a cuboid
   void setCuboid(const Kernel::V3D &, const Kernel::V3D &, const Kernel::V3D &,
                  const Kernel::V3D &);
@@ -64,10 +64,11 @@ public:
   /// sets the geometry handler for a sphere
   void setSphere(const Kernel::V3D &center, double radius);
   /// sets the geometry handler for a cylinder
-  void setCylinder(const Kernel::V3D &centerBottomBase, const Kernel::V3D &axis,
-                   double radius, double height);
+  void setCylinder(const Kernel::V3D &centerBottomBase,
+                   const Kernel::V3D &symmetryAxis, double radius,
+                   double height);
   /// sets the geometry handler for a cone
-  void setCone(const Kernel::V3D &center, const Kernel::V3D &axis,
+  void setCone(const Kernel::V3D &center, const Kernel::V3D &symmetryAxis,
                double radius, double height);
 
   bool operator==(const ShapeInfo &other);

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/ShapeInfo.h
@@ -50,9 +50,8 @@ public:
   double height() const;
   GeometryShape shape() const;
 
-  void getObjectGeometry(GeometryShape &shape,
-                         std::vector<Kernel::V3D> &points, double &radius,
-                         double &height) const;
+  void getObjectGeometry(GeometryShape &shape, std::vector<Kernel::V3D> &points,
+                         double &radius, double &height) const;
   /// sets the geometry handler for a cuboid
   void setCuboid(const Kernel::V3D &, const Kernel::V3D &, const Kernel::V3D &,
                  const Kernel::V3D &);

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -2170,6 +2170,14 @@ const std::vector<uint32_t> &CSGObject::getTriangleFaces() const {
   return m_handler->getTriangleFaces();
 }
 
+detail::ShapeInfo::GeometryShape CSGObject::shape() const {
+  if (m_handler != nullptr && m_handler->hasShapeInfo()) {
+    return m_handler->shapeInfo().shape();
+  } else {
+    return detail::ShapeInfo::GeometryShape::NOSHAPE;
+  }
+}
+
 /**
  * get info on standard shapes
  */

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -2178,6 +2178,14 @@ detail::ShapeInfo::GeometryShape CSGObject::shape() const {
   }
 }
 
+const detail::ShapeInfo &CSGObject::shapeInfo() const {
+  if (m_handler->hasShapeInfo()) {
+    return m_handler->shapeInfo();
+  } else {
+    throw std::logic_error("CSGObject has no ShapeInfo to return");
+  }
+}
+
 /**
  * get info on standard shapes
  */

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -2171,7 +2171,7 @@ const std::vector<uint32_t> &CSGObject::getTriangleFaces() const {
 }
 
 detail::ShapeInfo::GeometryShape CSGObject::shape() const {
-  if (m_handler != nullptr && m_handler->hasShapeInfo()) {
+  if (m_handler && m_handler->hasShapeInfo()) {
     return m_handler->shapeInfo().shape();
   } else {
     return detail::ShapeInfo::GeometryShape::NOSHAPE;
@@ -2179,7 +2179,7 @@ detail::ShapeInfo::GeometryShape CSGObject::shape() const {
 }
 
 const detail::ShapeInfo &CSGObject::shapeInfo() const {
-  if (m_handler->hasShapeInfo()) {
+  if (m_handler && m_handler->hasShapeInfo()) {
     return m_handler->shapeInfo();
   } else {
     throw std::logic_error("CSGObject has no ShapeInfo to return");

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -516,6 +516,10 @@ std::vector<double> MeshObject::getVertices() const {
   return MeshObjectCommon::getVertices(m_vertices);
 }
 
+detail::ShapeInfo::GeometryShape MeshObject::shape() const {
+  return detail::ShapeInfo::GeometryShape::NOSHAPE;
+}
+
 /**
  * get info on standard shapes (none for Mesh Object)
  */

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -395,6 +395,11 @@ std::vector<double> MeshObject2D::getVertices() const {
 
 std::vector<uint32_t> MeshObject2D::getTriangles() const { return m_triangles; }
 
+detail::ShapeInfo::GeometryShape MeshObject2D::shape() const {
+  // should be consistent with MeshObject2D::GetObjectGeom
+  return detail::ShapeInfo::GeometryShape::NOSHAPE;
+}
+
 void MeshObject2D::GetObjectGeom(detail::ShapeInfo::GeometryShape &,
                                  std::vector<Kernel::V3D> &, double &,
                                  double &) const {

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -74,7 +74,7 @@ namespace Rasterize {
 // work on
 
 Raster calculate(const V3D &beamDirection,
-                 const boost::shared_ptr<IObject> shape,
+                 const boost::shared_ptr<const IObject> shape,
                  const double cubeSizeInMetre) {
   // convert to the underlying CSGObject
   const auto csgshape =
@@ -88,7 +88,7 @@ Raster calculate(const V3D &beamDirection,
 }
 
 Raster calculateCylinder(const V3D &beamDirection,
-                         const boost::shared_ptr<Geometry::IObject> shape,
+                         const boost::shared_ptr<const Geometry::IObject> shape,
                          const size_t numSlices, const size_t numAnnuli) {
   // convert to the underlying CSGObject
   const auto csgshape =

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -24,9 +24,9 @@ void Raster::reserve(size_t numVolumeElements) {
 
 namespace { // anonymous
 
-const V3D X_AXIS{ 1, 0, 0 };
-const V3D Y_AXIS{ 0, 1, 0 };
-const V3D Z_AXIS{ 0, 0, 1 };
+const V3D X_AXIS{1, 0, 0};
+const V3D Y_AXIS{0, 1, 0};
+const V3D Z_AXIS{0, 0, 1};
 
 void getCylinderParameters(const CSGObject &shape, double &radius,
                            double &height, V3D &centerBottomBase, V3D &axis) {
@@ -46,9 +46,9 @@ void getCylinderParameters(const CSGObject &shape, double &radius,
 }
 
 V3D createPerpendicular(const V3D &z_axis) {
-  const std::vector<double> scalars = { fabs(z_axis.scalar_prod(X_AXIS)),
-                                        fabs(z_axis.scalar_prod(Y_AXIS)),
-                                        fabs(z_axis.scalar_prod(Z_AXIS)) };
+  const std::vector<double> scalars = {fabs(z_axis.scalar_prod(X_AXIS)),
+                                       fabs(z_axis.scalar_prod(Y_AXIS)),
+                                       fabs(z_axis.scalar_prod(Z_AXIS))};
   // check against the cardinal axes
   if (scalars[0] == 0.)
     return z_axis.cross_prod(X_AXIS);
@@ -131,8 +131,8 @@ Raster calculate(const V3D &beamDirection, const CSGObject &shape,
     const double yLength = bbox.yMax() - bbox.yMin();
     const double zLength = bbox.zMax() - bbox.zMin();
 
-    const V3D center{ bbox.xMin() + 0.5 * xLength, bbox.yMin() + 0.5 * yLength,
-                      bbox.zMin() + 0.5 * zLength };
+    const V3D center{bbox.xMin() + 0.5 * xLength, bbox.yMin() + 0.5 * yLength,
+                     bbox.zMin() + 0.5 * zLength};
 
     const size_t numXSlices = static_cast<size_t>(xLength / cubeSizeInMetre);
     const size_t numYSlices = static_cast<size_t>(yLength / cubeSizeInMetre);
@@ -148,8 +148,7 @@ Raster calculate(const V3D &beamDirection, const CSGObject &shape,
     Raster result;
     try {
       result.reserve(numVolumeElements);
-    }
-    catch (...) {
+    } catch (...) {
       // Typically get here if the number of volume elements is too large
       // Provide a bit more information
       throw std::logic_error(

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -56,9 +56,15 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
 Raster calculateCylinder(const Kernel::V3D &beamDirection,
                          const CSGObject &shape, const size_t numSlices,
                          const size_t numAnnuli) {
+  if (numSlices == 0)
+    throw std::runtime_error("Tried to section cylinder into zero slices");
+  if (numAnnuli == 0)
+    throw std::runtime_error("Tried to section cylinder into zero annuli");
+
   // get the geometry for the volume elements
   double radius, height;
   getCylinderParameters(shape, radius, height);
+
   const double sliceThickness{ height / static_cast<double>(numSlices) };
   const double deltaR{ radius / static_cast<double>(numAnnuli) };
 
@@ -71,6 +77,7 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
 
   Raster result;
   result.resize(numVolumeElements);
+  result.totalvolume = height * M_PI * radius * radius;
 
   // loop over the elements of the shape and create everything
   size_t counter = 0;

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -8,22 +8,28 @@
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/Track.h"
+#include <iostream> // REMOVE
 
 namespace Mantid {
 namespace Geometry {
 
 using Geometry::CSGObject;
+using Kernel::V3D;
 
-void Raster::resize(size_t numVolumeElements) {
-  l1.resize(numVolumeElements);
-  volume.resize(numVolumeElements);
-  position.resize(numVolumeElements);
+void Raster::reserve(size_t numVolumeElements) {
+  l1.reserve(numVolumeElements);
+  volume.reserve(numVolumeElements);
+  position.reserve(numVolumeElements);
 }
 
 namespace { // anonymous
 
+const V3D X_AXIS{ 1, 0, 0 };
+const V3D Y_AXIS{ 0, 1, 0 };
+const V3D Z_AXIS{ 0, 0, 1 };
+
 void getCylinderParameters(const CSGObject &shape, double &radius,
-                           double &height) {
+                           double &height, V3D &centerBottomBase, V3D &axis) {
   // fundamental checks for any object
   if (!shape.hasValidShape())
     throw std::logic_error("Shape[CSGObject] does not have a valid shape");
@@ -33,13 +39,55 @@ void getCylinderParameters(const CSGObject &shape, double &radius,
   const auto &shapeInfo = shape.shapeInfo();
   radius = shapeInfo.radius();
   height = shapeInfo.height();
+
+  std::vector<V3D> points = shapeInfo.points();
+  centerBottomBase = points[0];
+  axis = points[1];
+}
+
+V3D createPerpendicular(const V3D &z_axis) {
+  const std::vector<double> scalars = { fabs(z_axis.scalar_prod(X_AXIS)),
+                                        fabs(z_axis.scalar_prod(Y_AXIS)),
+                                        fabs(z_axis.scalar_prod(Z_AXIS)) };
+  // check against the cardinal axes
+  if (scalars[0] == 0.)
+    return z_axis.cross_prod(X_AXIS);
+  else if (scalars[1] == 0.)
+    return z_axis.cross_prod(Y_AXIS);
+  else if (scalars[2] == 0.)
+    return z_axis.cross_prod(Z_AXIS);
+
+  // see which one is smallest
+  if (scalars[0] < scalars[1] && scalars[0] < scalars[2])
+    return z_axis.cross_prod(X_AXIS);
+  else if (scalars[1] < scalars[0] && scalars[1] < scalars[2])
+    return z_axis.cross_prod(Y_AXIS);
+  else
+    return z_axis.cross_prod(Z_AXIS);
 }
 
 } // namespace
 
 namespace Rasterize {
 
-Raster calculateCylinder(const Kernel::V3D &beamDirection,
+// --------- collection of calculations that convert to CSGObjects and pass the
+// work on
+
+Raster calculate(const V3D &beamDirection,
+                 const boost::shared_ptr<IObject> shape,
+                 const double cubeSizeInMetre) {
+  // convert to the underlying CSGObject
+  const auto csgshape =
+      boost::dynamic_pointer_cast<const Geometry::CSGObject>(shape);
+  if (!csgshape)
+    throw std::logic_error("Failed to convert IObject to CSGObject");
+  if (!(csgshape->hasValidShape()))
+    throw std::logic_error("Shape[IObject] does not have a valid shape");
+
+  return calculate(beamDirection, *csgshape, cubeSizeInMetre);
+}
+
+Raster calculateCylinder(const V3D &beamDirection,
                          const boost::shared_ptr<Geometry::IObject> shape,
                          const size_t numSlices, const size_t numAnnuli) {
   // convert to the underlying CSGObject
@@ -53,9 +101,109 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
   return calculateCylinder(beamDirection, *csgshape, numSlices, numAnnuli);
 }
 
-Raster calculateCylinder(const Kernel::V3D &beamDirection,
-                         const CSGObject &shape, const size_t numSlices,
-                         const size_t numAnnuli) {
+// --------- actual calculations
+
+/*
+ * This method attempts to convert the object to one of the primitive types. If
+ * that is not found it uses the arbitrary shape code.
+ */
+Raster calculate(const V3D &beamDirection, const CSGObject &shape,
+                 const double cubeSizeInMetre) {
+  if (cubeSizeInMetre <= 0.)
+    throw std::runtime_error("Tried to section shape into zero size elements");
+
+  if (shape.shape() == Geometry::detail::ShapeInfo::GeometryShape::CYLINDER) {
+    double radius, height;
+    V3D center, axis; // these values are ignored
+    getCylinderParameters(shape, radius, height, center, axis);
+    const size_t numSlice =
+        std::max<size_t>(1, static_cast<size_t>(height / cubeSizeInMetre));
+    const size_t numAnnuli =
+        std::max<size_t>(1, static_cast<size_t>(radius / cubeSizeInMetre));
+    return calculateCylinder(beamDirection, shape, numSlice, numAnnuli);
+  } else { // arbitrary shape code
+    const auto bbox = shape.getBoundingBox();
+    assert(bbox.xMax() > bbox.xMin());
+    assert(bbox.yMax() > bbox.yMin());
+    assert(bbox.zMax() > bbox.zMin());
+
+    const double xLength = bbox.xMax() - bbox.xMin();
+    const double yLength = bbox.yMax() - bbox.yMin();
+    const double zLength = bbox.zMax() - bbox.zMin();
+
+    const V3D center{ bbox.xMin() + 0.5 * xLength, bbox.yMin() + 0.5 * yLength,
+                      bbox.zMin() + 0.5 * zLength };
+
+    const size_t numXSlices = static_cast<size_t>(xLength / cubeSizeInMetre);
+    const size_t numYSlices = static_cast<size_t>(yLength / cubeSizeInMetre);
+    const size_t numZSlices = static_cast<size_t>(zLength / cubeSizeInMetre);
+    const double XSliceThickness = xLength / static_cast<double>(numXSlices);
+    const double YSliceThickness = yLength / static_cast<double>(numYSlices);
+    const double ZSliceThickness = zLength / static_cast<double>(numZSlices);
+    const double elementVolume =
+        XSliceThickness * YSliceThickness * ZSliceThickness;
+
+    const size_t numVolumeElements = numXSlices * numYSlices * numZSlices;
+
+    Raster result;
+    try {
+      result.reserve(numVolumeElements);
+    }
+    catch (...) {
+      // Typically get here if the number of volume elements is too large
+      // Provide a bit more information
+      throw std::logic_error(
+          "Too many volume elements requested - try increasing the value "
+          "of the ElementSize property.");
+    }
+
+    // go through the bounding box generating cubes and seeing if they are
+    // inside the shape
+    for (size_t i = 0; i < numZSlices; ++i) {
+      const double z =
+          (static_cast<double>(i) + 0.5) * ZSliceThickness + bbox.xMin();
+
+      for (size_t j = 0; j < numYSlices; ++j) {
+        const double y =
+            (static_cast<double>(j) + 0.5) * YSliceThickness + bbox.yMin();
+
+        for (size_t k = 0; k < numXSlices; ++k) {
+          const double x =
+              (static_cast<double>(k) + 0.5) * XSliceThickness + bbox.zMin();
+          // Set the current position in the sample in Cartesian coordinates.
+          const Kernel::V3D currentPosition = V3D(x, y, z);
+          // Check if the current point is within the object. If not, skip.
+          if (shape.isValid(currentPosition)) {
+            // Create track for distance in sample before scattering point
+            Track incoming(currentPosition, beamDirection * -1.0);
+            // We have an issue where occasionally, even though a point is
+            // within
+            // the object a track segment to the surface isn't correctly
+            // created.
+            // In the context of this algorithm I think it's safe to just chuck
+            // away the element in this case.
+            // This will also throw away points that are inside a gauge volume
+            // but
+            // outside the sample
+            if (shape.interceptSurface(incoming) > 0) {
+              result.l1.push_back(incoming.cbegin()->distFromStart);
+              result.position.push_back(currentPosition);
+              result.volume.push_back(elementVolume);
+            }
+          }
+        }
+      }
+    }
+
+    // Record the number of elements we ended up with
+    result.totalvolume = static_cast<double>(result.l1.size()) * elementVolume;
+
+    return result;
+  }
+}
+
+Raster calculateCylinder(const V3D &beamDirection, const CSGObject &shape,
+                         const size_t numSlices, const size_t numAnnuli) {
   if (numSlices == 0)
     throw std::runtime_error("Tried to section cylinder into zero slices");
   if (numAnnuli == 0)
@@ -63,7 +211,10 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
 
   // get the geometry for the volume elements
   double radius, height;
-  getCylinderParameters(shape, radius, height);
+  V3D centerBottomBase, z_prime;
+  getCylinderParameters(shape, radius, height, centerBottomBase, z_prime);
+  V3D center = (z_prime * .5 * height) + centerBottomBase;
+  z_prime.normalize();
 
   const double sliceThickness{height / static_cast<double>(numSlices)};
   const double deltaR{radius / static_cast<double>(numAnnuli)};
@@ -76,11 +227,15 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
   const size_t numVolumeElements = numSlices * numAnnuli * (numAnnuli + 1) * 3;
 
   Raster result;
-  result.resize(numVolumeElements);
+  result.reserve(numVolumeElements);
   result.totalvolume = height * M_PI * radius * radius;
 
+  // Assume that z' = axis. Then select whatever has the smallest dot product
+  // with axis to be the x' direction
+  V3D x_prime = createPerpendicular(z_prime);
+  V3D y_prime = z_prime.cross_prod(x_prime);
+
   // loop over the elements of the shape and create everything
-  size_t counter = 0;
   // loop over slices
   for (size_t i = 0; i < numSlices; ++i) {
     const double z =
@@ -94,30 +249,38 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
       const double R =
           (static_cast<double>(j) * radius / static_cast<double>(numAnnuli)) +
           (0.5 * deltaR);
+
+      // all the volume elements in the ring/slice are the same
+      const double outerR = R + (deltaR / 2.0);
+      const double innerR = outerR - deltaR;
+      const double elementVolume = M_PI * (outerR * outerR - innerR * innerR) *
+                                   sliceThickness / static_cast<double>(Ni);
+
       // loop over elements in current annulus
       for (size_t k = 0; k < Ni; ++k) {
         const double phi =
             2. * M_PI * static_cast<double>(k) / static_cast<double>(Ni);
-        // Calculate the current position in the sample in Cartesian
-        // coordinates.
-        // Remember that our cylinder has its axis along the y axis
-        result.position[counter](R * sin(phi), z, R * cos(phi));
-        assert(shape->isValid(m_elementPositions[counter]));
+        const double rSinPhi = R * sin(phi);
+        const double rCosPhi = R * cos(phi);
+
+        // Calculate the current position in the shape in Cartesian coordinates
+        const double xcomp =
+            rSinPhi * x_prime[0] + rCosPhi * y_prime[0] + z * z_prime[0];
+        const double ycomp =
+            rSinPhi * x_prime[1] + rCosPhi * y_prime[1] + z * z_prime[1];
+        const double zcomp =
+            rSinPhi * x_prime[2] + rCosPhi * y_prime[2] + z * z_prime[2];
+        const auto position = center + V3D(xcomp, ycomp, zcomp);
+
+        result.position.push_back(position);
+        assert(shape->isValid(position));
         // Create track for distance in cylinder before scattering point
-        Track incoming(result.position[counter], beamDirection * -1.0);
+        Track incoming(position, beamDirection * -1.0);
 
         shape.interceptSurface(incoming);
-        result.l1[counter] = incoming.cbegin()->distFromStart;
+        result.l1.push_back(incoming.cbegin()->distFromStart);
 
-        // Also calculate element volumes here
-        const double outerR = R + (deltaR / 2.0);
-        const double innerR = outerR - deltaR;
-        const double elementVolume = M_PI *
-                                     (outerR * outerR - innerR * innerR) *
-                                     sliceThickness / static_cast<double>(Ni);
-        result.volume[counter] = elementVolume;
-
-        counter++;
+        result.volume.push_back(elementVolume);
       } // loop over k
     }   // loop over j
   }     // loop over i

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -35,7 +35,7 @@ void getCylinderParameters(const CSGObject &shape, double &radius,
   height = shapeInfo.height();
 }
 
-} // anonymous
+} // namespace
 
 namespace Rasterize {
 
@@ -65,8 +65,8 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
   double radius, height;
   getCylinderParameters(shape, radius, height);
 
-  const double sliceThickness{ height / static_cast<double>(numSlices) };
-  const double deltaR{ radius / static_cast<double>(numAnnuli) };
+  const double sliceThickness{height / static_cast<double>(numSlices)};
+  const double deltaR{radius / static_cast<double>(numAnnuli)};
 
   /* The number of volume elements is
    * numslices*(1+2+3+.....+numAnnuli)*6
@@ -124,6 +124,6 @@ Raster calculateCylinder(const Kernel::V3D &beamDirection,
 
   return result;
 }
-}
+} // namespace Rasterize
 } // namespace Geometry
 } // namespace Mantid

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -1,0 +1,122 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidGeometry/Rasterize.h"
+#include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include "MantidGeometry/Objects/Track.h"
+
+namespace Mantid {
+namespace Geometry {
+
+using Geometry::CSGObject;
+
+void Raster::resize(size_t numVolumeElements) {
+  l1.resize(numVolumeElements);
+  volume.resize(numVolumeElements);
+  position.resize(numVolumeElements);
+}
+
+namespace { // anonymous
+
+void getCylinderParameters(const CSGObject &shape, double &radius,
+                           double &height) {
+  // fundamental checks for any object
+  if (!shape.hasValidShape())
+    throw std::logic_error("Shape[CSGObject] does not have a valid shape");
+  if (shape.shape() != Geometry::detail::ShapeInfo::GeometryShape::CYLINDER)
+    throw std::logic_error("Shape[CSGObject] is not a cylinder");
+
+  const auto &shapeInfo = shape.shapeInfo();
+  radius = shapeInfo.radius();
+  height = shapeInfo.height();
+}
+
+} // anonymous
+
+namespace Rasterize {
+
+Raster calculateCylinder(const Kernel::V3D &beamDirection,
+                         const boost::shared_ptr<Geometry::IObject> shape,
+                         const size_t numSlices, const size_t numAnnuli) {
+  // convert to the underlying CSGObject
+  const auto csgshape =
+      boost::dynamic_pointer_cast<const Geometry::CSGObject>(shape);
+  if (!csgshape)
+    throw std::logic_error("Failed to convert IObject to CSGObject");
+  if (!(csgshape->hasValidShape()))
+    throw std::logic_error("Shape[IObject] does not have a valid shape");
+
+  return calculateCylinder(beamDirection, *csgshape, numSlices, numAnnuli);
+}
+
+Raster calculateCylinder(const Kernel::V3D &beamDirection,
+                         const CSGObject &shape, const size_t numSlices,
+                         const size_t numAnnuli) {
+  // get the geometry for the volume elements
+  double radius, height;
+  getCylinderParameters(shape, radius, height);
+  const double sliceThickness{ height / static_cast<double>(numSlices) };
+  const double deltaR{ radius / static_cast<double>(numAnnuli) };
+
+  /* The number of volume elements is
+   * numslices*(1+2+3+.....+numAnnuli)*6
+   * Since the first annulus is separated in 6 segments, the next one in 12 and
+   * so on.....
+   */
+  const size_t numVolumeElements = numSlices * numAnnuli * (numAnnuli + 1) * 3;
+
+  Raster result;
+  result.resize(numVolumeElements);
+
+  // loop over the elements of the shape and create everything
+  size_t counter = 0;
+  // loop over slices
+  for (size_t i = 0; i < numSlices; ++i) {
+    const double z =
+        (static_cast<double>(i) + 0.5) * sliceThickness - 0.5 * height;
+
+    // Number of elements in 1st annulus
+    size_t Ni = 0;
+    // loop over annuli
+    for (size_t j = 0; j < numAnnuli; ++j) {
+      Ni += 6;
+      const double R =
+          (static_cast<double>(j) * radius / static_cast<double>(numAnnuli)) +
+          (0.5 * deltaR);
+      // loop over elements in current annulus
+      for (size_t k = 0; k < Ni; ++k) {
+        const double phi =
+            2. * M_PI * static_cast<double>(k) / static_cast<double>(Ni);
+        // Calculate the current position in the sample in Cartesian
+        // coordinates.
+        // Remember that our cylinder has its axis along the y axis
+        result.position[counter](R * sin(phi), z, R * cos(phi));
+        assert(shape->isValid(m_elementPositions[counter]));
+        // Create track for distance in cylinder before scattering point
+        Track incoming(result.position[counter], beamDirection * -1.0);
+
+        shape.interceptSurface(incoming);
+        result.l1[counter] = incoming.cbegin()->distFromStart;
+
+        // Also calculate element volumes here
+        const double outerR = R + (deltaR / 2.0);
+        const double innerR = outerR - deltaR;
+        const double elementVolume = M_PI *
+                                     (outerR * outerR - innerR * innerR) *
+                                     sliceThickness / static_cast<double>(Ni);
+        result.volume[counter] = elementVolume;
+
+        counter++;
+      } // loop over k
+    }   // loop over j
+  }     // loop over i
+
+  return result;
+}
+}
+} // namespace Geometry
+} // namespace Mantid

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -141,8 +141,6 @@ Raster calculate(const V3D &beamDirection, const CSGObject &shape,
     const double yLength = bbox.yMax() - bbox.yMin();
     const double zLength = bbox.zMax() - bbox.zMin();
 
-    const V3D center{bbox.centrePoint()};
-
     const size_t numXSlices = static_cast<size_t>(xLength / cubeSizeInMetre);
     const size_t numYSlices = static_cast<size_t>(yLength / cubeSizeInMetre);
     const size_t numZSlices = static_cast<size_t>(zLength / cubeSizeInMetre);

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -57,10 +57,9 @@ CylinderParameters getCylinderParameters(const CSGObject &shape) {
 // since cylinders are symmetric around the main axis, choose a random
 // perpendicular to have as the second axis
 V3D createPerpendicular(const V3D &symmetryAxis) {
-  const std::vector<double> scalars = { fabs(symmetryAxis.scalar_prod(X_AXIS)),
-                                        fabs(symmetryAxis.scalar_prod(Y_AXIS)),
-                                        fabs(
-                                            symmetryAxis.scalar_prod(Z_AXIS)) };
+  const std::vector<double> scalars = {fabs(symmetryAxis.scalar_prod(X_AXIS)),
+                                       fabs(symmetryAxis.scalar_prod(Y_AXIS)),
+                                       fabs(symmetryAxis.scalar_prod(Z_AXIS))};
   // check against the cardinal axes
   if (scalars[0] == 0.)
     return symmetryAxis.cross_prod(X_AXIS);
@@ -142,7 +141,7 @@ Raster calculate(const V3D &beamDirection, const CSGObject &shape,
     const double yLength = bbox.yMax() - bbox.yMin();
     const double zLength = bbox.zMax() - bbox.zMin();
 
-    const V3D center{ bbox.centrePoint() };
+    const V3D center{bbox.centrePoint()};
 
     const size_t numXSlices = static_cast<size_t>(xLength / cubeSizeInMetre);
     const size_t numYSlices = static_cast<size_t>(yLength / cubeSizeInMetre);
@@ -220,8 +219,8 @@ Raster calculateCylinder(const V3D &beamDirection, const CSGObject &shape,
       (params.symmetryaxis * .5 * params.height) + params.centerBottomBase;
   params.symmetryaxis.normalize();
 
-  const double sliceThickness{ params.height / static_cast<double>(numSlices) };
-  const double deltaR{ params.radius / static_cast<double>(numAnnuli) };
+  const double sliceThickness{params.height / static_cast<double>(numSlices)};
+  const double deltaR{params.radius / static_cast<double>(numAnnuli)};
 
   /* The number of volume elements is
    * numslices*(1+2+3+.....+numAnnuli)*6

--- a/Framework/Geometry/src/Rasterize.cpp
+++ b/Framework/Geometry/src/Rasterize.cpp
@@ -8,7 +8,6 @@
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/Track.h"
-#include <iostream> // REMOVE
 
 namespace Mantid {
 namespace Geometry {
@@ -259,16 +258,16 @@ Raster calculateCylinder(const V3D &beamDirection, const CSGObject &shape,
       for (size_t k = 0; k < Ni; ++k) {
         const double phi =
             2. * M_PI * static_cast<double>(k) / static_cast<double>(Ni);
-        const double rSinPhi = R * sin(phi);
-        const double rCosPhi = R * cos(phi);
+        const double rSinPhi = -1. * R * sin(phi);
+        const double rCosPhi = -1. * R * cos(phi);
 
         // Calculate the current position in the shape in Cartesian coordinates
         const double xcomp =
-            rSinPhi * x_prime[0] + rCosPhi * y_prime[0] + z * z_prime[0];
+            rCosPhi * x_prime[0] + rSinPhi * y_prime[0] + z * z_prime[0];
         const double ycomp =
-            rSinPhi * x_prime[1] + rCosPhi * y_prime[1] + z * z_prime[1];
+            rCosPhi * x_prime[1] + rSinPhi * y_prime[1] + z * z_prime[1];
         const double zcomp =
-            rSinPhi * x_prime[2] + rCosPhi * y_prime[2] + z * z_prime[2];
+            rCosPhi * x_prime[2] + rSinPhi * y_prime[2] + z * z_prime[2];
         const auto position = center + V3D(xcomp, ycomp, zcomp);
 
         result.position.push_back(position);

--- a/Framework/Geometry/src/Rendering/ShapeInfo.cpp
+++ b/Framework/Geometry/src/Rendering/ShapeInfo.cpp
@@ -58,9 +58,10 @@ void ShapeInfo::setSphere(const V3D &c, double r) {
   m_height = 0;
 }
 
-void ShapeInfo::setCylinder(const V3D &c, const V3D &a, double r, double h) {
+void ShapeInfo::setCylinder(const V3D &centerBottomBase, const V3D &axis,
+                            double r, double h) {
   m_shape = GeometryShape::CYLINDER;
-  m_points.assign({c, a});
+  m_points.assign({ centerBottomBase, axis });
   m_radius = r;
   m_height = h;
 }

--- a/Framework/Geometry/src/Rendering/ShapeInfo.cpp
+++ b/Framework/Geometry/src/Rendering/ShapeInfo.cpp
@@ -61,7 +61,7 @@ void ShapeInfo::setSphere(const V3D &c, double r) {
 void ShapeInfo::setCylinder(const V3D &centerBottomBase, const V3D &axis,
                             double r, double h) {
   m_shape = GeometryShape::CYLINDER;
-  m_points.assign({ centerBottomBase, axis });
+  m_points.assign({centerBottomBase, axis});
   m_radius = r;
   m_height = h;
 }

--- a/Framework/Geometry/src/Rendering/ShapeInfo.cpp
+++ b/Framework/Geometry/src/Rendering/ShapeInfo.cpp
@@ -25,13 +25,13 @@ double ShapeInfo::height() const { return m_height; }
 
 ShapeInfo::GeometryShape ShapeInfo::shape() const { return m_shape; }
 
-void ShapeInfo::getObjectGeometry(ShapeInfo::GeometryShape &myshape,
+void ShapeInfo::getObjectGeometry(ShapeInfo::GeometryShape &shape,
                                   std::vector<Kernel::V3D> &points,
-                                  double &myradius, double &myheight) const {
-  myshape = m_shape;
+                                  double &radius, double &height) const {
+  shape = m_shape;
   points = m_points;
-  myradius = m_radius;
-  myheight = m_height;
+  radius = m_radius;
+  height = m_height;
 }
 
 void ShapeInfo::setCuboid(const V3D &p1, const V3D &p2, const V3D &p3,
@@ -51,26 +51,26 @@ void ShapeInfo::setHexahedron(const V3D &p1, const V3D &p2, const V3D &p3,
   m_height = 0;
 }
 
-void ShapeInfo::setSphere(const V3D &c, double r) {
+void ShapeInfo::setSphere(const V3D &center, double radius) {
   m_shape = GeometryShape::SPHERE;
-  m_points.assign({c});
-  m_radius = r;
+  m_points.assign({center});
+  m_radius = radius;
   m_height = 0;
 }
 
-void ShapeInfo::setCylinder(const V3D &centerBottomBase, const V3D &axis,
-                            double r, double h) {
+void ShapeInfo::setCylinder(const V3D &centerBottomBase,
+                            const V3D &symmetryAxis, double radius, double height) {
   m_shape = GeometryShape::CYLINDER;
-  m_points.assign({centerBottomBase, axis});
-  m_radius = r;
-  m_height = h;
+  m_points.assign({ centerBottomBase, symmetryAxis });
+  m_radius = radius;
+  m_height = height;
 }
 
-void ShapeInfo::setCone(const V3D &c, const V3D &a, double r, double h) {
+void ShapeInfo::setCone(const V3D &center, const V3D &symmetryAxis, double radius, double height) {
   m_shape = GeometryShape::CONE;
-  m_points.assign({c, a});
-  m_radius = r;
-  m_height = h;
+  m_points.assign({center, symmetryAxis});
+  m_radius = radius;
+  m_height = height;
 }
 
 bool ShapeInfo::operator==(const ShapeInfo &other) {

--- a/Framework/Geometry/src/Rendering/ShapeInfo.cpp
+++ b/Framework/Geometry/src/Rendering/ShapeInfo.cpp
@@ -59,14 +59,16 @@ void ShapeInfo::setSphere(const V3D &center, double radius) {
 }
 
 void ShapeInfo::setCylinder(const V3D &centerBottomBase,
-                            const V3D &symmetryAxis, double radius, double height) {
+                            const V3D &symmetryAxis, double radius,
+                            double height) {
   m_shape = GeometryShape::CYLINDER;
-  m_points.assign({ centerBottomBase, symmetryAxis });
+  m_points.assign({centerBottomBase, symmetryAxis});
   m_radius = radius;
   m_height = height;
 }
 
-void ShapeInfo::setCone(const V3D &center, const V3D &symmetryAxis, double radius, double height) {
+void ShapeInfo::setCone(const V3D &center, const V3D &symmetryAxis,
+                        double radius, double height) {
   m_shape = GeometryShape::CONE;
   m_points.assign({center, symmetryAxis});
   m_radius = radius;

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -1,0 +1,90 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_GEOMETRY_RASTERIZETEST_H_
+#define MANTID_GEOMETRY_RASTERIZETEST_H_
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidGeometry/Rasterize.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidKernel/V3D.h"
+
+using namespace Mantid::Geometry;
+using Mantid::Kernel::V3D;
+
+class RasterizeTest : public CxxTest::TestSuite {
+private:
+  // all examples are taken from ShapeFactoryTest
+  std::string cylinderXml =
+      "<cylinder id=\"shape\"> "
+      "(<centre-of-bottom-base x=\"0.0\" y=\"0.0\" z=\"0.0\"/>)"
+      "(<axis x=\"0.0\" y=\"0.0\" z=\"1\" /> )"
+      "<radius val=\"0.1\" /> "
+      "<height val=\"3\" /> "
+      "</cylinder>";
+
+  std::string sphereXml = "<sphere id=\"shape\"> "
+                          "(<centre x=\"4.1\"  y=\"2.1\" z=\"8.1\" /> )"
+                          "<radius val=\"3.2\" /> "
+                          "</sphere>"
+                          "<algebra val=\"shape\" /> ";
+
+  boost::shared_ptr<IObject> createCylinder() {
+    return ShapeFactory().createShape(cylinderXml);
+  }
+
+  boost::shared_ptr<IObject> createSphere() {
+    return ShapeFactory().createShape(sphereXml);
+  }
+
+  void simpleRasterChecks(const Raster &raster, const size_t numEle) {
+    TS_ASSERT_EQUALS(raster.l1.size(), numEle);
+    TS_ASSERT_EQUALS(raster.position.size(), numEle);
+    TS_ASSERT_EQUALS(raster.volume.size(), numEle);
+
+    // all lengths into the shape should be positive
+    for (const auto &ele : raster.l1)
+      TS_ASSERT(ele > 0.);
+
+    // all element volumes should be positive
+    for (const auto &ele : raster.volume)
+      TS_ASSERT(ele > 0.);
+  }
+
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static RasterizeTest *createSuite() { return new RasterizeTest(); }
+  static void destroySuite(RasterizeTest *suite) { delete suite; }
+
+  void test_calculateCylinder() {
+    const size_t NUM_SLICE{ 3 };
+    const size_t NUM_ANNULLI{ 3 };
+
+    boost::shared_ptr<IObject> cylinder = createCylinder();
+    TS_ASSERT(cylinder);
+    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder,
+                                                     NUM_SLICE, NUM_ANNULLI);
+
+    // all the vector lengths should match
+    constexpr size_t NUM_ELEMENTS =
+        NUM_SLICE * NUM_ANNULLI * (NUM_ANNULLI + 1) * 3;
+    simpleRasterChecks(raster, NUM_ELEMENTS);
+  }
+
+  void test_calculateCylinderFromSphere() {
+    boost::shared_ptr<IObject> sphere = createSphere();
+    TS_ASSERT(sphere);
+    TS_ASSERT_THROWS(
+        Rasterize::calculateCylinder(V3D(0., 0., 1.), sphere, 3, 3),
+        std::logic_error);
+  }
+};
+
+#endif /* MANTID_GEOMETRY_RASTERIZETEST_H_ */

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -7,13 +7,13 @@
 #ifndef MANTID_GEOMETRY_RASTERIZETEST_H_
 #define MANTID_GEOMETRY_RASTERIZETEST_H_
 
-#include <cxxtest/TestSuite.h>
-#include <numeric>
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidGeometry/Rasterize.h"
 #include "MantidKernel/V3D.h"
+#include <cxxtest/TestSuite.h>
+#include <numeric>
 
 using namespace Mantid::Geometry;
 using Mantid::Kernel::V3D;
@@ -121,8 +121,8 @@ public:
   }
 
   void test_calculateOffsetCylinder() {
-    const size_t NUM_SLICE{ 3 };
-    const size_t NUM_ANNULLI{ 3 };
+    const size_t NUM_SLICE{3};
+    const size_t NUM_ANNULLI{3};
 
     boost::shared_ptr<IObject> cylinder = createCylinder(false);
     TS_ASSERT(cylinder);

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -8,7 +8,7 @@
 #define MANTID_GEOMETRY_RASTERIZETEST_H_
 
 #include <cxxtest/TestSuite.h>
-
+#include <numeric>
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
@@ -20,41 +20,83 @@ using Mantid::Kernel::V3D;
 
 class RasterizeTest : public CxxTest::TestSuite {
 private:
-  // all examples are taken from ShapeFactoryTest
-  std::string cylinderXml =
+  // all examples are taken from ShapeFactoryTest with some small modifications
+  const std::string cylinderXml =
       "<cylinder id=\"shape\"> "
-      "(<centre-of-bottom-base x=\"0.0\" y=\"0.0\" z=\"0.0\"/>)"
+      "(<centre-of-bottom-base x=\"0.0\" y=\"-1.5\" z=\"0\"/>)"
+      "(<axis x=\"0.0\" y=\"1\" z=\"0\" /> )"
+      "<radius val=\"0.1\" /> "
+      "<height val=\"3\" /> "
+      "</cylinder>";
+  const std::string cylinderOffsetXml =
+      "<cylinder id=\"shape\"> "
+      "(<centre-of-bottom-base x=\"0.0\" y=\"3.0\" z=\"0.0\"/>)"
       "(<axis x=\"0.0\" y=\"0.0\" z=\"1\" /> )"
       "<radius val=\"0.1\" /> "
       "<height val=\"3\" /> "
       "</cylinder>";
+  static constexpr double CYLINDER_VOLUME = M_PI * .1 * .1 * 3.;
 
-  std::string sphereXml = "<sphere id=\"shape\"> "
-                          "(<centre x=\"4.1\"  y=\"2.1\" z=\"8.1\" /> )"
-                          "<radius val=\"3.2\" /> "
-                          "</sphere>"
-                          "<algebra val=\"shape\" /> ";
+  const std::string sphereXml = "<sphere id=\"shape\"> "
+                                "(<centre x=\"0.0\"  y=\"0.0\" z=\"0.0\" /> )"
+                                "<radius val=\"3.2\" /> "
+                                "</sphere>"
+                                "<algebra val=\"shape\" /> ";
+  const std::string sphereOffsetXml = "<sphere id=\"shape\"> "
+                                      "(<centre x=\"4\"  y=\"4\" z=\"4\" /> )"
+                                      "<radius val=\"3.2\" /> "
+                                      "</sphere>"
+                                      "<algebra val=\"shape\" /> ";
+  static constexpr double SPHERE_VOLUME = (4. / 3.) * M_PI * 3.2 * 3.2 * 3.2;
 
-  boost::shared_ptr<IObject> createCylinder() {
-    return ShapeFactory().createShape(cylinderXml);
+  boost::shared_ptr<IObject> createCylinder(bool centered) {
+    if (centered)
+      return ShapeFactory().createShape(cylinderXml);
+    else
+      return ShapeFactory().createShape(cylinderOffsetXml);
   }
 
-  boost::shared_ptr<IObject> createSphere() {
-    return ShapeFactory().createShape(sphereXml);
+  boost::shared_ptr<IObject> createSphere(bool centered) {
+    if (centered)
+      return ShapeFactory().createShape(sphereXml);
+    else
+      return ShapeFactory().createShape(sphereOffsetXml);
   }
 
-  void simpleRasterChecks(const Raster &raster, const size_t numEle) {
+  void simpleRasterChecks(const Raster &raster,
+                          const boost::shared_ptr<IObject> &shape,
+                          const size_t numEle, const double volume,
+                          const double relVolumeTol = 0.001) {
     TS_ASSERT_EQUALS(raster.l1.size(), numEle);
     TS_ASSERT_EQUALS(raster.position.size(), numEle);
     TS_ASSERT_EQUALS(raster.volume.size(), numEle);
 
     // all lengths into the shape should be positive
+    size_t numPositiveL1 = 0;
     for (const auto &ele : raster.l1)
-      TS_ASSERT(ele > 0.);
+      if (ele > 0.)
+        numPositiveL1 += 1;
+    TS_ASSERT_EQUALS(numPositiveL1, numEle);
 
     // all element volumes should be positive
+    size_t numPositiveVolume = 0;
     for (const auto &ele : raster.volume)
-      TS_ASSERT(ele > 0.);
+      if (ele > 0.)
+        numPositiveVolume += 1;
+    TS_ASSERT_EQUALS(numPositiveVolume, numEle);
+
+    size_t numValidPos = 0;
+    for (const auto &pos : raster.position)
+      if (shape->isValid(pos))
+        numValidPos++;
+    TS_ASSERT_EQUALS(numValidPos, numEle);
+
+    TS_ASSERT_DELTA(raster.totalvolume, volume,
+                    volume * relVolumeTol); // no more than 1% different
+    double sumOfVolumes =
+        std::accumulate(raster.volume.begin(), raster.volume.end(), 0.);
+    TS_ASSERT_DELTA(sumOfVolumes, volume,
+                    volume * relVolumeTol); // no more than 1% different
   }
 
 public:
@@ -67,7 +109,7 @@ public:
     const size_t NUM_SLICE{3};
     const size_t NUM_ANNULLI{3};
 
-    boost::shared_ptr<IObject> cylinder = createCylinder();
+    boost::shared_ptr<IObject> cylinder = createCylinder(true);
     TS_ASSERT(cylinder);
     const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder,
                                                      NUM_SLICE, NUM_ANNULLI);
@@ -75,15 +117,59 @@ public:
     // all the vector lengths should match
     constexpr size_t NUM_ELEMENTS =
         NUM_SLICE * NUM_ANNULLI * (NUM_ANNULLI + 1) * 3;
-    simpleRasterChecks(raster, NUM_ELEMENTS);
+    simpleRasterChecks(raster, cylinder, NUM_ELEMENTS, CYLINDER_VOLUME);
   }
 
-  void test_calculateCylinderFromSphere() {
-    boost::shared_ptr<IObject> sphere = createSphere();
+  void test_calculateOffsetCylinder() {
+    const size_t NUM_SLICE{ 3 };
+    const size_t NUM_ANNULLI{ 3 };
+
+    boost::shared_ptr<IObject> cylinder = createCylinder(false);
+    TS_ASSERT(cylinder);
+    const auto raster = Rasterize::calculateCylinder(V3D(0., 0., 1.), cylinder,
+                                                     NUM_SLICE, NUM_ANNULLI);
+
+    // all the vector lengths should match
+    constexpr size_t NUM_ELEMENTS =
+        NUM_SLICE * NUM_ANNULLI * (NUM_ANNULLI + 1) * 3;
+    simpleRasterChecks(raster, cylinder, NUM_ELEMENTS, CYLINDER_VOLUME);
+  }
+
+  void test_calculateCylinderOnSphere() {
+    boost::shared_ptr<IObject> sphere = createSphere(true);
     TS_ASSERT(sphere);
     TS_ASSERT_THROWS(
         Rasterize::calculateCylinder(V3D(0., 0., 1.), sphere, 3, 3),
         std::logic_error);
+  }
+
+  void test_calculateArbitraryOnCylinder() {
+    boost::shared_ptr<IObject> cylinder = createCylinder(true);
+    TS_ASSERT(cylinder);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), cylinder, .1);
+
+    // all the vector lengths should match
+    simpleRasterChecks(raster, cylinder, 180, CYLINDER_VOLUME);
+  }
+
+  void test_calculateArbitraryOnSphere() {
+    boost::shared_ptr<IObject> sphere = createSphere(true);
+    TS_ASSERT(sphere);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, .5);
+
+    // volume is calculated poorly due to approximating all volume elements as
+    // boxes
+    simpleRasterChecks(raster, sphere, 912, SPHERE_VOLUME, .01);
+  }
+
+  void test_calculateArbitraryOnOffsetSphere() {
+    boost::shared_ptr<IObject> sphere = createSphere(false);
+    TS_ASSERT(sphere);
+    const auto raster = Rasterize::calculate(V3D(0., 0., 1.), sphere, .5);
+
+    // volume is calculated poorly due to approximating all volume elements as
+    // boxes
+    simpleRasterChecks(raster, sphere, 912, SPHERE_VOLUME, .01);
   }
 };
 

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -9,10 +9,10 @@
 
 #include <cxxtest/TestSuite.h>
 
-#include "MantidGeometry/Rasterize.h"
-#include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/CSGObject.h"
+#include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
+#include "MantidGeometry/Rasterize.h"
 #include "MantidKernel/V3D.h"
 
 using namespace Mantid::Geometry;
@@ -64,8 +64,8 @@ public:
   static void destroySuite(RasterizeTest *suite) { delete suite; }
 
   void test_calculateCylinder() {
-    const size_t NUM_SLICE{ 3 };
-    const size_t NUM_ANNULLI{ 3 };
+    const size_t NUM_SLICE{3};
+    const size_t NUM_ANNULLI{3};
 
     boost::shared_ptr<IObject> cylinder = createCylinder();
     TS_ASSERT(cylinder);

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -97,8 +97,8 @@ public:
   static void destroySuite(RasterizeTest *suite) { delete suite; }
 
   void test_calculateCylinder() {
-    constexpr size_t NUM_SLICE{ 3 };
-    constexpr size_t NUM_ANNULLI{ 3 };
+    constexpr size_t NUM_SLICE{3};
+    constexpr size_t NUM_ANNULLI{3};
 
     boost::shared_ptr<CSGObject> cylinder = createCylinder(true);
     TS_ASSERT(cylinder);
@@ -112,8 +112,8 @@ public:
   }
 
   void test_calculateOffsetCylinder() {
-    constexpr size_t NUM_SLICE{ 3 };
-    constexpr size_t NUM_ANNULLI{ 3 };
+    constexpr size_t NUM_SLICE{3};
+    constexpr size_t NUM_ANNULLI{3};
 
     boost::shared_ptr<CSGObject> cylinder = createCylinder(false);
     TS_ASSERT(cylinder);

--- a/Framework/Geometry/test/RasterizeTest.h
+++ b/Framework/Geometry/test/RasterizeTest.h
@@ -23,27 +23,27 @@ private:
   // all examples are taken from ShapeFactoryTest with some small modifications
   const std::string cylinderXml =
       "<cylinder id=\"shape\"> "
-      "(<centre-of-bottom-base x=\"0.0\" y=\"-1.5\" z=\"0\"/>)"
-      "(<axis x=\"0.0\" y=\"1\" z=\"0\" /> )"
+      "<centre-of-bottom-base x=\"0.0\" y=\"-1.5\" z=\"0\"/>"
+      "<axis x=\"0.0\" y=\"1\" z=\"0\" /> "
       "<radius val=\"0.1\" /> "
       "<height val=\"3\" /> "
       "</cylinder>";
   const std::string cylinderOffsetXml =
       "<cylinder id=\"shape\"> "
-      "(<centre-of-bottom-base x=\"0.0\" y=\"3.0\" z=\"0.0\"/>)"
-      "(<axis x=\"0.0\" y=\"0.0\" z=\"1\" /> )"
+      "<centre-of-bottom-base x=\"0.0\" y=\"3.0\" z=\"0.0\"/>"
+      "<axis x=\"0.0\" y=\"0.0\" z=\"1\" /> "
       "<radius val=\"0.1\" /> "
       "<height val=\"3\" /> "
       "</cylinder>";
   static constexpr double CYLINDER_VOLUME = M_PI * .1 * .1 * 3.;
 
   const std::string sphereXml = "<sphere id=\"shape\"> "
-                                "(<centre x=\"0.0\"  y=\"0.0\" z=\"0.0\" /> )"
+                                "<centre x=\"0.0\"  y=\"0.0\" z=\"0.0\" /> "
                                 "<radius val=\"3.2\" /> "
                                 "</sphere>"
                                 "<algebra val=\"shape\" /> ";
   const std::string sphereOffsetXml = "<sphere id=\"shape\"> "
-                                      "(<centre x=\"4\"  y=\"4\" z=\"4\" /> )"
+                                      "<centre x=\"4\"  y=\"4\" z=\"4\" /> "
                                       "<radius val=\"3.2\" /> "
                                       "</sphere>"
                                       "<algebra val=\"shape\" /> ";

--- a/docs/source/algorithms/CylinderAbsorption-v1.rst
+++ b/docs/source/algorithms/CylinderAbsorption-v1.rst
@@ -28,10 +28,11 @@ path lengths over the volume elements.
 Assumptions
 ###########
 
-Although no assumptions are made about the beam direction or the sample
-position, the cylinder will be constructed with its centre at the sample
-position and it's axis along the y axis (which in the case of most
-instruments is the vertical).
+Although no assumptions are made about the beam direction or the
+sample position, the cylinder will be constructed with its centre at
+the sample position and it's axis along the y axis (which in the case
+of most instruments is the vertical). The sample geometry can also be
+set using :ref:`SetSample <algm-SetSample>`.
 
 Restrictions on the input workspace
 ###################################
@@ -57,21 +58,21 @@ there (e.g. there's no multiple scattering and no concentric cylinders).
 Usage
 -----
 
-**Example - Using a X Section Values**  
+**Example - Using a X Section Values**
 
 .. testcode:: XSectionValues
 
     ws = CreateSampleWorkspace()
     ws = ConvertUnits(ws,"Wavelength")
 
-    wsOut = CylinderAbsorption(ws, AttenuationXSection=5.08, 
-        ScatteringXSection=5.1,SampleNumberDensity=0.07192, 
-        NumberOfWavelengthPoints=5, CylinderSampleHeight=4, 
+    wsOut = CylinderAbsorption(ws, AttenuationXSection=5.08,
+        ScatteringXSection=5.1,SampleNumberDensity=0.07192,
+        NumberOfWavelengthPoints=5, CylinderSampleHeight=4,
         CylinderSampleRadius=0.4, NumberOfSlices=2, NumberOfAnnuli=2)
 
 
     print ("The Absorption correction is calculated to match the input workspace")
-    print ("  over %i bins, ranging from  %.2f to %.2f" % 
+    print ("  over %i bins, ranging from  %.2f to %.2f" %
         (wsOut.blocksize(),
         wsOut.readY(0)[0],
         wsOut.readY(0)[wsOut.blocksize()-1]))
@@ -84,7 +85,7 @@ Output:
       over 100 bins, ranging from  0.77 to 0.37
 
 
-**Example - Using a SetSampleMaterial**  
+**Example - Using a SetSampleMaterial**
 
 .. testcode:: XSectionValues
 
@@ -92,13 +93,13 @@ Output:
     ws = ConvertUnits(ws,"Wavelength")
     SetSampleMaterial(ws,ChemicalFormula='Cd')
 
-    wsOut = CylinderAbsorption(ws, 
-        NumberOfWavelengthPoints=5, CylinderSampleHeight=4, 
+    wsOut = CylinderAbsorption(ws,
+        NumberOfWavelengthPoints=5, CylinderSampleHeight=4,
         CylinderSampleRadius=0.4, NumberOfSlices=2, NumberOfAnnuli=2)
 
 
     print ("The Absorption correction is calculated to match the input workspace")
-    print ("  over %i bins, ranging from  %.2f to %.2f" % 
+    print ("  over %i bins, ranging from  %.2f to %.2f" %
         (wsOut.blocksize(),
         wsOut.readY(0)[0],
         wsOut.readY(0)[wsOut.blocksize()-1]))

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -87,7 +87,7 @@ Improvements
 - :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>` and :ref:`LoadNexusProcessed <algm-LoadNexusProcessed>` can now save and load a ``MaskWorkspace``.
 - :ref:`FitPeaks <algm-FitPeaks>` can output parameters' uncertainty (fitting error) in an optional workspace.
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
-- All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``).
+- All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``). If the sample shape is a cylinder it will use the specialized code for rasterizing it.
 - :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now will check the workspace's sample object for geometry
 - Various clarifications and additional links in the geometry and material documentation pages
 - :ref:`SetSample <algm-SetSample>` and :ref:`SetSampleMaterial <algm-SetSampleMaterial>` now accept materials without ``ChemicalFormula`` or ``AtomicNumber``. In this case, all cross sections and ``SampleNumberDensity`` have to be given.

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -88,6 +88,7 @@ Improvements
 - :ref:`FitPeaks <algm-FitPeaks>` can output parameters' uncertainty (fitting error) in an optional workspace.
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
 - All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``).
+- :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now will check the workspace's sample object for geometry
 - Various clarifications and additional links in the geometry and material documentation pages
 - :ref:`SetSample <algm-SetSample>` and :ref:`SetSampleMaterial <algm-SetSampleMaterial>` now accept materials without ``ChemicalFormula`` or ``AtomicNumber``. In this case, all cross sections and ``SampleNumberDensity`` have to be given.
 


### PR DESCRIPTION
The main point of this is to add support to `CylinderAbsorption` to get the sample information from the workspace's sample object rather than just the input parameters.

**To test:**

Reviewing the actual source is probably the best way. Some unit tests were added to provide better coverage.

Refs #23887

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
