### PR TITLE
Fix compiler warnings and framework-only build on MacOS.

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
@@ -47,6 +47,7 @@ public:
       : m_filename(filename), m_setMaterial(true), m_params(params) {}
   virtual ~LoadStl() = default;
   virtual std::unique_ptr<Geometry::MeshObject> readStl() = 0;
+  virtual ~LoadStl() = default;
 
 protected:
   bool areEqualVertices(Kernel::V3D const &v1, Kernel::V3D const &v2) const;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadStl.h
@@ -45,7 +45,6 @@ public:
   LoadStl(std::string filename) : m_filename(filename), m_setMaterial(false) {}
   LoadStl(std::string filename, ReadMaterial::MaterialParameters params)
       : m_filename(filename), m_setMaterial(true), m_params(params) {}
-  virtual ~LoadStl() = default;
   virtual std::unique_ptr<Geometry::MeshObject> readStl() = 0;
   virtual ~LoadStl() = default;
 

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -2102,7 +2102,6 @@ int CSGObject::searchForObject(Kernel::V3D &point) const {
   // Method - check if point in object, if not search directions along
   // principle axes using interceptSurface
   //
-  Kernel::V3D testPt;
   if (isValid(point))
     return 1;
   for (const auto &dir :

--- a/Framework/Geometry/src/Surfaces/Torus.cpp
+++ b/Framework/Geometry/src/Surfaces/Torus.cpp
@@ -153,7 +153,6 @@ int Torus::setSurface(const std::string &Pstr)
     return errAxis;
 
   Kernel::V3D Norm;
-  Kernel::V3D Cent;
   Kernel::V3D PtVec;
   Norm[ptype] = 1.0;
 

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -99,6 +99,7 @@ endif ()
 
 # directives similar to linux for conda framework-only build
 set ( BIN_DIR bin )
+set ( WORKBENCH_BIN_DIR bin )
 set ( ETC_DIR etc )
 set ( LIB_DIR lib )
 set ( PLUGINS_DIR plugins )


### PR DESCRIPTION
**Description of work.**

Fixes two warnings found when building on newer versions of XCode.

```
[595/4049] Building CXX object Framework/Geometry/CMakeFiles/Geometry.dir/src/Objects/CSGObject.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/src/Objects/CSGObject.cpp:2105:15: warning: unused variable 'testPt' [-Wunused-variable]
  Kernel::V3D testPt;
              ^
1 warning generated.
[596/4049] Building CXX object Framework/Geometry/CMakeFiles/Geometry.dir/src/Surfaces/Torus.cpp.o
/Users/svh/Documents/MantidProject/mantid/Framework/Geometry/src/Surfaces/Torus.cpp:156:15: warning: unused variable 'Cent' [-Wunused-variable]
  Kernel::V3D Cent;
              ^
1 warning generated.
[598/4049] Linking CXX shared library bin/libMantidGeometry.dylib
```

Defines `WORKBENCH_BIN_DIR` when `ENABLE_MANTIDPLOT=OFF`

**To test:**

Try framework-only build on MacOS?

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because not user-facing issues.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
