### PR TITLE
Set the loader name at the top of the file

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -343,8 +343,9 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         self._filenames = filenames = sorted(self._getLinearizedFilenames('Filename'))
         import collections
         self._accumulate_calls = collections.defaultdict(int) # bookkeeping for __accumulate
-        # get the instrument name
+        # get the instrument name - will not work if the instrument has a '_' in its name
         self.instr = os.path.basename(filenames[0]).split('_')[0]
+        self.__loaderName = 'Load'   # set the loader to be generic on first load
         for ext in ['_cal', '_group',' _mask']:
             if AnalysisDataService.doesExist(self.instr+ext):
                 DeleteWorkspace(Workspace=self.instr+ext)
@@ -460,6 +461,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         else:
             n = N
         for (i, f) in enumerate(files):
+            self.__loaderName = 'Load'  # reset to generic load with each file
             wkspname = self.__processFile2_withcache(f, useCaching, unfocusname, unfocusname_file)
             # accumulate into partial sum
             grain_start = i//n*n
@@ -490,7 +492,6 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         # default name is based off of filename
         wkspname = os.path.split(filename)[-1].split('.')[0]
 
-        self.__loaderName = 'Load'  # reset to generic load with each file
         if useCaching:
             self.__determineCharacterizations(filename, wkspname)  # updates instance variable
             cachefile = self.__getCacheName(wkspname)


### PR DESCRIPTION
The caching work introduced by #24653 introduced a variable access before it was assigned. This fixes that issue.

**To test:**

Try running a reduction that uses `AlignAndFocusPowderFromFiles` and see that it works again.

*There is no associated issue.*

*This does not require release notes* because it is fixing a bug in a new feature.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
