### PR TITLE
Fix issue with enginX Script with empty output folder

### DIFF
--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -29,6 +29,8 @@ def main(vanadium_run, user, focus_run, **kwargs):
         crop_name (string): what to call the cropped bank workspace
         crop_on (string): the bank of spectrum to crop on if cropping
         pre_process_run (bool): set whether or not to pre-process run before focusing
+        params (string): rebin parameters for pre-process
+        time_period (string): time period for pre-process
         grouping_file (string): the path of the grouping file for texture focusing
         directory (string): the path of the directory to save to
 
@@ -308,6 +310,8 @@ def save_calibration(ceria_run, van_run, cal_dir, cal_gen, name, bank_names, zer
                                         ceria_run=ceria_run, vanadium_run=van_run,
                                         template_file=template_file)
     # copy the param file to the general directory
+    if not os.path.exists(cal_gen):
+        os.makedirs(cal_gen)
     copy2(gsas_iparm_fname, cal_gen)
 
 
@@ -515,6 +519,8 @@ def _save_out(run_number, focus_dir, focus_gen, output, join_string, bank_id):
     simple.SaveOpenGenieAscii(InputWorkspace=output, Filename=filename + ".his", OpenGenieFormat="ENGIN-X Format")
     simple.SaveNexus(InputWorkspace=output, Filename=filename + ".nxs")
     simple.ExportSampleLogsToHDF5(InputWorkspace=output, Filename=hdf5_name, Blacklist="bankid")
+    if not os.path.exists(focus_gen):
+        os.makedirs(focus_gen)
     # copy the files to the general directory
     copy2(filename+".dat", focus_gen)
     copy2(filename + ".gss", focus_gen)


### PR DESCRIPTION
**Description of work.**
added a check for the presence of the general focus and calibration folders in the enginx scripts, generating the folders if they are not present.
**To test:**
set the output directory to an empty folder, enable the isis data-search archive, then run the script
```
from __future__ import (absolute_import, division, print_function)
from Engineering.EnginX import main


main("236516", "test", "299080", force_vanadium=True, force_cal=True, directory=output_dir)
```
the output folder should have the following sub folders `User`, `Focus`, and `Calibration`, but no actual files.
Fixes #24690 


*This does not require release notes* because **The EnginX Scripts do not yet exist in a release build of mantid**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
