### PR TITLE
Change marker type for workbench sample logs plot

### DIFF
--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -123,7 +123,6 @@ class SampleLogsView(QSplitter):
             ax.plot(ws,
                     LogName=log_text,
                     label=log_text,
-                    marker='.',
                     FullTime=not self.full_time.isChecked(),
                     ExperimentInfo=exp)
 


### PR DESCRIPTION
The marker '.' was originally used so that single value logs would be observable, since #23742 there is always two values making this redundant.

Before:
![figure_1-4](https://user-images.githubusercontent.com/5595210/51866209-5b541300-2316-11e9-8012-d991a04e6642.png)

After:
![figure_1-5](https://user-images.githubusercontent.com/5595210/51866220-6444e480-2316-11e9-8a83-4f57673de369.png)



**To test:**

Compare plotting sample logs before and after this change. For the above plots I used `ws=Load('PG3_42941',metaDataOnly=True)`

*There is no associated issue.*

*This does not require release notes* because workbench

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
