### PR TITLE
DirectILLCollectData: handle broken monitors gracefully

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -19,6 +19,8 @@ from mantid.simpleapi import (AddSampleLog, CalculateFlatBackground, CloneWorksp
                               FindEPP, GetEiMonDet, LoadAndMerge, Minus, NormaliseToMonitor, Scale)
 import numpy
 
+_MONSUM_LIMIT = 100
+
 
 def _applyIncidentEnergyCalibration(ws, wsType, eiWS, wsNames, report,
                                     algorithmLogging):
@@ -143,6 +145,16 @@ def _fitEPP(ws, wsType, wsNames, algorithmLogging):
                     OutputWorkspace=eppWSName,
                     EnableLogging=algorithmLogging)
     return eppWS
+
+
+def _monitorCounts(ws):
+    """Return the total monitor counts from the sample logs"""
+    logs = ws.run()
+    instrument = ws.getInstrument()
+    if instrument.getName() == 'IN6':
+        return logs.getProperty('monitor1.monsum').value
+    else:
+        return logs.getProperty('monitor.monsum').value
 
 
 def _normalizeToMonitor(ws, monWS, monIndex, integrationBegin, integrationEnd,
@@ -299,7 +311,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
         progress.report('Normalising to monitor/time')
         monWS = self._flatBkgMon(monWS, wsNames, wsCleanup, subalgLogging)
         monEPPWS = self._createEPPWSMon(monWS, wsNames, wsCleanup, subalgLogging)
-        mainWS = self._normalize(mainWS, monWS, monEPPWS, wsNames, wsCleanup, subalgLogging)
+        mainWS = self._normalize(mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging)
 
         # Time-independent background.
         progress.report('Calculating backgrounds')
@@ -663,17 +675,27 @@ class DirectILLCollectData(DataProcessorAlgorithm):
 
     def _eiCalibrationEnabled(self, mainWS, report):
         """Return true if incident energy calibration should be perfomed, false if not."""
-        eppMethod = self.getProperty(common.PROP_INCIDENT_ENERGY_CALIBRATION).value
-        if eppMethod == common.INCIDENT_ENERGY_CALIBRATION_AUTO:
+        calibration = self.getProperty(common.PROP_INCIDENT_ENERGY_CALIBRATION).value
+        state = None
+        ENABLED_AUTOMATICALLY = 1
+        if calibration == common.INCIDENT_ENERGY_CALIBRATION_OFF:
+            return False
+        elif calibration == common.INCIDENT_ENERGY_CALIBRATION_AUTO:
             instrument = mainWS.getInstrument()
             if instrument.hasParameter('enable_incident_energy_calibration'):
                 enabled = instrument.getBoolParameter('enable_incident_energy_calibration')[0]
                 if not enabled:
                     report.notice('Incident energy calibration disabled by the IPF.')
                     return False
+                else:
+                    state = ENABLED_AUTOMATICALLY
+        monitorCounts = _monitorCounts(mainWS)
+        if monitorCounts < _MONSUM_LIMIT:
+            report.warning("'monsum' less than {}. Disabling incident energy calibration.".format(_MONSUM_LIMIT))
+            return False
+        if state == ENABLED_AUTOMATICALLY:
             report.notice('Incident energy calibration enabled.')
-            return True
-        return eppMethod == common.INCIDENT_ENERGY_CALIBRATION_ON
+        return True
 
     def _flatBkgDet(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
         """Subtract flat background from a detector workspace."""
@@ -745,11 +767,17 @@ class DirectILLCollectData(DataProcessorAlgorithm):
             monIndex = common.convertToWorkspaceIndex(monIndex, monWS)
         return monIndex
 
-    def _normalize(self, mainWS, monWS, monEPPWS, wsNames, wsCleanup, subalgLogging):
+    def _normalize(self, mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging):
         """Normalize to monitor or measurement time."""
         normalisationMethod = self.getProperty(common.PROP_NORMALISATION).value
-        if normalisationMethod != common.NORM_METHOD_OFF:
-            if normalisationMethod == common.NORM_METHOD_MON:
+        if normalisationMethod == common.NORM_METHOD_OFF:
+            return mainWS
+        if normalisationMethod == common.NORM_METHOD_MON:
+            monitorCounts = _monitorCounts(monWS)
+            if monitorCounts < _MONSUM_LIMIT:
+                report.warning("'monsum' less than {}. Disabling normalization to monitor.".format(_MONSUM_LIMIT))
+                normalisationMethod = common.NORM_METHOD_TIME
+            else:
                 sigmaMultiplier = \
                     self.getProperty(common.PROP_MON_PEAK_SIGMA_MULTIPLIER).value
                 monIndex = self._monitorIndex(monWS)
@@ -768,13 +796,10 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                                                    subalgLogging)
                 normalizedWS = _scaleAfterMonitorNormalization(normalizedWS, wsNames, wsCleanup,
                                                                subalgLogging)
-            elif normalisationMethod == common.NORM_METHOD_TIME:
-                normalizedWS = _normalizeToTime(mainWS, wsNames, wsCleanup, subalgLogging)
-            else:
-                raise RuntimeError('Unknonwn normalisation method ' + normalisationMethod)
-            wsCleanup.cleanup(mainWS)
-            return normalizedWS
-        return mainWS
+        if normalisationMethod == common.NORM_METHOD_TIME:
+            normalizedWS = _normalizeToTime(mainWS, wsNames, wsCleanup, subalgLogging)
+        wsCleanup.cleanup(mainWS)
+        return normalizedWS
 
     def _outputDetEPPWS(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
         """Set the output epp workspace property, if needed."""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
@@ -95,6 +95,32 @@ class DirectILLCollectDataTest(unittest.TestCase):
         originalEs = inWS.extractE()
         numpy.testing.assert_almost_equal(es, originalEs[:-1, :] / duration)
 
+    def testNormalisationToTimeWhenMonitorCountsAreTooLow(self):
+        outWSName = 'outWS'
+        duration = 3612.3
+        logs = mtd[self._TEST_WS_NAME].mutableRun()
+        logs.addProperty('duration', duration, True)
+        monsum = 10
+        logs.addProperty('monitor.monsum', monsum, True)
+        algProperties = {
+            'InputWorkspace': self._TEST_WS_NAME,
+            'OutputWorkspace': outWSName,
+            'FlatBkg': 'Flat Bkg OFF',
+            'IncidentEnergyCalibration': 'Energy Calibration OFF',
+            'Normalisation': 'Normalisation Monitor',
+            'rethrow': True
+        }
+        run_algorithm('DirectILLCollectData', **algProperties)
+        self.assertTrue(mtd.doesExist(outWSName))
+        outWS = mtd[outWSName]
+        inWS = mtd[self._TEST_WS_NAME]
+        ys = outWS.extractY()
+        originalYs = inWS.extractY()
+        numpy.testing.assert_almost_equal(ys, originalYs[:-1, :] / duration)
+        es = outWS.extractE()
+        originalEs = inWS.extractE()
+        numpy.testing.assert_almost_equal(es, originalEs[:-1, :] / duration)
+
     def testRawWorkspaceOutput(self):
         outWSName = 'outWS'
         rawWSName = 'rawWS'

--- a/Framework/PythonInterface/test/testhelpers/illhelpers.py
+++ b/Framework/PythonInterface/test/testhelpers/illhelpers.py
@@ -177,6 +177,15 @@ def _fillTemplateTOFWorkspace(templateWS, bkgLevel):
     run_algorithm('AddSampleLog', **kwargs)
     kwargs = {
         'Workspace': ws,
+        'LogName': 'monitor.monsum',
+        'LogText': str(1000),
+        'LogType': 'Number',
+        'NumberType': 'Int',
+        'child': True
+    }
+    run_algorithm('AddSampleLog', **kwargs)
+    kwargs = {
+        'Workspace': ws,
         'ParameterName': 'default-incident-monitor-spectrum',
         'ParameterType': 'Number',
         'Value': str(98305),

--- a/docs/source/algorithms/DirectILLCollectData-v1.rst
+++ b/docs/source/algorithms/DirectILLCollectData-v1.rst
@@ -43,6 +43,10 @@ If *Normalisation* is set to :literal:`'Normalisation Monitor'`, the data is div
 
 Afterwards, the intensities are multiplied by a factor defined by the 'scaling_after_monitor_normalisation' entry in instrument parameters, if present.
 
+.. note::
+
+    If the sample log entry ``monitor.monsum`` (``monitor1.monsum`` on IN6) is less than 100, monitor normalisation will be disabled and the data normalised to time.
+
 Normalisation to time
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -74,6 +78,10 @@ The incident energy and the nominal TOF channel are needed to adjust the TOF axi
 The incident energy written in the data files of IN4 and IN6 and accessible via the `Ei` sample log may be inaccurate. To ensure a correct value is used for the TOF axis adjustment, the value can be calibrated using :ref:`GetEiMonDet <algm-GetEiMonDet>`. The operation is controlled by *IncidentEnergyCalibration*. Elastic peak positions are needed for the calculation which can be supplied by *EPPWorkspace*, otherwise :ref:`FindEPP <algm-FindEPP>` is used.
 
 The calibrated energy can be retrieved as a single-value workspace using the *OutputIncidentEnergyWorkspace* property. This workspace can be passed to further calls to :ref:`DirectILLCollectData <algm-DirectILLCollectData>` to force a common `Ei` and thus a common TOF axis between the datasets. This is needed for, e.g., empty container subtraction.
+
+.. note::
+
+    Incident energy calibration will be disabled if the sample log entry ``monitor.monsum`` (``monitor1.monsum`` on IN6) is less than 100.
 
 TOF axis adjustment
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -32,6 +32,7 @@ Improvements
 
 - :ref:`ComputeIncoherentDOS <algm-ComputeIncoherentDOS>` now supports computation from :math:`S(2\theta,E)` workspace.
 - The upper limit of the empty container scaling factor in :ref:`DirectILLApplySelfShielding <algm-DirectILLApplySelfShielding>` has been removed.
+- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` now automatically disables incident energy calibration and normalises to time instead of monitor counts if the monitor counts are deemed to low.
 
 Bugfixes
 ########

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -32,7 +32,7 @@ Improvements
 
 - :ref:`ComputeIncoherentDOS <algm-ComputeIncoherentDOS>` now supports computation from :math:`S(2\theta,E)` workspace.
 - The upper limit of the empty container scaling factor in :ref:`DirectILLApplySelfShielding <algm-DirectILLApplySelfShielding>` has been removed.
-- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` now automatically disables incident energy calibration and normalises to time instead of monitor counts if the monitor counts are deemed to low.
+- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` now automatically disables incident energy calibration and normalises to time instead of monitor counts if the monitor counts are deemed too low.
 
 Bugfixes
 ########


### PR DESCRIPTION
Incident energy calibration will get disabled and duration used for normalization instead of monitor counts when `monintor.monsum` sample log is below certain threshold. This enables reduction of certain IN6 files which have been recorded with a broken monitor without changes to the default reduction workflows.

**Report to:** Björn Fåk/ILL.

**To test:**

Grab the testdata below:

[testdata.zip](https://github.com/mantidproject/mantid/files/2807838/testdata.zip)

Run `DirectILLCollectData` setting the `Run` property to the test data. Check that the logs contain two warnings: `'monsum' less than 100. Disabling normalization to monitor.` and `'monsum' less than 100. Disabling incident energy calibration.`

Fixes #24495.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
