### PR TITLE
Added compare workspace tolerance

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -163,11 +163,11 @@ public:
     return vec;
   }
 
-  virtual bool equals(Column *,double) const {
+  virtual bool equals(Column *, double) const {
     throw std::runtime_error("equals not implemented");
   };
 
-  virtual bool equalsRelErr(Column *,double) const {
+  virtual bool equalsRelErr(Column *, double) const {
     throw std::runtime_error("equals not implemented");
   };
 

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -163,11 +163,11 @@ public:
     return vec;
   }
 
-  virtual bool equals(Column *, double) const {
+  virtual bool equals(const Column &, double) const {
     throw std::runtime_error("equals not implemented");
   };
 
-  virtual bool equalsRelErr(Column *, double) const {
+  virtual bool equalsRelErr(const Column &, double) const {
     throw std::runtime_error("equals not implemented");
   };
 
@@ -182,6 +182,15 @@ protected:
   virtual void *void_pointer(size_t index) = 0;
   /// Pointer to a data element
   virtual const void *void_pointer(size_t index) const = 0;
+
+  bool possibleToCompare(const Column &otherColumn) const {
+    if (otherColumn.get_type_info() != this->get_type_info())
+      return false;
+    if (otherColumn.size() != this->size()) {
+      return false;
+    }
+    return true;
+  }
 
   std::string m_name; ///< name
   std::string m_type; ///< type

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -163,6 +163,8 @@ public:
     return vec;
   }
 
+  virtual bool equals(Column *otherColumn,double tolerance) const =0;
+
 protected:
   /// Sets the new column size.
   virtual void resize(size_t count) = 0;

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -167,6 +167,10 @@ public:
     throw std::runtime_error("equals not implemented");
   };
 
+  virtual bool equalsRelErr(Column *,double) const {
+    throw std::runtime_error("equals not implemented");
+  };
+
 protected:
   /// Sets the new column size.
   virtual void resize(size_t count) = 0;

--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -163,7 +163,9 @@ public:
     return vec;
   }
 
-  virtual bool equals(Column *otherColumn,double tolerance) const =0;
+  virtual bool equals(Column *,double) const {
+    throw std::runtime_error("equals not implemented");
+  };
 
 protected:
   /// Sets the new column size.

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1145,31 +1145,31 @@ void CompareWorkspaces::doTableComparison(
   const bool checkAllData = getProperty("CheckAllData");
   const bool relErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
-  
+
   for (size_t i = 0; i < numCols; ++i) {
     const auto c1 =
         boost::const_pointer_cast<ITableWorkspace>(tws1)->getColumn(i);
     const auto c2 =
         boost::const_pointer_cast<ITableWorkspace>(tws2)->getColumn(i);
-    
-        if(relErr){
-          if (!c1->equalsRelErr(c2.get(),tolerance)) {
-            g_log.debug() << "Table data mismatch at column " << i;
-            recordMismatch("Table data mismatch");
-            if (!checkAllData){
-              return;
-            }
-          }
-        }else{
-    
-          if (!c1->equals(c2.get(),tolerance)) {
-            g_log.debug() << "Table data mismatch at column " << i;
-            recordMismatch("Table data mismatch");
-            if (!checkAllData){
-              return;
-            } 
-          }
+
+    if (relErr) {
+      if (!c1->equalsRelErr(c2.get(), tolerance)) {
+        g_log.debug() << "Table data mismatch at column " << i;
+        recordMismatch("Table data mismatch");
+        if (!checkAllData) {
+          return;
         }
+      }
+    } else {
+
+      if (!c1->equals(c2.get(), tolerance)) {
+        g_log.debug() << "Table data mismatch at column " << i;
+        recordMismatch("Table data mismatch");
+        if (!checkAllData) {
+          return;
+        }
+      }
+    }
   } // loop over columns
 }
 

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1147,10 +1147,8 @@ void CompareWorkspaces::doTableComparison(
   const double tolerance = getProperty("Tolerance");
   bool mismatch = false;
   for (size_t i = 0; i < numCols; ++i) {
-    const auto c1 =
-        boost::const_pointer_cast<ITableWorkspace>(tws1)->getColumn(i);
-    const auto c2 =
-        boost::const_pointer_cast<ITableWorkspace>(tws2)->getColumn(i);
+    const auto c1 = tws1->getColumn(i);
+    const auto c2 = tws2->getColumn(i);
 
     if (relErr) {
       if (!c1->equalsRelErr(*c2, tolerance)) {

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1145,7 +1145,7 @@ void CompareWorkspaces::doTableComparison(
   const bool checkAllData = getProperty("CheckAllData");
   const bool relErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
-
+  bool mismatch = false;
   for (size_t i = 0; i < numCols; ++i) {
     const auto c1 =
         boost::const_pointer_cast<ITableWorkspace>(tws1)->getColumn(i);
@@ -1153,21 +1153,21 @@ void CompareWorkspaces::doTableComparison(
         boost::const_pointer_cast<ITableWorkspace>(tws2)->getColumn(i);
 
     if (relErr) {
-      if (!c1->equalsRelErr(c2.get(), tolerance)) {
-        g_log.debug() << "Table data mismatch at column " << i;
-        recordMismatch("Table data mismatch");
-        if (!checkAllData) {
-          return;
-        }
+      if (!c1->equalsRelErr(*c2, tolerance)) {
+        mismatch = true;
       }
     } else {
 
-      if (!c1->equals(c2.get(), tolerance)) {
-        g_log.debug() << "Table data mismatch at column " << i;
-        recordMismatch("Table data mismatch");
-        if (!checkAllData) {
-          return;
-        }
+      if (!c1->equals(*c2, tolerance)) {
+        mismatch = true;
+      }
+    }
+    if (mismatch) {
+      g_log.debug() << "Table data mismatch at column " << i;
+      recordMismatch("Table data mismatch");
+      mismatch = false;
+      if (!checkAllData) {
+        return;
       }
     }
   } // loop over columns

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1161,7 +1161,7 @@ void CompareWorkspaces::doTableComparison(
       }
     }
     if (mismatch) {
-      g_log.debug() << "Table data mismatch at column " << i;
+      g_log.debug() << "Table data mismatch at column " << i << std::endl;
       recordMismatch("Table data mismatch");
       mismatch = false;
       if (!checkAllData) {

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1143,6 +1143,7 @@ void CompareWorkspaces::doTableComparison(
   }
 
   const bool checkAllData = getProperty("CheckAllData");
+  const bool relErr = getProperty("ToleranceRelErr");
   const double tolerance = getProperty("Tolerance");
   
   for (size_t i = 0; i < numCols; ++i) {
@@ -1151,12 +1152,22 @@ void CompareWorkspaces::doTableComparison(
     const auto c2 =
         boost::const_pointer_cast<ITableWorkspace>(tws2)->getColumn(i);
     
+        if(relErr){
+          if (!c1->equalsRelErr(c2.get(),tolerance)) {
+            g_log.debug() << "Table data mismatch at column " << i;
+            recordMismatch("Table data mismatch");
+            if (!checkAllData){
+              return;
+            }
+          }
+        }else{
     
-        if (!c1->equals(c2.get(),tolerance)) {
-          g_log.debug() << "Table data mismatch at column " << i;
-          recordMismatch("Table data mismatch");
-          if (!checkAllData){
-            return;
+          if (!c1->equals(c2.get(),tolerance)) {
+            g_log.debug() << "Table data mismatch at column " << i;
+            recordMismatch("Table data mismatch");
+            if (!checkAllData){
+              return;
+            } 
           }
         }
   } // loop over columns

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1161,7 +1161,7 @@ void CompareWorkspaces::doTableComparison(
       }
     }
     if (mismatch) {
-      g_log.debug() << "Table data mismatch at column " << i << std::endl;
+      g_log.debug() << "Table data mismatch at column " << i << "\n";
       recordMismatch("Table data mismatch");
       mismatch = false;
       if (!checkAllData) {

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1143,23 +1143,22 @@ void CompareWorkspaces::doTableComparison(
   }
 
   const bool checkAllData = getProperty("CheckAllData");
-
-  for (size_t i = 0; i < numRows; ++i) {
-    const TableRow r1 =
-        boost::const_pointer_cast<ITableWorkspace>(tws1)->getRow(i);
-    const TableRow r2 =
-        boost::const_pointer_cast<ITableWorkspace>(tws2)->getRow(i);
-    // Easiest, if not the fastest, way to compare is via strings
-    std::stringstream r1s, r2s;
-    r1s << r1;
-    r2s << r2;
-    if (r1s.str() != r2s.str()) {
-      g_log.debug() << "Table data mismatch at row " << i << " (" << r1s.str()
-                    << " vs " << r2s.str() << ")\n";
-      recordMismatch("Table data mismatch");
-      if (!checkAllData)
-        return;
-    }
+  const double tolerance = getProperty("Tolerance");
+  
+  for (size_t i = 0; i < numCols; ++i) {
+    const auto c1 =
+        boost::const_pointer_cast<ITableWorkspace>(tws1)->getColumn(i);
+    const auto c2 =
+        boost::const_pointer_cast<ITableWorkspace>(tws2)->getColumn(i);
+    
+    
+        if (!c1->equals(c2.get(),tolerance)) {
+          g_log.debug() << "Table data mismatch at column " << i;
+          recordMismatch("Table data mismatch");
+          if (!checkAllData){
+            return;
+          }
+        }
   } // loop over columns
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -68,13 +68,14 @@ public:
   void fromDouble(size_t i, double value) override;
 
   /// Reference to the data.
-  const std::vector<Peak> &data() const { return m_peaks; } 
+  const std::vector<Peak> &data() const { return m_peaks; }
 
-  bool equals(Column *otherColumn,double tolerance) const override {
+  bool equals(Column *otherColumn, double tolerance) const override {
     (void)otherColumn;
     (void)tolerance;
-    throw std::runtime_error("equals not implemented, to compare use peaksworkspace");
-    }
+    throw std::runtime_error(
+        "equals not implemented, to compare use peaksworkspace");
+  }
 
 protected:
   /// Sets the new column size.

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -70,11 +70,11 @@ public:
   /// Reference to the data.
   const std::vector<Peak> &data() const { return m_peaks; }
 
-  bool equals(Column *otherColumn, double tolerance) const override {
+  bool equals(const Column &otherColumn, double tolerance) const override {
     (void)otherColumn;
     (void)tolerance;
     throw std::runtime_error(
-        "equals not implemented, to compare use peaksworkspace");
+        "equals not implemented, to compare use CompareWorkspace");
   }
 
 protected:

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -67,6 +67,14 @@ public:
   /// Assign from double
   void fromDouble(size_t i, double value) override;
 
+  /// Reference to the data.
+  const std::vector<Peak> &data() const { return m_peaks; } 
+
+  bool equals(Column *otherColumn,double tolerance) const override {
+    (void)otherColumn;
+    (void)tolerance;
+    return true;}
+
 protected:
   /// Sets the new column size.
   void resize(size_t count) override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakColumn.h
@@ -73,7 +73,8 @@ public:
   bool equals(Column *otherColumn,double tolerance) const override {
     (void)otherColumn;
     (void)tolerance;
-    return true;}
+    throw std::runtime_error("equals not implemented, to compare use peaksworkspace");
+    }
 
 protected:
   /// Sets the new column size.

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -246,12 +246,12 @@ private:
   return true;
   }
 };
-///Template specialisation for long int
+///Template specialisation for long64
 template<>
-inline bool TableColumn<long>::compareVectors(const std::vector<long> &newVector, double tolerance) const {
-  long roundedTol = lround(tolerance);
+inline bool TableColumn<int64_t>::compareVectors(const std::vector<int64_t> &newVector, double tolerance) const {
+  int64_t roundedTol = llround(tolerance);
   for(size_t i =0; i<m_data.size(); i++){
-      if(std::labs(m_data[i]-newVector[i])>roundedTol){
+      if(std::llabs(m_data[i]-newVector[i])>roundedTol){
         return false;
       }
     }

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -197,6 +197,19 @@ public:
   /// Re-arrange values in this column according to indices in indexVec
   void sortValues(const std::vector<size_t> &indexVec) override;
 
+  bool equals(Column *otherColumn,double tolerance) const override{
+    auto convertedOtherColumn = dynamic_cast<TableColumn*>(otherColumn);
+    if(!convertedOtherColumn){
+      return false;
+    }
+    auto type = this->type();
+    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=type){
+      return false;
+    }
+    auto otherData = convertedOtherColumn->data();
+    return compareVectors(otherData, tolerance);
+  }
+
 protected:
   /// Resize.
   void resize(size_t count) override { m_data.resize(count); }
@@ -220,6 +233,16 @@ private:
   /// Column data
   std::vector<Type> m_data;
   friend class TableWorkspace;
+
+  //helper function template for equality
+  bool compareVectors(const std::vector<Type> &newVector, double tolerance) const{
+    for(size_t i =0; i<m_data.size(); i++){
+      if(fabs(m_data[i]-newVector[i])>tolerance){
+        return false;
+      }
+    }
+  return true;
+  }
 };
 
 /// Template specialization for strings so they can contain spaces

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -248,7 +248,7 @@ private:
   bool compareVectors(const std::vector<Type> &newVector,
                       double tolerance) const {
     for (size_t i = 0; i < m_data.size(); i++) {
-      if (fabs(m_data[i] - newVector[i]) > tolerance) {
+      if (fabs((double)m_data[i] - (double)newVector[i]) > tolerance) {
         return false;
       }
     }
@@ -259,8 +259,8 @@ private:
   bool compareVectorsRelError(const std::vector<Type> &newVector,
                               double tolerance) const {
     for (size_t i = 0; i < m_data.size(); i++) {
-      double num = fabs(m_data[i] - newVector[i]);
-      double den = (fabs(m_data[i]) + fabs(newVector[i])) / 2;
+      double num = fabs((double)m_data[i] - (double)newVector[i]);
+      double den = (fabs((double)m_data[i]) + fabs((double)newVector[i])) / 2;
       if (den < tolerance && num > tolerance) {
         return false;
       } else if (num / den > tolerance) {
@@ -288,9 +288,10 @@ TableColumn<int64_t>::compareVectors(const std::vector<int64_t> &newVector,
 template <>
 inline bool TableColumn<unsigned long>::compareVectors(
     const std::vector<unsigned long> &newVector, double tolerance) const {
-  long roundedTol = lround(tolerance);
+  long long roundedTol = llround(tolerance);
   for (size_t i = 0; i < m_data.size(); i++) {
-    if (std::labs(m_data[i] - newVector[i]) > roundedTol) {
+    if (std::llabs((long long)m_data[i] - (long long)newVector[i]) >
+        roundedTol) {
       return false;
     }
   }
@@ -359,10 +360,10 @@ inline bool TableColumn<int64_t>::compareVectorsRelError(
 template <>
 inline bool TableColumn<unsigned long>::compareVectorsRelError(
     const std::vector<unsigned long> &newVector, double tolerance) const {
-  long unsigned int roundedTol = lround(tolerance);
+  long long roundedTol = lround(tolerance);
   for (size_t i = 0; i < m_data.size(); i++) {
-    long unsigned int num = labs(m_data[i] - newVector[i]);
-    long unsigned int den = (labs(m_data[i]) + labs(newVector[i])) / 2;
+    long long num = labs((long long)m_data[i] - (long long)newVector[i]);
+    long long den = (m_data[i] + newVector[i]) / 2;
     if (den < roundedTol && num > roundedTol) {
       return false;
     } else if (num / den > roundedTol) {

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -9,11 +9,13 @@
 
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/shared_ptr.hpp>
+#include <cmath>
 #include <limits>
 #include <sstream>
 #include <vector>
 
 #include "MantidAPI/Column.h"
+#include "MantidKernel/V3D.h"
 
 namespace Mantid {
 namespace DataObjects {
@@ -171,9 +173,9 @@ public:
   }
 
   /// Reference to the data.
-  std::vector<Type> &data() { return m_data; }
+  std::vector<Type> &data() { return m_data; } 
   /// Const reference to the data.
-  const std::vector<Type> &data() const { return m_data; }
+  const std::vector<Type> &data() const { return m_data; } 
   /// Pointer to the data array
   Type *dataArray() { return &m_data[0]; }
 
@@ -244,6 +246,59 @@ private:
   return true;
   }
 };
+///Template specialisation for long int
+template<>
+inline bool TableColumn<long>::compareVectors(const std::vector<long> &newVector, double tolerance) const {
+  long roundedTol = lround(tolerance);
+  for(size_t i =0; i<m_data.size(); i++){
+      if(abs(m_data[i]-newVector[i])>roundedTol){
+        return false;
+      }
+    }
+  return true;
+  }
+
+
+///Template specialisation for unsigned long int
+template<>
+inline bool TableColumn<unsigned long>::compareVectors(const std::vector<unsigned long> &newVector, double tolerance) const {
+  long roundedTol = lround(tolerance);
+  for(size_t i =0; i<m_data.size(); i++){
+      if(abs(m_data[i]-newVector[i])>roundedTol){
+        return false;
+      }
+    }
+  return true;
+  }
+}
+
+
+///Template specialisation for strings for comparison
+template <>
+inline bool TableColumn<std::string>::compareVectors(const std::vector<std::string> &newVector, double tolerance) const {
+  (void)tolerance;
+  for(size_t i =0; i<m_data.size(); i++){
+      if(m_data[i]!=newVector[i]){
+        return false;
+      }
+    }
+  return true;
+}
+
+///Template specialisation for V3D for comparison
+template <>
+inline bool TableColumn<Kernel::V3D>::compareVectors(const std::vector<Kernel::V3D> &newVector, double tolerance)const {
+  for(size_t i =0; i<m_data.size(); i++){
+      double dif_x= m_data[i].X() - newVector[i].X();
+      double dif_y= m_data[i].Y() - newVector[i].Y();
+      double dif_z= m_data[i].Z() - newVector[i].Z();
+      if(dif_x>tolerance||dif_y>tolerance||dif_z>tolerance){
+        return false;
+      }
+  }
+  return true;
+}
+
 
 /// Template specialization for strings so they can contain spaces
 template <>

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -251,7 +251,7 @@ template<>
 inline bool TableColumn<long>::compareVectors(const std::vector<long> &newVector, double tolerance) const {
   long roundedTol = lround(tolerance);
   for(size_t i =0; i<m_data.size(); i++){
-      if(abs(m_data[i]-newVector[i])>roundedTol){
+      if(std::labs(m_data[i]-newVector[i])>roundedTol){
         return false;
       }
     }
@@ -264,13 +264,13 @@ template<>
 inline bool TableColumn<unsigned long>::compareVectors(const std::vector<unsigned long> &newVector, double tolerance) const {
   long roundedTol = lround(tolerance);
   for(size_t i =0; i<m_data.size(); i++){
-      if(abs(m_data[i]-newVector[i])>roundedTol){
+      if(std::labs(m_data[i]-newVector[i])>roundedTol){
         return false;
       }
     }
   return true;
   }
-}
+
 
 
 ///Template specialisation for strings for comparison
@@ -289,9 +289,9 @@ inline bool TableColumn<std::string>::compareVectors(const std::vector<std::stri
 template <>
 inline bool TableColumn<Kernel::V3D>::compareVectors(const std::vector<Kernel::V3D> &newVector, double tolerance)const {
   for(size_t i =0; i<m_data.size(); i++){
-      double dif_x= m_data[i].X() - newVector[i].X();
-      double dif_y= m_data[i].Y() - newVector[i].Y();
-      double dif_z= m_data[i].Z() - newVector[i].Z();
+      double dif_x= fabs(m_data[i].X() - newVector[i].X());
+      double dif_y= fabs(m_data[i].Y() - newVector[i].Y());
+      double dif_z= fabs(m_data[i].Z() - newVector[i].Z());
       if(dif_x>tolerance||dif_y>tolerance||dif_z>tolerance){
         return false;
       }

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -173,9 +173,9 @@ public:
   }
 
   /// Reference to the data.
-  std::vector<Type> &data() { return m_data; } 
+  std::vector<Type> &data() { return m_data; }
   /// Const reference to the data.
-  const std::vector<Type> &data() const { return m_data; } 
+  const std::vector<Type> &data() const { return m_data; }
   /// Pointer to the data array
   Type *dataArray() { return &m_data[0]; }
 
@@ -199,26 +199,28 @@ public:
   /// Re-arrange values in this column according to indices in indexVec
   void sortValues(const std::vector<size_t> &indexVec) override;
 
-  bool equals(Column *otherColumn,double tolerance) const override{
-    auto convertedOtherColumn = dynamic_cast<TableColumn*>(otherColumn);
-    if(!convertedOtherColumn){
+  bool equals(Column *otherColumn, double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<TableColumn *>(otherColumn);
+    if (!convertedOtherColumn) {
       return false;
     }
     auto type = this->type();
-    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=type){
+    if (convertedOtherColumn->size() != this->size() ||
+        convertedOtherColumn->type() != type) {
       return false;
     }
     auto otherData = convertedOtherColumn->data();
     return compareVectors(otherData, tolerance);
   }
 
-  bool equalsRelErr(Column *otherColumn,double tolerance) const override{
-    auto convertedOtherColumn = dynamic_cast<TableColumn*>(otherColumn);
-    if(!convertedOtherColumn){
+  bool equalsRelErr(Column *otherColumn, double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<TableColumn *>(otherColumn);
+    if (!convertedOtherColumn) {
       return false;
     }
     auto type = this->type();
-    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=type){
+    if (convertedOtherColumn->size() != this->size() ||
+        convertedOtherColumn->type() != type) {
       return false;
     }
     auto otherData = convertedOtherColumn->data();
@@ -249,166 +251,172 @@ private:
   std::vector<Type> m_data;
   friend class TableWorkspace;
 
-  //helper function template for equality
-  bool compareVectors(const std::vector<Type> &newVector, double tolerance) const{
-    for(size_t i =0; i<m_data.size(); i++){
-      if(fabs(m_data[i]-newVector[i])>tolerance){
+  // helper function template for equality
+  bool compareVectors(const std::vector<Type> &newVector,
+                      double tolerance) const {
+    for (size_t i = 0; i < m_data.size(); i++) {
+      if (fabs(m_data[i] - newVector[i]) > tolerance) {
         return false;
       }
     }
     return true;
   }
 
-  //helper function template for equality with relative error
-  bool compareVectorsRelError(const std::vector<Type> &newVector, double tolerance) const{
-    for(size_t i =0; i<m_data.size(); i++){
-      double num = fabs(m_data[i]-newVector[i]);
-      double den = (fabs(m_data[i])+fabs(newVector[i]))/2;
-      if (den<tolerance&&num>tolerance){
+  // helper function template for equality with relative error
+  bool compareVectorsRelError(const std::vector<Type> &newVector,
+                              double tolerance) const {
+    for (size_t i = 0; i < m_data.size(); i++) {
+      double num = fabs(m_data[i] - newVector[i]);
+      double den = (fabs(m_data[i]) + fabs(newVector[i])) / 2;
+      if (den < tolerance && num > tolerance) {
         return false;
-      }else if(num/den >tolerance){
+      } else if (num / den > tolerance) {
         return false;
       }
     }
     return true;
   }
 };
-///Template specialisation for long64
-template<>
-inline bool TableColumn<int64_t>::compareVectors(const std::vector<int64_t> &newVector, double tolerance) const {
+/// Template specialisation for long64
+template <>
+inline bool
+TableColumn<int64_t>::compareVectors(const std::vector<int64_t> &newVector,
+                                     double tolerance) const {
   int64_t roundedTol = llround(tolerance);
-  for(size_t i =0; i<m_data.size(); i++){
-      if(std::llabs(m_data[i]-newVector[i])>roundedTol){
-        return false;
-      }
+  for (size_t i = 0; i < m_data.size(); i++) {
+    if (std::llabs(m_data[i] - newVector[i]) > roundedTol) {
+      return false;
     }
-  return true;
   }
+  return true;
+}
 
-
-///Template specialisation for unsigned long int
-template<>
-inline bool TableColumn<unsigned long>::compareVectors(const std::vector<unsigned long> &newVector, double tolerance) const {
+/// Template specialisation for unsigned long int
+template <>
+inline bool TableColumn<unsigned long>::compareVectors(
+    const std::vector<unsigned long> &newVector, double tolerance) const {
   long roundedTol = lround(tolerance);
-  for(size_t i =0; i<m_data.size(); i++){
-      if(std::labs(m_data[i]-newVector[i])>roundedTol){
-        return false;
-      }
+  for (size_t i = 0; i < m_data.size(); i++) {
+    if (std::labs(m_data[i] - newVector[i]) > roundedTol) {
+      return false;
     }
-  return true;
-  }
-
-
-
-///Template specialisation for strings for comparison
-template <>
-inline bool TableColumn<std::string>::compareVectors(const std::vector<std::string> &newVector, double tolerance) const {
-  (void)tolerance;
-  for(size_t i =0; i<m_data.size(); i++){
-      if(m_data[i]!=newVector[i]){
-        return false;
-      }
-    }
-  return true;
-}
-
-///Template specialisation for strings for comparison
-template <>
-inline bool TableColumn<API::Boolean>::compareVectors(const std::vector<API::Boolean> &newVector, double tolerance) const {
-  (void)tolerance;
-  for(size_t i =0; i<m_data.size(); i++){
-      if(!(m_data[i]==newVector[i])){
-        return false;
-      }
-    }
-  return true;
-}
-
-///Template specialisation for V3D for comparison
-template <>
-inline bool TableColumn<Kernel::V3D>::compareVectors(const std::vector<Kernel::V3D> &newVector, double tolerance)const {
-  for(size_t i =0; i<m_data.size(); i++){
-      double dif_x= fabs(m_data[i].X() - newVector[i].X());
-      double dif_y= fabs(m_data[i].Y() - newVector[i].Y());
-      double dif_z= fabs(m_data[i].Z() - newVector[i].Z());
-      if(dif_x>tolerance||dif_y>tolerance||dif_z>tolerance){
-        return false;
-      }
   }
   return true;
 }
 
-///Template specialisation for long64 with relative error
-template<>
-inline bool TableColumn<int64_t>::compareVectorsRelError(const std::vector<int64_t> &newVector, double tolerance) const {
+/// Template specialisation for strings for comparison
+template <>
+inline bool TableColumn<std::string>::compareVectors(
+    const std::vector<std::string> &newVector, double tolerance) const {
+  (void)tolerance;
+  for (size_t i = 0; i < m_data.size(); i++) {
+    if (m_data[i] != newVector[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Template specialisation for strings for comparison
+template <>
+inline bool TableColumn<API::Boolean>::compareVectors(
+    const std::vector<API::Boolean> &newVector, double tolerance) const {
+  (void)tolerance;
+  for (size_t i = 0; i < m_data.size(); i++) {
+    if (!(m_data[i] == newVector[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Template specialisation for V3D for comparison
+template <>
+inline bool TableColumn<Kernel::V3D>::compareVectors(
+    const std::vector<Kernel::V3D> &newVector, double tolerance) const {
+  for (size_t i = 0; i < m_data.size(); i++) {
+    double dif_x = fabs(m_data[i].X() - newVector[i].X());
+    double dif_y = fabs(m_data[i].Y() - newVector[i].Y());
+    double dif_z = fabs(m_data[i].Z() - newVector[i].Z());
+    if (dif_x > tolerance || dif_y > tolerance || dif_z > tolerance) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Template specialisation for long64 with relative error
+template <>
+inline bool TableColumn<int64_t>::compareVectorsRelError(
+    const std::vector<int64_t> &newVector, double tolerance) const {
   int64_t roundedTol = llround(tolerance);
-  for(size_t i =0; i<m_data.size(); i++){
-      int64_t num = llabs(m_data[i]-newVector[i]);
-      int64_t den = (llabs(m_data[i])+llabs(newVector[i]))/2;
-      if (den<roundedTol&&num>roundedTol){
-        return false;
-      }else if(num/den >roundedTol){
-        return false;
-      }
+  for (size_t i = 0; i < m_data.size(); i++) {
+    int64_t num = llabs(m_data[i] - newVector[i]);
+    int64_t den = (llabs(m_data[i]) + llabs(newVector[i])) / 2;
+    if (den < roundedTol && num > roundedTol) {
+      return false;
+    } else if (num / den > roundedTol) {
+      return false;
     }
-    return true;
-  }
-
-
-///Template specialisation for unsigned long int
-template<>
-inline bool TableColumn<unsigned long>::compareVectorsRelError(const std::vector<unsigned long> &newVector, double tolerance) const {
-  long unsigned int roundedTol = lround(tolerance);
-  for(size_t i =0; i<m_data.size(); i++){
-      long unsigned int num = labs(m_data[i]-newVector[i]);
-      long unsigned int den = (labs(m_data[i])+labs(newVector[i]))/2;
-      if (den<roundedTol&&num>roundedTol){
-        return false;
-      }else if(num/den >roundedTol){
-        return false;
-      }
-    }
-    return true;
-  }
-
-
-
-///Template specialisation for strings for comparison
-template <>
-inline bool TableColumn<std::string>::compareVectorsRelError(const std::vector<std::string> &newVector, double tolerance) const {
-  return compareVectors(newVector,tolerance);
-}
-
-///Template specialisation for bools for comparison
-template <>
-inline bool TableColumn<API::Boolean>::compareVectorsRelError(const std::vector<API::Boolean> &newVector, double tolerance) const {
-  return compareVectors(newVector,tolerance);
-}
-
-///Template specialisation for V3D for comparison
-template <>
-inline bool TableColumn<Kernel::V3D>::compareVectorsRelError(const std::vector<Kernel::V3D> &newVector, double tolerance)const {
-  for(size_t i =0; i<m_data.size(); i++){
-      double dif_x= fabs(m_data[i].X() - newVector[i].X());
-      double dif_y= fabs(m_data[i].Y() - newVector[i].Y());
-      double dif_z= fabs(m_data[i].Z() - newVector[i].Z());
-      double den_x = 0.5*(fabs(m_data[i].X())+fabs(newVector[i].X()));
-      double den_y = 0.5*(fabs(m_data[i].X())+fabs(newVector[i].X()));
-      double den_z = 0.5*(fabs(m_data[i].X())+fabs(newVector[i].X()));
-      if(den_x>tolerance||den_y>tolerance||den_z>tolerance){
-        if(dif_x/den_x>tolerance||dif_y/den_y>tolerance||dif_z/den_z>tolerance){
-          return false;
-        }
-      }else{
-        if(dif_x>tolerance||dif_y>tolerance||dif_z>tolerance){
-          return false;
-        }
-      }
-      
   }
   return true;
 }
 
+/// Template specialisation for unsigned long int
+template <>
+inline bool TableColumn<unsigned long>::compareVectorsRelError(
+    const std::vector<unsigned long> &newVector, double tolerance) const {
+  long unsigned int roundedTol = lround(tolerance);
+  for (size_t i = 0; i < m_data.size(); i++) {
+    long unsigned int num = labs(m_data[i] - newVector[i]);
+    long unsigned int den = (labs(m_data[i]) + labs(newVector[i])) / 2;
+    if (den < roundedTol && num > roundedTol) {
+      return false;
+    } else if (num / den > roundedTol) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Template specialisation for strings for comparison
+template <>
+inline bool TableColumn<std::string>::compareVectorsRelError(
+    const std::vector<std::string> &newVector, double tolerance) const {
+  return compareVectors(newVector, tolerance);
+}
+
+/// Template specialisation for bools for comparison
+template <>
+inline bool TableColumn<API::Boolean>::compareVectorsRelError(
+    const std::vector<API::Boolean> &newVector, double tolerance) const {
+  return compareVectors(newVector, tolerance);
+}
+
+/// Template specialisation for V3D for comparison
+template <>
+inline bool TableColumn<Kernel::V3D>::compareVectorsRelError(
+    const std::vector<Kernel::V3D> &newVector, double tolerance) const {
+  for (size_t i = 0; i < m_data.size(); i++) {
+    double dif_x = fabs(m_data[i].X() - newVector[i].X());
+    double dif_y = fabs(m_data[i].Y() - newVector[i].Y());
+    double dif_z = fabs(m_data[i].Z() - newVector[i].Z());
+    double den_x = 0.5 * (fabs(m_data[i].X()) + fabs(newVector[i].X()));
+    double den_y = 0.5 * (fabs(m_data[i].X()) + fabs(newVector[i].X()));
+    double den_z = 0.5 * (fabs(m_data[i].X()) + fabs(newVector[i].X()));
+    if (den_x > tolerance || den_y > tolerance || den_z > tolerance) {
+      if (dif_x / den_x > tolerance || dif_y / den_y > tolerance ||
+          dif_z / den_z > tolerance) {
+        return false;
+      }
+    } else {
+      if (dif_x > tolerance || dif_y > tolerance || dif_z > tolerance) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
 
 /// Template specialization for strings so they can contain spaces
 template <>

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -199,31 +199,24 @@ public:
   /// Re-arrange values in this column according to indices in indexVec
   void sortValues(const std::vector<size_t> &indexVec) override;
 
-  bool equals(Column *otherColumn, double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<TableColumn *>(otherColumn);
-    if (!convertedOtherColumn) {
+  bool equals(const Column &otherColumn, double tolerance) const override {
+    if (!possibleToCompare(otherColumn)) {
       return false;
     }
-    auto type = this->type();
-    if (convertedOtherColumn->size() != this->size() ||
-        convertedOtherColumn->type() != type) {
-      return false;
-    }
-    auto otherData = convertedOtherColumn->data();
+    const auto &otherColumnTyped =
+        static_cast<const TableColumn<Type> &>(otherColumn);
+    const auto &otherData = otherColumnTyped.data();
     return compareVectors(otherData, tolerance);
   }
 
-  bool equalsRelErr(Column *otherColumn, double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<TableColumn *>(otherColumn);
-    if (!convertedOtherColumn) {
+  bool equalsRelErr(const Column &otherColumn,
+                    double tolerance) const override {
+    if (!possibleToCompare(otherColumn)) {
       return false;
     }
-    auto type = this->type();
-    if (convertedOtherColumn->size() != this->size() ||
-        convertedOtherColumn->type() != type) {
-      return false;
-    }
-    auto otherData = convertedOtherColumn->data();
+    const auto &otherColumnTyped =
+        static_cast<const TableColumn<Type> &>(otherColumn);
+    const auto &otherData = otherColumnTyped.data();
     return compareVectorsRelError(otherData, tolerance);
   }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/TableColumn.h
@@ -312,6 +312,18 @@ inline bool TableColumn<std::string>::compareVectors(const std::vector<std::stri
   return true;
 }
 
+///Template specialisation for strings for comparison
+template <>
+inline bool TableColumn<API::Boolean>::compareVectors(const std::vector<API::Boolean> &newVector, double tolerance) const {
+  (void)tolerance;
+  for(size_t i =0; i<m_data.size(); i++){
+      if(!(m_data[i]==newVector[i])){
+        return false;
+      }
+    }
+  return true;
+}
+
 ///Template specialisation for V3D for comparison
 template <>
 inline bool TableColumn<Kernel::V3D>::compareVectors(const std::vector<Kernel::V3D> &newVector, double tolerance)const {
@@ -364,6 +376,12 @@ inline bool TableColumn<unsigned long>::compareVectorsRelError(const std::vector
 ///Template specialisation for strings for comparison
 template <>
 inline bool TableColumn<std::string>::compareVectorsRelError(const std::vector<std::string> &newVector, double tolerance) const {
+  return compareVectors(newVector,tolerance);
+}
+
+///Template specialisation for bools for comparison
+template <>
+inline bool TableColumn<API::Boolean>::compareVectorsRelError(const std::vector<API::Boolean> &newVector, double tolerance) const {
   return compareVectors(newVector,tolerance);
 }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -148,6 +148,32 @@ public:
     return true;
   }
 
+  bool equalsRelErr(Column* otherColumn,double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<VectorColumn*>(otherColumn);
+    if(!convertedOtherColumn){
+      return false;
+    }
+    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=this->type()){
+      return false;
+    }
+    auto otherData = convertedOtherColumn->data();
+    for(size_t i =0; i<m_data.size(); i++){
+      if(m_data[i].size()!=otherData[i].size()){
+        return false;
+      }
+      for(size_t j =0; j<m_data[i].size();j++){
+        double num = fabs(m_data[i][j]-otherData[i][j]);
+        double den = (fabs(m_data[i][j])+fabs(otherData[i][j]))/2;
+      if (den<tolerance&&num>tolerance){
+        return false;
+      }else if(num/den >tolerance){
+        return false;
+      }
+      }
+    }
+    return true;
+  }
+
 protected:
   /// Sets the new column size.
   void resize(size_t count) override { m_data.resize(count); }

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -138,7 +138,7 @@ public:
         return false;
       }
       for (size_t j = 0; j < m_data[i].size(); j++) {
-        if (abs(m_data[i][j] - otherData[i][j]) > tolerance) {
+        if (fabs((double)m_data[i][j] - (double)otherData[i][j]) > tolerance) {
           return false;
         }
       }
@@ -159,8 +159,9 @@ public:
         return false;
       }
       for (size_t j = 0; j < m_data[i].size(); j++) {
-        double num = fabs(m_data[i][j] - otherData[i][j]);
-        double den = (fabs(m_data[i][j]) + fabs(otherData[i][j])) / 2;
+        double num = fabs((double)m_data[i][j] - (double)otherData[i][j]);
+        double den =
+            (fabs((double)m_data[i][j]) + fabs((double)otherData[i][j])) / 2;
         if (den < tolerance && num > tolerance) {
           return false;
         } else if (num / den > tolerance) {

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -14,6 +14,7 @@
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/lexical_cast.hpp>
 
+#include <cmath>
 namespace Mantid {
 namespace DataObjects {
 
@@ -139,7 +140,7 @@ public:
         return false;
       }
       for(size_t j =0; j<m_data[i].size();j++){
-        if(m_data[i][j]-m_data[i][j]>tolerance){
+        if(abs(m_data[i][j]-otherData[i][j])>tolerance){
           return false;
         }
       }

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -122,6 +122,31 @@ public:
     throw std::runtime_error("VectorColumn is not assignable from double.");
   }
 
+  /// Reference to the data.
+  const std::vector<std::vector<Type>> &data() const { return m_data; } 
+
+  bool equals(Column* otherColumn,double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<VectorColumn*>(otherColumn);
+    if(!convertedOtherColumn){
+      return false;
+    }
+    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=this->type()){
+      return false;
+    }
+    auto otherData = convertedOtherColumn->data();
+    for(size_t i =0; i<m_data.size(); i++){
+      if(m_data[i].size()!=otherData[i].size()){
+        return false;
+      }
+      for(size_t j =0; j<m_data[i].size();j++){
+        if(m_data[i][j]-m_data[i][j]>tolerance){
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
 protected:
   /// Sets the new column size.
   void resize(size_t count) override { m_data.resize(count); }

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -126,16 +126,13 @@ public:
   /// Reference to the data.
   const std::vector<std::vector<Type>> &data() const { return m_data; }
 
-  bool equals(Column *otherColumn, double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<VectorColumn *>(otherColumn);
-    if (!convertedOtherColumn) {
+  bool equals(const Column &otherColumn, double tolerance) const override {
+    if (!possibleToCompare(otherColumn)) {
       return false;
     }
-    if (convertedOtherColumn->size() != this->size() ||
-        convertedOtherColumn->type() != this->type()) {
-      return false;
-    }
-    auto otherData = convertedOtherColumn->data();
+    const auto &otherColumnTyped =
+        static_cast<const VectorColumn<Type> &>(otherColumn);
+    const auto &otherData = otherColumnTyped.data();
     for (size_t i = 0; i < m_data.size(); i++) {
       if (m_data[i].size() != otherData[i].size()) {
         return false;
@@ -149,16 +146,14 @@ public:
     return true;
   }
 
-  bool equalsRelErr(Column *otherColumn, double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<VectorColumn *>(otherColumn);
-    if (!convertedOtherColumn) {
+  bool equalsRelErr(const Column &otherColumn,
+                    double tolerance) const override {
+    if (!possibleToCompare(otherColumn)) {
       return false;
     }
-    if (convertedOtherColumn->size() != this->size() ||
-        convertedOtherColumn->type() != this->type()) {
-      return false;
-    }
-    auto otherData = convertedOtherColumn->data();
+    const auto &otherColumnTyped =
+        static_cast<const VectorColumn<Type> &>(otherColumn);
+    const auto &otherData = otherColumnTyped.data();
     for (size_t i = 0; i < m_data.size(); i++) {
       if (m_data[i].size() != otherData[i].size()) {
         return false;

--- a/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/VectorColumn.h
@@ -124,23 +124,24 @@ public:
   }
 
   /// Reference to the data.
-  const std::vector<std::vector<Type>> &data() const { return m_data; } 
+  const std::vector<std::vector<Type>> &data() const { return m_data; }
 
-  bool equals(Column* otherColumn,double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<VectorColumn*>(otherColumn);
-    if(!convertedOtherColumn){
+  bool equals(Column *otherColumn, double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<VectorColumn *>(otherColumn);
+    if (!convertedOtherColumn) {
       return false;
     }
-    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=this->type()){
+    if (convertedOtherColumn->size() != this->size() ||
+        convertedOtherColumn->type() != this->type()) {
       return false;
     }
     auto otherData = convertedOtherColumn->data();
-    for(size_t i =0; i<m_data.size(); i++){
-      if(m_data[i].size()!=otherData[i].size()){
+    for (size_t i = 0; i < m_data.size(); i++) {
+      if (m_data[i].size() != otherData[i].size()) {
         return false;
       }
-      for(size_t j =0; j<m_data[i].size();j++){
-        if(abs(m_data[i][j]-otherData[i][j])>tolerance){
+      for (size_t j = 0; j < m_data[i].size(); j++) {
+        if (abs(m_data[i][j] - otherData[i][j]) > tolerance) {
           return false;
         }
       }
@@ -148,27 +149,28 @@ public:
     return true;
   }
 
-  bool equalsRelErr(Column* otherColumn,double tolerance) const override {
-    auto convertedOtherColumn = dynamic_cast<VectorColumn*>(otherColumn);
-    if(!convertedOtherColumn){
+  bool equalsRelErr(Column *otherColumn, double tolerance) const override {
+    auto convertedOtherColumn = dynamic_cast<VectorColumn *>(otherColumn);
+    if (!convertedOtherColumn) {
       return false;
     }
-    if(convertedOtherColumn->size()!=this->size()||convertedOtherColumn->type()!=this->type()){
+    if (convertedOtherColumn->size() != this->size() ||
+        convertedOtherColumn->type() != this->type()) {
       return false;
     }
     auto otherData = convertedOtherColumn->data();
-    for(size_t i =0; i<m_data.size(); i++){
-      if(m_data[i].size()!=otherData[i].size()){
+    for (size_t i = 0; i < m_data.size(); i++) {
+      if (m_data[i].size() != otherData[i].size()) {
         return false;
       }
-      for(size_t j =0; j<m_data[i].size();j++){
-        double num = fabs(m_data[i][j]-otherData[i][j]);
-        double den = (fabs(m_data[i][j])+fabs(otherData[i][j]))/2;
-      if (den<tolerance&&num>tolerance){
-        return false;
-      }else if(num/den >tolerance){
-        return false;
-      }
+      for (size_t j = 0; j < m_data[i].size(); j++) {
+        double num = fabs(m_data[i][j] - otherData[i][j]);
+        double den = (fabs(m_data[i][j]) + fabs(otherData[i][j])) / 2;
+        if (den < tolerance && num > tolerance) {
+          return false;
+        } else if (num / den > tolerance) {
+          return false;
+        }
       }
     }
     return true;

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -452,6 +452,39 @@ public:
     TS_ASSERT(!column.equals(column2.get(),1));
   }
 
+  void test_equals_general_tolerance_fail(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("int", "col2");
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto &data = column.data();
+    data[0] = 5;
+    data[1] = 7;
+    data[2] = 3;
+    data[3] = 12;
+    data[4] = 1;
+    data[5] = 6;
+    data[6] = 3;
+    data[7] = 2;
+    data[8] = 0;
+    data[9] = 12;
+    auto &data2 = column2.data();
+    data2[0] = 7;
+    data2[1] = 6;
+    data2[2] = 4;
+    data2[3] = 13;
+    data2[4] = 2;
+    data2[5] = 5;
+    data2[6] = 2;
+    data2[7] = 1;
+    data2[8] = 1;
+    data2[9] = 11;
+    Mantid::API::Column *columnPointer = &column2;
+    TS_ASSERT(!column.equals(columnPointer,1));
+  }
+
 private:
   std::vector<size_t> makeIndexVector(size_t n) {
     std::vector<size_t> vec(n);

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -322,7 +322,7 @@ public:
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
-    ws.addColumn("int", "col2");
+
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
     auto &data = column.data();
     data[0] = 5;
@@ -337,8 +337,19 @@ public:
     data[9] = 12;
 
     auto column2 =
-        ws.getColumn("col2");
-    auto &data2 = column2.data();
+       std::unique_ptr<Mantid::API::Column>(column.clone());
+
+
+    TS_ASSERT(column.equals(column2.get(),0))
+  }
+
+  void test_equals_fail(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto &data = column.data();
     data[0] = 5;
     data[1] = 7;
     data[2] = 3;
@@ -349,7 +360,12 @@ public:
     data[7] = 2;
     data[8] = 0;
     data[9] = 12;
-    TS_ASSERT(column.equals(column2.get(),0))
+
+    auto column2 =
+       std::unique_ptr<Mantid::API::Column>(column.clone());
+
+    data[0] = 9;
+    TS_ASSERT(!column.equals(column2.get(),0))
   }
 
 private:

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -340,7 +340,7 @@ public:
        std::unique_ptr<Mantid::API::Column>(column.clone());
 
 
-    TS_ASSERT(column.equals(column2.get(),0))
+    TS_ASSERT(column.equals(column2.get(),0));
   }
 
   void test_equals_fail(){
@@ -365,7 +365,91 @@ public:
        std::unique_ptr<Mantid::API::Column>(column.clone());
 
     data[0] = 9;
-    TS_ASSERT(!column.equals(column2.get(),0))
+
+    TS_ASSERT(!column.equals(column2.get(),0));
+  }
+
+  void test_equals_fail_wrong_type(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("vector_int", "col2");
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto column2 = ws.getColumn("col2");  
+    TS_ASSERT(!column.equals(column2.get(),0));
+  }
+
+  void test_equals_tolerance_normal_case(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("int", "col2");
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto &data = column.data();
+    data[0] = 5;
+    data[1] = 7;
+    data[2] = 3;
+    data[3] = 12;
+    data[4] = 1;
+    data[5] = 6;
+    data[6] = 3;
+    data[7] = 2;
+    data[8] = 0;
+    data[9] = 12;
+    auto &data2 = column2.data();
+    data2[0] = 6;
+    data2[1] = 6;
+    data2[2] = 4;
+    data2[3] = 13;
+    data2[4] = 2;
+    data2[5] = 5;
+    data2[6] = 2;
+    data2[7] = 1;
+    data2[8] = 1;
+    data2[9] = 11;
+    Mantid::API::Column *columnPointer = &column2;
+    TS_ASSERT(column.equals(columnPointer,1));
+  }
+
+  void test_equals_tolerance_int64(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("long64", "col1");
+    ws.addColumn("long64", "col2");
+    auto column = static_cast<TableColumn<int64_t> &>(*ws.getColumn("col1"));
+    auto column2 = static_cast<TableColumn<int64_t> &>(*ws.getColumn("col2"));    
+    auto &data = column.data();
+    data[0] = 165538;
+    auto &data2 = column2.data();
+    data2[0] = 165539;
+    Mantid::API::Column *columnPointer = &column2;
+    TS_ASSERT(column.equals(columnPointer,1));
+  }
+
+    void test_equals_string(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("str", "col1");
+    auto column = static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
+    auto &data = column.data();
+    data[0] = "hello";
+    auto column2 =
+       std::unique_ptr<Mantid::API::Column>(column.clone());
+    TS_ASSERT(column.equals(column2.get(),0));
+  }
+
+  void test_equals_string_tolerance_fail(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("str", "col1");
+    auto column = static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
+    auto &data = column.data();
+    data[0] = "1";
+    auto column2 =
+       std::unique_ptr<Mantid::API::Column>(column.clone());
+    data[0] = "2";
+    TS_ASSERT(!column.equals(column2.get(),1));
   }
 
 private:

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -338,7 +338,7 @@ public:
 
     auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
 
-    TS_ASSERT(column.equals(column2.get(), 0));
+    TS_ASSERT(column.equals(*column2, 0));
   }
 
   void test_equals_fail() {
@@ -363,7 +363,7 @@ public:
 
     data[0] = 9;
 
-    TS_ASSERT(!column.equals(column2.get(), 0));
+    TS_ASSERT(!column.equals(*column2, 0));
   }
 
   void test_equals_fail_wrong_type() {
@@ -373,7 +373,7 @@ public:
     ws.addColumn("vector_int", "col2");
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
     auto column2 = ws.getColumn("col2");
-    TS_ASSERT(!column.equals(column2.get(), 0));
+    TS_ASSERT(!column.equals(*column2, 0));
   }
 
   void test_equals_tolerance_normal_case() {
@@ -405,8 +405,7 @@ public:
     data2[7] = 1;
     data2[8] = 1;
     data2[9] = 11;
-    Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equals(columnPointer, 1));
+    TS_ASSERT(column.equals(column2, 1));
   }
 
   void test_equalsRelErr() {
@@ -438,8 +437,7 @@ public:
     data2[7] = 3;
     data2[8] = 0;
     data2[9] = 12;
-    Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equalsRelErr(columnPointer, 1));
+    TS_ASSERT(column.equalsRelErr(column2, 1));
   }
 
   void test_equals_tolerance_int64() {
@@ -453,8 +451,7 @@ public:
     data[0] = 165538;
     auto &data2 = column2.data();
     data2[0] = 165539;
-    Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equals(columnPointer, 1));
+    TS_ASSERT(column.equals(column2, 1));
   }
 
   void test_equals_string() {
@@ -466,7 +463,7 @@ public:
     auto &data = column.data();
     data[0] = "hello";
     auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
-    TS_ASSERT(column.equals(column2.get(), 0));
+    TS_ASSERT(column.equals(*column2, 0));
   }
 
   void test_equals_string_tolerance_fail() {
@@ -479,7 +476,7 @@ public:
     data[0] = "1";
     auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
     data[0] = "2";
-    TS_ASSERT(!column.equals(column2.get(), 1));
+    TS_ASSERT(!column.equals(*column2, 1));
   }
 
   void test_equals_general_tolerance_fail() {
@@ -511,8 +508,7 @@ public:
     data2[7] = 1;
     data2[8] = 1;
     data2[9] = 11;
-    Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(!column.equals(columnPointer, 1));
+    TS_ASSERT(!column.equals(*ws.getColumn("col2"), 1));
   }
 
 private:

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -318,7 +318,7 @@ public:
     TS_ASSERT(col->isNumber());
   }
 
-  void test_equals_pass(){
+  void test_equals_pass() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
@@ -336,14 +336,12 @@ public:
     data[8] = 0;
     data[9] = 12;
 
-    auto column2 =
-       std::unique_ptr<Mantid::API::Column>(column.clone());
+    auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
 
-
-    TS_ASSERT(column.equals(column2.get(),0));
+    TS_ASSERT(column.equals(column2.get(), 0));
   }
 
-  void test_equals_fail(){
+  void test_equals_fail() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
@@ -361,31 +359,30 @@ public:
     data[8] = 0;
     data[9] = 12;
 
-    auto column2 =
-       std::unique_ptr<Mantid::API::Column>(column.clone());
+    auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
 
     data[0] = 9;
 
-    TS_ASSERT(!column.equals(column2.get(),0));
+    TS_ASSERT(!column.equals(column2.get(), 0));
   }
 
-  void test_equals_fail_wrong_type(){
+  void test_equals_fail_wrong_type() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
     ws.addColumn("vector_int", "col2");
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
-    auto column2 = ws.getColumn("col2");  
-    TS_ASSERT(!column.equals(column2.get(),0));
+    auto column2 = ws.getColumn("col2");
+    TS_ASSERT(!column.equals(column2.get(), 0));
   }
 
-  void test_equals_tolerance_normal_case(){
+  void test_equals_tolerance_normal_case() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
     ws.addColumn("int", "col2");
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
-    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));
     auto &data = column.data();
     data[0] = 5;
     data[1] = 7;
@@ -409,16 +406,16 @@ public:
     data2[8] = 1;
     data2[9] = 11;
     Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equals(columnPointer,1));
+    TS_ASSERT(column.equals(columnPointer, 1));
   }
 
-  void test_equalsRelErr(){
+  void test_equalsRelErr() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
     ws.addColumn("int", "col2");
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
-    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));
     auto &data = column.data();
     data[0] = 100;
     data[1] = 7;
@@ -442,56 +439,56 @@ public:
     data2[8] = 0;
     data2[9] = 12;
     Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equalsRelErr(columnPointer,1));
+    TS_ASSERT(column.equalsRelErr(columnPointer, 1));
   }
 
-  void test_equals_tolerance_int64(){
+  void test_equals_tolerance_int64() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("long64", "col1");
     ws.addColumn("long64", "col2");
     auto column = static_cast<TableColumn<int64_t> &>(*ws.getColumn("col1"));
-    auto column2 = static_cast<TableColumn<int64_t> &>(*ws.getColumn("col2"));    
+    auto column2 = static_cast<TableColumn<int64_t> &>(*ws.getColumn("col2"));
     auto &data = column.data();
     data[0] = 165538;
     auto &data2 = column2.data();
     data2[0] = 165539;
     Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(column.equals(columnPointer,1));
+    TS_ASSERT(column.equals(columnPointer, 1));
   }
 
-    void test_equals_string(){
+  void test_equals_string() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("str", "col1");
-    auto column = static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
+    auto column =
+        static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
     auto &data = column.data();
     data[0] = "hello";
-    auto column2 =
-       std::unique_ptr<Mantid::API::Column>(column.clone());
-    TS_ASSERT(column.equals(column2.get(),0));
+    auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
+    TS_ASSERT(column.equals(column2.get(), 0));
   }
 
-  void test_equals_string_tolerance_fail(){
+  void test_equals_string_tolerance_fail() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("str", "col1");
-    auto column = static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
+    auto column =
+        static_cast<TableColumn<std::string> &>(*ws.getColumn("col1"));
     auto &data = column.data();
     data[0] = "1";
-    auto column2 =
-       std::unique_ptr<Mantid::API::Column>(column.clone());
+    auto column2 = std::unique_ptr<Mantid::API::Column>(column.clone());
     data[0] = "2";
-    TS_ASSERT(!column.equals(column2.get(),1));
+    TS_ASSERT(!column.equals(column2.get(), 1));
   }
 
-  void test_equals_general_tolerance_fail(){
+  void test_equals_general_tolerance_fail() {
     const size_t n = 10;
     TableWorkspace ws(n);
     ws.addColumn("int", "col1");
     ws.addColumn("int", "col2");
     auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
-    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));
     auto &data = column.data();
     data[0] = 5;
     data[1] = 7;
@@ -515,7 +512,7 @@ public:
     data2[8] = 1;
     data2[9] = 11;
     Mantid::API::Column *columnPointer = &column2;
-    TS_ASSERT(!column.equals(columnPointer,1));
+    TS_ASSERT(!column.equals(columnPointer, 1));
   }
 
 private:

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -318,6 +318,40 @@ public:
     TS_ASSERT(col->isNumber());
   }
 
+  void test_equals_pass(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("int", "col2");
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto &data = column.data();
+    data[0] = 5;
+    data[1] = 7;
+    data[2] = 3;
+    data[3] = 12;
+    data[4] = 1;
+    data[5] = 6;
+    data[6] = 3;
+    data[7] = 2;
+    data[8] = 0;
+    data[9] = 12;
+
+    auto column2 =
+        ws.getColumn("col2");
+    auto &data2 = column2.data();
+    data[0] = 5;
+    data[1] = 7;
+    data[2] = 3;
+    data[3] = 12;
+    data[4] = 1;
+    data[5] = 6;
+    data[6] = 3;
+    data[7] = 2;
+    data[8] = 0;
+    data[9] = 12;
+    TS_ASSERT(column.equals(column2.get(),0))
+  }
+
 private:
   std::vector<size_t> makeIndexVector(size_t n) {
     std::vector<size_t> vec(n);

--- a/Framework/DataObjects/test/TableColumnTest.h
+++ b/Framework/DataObjects/test/TableColumnTest.h
@@ -412,6 +412,39 @@ public:
     TS_ASSERT(column.equals(columnPointer,1));
   }
 
+  void test_equalsRelErr(){
+    const size_t n = 10;
+    TableWorkspace ws(n);
+    ws.addColumn("int", "col1");
+    ws.addColumn("int", "col2");
+    auto column = static_cast<TableColumn<int> &>(*ws.getColumn("col1"));
+    auto column2 = static_cast<TableColumn<int> &>(*ws.getColumn("col2"));    
+    auto &data = column.data();
+    data[0] = 100;
+    data[1] = 7;
+    data[2] = 3;
+    data[3] = 12;
+    data[4] = 1;
+    data[5] = 6;
+    data[6] = 3;
+    data[7] = 2;
+    data[8] = 0;
+    data[9] = 12;
+    auto &data2 = column2.data();
+    data2[0] = 90;
+    data2[1] = 6;
+    data2[2] = 3;
+    data2[3] = 12;
+    data2[4] = 1;
+    data2[5] = 7;
+    data2[6] = 2;
+    data2[7] = 3;
+    data2[8] = 0;
+    data2[9] = 12;
+    Mantid::API::Column *columnPointer = &column2;
+    TS_ASSERT(column.equalsRelErr(columnPointer,1));
+  }
+
   void test_equals_tolerance_int64(){
     const size_t n = 10;
     TableWorkspace ws(n);

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -187,6 +187,24 @@ public:
     TS_ASSERT(!col2.equals(compare.get(),1));
     
   }
+
+  void test_equalsRelErr(){
+    VectorColumnTestHelper<int> col;
+    VectorColumnTestHelper<int> col2;
+
+    col.resize(3);
+    col2.resize(3);
+
+    col.read(0, "100,2,3");
+    col.read(1, "3,4,5");
+    col.read(2, "7,8,9,10");
+    auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
+    col2.read(0, "90,2,2");
+    col2.read(1, "3,4,5");
+    col2.read(2, "7,8,9,11");
+    TS_ASSERT(col2.equalsRelErr(compare.get(),1));
+    
+  }
 };
 
 #endif /* MANTID_DATAOBJECTS_VECTORCOLUMNTEST_H_ */

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -119,6 +119,45 @@ public:
     VectorColumnTestHelper<int> col;
     TS_ASSERT(!col.isNumber());
   }
+
+  void test_equals(){
+    VectorColumnTestHelper<int> col;
+
+    col.resize(3);
+
+    col.read(0, "1,2,3");
+    col.read(1, "3,4,5");
+    col.read(2, "7,8,9,10");
+    auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
+
+    TS_ASSERT(col.equals(compare.get(),0));
+    
+  }
+
+  void test_equals_failure_wrong_val(){
+    VectorColumnTestHelper<int> col;
+    VectorColumnTestHelper<int> col2;
+
+    col.resize(3);
+    col2.resize(3);
+
+    col.read(0, "1,2,3");
+    col.read(1, "3,4,5");
+    col.read(2, "7,8,9,10");
+    auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
+    
+    
+
+    
+
+    col2.read(0, "1,2,3");
+    col2.read(1, "3,4,5");
+    col2.read(2, "7,8,9,11");
+
+
+    TS_ASSERT(!col2.equals(compare.get(),0));
+    
+  }
 };
 
 #endif /* MANTID_DATAOBJECTS_VECTORCOLUMNTEST_H_ */

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -120,7 +120,7 @@ public:
     TS_ASSERT(!col.isNumber());
   }
 
-  void test_equals(){
+  void test_equals() {
     VectorColumnTestHelper<int> col;
 
     col.resize(3);
@@ -130,11 +130,10 @@ public:
     col.read(2, "7,8,9,10");
     auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
 
-    TS_ASSERT(col.equals(compare.get(),0));
-    
+    TS_ASSERT(col.equals(compare.get(), 0));
   }
 
-  void test_equals_failure(){
+  void test_equals_failure() {
     VectorColumnTestHelper<int> col;
     VectorColumnTestHelper<int> col2;
 
@@ -148,11 +147,10 @@ public:
     col2.read(0, "1,2,3");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(!col2.equals(compare.get(),0));
-    
+    TS_ASSERT(!col2.equals(compare.get(), 0));
   }
 
-  void test_equals_tolerance(){
+  void test_equals_tolerance() {
     VectorColumnTestHelper<int> col;
     VectorColumnTestHelper<int> col2;
 
@@ -166,11 +164,10 @@ public:
     col2.read(0, "1,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(col2.equals(compare.get(),1));
-    
+    TS_ASSERT(col2.equals(compare.get(), 1));
   }
 
-  void test_equals_tolerance_fail(){
+  void test_equals_tolerance_fail() {
     VectorColumnTestHelper<int> col;
     VectorColumnTestHelper<int> col2;
 
@@ -184,11 +181,10 @@ public:
     col2.read(0, "1,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,12");
-    TS_ASSERT(!col2.equals(compare.get(),1));
-    
+    TS_ASSERT(!col2.equals(compare.get(), 1));
   }
 
-  void test_equalsRelErr(){
+  void test_equalsRelErr() {
     VectorColumnTestHelper<int> col;
     VectorColumnTestHelper<int> col2;
 
@@ -202,8 +198,7 @@ public:
     col2.read(0, "90,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(col2.equalsRelErr(compare.get(),1));
-    
+    TS_ASSERT(col2.equalsRelErr(compare.get(), 1));
   }
 };
 

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -130,7 +130,7 @@ public:
     col.read(2, "7,8,9,10");
     auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
 
-    TS_ASSERT(col.equals(compare.get(), 0));
+    TS_ASSERT(col.equals(*compare, 0));
   }
 
   void test_equals_failure() {
@@ -147,7 +147,7 @@ public:
     col2.read(0, "1,2,3");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(!col2.equals(compare.get(), 0));
+    TS_ASSERT(!col2.equals(*compare, 0));
   }
 
   void test_equals_tolerance() {
@@ -164,7 +164,7 @@ public:
     col2.read(0, "1,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(col2.equals(compare.get(), 1));
+    TS_ASSERT(col2.equals(*compare, 1));
   }
 
   void test_equals_tolerance_fail() {
@@ -181,7 +181,7 @@ public:
     col2.read(0, "1,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,12");
-    TS_ASSERT(!col2.equals(compare.get(), 1));
+    TS_ASSERT(!col2.equals(*compare, 1));
   }
 
   void test_equalsRelErr() {
@@ -198,7 +198,7 @@ public:
     col2.read(0, "90,2,2");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-    TS_ASSERT(col2.equalsRelErr(compare.get(), 1));
+    TS_ASSERT(col2.equalsRelErr(*compare, 1));
   }
 };
 

--- a/Framework/DataObjects/test/VectorColumnTest.h
+++ b/Framework/DataObjects/test/VectorColumnTest.h
@@ -134,7 +134,7 @@ public:
     
   }
 
-  void test_equals_failure_wrong_val(){
+  void test_equals_failure(){
     VectorColumnTestHelper<int> col;
     VectorColumnTestHelper<int> col2;
 
@@ -145,17 +145,46 @@ public:
     col.read(1, "3,4,5");
     col.read(2, "7,8,9,10");
     auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
-    
-    
-
-    
-
     col2.read(0, "1,2,3");
     col2.read(1, "3,4,5");
     col2.read(2, "7,8,9,11");
-
-
     TS_ASSERT(!col2.equals(compare.get(),0));
+    
+  }
+
+  void test_equals_tolerance(){
+    VectorColumnTestHelper<int> col;
+    VectorColumnTestHelper<int> col2;
+
+    col.resize(3);
+    col2.resize(3);
+
+    col.read(0, "1,2,3");
+    col.read(1, "3,4,5");
+    col.read(2, "7,8,9,10");
+    auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
+    col2.read(0, "1,2,2");
+    col2.read(1, "3,4,5");
+    col2.read(2, "7,8,9,11");
+    TS_ASSERT(col2.equals(compare.get(),1));
+    
+  }
+
+  void test_equals_tolerance_fail(){
+    VectorColumnTestHelper<int> col;
+    VectorColumnTestHelper<int> col2;
+
+    col.resize(3);
+    col2.resize(3);
+
+    col.read(0, "1,2,3");
+    col.read(1, "3,4,5");
+    col.read(2, "7,8,9,10");
+    auto compare = std::unique_ptr<Mantid::API::Column>(col.clone());
+    col2.read(0, "1,2,2");
+    col2.read(1, "3,4,5");
+    col2.read(2, "7,8,9,12");
+    TS_ASSERT(!col2.equals(compare.get(),1));
     
   }
 };

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
@@ -46,7 +46,7 @@ class TransformToIqtTest(unittest.TestCase):
                                      ResolutionWorkspace=can,
                                      BinReductionFactor=10)
 
-        self.assertTrue(CompareWorkspaces(params, self._param_table)[0])
+        self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
     def test_with_resolution_reduction(self):
@@ -61,7 +61,7 @@ class TransformToIqtTest(unittest.TestCase):
                                      ResolutionWorkspace=resolution,
                                      BinReductionFactor=10)
 
-        self.assertTrue(CompareWorkspaces(params, self._param_table)[0])
+        self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
 if __name__ == '__main__':

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -411,10 +411,6 @@ class ColumnTester : public Column {
   void fromDouble(size_t, double) override {
     throw std::runtime_error("fromDouble not implemented");
   }
-  
-  bool equals(Column *otherColumn,double tolerance) const{
-    throw std::runtime_error("equals not implemented");
-  }
 
 protected:
   void resize(size_t) override {

--- a/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/FakeObjects.h
@@ -411,6 +411,10 @@ class ColumnTester : public Column {
   void fromDouble(size_t, double) override {
     throw std::runtime_error("fromDouble not implemented");
   }
+  
+  bool equals(Column *otherColumn,double tolerance) const{
+    throw std::runtime_error("equals not implemented");
+  }
 
 protected:
   void resize(size_t) override {

--- a/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
+++ b/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
@@ -23,15 +23,6 @@ ref_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(DIRS[0]))
 root_directory = os.path.join(DIRS[0], "ENGINX")
 cal_directory = os.path.join(root_directory, "cal")
 focus_directory = os.path.join(root_directory, "focus")
-param_deltas = [0.1, 0.1, 1, 2]
-cal_deltas = [0.1, 90000, 0.8, 52000, 1, 0.1, 4, 3, 250, 9, 800, 1.5, 10, 0.5, 5, 0.5]
-
-
-def _skip_test():
-    """Helper function to determine if we run the test"""
-    import platform
-    # Issue with comparing values in tables on other platforms
-    return "linux" not in platform.platform().lower()
 
 
 class CreateVanadiumTest(systemtesting.MantidSystemTest):
@@ -50,14 +41,12 @@ class CreateVanadiumTest(systemtesting.MantidSystemTest):
 
 class CreateCalibrationWholeTest(systemtesting.MantidSystemTest):
 
-    def skipTests(self):
-        return _skip_test()
-
     def runTest(self):
         os.makedirs(cal_directory)
         main(vanadium_run="236516", user="test", focus_run=None, do_cal=True, directory=cal_directory)
 
     def validate(self):
+        self.tolerance(1e-6)
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_1", "engggui_calibration_bank_1.nxs",
                    "engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
@@ -74,15 +63,13 @@ class CreateCalibrationWholeTest(systemtesting.MantidSystemTest):
 
 class CreateCalibrationCroppedTest(systemtesting.MantidSystemTest):
 
-    def skipTests(self):
-        return _skip_test()
-
     def runTest(self):
         os.makedirs(cal_directory)
         main(vanadium_run="236516", user="test", focus_run=None, do_cal=True, directory=cal_directory,
              crop_type="spectra", crop_on="1-20")
 
     def validate(self):
+        self.tolerance(1e-6)
         if _current_os_has_gsl_lvl2():
             return ("cropped", "engggui_calibration_bank_cropped.nxs",
                     "engg_calibration_banks_parameters", "engggui_calibration_bank_cropped_parameters.nxs")
@@ -96,15 +83,13 @@ class CreateCalibrationCroppedTest(systemtesting.MantidSystemTest):
 
 class CreateCalibrationBankTest(systemtesting.MantidSystemTest):
 
-    def skipTests(self):
-        return _skip_test()
-
     def runTest(self):
         os.makedirs(cal_directory)
         main(vanadium_run="236516", user="test", focus_run=None, do_cal=True, directory=cal_directory,
              crop_type="banks", crop_on="South")
 
     def validate(self):
+        self.tolerance(1e-6)
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
                    "engg_calibration_banks_parameters", "engggui_calibration_bank_south_parameters.nxs")

--- a/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
+++ b/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
@@ -46,7 +46,7 @@ class CreateCalibrationWholeTest(systemtesting.MantidSystemTest):
         main(vanadium_run="236516", user="test", focus_run=None, do_cal=True, directory=cal_directory)
 
     def validate(self):
-        self.tolerance(1e-6)
+        self.tolerance = 1e-6
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_1", "engggui_calibration_bank_1.nxs",
                    "engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
@@ -69,7 +69,7 @@ class CreateCalibrationCroppedTest(systemtesting.MantidSystemTest):
              crop_type="spectra", crop_on="1-20")
 
     def validate(self):
-        self.tolerance(1e-6)
+        self.tolerance = 1e-6
         if _current_os_has_gsl_lvl2():
             return ("cropped", "engggui_calibration_bank_cropped.nxs",
                     "engg_calibration_banks_parameters", "engggui_calibration_bank_cropped_parameters.nxs")
@@ -89,7 +89,7 @@ class CreateCalibrationBankTest(systemtesting.MantidSystemTest):
              crop_type="banks", crop_on="South")
 
     def validate(self):
-        self.tolerance(1e-6)
+        self.tolerance = 1e-6
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
                    "engg_calibration_banks_parameters", "engggui_calibration_bank_south_parameters.nxs")

--- a/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
+++ b/Testing/SystemTests/tests/analysis/EnginXScriptTest.py
@@ -46,7 +46,8 @@ class CreateCalibrationWholeTest(systemtesting.MantidSystemTest):
         main(vanadium_run="236516", user="test", focus_run=None, do_cal=True, directory=cal_directory)
 
     def validate(self):
-        self.tolerance = 1e-6
+        self.tolerance_is_reller = True
+        self.tolerance = 1e-2
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_1", "engggui_calibration_bank_1.nxs",
                    "engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
@@ -69,7 +70,8 @@ class CreateCalibrationCroppedTest(systemtesting.MantidSystemTest):
              crop_type="spectra", crop_on="1-20")
 
     def validate(self):
-        self.tolerance = 1e-6
+        self.tolerance_is_reller = True
+        self.tolerance = 1e-2
         if _current_os_has_gsl_lvl2():
             return ("cropped", "engggui_calibration_bank_cropped.nxs",
                     "engg_calibration_banks_parameters", "engggui_calibration_bank_cropped_parameters.nxs")
@@ -89,7 +91,8 @@ class CreateCalibrationBankTest(systemtesting.MantidSystemTest):
              crop_type="banks", crop_on="South")
 
     def validate(self):
-        self.tolerance = 1e-6
+        self.tolerance_is_reller = True
+        self.tolerance = 1e-2
         if _current_os_has_gsl_lvl2():
             return("engg_calibration_bank_2", "engggui_calibration_bank_2.nxs",
                    "engg_calibration_banks_parameters", "engggui_calibration_bank_south_parameters.nxs")

--- a/Testing/SystemTests/tests/analysis/ISIS_WISHDiffractionFocussing.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_WISHDiffractionFocussing.py
@@ -159,6 +159,8 @@ class WISHDiffractionFocussingAnalysisTest(systemtesting.MantidSystemTest):
     def validate(self):
         self.assertEqual(self.table.rowCount(), 8)
         self.assertEqual(len(self.output_names), 8)
+        self.tolerance=1e-5
+        self.tolerance_is_reller = True
         return self.table.name() , "WISHDiffractionFocussingResult.nxs"
 
 


### PR DESCRIPTION
**Description of work.**
implemented comparing `tableworkspaces` with tolerance, by changing to comparing columns instead of rows, and adding an equality (with tolerance) function to Column. added tolerances to the failing enginX tests.


**To test:**
Run the EnginXScript system tests on windows, they should all pass. Ensure all the unit tests for TableColumn and VectorColumn pass.

Fixes #24546 
Also fixes failing system tests on windows and mac

*This does not require release notes* because **`compareworkspaces` is an algorithm used for testing**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
