### PR TITLE
Add ScaleRHSWorkspace Property to CTW

### DIFF
--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,6 +147,7 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
+    stitch->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,8 +147,7 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
-    stitch->setProperty("ScaleRHSWorkspace",
-                             getProperty("ScaleRHSWorkspace"));
+    stitch->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,7 +147,7 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
-    stitch->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
+    stitch->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,7 +147,8 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
-    stitch->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    stitch->setProperty("ScaleRHSWorkspace",
+                        getPropertyValue("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,8 +147,8 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
-    stitch->setPropertyValue("ScaleRHSWorkspace",
-                             getPropertyValue("ScaleRHSWorkspace"));
+    stitch->setProperty("ScaleRHSWorkspace",
+                             getProperty("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -147,7 +147,8 @@ void CreateTransmissionWorkspace2::exec() {
     stitch->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     stitch->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
     stitch->setPropertyValue("Params", getPropertyValue("Params"));
-    stitch->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    stitch->setPropertyValue("ScaleRHSWorkspace",
+                             getPropertyValue("ScaleRHSWorkspace"));
     stitch->execute();
     outWS = stitch->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,6 +520,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
+    alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSW"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,7 +520,8 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    alg->setProperty("ScaleRHSWorkspace",
+                     getPropertyValue("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,7 +520,8 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+    alg->setPropertyValue("ScaleRHSWorkspace",
+                          getPropertyValue("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,7 +520,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSW"));
+    alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,8 +520,8 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setPropertyValue("ScaleRHSWorkspace",
-                          getPropertyValue("ScaleRHSWorkspace"));
+    alg->setProperty("ScaleRHSWorkspace",
+                          getProperty("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,7 +520,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
+    alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -520,8 +520,7 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Params", getPropertyValue("Params"));
     alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
     alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
-    alg->setProperty("ScaleRHSWorkspace",
-                          getProperty("ScaleRHSWorkspace"));
+    alg->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
     alg->setPropertyValue("I0MonitorIndex", getPropertyValue("I0MonitorIndex"));
     alg->setPropertyValue("WavelengthMin", getPropertyValue("WavelengthMin"));
     alg->setPropertyValue("WavelengthMax", getPropertyValue("WavelengthMax"));

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -176,11 +176,10 @@ void ReflectometryWorkflowBase2::initStitchProperties() {
                   "End wavelength (angstroms) for stitching transmission runs "
                   "together. Only used if a second transmission run is "
                   "provided.");
-  declareProperty(
-      make_unique<PropertyWithValue<bool>>("ScaleRHSWorkspace", true,
-                                           Direction::Input),
-      "Scale the right-hand-side or left-hand-side workspace. "
-	  "Only used if a second transmission run is provided.");
+  declareProperty(make_unique<PropertyWithValue<bool>>("ScaleRHSWorkspace",
+                                                       true, Direction::Input),
+                  "Scale the right-hand-side or left-hand-side workspace. "
+                  "Only used if a second transmission run is provided.");
 }
 
 /** Initialize algorithmic correction properties
@@ -669,7 +668,8 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+      alg->setPropertyValue("ScaleRHSWorkspace",
+                            getPropertyValue("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -668,8 +668,7 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setProperty("ScaleRHSWorkspace",
-                            getProperty("ScaleRHSWorkspace"));
+      alg->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -668,8 +668,8 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setPropertyValue("ScaleRHSWorkspace",
-                            getPropertyValue("ScaleRHSWorkspace"));
+      alg->setProperty("ScaleRHSWorkspace",
+                            getProperty("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -668,7 +668,7 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setProperty("ScaleRHSWorkspace", getProperty("ScaleRHSWorkspace"));
+      alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -151,6 +151,7 @@ void ReflectometryWorkflowBase2::initTransmissionProperties() {
   setPropertyGroup("Params", "Transmission");
   setPropertyGroup("StartOverlap", "Transmission");
   setPropertyGroup("EndOverlap", "Transmission");
+  setPropertyGroup("ScaleRHSWorkspace", "Transmission");
 }
 
 /** Initialize properties used for stitching transmission runs
@@ -178,7 +179,7 @@ void ReflectometryWorkflowBase2::initStitchProperties() {
   declareProperty(
       make_unique<PropertyWithValue<bool>>("ScaleRHSWorkspace", true,
                                            Direction::Input),
-      "Whether the right-hand-side or left-hand-side workspace is scaled. "
+      "Scale the right-hand-side or left-hand-side workspace. "
 	  "Only used if a second transmission run is provided.");
 }
 
@@ -668,6 +669,7 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
+      alg->setPropertyValue("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -175,6 +175,11 @@ void ReflectometryWorkflowBase2::initStitchProperties() {
                   "End wavelength (angstroms) for stitching transmission runs "
                   "together. Only used if a second transmission run is "
                   "provided.");
+  declareProperty(
+      make_unique<PropertyWithValue<bool>>("ScaleRHSWorkspace", true,
+                                           Direction::Input),
+      "Whether the right-hand-side or left-hand-side workspace is scaled. "
+	  "Only used if a second transmission run is provided.");
 }
 
 /** Initialize algorithmic correction properties

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -668,7 +668,8 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(
       alg->setPropertyValue("StartOverlap", getPropertyValue("StartOverlap"));
       alg->setPropertyValue("EndOverlap", getPropertyValue("EndOverlap"));
       alg->setPropertyValue("Params", getPropertyValue("Params"));
-      alg->setProperty("ScaleRHSWorkspace", getPropertyValue("ScaleRHSWorkspace"));
+      alg->setProperty("ScaleRHSWorkspace",
+                       getPropertyValue("ScaleRHSWorkspace"));
     }
   }
 

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -363,6 +363,32 @@ public:
     TS_ASSERT_DELTA(outLam->x(0)[3], 2.0924, 0.0001);
   }
 
+  void test_two_transmission_runs_stitch_ScaleRHSWorkspace() {
+
+    CreateTransmissionWorkspace2 alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("FirstTransmissionRun", m_multiDetectorWS);
+    alg.setProperty("SecondTransmissionRun", m_multiDetectorWS);
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("Params", "0.1");
+    alg.setPropertyValue("ProcessingInstructions", "2");
+    alg.setPropertyValue("OutputWorkspace", "outWS");
+    alg.setPropertyValue("ScaleRHSWorkspace", false);
+    alg.execute();
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 126);
+    TS_ASSERT(outLam->x(0)[0] >= 1.5);
+    TS_ASSERT(outLam->x(0)[7] <= 15.0);
+    TS_ASSERT_DELTA(outLam->x(0)[0], 1.7924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[1], 1.8924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[2], 1.9924, 0.0001);
+    TS_ASSERT_DELTA(outLam->x(0)[3], 2.0924, 0.0001);
+  }
+
   void test_one_run_store_in_ADS() {
     AnalysisDataService::Instance().clear();
     auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -375,7 +375,7 @@ public:
     alg.setProperty("Params", "0.1");
     alg.setPropertyValue("ProcessingInstructions", "2");
     alg.setPropertyValue("OutputWorkspace", "outWS");
-    alg.setPropertyValue("ScaleRHSWorkspace", false);
+    alg.setProperty("ScaleRHSWorkspace", false);
     alg.execute();
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -372,7 +372,6 @@ public:
     alg.setProperty("SecondTransmissionRun", m_multiDetectorWS);
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("Params", "0.1");
     alg.setPropertyValue("ProcessingInstructions", "2");
     alg.setPropertyValue("OutputWorkspace", "outWS");
     alg.setProperty("ScaleRHSWorkspace", false);
@@ -380,13 +379,12 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 
     TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outLam->blocksize(), 126);
+    TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
-    TS_ASSERT(outLam->x(0)[7] <= 15.0);
-    TS_ASSERT_DELTA(outLam->x(0)[0], 1.7924, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[1], 1.8924, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[2], 1.9924, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[3], 2.0924, 0.0001);
+    TS_ASSERT(outLam->x(0)[14] <= 15.0);
+    TS_ASSERT_DELTA(outLam->y(0)[0], 2.000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[7], 2.000, 0.0001);
+    TS_ASSERT_DELTA(outLam->y(0)[13], 2.000, 0.0001);
   }
 
   void test_one_run_store_in_ADS() {

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -365,16 +365,23 @@ public:
 
   void test_two_transmission_runs_stitch_ScaleRHSWorkspace() {
 
+    auto lhsWS = m_multiDetectorWS;
+    auto rhsWS = m_multiDetectorWS;
+
+    // Modify counts for rhsWS (only for this test)
+    auto &Y = rhsWS->mutableY(1);
+    std::fill(Y.begin(), Y.end(), 3.0);
+
     CreateTransmissionWorkspace2 alg;
     alg.setChild(true);
     alg.initialize();
-    alg.setProperty("FirstTransmissionRun", m_multiDetectorWS);
-    alg.setProperty("SecondTransmissionRun", m_multiDetectorWS);
+    alg.setProperty("FirstTransmissionRun", lhsWS);
+    alg.setProperty("SecondTransmissionRun", rhsWS);
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ScaleRHSWorkspace", false);
     alg.setPropertyValue("ProcessingInstructions", "2");
     alg.setPropertyValue("OutputWorkspace", "outWS");
-    alg.setProperty("ScaleRHSWorkspace", false);
     alg.execute();
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspace");
 
@@ -382,9 +389,15 @@ public:
     TS_ASSERT_EQUALS(outLam->blocksize(), 14);
     TS_ASSERT(outLam->x(0)[0] >= 1.5);
     TS_ASSERT(outLam->x(0)[14] <= 15.0);
-    TS_ASSERT_DELTA(outLam->y(0)[0], 2.000, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[7], 2.000, 0.0001);
-    TS_ASSERT_DELTA(outLam->y(0)[13], 2.000, 0.0001);
+
+    // No monitors considered because MonitorBackgroundWavelengthMin
+    // and MonitorBackgroundWavelengthMax were not set
+    // Y counts must be all 3.0000
+    const auto &y_counts = outLam->counts(0);
+    for (auto itr = y_counts.begin(); itr != y_counts.end(); ++itr) {
+      TS_ASSERT_DELTA(3.0, *itr, 0.000001);
+    }
+
   }
 
   void test_one_run_store_in_ADS() {

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -397,7 +397,6 @@ public:
     for (auto itr = y_counts.begin(); itr != y_counts.end(); ++itr) {
       TS_ASSERT_DELTA(3.0, *itr, 0.000001);
     }
-
   }
 
   void test_one_run_store_in_ADS() {


### PR DESCRIPTION
**Description of work.**
This PR exposes the optional property ScaleRHSWorkspace from Stitch1D to CreateTransmissionWorkspace2 which is run through CreateTransmissionWorkspaceAuto2. It is also exposed in ReflectometryReductionOne2 and ReflectometryReductionOneAuto2.

**Report to:** Max at ISIS.

**To test:**

Load some data and run CreateTransmissionWorkspaceAuto with two transmissions runs with ScaleRHSWorkspace set to true and then false. Similarly run ReflectometryReductionOneAuto with two transmission runs and ScaleRHSWorkspace set to true and false.

Fixes #23821.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
