### PR TITLE
Add RunNumber to Each Workspace in Multi-Period Event Data

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -688,6 +688,17 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     m_ws->mutableRun().addProperty("run_start", run_start.toISO8601String(),
                                    true);
   }
+  // set more properties on the workspace
+  try {
+    // this is a static method that is why it is passing the
+    // file object and the file path
+    loadEntryMetadata<EventWorkspaceCollection_sptr>(m_filename, m_ws,
+                                                     m_top_entry_name);
+  } catch (std::runtime_error &e) {
+    // Missing metadata is not a fatal error. Log and go on with your life
+    g_log.error() << "Error loading metadata: " << e.what() << '\n';
+  }
+  
   m_ws->setNPeriods(
       static_cast<size_t>(nPeriods),
       periodLog); // This is how many workspaces we are going to make.
@@ -775,17 +786,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
   std::string outName = getPropertyValue("OutputWorkspace");
   if (AnalysisDataService::Instance().doesExist(outName))
     AnalysisDataService::Instance().remove(outName);
-
-  // set more properties on the workspace
-  try {
-    // this is a static method that is why it is passing the
-    // file object and the file path
-    loadEntryMetadata<EventWorkspaceCollection_sptr>(m_filename, m_ws,
-                                                     m_top_entry_name);
-  } catch (std::runtime_error &e) {
-    // Missing metadata is not a fatal error. Log and go on with your life
-    g_log.error() << "Error loading metadata: " << e.what() << '\n';
-  }
 
   // --------------------------- Time filtering
   // ------------------------------------

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -698,7 +698,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     // Missing metadata is not a fatal error. Log and go on with your life
     g_log.error() << "Error loading metadata: " << e.what() << '\n';
   }
-  
+
   m_ws->setNPeriods(
       static_cast<size_t>(nPeriods),
       periodLog); // This is how many workspaces we are going to make.


### PR DESCRIPTION
**Description of work.**
Swap the ordering of adding information to logs in `LoadEventNexus` so that metadata is added before we copy the metadata to each workspace in the collection

**Report to:** nobody

**To test:**
In Mantid, load `LARMOR13065`. (this is in ExternalData/Testing/Data/SystemTest/LARMOR of your build directory)
This should produce a group workspace with 4 constituents.
Right click on each individual workspace and click `sample logs`.
The logs should contain mostly the same elements, but this PR is specifically to ensure that each workspace has the property `run number`, and the value should be 13065 in each workspace.

Fixes #24583 

*This does not require release notes* because **internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
