### PR TITLE
Fix BeamCentre property type in ReflectometrySumInQ

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
@@ -33,6 +33,7 @@ public:
     double horizon{std::numeric_limits<double>::quiet_NaN()};
     double twoTheta{std::numeric_limits<double>::quiet_NaN()};
     double delta{std::numeric_limits<double>::quiet_NaN()};
+    size_t referenceWSIndex{0};
   };
 
   struct MinMax {
@@ -65,13 +66,12 @@ private:
   MinMax findWavelengthMinMax(const API::MatrixWorkspace &detectorWS,
                               const Indexing::SpectrumIndexSet &indices,
                               const Angles &refAngles);
-  void
-  processValue(const int inputIdx, const MinMax &twoThetaRange,
-               const Angles &refAngles,
-               const Mantid::HistogramData::BinEdges &inputX,
-               const Mantid::HistogramData::Counts &inputY,
-               const Mantid::HistogramData::CountStandardDeviations &inputE,
-               API::MatrixWorkspace &IvsLam, std::vector<double> &outputE);
+  void processValue(const int inputIdx, const MinMax &twoThetaRange,
+                    const Angles &refAngles,
+                    const HistogramData::BinEdges &inputX,
+                    const HistogramData::Counts &inputY,
+                    const HistogramData::CountStandardDeviations &inputE,
+                    API::MatrixWorkspace &IvsLam, std::vector<double> &outputE);
   MinMax projectedLambdaRange(const MinMax &wavelengthRange,
                               const MinMax &twoThetaRange,
                               const Angles &refAngles);

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometrySumInQ.h
@@ -68,9 +68,9 @@ private:
                               const Angles &refAngles);
   void processValue(const int inputIdx, const MinMax &twoThetaRange,
                     const Angles &refAngles,
-                    const HistogramData::BinEdges &inputX,
-                    const HistogramData::Counts &inputY,
-                    const HistogramData::CountStandardDeviations &inputE,
+                    const HistogramData::BinEdges &edges,
+                    const HistogramData::Counts &counts,
+                    const HistogramData::CountStandardDeviations &stdDevs,
                     API::MatrixWorkspace &IvsLam, std::vector<double> &outputE);
   MinMax projectedLambdaRange(const MinMax &wavelengthRange,
                               const MinMax &twoThetaRange,

--- a/Framework/Algorithms/src/ReflectometrySumInQ.cpp
+++ b/Framework/Algorithms/src/ReflectometrySumInQ.cpp
@@ -41,15 +41,15 @@ const static std::string PARTIAL_BINS{"IncludePartialBins"};
 double centreTwoTheta(const double wsIndex,
                       const Mantid::API::SpectrumInfo &spectrumInfo) {
   double twoTheta;
-  const auto index{static_cast<size_t>(wsIndex)};
+  const size_t index{static_cast<size_t>(wsIndex)};
   if (wsIndex == static_cast<double>(index)) {
     twoTheta = spectrumInfo.twoTheta(index);
   } else {
     // Linear interpolation. Straight from Wikipedia.
-    const auto x0{static_cast<double>(index)};
-    const auto x1{static_cast<double>(index + 1)};
-    const auto y0{spectrumInfo.twoTheta(index)};
-    const auto y1{spectrumInfo.twoTheta(index + 1)};
+    const double x0{static_cast<double>(index)};
+    const double x1{static_cast<double>(index + 1)};
+    const double y0{spectrumInfo.twoTheta(index)};
+    const double y1{spectrumInfo.twoTheta(index + 1)};
     twoTheta = (y0 * (x1 - wsIndex) + y1 * (wsIndex - x0)) / (x1 - x0);
   }
   return twoTheta;
@@ -434,9 +434,9 @@ ReflectometrySumInQ::MinMax ReflectometrySumInQ::findWavelengthMinMax(
  * @param inputIdx [in] :: the index of the input histogram
  * @param twoThetaRange [in] :: the 2theta width of the pixel
  * @param refAngles [in] :: the reference 2theta angles
- * @param inputX [in] :: the input spectrum X values
- * @param inputY [in] :: the input spectrum Y values
- * @param inputE [in] :: the input spectrum E values
+ * @param edges [in] :: the input spectrum bin edges
+ * @param counts [in] :: the input spectrum counts
+ * @param stdDevs [in] :: the input spectrum count standard deviations
  * @param IvsLam [in,out] :: the output workspace
  * @param outputE [in,out] :: the projected E values
  */

--- a/Framework/Algorithms/src/ReflectometrySumInQ.cpp
+++ b/Framework/Algorithms/src/ReflectometrySumInQ.cpp
@@ -33,6 +33,29 @@ const static std::string PARTIAL_BINS{"IncludePartialBins"};
 } // namespace Prop
 
 /**
+ * Interpolate the 2theta of a given fractional workspace index.
+ * @param wsIndex a fractional workspace index
+ * @param spectrumInfo a spectrum info
+ * @return the interpolated 2theta in radians
+ */
+double centreTwoTheta(const double wsIndex,
+                      const Mantid::API::SpectrumInfo &spectrumInfo) {
+  double twoTheta;
+  const auto index{static_cast<size_t>(wsIndex)};
+  if (wsIndex == static_cast<double>(index)) {
+    twoTheta = spectrumInfo.twoTheta(index);
+  } else {
+    // Linear interpolation. Straight from Wikipedia.
+    const auto x0{static_cast<double>(index)};
+    const auto x1{static_cast<double>(index + 1)};
+    const auto y0{spectrumInfo.twoTheta(index)};
+    const auto y1{spectrumInfo.twoTheta(index + 1)};
+    twoTheta = (y0 * (x1 - wsIndex) + y1 * (wsIndex - x0)) / (x1 - x0);
+  }
+  return twoTheta;
+}
+
+/**
  * Project a wavelength to given reference angle by keeping the momentum
  * transfer constant.
  * @param wavelength the wavelength to project
@@ -223,19 +246,11 @@ void ReflectometrySumInQ::init() {
   auto inputWSValidator = boost::make_shared<Kernel::CompositeValidator>();
   inputWSValidator->add<API::WorkspaceUnitValidator>("Wavelength");
   inputWSValidator->add<API::InstrumentValidator>();
-  auto mandatoryNonnegativeDouble =
-      boost::make_shared<Kernel::CompositeValidator>();
-  mandatoryNonnegativeDouble->add<Kernel::MandatoryValidator<double>>();
-  auto nonnegativeDouble =
-      boost::make_shared<Kernel::BoundedValidator<double>>();
-  nonnegativeDouble->setLower(0.);
-  mandatoryNonnegativeDouble->add(nonnegativeDouble);
-  auto mandatoryNonnegativeInt =
-      boost::make_shared<Kernel::CompositeValidator>();
-  mandatoryNonnegativeInt->add<Kernel::MandatoryValidator<int>>();
-  auto nonnegativeInt = boost::make_shared<Kernel::BoundedValidator<int>>();
-  nonnegativeInt->setLower(0);
-  mandatoryNonnegativeInt->add(nonnegativeInt);
+  auto mandatoryNonnegative = boost::make_shared<Kernel::CompositeValidator>();
+  mandatoryNonnegative->add<Kernel::MandatoryValidator<double>>();
+  auto nonnegative = boost::make_shared<Kernel::BoundedValidator<double>>();
+  nonnegative->setLower(0.);
+  mandatoryNonnegative->add(nonnegative);
   declareWorkspaceInputProperties<API::MatrixWorkspace,
                                   API::IndexType::SpectrumNum |
                                       API::IndexType::WorkspaceIndex>(
@@ -246,7 +261,7 @@ void ReflectometrySumInQ::init() {
           Prop::OUTPUT_WS, "", Kernel::Direction::Output),
       "A single histogram workspace containing the result of summation in Q.");
   declareProperty(
-      Prop::BEAM_CENTRE, EMPTY_INT(), mandatoryNonnegativeInt,
+      Prop::BEAM_CENTRE, EMPTY_DBL(), mandatoryNonnegative,
       "Fractional workspace index of the specular reflection centre.");
   declareProperty(Prop::IS_FLAT_SAMPLE, true,
                   "If true, the summation is handled as the standard divergent "
@@ -288,7 +303,8 @@ std::map<std::string, std::string> ReflectometrySumInQ::validateInputs() {
   }
 
   const auto &spectrumInfo = inWS->spectrumInfo();
-  const int beamCentre = getProperty(Prop::BEAM_CENTRE);
+  const double beamCentre = getProperty(Prop::BEAM_CENTRE);
+  const size_t beamCentreIndex = static_cast<size_t>(beamCentre);
   bool beamCentreFound{false};
   for (const auto i : indices) {
     if (spectrumInfo.isMonitor(i)) {
@@ -300,8 +316,9 @@ std::map<std::string, std::string> ReflectometrySumInQ::validateInputs() {
           "A neighbour to any detector in the index set cannot be a monitor";
       break;
     }
-    if (i == static_cast<size_t>(beamCentre)) {
+    if (i == beamCentreIndex) {
       beamCentreFound = true;
+      break;
     }
   }
   if (!beamCentreFound) {
@@ -325,8 +342,7 @@ API::MatrixWorkspace_sptr ReflectometrySumInQ::constructIvsLamWS(
 
   // Calculate the number of bins based on the min/max wavelength, using
   // the same bin width as the input workspace
-  const int twoThetaRIdx = getProperty(Prop::BEAM_CENTRE);
-  const auto &edges = detectorWS.binEdges(static_cast<size_t>(twoThetaRIdx));
+  const auto &edges = detectorWS.binEdges(refAngles.referenceWSIndex);
   const double binWidth =
       (edges.back() - edges.front()) / static_cast<double>(edges.size());
   const auto wavelengthRange =
@@ -349,7 +365,7 @@ API::MatrixWorkspace_sptr ReflectometrySumInQ::constructIvsLamWS(
                                                     std::move(modelHistogram));
 
   // Set the detector IDs and specturm number from the twoThetaR detector.
-  const auto &thetaSpec = detectorWS.getSpectrum(twoThetaRIdx);
+  const auto &thetaSpec = detectorWS.getSpectrum(refAngles.referenceWSIndex);
   auto &outSpec = outputWS->getSpectrum(0);
   outSpec.clearDetectorIDs();
   outSpec.addDetectorIDs(thetaSpec.getDetectorIDs());
@@ -505,16 +521,15 @@ ReflectometrySumInQ::projectedLambdaRange(const MinMax &wavelengthRange,
 ReflectometrySumInQ::Angles
 ReflectometrySumInQ::referenceAngles(const API::SpectrumInfo &spectrumInfo) {
   Angles a;
-  const int beamCentre = getProperty(Prop::BEAM_CENTRE);
-  const double centreTwoTheta =
-      spectrumInfo.twoTheta(static_cast<size_t>(beamCentre));
+  const double beamCentre = getProperty(Prop::BEAM_CENTRE);
   const bool isFlat = getProperty(Prop::IS_FLAT_SAMPLE);
   if (isFlat) {
-    a.horizon = centreTwoTheta / 2.;
+    a.horizon = centreTwoTheta(beamCentre, spectrumInfo) / 2.;
   } else {
     a.horizon = 0.;
   }
-  a.twoTheta = centreTwoTheta;
+  a.referenceWSIndex = static_cast<size_t>(beamCentre);
+  a.twoTheta = spectrumInfo.twoTheta(a.referenceWSIndex);
   a.delta = a.twoTheta - a.horizon;
   return a;
 }

--- a/Framework/Algorithms/test/ReflectometrySumInQTest.h
+++ b/Framework/Algorithms/test/ReflectometrySumInQTest.h
@@ -92,7 +92,7 @@ public:
         TS_ASSERT_THROWS_NOTHING(
             alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
         TS_ASSERT_THROWS_NOTHING(
-            alg.setProperty("BeamCentre", static_cast<int>(i)))
+            alg.setProperty("BeamCentre", static_cast<double>(i)))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", isFlatSample))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludePartialBins", true))
         TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -132,7 +132,7 @@ public:
         TS_ASSERT_THROWS_NOTHING(
             alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
         TS_ASSERT_THROWS_NOTHING(
-            alg.setProperty("BeamCentre", static_cast<int>(beamCentre)))
+            alg.setProperty("BeamCentre", static_cast<double>(beamCentre)))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", isFlatSample))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludePartialBins", true))
         TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -165,7 +165,7 @@ public:
         TS_ASSERT_THROWS_NOTHING(
             alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
         TS_ASSERT_THROWS_NOTHING(
-            alg.setProperty("BeamCentre", static_cast<int>(i)))
+            alg.setProperty("BeamCentre", static_cast<double>(i)))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", isFlatSample))
         TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludePartialBins", false))
         TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -212,7 +212,8 @@ public:
           alg.setPropertyValue("InputWorkspaceIndexSet", indexSetValue.str()))
       TS_ASSERT_THROWS_NOTHING(
           alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
-      TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", spectrum1))
+      TS_ASSERT_THROWS_NOTHING(
+          alg.setProperty("BeamCentre", static_cast<double>(spectrum1)))
       TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", isFlatSample))
       TS_ASSERT_THROWS_NOTHING(alg.setProperty("IncludePartialBins", true))
       TS_ASSERT_THROWS_NOTHING(alg.execute())
@@ -242,7 +243,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BeamCentre", static_cast<int>(detectorIdx)))
+        alg.setProperty("BeamCentre", static_cast<double>(detectorIdx)))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e,
                             e.what(),
@@ -264,7 +265,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(
-        alg.setProperty("BeamCentre", static_cast<int>(monitorIdx)))
+        alg.setProperty("BeamCentre", static_cast<double>(monitorIdx)))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e,
                             e.what(),
@@ -284,7 +285,7 @@ public:
         alg.setPropertyValue("InputWorkspaceIndexSet", "0, 1"))
     TS_ASSERT_THROWS_NOTHING(
         alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
-    TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", 2))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", 2.))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
     TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e,
                             e.what(),
@@ -372,7 +373,7 @@ public:
     alg.setProperty("InputWorkspace", m_workspace);
     alg.setProperty("InputWorkspaceIndexSet", m_fullIndexSet);
     alg.setPropertyValue("OutputWorkspace", "_unused_for_child");
-    alg.setProperty("BeamCentre", 49);
+    alg.setProperty("BeamCentre", 49.);
     alg.setProperty("FlatSample", true);
     for (int repetitions = 0; repetitions < 1000; ++repetitions) {
       alg.execute();

--- a/docs/source/algorithms/ReflectometrySumInQ-v1.rst
+++ b/docs/source/algorithms/ReflectometrySumInQ-v1.rst
@@ -10,10 +10,13 @@
 Description
 -----------
 
-This algorithm sums the Y values of histograms given by *InputWorkspaceIndexSet* into a single single histogram. The summation is done using the method proposed by Cubitt et al. [#CUBITT]_ This involves a projection to an
-arbitrary reference angle, :math:`2\theta_R`, with a "virtual" wavelength,
-:math:`\lambda_v`. This is the wavelength the neutron would have had if it had
-arrived at :math:`2\theta_R` with the same momentum transfer (:math:`Q`).
+This algorithm sums the Y values of histograms given by 
+*InputWorkspaceIndexSet* into a single single histogram. The summation is done 
+using the method proposed by Cubitt et al. [#CUBITT]_ This involves a 
+projection to an arbitrary reference angle, :math:`2\theta_R`, with a 
+"virtual" wavelength, :math:`\lambda_v`. This is the wavelength the neutron 
+would have had if it had arrived at :math:`2\theta_R` with the same momentum 
+transfer (:math:`Q`).
 
 Counts are considered to be spread evenly over the input pixel, and the
 top-left and bottom-right corner of the pixel are projected onto
@@ -24,7 +27,9 @@ bins.
 
 The input workspace should have wavelength as the X units as well as an instrument.
 
-To produce a reflectivity, the input workspace has to be the reflected beam workspace where each histogram is individually divided by the summed (in lambda) direct beam data.
+To produce a reflectivity, the input workspace has to be the reflected beam 
+workspace where each histogram is individually divided by the summed (in 
+lambda) direct beam data.
 
 Usage
 -----

--- a/docs/source/release/v3.14.0/reflectometry.rst
+++ b/docs/source/release/v3.14.0/reflectometry.rst
@@ -41,6 +41,7 @@ Bug fixes
 - :ref:`algm-ReflectometryReductionOneAuto` No longer sums all of a transmission run's workspaces and instead will use the first run only
 - In :ref:`algm-ReflectometryReductionOneAuto` an issue where if you gave only one of either MomentumTransferMax or MomentumTransferMin were specified it would be ignored, this has been fixed.
 - Reverted property names for polarization correction coefficients in :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto-v2>` for backwards compatibility.
+- Fixed the ``BeamCenter`` property of :ref:`ReflectometrySumInQ <algm-ReflectometrySumInQ>` to actually be a fractional workspace index.
 
 Liquids Reflectometer
 ---------------------


### PR DESCRIPTION
The property should have been a `double`, not an `int`. This change gives a more accurate horizon angle: we now interpolate the beam centre angle from two neighboring detectors and calculate the horizon angle from that. The reference 2theta, on the other hand, is picked as before: we truncate BeamCentre to nearest integer and use the result as a workspace index. This should not matter as the reference 2theta can be chosen arbitrarily and gives nice connection between the input and the output workspaces.

**Report to:** [nobody].

**To test:**

The script below should run without issues when the unit test data directory is included in Mantid's data search directories:

```python
LoadILLReflectometry(
    'ILL/Figaro/000002.nxs',
    OutputWorkspace='ws',
    XUnit='Wavelength',
    OutputBeamPosition='beampos')
beamcentre = mtd['beampos'].cell('PeakCentre', 0)
ReflectometrySumInQ(
    'ws',
    InputWorkspaceIndexSet='123-130',
    OutputWorkspace='sum',
    BeamCentre=beamcentre,
    FlatSample=True)
```

Check that the single histogram in `sum` has the same 2theta, l2, spectrum number and detector ID as the histogram at ws index 127 in `ws`. This corresponds to `BeamCentre` of 127.801 given in the table workspace.


Fixes #24758.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
