### PR TITLE
Fix IntegrateMDHistoWorkspace for NaNs outside integration range

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -235,10 +235,12 @@ void performWeightedSum(MDHistoWorkspaceIterator const *const iterator,
                         double &sumSQErrors, double &sumNEvents) {
   if (!iterator->getIsMasked()) {
     const double weight = box.fraction(iterator->getBoxExtents());
-    sumSignal += weight * iterator->getSignal();
-    const double error = iterator->getError();
-    sumSQErrors += weight * (error * error);
-    sumNEvents += weight * double(iterator->getNumEventsFraction());
+    if (weight != 0) {
+      sumSignal += weight * iterator->getSignal();
+      const double error = iterator->getError();
+      sumSQErrors += weight * (error * error);
+      sumNEvents += weight * double(iterator->getNumEventsFraction());
+    }
   }
 }
 

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -114,6 +114,7 @@ Bugfixes
 - Fixed an issue in :ref:`Rebin2D <algm-Rebin2D>` where `NaN` values would result if there were zero-area bins in the input workspace.
 - Fixed the `CheckSample` option of algorithm :ref:`CompareWorkspaces <algm-CompareWorkspaces>`: it crashed Mantid when comparing the run's sample logs. The algorithm's debug logging will now tell explicitly about the first entry which caused the log mismatch.
 - Fixed a bug in :ref:`MayersSampleCorrection <algm-MayersSampleCorrection>` when using the multiple scattering correction.
+- Fixed a bug in :ref:`IntegrateMDHistoWorkspace <algm-IntegrateMDHistoWorkspace>` in some cases where NaN's are present outside the integration range.
 
 Python
 ------


### PR DESCRIPTION
There are cases where outside the integration range are NaN's and are therefore calculated to have a weight of 0. This shouldn't be included in the integration and causes the output to just be NaN because 0*NaN=NaN. If there is a NaN inside the integration range the output will still be correctly NaN.


**Report to:** Matthias Frontzek

**To test:**

This is a simple example integration from 3 to 8 which doesn't have NaN in that range and should be 25 regardless of the presence of the NaN.

This is the current output for master:

```python
import numpy as np
from mantid.simpleapi import *

s=list(range(10))
e=range(10)

ws=CreateMDHistoWorkspace(Dimensionality=1,Extents='0,10',SignalInput=s,ErrorInput=e,NumberOfBins='10',Names='Dim1',Units='Units')
print(ws.getSignalArray())
# [ 0.  1.  2.  3.  4.  5.  6.  7.  8.  9.]

integ=IntegrateMDHistoWorkspace(ws, P1Bin='3,8')
print(integ.getSignalArray())
# [ 25.]

s[0]=np.nan
ws2=CreateMDHistoWorkspace(Dimensionality=1,Extents='0,10',SignalInput=s,ErrorInput=e,NumberOfBins='10',Names='Dim1',Units='Units')
print(ws2.getSignalArray())
# [ nan   1.   2.   3.   4.   5.   6.   7.   8.   9.]

integ2=IntegrateMDHistoWorkspace(ws2, P1Bin='3,8')
print(integ2.getSignalArray())
# [ nan]

```

After this change the last print should correctly show 25

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
