### PR TITLE
Uniform space separation for Limit strings in user file

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -36,6 +36,7 @@ Improved
 * Can export table as a csv, which can be re-loaded as a batch file.
 * File path to batch file will be added to your directories automatically upon loading
 * Workspaces are centred upon loading.
+* All limit strings in the user file (L/ ) are now space-separable to allow for uniform structure in the user file. For backwards compatibility, any string which was comma separable remains comma separable as well.
 
 Bug fixes
 #########

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -624,7 +624,6 @@ class LimitParser(UserFileComponentParser):
             output = self._extract_wavelength_limit(setting)
         elif self._is_qxy_limit(setting):
             output = self._extract_qxy_limit(setting)
-            print("qxy: {}".format(output))
         else:
             raise RuntimeError("LimitParser: Unknown command for L: {0}".format(line))
         return output

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -730,7 +730,10 @@ class LimitParser(UserFileComponentParser):
         if does_pattern_match(self._qxy_simple_pattern, line):
             output = self._extract_simple_pattern(qxy_range, LimitsId.qxy)
         else:
-            output = self._extract_complex_pattern(qxy_range, LimitsId.qxy)
+            # v2 GUI cannot currently support complex QXY ranges
+            #output = self._extract_complex_pattern(qxy_range, LimitsId.qxy)
+            raise ValueError("QXY Limits: The expression {0} is currently not supported."
+                             " Use a simple pattern".format(line))
         return output
 
     def _extract_wavelength_limit(self, line):

--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -115,7 +115,7 @@ start_string = "^\\s*"
 end_string = "\\s*$"
 space_string = "\\s+"
 rebin_string = "(\\s*[-+]?\\d+(\\.\\d+)?)(\\s*,\\s*[-+]?\\d+(\\.\\d+)?)*"
-comma_or_space_separator_string = ",? *"  # Will split the input string if commas OR spaces separate values
+rebin_string_no_comma = "(\\s*[-+]?\\d+(\\.\\d+)?)(\\s*\\s*[-+]?\\d+(\\.\\d+)?)*"
 
 
 # ----------------------------------------------------------------
@@ -511,21 +511,25 @@ class LimitParser(UserFileComponentParser):
         L/PHI[/NOMIRROR] d1 d2
 
         L/Q/ q1 q2 [dq[/LIN]]  or  L/Q q1 q2 [dq[/LOG]]
-        L/Q q1,dq1,q2,dq2,q3 [/LIN]]  or  L/Q q1,dq1,q2,dq2,q3 [/LOG]]
-        but apparently also L/Q q1, dq1, q2, dq2, q3, dq3, ... [/LOG | /LIN] is allowed
+        L/Q q1 dq1 q2 dq2 q3 [/LIN]]  or  L/Q q1 dq1 q2 dq2 q3 [/LOG]]
+        but apparently also L/Q q1 dq1 q2 dq2 q3 dq3 ... [/LOG | /LIN] is allowed
 
         L/Q/RCut c
         L/Q/WCut c
 
         L/QXY qxy1 qxy2 [dqxy[/LIN]]  or  L/QXY qxy1 qxy2 [dqxy[/LOG]]
-        L/QXY qxy1,dqxy1,qxy3,dqxy2,qxy2 [/LIN]]  or  L/QXY qxy1,dqxy1,qxy3,dqxy2,qxy2 [/LOG]]
+        L/QXY qxy1 dqxy1 qxy3 dqxy2 qxy2 [/LIN]]  or  L/QXY qxy1 dqxy1 qxy3 dqxy2 qxy2 [/LOG]]
 
         L/R r1 r2  or undocumented L/R  r1 r2 step where step is actually ignored
 
         L/WAV l1 l2 [dl[/LIN]  or  L/WAV l1 l2 [dl[/LOG]
-        L/WAV l1,dl1,l3,dl2,l2 [/LIN]  or  L/WAV l1,dl1,l3,dl2,l2 [/LOG]
+        L/WAV l1 dl1 l3 dl2 l2 [/LIN]  or  L/WAV l1 dl1 l3 dl2 l2 [/LOG]
 
         L/EVENTSTIME rebin_str
+
+    Note that the docs state that all limit strings should be space-separated, however complex ranges
+    used to be comma-separated ONLY. They remain as such so existing user files are not broken.
+    We replace commas present in a string with spaces so that all inputs are effectively space-separated.
     """
     Type = "L"
 
@@ -541,12 +545,12 @@ class LimitParser(UserFileComponentParser):
         self._simple_range = "\\s*" + self._range + self._simple_step
 
         self._comma = "\\s*,\\s*"
-        self._complex_range = "\\s*" + float_number + self._comma + float_number + self._comma + float_number + \
-                              self._comma + float_number + self._comma + float_number +\
+        self._complex_range = "\\s*" + float_number + space_string + float_number + space_string + float_number + \
+                              space_string + float_number + space_string + float_number +\
                               "(\\s*" + self._lin_or_log + ")?"
         # The complex pattern is normally a rebin string, such as
 
-        self._complex_range_2 = "\\s*" + float_number + "(" + self._comma + float_number + ")*\\s*" +\
+        self._complex_range_2 = "\\s*" + float_number + "(" + space_string + float_number + ")*\\s*" +\
                                 "(\\s*" + self._lin_or_log + ")?"
 
         # Angle limits
@@ -559,7 +563,7 @@ class LimitParser(UserFileComponentParser):
         # Event time limits
         self._events_time = "\\s*EVENTSTIME\\s*"
         self._events_time_pattern = re.compile(start_string + self._events_time +
-                                               space_string + rebin_string + end_string)
+                                               space_string + rebin_string_no_comma + end_string)
 
         self._events_time_pattern_simple_pattern = re.compile(start_string + self._events_time +
                                                               space_string + self._simple_range + end_string)
@@ -569,11 +573,8 @@ class LimitParser(UserFileComponentParser):
         self._q_simple_pattern = re.compile(start_string + self._q + space_string +
                                             self._simple_range + end_string)
 
-        q_complex_range = ",?".join(self._complex_range.split(","))  # allow comma and space separation for q ranges
-        q_complex_range_2 = ",?".join(self._complex_range_2.split(","))
-
-        self._q_complex_pattern = re.compile(start_string + self._q + space_string + q_complex_range + end_string)
-        self._q_complex_pattern_2 = re.compile(start_string + self._q + space_string + q_complex_range_2 +
+        self._q_complex_pattern = re.compile(start_string + self._q + space_string + self._complex_range + end_string)
+        self._q_complex_pattern_2 = re.compile(start_string + self._q + space_string + self._complex_range_2 +
                                                end_string)
 
         # Qxy limits
@@ -607,7 +608,7 @@ class LimitParser(UserFileComponentParser):
     def parse_line(self, line):
         # Get the settings, ie remove command
         setting = UserFileComponentParser.get_settings(line, LimitParser.get_type_pattern())
-
+        setting = setting.replace(",", " ")
         # Determine the qualifier and extract the user setting
         if self._is_angle_limit(setting):
             output = self._extract_angle_limit(setting)
@@ -623,6 +624,7 @@ class LimitParser(UserFileComponentParser):
             output = self._extract_wavelength_limit(setting)
         elif self._is_qxy_limit(setting):
             output = self._extract_qxy_limit(setting)
+            print("qxy: {}".format(output))
         else:
             raise RuntimeError("LimitParser: Unknown command for L: {0}".format(line))
         return output
@@ -658,7 +660,7 @@ class LimitParser(UserFileComponentParser):
             # We have to make sure that there is an odd number of elements
             range_with_steps_string = re.sub(self._q, "", line)
             range_with_steps_string = re.sub(self._lin_or_log, "", range_with_steps_string)
-            range_with_steps = extract_float_list(range_with_steps_string, comma_or_space_separator_string)
+            range_with_steps = extract_float_list(range_with_steps_string, " ")
             pattern_matches = len(range_with_steps) > 5 and (len(range_with_steps) % 2 == 1)
         return pattern_matches
 
@@ -670,15 +672,16 @@ class LimitParser(UserFileComponentParser):
 
     def _extract_event_binning(self, line):
         event_binning = re.sub(self._events_time, "", line)
-        if does_pattern_match(self._events_time_pattern_simple_pattern, line):
+        if does_pattern_match(self._events_time_pattern, line):
+            rebin_values = extract_float_list(event_binning, separator=" ")
+            binning_string = ",".join([str(val) for val in rebin_values])
+        else:
             simple_pattern = self._extract_simple_pattern(event_binning, LimitsId.events_binning)
             rebin_values = simple_pattern[LimitsId.events_binning]
             prefix = -1. if rebin_values.step_type is RangeStepType.Log else 1.
             binning_string = str(rebin_values.start) + "," + str(prefix*rebin_values.step) + "," + \
                              str(rebin_values.stop)  # noqa
-        else:
-            rebin_values = extract_float_list(event_binning)
-            binning_string = ",".join([str(val) for val in rebin_values])
+
         output = {LimitsId.events_binning: binning_string}
         return output
 
@@ -775,7 +778,7 @@ class LimitParser(UserFileComponentParser):
         # Remove the step type
         range_with_steps_string = re.sub(self._lin_or_log, "", complex_range_input)
         range_with_steps = extract_float_range_midpoint_and_steps(range_with_steps_string,
-                                                                  comma_or_space_separator_string)
+                                                                  " ")
 
         # Check if there is a sign on the individual steps, this shows if something had been marked as linear or log.
         # If there is an explicit LOG/LIN command, then this overwrites the sign
@@ -799,7 +802,7 @@ class LimitParser(UserFileComponentParser):
 
         # Remove the step type
         range_with_steps_string = re.sub(self._lin_or_log, "", complex_range_input)
-        range_with_steps = extract_float_list(range_with_steps_string, comma_or_space_separator_string)
+        range_with_steps = extract_float_list(range_with_steps_string, " ")
 
         if step_type is not None:
             prefix = -1.0 if step_type is RangeStepType.Log else 1.0

--- a/scripts/SANS/sans/user_file/user_file_reader.py
+++ b/scripts/SANS/sans/user_file/user_file_reader.py
@@ -24,7 +24,7 @@ class UserFileReader(object):
         # 2. Exists and is a sequence type => extend the existing list
         # 3. Does not exist and is a standard value => create a list with that value and add it
         # 4. Does not exist and is a sequence type => add the list itself
-        for key, value in list(parsed.items()):
+        for key, value in parsed.items():
             if not isinstance(value, list):
                 value = [value]
             if key not in output:

--- a/scripts/SANS/sans/user_file/user_file_reader.py
+++ b/scripts/SANS/sans/user_file/user_file_reader.py
@@ -5,6 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
 from sans.common.file_information import find_full_file_path
 from sans.user_file.user_file_parser import UserFileParser
 
@@ -24,16 +25,12 @@ class UserFileReader(object):
         # 3. Does not exist and is a standard value => create a list with that value and add it
         # 4. Does not exist and is a sequence type => add the list itself
         for key, value in list(parsed.items()):
-            is_list = isinstance(value, list)
-            is_key_in_output = key in output
-            if is_key_in_output and is_list:
-                output[key].extend(value)
-            elif is_key_in_output and not is_list:
-                output[key].append(value)
-            elif not is_key_in_output and is_list:
+            if not isinstance(value, list):
+                value = [value]
+            if key not in output:
                 output[key] = value
             else:
-                output[key] = [value]
+                output[key].extend(value)
 
     def read_user_file(self):
         # Read in all elements

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -202,7 +202,9 @@ class LimitParserTest(unittest.TestCase):
 
     def test_that_event_time_limit_is_parsed_correctly(self):
         valid_settings = {"L  / EVEnTStime 0,-10,32,434,34523,35": {LimitsId.events_binning:
-                                                                    "0.0,-10.0,32.0,434.0,34523.0,35.0"}}
+                                                                    "0.0,-10.0,32.0,434.0,34523.0,35.0"},
+                          "L / Eventstime 0 -10 32 434 34523 35": {LimitsId.events_binning:
+                                                                   "0.0,-10.0,32.0,434.0,34523.0,35.0"}}
 
         invalid_settings = {"L  / EEnTStime 0,-10,32,434,34523,35": RuntimeError,
                             "L/EVENTSTIME 123g, sdf": RuntimeError,
@@ -246,13 +248,13 @@ class LimitParserTest(unittest.TestCase):
                                                                               rebin_string="-12.0,-2.7,34.6")},
                           "L/q -12 3.6 2 /LIN": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
                                                                             rebin_string="-12.0,2.0,3.6")},
-                          "L/q -12 ,  0.41  ,23 ,-34.8, 3.6": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
+                          "L/q -12   0.41  23 -34.8 3.6": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
                                                               rebin_string="-12.0,0.41,23.0,-34.8,3.6")},  # noqa
-                          "L/q -12  , 0.42 , 23 ,-34.8 ,3.6 /LIn": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
+                          "L/q -12   0.42  23 -34.8 3.6 /LIn": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
                                                                    rebin_string="-12.0,0.42,23.0,34.8,3.6")},
                           "L/q -12   0.43     23 -34.8 3.6": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
                                                                             rebin_string="-12.0,0.43,23.0,-34.8,3.6")},
-                          "L/q -12  , 0.44 , 23  ,34.8,3.6  /Log": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
+                          "L/q -12   0.44  23  ,34.8,3.6  /Log": {LimitsId.q: q_rebin_values(min=-12., max=3.6,
                                                                     rebin_string="-12.0,-0.44,23.0,-34.8,3.6")},
                           "L/q -12  , 0.45 , 23  ,34.8 ,3.6, .123, 5.6  /Log": {LimitsId.q: q_rebin_values(min=-12.,
                                                                                                           max=5.6,
@@ -283,16 +285,16 @@ class LimitParserTest(unittest.TestCase):
                                                                                 step_type=RangeStepType.Log)},
                           "L/qxY -12 3.6 2 /LIN": {LimitsId.qxy: simple_range(start=-12, stop=3.6, step=2,
                                                                               step_type=RangeStepType.Lin)},
-                          "L/qxy -12  , 0.4,  23, -34.8, 3.6": {LimitsId.qxy: complex_range(start=-12, step1=0.4,
-                                                                mid=23, step2=34.8, stop=3.6,
+                          "L/qxy -12  , 0.4,  23, -3.48, 36": {LimitsId.qxy: complex_range(start=-12, step1=0.4,
+                                                                mid=23, step2=3.48, stop=36,
                                                                 step_type1=RangeStepType.Lin,
                                                                 step_type2=RangeStepType.Log)},
-                          "L/qXY -12  , 0.4 , 23 ,34.8 ,3.6 /LIn": {LimitsId.qxy: complex_range(start=-12,
-                                                                    step1=0.4, mid=23, step2=34.8, stop=3.6,
+                          "L/qXY -12   0.4  23 3.48 36 /LIn": {LimitsId.qxy: complex_range(start=-12,
+                                                                    step1=0.4, mid=23, step2=3.48, stop=36,
                                                                     step_type1=RangeStepType.Lin,
                                                                     step_type2=RangeStepType.Lin)},
-                          "L/qXY -12   ,0.4,  23  ,34.8 ,3.6  /Log": {LimitsId.qxy: complex_range(start=-12,
-                                                                      step1=0.4, mid=23, step2=34.8, stop=3.6,
+                          "L/qXY -12   0.4  23  3.48 36  /Log": {LimitsId.qxy: complex_range(start=-12,
+                                                                      step1=0.4, mid=23, step2=3.48, stop=36,
                                                                       step_type1=RangeStepType.Log,
                                                                       step_type2=RangeStepType.Log)}}
 

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -284,19 +284,21 @@ class LimitParserTest(unittest.TestCase):
                           "L/QXY -12 34.6 2.7/LOG": {LimitsId.qxy: simple_range(start=-12, stop=34.6, step=2.7,
                                                                                 step_type=RangeStepType.Log)},
                           "L/qxY -12 3.6 2 /LIN": {LimitsId.qxy: simple_range(start=-12, stop=3.6, step=2,
-                                                                              step_type=RangeStepType.Lin)},
-                          "L/qxy -12  , 0.4,  23, -3.48, 36": {LimitsId.qxy: complex_range(start=-12, step1=0.4,
-                                                                mid=23, step2=3.48, stop=36,
-                                                                step_type1=RangeStepType.Lin,
-                                                                step_type2=RangeStepType.Log)},
-                          "L/qXY -12   0.4  23 3.48 36 /LIn": {LimitsId.qxy: complex_range(start=-12,
-                                                                    step1=0.4, mid=23, step2=3.48, stop=36,
-                                                                    step_type1=RangeStepType.Lin,
-                                                                    step_type2=RangeStepType.Lin)},
-                          "L/qXY -12   0.4  23  3.48 36  /Log": {LimitsId.qxy: complex_range(start=-12,
-                                                                      step1=0.4, mid=23, step2=3.48, stop=36,
-                                                                      step_type1=RangeStepType.Log,
-                                                                      step_type2=RangeStepType.Log)}}
+                                                                              step_type=RangeStepType.Lin)}}
+        """
+        These tests should be added back to valid settings when SANS GUI can accept complex QXY strings.
+        "L/qxy -12  , 0.4,  23, -3.48, 36": {LimitsId.qxy: complex_range(start=-12, step1=0.4,
+                                               mid=23, step2=3.48, stop=36,
+                                               step_type1=RangeStepType.Lin,
+                                               step_type2=RangeStepType.Log)},
+        "L/qXY -12   0.4  23 3.48 36 /LIn": {LimitsId.qxy: complex_range(start=-12,
+                                                    step1=0.4, mid=23, step2=3.48, stop=36,
+                                                    step_type1=RangeStepType.Lin,
+                                                    step_type2=RangeStepType.Lin)},
+        "L/qXY -12   0.4  23  3.48 36  /Log": {LimitsId.qxy: complex_range(start=-12,
+                                                      step1=0.4, mid=23, step2=3.48, stop=36,
+                                                      step_type1=RangeStepType.Log,
+                                                      step_type2=RangeStepType.Log)}"""
 
         invalid_settings = {"L/QXY 12 2 3 4": RuntimeError,
                             "L/QXY 12 2 3 4 23 3": RuntimeError,

--- a/scripts/test/SANS/user_file/user_file_reader_test.py
+++ b/scripts/test/SANS/user_file/user_file_reader_test.py
@@ -91,15 +91,15 @@ class UserFileReaderTest(unittest.TestCase):
                            QResolutionId.moderator: ["moderator_rkh_file.txt"],
                            TubeCalibrationFileId.file: ["TUBE_SANS2D_BOTH_31681_25Sept15.nxs"]}
 
-        self.assertTrue(len(expected_values) == len(output))
+        self.assertEqual(len(expected_values), len(output))
         for key, value in list(expected_values.items()):
             self.assertTrue(key in output)
-            self.assertTrue(len(output[key]) == len(value))
+            self.assertEqual(len(output[key]), len(value))
             elements = output[key]
             # Make sure that the different entries are sorted
             UserFileReaderTest._sort_list(elements)
             UserFileReaderTest._sort_list(value)
-            self.assertTrue(elements == value)
+            self.assertEqual(elements, value, "{} is not {}".format(elements, value))
 
         # clean up
         if os.path.exists(user_file_path):


### PR DESCRIPTION
**Description of work.**
Changes parsing of user file limit string (L/ ) to make all values space-separated. Previously, "complex strings" were comma separated; these remain comma-separable as well for backwards-compatibility.

For reference, complex strings are of the form `start, step1, mid, step2, stop` and simple strings are `start, stop` or `start, stop, step`

During development of this PR, it was discovered that the current SANS v2 GUI cannot accept complex L/ WAV and L/ QXY strings from the user file. This has been raised as a separate issue #24659 

**Report to:** nobody

**To test:**
[sans2d_user_file_spaces.txt](https://github.com/mantidproject/mantid/files/2817581/sans2d_user_file_spaces.txt)
1. Interfaces -> SANS -> SANS v2
2. Load the attached user file. This should not fail or produce any warnings.
3. Settings (left) -> Q, Wavelength, Detector Limits (top)
4. Q limits -> Q1D Rebin String should be 0.005,-0.06,0.06,-0.0025,0.15,-0.08,1.5
5. Q limits -> Qxy should have max 0.15 and Step 0.002
6. Wavelength should be min 1.75, max 16.5, step 0.05
7. Open up the attached user file, see that all lines beginning with `L/` (! are comment lines. Ignore.) have space-separated values.

Fixes #24397 

Release notes added, however the online docs should be updated after this PR has merged.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
