### PR TITLE
Indirect - Re-organisation of the Reduction and Analysis interfaces

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -21,6 +21,8 @@ set ( SRC_FILES
 	IndirectCorrections.cpp
 	IndirectDataAnalysis.cpp
 	IndirectDataAnalysisTab.cpp
+	IndirectDataManipulation.cpp
+	IndirectDataManipulationTab.cpp
 	IndirectDataReduction.cpp
 	IndirectDataReductionTab.cpp
 	IndirectDataTablePresenter.cpp
@@ -98,6 +100,8 @@ set ( INC_FILES
 	IndirectCorrections.h
 	IndirectDataAnalysis.h
 	IndirectDataAnalysisTab.h
+	IndirectDataManipulation.h
+	IndirectDataManipulationTab.h
 	IndirectDataReduction.h
 	IndirectDataReductionTab.h
 	IndirectDataTablePresenter.h
@@ -169,6 +173,8 @@ set ( MOC_FILES
     IndirectCorrections.h
     IndirectDataAnalysis.h
     IndirectDataAnalysisTab.h
+    IndirectDataManipulation.h
+    IndirectDataManipulationTab.h
     IndirectDataReduction.h
     IndirectDataReductionTab.h
     IndirectDataTablePresenter.h
@@ -225,6 +231,7 @@ set ( UI_FILES
    IndirectBayes.ui
    IndirectCorrections.ui
    IndirectDataAnalysis.ui
+   IndirectDataManipulation.ui
    IndirectDataReduction.ui
    IndirectDiffractionReduction.ui
    IndirectFitDataView.ui

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -56,7 +56,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 Elwin::Elwin(QWidget *parent)
-    : IndirectDataAnalysisTab(parent), m_elwTree(nullptr) {
+    : IndirectDataManipulationTab(parent), m_elwTree(nullptr) {
   m_uiForm.setupUi(parent);
 }
 
@@ -71,13 +71,13 @@ void Elwin::setup() {
 
   // Create Properties
   m_properties["IntegrationStart"] = m_dblManager->addProperty("Start");
-  m_dblManager->setDecimals(m_properties["IntegrationStart"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["IntegrationStart"], DECIMAL_PLACES);
   m_properties["IntegrationEnd"] = m_dblManager->addProperty("End");
-  m_dblManager->setDecimals(m_properties["IntegrationEnd"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["IntegrationEnd"], DECIMAL_PLACES);
   m_properties["BackgroundStart"] = m_dblManager->addProperty("Start");
-  m_dblManager->setDecimals(m_properties["BackgroundStart"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["BackgroundStart"], DECIMAL_PLACES);
   m_properties["BackgroundEnd"] = m_dblManager->addProperty("End");
-  m_dblManager->setDecimals(m_properties["BackgroundEnd"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["BackgroundEnd"], DECIMAL_PLACES);
 
   m_properties["BackgroundSubtraction"] =
       m_blnManager->addProperty("Background Subtraction");
@@ -478,13 +478,13 @@ void Elwin::newPreviewFileSelected(int index) {
  * Replots the preview plot.
  */
 void Elwin::plotInput() {
-  IndirectDataAnalysisTab::plotInput(m_uiForm.ppPlot);
-  IndirectDataAnalysisTab::updatePlotRange("ElwinIntegrationRange",
-                                           m_uiForm.ppPlot, "IntegrationStart",
-                                           "IntegrationEnd");
-  setDefaultResolution(inputWorkspace(),
+  IndirectDataManipulationTab::plotInput(m_uiForm.ppPlot);
+  IndirectDataManipulationTab::updatePlotRange(
+      "ElwinIntegrationRange", m_uiForm.ppPlot, "IntegrationStart",
+      "IntegrationEnd");
+  setDefaultResolution(getInputWorkspace(),
                        m_uiForm.ppPlot->getCurveRange("Sample"));
-  setDefaultSampleLog(inputWorkspace());
+  setDefaultSampleLog(getInputWorkspace());
 }
 
 void Elwin::twoRanges(QtProperty *prop, bool val) {

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -7,14 +7,14 @@
 #ifndef MANTIDQTCUSTOMINTERFACESIDA_ELWIN_H_
 #define MANTIDQTCUSTOMINTERFACESIDA_ELWIN_H_
 
-#include "IndirectDataAnalysisTab.h"
+#include "IndirectDataManipulationTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "ui_Elwin.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
-class DLLExport Elwin : public IndirectDataAnalysisTab {
+class DLLExport Elwin : public IndirectDataManipulationTab {
   Q_OBJECT
 
 public:
@@ -39,7 +39,6 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-  void setBrowserWorkspace() override{};
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
@@ -37,14 +37,11 @@ IndirectDataAnalysis::IndirectDataAnalysis(QWidget *parent)
       m_changeObserver(*this, &IndirectDataAnalysis::handleDirectoryChange) {
   m_uiForm.setupUi(this);
 
-  // Allows us to get a handle on a tab using an enum, for example
-  // "m_tabs[ELWIN]".
+  // Allows us to get a handle on a tab using an enum
   // All tabs MUST appear here to be shown in interface.
   // We make the assumption that each map key corresponds to the order in which
   // the tabs appear.
-  //m_tabs.emplace(ELWIN, new Elwin(m_uiForm.twIDATabs->widget(ELWIN)));
   m_tabs.emplace(MSD_FIT, new MSDFit(m_uiForm.twIDATabs->widget(MSD_FIT)));
-  //m_tabs.emplace(IQT, new Iqt(m_uiForm.twIDATabs->widget(IQT)));
   m_tabs.emplace(IQT_FIT, new IqtFit(m_uiForm.twIDATabs->widget(IQT_FIT)));
   m_tabs.emplace(CONV_FIT, new ConvFit(m_uiForm.twIDATabs->widget(CONV_FIT)));
   m_tabs.emplace(JUMP_FIT, new JumpFit(m_uiForm.twIDATabs->widget(JUMP_FIT)));

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
@@ -42,9 +42,9 @@ IndirectDataAnalysis::IndirectDataAnalysis(QWidget *parent)
   // All tabs MUST appear here to be shown in interface.
   // We make the assumption that each map key corresponds to the order in which
   // the tabs appear.
-  m_tabs.emplace(ELWIN, new Elwin(m_uiForm.twIDATabs->widget(ELWIN)));
+  //m_tabs.emplace(ELWIN, new Elwin(m_uiForm.twIDATabs->widget(ELWIN)));
   m_tabs.emplace(MSD_FIT, new MSDFit(m_uiForm.twIDATabs->widget(MSD_FIT)));
-  m_tabs.emplace(IQT, new Iqt(m_uiForm.twIDATabs->widget(IQT)));
+  //m_tabs.emplace(IQT, new Iqt(m_uiForm.twIDATabs->widget(IQT)));
   m_tabs.emplace(IQT_FIT, new IqtFit(m_uiForm.twIDATabs->widget(IQT_FIT)));
   m_tabs.emplace(CONV_FIT, new ConvFit(m_uiForm.twIDATabs->widget(CONV_FIT)));
   m_tabs.emplace(JUMP_FIT, new JumpFit(m_uiForm.twIDATabs->widget(JUMP_FIT)));

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
@@ -27,7 +27,7 @@ namespace IDA {
 // The assumption is made elsewhere that the ordering of these enums matches the
 // ordering of the
 // tabs as they appear in the interface itself.
-enum IDATabChoice { ELWIN, MSD_FIT, IQT, IQT_FIT, CONV_FIT, JUMP_FIT };
+enum IDATabChoice { MSD_FIT, IQT_FIT, CONV_FIT, JUMP_FIT };
 
 // Number of decimal places in property browsers.
 static const unsigned int NUM_DECIMALS = 6;

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.ui
@@ -56,19 +56,9 @@
       <property name="currentIndex">
        <number>0</number>
       </property>
-      <widget class="QWidget" name="tabElwin">
-       <attribute name="title">
-        <string>Elwin</string>
-       </attribute>
-      </widget>
       <widget class="QWidget" name="tabMSD">
        <attribute name="title">
         <string>MSD Fit</string>
-       </attribute>
-      </widget>
-      <widget class="QWidget" name="tabIqt">
-       <attribute name="title">
-        <string>I(Q, t)</string>
        </attribute>
       </widget>
       <widget class="QWidget" name="tabIqtFit">

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
@@ -24,8 +24,8 @@ IndirectDataManipulation::IndirectDataManipulation(QWidget *parent)
     : UserSubWindow(parent) {
   m_uiForm.setupUi(this);
 
-  // m_tabs.emplace(SYMMETRISE2, new IndirectSymmetrise(
-  //                                m_uiForm.twIDMTabs->widget(SYMMETRISE2)));
+  m_tabs.emplace(SYMMETRISE, new IndirectSymmetrise(
+                                 m_uiForm.twIDMTabs->widget(SYMMETRISE)));
   // m_tabs.emplace(SQW2, new IndirectSqw(m_uiForm.twIDMTabs->widget(SQW2)));
   // m_tabs.emplace(MOMENTS2,
   //               new IndirectMoments(m_uiForm.twIDMTabs->widget(MOMENTS2)));

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
@@ -12,23 +12,16 @@ namespace IDA {
 DECLARE_SUBWINDOW(IndirectDataManipulation)
 
 IndirectDataManipulation::IndirectDataManipulation(QWidget *parent)
-    : UserSubWindow(parent),
-      m_changeObserver(*this,
-                       &IndirectDataManipulation::handleDirectoryChange) {
+    : UserSubWindow(parent) {
   m_uiForm.setupUi(this);
 
-  //m_tabs.emplace(SYMMETRISE2, new IndirectSymmetrise(
+  // m_tabs.emplace(SYMMETRISE2, new IndirectSymmetrise(
   //                                m_uiForm.twIDMTabs->widget(SYMMETRISE2)));
-  //m_tabs.emplace(SQW2, new IndirectSqw(m_uiForm.twIDMTabs->widget(SQW2)));
-  //m_tabs.emplace(MOMENTS2,
+  // m_tabs.emplace(SQW2, new IndirectSqw(m_uiForm.twIDMTabs->widget(SQW2)));
+  // m_tabs.emplace(MOMENTS2,
   //               new IndirectMoments(m_uiForm.twIDMTabs->widget(MOMENTS2)));
-  m_tabs.emplace(ELWIN2, new Elwin(m_uiForm.twIDMTabs->widget(ELWIN2)));
-  m_tabs.emplace(IQT2, new Iqt(m_uiForm.twIDMTabs->widget(IQT2)));
-}
-
-void IndirectDataManipulation::handleDirectoryChange(
-    Mantid::Kernel::ConfigValChangeNotification_ptr pNf) {
-  std::string key = pNf->key();
+  // m_tabs.emplace(ELWIN2, new Elwin(m_uiForm.twIDMTabs->widget(ELWIN2)));
+  // m_tabs.emplace(IQT2, new Iqt(m_uiForm.twIDMTabs->widget(IQT2)));
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
@@ -1,0 +1,36 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectDataManipulation.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+DECLARE_SUBWINDOW(IndirectDataManipulation)
+
+IndirectDataManipulation::IndirectDataManipulation(QWidget *parent)
+    : UserSubWindow(parent),
+      m_changeObserver(*this,
+                       &IndirectDataManipulation::handleDirectoryChange) {
+  m_uiForm.setupUi(this);
+
+  //m_tabs.emplace(SYMMETRISE2, new IndirectSymmetrise(
+  //                                m_uiForm.twIDMTabs->widget(SYMMETRISE2)));
+  //m_tabs.emplace(SQW2, new IndirectSqw(m_uiForm.twIDMTabs->widget(SQW2)));
+  //m_tabs.emplace(MOMENTS2,
+  //               new IndirectMoments(m_uiForm.twIDMTabs->widget(MOMENTS2)));
+  m_tabs.emplace(ELWIN2, new Elwin(m_uiForm.twIDMTabs->widget(ELWIN2)));
+  m_tabs.emplace(IQT2, new Iqt(m_uiForm.twIDMTabs->widget(IQT2)));
+}
+
+void IndirectDataManipulation::handleDirectoryChange(
+    Mantid::Kernel::ConfigValChangeNotification_ptr pNf) {
+  std::string key = pNf->key();
+}
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.cpp
@@ -6,6 +6,15 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDataManipulation.h"
 
+#include "Elwin.h"
+#include "IndirectMoments.h"
+#include "IndirectSqw.h"
+#include "IndirectSymmetrise.h"
+#include "Iqt.h"
+
+#include "MantidQtWidgets/Common/HelpWindow.h"
+#include "MantidQtWidgets/Common/ManageUserDirectories.h"
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -21,7 +30,44 @@ IndirectDataManipulation::IndirectDataManipulation(QWidget *parent)
   // m_tabs.emplace(MOMENTS2,
   //               new IndirectMoments(m_uiForm.twIDMTabs->widget(MOMENTS2)));
   // m_tabs.emplace(ELWIN2, new Elwin(m_uiForm.twIDMTabs->widget(ELWIN2)));
-  // m_tabs.emplace(IQT2, new Iqt(m_uiForm.twIDMTabs->widget(IQT2)));
+  m_tabs.emplace(ELWIN, new Elwin(m_uiForm.twIDMTabs->widget(ELWIN)));
+  m_tabs.emplace(IQT, new Iqt(m_uiForm.twIDMTabs->widget(IQT)));
+}
+
+void IndirectDataManipulation::initLayout() {
+  // Set up all tabs
+  for (auto tab = m_tabs.begin(); tab != m_tabs.end(); ++tab) {
+    tab->second->setupTab();
+    connect(tab->second, SIGNAL(runAsPythonScript(QString const &, bool)), this,
+            SIGNAL(runAsPythonScript(QString const &, bool)));
+    connect(tab->second, SIGNAL(showMessageBox(const QString &)), this,
+            SLOT(showMessageBox(QString const &)));
+  }
+  connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(handleHelp()));
+  connect(m_uiForm.pbPythonExport, SIGNAL(clicked()), this,
+          SLOT(handleExportToPython()));
+  connect(m_uiForm.pbManageDirs, SIGNAL(clicked()), this,
+          SLOT(handleManageDirectories()));
+}
+
+void IndirectDataManipulation::handleHelp() {
+  MantidQt::API::HelpWindow::showCustomInterface(
+      nullptr, QString("Indirect Data Manipulation"));
+}
+
+void IndirectDataManipulation::handleExportToPython() {
+  std::size_t const currentTab = m_uiForm.twIDMTabs->currentIndex();
+  m_tabs[currentTab]->exportPythonScript();
+}
+
+void IndirectDataManipulation::handleManageDirectories() {
+  auto dialog = new MantidQt::API::ManageUserDirectories(this);
+  dialog->show();
+  dialog->setFocus();
+}
+
+void IndirectDataManipulation::showMessageBox(QString const &message) {
+  showInformationBox(message);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
@@ -9,21 +9,13 @@
 
 #include "ui_IndirectDataManipulation.h"
 
-#include "IndirectDataManipulationTab.h"
-
-#include "Elwin.h"
-#include "IndirectMoments.h"
-#include "IndirectSqw.h"
-#include "IndirectSymmetrise.h"
-#include "Iqt.h"
-
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-enum IDMTabChoice { SYMMETRISE2, SQW2, MOMENTS2, ELWIN2, IQT2 };
+enum IDMTabChoice { SYMMETRISE2, SQW2, MOMENTS2, ELWIN, IQT };
 
 class IndirectDataManipulation : public MantidQt::API::UserSubWindow {
   Q_OBJECT
@@ -32,15 +24,20 @@ class IndirectDataManipulation : public MantidQt::API::UserSubWindow {
 
 public:
   explicit IndirectDataManipulation(QWidget *parent = nullptr);
-  ~IndirectDataManipulation() override{};
 
   static std::string name() { return "Data Manipulation"; }
   static QString categoryInfo() { return "Indirect"; }
 
-private:
-  void initLayout() override{};
+private slots:
+  void handleHelp();
+  void handleExportToPython();
+  void handleManageDirectories();
+  void showMessageBox(QString const &message);
 
-  std::map<unsigned int, IndirectDataManipulationTab *> m_tabs;
+private:
+  void initLayout() override;
+
+  std::map<std::size_t, IndirectDataManipulationTab *> m_tabs;
 
   Ui::IndirectDataManipulation m_uiForm;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
@@ -19,9 +19,6 @@
 
 #include "MantidQtWidgets/Common/UserSubWindow.h"
 
-#include "MantidKernel/ConfigService.h"
-#include <Poco/NObserver.h>
-
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -35,18 +32,14 @@ class IndirectDataManipulation : public MantidQt::API::UserSubWindow {
 
 public:
   explicit IndirectDataManipulation(QWidget *parent = nullptr);
-  ~IndirectDataManipulation() override;
+  ~IndirectDataManipulation() override{};
 
   static std::string name() { return "Data Manipulation"; }
   static QString categoryInfo() { return "Indirect"; }
 
 private:
-  void
-  handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
+  void initLayout() override{};
 
-  Poco::NObserver<IndirectDataManipulation,
-                  Mantid::Kernel::ConfigValChangeNotification>
-      m_changeObserver;
   std::map<unsigned int, IndirectDataManipulationTab *> m_tabs;
 
   Ui::IndirectDataManipulation m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
@@ -15,7 +15,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-enum IDMTabChoice { SYMMETRISE2, SQW2, MOMENTS2, ELWIN, IQT };
+enum IDMTabChoice { SYMMETRISE, SQW2, MOMENTS2, ELWIN, IQT };
 
 class IndirectDataManipulation : public MantidQt::API::UserSubWindow {
   Q_OBJECT

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.h
@@ -1,0 +1,59 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATION_H_
+#define MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATION_H_
+
+#include "ui_IndirectDataManipulation.h"
+
+#include "IndirectDataManipulationTab.h"
+
+#include "Elwin.h"
+#include "IndirectMoments.h"
+#include "IndirectSqw.h"
+#include "IndirectSymmetrise.h"
+#include "Iqt.h"
+
+#include "MantidQtWidgets/Common/UserSubWindow.h"
+
+#include "MantidKernel/ConfigService.h"
+#include <Poco/NObserver.h>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+enum IDMTabChoice { SYMMETRISE2, SQW2, MOMENTS2, ELWIN2, IQT2 };
+
+class IndirectDataManipulation : public MantidQt::API::UserSubWindow {
+  Q_OBJECT
+
+  friend class IndirectDataManipulationTab;
+
+public:
+  explicit IndirectDataManipulation(QWidget *parent = nullptr);
+  ~IndirectDataManipulation() override;
+
+  static std::string name() { return "Data Manipulation"; }
+  static QString categoryInfo() { return "Indirect"; }
+
+private:
+  void
+  handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
+
+  Poco::NObserver<IndirectDataManipulation,
+                  Mantid::Kernel::ConfigValChangeNotification>
+      m_changeObserver;
+  std::map<unsigned int, IndirectDataManipulationTab *> m_tabs;
+
+  Ui::IndirectDataManipulation m_uiForm;
+};
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATION_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulation.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulation.ui
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>IndirectDataManipulation</class>
+ <widget class="QMainWindow" name="IndirectDataManipulation">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>741</width>
+    <height>758</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>200</width>
+    <height>200</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Indirect Data Manipulation</string>
+  </property>
+  <widget class="QWidget" name="centralwidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="twIDMTabs">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QWidget" name="tabSymmetrise">
+       <attribute name="title">
+        <string>Symmetrise</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabSqw">
+       <attribute name="title">
+        <string>S(Q, w)</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabMoments">
+       <attribute name="title">
+        <string>Moments</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabElwin">
+       <attribute name="title">
+        <string>Elwin</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabIqt">
+       <attribute name="title">
+        <string>I(Q, t)</string>
+       </attribute>
+      </widget>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="layout_bottom">
+      <item>
+       <widget class="QPushButton" name="pbHelp">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>25</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Open interface help page in your web browser.</string>
+        </property>
+        <property name="text">
+         <string>?</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbPythonExport">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>30</width>
+          <height>25</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Export a Python script for the algorithms run on this tab.</string>
+        </property>
+        <property name="text">
+         <string>Py</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_14">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbManageDirs">
+        <property name="text">
+         <string>Manage Directories</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.cpp
@@ -1,0 +1,20 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectDataManipulationTab.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+IndirectDataManipulationTab::IndirectDataManipulationTab(QWidget *parent)
+    : IndirectTab(parent) {
+  //m_parent = dynamic_cast<IndirectDataManipulation *>(parent);
+}
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.cpp
@@ -6,13 +6,74 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDataManipulationTab.h"
 
+using namespace Mantid::API;
+using namespace MantidQt::MantidWidgets;
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
 IndirectDataManipulationTab::IndirectDataManipulationTab(QWidget *parent)
-    : IndirectTab(parent) {
-  //m_parent = dynamic_cast<IndirectDataManipulation *>(parent);
+    : IndirectTab(parent), m_inputWorkspace(), m_selectedSpectrum(0),
+      m_dblEdFac(nullptr), m_blnEdFac(nullptr) {
+  // m_parent = dynamic_cast<IndirectDataManipulation *>(parent);
+  m_dblEdFac = new DoubleEditorFactory(this);
+  m_blnEdFac = new QtCheckBoxFactory(this);
+}
+
+void IndirectDataManipulationTab::setInputWorkspace(
+    MatrixWorkspace_sptr workspace) {
+  m_inputWorkspace = workspace;
+}
+
+MatrixWorkspace_sptr IndirectDataManipulationTab::getInputWorkspace() const {
+  return m_inputWorkspace;
+}
+
+int IndirectDataManipulationTab::getSelectedSpectrum() const {
+  return m_selectedSpectrum;
+}
+
+void IndirectDataManipulationTab::plotInput(PreviewPlot *previewPlot) {
+  previewPlot->clear();
+  auto const inputWS = getInputWorkspace();
+  auto const spectrum = getSelectedSpectrum();
+
+  if (inputWS && inputWS->x(spectrum).size() > 1)
+    previewPlot->addSpectrum("Sample", inputWS, spectrum);
+}
+
+/*
+ * Updates the plot range with the specified name, to match the range of
+ * the sample curve.
+ *
+ * @param rangeName           The name of the range to update.
+ * @param previewPlot         The preview plot widget, in which the range
+ *                            is specified.
+ * @param startRangePropName  The name of the property specifying the start
+ *                            value for the range.
+ * @parma endRangePropName    The name of the property specifying the end
+ *                            value for the range.
+ */
+void IndirectDataManipulationTab::updatePlotRange(
+    std::string const &rangeName, PreviewPlot *previewPlot,
+    std::string const &startRangePropName,
+    std::string const &endRangePropName) {
+
+  if (getInputWorkspace()) {
+    try {
+      QPair<double, double> const curveRange =
+          previewPlot->getCurveRange("Sample");
+      auto const rangeSelector =
+          previewPlot->getRangeSelector(QString::fromStdString(rangeName));
+      setPlotPropertyRange(
+          rangeSelector,
+          m_properties[QString::fromStdString(startRangePropName)],
+          m_properties[QString::fromStdString(endRangePropName)], curveRange);
+    } catch (std::exception const &ex) {
+      showMessageBox(ex.what());
+    }
+  }
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.h
@@ -1,0 +1,32 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATIONTAB_H_
+#define MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATIONTAB_H_
+#include "IndirectDataManipulation.h"
+#include "IndirectTab.h"
+
+#include "DllConfig.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace IDA {
+
+class MANTIDQT_INDIRECT_DLL IndirectDataManipulationTab : public IndirectTab {
+  Q_OBJECT
+
+public:
+  IndirectDataManipulationTab(QWidget *parent = nullptr);
+
+private:
+  //IndirectDataManipulation *m_parent;
+};
+
+} // namespace IDA
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif /* MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATIONTAB_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataManipulationTab.h
@@ -6,14 +6,20 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATIONTAB_H_
 #define MANTIDQTCUSTOMINTERFACES_INDIRECTDATAMANIPULATIONTAB_H_
-#include "IndirectDataManipulation.h"
 #include "IndirectTab.h"
 
 #include "DllConfig.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+
+#include <MantidQtWidgets/Common/QtPropertyBrowser/QtCheckBoxFactory>
+#include <QSettings>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
+
+// Number of decimal places in property browsers.
+static std::size_t const DECIMAL_PLACES(6);
 
 class MANTIDQT_INDIRECT_DLL IndirectDataManipulationTab : public IndirectTab {
   Q_OBJECT
@@ -21,8 +27,31 @@ class MANTIDQT_INDIRECT_DLL IndirectDataManipulationTab : public IndirectTab {
 public:
   IndirectDataManipulationTab(QWidget *parent = nullptr);
 
+  void setInputWorkspace(Mantid::API::MatrixWorkspace_sptr workspace);
+  Mantid::API::MatrixWorkspace_sptr getInputWorkspace() const;
+
+  int getSelectedSpectrum() const;
+
+  void plotInput(MantidQt::MantidWidgets::PreviewPlot *previewPlot);
+
+protected:
+  void updatePlotRange(std::string const &rangeName,
+                       MantidQt::MantidWidgets::PreviewPlot *previewPlot,
+                       std::string const &startRangePropName = "",
+                       std::string const &endRangePropName = "");
+
+  DoubleEditorFactory *m_dblEdFac;
+  QtCheckBoxFactory *m_blnEdFac;
+
 private:
-  //IndirectDataManipulation *m_parent;
+  void setup() override = 0;
+  void run() override = 0;
+  bool validate() override = 0;
+  virtual void loadSettings(QSettings const &settings) = 0;
+
+  Mantid::API::MatrixWorkspace_sptr m_inputWorkspace;
+  int m_selectedSpectrum;
+  // IndirectDataManipulation *m_parent;
 };
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.cpp
@@ -109,7 +109,7 @@ void IndirectDataReduction::initLayout() {
   addTab<ISISCalibration>("ISIS Calibration");
   addTab<ISISDiagnostics>("ISIS Diagnostics");
   addTab<IndirectTransmission>("Transmission");
-  addTab<IndirectSymmetrise>("Symmetrise");
+  //addTab<IndirectSymmetrise>("Symmetrise");
   addTab<IndirectSqw>("S(Q, w)");
   addTab<IndirectMoments>("Moments");
   addTab<ILLEnergyTransfer>("ILL Energy Transfer");

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -7,7 +7,7 @@
 #ifndef MANTIDQTCUSTOMINTERFACES_INDIRECTSYMMETRISE_H_
 #define MANTIDQTCUSTOMINTERFACES_INDIRECTSYMMETRISE_H_
 
-#include "IndirectDataReductionTab.h"
+#include "IndirectDataManipulationTab.h"
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
@@ -33,16 +33,13 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
-/** IndirectSymmetrise
+namespace IDA {
 
-  @author Dan Nixon
-  @date 23/07/2014
-*/
-class DLLExport IndirectSymmetrise : public IndirectDataReductionTab {
+class DLLExport IndirectSymmetrise : public IndirectDataManipulationTab {
   Q_OBJECT
 
 public:
-  IndirectSymmetrise(IndirectDataReduction *idrUI, QWidget *parent = nullptr);
+  IndirectSymmetrise(QWidget *parent = nullptr);
   ~IndirectSymmetrise() override;
 
   void setup() override;
@@ -65,19 +62,20 @@ private slots:
   void plotClicked();
   void saveClicked();
 
+private:
+  void loadSettings(const QSettings &settings) override{};
+
+  void setRunIsRunning(bool running);
+  void setPlotIsPlotting(bool plotting);
+  void setButtonsEnabled(bool enabled);
   void setRunEnabled(bool enabled);
   void setPlotEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
-  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
-  void updateRunButton(bool enabled = true,
-                       std::string const &enableOutputButtons = "unchanged",
-                       QString const message = "Run",
-                       QString const tooltip = "");
-  void setPlotIsPlotting(bool plotting);
 
-private:
   Ui::IndirectSymmetrise m_uiForm;
 };
+
+} // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.ui
@@ -135,18 +135,6 @@
       </item>
       <item>
        <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Run</string>
         </property>
@@ -226,15 +214,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
-  </customwidget>
-  <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/LegacyQwt/PreviewPlot.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -109,7 +109,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 Iqt::Iqt(QWidget *parent)
-    : IndirectDataAnalysisTab(parent), m_iqtTree(nullptr), m_iqtResFileType() {
+    : IndirectDataManipulationTab(parent), m_iqtTree(nullptr),
+      m_iqtResFileType() {
   m_uiForm.setupUi(parent);
 }
 
@@ -119,14 +120,14 @@ void Iqt::setup() {
 
   // Create and configure properties
   m_properties["ELow"] = m_dblManager->addProperty("ELow");
-  m_dblManager->setDecimals(m_properties["ELow"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["ELow"], DECIMAL_PLACES);
 
   m_properties["EWidth"] = m_dblManager->addProperty("EWidth");
-  m_dblManager->setDecimals(m_properties["EWidth"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EWidth"], DECIMAL_PLACES);
   m_properties["EWidth"]->setEnabled(false);
 
   m_properties["EHigh"] = m_dblManager->addProperty("EHigh");
-  m_dblManager->setDecimals(m_properties["EHigh"], NUM_DECIMALS);
+  m_dblManager->setDecimals(m_properties["EHigh"], DECIMAL_PLACES);
 
   m_properties["SampleBinning"] = m_dblManager->addProperty("SampleBinning");
   m_dblManager->setDecimals(m_properties["SampleBinning"], 0);
@@ -231,7 +232,7 @@ void Iqt::algorithmComplete(bool error) {
   } else {
     auto const lastSpectrumIndex =
         static_cast<int>(getWsNumberOfSpectra(m_pythonExportWsName)) - 1;
-    auto const selectedSpec = selectedSpectrum();
+    auto const selectedSpec = getSelectedSpectrum();
 
     setPlotSpectrumIndexMax(lastSpectrumIndex);
     setPlotSpectrumIndex(selectedSpec);
@@ -456,7 +457,7 @@ void Iqt::plotInput(const QString &wsname) {
     return;
   }
 
-  IndirectDataAnalysisTab::plotInput(m_uiForm.ppPlot);
+  IndirectDataManipulationTab::plotInput(m_uiForm.ppPlot);
   auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
 
   try {

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -7,13 +7,14 @@
 #ifndef MANTIDQTCUSTOMINTERFACESIDA_IQT_H_
 #define MANTIDQTCUSTOMINTERFACESIDA_IQT_H_
 
-#include "IndirectDataAnalysisTab.h"
+#include "IndirectDataManipulationTab.h"
 #include "ui_Iqt.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
-class DLLExport Iqt : public IndirectDataAnalysisTab {
+
+class DLLExport Iqt : public IndirectDataManipulationTab {
   Q_OBJECT
 
 public:
@@ -24,7 +25,6 @@ private:
   void setup() override;
   bool validate() override;
   void loadSettings(const QSettings &settings) override;
-  void setBrowserWorkspace() override{};
 
   bool isErrorsEnabled();
 


### PR DESCRIPTION
**Description of work.**
This PR re-organizes some of the indirect interfaces as follows:
-	Data Manipulation: Symmetrise, Sqw, Moments, Elwin & Iqt
-	Data Reduction: Energy Transfer, Calibration, Diagnostics & Transmission
-	Data Analysis: MSDFit, IqtFit, ConvFit & F(Q)Fit

This is a good idea because:
- It will mean the interfaces are more organised for one! (Data Reduction especially would appear to be less crowded)
- Data Reduction would be the only interface to use raw files (and therefore the ONLY instrument dependent interface)
- It will make it easier for the sharing of code between interfaces and hence it would be easier for an MVP style to be introduced to these interfaces.
- Once an MVP style has been adopted, we can create unit tests (automated testing) for these interfaces.

**To test:**
No tests as of yet

Fixes #24610 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
