### PR TITLE
Close the NeXus file properly in LoadILLTOF

### DIFF
--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -272,7 +272,7 @@ void LoadILLTOF2::addAllNexusFieldsAsProperties(const std::string &filename) {
     throw Kernel::Exception::FileError("Unable to open File:", filename);
   }
   m_loader.addNexusFieldsToWsRun(nxfileID, runDetails);
-
+  stat = NXclose(&nxfileID);
   g_log.debug() << "End parsing properties from : " << filename << '\n';
 }
 

--- a/docs/source/release/v3.14.0/direct_inelastic.rst
+++ b/docs/source/release/v3.14.0/direct_inelastic.rst
@@ -40,6 +40,7 @@ Bugfixes
 - Fixed a bug in :ref:`DirectILLCollectData <algm-DirectILLCollectData>` which prevented the *OutputIncidentEnergyWorkspace* being generated if *IncidentEnergyCalibration* was turned off.
 - Fixed the detector :math:`2\theta` width calculation in :ref:`SofQWNormalisedPolygon <algm-SofQWNormalisedPolygon>`. The algorithm was computing the angle between the detector center and top point, not the actual :math:`2\theta` width.
 - Fixed a bug in :ref:`Rebin2D <algm-Rebin2D>` which requires that an input workspace had to have fractional area weights for the `UseFractionalArea` option to work. The behaviour is now that if the input workspace does not have fractional areas, and `UseFractionalArea` is true, then fractional area tracking will be used with input fractions set to unity.
+- :ref:`LoadILLTOF <algm-LoadILLTOF>` now properly closes the loaded file.
 
 Interfaces
 ----------


### PR DESCRIPTION
This PR adds the missing call to `NXclose` in `LoadILLTOF`.

**Report to:** [nobody].

**To test:**

The script below should print the instrument name `IN4` without issues after the `filename` is set to point to the correct path in Mantid's build directory.

```python
import h5py

def sniff(filename):
    with h5py.File(filename, 'r') as hf:
        instrument = hf.get('entry0/instrument/name')[0]
        return instrument

# Fix the path below
filename = 'ExternalData/Testing/Data/UnitTest/ILL/IN4/084446.nxs'
ws = LoadILLTOF(filename)
print(sniff(filename))
```


Fixes #24681.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
