### PR TITLE
Fixes the bug currently in MayersSampleCorrection

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -178,7 +178,7 @@ MayersSampleCorrectionStrategy::getCorrectedHisto() {
     if (m_pars.mscat) {
       const double msVal = chebyPoly(msCoeffs, xcap);
       const double beta = m_pars.sigmaSc * msVal / sigt;
-      corrfact *= (1.0 - beta) / rns;
+      corrfact *= (1.0 - (beta / rns));
     }
     // apply correction
 

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -81,11 +81,11 @@ public:
     TS_ASSERT_DELTA(100.0, tof.front(), delta);
     TS_ASSERT_DELTA(199.0, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.375086, signal.front(), delta);
-    TS_ASSERT_DELTA(0.377762, signal.back(), delta);
+    TS_ASSERT_DELTA(2.308089, signal.front(), delta);
+    TS_ASSERT_DELTA(2.314809, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.265226, error.front(), delta);
-    TS_ASSERT_DELTA(0.267118, error.back(), delta);
+    TS_ASSERT_DELTA(1.632065, error.front(), delta);
+    TS_ASSERT_DELTA(1.636817, error.back(), delta);
   }
 
   void
@@ -105,11 +105,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.375086, signal.front(), delta);
-    TS_ASSERT_DELTA(0.377762, signal.back(), delta);
+    TS_ASSERT_DELTA(2.308089, signal.front(), delta);
+    TS_ASSERT_DELTA(2.314809, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.265226, error.front(), delta);
-    TS_ASSERT_DELTA(0.267118, error.back(), delta);
+    TS_ASSERT_DELTA(1.632065, error.front(), delta);
+    TS_ASSERT_DELTA(1.636817, error.back(), delta);
   }
 
   void test_Corrects_For_Absorption_For_Histogram_Data() {
@@ -157,11 +157,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.374857, signal.front(), delta);
-    TS_ASSERT_DELTA(0.377747, signal.back(), delta);
+    TS_ASSERT_DELTA(2.307860, signal.front(), delta);
+    TS_ASSERT_DELTA(2.314794, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.265064, error.front(), delta);
-    TS_ASSERT_DELTA(0.267107, error.back(), delta);
+    TS_ASSERT_DELTA(1.631904, error.front(), delta);
+    TS_ASSERT_DELTA(1.636807, error.back(), delta);
   }
 
   void test_MutlipleScattering_NRuns_Parameter() {
@@ -184,11 +184,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.375848, signal.front(), delta);
-    TS_ASSERT_DELTA(0.386508, signal.back(), delta);
+    TS_ASSERT_DELTA(2.308851, signal.front(), delta);
+    TS_ASSERT_DELTA(2.323555, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.265765, error.front(), delta);
-    TS_ASSERT_DELTA(0.273302, error.back(), delta);
+    TS_ASSERT_DELTA(1.632604, error.front(), delta);
+    TS_ASSERT_DELTA(1.643002, error.back(), delta);
   }
 
   // ---------------------- Failure tests -----------------------------

--- a/Framework/Algorithms/test/MayersSampleCorrectionTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionTest.h
@@ -47,11 +47,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(0.374435, signal.front(), delta);
-    TS_ASSERT_DELTA(0.377909, signal.back(), delta);
+    TS_ASSERT_DELTA(2.307439, signal.front(), delta);
+    TS_ASSERT_DELTA(2.314956, signal.back(), delta);
 
-    TS_ASSERT_DELTA(0.264766, error.front(), delta);
-    TS_ASSERT_DELTA(0.267222, error.back(), delta);
+    TS_ASSERT_DELTA(1.631606, error.front(), delta);
+    TS_ASSERT_DELTA(1.636921, error.back(), delta);
   }
 
   void test_Success_With_Just_Absorption_Correction() {

--- a/docs/source/algorithms/MayersSampleCorrection-v1.rst
+++ b/docs/source/algorithms/MayersSampleCorrection-v1.rst
@@ -89,7 +89,7 @@ Output:
 .. testoutput:: WithMultipleScattering
 
    Uncorrected signal: 0.0556
-   Corrected signal: 0.0120
+   Corrected signal: 0.0736
 
 References
 ----------

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -111,6 +111,7 @@ Bugfixes
 - Fixed a bug in `AlignAndFocusPowder <algm-AlignAndFocusPowder>` where a histogram input workspace did not clone propertly to the output workspace and properly masking a grouping workspace passed to `DiffractionFocussing <algm-DiffractionFocussing>`. Also adds initial unit tests for `AlignAndFocusPowder <algm-AlignAndFocusPowder>`.
 - Fixed a bug in :ref:`ExtractSpectra <algm-ExtractSpectra>` which was causing a wrong last value in the output's vertical axis if the axis type was ``BinEdgeAxis``.
 - Fixed an issue in :ref:`Rebin2D <algm-Rebin2D>` where `NaN` values would result if there were zero-area bins in the input workspace.
+- Fixed a bug in :ref:`MayersSampleCorrection <algm-MayersSampleCorrection>` for when using the multiple scattering correction.
 
 Python
 ------


### PR DESCRIPTION
When using the `MultipleScattering`==`True`, the correction disagreed both with the `CarpenterSampleCorrection` and what is sensible for the correction.

This fixes the bug where the conversion factor `rns` that is used in the multiple scattering was incorrectly applied to the absorption (attenuation) factor as well, causing the overall correction to reduce the signal far too much.

Example
--------

First, an example for a powder diffraction sample workspace spectrum with material as vanadium:
  Before bug fix
![image](https://user-images.githubusercontent.com/17032543/52093459-40d5a000-2589-11e9-90af-fbf826db1638.png)

  After bug fix
![image](https://user-images.githubusercontent.com/17032543/52093487-6498e600-2589-11e9-96c9-7a594b10dd12.png)

Second, an example for a diamond spectrum from POWGEN at SNS:
  Before bug fix
![image](https://user-images.githubusercontent.com/17032543/52093563-96aa4800-2589-11e9-9f73-187536a8fb8a.png)

  After bug fix
![image](https://user-images.githubusercontent.com/17032543/52093576-a9bd1800-2589-11e9-9c14-740588295852.png)

**Report to:** anyone using the `MayersSampleCorrection` or interested in multiple scattering for cylinders (using isotropic scattering assumption), @Anders-Markvardsen 

**To test:**

I used the following script to perform both the tests above, if it helps. If you would like to try on another instrument, modify the `make_instrument_workspace` function:

```python
from __future__ import (absolute_import, division, print_function)

from mantid.simpleapi import *
import matplotlib.pyplot as plt

def cylinder_sample(workspace, radius, height):
    # Define function to create sample shape
    radius_m = radius/100.
    height_m = height/100.
    xml = '<cylinder id="sample">' \
               '<centre-of-bottom-base x="0.0" y="{0}" z="0.0" />' \
                '<axis x="0.0" y="1.0" z="0" />' \
                '<radius val="{1}" />' \
                '<height val="{2}" />'\
                '</cylinder>'.format(0.5*height_m, radius_m, height_m)
    CreateSampleShape(InputWorkspace=workspace, ShapeXML=xml)
    SetSampleMaterial(workspace, ChemicalFormula=material,
                      SampleNumberDensity=num_density)
    return workspace


def make_sample_workspace():
    # Create a fake workspace with TOF data
    sample_ws = CreateSampleWorkspace(Function='Powder Diffraction',
                                      NumBanks=1,BankPixelWidth=1,XUnit='TOF',
                                      XMin=1000,XMax=10000)
    return sample_ws

def make_instrument_workspace(instrument, run_type='diamond', params="300.,10.0,166667.0"):
    # Select instrument for runs
    if instrument == "PG3":
        dia_run = 39169
        van_run = 37830
    elif instrument == "NOM":
        dia_run = 122825
        van_run = 122827
    else:
        raise Exception("Instrument %s not a selection in [NOM, PG3]" % instrument)

    # Select sample type
    if run_type =='diamond':
        wksp = "%s_%d" % (instrument, dia_run)
    elif run_type =='vanadium':
        wksp = "%s_%d" % (instrument, dia_run)
    else:
        raise Exception("Run type %s not a selection in [diamond, vanadium]" % run_type)

    # Focus down to a few spectra
    Load(Filename=wksp, OutputWorkspace=wksp)
    Rebin(InputWorkspace=wksp, OutputWorkspace=wksp, Params=params)
    grp_wksp, spectra_count, group_count = CreateGroupingWorkspace(InstrumentName=instrument, GroupDetectorsBy='Group')
    DiffractionFocussing(InputWorkspace=wksp, OutputWorkspace=wksp, GroupingWorkspace=grp_wksp, PreserveEvents=False)
    return wksp


def get_mayers_results(sample_ws):
    # CalculateMayersSampleCorrections
    ConvertUnits(InputWorkspace=sample_ws, OutputWorkspace=sample_ws, Target="TOF")
    mayers_abs = MayersSampleCorrection(sample_ws, MultipleScattering=False)
    mayers_ms = MayersSampleCorrection(sample_ws, MultipleScattering=True)
    return mayers_abs, mayers_ms


def get_carpenter_results(sample_ws):
    ConvertUnits(InputWorkspace=sample_ws, OutputWorkspace=sample_ws, Target="Wavelength")
    corrections = CalculateCarpenterSampleCorrection(InputWorkspace=sample_ws,CylinderSampleRadius=0.2)
    absCorr = corrections.getItem(0)
    carpenter_abs = Divide(sample_ws, absCorr)
    carpenter_ms  = CarpenterSampleCorrection(sample_ws)
    return carpenter_abs, carpenter_ms

def plot_abs(axis, sample_ws, mayers_abs, carpenter_abs, wkspIndex=0):
    axis.plot(sample_ws, wkspIndex=wkspIndex,label='Sample')
    axis.plot(mayers_abs, wkspIndex=wkspIndex, label='Mayers')
    axis.plot(carpenter_abs, wkspIndex=wkspIndex, label='Carpenter')
    axis.set_title("Absorption")
    axis.legend()

def plot_ms(axis, sample_ws, mayers_ms, carpenter_ms, wkspIndex=0):
    axis.plot(sample_ws, wkspIndex=wkspIndex, label='Sample')
    axis.plot(mayers_ms, wkspIndex=wkspIndex, label='Mayers')
    axis.plot(carpenter_ms, wkspIndex=wkspIndex, label='Carpenter')
    axis.set_title("Multiple Scattering")
    axis.legend()


if __name__=="__main__":
    # Set sample workspace with instrument
    sample_ws = make_sample_workspace()
    sample_ws = make_instrument_workspace('PG3')

    # Set sample material
    material = 'V'
    num_density = 0.07261
    cyl_height_cm = 4
    cyl_radius_cm = 0.25
    sample_ws = cylinder_sample(sample_ws, cyl_radius_cm, cyl_height_cm)

    # Calculate corrections
    mayers_abs, mayers_ms = get_mayers_results(sample_ws)
    carpenter_abs, carpenter_ms = get_carpenter_results(sample_ws)

    # Get all wksps in wavelength
    sample_ws = ConvertUnits(sample_ws, "Wavelength")
    mayers_abs = ConvertUnits(mayers_abs, "Wavelength")
    mayers_ms = ConvertUnits(mayers_ms, "Wavelength")
    carpenter_abs = ConvertUnits(carpenter_abs, "Wavelength")
    carpenter_ms = ConvertUnits(carpenter_ms, "Wavelength")

    # Plot
    fig, ax = plt.subplots(2, subplot_kw={'projection':'mantid'}, sharex=True)
    plot_abs(ax[0], sample_ws, mayers_abs, carpenter_abs)
    plot_ms(ax[1], sample_ws, mayers_ms, carpenter_ms)
    plt.show()
```

<!-- Instructions for testing. -->

Re #22556 (does not fix since the issue discusses refactor as well, will be a separate PR to fully close the issue)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
