### PR TITLE
Avoid summing empty list of detectors

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -493,25 +493,6 @@ void InstrumentActor::sumDetectors(const std::vector<size_t> &dets,
 void InstrumentActor::sumDetectorsUniform(const std::vector<size_t> &dets,
                                           std::vector<double> &x,
                                           std::vector<double> &y) const {
-  /*
-<<<<<<< HEAD
-||||||| merged common ancestors
-
-  bool isDataEmpty = dets.empty();
-
-  auto wi = getWorkspaceIndex(dets[0]);
-
-  if (wi == INVALID_INDEX)
-    isDataEmpty = true;
-
-  if (isDataEmpty) {
-    x.clear();
-    y.clear();
-    return;
-  }
-
-=======
-*/
   auto firstWorkspaceIndex = [this](const std::vector<size_t> &dets) {
     if (dets.empty())
       return INVALID_INDEX;
@@ -530,19 +511,7 @@ void InstrumentActor::sumDetectorsUniform(const std::vector<size_t> &dets,
     y.clear();
     return;
   }
-/*
->>>>>>> origin/master
 
-  size_t wi;
-  for (const auto det : dets) {
-    wi = getWorkspaceIndex(det);
-    if (wi != INVALID_INDEX) {
-      // first valid index is the one to use
-      getBinMinMaxIndex(wi, imin, imax);
-      break;
-    }
-  }
-*/
   // find the bins inside the integration range
   size_t imin, imax;
   getBinMinMaxIndex(wi, imin, imax);


### PR DESCRIPTION
Before choosing the method for how to sum the selected detectors, make sure that the list is not empty. Also a minor fix in the uniform branch to protect against the case when the first detector id supplied does not point at a workspace index.

The issue was that when the shape is initially drawn, it is not selecting *any* detectors. As the shape is expanded there are detectors. This change gets around the issue.

**Report to:** Feng Ye

**To test:**

Draw shapes on the pick tab of the instrument view. It won't crash anymore.

Fixes #24761.

*This does not require release notes* because it fixes a bug introduced in this release cycle.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
