### PR TITLE
Prevent crash when deleting workspace with an open plot

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -64,7 +64,7 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
         """
         Called when the ADS is deleted all of its workspaces
         """
-        self.window.close()
+        self.window.emit_close()
 
     @_catch_exceptions
     def deleteHandle(self, _, workspace):
@@ -85,7 +85,7 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
             if isinstance(ax, MantidAxes):
                 empty_axes = empty_axes & ax.remove_workspace_artists(workspace)
         if empty_axes:
-            self.window.close()
+            self.window.emit_close()
         else:
             self.canvas.draw_idle()
 

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -14,25 +14,32 @@ from __future__ import absolute_import
 import weakref
 
 # 3rdparty imports
-from qtpy.QtCore import QEvent, Signal
+from qtpy.QtCore import QEvent, Signal, Slot
 from qtpy.QtWidgets import QMainWindow
 
 # local imports
-from mantidqt.plotting.figuretype import figure_type, FigureType
+from mantidqt.plotting.figuretype import FigureType, figure_type
+from mantidqt.widgets.common.observing_view import ObservingView
 
 
-class FigureWindow(QMainWindow):
+class FigureWindow(QMainWindow, ObservingView):
     """A MainWindow that will hold plots"""
     activated = Signal()
     closing = Signal()
     visibility_changed = Signal()
+    close_signal = Signal()
 
     def __init__(self, canvas, parent=None):
         QMainWindow.__init__(self, parent=parent)
         # attributes
         self._canvas = weakref.proxy(canvas)
+        self.close_signal.connect(self._run_close)
 
         self.setAcceptDrops(True)
+
+    @Slot()
+    def _run_close(self):
+        self.close()
 
     def event(self, event):
         if event.type() == QEvent.WindowActivate:


### PR DESCRIPTION
**Description of work.**
This fixes a crash on Windows for making a call from the C++ thread to
the GUI thread. Instead, the call now emits a signal that runs close in the GUI thread. This uses the same pattern as Matrix/Table displays, and the Instrument view.

**To test:**
> Note: the original crash can only be replicated on Windows, but this fix should work on all OSs.

Load a workspace, plot a spectra and delete it. The plot window should close, and workspace deleted.

<!-- Instructions for testing. -->

Fixes #24617 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
