### PR TITLE
subplot_context python3 failure fixed

### DIFF
--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -136,7 +136,10 @@ class SubPlotContextTest(unittest.TestCase):
         self.context._vLines = {
             "two": mock.MagicMock(), "four": mock.MagicMock()}
         result = self.context.vlines
-        self.assertEquals(["three", "two", "four"], result)
+        expect = ["two", "three","four"] 
+        for key in expect:
+            self.assertIn(key, result)
+        self.assertEquals(len(result), len(expect))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
One of the subplot_context tests was failing on python3 as the key list was not always in the same order. This PR makes the test independent of the order by explicitly checking that a key is in the output and that the length is what is expected. 

There is no issue