### PR TITLE
Hide the matplotlib toolbar in workbench instrument view

### DIFF
--- a/qt/widgets/mplcpp/src/Zoomer.cpp
+++ b/qt/widgets/mplcpp/src/Zoomer.cpp
@@ -18,12 +18,14 @@ const char *TOOLBAR_MODE_ATTR = "mode";
 const char *TOOLBAR_MODE_ZOOM = "zoom rect";
 
 /// Return the matplotlib NavigationToolbar type appropriate
-/// for our backend
+/// for our backend. It is returned hidden
 Python::Object mplNavigationToolbar(FigureCanvasQt *canvas) {
   auto backend = backendModule();
   bool showCoordinates(false);
-  return Python::Object(backend.attr(TOOLBAR_CLS)(
+  auto obj = Python::Object(backend.attr(TOOLBAR_CLS)(
       canvas->pyobj(), canvas->pyobj(), showCoordinates));
+  obj.attr("hide")();
+  return obj;
 }
 
 } // namespace


### PR DESCRIPTION
**Description of work.**

See commit comment.

This was broken by accident in #24700 when we fixed a memory leak.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Before the merge check:
* start workbench and load a workspace with an instrument
* show the instrument and switch to the pick tab
* the miniplot will erroneously have the matplotlib toolbar over the top

Merge the fix and see that it is gone but check the zooming still works on the plot itself.


*There is no associated issue.*

*This does not require release notes* because **the workbench has not been released yet.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
