### PR TITLE
Fix transient imports, destroy toolbar on widgetclosed

### DIFF
--- a/qt/applications/workbench/workbench/plotting/backend_workbench.py
+++ b/qt/applications/workbench/workbench/plotting/backend_workbench.py
@@ -19,19 +19,15 @@ from __future__ import (absolute_import, division, print_function,
 # std imports
 import importlib
 
-
+# local imports
+from matplotlib.backends.backend_qt5agg import (draw_if_interactive as draw_if_interactive_impl,
+                                                show as show_impl)  # noqa
 # 3rd party imports
 # Put these first so that the correct Qt version is selected by qtpy
 from qtpy import QT_VERSION
 
-# local imports
-from workbench.plotting.figuremanager import (backend_version,  # noqa
-    draw_if_interactive as draw_if_interactive_impl,
-    new_figure_manager as new_figure_manager_impl,
-    new_figure_manager_given_figure as new_figure_manager_given_figure_impl,
-    show as show_impl,
-    QAppThreadCall
-)
+from workbench.plotting.figuremanager import (QAppThreadCall, new_figure_manager as new_figure_manager_impl,
+                                              new_figure_manager_given_figure as new_figure_manager_given_figure_impl)
 
 # Import the *real* matplotlib backend for the canvas
 mpl_qtagg_backend = importlib.import_module('matplotlib.backends.backend_qt{}agg'.format(QT_VERSION[0]))
@@ -39,7 +35,6 @@ try:
     FigureCanvas = getattr(mpl_qtagg_backend, 'FigureCanvasQTAgg')
 except KeyError:
     raise ImportError("Unknown form of matplotlib Qt backend.")
-
 
 # -----------------------------------------------------------------------------
 # Backend implementation

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -259,6 +259,15 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         del self._ads_observer
         for id in self._cids:
             self.canvas.mpl_disconnect(id)
+        self.window.close()
+
+        try:
+            Gcf.destroy(self.num)
+        except AttributeError:
+            pass
+            # It seems that when the python session is killed,
+            # Gcf can get destroyed before the Gcf.destroy
+            # line is run, leading to a useless AttributeError.
 
     def grid_toggle(self):
         """

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -215,6 +215,11 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         Gcf.set_active(self)
 
     def _widgetclosed(self):
+        # this method is called both if the user closes the window through the X
+        # and if they select the plot in plot manager and click delete
+        if self.toolbar:
+            self.toolbar.destroy()
+
         if self.window._destroying:
             return
         self.window._destroying = True
@@ -231,7 +236,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             # line is run, leading to a useless AttributeError.
 
     def _get_toolbar(self, canvas, parent):
-            return WorkbenchNavigationToolbar(canvas, parent, False)
+        return WorkbenchNavigationToolbar(canvas, parent, False)
 
     def resize(self, width, height):
         'set the canvas size in pixels'
@@ -267,8 +272,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             return
         self.window._destroying = True
         self.window.destroyed.connect(self._widgetclosed)
-        if self.toolbar:
-            self.toolbar.destroy()
         self.window.close()
 
     def grid_toggle(self):


### PR DESCRIPTION
**Description of work.**
A couple of transient imports were detected (draw_if_interactive and show) they were imported in `workbench.plotting.figuremanager` but not used.

The `figuremanager` now destroys the toolbar in the `widgetclose` event, which is called both when user clicks `X`, and when it is `Deleted` from the plot manager. Previously if the user clicked X, the `widgetclose` event was never called, and the toolbar never destroyed, because [this would throw the exception as the comment describes](https://github.com/DTasev/mantid/blob/24537_workbench_plot_toolbar_bug/qt/applications/workbench/workbench/plotting/figuremanager.py#L234), so `Gcf.destroy()` never got executed -> and the toolbar was being deleted in the `destroy` event.

**To test:**
Open a plot, move the toolbar outside the window, close the plot via:
- Clicking X
- Selecting in plot manager and clicking delete

<!-- Instructions for testing. -->

Fixes #24537 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
