### PR TITLE
LoadEventAndCompress reads logs less often

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -285,7 +285,8 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             # get the underlying loader name if we used the generic one
             if self.__loaderName == 'Load':
                 self.__loaderName = loader.getPropertyValue('LoaderName')
-            canSkipLoadingLogs = self.__loaderName == 'LoadEventNexus'
+            # only LoadEventNexus can turn off loading logs, but FilterBadPulses requires them to be loaded from the file
+            canSkipLoadingLogs = self.__loaderName == 'LoadEventNexus' and self.filterBadPulses <= 0.
 
             if determineCharacterizations and j == 0:
                 self.__determineCharacterizations(filename, chunkname)  # updates instance variable

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/LoadEventAndCompress.h
@@ -30,8 +30,7 @@ protected:
   API::ITableWorkspace_sptr
   determineChunk(const std::string &filename) override;
   API::MatrixWorkspace_sptr loadChunk(const size_t rowIndex) override;
-  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp,
-                                         double filterBadPulses);
+  API::MatrixWorkspace_sptr processChunk(API::MatrixWorkspace_sptr &wksp);
 
   Parallel::ExecutionMode getParallelExecutionMode(
       const std::map<std::string, Parallel::StorageMode> &storageModes)
@@ -42,6 +41,7 @@ private:
   void exec() override;
 
   API::ITableWorkspace_sptr m_chunkingTable;
+  double m_filterBadPulses;
 };
 
 } // namespace WorkflowAlgorithms

--- a/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
+++ b/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
@@ -20,7 +20,7 @@ using namespace Mantid::API;
 
 namespace {
 const std::string FILENAME{"ARCS_sim_event.nxs"};
-const double CHUNKSIZE{.005}; // REALLY small file
+const double CHUNKSIZE{.00001}; // REALLY small file
 const size_t NUMEVENTS(117760);
 } // anonymous namespace
 

--- a/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
+++ b/Framework/WorkflowAlgorithms/test/LoadEventAndCompressTest.h
@@ -18,7 +18,14 @@ using Mantid::WorkflowAlgorithms::LoadEventAndCompress;
 using namespace Mantid::DataObjects;
 using namespace Mantid::API;
 
+namespace {
+const std::string FILENAME{"ARCS_sim_event.nxs"};
+const double CHUNKSIZE{.005}; // REALLY small file
+const size_t NUMEVENTS(117760);
+} // anonymous namespace
+
 class LoadEventAndCompressTest : public CxxTest::TestSuite {
+
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -34,8 +41,6 @@ public:
   }
 
   void test_exec() {
-    const std::string FILENAME("ARCS_sim_event.nxs");
-
     // run without chunks
     const std::string WS_NAME_NO_CHUNKS("LoadEventAndCompress_no_chunks");
     LoadEventAndCompress algWithoutChunks;
@@ -57,6 +62,7 @@ public:
     if (!wsNoChunks)
       return;
     TS_ASSERT_EQUALS(wsNoChunks->getEventType(), EventType::WEIGHTED_NOTIME);
+    TS_ASSERT_EQUALS(wsNoChunks->getNEvents(), NUMEVENTS);
 
     // run without chunks
     const std::string WS_NAME_CHUNKS("LoadEventAndCompress_chunks");
@@ -68,7 +74,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         algWithChunks.setPropertyValue("OutputWorkspace", WS_NAME_CHUNKS));
     TS_ASSERT_THROWS_NOTHING(
-        algWithChunks.setProperty("MaxChunkSize", .005)); // REALLY small file
+        algWithChunks.setProperty("MaxChunkSize", CHUNKSIZE));
     TS_ASSERT_THROWS_NOTHING(algWithChunks.execute(););
     TS_ASSERT(algWithChunks.isExecuted());
 
@@ -83,6 +89,7 @@ public:
     if (!wsWithChunks)
       return;
     TS_ASSERT_EQUALS(wsWithChunks->getEventType(), EventType::WEIGHTED_NOTIME);
+    TS_ASSERT_EQUALS(wsWithChunks->getNEvents(), NUMEVENTS);
 
     // compare the two workspaces
     TS_ASSERT_EQUALS(wsWithChunks->getNumberEvents(),
@@ -96,6 +103,34 @@ public:
     // Remove workspace from the data service.
     AnalysisDataService::Instance().remove(WS_NAME_NO_CHUNKS);
     AnalysisDataService::Instance().remove(WS_NAME_CHUNKS);
+  }
+
+  void test_execNoFilter() {
+    // run without chunks
+    const std::string WS_NAME("LoadEventAndCompress_no_filter");
+    LoadEventAndCompress alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", FILENAME));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("FilterBadPulses", "0"));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxChunkSize", CHUNKSIZE));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", WS_NAME));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from data service
+    EventWorkspace_sptr wksp;
+    TS_ASSERT_THROWS_NOTHING(
+        wksp = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(
+            WS_NAME));
+    TS_ASSERT(wksp);
+    if (!wksp)
+      return;
+    TS_ASSERT_EQUALS(wksp->getEventType(), EventType::WEIGHTED_NOTIME);
+    TS_ASSERT_EQUALS(wksp->getNEvents(), NUMEVENTS);
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove(WS_NAME);
   }
 };
 


### PR DESCRIPTION
Don't read in the logs for chunks past the first one.

This trades reading the logs from disk to running an algorithm. Since the logs are only needed for `FilterBadPulses` this checks for that being required as well.

This is a very similar technique to what was used in #24412.

**To test:**

Try using it with small enough chunks that it will accumulate data.

*There is no associated issue.*

*This does not require release notes* because it is a minor performance improvement.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
