### PR TITLE
Monitor moving functionality for ZOOM

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -18,3 +18,4 @@ Improvements
 ############
 
 - Increased font size in run table.
+- For ZOOM, SHIFT user file command now moves monitor 5.

--- a/scripts/SANS/sans/algorithm_detail/move_workspaces.py
+++ b/scripts/SANS/sans/algorithm_detail/move_workspaces.py
@@ -688,6 +688,33 @@ class SANSMoveZOOM(SANSMove):
     def _move_low_angle_bank(move_info, workspace, coordinates):
         move_low_angle_bank_for_SANS2D_and_ZOOM(move_info, workspace, coordinates, use_rear_det_z=False)
 
+    @staticmethod
+    def _move_monitor_n(workspace, move_info, monitor_spectrum_number):
+        monitor_offset = move_info.monitor_n_offset
+        if monitor_offset != 0.0:
+            monitor_spectrum_number_as_string = str(monitor_spectrum_number)
+            monitor_n_name = move_info.monitor_names[monitor_spectrum_number_as_string]
+            instrument = workspace.getInstrument()
+            monitor_n = instrument.getComponentByName(monitor_n_name)
+
+            # Get position of monitor n
+            monitor_position = monitor_n.getPos()
+            z_position_monitor = monitor_position.getZ()
+
+            # The location is relative to the rear-detector, get this position
+            lab_detector = move_info.detectors[DetectorType.to_string(DetectorType.LAB)]
+            detector_name = lab_detector.detector_name
+            lab_detector_component = instrument.getComponentByName(detector_name)
+            detector_position = lab_detector_component.getPos()
+            z_position_detector = detector_position.getZ()
+
+            monitor_n_offset = monitor_offset
+            z_new = z_position_detector + monitor_n_offset
+            z_move = z_new - z_position_monitor
+            offset = {CanonicalCoordinates.Z: z_move}
+
+            move_component(workspace, offset, monitor_n_name)
+
     def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
         # For ZOOM we only have to coordinates
         assert len(coordinates) == 2
@@ -700,6 +727,10 @@ class SANSMoveZOOM(SANSMove):
 
         # Move the sample holder
         move_sample_holder(workspace, move_info.sample_offset, move_info.sample_offset_direction)
+
+        # Move the monitor
+        monitor_spectrum = 5  # Only M5 can be moved for ZOOM
+        self._move_monitor_n(workspace, move_info, monitor_spectrum_number=monitor_spectrum)
 
     def do_move_with_elementary_displacement(self, move_info, workspace, coordinates, component):
         # For ZOOM we only have to coordinates

--- a/scripts/SANS/sans/state/move.py
+++ b/scripts/SANS/sans/state/move.py
@@ -195,6 +195,7 @@ class StateMoveLARMOR(StateMove):
 @rename_descriptor_names
 class StateMoveZOOM(StateMove):
     lab_detector_default_sd_m = FloatParameter()
+    monitor_n_offset = FloatParameter()
 
     def __init__(self):
         super(StateMoveZOOM, self).__init__()
@@ -202,6 +203,7 @@ class StateMoveZOOM(StateMove):
 
         # Set the monitor names
         self.monitor_names = {}
+        self.monitor_n_offset = 0.0
 
         # Setup the detectors
         self.detectors = {DetectorType.to_string(DetectorType.LAB): StateMoveDetector()}
@@ -270,7 +272,7 @@ class StateMoveZOOMBuilder(object):
         self.state = StateMoveZOOM()
         # TODO: At the moment we set the monitor names up manually here. In principle we have all necessary information
         #       in the IDF we should be able to parse it and get.
-        invalid_monitor_names = ["monitor5", "monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
+        invalid_monitor_names = ["monitor6", "monitor7", "monitor8", "monitor9", "monitor10"]
         invalid_detector_types = [DetectorType.HAB]
         setup_idf_and_ipf_content(self.state, data_info,
                                   invalid_detector_types=invalid_detector_types,


### PR DESCRIPTION
**Description of work.**
This PR copies SANS2D's functionality for moving a monitor to ZOOM.
If a non-zero monitor offset has been applied, then ZOOM's M5 will be shifted.

**Report to:** Diego ZOOM

**To test:**
THIS PR IS BEING TESTED BY ZOOM SCIENTISTS.
Code review is required

1. Interfaces -> SANS -> SANS v2
2. Load the attached user file
3. In the table, fill the first six columns with the following data: 4905 | 4905 | 4913 | 4913 | 4913 | 4913
4. In settings -> Adjustment, change Transmission Monitor to 5 and Monitor Shift to -40000
5. In Runs, click Process All
6. Change the output name in the table, and change monitor shift to 0
7. Click Process All again
8. In the two group workspaces plot the workspaces named `xxxxx_trans_Sample` and `xxxxx_trans_Sample_unfitted` on the same graph. All four lines should be different

Fixes #24747 


[USER_ZOOM_dummy.txt](https://github.com/mantidproject/mantid/files/2856493/USER_ZOOM_dummy.txt)


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
