### PR TITLE
Add Python API docs for RebinParamsValidator

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/RebinParamsValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/RebinParamsValidator.cpp
@@ -26,5 +26,7 @@ void export_RebinParamsValidator() {
       .def("__init__",
            make_constructor(
                &createRebinParamsValidator, default_call_policies(),
-               (arg("AllowEmpty") = false, arg("AllowRange") = false)));
+               (arg("AllowEmpty") = false, arg("AllowRange") = false)),
+           "Constructs a validator verifying that the given float array is "
+           "valid sequence of rebinning parameters.");
 }

--- a/docs/source/api/python/mantid/kernel/RebinParamsValidator.rst
+++ b/docs/source/api/python/mantid/kernel/RebinParamsValidator.rst
@@ -1,0 +1,15 @@
+======================
+ RebinParamsValidator
+======================
+
+This is a Python binding to the C++ class Mantid::Kernel::RebinParamsValidator.
+
+*bases:* :py:obj:`mantid.kernel.IValidator`
+
+.. module:`mantid.kernel`
+
+.. autoclass:: mantid.kernel.RebinParamsValidator 
+    :members:
+    :undoc-members:
+    :inherited-members:
+


### PR DESCRIPTION
Add the missing `.rst` file and docstring for `RebinParamsValidator`.

**Report to:** [nobody].

**To test:**

Build the `all` and `docs-html` targets and check that the documentation for `mantid.kernel.RebinParamsValidator` appears in the correct place.

*There is no associated issue.*

*This does not require release notes* because it is an insignificant addition to the API docs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
