### PR TITLE
Only store workspace names in AlignAndFocusPowderFromFiles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -436,17 +436,17 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                            OutputWorkspace=self.instr + '_cal')
             self.setProperty('CalibrationWorkspace', self.__calWksp)
         elif mtd.doesExist(self.instr + '_cal'):
-            self.__calWksp = mtd[self.instr + '_cal']
+            self.__calWksp = self.instr + '_cal'
 
         if not self.getProperty('GroupingWorkspace').isDefault:
             self.__grpWksp = self.getPropertyValue('GroupingWorkspace')
         elif mtd.doesExist(self.instr + '_group'):
-            self.__grpWksp = mtd[self.instr + '_group']
+            self.__grpWksp = self.instr + '_group'
 
         if not self.getProperty('MaskWorkspace').isDefault:
             self.__mskWksp = self.getPropertyValue('MaskWorkspace')
         elif mtd.doesExist(self.instr + '_mask'):
-            self.__mskWksp = mtd[self.instr + '_mask']
+            self.__mskWksp = self.instr + '_mask'
 
         # check that anything was specified
         if self.getProperty('CalFileName').isDefault and self.getProperty('GroupFilename').isDefault:


### PR DESCRIPTION
There was a bug hiding where one branch of the if/else was storing workspace handles (which get invalidated) rather than workspace names. This corrects that.

**To test:**

Code review should be sufficient.

*There is no associated issue.*

*This does not require release notes* because it fixes a bug introduced during this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
