### PR TITLE
Fixed swapped test names in Wish tests

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_WISHPowderReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_WISHPowderReductionTest.py
@@ -37,7 +37,7 @@ linked_panels = {
 }
 
 
-class WISHPowderReductionTest(MantidSystemTest):
+class WISHPowderReductionNoAbsorptionTest(MantidSystemTest):
     # still missing required files check with ./systemtest -R PowderReduction --showskipped
     def requiredFiles(self):
         input_files = ["vana19612-{}foc-SF-SS.nxs".format(panel) for panel in panels]
@@ -73,7 +73,7 @@ class WISHPowderReductionTest(MantidSystemTest):
             mantid.DeleteWorkspace(ws + "-d")
 
 
-class WISHPowderReductionNoAbsorptionTest(MantidSystemTest):
+class WISHPowderReductionTest(MantidSystemTest):
     # still missing required files check with ./systemtest -R PowderReduction --showskipped
     def requiredFiles(self):
         input_files = ["vana19612-{}foc-SF-SS.nxs".format(panel) for panel in panels]


### PR DESCRIPTION
**Description of work.**
Fixed Wish test names being reversed (the test `WISHPowderReductionNoAbsorptionTest` referred to the test that did run absorption corrections)

Fixes #24704 


*This does not require release notes* because **change only in system tests**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
