### PR TITLE
Delete Sample Logs windows on close

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -99,7 +99,6 @@ endif ()
 
     mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
-    mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
 
     mantidqt/widgets/observers/test/test_ads_observer.py
     mantidqt/widgets/observers/test/test_observing_presenter.py
@@ -125,7 +124,9 @@ endif ()
   set ( PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
-  )
+
+    mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+ )
 
   # Tests
   set ( PYUNITTEST_RUN_SERIAL ON )

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -99,6 +99,7 @@ endif ()
 
     mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+    mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
 
     mantidqt/widgets/observers/test/test_ads_observer.py
     mantidqt/widgets/observers/test/test_observing_presenter.py

--- a/qt/python/mantidqt/widgets/samplelogs/presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/presenter.py
@@ -33,7 +33,7 @@ class SampleLogs(object):
         self.plot_logs()
 
     def doubleClicked(self, i):
-        """When a log is doubleCliked, print the log, later this should
+        """When a log is doubleClicked, print the log, later this should
         display the data in a table workspace or something
         """
         self.print_selected_logs()

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -1,0 +1,16 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+from mantid.simpleapi import CreateSampleWorkspace
+from mantidqt.utils.qt.test import GuiTest
+from mantidqt.widgets.samplelogs.presenter import SampleLogs
+
+
+class SampleLogsViesTest(GuiTest):
+    def test_deleted_on_close(self):
+        ws = CreateSampleWorkspace()
+        pres = SampleLogs(ws)

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -5,12 +5,21 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from qtpy.QtWidgets import QApplication
+
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.utils.qt.test import GuiTest
+from mantidqt.utils.qt.test.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
 
 
-class SampleLogsViesTest(GuiTest):
+class SampleLogsViewTest(GuiTest, QtWidgetFinder):
     def test_deleted_on_close(self):
         ws = CreateSampleWorkspace()
         pres = SampleLogs(ws)
+        self.assert_window_created()
+        pres.view.close()
+
+        QApplication.processEvents()
+
+        self.assert_no_widgets()

--- a/qt/python/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/view.py
@@ -31,6 +31,7 @@ class SampleLogsView(QSplitter):
 
         self.setWindowTitle("{} sample logs".format(name))
         self.setWindowFlags(Qt.Window)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
 
         # Create sample log table
         self.table = QTableView()
@@ -87,6 +88,10 @@ class SampleLogsView(QSplitter):
 
         self.resize(1200,800)
         self.show()
+
+    def closeEvent(self, event):
+        self.deleteLater()
+        super(SampleLogsView, self).closeEvent(event)
 
     def tableMenu(self, event):
         """Right click menu for table, can plot or print selected logs"""

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
@@ -14,7 +14,6 @@ from mantidqt.utils.qt.test.qt_widget_finder import QtWidgetFinder
 
 
 class MatrixWorkspaceDisplayViewTest(GuiTest, QtWidgetFinder):
-
     def test_window_deleted_correctly(self):
         ws = CreateSampleWorkspace()
 


### PR DESCRIPTION
**Description of work.**
SampleLogs windows are now deleted on close.

**To test:**
Run the following in the Workbench editor:
```python
from qtpy.QtWidgets import QApplication

a = QApplication.topLevelWidgets()
all = [x for x in a if "sample".lower() in str(type(x)).lower()]
print(all)
```
An empty list `[]` should be printed in the Messages log.

Load a workspace, open it's sample logs.

Run the code above again, something like this will show: `[<mantidqt.widgets.samplelogs.view.SampleLogsView object at 0x0000000041EDEA68>]`

Close the window, run the code again, it should be back to `[]`.


<!-- Instructions for testing. -->
*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
