### PR TITLE
Overwrite default RKH append property to false in SANS

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -53,6 +53,7 @@ Bug fixes
 * Fixed error message when trying to load or process table with empty rows.
 * Removed option to process in non-compatibility mode to avoid calculation issues.
 * Default name for added runs has correct number of digits.
+* RKH files no longer append to existing files, but overwrite instead.
 
 Improvements
 ############

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -58,6 +58,7 @@ def get_save_strategy(file_format_bundle, file_name, save_options):
     elif file_format is SaveType.RKH:
         file_name = get_file_name(file_format_bundle, file_name, "", ".txt")
         save_name = "SaveRKH"
+        save_options.update({"Append": False})
     elif file_format is SaveType.CSV:
         file_name = get_file_name(file_format_bundle, file_name, "", ".csv")
         save_name = "SaveCSV"


### PR DESCRIPTION
**Description of work.**
When calling SaveRKH algorithm from SANS, sets the Append property to False so an existing file with the same name will be overwritten, not appended to. This is a SANS only change. The option to choose to append or not is not exposed to the user on the SANS side, as none of the scientists want this functionality.

**Report to:** James D

**To test:** 
1. Interfaces -> SANS -> SANS v2
2. Load attached user file (MaskFile) and batch file
3. In Manage Directories (top right), choose an output directory 
4. At the bottom of the main GUI, select the "File" radio button, and check the RKH button and uncheck NxCanSAS
5. Click process all
6. This should create a .txt file in your chosen output directory which is about 16kB 
7. Click process all
8. This should overwrite the file, thus your output .txt should still be about 16kB

Fixes #24490 

[Mantid_loqData.zip](https://github.com/mantidproject/mantid/files/2851302/Mantid_loqData.zip)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
