### PR TITLE
Indirect IqtFit - Prevent a crash with Plot Current Preview

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
@@ -12,6 +12,7 @@
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include "MantidKernel/make_unique.h"
 
 namespace {
@@ -100,6 +101,11 @@ void setFirstBackground(IFunction_sptr function, double value) {
   firstFunctionWithParameter(function, "Background", "A0")
       ->setParameter("A0", value);
 }
+
+MatrixWorkspace_sptr castToMatrixWorkspace(Workspace_sptr workspace) {
+  return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+}
+
 } // namespace
 
 namespace MantidQt {
@@ -242,8 +248,8 @@ MatrixWorkspace_sptr IndirectFitPlotModel::getResultWorkspace() const {
 
   if (location) {
     const auto group = location->result.lock();
-    return boost::dynamic_pointer_cast<MatrixWorkspace>(
-        group->getItem(location->index));
+    if (group)
+      return castToMatrixWorkspace(group->getItem(location->index));
   }
   return nullptr;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.cpp
@@ -317,7 +317,8 @@ void IndirectFitPlotPresenter::updateFitRangeSelector() {
 }
 
 void IndirectFitPlotPresenter::plotCurrentPreview() {
-  if (m_model->getWorkspace()) {
+  const auto inputWorkspace = m_model->getWorkspace();
+  if (inputWorkspace && !inputWorkspace->getName().empty()) {
     const auto plotString = getPlotString(m_model->getActiveSpectrum());
     m_pythonRunner.runPythonCode(QString::fromStdString(plotString));
   } else

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -17,6 +17,10 @@ using MantidQt::API::BatchAlgorithmRunner;
 
 namespace {
 
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
 MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
   return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
       workspaceName);
@@ -198,9 +202,11 @@ void IndirectSqw::plotRqwContour() {
 
     convertToSpectrumAxis(sampleName, outputName);
 
-    auto const rqwWorkspace = getADSMatrixWorkspace(outputName);
-    if (rqwWorkspace)
-      m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);
+    if (doesExistInADS(outputName)) {
+      auto const rqwWorkspace = getADSMatrixWorkspace(outputName);
+      if (rqwWorkspace)
+        m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);
+    }
   } else {
     emit showMessageBox("Invalid filename.");
   }

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -17,10 +17,6 @@ using MantidQt::API::BatchAlgorithmRunner;
 
 namespace {
 
-bool doesExistInADS(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().doesExist(workspaceName);
-}
-
 MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
   return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
       workspaceName);
@@ -202,7 +198,7 @@ void IndirectSqw::plotRqwContour() {
 
     convertToSpectrumAxis(sampleName, outputName);
 
-    if (doesExistInADS(outputName)) {
+    if (AnalysisDataService::Instance().doesExist(outputName)) {
       auto const rqwWorkspace = getADSMatrixWorkspace(outputName);
       if (rqwWorkspace)
         m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);


### PR DESCRIPTION
**Description of work.**
This PR prevents a crash in Indirect Data Analysis IqtFit interface when clicking Plot Current Preview after deleting the result data of a fit.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`IqtFit` interface
2. Load the data below
3. Set the number of exponentials to 2.
4. Select a `Flat Background`
4. Slide the the EndX slider slightly to the left
5. Click Run and wait
6. Delete all of the output workspaces (not the input one)
7. Click `Plot Current Preview`, there should be no crash - just a plot of the input data.

**Data Files**
[irs26176_graphite002_iqt.zip](https://github.com/mantidproject/mantid/files/2802302/irs26176_graphite002_iqt.zip)

Fixes #24611 

I think no release notes are required as the users do not know about this bug.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
