### PR TITLE
Moved the place where sample closeGroup was called

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -636,7 +636,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
 
   // get the sample name - nested try/catch to leave the handle in an
   // appropriate state
-  try {
+  if (exists(file, "sample")) {
     file.openGroup("sample", "NXsample");
     try {
       if (exists(file, "name")) {
@@ -666,8 +666,6 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
       // let it drop on floor if an exception occurs while reading sample
     }
     file.closeGroup();
-  } catch (::NeXus::Exception &) {
-    // If an exception occurs while opening the group "sample"
   }
 
   // get the duration

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -652,12 +652,10 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
                 std::multiplies<int64_t>());
             boost::scoped_array<char> val_array(new char[total_length]);
             file.getData(val_array.get());
-            file.closeData();
             name = std::string(val_array.get(), total_length);
           }
         }
         file.closeData();
-
         if (!name.empty()) {
           WS->mutableSample().setName(name);
         }

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -196,6 +196,25 @@ public:
 
   void test_SingleBank_PixelsOnlyInThatBank() { doTestSingleBank(true, false); }
 
+  void test_load_event_nexus_ornl_eqsans() {
+    // This file has a 2D entry/sample/name
+    const std::string file = "EQSANS_89157.nxs.h5";
+    LoadEventNexus alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("Filename", file);
+    alg.setProperty("MetaDataOnly", true);
+    alg.setProperty("OutputWorkspace", "dummy_for_child");
+    alg.execute();
+    Workspace_sptr ws = alg.getProperty("OutputWorkspace");
+    auto eventWS = boost::dynamic_pointer_cast<EventWorkspace>(ws);
+    TS_ASSERT(eventWS);
+    const double duration =
+        eventWS->mutableRun().getPropertyValueAsType<double>("duration");
+    TS_ASSERT_DELTA(duration, 7200.012, 0.01);
+  }
+
   void test_Normal_vs_Precount() {
     Mantid::API::FrameworkManager::Instance();
     LoadEventNexus ld;

--- a/Testing/Data/UnitTest/EQSANS_89157.nxs.h5.md5
+++ b/Testing/Data/UnitTest/EQSANS_89157.nxs.h5.md5
@@ -1,0 +1,1 @@
+b085aeef3c4d4b585a1109c9adb018b1


### PR DESCRIPTION
**Description of work.**

Just moved the `file.closeGroup();`.
An exception was happening after the `file.openGroup("sample", "NXsample");` and the `file.closeGroup();` was never called.

**To test:**

<!-- Instructions for testing. -->

- Tests should pass
- Using any EQSANS SNS files, one should see `duration` in the logs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
