### PR TITLE
Fix sample log comparison in CompareWorkspaces

### DIFF
--- a/Framework/Algorithms/test/CompareWorkspacesTest.h
+++ b/Framework/Algorithms/test/CompareWorkspacesTest.h
@@ -1009,6 +1009,33 @@ public:
     TS_ASSERT_EQUALS(table->cell<std::string>(0, 0), "Log mismatch");
   }
 
+  void testSameLogsButInDifferentOrder() {
+    MatrixWorkspace_sptr ws1 =
+        WorkspaceCreationHelper::create2DWorkspace123(1, 1);
+    MatrixWorkspace_sptr ws2 = ws1->clone();
+    ws1->mutableRun().addProperty("property1", 1);
+    ws1->mutableRun().addProperty("property2", 2);
+    // Add same properties to ws2 but in reverse order.
+    ws2->mutableRun().addProperty("property2", 2);
+    ws2->mutableRun().addProperty("property1", 1);
+    CompareWorkspaces compare;
+    compare.initialize();
+    compare.setChild(true);
+    compare.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("Workspace1", ws1))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("Workspace2", ws2))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckType", false))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckAxes", false))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckSpectraMap", false))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckInstrument", false))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckMasking", false))
+    TS_ASSERT_THROWS_NOTHING(compare.setProperty("CheckSample", true))
+    TS_ASSERT_THROWS_NOTHING(compare.execute())
+    TS_ASSERT(compare.isExecuted())
+    const bool workspacesMatch = compare.getProperty("Result");
+    TS_ASSERT(workspacesMatch)
+  }
+
   void test_Input_With_Two_Groups_That_Are_The_Same_Matches() {
     // Create a group
     const std::string groupName("TestGroup");


### PR DESCRIPTION
`CompareWorkspaces` failed to check the sample logs if the log entries were sorted differently even though the data itself matched perfectly. This PR sorts the log entries alphabetically by name before comparing them one-by-one.

**To test:**

The logs in the two workspaces below should match.

```python
ws1 = CreateSampleWorkspace()
ws1.mutableRun().addProperty('p1', 42., True)
ws1.mutableRun().addProperty('p2', 24., True)

ws2 = CreateSampleWorkspace()
# Add logs in reverse order
ws2.mutableRun().addProperty('p2', 24., True)
ws2.mutableRun().addProperty('p1', 42., True)

CompareWorkspaces(ws1, ws2, CheckType=False, CheckAxes=False, CheckSpectraMap=False, CheckInstrument=False, CheckMasking=False, CheckSample=True)
```

Fixes #24755.

*This does not require release notes* because a fix to the sample logs check in `CompareWorkspaces` is already mentioned there; this merely makes it work as promised.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
