### PR TITLE
Add PyStoG as an external project

### DIFF
--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -101,7 +101,12 @@ def main(argv):
         raise ValueError("Test path '{}' is not a file".format(pathname))
 
     # Add the directory of the test to the Python path
-    sys.path.insert(0, os.path.dirname(pathname))
+    dirname = os.path.dirname(pathname)
+    # if the directory ends with 'tests' add the parent directory as well
+    # this is used in the external project PyStoG
+    sys.path.insert(0, dirname)
+    if os.path.split(dirname)[-1] == 'tests':
+        sys.path.insert(1, os.path.split(dirname)[0])
 
     # Load the test and copy over any module variables so that we have
     # the same environment defined here

--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -1,0 +1,96 @@
+include (ExternalProject)
+
+set ( _PyStoG_VERSION cfb40237984fa743372b3d92731c724c4b26a1f2)
+set ( _PyStoG_download_dir ${CMAKE_CURRENT_BINARY_DIR}/../PyStoG-download )
+set ( _PyStoG_source_dir ${_PyStoG_download_dir}/src/PyStoG/pystog )
+set ( _PyStoG_source_test_dir ${_PyStoG_download_dir}/src/PyStoG/tests )
+set ( _PyStoG_scripts_dir ${CMAKE_CURRENT_BINARY_DIR}/pystog )
+set ( _PyStoG_test_dir ${CMAKE_CURRENT_BINARY_DIR}/test/pystog/tests )
+
+ExternalProject_Add ( PyStoG
+  PREFIX ${_PyStoG_download_dir}
+  GIT_REPOSITORY "https://github.com/neutrons/pystog.git"
+  GIT_TAG ${_PyStoG_VERSION}
+  EXCLUDE_FROM_ALL 1
+
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  TEST_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+# clone the git repository
+message ( STATUS "Fetching/updating PyStoG" )
+execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_PyStoG_download_dir}/tmp/PyStoG-gitclone.cmake
+                  RESULT_VARIABLE _exit_code )
+if ( _exit_code EQUAL 0 )
+  execute_process ( COMMAND ${CMAKE_COMMAND} ARGS -P ${_PyStoG_download_dir}/tmp/PyStoG-gitupdate.cmake
+                    RESULT_VARIABLE _exit_code )
+  if ( NOT _exit_code EQUAL 0 )
+      message ( FATAL_ERROR "Unable to update PyStoG" )
+  endif ()
+else ()
+  message ( FATAL_ERROR "Unable to clone PyStoG" )
+endif()
+
+set ( _source_files
+  converter.py
+  fourier_filter.py
+  transformer.py
+  utils.py
+)
+
+set ( _test_files
+  test_converter.py
+  test_fourier_filter.py
+  test_transformer.py
+)
+
+set (_test_files_support
+  __init__.py
+  materials.py
+  utils.py
+)
+
+# copy over the source files we want
+file(MAKE_DIRECTORY ${_PyStoG_scripts_dir})
+foreach( _py_file ${_source_files} )
+  file(COPY ${_PyStoG_source_dir}/${_py_file}
+       DESTINATION ${_PyStoG_scripts_dir})
+endforeach()
+
+# copy over the relavant tests
+file(MAKE_DIRECTORY ${_PyStoG_test_dir} )
+foreach ( _py_file ${_test_files})
+  file(COPY ${_PyStoG_source_test_dir}/${_py_file}
+       DESTINATION ${_PyStoG_test_dir})
+endforeach()
+foreach ( _py_file ${_test_files_support})
+  file(COPY ${_PyStoG_source_test_dir}/${_py_file}
+       DESTINATION ${_PyStoG_test_dir})
+endforeach()
+
+# copy over the test data
+file (COPY ${_PyStoG_download_dir}/src/PyStoG/data/test_data
+       DESTINATION ${_PyStoG_test_dir})
+
+# register the tests
+if (PYUNITTEST_FOUND)
+  pyunittest_add_test ( ${_PyStoG_test_dir} python.scripts.pystog ${_test_files} )
+endif()
+
+# create the "simple" __init__.py
+set ( _PyStoG_INIT_CONTENTS "from pystog.converter import Converter
+from pystog.transformer import Transformer
+from pystog.fourier_filter import FourierFilter
+
+__all__ = ['Converter', 'Transformer', 'FourierFilter', ]
+
+__version__ = '${_PyStoG_VERSION}'
+")
+file(WRITE ${_PyStoG_scripts_dir}/__init__.py
+           ${_PyStoG_INIT_CONTENTS})
+
+# install the results
+install ( DIRECTORY ${_PyStoG_scripts_dir}
+          DESTINATION ${INBUNDLE}scripts )

--- a/docs/source/release/v3.14.0/diffraction.rst
+++ b/docs/source/release/v3.14.0/diffraction.rst
@@ -79,7 +79,7 @@ Improvements
 - :ref:`PDLoadCharacterizations <algm-PDLoadCharacterizations>` now sets the same run numbers for all rows when using an ``exp.ini`` file.
 - Focus now checks if the vanadium for a run is already loaded before loading it in to prevent reloading the same vanadium multiple times.
 - :ref:`SaveReflections <algm-SaveReflections>` now supports saving indexed modulated peaks in the Jana format.
-
+- `PyStoG <https://pystog.readthedocs.io/en/latest/>`_ has been added as an external project
 
 Bugfixes
 ########

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -18,6 +18,9 @@ set_property ( TARGET CompileUIErrorReporter PROPERTY FOLDER "CompilePyUI" )
 # External GUIs
 add_subdirectory ( ExternalInterfaces )
 
+# External projects
+include ( PyStoG )
+
 # --------------------------------------------------------------------
 # .pth files
 # --------------------------------------------------------------------
@@ -48,6 +51,7 @@ foreach ( _dir ${_pth_dirs} )
   list ( APPEND _pth_list_dev "${CMAKE_SOURCE_DIR}/scripts/${_dir}" )
   list ( APPEND _pth_list_install "${_scripts_rel_path}/${_dir}" )
 endforeach()
+list ( APPEND _pth_list_dev ${CMAKE_CURRENT_BINARY_DIR} )
 list ( APPEND _pth_list_dev ${MSLICE_DEV} )
 list ( APPEND _pth_list_install "${_scripts_rel_path}/ExternalInterfaces" )
 


### PR DESCRIPTION
Related to several issues for adopting PyStoG functionality. This adds the important bits as an external project. Only the needed files and associated tests are copied in.

**To test:**

Build and run the `python.scripts.pystog` tests.

Fixes #24442. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
