### PR TITLE
Adding to run info in muon analysis

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -13,6 +13,7 @@ Improvements
 - Elemental Analysis added to Muon Interfaces: Includes a selectable Periodic Table.
 - TF Asymmetry mode now displays the chi squared value at the top of the browser.
 - ALC interface now sorts the data into ascending order.
+- Muon Analysis now include number of event per frame and number of events per frame per detecotr in the run info box on the home tab.
 
 Bugfixes
 ########

--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -13,7 +13,7 @@ Improvements
 - Elemental Analysis added to Muon Interfaces: Includes a selectable Periodic Table.
 - TF Asymmetry mode now displays the chi squared value at the top of the browser.
 - ALC interface now sorts the data into ascending order.
-- Muon Analysis now include number of event per frame and number of events per frame per detecotr in the run info box on the home tab.
+- Muon Analysis now includes number of event per frame and number of events per frame per detector in the run info box on the home tab.
 
 Bugfixes
 ########

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -172,15 +172,16 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   if (run.hasProperty("goodfrm")) {
     auto goodFrames = run.getProperty("goodfrm")->value();
     out << goodFrames;
-  // Add counts divided by good frames to run information
-  out << "\nCounts/Good frames: ";
-  out << std::setprecision(3);
-  auto countsPerFrame = counts / std::stod(goodFrames);
-  out << countsPerFrame << " Events per frame";
-  // Add counts per detector per good frame
-  out << "\nCounts/(Good frames*number detectors): ";
-  out << std::setprecision(3);
-  out << countsPerFrame/runWs->getNumberHistograms() << " Events per frame per detector";
+    // Add counts divided by good frames to run information
+    out << "\nCounts/Good frames: ";
+    out << std::setprecision(3);
+    auto countsPerFrame = counts / std::stod(goodFrames);
+    out << countsPerFrame << " Events per frame";
+    // Add counts per detector per good frame
+    out << "\nCounts/(Good frames*number detectors): ";
+    out << std::setprecision(3);
+    out << countsPerFrame / runWs->getNumberHistograms()
+        << " Events per frame per detector";
   }
   // Add average temperature.
   out << "\nAverage Temperature: ";

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -157,13 +157,6 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
     end = run.getProperty("run_end")->value();
     out << end.toSimpleString();
   }
-
-  // Add the end time for the run
-  out << "\nGood frames: ";
-  if (run.hasProperty("goodfrm")) {
-    out << run.getProperty("goodfrm")->value();
-  }
-
   // Add counts to run information
   out << "\nCounts: ";
   double counts(0.0);
@@ -174,6 +167,21 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // output this number to three decimal places
   out << std::setprecision(3);
   out << counts / 1000000 << " MEv";
+  // Add the end time for the run
+  out << "\nGood frames: ";
+  if (run.hasProperty("goodfrm")) {
+    auto goodFrames = run.getProperty("goodfrm")->value();
+    out << goodFrames;
+  // Add counts divided by good frames to run information
+  out << "\nCounts/Good frames: ";
+  out << std::setprecision(3);
+  auto countsPerFrame = counts / std::stod(goodFrames);
+  out << countsPerFrame << " Events per frame";
+  // Add counts per detector per good frame
+  out << "\nCounts/(Good frames*number detectors): ";
+  out << std::setprecision(3);
+  out << countsPerFrame/runWs->getNumberHistograms() << " Events per frame per detector";
+  }
   // Add average temperature.
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -170,12 +170,12 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
   // Add the end time for the run
   out << "\nGood frames: ";
   if (run.hasProperty("goodfrm")) {
-    auto goodFrames = run.getProperty("goodfrm")->value();
+    const auto goodFrames = run.getProperty("goodfrm")->value();
     out << goodFrames;
     // Add counts divided by good frames to run information
     out << "\nCounts/Good frames: ";
     out << std::setprecision(3);
-    auto countsPerFrame = counts / std::stod(goodFrames);
+    const auto countsPerFrame = counts / std::stod(goodFrames);
     out << countsPerFrame << " Events per frame";
     // Add counts per detector per good frame
     out << "\nCounts/(Good frames*number detectors): ";

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -180,7 +180,7 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
     // Add counts per detector per good frame
     out << "\nCounts/(Good frames*number detectors): ";
     out << std::setprecision(3);
-    out << countsPerFrame /static_cast<double>(runWs->getNumberHistograms())
+    out << countsPerFrame / static_cast<double>(runWs->getNumberHistograms())
         << " Events per frame per detector";
   }
   // Add average temperature.

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -180,7 +180,7 @@ void printRunInfo(MatrixWorkspace_sptr runWs, std::ostringstream &out) {
     // Add counts per detector per good frame
     out << "\nCounts/(Good frames*number detectors): ";
     out << std::setprecision(3);
-    out << countsPerFrame / runWs->getNumberHistograms()
+    out << countsPerFrame /static_cast<double>(runWs->getNumberHistograms())
         << " Events per frame per detector";
   }
   // Add average temperature.


### PR DESCRIPTION
**Description of work.**
It was requested that the number of events per frame and number of events per frame per detector were added to the run info in muon analysis. In muon analysis the workspaces have the same number of histograms as detectors. 
**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->
Done. 
**To test:**
Open Muon Analysis
Load some data
At the bottom of the home tab you will see a box called run info
In the run info you will see counts (units are millions events) and number of good frames (frames)
Now there will be counts per frame and counts per frame per detector. 
<!-- Instructions for testing. -->

Fixes #24615. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
in release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
