### PR TITLE
ISIS reflectometry workflow algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometrySliceEventWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometrySliceEventWorkspace.py
@@ -78,7 +78,15 @@ class ReflectometrySliceEventWorkspace(DataProcessorAlgorithm):
         alg.setProperty("ExcludeSpecifiedLogs", False)
         alg.setProperty("TimeSeriesPropertyLogs", 'proton_charge')
         alg.execute()
-        return mtd[self._output_ws_group_name]
+        # Ensure the run number for the child workspaces is stored in the
+        # sample logs as a string (FilterEvents converts it to a double).
+        group = mtd[self._output_ws_group_name]
+        for ws in group:
+            if ws.run().hasProperty('run_number'):
+                run_number = int(ws.run()['run_number'].value)
+                AddSampleLog(Workspace=ws, LogName='run_number', LogType='String',
+                             LogText=str(run_number))
+        return group
 
     def _scale_monitors_for_each_slice(self, sliced_ws_group):
         """Create a group workspace which contains a copy of the monitors workspace for

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -128,7 +128,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         """Copy properties from the child reduction algorithm"""
         self._reduction_properties = [
             'SummationType', 'ReductionType', 'IncludePartialBins',
-            'AnalysisMode', 'ProcessingInstructions', 'CorrectDetectors',
+            'AnalysisMode', 'ProcessingInstructions', 'ThetaIn', 'ThetaLogName', 'CorrectDetectors',
             'DetectorCorrectionType', 'WavelengthMin', 'WavelengthMax', 'I0MonitorIndex',
             'MonitorBackgroundWavelengthMin', 'MonitorBackgroundWavelengthMax',
             'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
@@ -182,7 +182,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             # Check that the monitors workspace is also loaded
             if not AnalysisDataService.doesExist(workspace_name + '_monitors'):
                 self.log().information('Workspace ' + workspace_name + ' exists but ' +
-                                       workspace + '_monitors does not')
+                                       workspace_name + '_monitors does not')
                 return False
         else:
             # If not slicing, check that it's a Workspace2D

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -186,7 +186,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         """Return true if the given workspace exists in the ADS and is
         a valid reflectometry event workspace."""
         valid = True
-        if not _isEventWorkspace(workspace_name):
+        if not _hasWorkspaceID(workspace_name, "EventWorkspace"):
             self.log().information('Workspace ' + workspace_name +
                                    ' exists but is not an event workspace')
             valid = False
@@ -202,7 +202,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         """Return true if the given workspace exists in the ADS and is
         a valid reflectometry histogram workspace."""
         valid = True
-        if not _isWorkspace2D(workspace_name):
+        if not _hasWorkspaceID(workspace_name, "Workspace2D"):
             self.log().information('Workspace ' + workspace_name +
                                    ' exists but is not a Workspace2D')
             valid = False
@@ -406,20 +406,12 @@ def _getRunNumberAsString(workspace_name):
         raise RuntimeError('Could not find run number for workspace ' + workspace_name)
 
 
-def _isEventWorkspace(workspace_name):
+def _hasWorkspaceID(workspace_name, workspace_id):
     workspace = AnalysisDataService.retrieve(workspace_name)
     if isinstance(workspace, WorkspaceGroup):
-        return workspace[0].id() == "EventWorkspace"
+        return workspace[0].id() == workspace_id
     else:
-        return workspace.id() == "EventWorkspace"
-
-
-def _isWorkspace2D(workspace_name):
-    workspace = AnalysisDataService.retrieve(workspace_name)
-    if isinstance(workspace, WorkspaceGroup):
-        return workspace[0].id() == "Workspace2D"
-    else:
-        return workspace.id() == "Workspace2D"
+        return workspace.id() == workspace_id
 
 
 def _removeWorkspace(workspace_name):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -277,7 +277,8 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         # The reduction algorithm sets the output workspace names from the run number,
         # which by default is just the first run. Set it to the concatenated name,
         # e.g. 13461+13462
-        _setRunNumberForWorkspace(summed, concatenated_names)
+        ws = AnalysisDataService.retrieve(summed)
+        ws.run().addProperty('run_number', concatenated_names, True)
         return summed
 
     def _slicingEnabled(self):
@@ -377,12 +378,6 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         if value:
             self.setPropertyValue(property_name, value)
             self.setProperty(property_name, child_alg.getProperty(property_name).value)
-
-
-def _setRunNumberForWorkspace(workspace_name, run_number):
-    """Set the run number in the sample log for the given workspace"""
-    AddSampleLog(Workspace=workspace_name, LogName='run_number', LogText=str(run_number),
-                 LogType='String')
 
 
 def _throwIfNotValidReflectometryEventWorkspace(workspace_name):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -11,8 +11,7 @@ from __future__ import (absolute_import, division, print_function)
 from mantid.api import (AlgorithmFactory, AnalysisDataService, DataProcessorAlgorithm,
                         PropertyMode, WorkspaceGroup, WorkspaceProperty)
 
-from mantid.simpleapi import (AddSampleLog, LoadEventNexus, LoadNexus, MergeRuns,
-                              RenameWorkspace)
+from mantid.simpleapi import (LoadEventNexus, LoadNexus, MergeRuns, RenameWorkspace)
 
 from mantid.kernel import (CompositeValidator, Direction, EnabledWhenProperty,
                            IntBoundedValidator, Property, PropertyCriterion,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -146,8 +146,8 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             'MonitorBackgroundWavelengthMin', 'MonitorBackgroundWavelengthMax',
             'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
             'NormalizeByIntegratedMonitors', 'Params', 'StartOverlap', 'EndOverlap',
-            'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
-            'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax',
+            'TransmissionProcessingInstructions', 'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
+            'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax', 'ScaleFactor',
             'PolarizationAnalysis', 'CPp', 'CAp', 'CRho', 'CAlpha', 'FloodCorrection',
             'FloodWorkspace', 'Debug']
         self.copyProperties('ReflectometryReductionOneAuto', self._reduction_properties)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.api import (AlgorithmFactory, AnalysisDataService, DataProcessorAlgorithm,
+                        PropertyMode, WorkspaceGroup, WorkspaceProperty)
+
+from mantid.simpleapi import (AddSampleLog, LoadEventNexus, LoadISISNexus, Plus)
+
+from mantid.kernel import (CompositeValidator, Direction, StringArrayLengthValidator,
+                           StringArrayMandatoryValidator, StringArrayProperty)
+
+
+class Prop:
+    RUNS = 'InputRunList'
+    FIRST_TRANS_RUNS = 'FirstTransmissionRunList'
+    SECOND_TRANS_RUNS = 'SecondTransmissionRunList'
+    SLICE = 'SliceWorkspace'
+    OUTPUT_WS='OutputWorkspace'
+    OUTPUT_WS_BINNED='OutputWorkspaceBinned'
+    OUTPUT_WS_LAM='OutputWorkspaceWavelength'
+
+
+class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
+
+    def __init__(self):
+        """Initialize an instance of the algorithm."""
+        DataProcessorAlgorithm.__init__(self)
+        self._tofPrefix = "TOF_"
+        self._transPrefix = "TRANS_"
+
+    def category(self):
+        """Return the categories of the algrithm."""
+        return 'ISIS\\Reflectometry;Workflow\\Reflectometry'
+
+    def name(self):
+        """Return the name of the algorithm."""
+        return 'ReflectometryISISLoadAndProcess'
+
+    def summary(self):
+        """Return a summary of the algorithm."""
+        return "Reduce ISIS reflectometry data, including optional loading and summing/slicing of the input runs."
+
+    def seeAlso(self):
+        """Return a list of related algorithm names."""
+        return ['ReflectometrySliceEventWorkspace', 'ReflectometryReductionOneAuto']
+
+    def version(self):
+        """Return the version of the algorithm."""
+        return 1
+
+    def PyInit(self):
+        """Initialize the input and output properties of the algorithm."""
+        mandatoryInputRuns = CompositeValidator()
+        mandatoryInputRuns.add(StringArrayMandatoryValidator())
+        lenValidator = StringArrayLengthValidator()
+        lenValidator.setLengthMin(1)
+        mandatoryInputRuns.add(lenValidator)
+        self.declareProperty(StringArrayProperty(Prop.RUNS,
+                                                 values=[],
+                                                 validator=mandatoryInputRuns),
+                             doc='A list of run numbers or workspace names for the input runs. '
+                             'Multiple runs will be summed before reduction.')
+        self.declareProperty(StringArrayProperty(Prop.FIRST_TRANS_RUNS,
+                                                 values=[]),
+                             doc='A list of run numbers or workspace names for the first transmission run. '
+                             'Multiple runs will be summed before reduction.')
+        self.declareProperty(StringArrayProperty(Prop.SECOND_TRANS_RUNS,
+                                                 values=[]),
+                             doc='A list of run numbers or workspace names for the second transmission run. '
+                             'Multiple runs will be summed before reduction.')
+        self.declareProperty(WorkspaceProperty(Prop.OUTPUT_WS, '',
+                                               optional=PropertyMode.Optional,
+                                               direction=Direction.Output),
+                             doc='The output workspace, or workspace group if sliced.')
+        self.declareProperty(WorkspaceProperty(Prop.OUTPUT_WS_BINNED, '',
+                                               optional=PropertyMode.Optional,
+                                               direction=Direction.Output),
+                             doc='The binned output workspace, or workspace group if sliced.')
+        self.declareProperty(WorkspaceProperty(Prop.OUTPUT_WS_LAM, '',
+                                               optional=PropertyMode.Optional,
+                                               direction=Direction.Output),
+                             doc='The output workspace in wavelength, or workspace group if sliced.')
+        self.declareProperty('SliceWorkspace', False, doc = 'If true, slice the input workspace')
+        self._declareSliceAlgorithmProperties()
+        self._declareReductionAlgorithmProperties()
+
+    def PyExec(self):
+        """Execute the algorithm."""
+        # Convert run numbers to real workspaces
+        inputRuns = self.getProperty(Prop.RUNS).value
+        inputWorkspaces = self._getInputWorkspaces(inputRuns, False)
+        firstTransRuns = self.getProperty(Prop.FIRST_TRANS_RUNS).value
+        firstTransWorkspaces = self._getInputWorkspaces(firstTransRuns, True)
+        secondTransRuns = self.getProperty(Prop.SECOND_TRANS_RUNS).value
+        secondTransWorkspaces = self._getInputWorkspaces(secondTransRuns, True)
+        # Combine multiple input runs, if required
+        input_workspace = self._sumWorkspaces(inputRuns, inputWorkspaces, False)
+        first_trans_workspace = self._sumWorkspaces(firstTransRuns, firstTransWorkspaces, True)
+        second_trans_workspace = self._sumWorkspaces(secondTransRuns, secondTransWorkspaces, True)
+        # Slice the input workspace, if required
+        input_workspace = self._sliceWorkspace(input_workspace)
+        # Perform the reduction
+        alg = self._reduce(input_workspace, first_trans_workspace, second_trans_workspace)
+        self._finalize(alg)
+
+    def validateInputs(self):
+        """Return a dictionary containing issues found in properties."""
+        issues = dict()
+        if len(self.getProperty(Prop.RUNS).value) > 1 and self.getProperty(Prop.SLICE).value:
+            issues[Prop.SLICE] = "Cannot perform slicing when summing multiple input runs"
+        return issues
+
+    def _declareSliceAlgorithmProperties(self):
+        """Copy properties from the child slicing algorithm"""
+        self._slice_properties = [
+            'StartTime', 'StopTime','TimeInterval',
+            'LogName','MinimumLogValue','MaximumLogValue', 'LogValueInterval']
+        self.copyProperties('ReflectometrySliceEventWorkspace', self._slice_properties)
+
+    def _declareReductionAlgorithmProperties(self):
+        """Copy properties from the child reduction algorithm"""
+        self._reduction_properties = [
+            'SummationType', 'ReductionType', 'IncludePartialBins',
+            'AnalysisMode', 'ProcessingInstructions', 'CorrectDetectors',
+            'DetectorCorrectionType', 'WavelengthMin', 'WavelengthMax', 'I0MonitorIndex',
+            'MonitorBackgroundWavelengthMin', 'MonitorBackgroundWavelengthMax',
+            'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
+            'NormalizeByIntegratedMonitors', 'Params', 'StartOverlap', 'EndOverlap',
+            'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
+            'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax',
+            'PolarizationAnalysis', 'CPp', 'CAp', 'CRho', 'CAlpha', 'FloodCorrection',
+            'FloodWorkspace', 'Debug']
+        self.copyProperties('ReflectometryReductionOneAuto', self._reduction_properties)
+
+    def _getInputWorkspaces(self, runs, isTrans):
+        """Convert the given run numbers into real workspace names. Uses workspaces from
+        the ADS if they exist, or loads them otherwise."""
+        workspaces = list()
+        for run in runs:
+            ws = self._getRunFromADSOrNone(run, isTrans)
+            if not ws:
+                ws = self._loadRun(run, isTrans)
+            if not ws:
+                raise RuntimeError('Error loading run ' + run)
+            workspaces.append(ws)
+        return workspaces
+
+    def _prefixedRunName(self, run, isTrans):
+        """Add a prefix for TOF workspaces onto the given run name"""
+        if isTrans:
+            return self._transPrefix + run
+        else:
+            return self._tofPrefix + run
+
+    def _workspaceExists(self, workspace_name):
+        """Return true if the given workspace exists in the ADS
+        and is a valid reflectometry workspace for the requested reduction."""
+        if AnalysisDataService.doesExist(workspace_name):
+            self.log().information('Workspace ' + workspace_name + ' exists')
+            return True
+        else:
+            self.log().information('Workspace ' + workspace_name + ' does not exist')
+            return False
+
+    def _inputWorkspaceIsValid(self, workspace_name):
+        """Return true if the given workspace exists in the ADS and is
+        a valid reflectometry workspace for the requested reduction."""
+        workspace = AnalysisDataService.retrieve(workspace_name)
+        if self._slicingEnabled():
+            # If slicing, check that it's an event workspace
+            if workspace.id() != "EventWorkspace":
+                self.log().information('Workspace ' + workspace_name +
+                                       ' exists but is not an event workspace')
+                return False
+            # Check that the monitors workspace is also loaded
+            if not AnalysisDataService.doesExist(workspace_name + '_monitors'):
+                self.log().information('Workspace ' + workspace_name + ' exists but ' +
+                                       workspace + '_monitors does not')
+                return False
+        else:
+            # If not slicing, check that it's a Workspace2D
+            if workspace.id() != "Workspace2D":
+                self.log().information('Workspace ' + workspace_name +
+                                       ' exists but is not a Workspace2D')
+        return True
+
+    def _workspaceExistsAndIsValid(self, workspace_name, isTrans):
+        """Return true if the given workspace exists in the ADS and is valid"""
+        if not self._workspaceExists(workspace_name):
+            return False
+        # No further validation is currently required for transmission runs
+        if isTrans:
+            return True
+        # Do validation for input runs
+        return self._inputWorkspaceIsValid(workspace_name)
+
+    def _getRunFromADSOrNone(self, run, isTrans):
+        """Given a run name, return the name of the equivalent workspace in the ADS (
+        which may or may not have a prefix applied). Returns None if the workspace does
+        not exist or is not valid for the requested reflectometry reduction."""
+        # Try given run number
+        workspace_name = run
+        if self._workspaceExistsAndIsValid(workspace_name, isTrans):
+            return workspace_name
+        # Try with prefix
+        workspace_name = self._prefixedRunName(run, isTrans)
+        if self._workspaceExistsAndIsValid(workspace_name, isTrans):
+            return workspace_name
+        # Not found
+        return None
+
+    def _loadRun(self, run, isTrans):
+        """Load a run as an event workspace if slicing is requested, or a non-event
+        workspace otherwise"""
+        workspace_name=self._prefixedRunName(run, isTrans)
+        if self._slicingEnabled():
+            LoadEventNexus(Filename=run, OutputWorkspace=workspace_name, LoadMonitors=True)
+            _throwIfNotValidReflectometryEventWorkspace(workspace_name)
+            self.log().information('Loaded event workspace ' + workspace_name)
+        else:
+            LoadISISNexus(Filename=run, OutputWorkspace=workspace_name)
+            self.log().information('Loaded workspace ' + workspace_name)
+        return workspace_name
+
+    def _sumWorkspaces(self, runs, workspaces, isTrans):
+        """If there are multiple input workspaces, sum them and return the result. Otherwise
+        just return the single input workspace, or None if the list is empty."""
+        if len(workspaces) < 1:
+            return None
+        if len(workspaces) < 2:
+            return workspaces[0]
+        concatenated_names = "+".join(runs)
+        summed = self._prefixedRunName(concatenated_names, isTrans)
+        self.log().information('Summing workspaces' + " ".join(workspaces) + ' into ' + summed)
+        lhs = workspaces[0]
+        for rhs in workspaces[1:]:
+            Plus(LHSWorkspace=lhs, RHSWorkspace=rhs, OutputWorkspace = summed)
+            lhs = summed
+        # The reduction algorithm sets the output workspace names from the run number,
+        # which by default is just the first run. Set it to the concatenated name,
+        # e.g. 13461+13462
+        _setRunNumberForWorkspace(summed, concatenated_names)
+        return summed
+
+    def _slicingEnabled(self):
+        return self.getProperty(Prop.SLICE).value
+
+    def _runSliceAlgorithm(self, input_workspace, output_workspace):
+        """Run the child algorithm to perform the slicing"""
+        self.log().information('Running ReflectometrySliceEventWorkspace')
+        alg = self.createChildAlgorithm("ReflectometrySliceEventWorkspace")
+        for property in self._slice_properties:
+            alg.setProperty(property, self.getPropertyValue(property))
+        alg.setProperty("OutputWorkspace", output_workspace)
+        alg.setProperty("InputWorkspace", input_workspace)
+        alg.setProperty("MonitorWorkspace", _monitorWorkspace(input_workspace))
+        alg.execute()
+
+    def _sliceWorkspace(self, workspace):
+        """If slicing has been requested, slice the input workspace, otherwise
+        return it unchanged"""
+        if not self._slicingEnabled():
+            return workspace
+        sliced_workspace_name = self._getSlicedWorkspaceGroupName(workspace)
+        self.log().information('Slicing workspace ' + workspace + ' into ' + sliced_workspace_name)
+        self._runSliceAlgorithm(workspace, sliced_workspace_name)
+        return sliced_workspace_name
+
+    def _getSlicedWorkspaceGroupName(self, workspace):
+        return workspace + '_sliced'
+
+    def _setChildAlgorithmPropertyIfProvided(self, alg, property_name):
+        """Set the given property on the given algorithm if it is set in our
+        inputs. Leave it unset otherwise."""
+        if not self.getProperty(property_name).isDefault:
+            alg.setProperty(property_name, self.getPropertyValue(property_name))
+
+    def _reduce(self, input_workspace, first_trans_workspace, second_trans_workspace):
+        """Run the child algorithm to do the reduction. Return the child algorithm."""
+        self.log().information('Running ReflectometryReductionOneAuto on ' + input_workspace)
+        alg = self.createChildAlgorithm("ReflectometryReductionOneAuto")
+        for property in self._reduction_properties:
+            alg.setProperty(property, self.getPropertyValue(property))
+        self._setChildAlgorithmPropertyIfProvided(alg, Prop.OUTPUT_WS)
+        self._setChildAlgorithmPropertyIfProvided(alg, Prop.OUTPUT_WS_BINNED)
+        self._setChildAlgorithmPropertyIfProvided(alg, Prop.OUTPUT_WS_LAM)
+        alg.setProperty("InputWorkspace", input_workspace)
+        alg.setProperty("FirstTransmissionRun", first_trans_workspace)
+        alg.setProperty("SecondTransmissionRun", second_trans_workspace)
+        alg.execute()
+        return alg
+
+    def _removePrefix(self, workspace):
+        """Remove the TOF prefix from the given workspace name"""
+        prefix_len = len(self._tofPrefix)
+        name_start = workspace[:prefix_len]
+        if len(workspace) > prefix_len and name_start == self._tofPrefix:
+            return workspace[len(self._tofPrefix):]
+        else:
+            return workspace
+
+    def _finalize(self, child_alg):
+        """Set our output properties from the results in the given child algorithm"""
+        self._setOutputWorkspace(Prop.OUTPUT_WS, child_alg)
+        self._setOutputWorkspace(Prop.OUTPUT_WS_BINNED, child_alg)
+        self._setOutputWorkspace(Prop.OUTPUT_WS_LAM, child_alg)
+
+    def _setOutputWorkspace(self, property_name, child_alg):
+        """Set the given output property from the result in the given child algorithm,
+        if it exists"""
+        value = child_alg.getPropertyValue(property_name)
+        if value:
+            self.setPropertyValue(property_name, value)
+            self.setProperty(property_name, child_alg.getProperty(property_name).value)
+
+
+def _setRunNumberForWorkspace(workspace_name, run_number):
+    """Set the run number in the sample log for the given workspace"""
+    AddSampleLog(Workspace=workspace_name, LogName='run_number', LogText=str(run_number),
+                 LogType='String')
+
+
+def _throwIfNotValidReflectometryEventWorkspace(workspace_name):
+    workspace=AnalysisDataService.retrieve(workspace_name)
+    if isinstance(workspace, WorkspaceGroup):
+        raise RuntimeError('Slicing workspace groups is not supported')
+    if not workspace.run().hasProperty('proton_charge'):
+        raise RuntimeError('Cannot slice workspace: run must contain proton_charge')
+
+
+def _monitorWorkspace(workspace):
+    """Return the associated monitor workspace name for the given workspace"""
+    return workspace + '_monitors'
+
+
+AlgorithmFactory.subscribe(ReflectometryISISLoadAndProcess)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -225,9 +225,8 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
 
     def _renameWorkspaceBasedOnRunNumber(self, workspace_name, isTrans):
         """Rename the given workspace based on its run number and a standard prefix"""
-        workspace = AnalysisDataService.retrieve(workspace_name)
-        new_name = self._prefixedName(str(workspace.getRunNumber()), isTrans)
-        if new_name != workspace.name():
+        new_name = self._prefixedName(_getRunNumberAsString(workspace_name), isTrans)
+        if new_name != workspace_name:
             RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=new_name)
             # Also rename the monitor workspace, if there is one
             if AnalysisDataService.doesExist(_monitorWorkspace(workspace_name)):
@@ -386,6 +385,19 @@ def _throwIfNotValidReflectometryEventWorkspace(workspace_name):
 def _monitorWorkspace(workspace):
     """Return the associated monitor workspace name for the given workspace"""
     return workspace + '_monitors'
+
+
+def _getRunNumberAsString(workspace_name):
+    """Get the run number for a workspace. If it's a workspace group, get
+    the run number from the first child workspace."""
+    try:
+        workspace = AnalysisDataService.retrieve(workspace_name)
+        if not isinstance(workspace, WorkspaceGroup):
+            return str(workspace.getRunNumber())
+        # Get first child in the group
+        return str(workspace[0].getRunNumber())
+    except:
+        raise RuntimeError('Could not find run number for workspace ' + workspace_name)
 
 
 AlgorithmFactory.subscribe(ReflectometryISISLoadAndProcess)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -269,6 +269,8 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         total_duration = (run.endTime() - run.startTime()).total_seconds()
         slice_duration = total_duration / number_of_slices
         alg.setProperty("TimeInterval", slice_duration)
+        self.log().information('Slicing ' + workspace_name + ' into ' + str(number_of_slices)
+                               + ' even slices of duration ' + str(slice_duration))
 
     def _setSliceStartStopTimes(self, alg, workspace_name):
         """Set the start/stop time for the slicing algorithm based on the

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CMakeLists.txt
@@ -46,6 +46,7 @@ set ( TEST_PY_FILES
   ReflectometryILLPolarizationCorTest.py
   ReflectometryILLPreprocessTest.py
   ReflectometryILLSumForegroundTest.py
+  ReflectometryISISLoadAndProcessTest.py
   ResNorm2Test.py
   SANSDarkRunBackgroundCorrectionTest.py
   SANSFitShiftScaleTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -70,7 +70,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '13460'
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['LoadISISNexus', 'ReflectometryReductionOneAuto']
+        history = ['LoadNexus', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_input_run_that_is_in_ADS_with_prefixed_name_is_not_reloaded(self):
@@ -97,7 +97,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '13460'
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TEST_13460', 'TOF_13460']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['LoadISISNexus', 'ReflectometryReductionOneAuto']
+        history = ['LoadNexus', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_existing_workspace_is_used_when_name_passed_in_input_list(self):
@@ -114,7 +114,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = 'INTER13460'
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['LoadISISNexus', 'RenameWorkspace', 'ReflectometryReductionOneAuto']
+        history = ['LoadNexus', 'RenameWorkspace', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_overriding_output_names(self):
@@ -193,7 +193,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
                     'TRANS_LAM_13463', 'TRANS_LAM_13464']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['LoadISISNexus', 'LoadISISNexus', 'ReflectometryReductionOneAuto']
+        history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_trans_runs_are_not_loaded_if_in_ADS_without_prefix(self):
@@ -225,7 +225,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
                     'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['LoadISISNexus', 'LoadISISNexus', 'ReflectometryReductionOneAuto']
+        history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_existing_workspace_is_used_for_trans_runs_when_name_passed_in_input_list(self):
@@ -334,7 +334,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
         self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
 
-    def test_slicing_loads_input_run_if_loaded_run_is_incorrect_type(self):
+    def test_slicing_reloads_input_run_if_workspace_is_incorrect_type(self):
         self._create_workspace(38415, 'TOF_')
         args = self._default_options
         args.update(self._default_slice_options_real_run)
@@ -411,7 +411,8 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args = self._default_options
         args['InputRunList'] = '12345'
         outputs = ['IvsQ_12345', 'IvsQ_12345_1', 'IvsQ_12345_2', 'IvsQ_binned_12345',
-                   'IvsQ_binned_12345_2', 'IvsQ_binned_12345_1', 'IvsLam_12345', 'IvsLam_12345_1', 'IvsLam_12345_2', 'TOF_12345', 'TOF_12345_1', 'TOF_12345_2']
+                   'IvsQ_binned_12345_2', 'IvsQ_binned_12345_1', 'IvsLam_12345',
+                   'IvsLam_12345_1', 'IvsLam_12345_2', 'TOF_12345', 'TOF_12345_1', 'TOF_12345_2']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['CreateSampleWorkspace', 'AddSampleLog',  'CreateSampleWorkspace', 'AddSampleLog',
                    'GroupWorkspaces', 'ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -168,7 +168,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13461+13462', 'IvsQ_binned_13461+13462', 'TOF_13461', 'TOF_13462',
                     'TOF_13461+13462']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['Plus', 'AddSampleLog', 'ReflectometryReductionOneAuto']
+        history = ['MergeRuns', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13461+13462'], history)
 
     def test_trans_run_is_not_reloaded_if_in_ADS(self):
@@ -284,7 +284,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
                     'TRANS_13463+13464']
         self._assert_run_algorithm_succeeds(args, outputs)
-        history = ['Plus', 'AddSampleLog', 'ReflectometryReductionOneAuto']
+        history = ['MergeRuns', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_slicing_is_disallowed_if_summing_input_runs(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -1,0 +1,402 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+from mantid import config
+from mantid.api import mtd
+from mantid.simpleapi import (AddSampleLog, AddTimeSeriesLog, CreateSampleWorkspace,
+                              CropWorkspace, Rebin)
+from testhelpers import (assertRaisesNothing, create_algorithm)
+
+
+class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
+    def setUp(self):
+        self._oldFacility = config['default.facility']
+        if self._oldFacility.strip() == '':
+            self._oldFacility = 'TEST_LIVE'
+        self._oldInstrument = config['default.instrument']
+        config['default.facility'] = 'ISIS'
+        config['default.instrument'] = 'INTER'
+        # Set some commonly used properties
+        self._default_options = {
+            'ProcessingInstructions' : '4',
+            'ThetaIn' : 0.5,
+            'WavelengthMin' : 2,
+            'WavelengthMax' : 5,
+            'I0MonitorIndex' : 1,
+            'MomentumTransferStep' : 0.02
+            }
+        self._mandatory_output_names = {
+            'OutputWorkspace' : 'testIvsQ',
+            'OutputWorkspaceBinned' : 'testIvsQBin'
+            }
+        self._all_output_names = {
+            'OutputWorkspace' : 'testIvsQ',
+            'OutputWorkspaceBinned' : 'testIvsQBin',
+            'OutputWorkspaceWavelength' : 'testIvsLam'
+            }
+        self._default_slice_options_dummy_run = {
+            'SliceWorkspace' : True,
+            'TimeInterval' : 1200
+        }
+        self._default_slice_options_real_run = {
+            'SliceWorkspace' : True,
+            'TimeInterval' : 210
+        }
+        self._expected_sliced_outputs = [
+             'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
+             'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
+             'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
+             'IvsQ_binned_38415_3', 'TOF_38415', 'TOF_38415_monitors',
+             'TOF_38415_sliced', 'TOF_38415_sliced_1', 'TOF_38415_sliced_2',
+             'TOF_38415_sliced_3']
+
+    def tearDown(self):
+        mtd.clear()
+        config['default.facility'] = self._oldFacility
+        config['default.instrument'] = self._oldInstrument
+
+    def test_missing_input_runs(self):
+        self._assert_run_algorithm_throws()
+
+    def test_input_run_is_loaded_if_not_in_ADS(self):
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['LoadISISNexus', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_input_run_that_is_in_ADS_with_prefixed_name_is_not_reloaded(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_input_run_that_is_in_ADS_without_prefix_is_not_reloaded(self):
+        self._create_workspace(13460)
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', '13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_input_run_is_reloaded_if_in_ADS_with_unknown_prefix(self):
+        self._create_workspace(13460, 'TEST_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TEST_13460', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['LoadISISNexus', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_overriding_output_names(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args.update(self._mandatory_output_names)
+        outputs = ['testIvsQ', 'testIvsQBin', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['testIvsQBin'], history)
+
+    def test_overriding_output_names_includes_all_specified_outputs(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args.update(self._all_output_names)
+        # Current behaviour is that the optional workspaces are output even if
+        # Debug is not set
+        outputs = ['testIvsQ', 'testIvsQBin', 'testIvsLam', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['testIvsQBin'], history)
+
+    def test_debug_option_outputs_extra_workspaces(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['Debug'] = True
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'IvsLam_13460', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_debug_option_outputs_extra_workspaces_with_overridden_names(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['Debug'] = True
+        args.update(self._all_output_names)
+        outputs = ['testIvsQ', 'testIvsQBin', 'testIvsLam', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['testIvsQBin'], history)
+
+    def test_multiple_input_runs_are_summed(self):
+        self._create_workspace(13461, 'TOF_')
+        self._create_workspace(13462, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13461, 13462'
+        outputs = ['IvsQ_13461+13462', 'IvsQ_binned_13461+13462', 'TOF_13461', 'TOF_13462',
+                    'TOF_13461+13462']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['Plus', 'AddSampleLog', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13461+13462'], history)
+
+    def test_trans_run_is_not_reloaded_if_in_ADS(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TRANS_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_trans_runs_are_loaded_if_not_in_ADS(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463'
+        args['SecondTransmissionRunList'] = '13464'
+        # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
+        # creating the stitched transmission run
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
+                    'TRANS_LAM_13463', 'TRANS_LAM_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['LoadISISNexus', 'LoadISISNexus', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_trans_runs_are_not_loaded_if_in_ADS_without_prefix(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463)
+        self._create_workspace(13464)
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463'
+        args['SecondTransmissionRunList'] = '13464'
+        # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
+        # creating the stitched transmission run
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', '13463', '13464',
+                    'TRANS_LAM_13463', 'TRANS_LAM_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_trans_runs_are_reloaded_if_in_ADS_with_unknown_prefix(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TEST_')
+        self._create_workspace(13464, 'TEST_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463'
+        args['SecondTransmissionRunList'] = '13464'
+        # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
+        # creating the stitched transmission run
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
+                    'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['LoadISISNexus', 'LoadISISNexus', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_first_and_second_trans_runs_are_combined(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TRANS_')
+        self._create_workspace(13464, 'TRANS_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463'
+        args['SecondTransmissionRunList'] = '13464'
+        # The intermediate LAM workspaces are output by the algorithm that combines the runs
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
+                    'TRANS_LAM_13463', 'TRANS_LAM_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_first_and_second_trans_runs_are_combined_with_debug_output(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TRANS_')
+        self._create_workspace(13464, 'TRANS_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['Debug'] = True
+        args['FirstTransmissionRunList'] = '13463'
+        args['SecondTransmissionRunList'] = '13464'
+        # The intermediate LAM workspaces are output by the algorithm that combines the runs.
+        # The stitched TRANS_LAM_13463_13464 is only output with Debug on.
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'IvsLam_13460', 'TOF_13460', 'TRANS_13463',
+                    'TRANS_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TRANS_LAM_13463_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_multiple_trans_runs_are_summed(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TRANS_')
+        self._create_workspace(13464, 'TRANS_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = '13463, 13464'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
+                    'TRANS_13463+13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['Plus', 'AddSampleLog', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_slicing_is_disallowed_if_summing_input_runs(self):
+        self._create_workspace(13460, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['SliceWorkspace'] = True
+        self._assert_run_algorithm_fails(args)
+
+    def test_slicing_uses_run_in_ADS_with_correct_prefix(self):
+        self._create_event_workspace(38415, 'TOF_')
+        args = self._default_options.copy()
+        args.update(self._default_slice_options_dummy_run)
+        args['InputRunList'] = '38415'
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        # Note that the child sliced workspaces don't include the full history - this
+        # might be something we want to change in the underlying algorithms at some point
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_uses_run_in_ADS_with_no_prefix(self):
+        self._create_event_workspace(38415)
+        args = self._default_options
+        args.update(self._default_slice_options_dummy_run)
+        args['InputRunList'] = '38415'
+        outputs = [
+             'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
+             'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
+             'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
+             'IvsQ_binned_38415_3', '38415', '38415_monitors',
+             '38415_sliced', '38415_sliced_1', '38415_sliced_2',
+             '38415_sliced_3']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_loads_input_run_if_not_in_ADS(self):
+        args = self._default_options
+        args.update(self._default_slice_options_real_run)
+        args['InputRunList'] = '38415'
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_loads_input_run_if_loaded_run_is_incorrect_type(self):
+        self._create_workspace(38415, 'TOF_')
+        args = self._default_options
+        args.update(self._default_slice_options_real_run)
+        args['InputRunList'] = '38415'
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_loads_input_run_if_monitor_ws_not_in_ADS(self):
+        self._create_event_workspace(38415, 'TOF_', False)
+        args = self._default_options
+        args.update(self._default_slice_options_real_run)
+        args['InputRunList'] = '38415'
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def _create_workspace(self, run_number, prefix=''):
+        name = prefix + str(run_number)
+        ws = CreateSampleWorkspace(WorkspaceType='Histogram',NumBanks=1, NumMonitors=2,
+                              BankPixelWidth=2, XMin=200, OutputWorkspace=name)
+        AddSampleLog(Workspace=ws, LogName='run_number', LogText=str(run_number))
+
+    def _create_event_workspace(self, run_number, prefix='', includeMonitors=True):
+        name = prefix + str(run_number)
+        CreateSampleWorkspace(WorkspaceType='Event',NumBanks=1, NumMonitors=3,
+                              BankPixelWidth=2, XMin=200, OutputWorkspace=name)
+        if includeMonitors:
+            CropWorkspace(InputWorkspace=name,StartWorkspaceIndex=0,EndWorkspaceIndex=2,
+                          OutputWorkspace=name + '_monitors')
+            Rebin(InputWorkspace=name + '_monitors',Params='0,200,20000',
+                  OutputWorkspace=name + '_monitors',PreserveEvents=False)
+        CropWorkspace(InputWorkspace=name,StartWorkspaceIndex=3,EndWorkspaceIndex=4,
+                      OutputWorkspace=name)
+        AddSampleLog(Workspace=name, LogName='run_number', LogText=str(run_number))
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:00:00", Value=100)
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:10:00", Value=100)
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:20:00", Value=80)
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:30:00", Value=80)
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:40:00", Value=15)
+        AddTimeSeriesLog(Workspace=name, Name="proton_charge", Time="2010-01-01T00:50:00", Value=100)
+
+    def _check_history(self, ws, expected, unroll = True):
+        """Return true if algorithm names listed in algorithmNames are found in the
+        workspace's history. If unroll is true, checks the child histories, otherwise
+        checks the top level history (the latter is required for sliced workspaces where
+        the child workspaces have lost their parent's history)
+        """
+        history = ws.getHistory()
+        if unroll:
+            reductionHistory = history.getAlgorithmHistory(history.size() - 1)
+            algHistories = reductionHistory.getChildHistories()
+            algNames = [alg.name() for alg in algHistories]
+        else:
+            algNames = [alg.name() for alg in history]
+        self.assertEquals(algNames, expected)
+
+    def _assert_run_algorithm_succeeds(self, args, expected):
+        """Run the algorithm with the given args and check it succeeds, 
+        and that the additional workspaces produced match the expected list.
+        Clear these additional workspaces from the ADS"""
+        alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+        assertRaisesNothing(self, alg.execute)
+        actual = mtd.getObjectNames()
+        self.assertEquals(set(actual), set(expected))
+
+    def _assert_run_algorithm_fails(self, args):
+        """Run the algorithm with the given args and check it fails to produce output"""
+        alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+        assertRaisesNothing(self, alg.execute)
+        self.assertEquals(mtd.doesExist('output'), False)
+
+    def _assert_run_algorithm_throws(self, args = {}):
+        """Run the algorithm with the given args and check it throws"""
+        throws = False
+        alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+        try:
+            alg.execute()
+        except:
+            throws = True
+        self.assertEquals(throws, True)
+
+    def _assert_delta(self, value1, value2):
+        self.assertEquals(round(value1, 6), round(value2, 6))
+
+    def _clear(self, expected):
+        for workspace in expected:
+            mtd.remove(workspace)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -109,6 +109,14 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         history = ['ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
+    def test_loading_run_with_instrument_prefix_in_name(self):
+        args = self._default_options
+        args['InputRunList'] = 'INTER13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['LoadISISNexus', 'RenameWorkspace', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
     def test_overriding_output_names(self):
         self._create_workspace(13460, 'TOF_')
         args = self._default_options

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -100,6 +100,15 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         history = ['LoadISISNexus', 'ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
+    def test_existing_workspace_is_used_when_name_passed_in_input_list(self):
+        self._create_workspace(13460, 'TEST_')
+        args = self._default_options
+        args['InputRunList'] = 'TEST_13460'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TEST_13460']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
     def test_overriding_output_names(self):
         self._create_workspace(13460, 'TOF_')
         args = self._default_options
@@ -209,6 +218,20 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                     'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadISISNexus', 'LoadISISNexus', 'ReflectometryReductionOneAuto']
+        self._check_history(mtd['IvsQ_binned_13460'], history)
+
+    def test_existing_workspace_is_used_for_trans_runs_when_name_passed_in_input_list(self):
+        self._create_workspace(13460, 'TOF_')
+        self._create_workspace(13463, 'TEST_')
+        self._create_workspace(13464, 'TEST_')
+        args = self._default_options
+        args['InputRunList'] = '13460'
+        args['FirstTransmissionRunList'] = 'TEST_13463'
+        args['SecondTransmissionRunList'] = 'TEST_13464'
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TEST_13463', 'TEST_13464',
+                   'TRANS_LAM_13463', 'TRANS_LAM_13464']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto']
         self._check_history(mtd['IvsQ_binned_13460'], history)
 
     def test_first_and_second_trans_runs_are_combined(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -325,6 +325,56 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
         self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
 
+    def test_slicing_with_no_interval_returns_single_slice(self):
+        self._create_event_workspace(38415, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '38415'
+        args['SliceWorkspace'] = True
+        outputs = ['IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1',
+                   'IvsLam_38415', 'IvsLam_38415_1', 'TOF_38415', 'TOF_38415_monitors',
+                   'TOF_38415_sliced', 'TOF_38415_sliced_1']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_by_number_of_slices(self):
+        self._create_event_workspace(38415, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '38415'
+        args['SliceWorkspace'] = True
+        args['NumberOfSlices'] = 3;
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_by_log_value(self):
+        self._create_event_workspace(38415, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '38415'
+        args['SliceWorkspace'] = True
+        args['LogName'] = 'proton_charge';
+        args['LogValueInterval'] = 60;
+        outputs = self._expected_sliced_outputs
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
+                   'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
+    def test_slicing_by_log_value_with_no_interval_returns_single_slice(self):
+        self._create_event_workspace(38415, 'TOF_')
+        args = self._default_options
+        args['InputRunList'] = '38415'
+        args['SliceWorkspace'] = True
+        args['LogName'] = 'proton_charge';
+        outputs = ['IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1',
+                   'IvsLam_38415', 'IvsLam_38415_1', 'TOF_38415', 'TOF_38415_monitors',
+                   'TOF_38415_sliced', 'TOF_38415_sliced_1']
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
+        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+
     def _create_workspace(self, run_number, prefix=''):
         name = prefix + str(run_number)
         ws = CreateSampleWorkspace(WorkspaceType='Histogram',NumBanks=1, NumMonitors=2,

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -1,0 +1,117 @@
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+
+ReflectometryISISLoadAndProcess
+-------------------------------
+
+This algorithm performs full preparation and processing for a single run or combined set of runs in an ISIS reflectometry reduction. Note that a set of runs here is a set that will be combined prior to reduction (it does not deal with a group of runs that will be post-processed after reduction). This algorithm is primarily aimed at reducing a single row in the table on the ``ISIS Reflectometry`` interface.
+
+The steps this algorithm performs are:
+
+- Ensure the required workspaces are loaded.
+- Optionally sum multiple runs into a single input run prior to reduction.
+- Optionally sum multiple transmission runs into a single input prior to reduction.
+- Optionally perform time-slicing of the input run.
+- Validate that the workspaces are the correct type.
+- Run ReflectometryReductionOneAuto.
+
+Input runs and transmission runs are loaded if required, or existing workspaces are used if they are already in the ADS. When runs are loaded, they are named based on the run number with a ``TOF_`` or ``TRANS_`` prefix. To determine whether workspaces are already in the ADS, workspace names are matched based on the run number with or without this prefix. Other naming formats are not considered to match.
+
+Input runs can be combined before reduction by supplying a comma-separated list of run numbers. They will be summed using the :ref:`algm-Plus` algorithm. Similarly, multiple input runs for the first and/or second transmission workspace inputs can be summed prior to reduction.
+
+For time slicing, the input run must be an event workspace. If the workspace for the run already exists in the ADS but is the incorrect type, or does not have monitors loaded, it will be reloaded. Input properties for time slicing are the same as those for :ref:`algm-ReflectometrySliceEventWorkspace`.
+
+Input properties for the reduction are the same as those for :ref:`algm-ReflectometryReductionOneAuto`.
+
+Usage
+-------
+
+.. include:: ../usagedata-note.txt
+
+**Example: Run reduction on a single run**
+
+.. testcode:: ExSingleRun
+
+    ReflectometryISISLoadAndProcess(InputRunList='INTER13460')
+    names = mtd.getObjectNames()
+    names.sort()
+    print('Workspaces in the ADS after reduction: {}'.format(names))
+
+Output:
+
+.. testoutput:: ExSingleRun
+
+    Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460']
+
+**Example: Sum multiple input runs**
+
+.. testcode:: ExSumRuns
+
+    ReflectometryISISLoadAndProcess(InputRunList='INTER13460, INTER13462')
+    names = mtd.getObjectNames()
+    names.sort()
+    print('Workspaces in the ADS after reduction: {}'.format(names))
+
+Output:
+
+.. testoutput:: ExSumRuns
+
+    Workspaces in the ADS after reduction: ['IvsQ_INTER13460+INTER13462', 'IvsQ_binned_INTER13460+INTER13462', 'TOF_INTER13460', 'TOF_INTER13460+INTER13462', 'TOF_INTER13462']
+
+**Example: Sum multiple transmission runs into a single input**
+
+.. testcode:: ExSumTransmissionRuns
+
+    ReflectometryISISLoadAndProcess(InputRunList='INTER13460',FirstTransmissionRunList='INTER13463,INTER13464')
+    names = mtd.getObjectNames()
+    names.sort()
+    print('Workspaces in the ADS after reduction: {}'.format(names))
+
+Output:
+
+.. testoutput:: ExSumTransmissionRuns
+
+   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460', 'TRANS_INTER13463', 'TRANS_INTER13463+INTER13464', 'TRANS_INTER13464']
+
+**Example: Two separate transmission run inputs**
+
+.. testcode:: ExCombineTransmissionRuns
+
+    ReflectometryISISLoadAndProcess(InputRunList='INTER13460',FirstTransmissionRunList='INTER13463',
+                                    SecondTransmissionRunList='INTER13464')
+    names = mtd.getObjectNames()
+    names.sort()
+    print('Workspaces in the ADS after reduction: {}'.format(names))
+
+Output:
+
+.. testoutput:: ExCombineTransmissionRuns
+
+   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460', 'TRANS_INTER13463', 'TRANS_INTER13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
+
+**Example: Slice input run**
+
+.. testcode:: ExSliceRun
+
+    ReflectometryISISLoadAndProcess(InputRunList='INTER38415', SliceWorkspace=True, TimeInterval=210)
+    names = mtd.getObjectNames()
+    names.sort()
+    print('Workspaces in the ADS after reduction: {}'.format(names))
+
+Output:
+
+.. testoutput:: ExSliceRun
+
+   Workspaces in the ADS after reduction: ['IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3', 'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2', 'IvsQ_binned_38415_3', 'TOF_INTER38415', 'TOF_INTER38415_monitors', 'TOF_INTER38415_sliced', 'TOF_INTER38415_sliced_1', 'TOF_INTER38415_sliced_2', 'TOF_INTER38415_sliced_3']
+
+.. seealso :: Algorithm :ref:`algm-ReflectometrySliceEventWorkspace`, :ref:`algm-ReflectometryReductionOneAuto` and the ``ISIS Reflectometry`` interface.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -19,13 +19,13 @@ The steps this algorithm performs are:
 - Optionally sum multiple transmission runs into a single input prior to reduction.
 - Optionally perform time-slicing of the input run.
 - Validate that the workspaces are the correct type.
-- Run ReflectometryReductionOneAuto.
+- Run ReflectometryReductionOneAuto to perform the reduction.
 
 Input runs and transmission runs are loaded if required, or existing workspaces are used if they are already in the ADS. When runs are loaded, they are named based on the run number with a ``TOF_`` or ``TRANS_`` prefix. To determine whether workspaces are already in the ADS, workspace names are matched based on the run number with or without this prefix. Other naming formats are not considered to match.
 
 Input runs can be combined before reduction by supplying a comma-separated list of run numbers. They will be summed using the :ref:`algm-Plus` algorithm. Similarly, multiple input runs for the first and/or second transmission workspace inputs can be summed prior to reduction.
 
-For time slicing, the input run must be an event workspace. If the workspace for the run already exists in the ADS but is the incorrect type, or does not have monitors loaded, it will be reloaded. Input properties for time slicing are the same as those for :ref:`algm-ReflectometrySliceEventWorkspace`.
+For time slicing, the input run must be an event workspace. If the workspace for the run already exists in the ADS but is the incorrect type, or does not have monitors loaded, it will be reloaded.
 
 Input properties for the reduction are the same as those for :ref:`algm-ReflectometryReductionOneAuto`.
 
@@ -47,7 +47,7 @@ Output:
 
 .. testoutput:: ExSingleRun
 
-    Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460']
+    Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460']
 
 **Example: Sum multiple input runs**
 
@@ -62,7 +62,7 @@ Output:
 
 .. testoutput:: ExSumRuns
 
-    Workspaces in the ADS after reduction: ['IvsQ_INTER13460+INTER13462', 'IvsQ_binned_INTER13460+INTER13462', 'TOF_INTER13460', 'TOF_INTER13460+INTER13462', 'TOF_INTER13462']
+    Workspaces in the ADS after reduction: ['IvsQ_13460+13462', 'IvsQ_binned_13460+13462', 'TOF_13460', 'TOF_13460+13462', 'TOF_13462']
 
 **Example: Sum multiple transmission runs into a single input**
 
@@ -77,7 +77,7 @@ Output:
 
 .. testoutput:: ExSumTransmissionRuns
 
-   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460', 'TRANS_INTER13463', 'TRANS_INTER13463+INTER13464', 'TRANS_INTER13464']
+   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13463+13464', 'TRANS_13464']
 
 **Example: Two separate transmission run inputs**
 
@@ -93,7 +93,7 @@ Output:
 
 .. testoutput:: ExCombineTransmissionRuns
 
-   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_INTER13460', 'TRANS_INTER13463', 'TRANS_INTER13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
+   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
 
 **Example: Slice input run**
 
@@ -108,7 +108,7 @@ Output:
 
 .. testoutput:: ExSliceRun
 
-   Workspaces in the ADS after reduction: ['IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3', 'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2', 'IvsQ_binned_38415_3', 'TOF_INTER38415', 'TOF_INTER38415_monitors', 'TOF_INTER38415_sliced', 'TOF_INTER38415_sliced_1', 'TOF_INTER38415_sliced_2', 'TOF_INTER38415_sliced_3']
+   Workspaces in the ADS after reduction: ['IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3', 'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2', 'IvsQ_binned_38415_3', 'TOF_38415', 'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415_sliced_1', 'TOF_38415_sliced_2', 'TOF_38415_sliced_3']
 
 .. seealso :: Algorithm :ref:`algm-ReflectometrySliceEventWorkspace`, :ref:`algm-ReflectometryReductionOneAuto` and the ``ISIS Reflectometry`` interface.
 

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -18,6 +18,7 @@ New
 - :ref:`algm-SaveReflectometryAscii` is a general algorithm which saves the first spectrum of a workspace in Ascii format particularly suited for reflectometry data.
 - Some computations from :ref:`algm-ReflectometryMomentumTransfer` were extracted to a new algorithm, :ref:`algm-ReflectometryBeamStatistics`.
 - :ref:`algm-GroupToXResolution` can be used to group the reflectivity data (as point data) to the :math`Q_z` resolution.
+- Added algorithm :ref:`algm-ReflectometryISISLoadAndProcess` which performs full preparation and processing for a single run or combined set of runs in an ISIS reflectometry reduction.
 
 Improved
 ########


### PR DESCRIPTION
**Description of work.**
This PR implements a wrapper workflow algorithm for reducing a single "row" in an ISIS reflectometry reduction. See the linked issue for more details.

A related fix is added to `ReflectometrySliceEventWorkspace`, which ensures the run number is stored as a string in the sliced workspace. This is required for input runs to the child algorithm `ReflectometryReductionOneAuto`

**Report to:** noboty

**To test:**

The usage examples in the algorithm documentation are a good place to start. Try experimenting with different input properties, invalid input etc. and see if you can break it. Check the history of the `IvsQ_binned_` workspace (this is the final output) and check that any relevant properties that you set in the new algorithm are passed through to the child algorithms (`ReflectometryReductionOneAuto` and `ReflectometrySliceEventWorkspace`).

Fixes #24603 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
