### PR TITLE
TableWorkspaceDisplay column sort changes the workspace in the ADS

### DIFF
--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/model.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/model.py
@@ -107,7 +107,8 @@ class TableWorkspaceDisplayModel:
     def sort(self, column_index, sort_ascending):
         column_name = self.ws.getColumnNames()[column_index]
         if self.is_peaks_workspace():
-            SortPeaksWorkspace(self.ws, ColumnNameToSortBy=column_name, SortAscending=sort_ascending)
+            SortPeaksWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ws, ColumnNameToSortBy=column_name,
+                               SortAscending=sort_ascending)
         else:
-            SortTableWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ws, Columns=[column_name],
-                               Ascending=[sort_ascending])
+            SortTableWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ws, Columns=column_name,
+                               Ascending=sort_ascending)

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/model.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/model.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from mantid.dataobjects import PeaksWorkspace, TableWorkspace
 from mantid.kernel import V3D
+from mantid.simpleapi import DeleteTableRows, SortPeaksWorkspace, SortTableWorkspace, StatisticsOfTableWorkspace
 from mantidqt.widgets.tableworkspacedisplay.marked_columns import MarkedColumns
 
 
@@ -95,3 +96,18 @@ class TableWorkspaceDisplayModel:
 
     def workspace_equals(self, workspace_name):
         return self.ws.name() == workspace_name
+
+    def delete_rows(self, selected_rows):
+        DeleteTableRows(self.ws, selected_rows)
+
+    def get_statistics(self, selected_columns):
+        stats = StatisticsOfTableWorkspace(self.ws, selected_columns)
+        return stats
+
+    def sort(self, column_index, sort_ascending):
+        column_name = self.ws.getColumnNames()[column_index]
+        if self.is_peaks_workspace():
+            SortPeaksWorkspace(self.ws, ColumnNameToSortBy=column_name, SortAscending=sort_ascending)
+        else:
+            SortTableWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ws, Columns=[column_name],
+                               Ascending=[sort_ascending])

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
@@ -56,7 +56,7 @@ class TableWorkspaceDisplay(ObservingPresenter):
         """
 
         self.model = model if model else TableWorkspaceDisplayModel(ws)
-        self.name = self.model.get_name() if name is None else name
+        self.name = name if name else self.model.get_name()
         self.view = view if view else TableWorkspaceDisplayView(self, parent, self.name)
         self.parent = parent
         self.plot = plot
@@ -83,6 +83,9 @@ class TableWorkspaceDisplay(ObservingPresenter):
     def replace_workspace(self, workspace_name, workspace):
         if self.model.workspace_equals(workspace_name):
             self.model = TableWorkspaceDisplayModel(workspace)
+            # block signals to prevent triggering of handleItemChanged event
+            # which causes an infinite recursion and a stack overflow error
+            self.view.blockSignals(True)
             self.load_data(self.view)
             self.view.emit_repaint()
 

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
@@ -83,9 +83,6 @@ class TableWorkspaceDisplay(ObservingPresenter):
     def replace_workspace(self, workspace_name, workspace):
         if self.model.workspace_equals(workspace_name):
             self.model = TableWorkspaceDisplayModel(workspace)
-            # block signals to prevent triggering of handleItemChanged event
-            # which causes an infinite recursion and a stack overflow error
-            self.view.blockSignals(True)
             self.load_data(self.view)
             self.view.emit_repaint()
 
@@ -160,11 +157,6 @@ class TableWorkspaceDisplay(ObservingPresenter):
         selected_rows_str = ",".join([str(row) for row in selected_rows_list])
 
         self.model.delete_rows(selected_rows_str)
-
-        # Reverse the list so that we delete in order from bottom -> top
-        # this prevents the row index from shifting up when deleting rows above
-        for row in reversed(selected_rows_list):
-            self.view.removeRow(row)
 
     def _get_selected_columns(self, max_selected=None, message_if_over_max=None):
         selection_model = self.view.selectionModel()

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/presenter.py
@@ -14,7 +14,6 @@ from functools import partial
 from qtpy.QtCore import Qt
 
 from mantid.kernel import logger
-from mantid.simpleapi import DeleteTableRows, StatisticsOfTableWorkspace
 from mantidqt.widgets.common.observing_presenter import ObservingPresenter
 from mantidqt.widgets.common.table_copying import copy_cells, show_no_selection_to_copy_toast
 from mantidqt.widgets.common.workspacedisplay_ads_observer import WorkspaceDisplayADSObserver
@@ -157,7 +156,8 @@ class TableWorkspaceDisplay(ObservingPresenter):
         selected_rows_list = [index.row() for index in selected_rows]
         selected_rows_str = ",".join([str(row) for row in selected_rows_list])
 
-        DeleteTableRows(self.model.ws, selected_rows_str)
+        self.model.delete_rows(selected_rows_str)
+
         # Reverse the list so that we delete in order from bottom -> top
         # this prevents the row index from shifting up when deleting rows above
         for row in reversed(selected_rows_list):
@@ -181,7 +181,10 @@ class TableWorkspaceDisplay(ObservingPresenter):
             show_no_selection_to_copy_toast()
             raise ValueError("No selection")
         else:
-            return [index.column() for index in selected_columns]
+            col_selected = [index.column() for index in selected_columns]
+            if max_selected == 1:
+                return col_selected[0]
+            return col_selected
 
     def action_statistics_on_columns(self):
         try:
@@ -189,7 +192,7 @@ class TableWorkspaceDisplay(ObservingPresenter):
         except ValueError:
             return
 
-        stats = StatisticsOfTableWorkspace(self.model.ws, selected_columns)
+        stats = self.model.get_statistics(selected_columns)
         TableWorkspaceDisplay(stats, parent=self.parent, name="Column Statistics of {}".format(self.name))
 
     def action_hide_selected(self):
@@ -229,11 +232,10 @@ class TableWorkspaceDisplay(ObservingPresenter):
                             This will be the number in <ColumnName>[Y10] -> the 10
         """
         try:
-            selected_columns = self._get_selected_columns(1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE)
+            selected_column = self._get_selected_columns(1, self.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE)
         except ValueError:
             return
 
-        selected_column = selected_columns[0]
         try:
             err_column = ErrorColumn(selected_column, related_y_column, label_index)
         except ValueError as e:
@@ -246,14 +248,17 @@ class TableWorkspaceDisplay(ObservingPresenter):
     def action_set_as_none(self):
         self._action_set_as(self.model.marked_columns.remove)
 
-    def action_sort(self, order):
+    def action_sort(self, sort_ascending):
+        """
+        :type sort_ascending: bool
+        :param sort_ascending: Whether to sort ascending
+        """
         try:
-            selected_columns = self._get_selected_columns(1, self.TOO_MANY_SELECTED_TO_SORT)
+            selected_column = self._get_selected_columns(1, self.TOO_MANY_SELECTED_TO_SORT)
         except ValueError:
             return
 
-        selected_column = selected_columns[0]
-        self.view.sortByColumn(selected_column, order)
+        self.model.sort(selected_column, sort_ascending)
 
     def action_plot(self, plot_type):
         try:

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/test/test_tableworkspacedisplay_workbench_table_widget_item.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/test/test_tableworkspacedisplay_workbench_table_widget_item.py
@@ -74,24 +74,6 @@ class WorkbenchTableWidgetItemTest(unittest.TestCase):
         self.assertEqual(mock_data, w.data(Qt.DisplayRole))
         self.assertEqual(mock_data, w.display_data)
 
-    def test_lt(self):
-        """
-        Test that the widget properly compares with other widgets.
-
-        :return:
-        """
-        w1 = WorkbenchTableWidgetItem(500, editable=False)
-        w2 = WorkbenchTableWidgetItem(1500, editable=False)
-        self.assertTrue(w1 < w2)
-
-        w1 = WorkbenchTableWidgetItem(100.40, editable=False)
-        w2 = WorkbenchTableWidgetItem(100.41, editable=False)
-        self.assertTrue(w1 < w2)
-
-        w1 = WorkbenchTableWidgetItem("apples", editable=False)
-        w2 = WorkbenchTableWidgetItem("potatoes", editable=False)
-        self.assertTrue(w1 < w2)
-
     def test_reset(self):
         w = WorkbenchTableWidgetItem(500, editable=False)
 

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
@@ -178,10 +178,10 @@ class TableWorkspaceDisplayView(QTableWidget, ObservingView):
         show_all_columns.triggered.connect(self.presenter.action_show_all_columns)
 
         sort_ascending = QAction("Sort Ascending", menu_main)
-        sort_ascending.triggered.connect(partial(self.presenter.action_sort, Qt.AscendingOrder))
+        sort_ascending.triggered.connect(partial(self.presenter.action_sort, True))
 
         sort_descending = QAction("Sort Descending", menu_main)
-        sort_descending.triggered.connect(partial(self.presenter.action_sort, Qt.DescendingOrder))
+        sort_descending.triggered.connect(partial(self.presenter.action_sort, False))
 
         menu_main.addAction(copy_bin_values)
         menu_main.addAction(self.make_separator(menu_main))

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/view.py
@@ -178,10 +178,10 @@ class TableWorkspaceDisplayView(QTableWidget, ObservingView):
         show_all_columns.triggered.connect(self.presenter.action_show_all_columns)
 
         sort_ascending = QAction("Sort Ascending", menu_main)
-        sort_ascending.triggered.connect(partial(self.presenter.action_sort, True))
+        sort_ascending.triggered.connect(partial(self.presenter.action_sort, Qt.AscendingOrder))
 
         sort_descending = QAction("Sort Descending", menu_main)
-        sort_descending.triggered.connect(partial(self.presenter.action_sort, False))
+        sort_descending.triggered.connect(partial(self.presenter.action_sort, Qt.DescendingOrder))
 
         menu_main.addAction(copy_bin_values)
         menu_main.addAction(self.make_separator(menu_main))

--- a/qt/python/mantidqt/widgets/tableworkspacedisplay/workbench_table_widget_item.py
+++ b/qt/python/mantidqt/widgets/tableworkspacedisplay/workbench_table_widget_item.py
@@ -34,26 +34,6 @@ class WorkbenchTableWidgetItem(QTableWidgetItem):
         else:
             raise RuntimeError("'{}' is not a valid V3D string.".format(string))
 
-    def __lt__(self, other):
-        """
-        Overrides the comparison to other items. Used to provide correct sorting for types Qt doesn't handle
-        like V3D. Additionally, it makes sure strings are converted to floats for correct comparison.
-
-        This is necessary because if the data is a float then it is stored as a string.
-
-        :type other: WorkbenchTableWidgetItem
-        :param other: Other item that will be compared against
-        :return:
-        """
-        if self.is_v3d:
-            return self._get_v3d_from_str(self.data(Qt.DisplayRole)) < self._get_v3d_from_str(
-                other.data(Qt.DisplayRole))
-        try:
-            # if the data can be parsed as numbers then compare properly, otherwise default to the Qt implementation
-            return float(self.data(Qt.DisplayRole)) < float(other.data(Qt.DisplayRole))
-        except:
-            return super(WorkbenchTableWidgetItem, self).__lt__(other)
-
     def reset(self):
         self.setData(Qt.DisplayRole, self.display_data)
 


### PR DESCRIPTION
**Description of work.**
Changes the table sorting to use SortTable/PeaksWorkspace, so that the sorting is reflected in the ADS.

**To test:**
Open table workspace, right click a column and sort. Open the workspace anew, and it should look the same as the old window - meaning it has been changed 

This PR is dependent on ~~#24563~~ 

Fixes #24547 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
