### PR TITLE
Fix column types returned by TableWorkspace in Python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -303,20 +303,18 @@ PyObject *row(ITableWorkspace &self, int row) {
  * @param self A reference to the TableWorkspace python object that we were
  * called on
  */
-PyObject *columnTypes(ITableWorkspace &self) {
+boost::python::list columnTypes(ITableWorkspace &self) {
   int numCols = static_cast<int>(self.columnCount());
 
-  PyObject *list = PyList_New(numCols);
+  boost::python::list types;
 
   for (int col = 0; col < numCols; col++) {
-    Mantid::API::Column_const_sptr column = self.getColumn(col);
-    const std::type_info &typeID = column->get_type_info();
-    if (PyList_SetItem(list, col, FROM_CSTRING(typeID.name()))) {
-      throw std::runtime_error("Error while building list");
-    }
+    const auto column = self.getColumn(col);
+    const auto &type = column->type();
+    types.append(type);
   }
 
-  return list;
+  return types;
 }
 
 /**

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -211,12 +211,25 @@ class ITableWorkspaceTest(unittest.TestCase):
         table.addRow([3, 4])
         self.assertEquals(table.rowCount(), 2)
 
+    def test_column_types(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn(type="int",name="index")
+        table.addColumn(type="str",name="value")
+        table.addColumn(type="V3D",name="position")
+
+        types = table.columnTypes()
+
+        self.assertEqual(types[0], "int")
+        self.assertEqual(types[1], "str")
+        self.assertEqual(types[2], "V3D")
+
+
     def test_convert_to_dict(self):
         from mantid.kernel import V3D
         expected_output = {
-            'index': [1, 2], 
-            'value': ['10', '100'], 
-            'position': [V3D(0, 0, 1), V3D(1, 0, 0)] 
+            'index': [1, 2],
+            'value': ['10', '100'],
+            'position': [V3D(0, 0, 1), V3D(1, 0, 0)]
         }
 
         table = WorkspaceFactory.createTable()

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -145,6 +145,7 @@ Improvements
 - :ref:`ChudleyElliot <func-ChudleyElliot>` includes hbar in the definition
 - :ref:`Functions <FitFunctionsInPython>` may now have their constraint penalties for fitting set in python using ``function.setConstraintPenaltyFactor("parameterName", double)``.
 - :py:obj:`mantid.kernel.Logger` now handles unicode in python2
+- :py:meth:`mantid.api.ITableWorkspace.columnTypes` now returns human readable strings for non-primitive column types.
 
 
 Bugfixes


### PR DESCRIPTION
For more complex types such as V3D, the python API for TableWorkspace
used to return a incomprehensible string. Now it returns a proper
string type name.

**Description of work.**

Calling `.columnTypes()` on a table workspace from python with return rubbish strings for non-primitive types. e.g. I get something like:
```
>>> table.columnTypes()
['i',
 'i',
 'd',
 'd',
 'd',
 'd',
 'd',
 'd',
 'd',
 'd',
 'd',
 'd',
 'NSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE',
 'd',
 'd',
 'N6Mantid6Kernel3V3DE',
 'N6Mantid6Kernel3V3DE',
 'i']
```
Instead, with these changes I now get the following:
```
>>> table.columnTypes()
['int',
 'int',
 'double',
 'double',
 'double',
 'double',
 'double',
 'double',
 'double',
 'double',
 'double',
 'double',
 'str',
 'double',
 'double',
 'V3D',
 'V3D',
 'int']
```

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
Not much to test. 
 - Check tests pass.
 - Code review.

*There is no associated issue.*

I added a note to the `framework.rst` release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
