### PR TITLE
 FDA now lets user pick phase table for maxent

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -14,6 +14,7 @@ Improvements
 - TF Asymmetry mode now displays the chi squared value at the top of the browser.
 - ALC interface now sorts the data into ascending order.
 - Muon Analysis now includes number of event per frame and number of events per frame per detector in the run info box on the home tab.
+- Frequency Domain Analysis now lets the user select the phase table in MaxEnt mode.
 
 Bugfixes
 ########

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import math
 from Muon.GUI.Common import thread_model
-
+import mantid.simpleapi as mantid
 
 class MaxEntPresenter(object):
 
@@ -105,6 +105,20 @@ class MaxEntPresenter(object):
         self.activate()
         self.thread.deleteLater()
         self.thread = None
+        self.updatePhaseOptions()
+
+    def updatePhaseOptions(self):
+        inputs ={}
+        self.view.addOutputPhases(inputs)
+        name = inputs['OutputPhaseTable']
+        if self.phaseTableAdded(name):
+            index = self.view.getPhaseTableIndex()
+            self.view.addPhaseTableToGUI(name)
+            self.view.setPhaseTableIndex(index)
+
+    def phaseTableAdded(self, name):
+        return mantid.AnalysisDataService.doesExist(name)
+
 
     def getMaxEntInput(self):
         inputs = self.view.initMaxEntInput()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter.py
@@ -11,6 +11,7 @@ import math
 from Muon.GUI.Common import thread_model
 import mantid.simpleapi as mantid
 
+
 class MaxEntPresenter(object):
 
     """
@@ -108,17 +109,17 @@ class MaxEntPresenter(object):
         self.updatePhaseOptions()
 
     def updatePhaseOptions(self):
-        inputs ={}
+        inputs = {}
         self.view.addOutputPhases(inputs)
         name = inputs['OutputPhaseTable']
-        if self.phaseTableAdded(name):
+        current_list = self.view.getPhaseTableOptions()
+        if self.phaseTableAdded(name) and name not in current_list:
             index = self.view.getPhaseTableIndex()
             self.view.addPhaseTableToGUI(name)
             self.view.setPhaseTableIndex(index)
 
     def phaseTableAdded(self, name):
         return mantid.AnalysisDataService.doesExist(name)
-
 
     def getMaxEntInput(self):
         inputs = self.view.initMaxEntInput()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -13,6 +13,7 @@ from Muon.GUI.Common.utilities import table_utils
 
 construct = "Construct"
 
+
 class MaxEntView(QtGui.QWidget):
 
     """
@@ -172,8 +173,11 @@ class MaxEntView(QtGui.QWidget):
     def getPhaseTableIndex(self):
         return self.phaseTable_box.currentIndex()
 
-    def setPhaseTableIndex(self,index):
+    def setPhaseTableIndex(self, index):
         self.phaseTable_box.setCurrentIndex(index)
+
+    def getPhaseTableOptions(self):
+        return [self.phaseTable_box.itemText(j) for j in range(self.phaseTable_box.count())]
 
     def addPhaseTableToGUI(self, option):
         self.phaseTable_box.addItem(option)
@@ -233,7 +237,7 @@ class MaxEntView(QtGui.QWidget):
 
     def addPhaseTable(self, inputs):
         if self.usePhases():
-           inputs['InputPhaseTable'] = "PhaseTable"
+            inputs['InputPhaseTable'] = "PhaseTable"
         else:
             inputs['InputPhaseTable'] = self.phaseTable_box.currentText()
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -11,6 +11,8 @@ from PyQt4 import QtCore, QtGui
 from Muon.GUI.Common.utilities import table_utils
 
 
+construct = "Construct"
+
 class MaxEntView(QtGui.QWidget):
 
     """
@@ -63,9 +65,10 @@ class MaxEntView(QtGui.QWidget):
         self.use_phaseTable_box = table_utils.addCheckBoxToTable(
             self.table, False, 4)
 
-        table_utils.setRowName(self.table, 5, "Construct Phase Table")
-        self.phaseTable_box = table_utils.addCheckBoxToTable(
-            self.table, True, 5)
+        table_utils.setRowName(self.table, 5, "Select Phase Table")
+        options = [construct]
+        self.phaseTable_box = table_utils.addComboToTable(
+            self.table, 5, options)
 
         table_utils.setRowName(self.table, 6, "Fix phases")
         self.fix_phase_box = table_utils.addCheckBoxToTable(
@@ -166,6 +169,15 @@ class MaxEntView(QtGui.QWidget):
         self.ws.clear()
         self.ws.addItems(options)
 
+    def getPhaseTableIndex(self):
+        return self.phaseTable_box.currentIndex()
+
+    def setPhaseTableIndex(self,index):
+        self.phaseTable_box.setCurrentIndex(index)
+
+    def addPhaseTableToGUI(self, option):
+        self.phaseTable_box.addItem(option)
+
     def addNPoints(self, options):
         self.N_points.clear()
         self.N_points.addItems(options)
@@ -220,7 +232,10 @@ class MaxEntView(QtGui.QWidget):
         return inputs
 
     def addPhaseTable(self, inputs):
-        inputs['InputPhaseTable'] = "PhaseTable"
+        if self.usePhases():
+           inputs['InputPhaseTable'] = "PhaseTable"
+        else:
+            inputs['InputPhaseTable'] = self.phaseTable_box.currentText()
 
     def outputPhases(self):
         return self.output_phase_box.checkState() == QtCore.Qt.Checked
@@ -251,7 +266,7 @@ class MaxEntView(QtGui.QWidget):
             str(self.ws.currentText()) + ";TimeDomain;MaxEnt"
 
     def calcPhases(self):
-        return self.phaseTable_box.checkState() == QtCore.Qt.Checked
+        return self.phaseTable_box.currentText() == construct
 
     def usePhases(self):
         return self.use_phaseTable_box.checkState() == QtCore.Qt.Checked

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -19,7 +19,8 @@ if sys.version_info.major == 3:
     from unittest import mock
 else:
     import mock
-
+def test(inputs):
+    inputs["OutputPhaseTable"] = "test"
 
 class MaxEntPresenterTest(unittest.TestCase):
     def setUp(self):
@@ -87,6 +88,40 @@ class MaxEntPresenterTest(unittest.TestCase):
         self.presenter.deactivate()
         assert(self.view.deactivateCalculateButton.call_count==1)
 
+    def test_updatePhaseOptions(self):
+        self.view.addOutputPhases = mock.MagicMock(side_effect = test)
+        self.view.addPhaseTableToGUI = mock.MagicMock()
+        self.presenter.thread = mock.MagicMock()
+        self.presenter.phaseTableAdded = mock.Mock(return_value = True)
+        self.view.getPhaseTableIndex = mock.Mock(return_value = 2)
+        self.view.setPhaseTableIndex = mock.Mock()
+
+        inputs = {}
+        self.view.addOutputPhases(inputs)
+        self.presenter.handleFinished()
+
+        self.assertEquals(inputs["OutputPhaseTable"],"test")
+        self.assertEquals(self.view.getPhaseTableIndex.call_count, 1)
+        self.assertEquals(self.view.addPhaseTableToGUI.call_count, 1)
+        self.assertEquals(self.view.setPhaseTableIndex.call_count, 1)
+        self.view.setPhaseTableIndex.assert_called_with(2)
+
+    def test_noUpdatePhaseOptions(self):
+        self.view.addOutputPhases = mock.MagicMock(side_effect = test)
+        self.view.addPhaseTableToGUI = mock.MagicMock()
+        self.presenter.thread = mock.MagicMock()
+        self.presenter.phaseTableAdded = mock.Mock(return_value = False)
+        self.view.getPhaseTableIndex = mock.Mock(return_value = 2)
+        self.view.setPhaseTableIndex = mock.Mock()
+
+        inputs = {}
+        self.view.addOutputPhases(inputs)
+        self.presenter.handleFinished()
+
+        self.assertEquals(inputs["OutputPhaseTable"],"test")
+        self.assertEquals(self.view.getPhaseTableIndex.call_count, 0)
+        self.assertEquals(self.view.addPhaseTableToGUI.call_count, 0)
+        self.assertEquals(self.view.setPhaseTableIndex.call_count, 0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -95,16 +95,37 @@ class MaxEntPresenterTest(unittest.TestCase):
         self.presenter.phaseTableAdded = mock.Mock(return_value = True)
         self.view.getPhaseTableIndex = mock.Mock(return_value = 2)
         self.view.setPhaseTableIndex = mock.Mock()
+        self.view.getPhaseTableOptions = mock.Mock(return_value = [])
 
         inputs = {}
         self.view.addOutputPhases(inputs)
         self.presenter.handleFinished()
 
         self.assertEquals(inputs["OutputPhaseTable"],"test")
+        self.assertEquals(self.view.getPhaseTableOptions.call_count, 1)
         self.assertEquals(self.view.getPhaseTableIndex.call_count, 1)
         self.assertEquals(self.view.addPhaseTableToGUI.call_count, 1)
         self.assertEquals(self.view.setPhaseTableIndex.call_count, 1)
         self.view.setPhaseTableIndex.assert_called_with(2)
+
+    def test_phaseOptionAlreadyExists(self):
+        self.view.addOutputPhases = mock.MagicMock(side_effect = test)
+        self.view.addPhaseTableToGUI = mock.MagicMock()
+        self.presenter.thread = mock.MagicMock()
+        self.presenter.phaseTableAdded = mock.Mock(return_value = True)
+        self.view.getPhaseTableIndex = mock.Mock(return_value = 2)
+        self.view.setPhaseTableIndex = mock.Mock()
+        self.view.getPhaseTableOptions = mock.Mock(return_value = ["test"])
+
+        inputs = {}
+        self.view.addOutputPhases(inputs)
+        self.presenter.handleFinished()
+
+        self.assertEquals(inputs["OutputPhaseTable"],"test")
+        self.assertEquals(self.view.getPhaseTableOptions.call_count, 1)
+        self.assertEquals(self.view.getPhaseTableIndex.call_count, 0)
+        self.assertEquals(self.view.addPhaseTableToGUI.call_count, 0)
+        self.assertEquals(self.view.setPhaseTableIndex.call_count, 0)
 
     def test_noUpdatePhaseOptions(self):
         self.view.addOutputPhases = mock.MagicMock(side_effect = test)
@@ -113,12 +134,14 @@ class MaxEntPresenterTest(unittest.TestCase):
         self.presenter.phaseTableAdded = mock.Mock(return_value = False)
         self.view.getPhaseTableIndex = mock.Mock(return_value = 2)
         self.view.setPhaseTableIndex = mock.Mock()
+        self.view.getPhaseTableOptions = mock.Mock(return_value = [])
 
         inputs = {}
         self.view.addOutputPhases(inputs)
         self.presenter.handleFinished()
 
         self.assertEquals(inputs["OutputPhaseTable"],"test")
+        self.assertEquals(self.view.getPhaseTableOptions.call_count, 1)
         self.assertEquals(self.view.getPhaseTableIndex.call_count, 0)
         self.assertEquals(self.view.addPhaseTableToGUI.call_count, 0)
         self.assertEquals(self.view.setPhaseTableIndex.call_count, 0)


### PR DESCRIPTION
**Description of work.**
The frequency domain analysis GUI would only allow the user to generate a phase table from the current data set. This change allows other phase tables to be used. 


**To test:**
Open Muon Analysis and load MUSR 62260

Open FDA and switch to maxent
Change the workspace to `MUSR 62260`
Change the start value to 1
Tick `use phases` - a combo-box will appear in the table with a single option of `construct`
Tick `output phase table option`
Click run
The combo-box will now also include the phase table that was just created

Change the run in Muon Analysis (62261)
Click run in the FDA to update the GUI
Tick fix phases and do a run
Look at the output of the maxent and phase table
Change the phase table in the combo-box to the output of 62260
Run maxent
The output should be different

<!-- Instructions for testing. -->

Fixes #24680. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
In release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
