### PR TITLE
Add workspace name to exceptions in NormaliseByCurrent

### DIFF
--- a/Framework/Algorithms/src/NormaliseByCurrent.cpp
+++ b/Framework/Algorithms/src/NormaliseByCurrent.cpp
@@ -78,15 +78,16 @@ double NormaliseByCurrent::extractCharge(
     } else {
       throw Exception::NotFoundError(
           "Proton charge log (proton_charge_by_period) not found for this "
-          "multiperiod data workspace",
+          "multiperiod data workspace (" +
+              inputWS->getName() + ")",
           "proton_charge_by_period");
     }
 
     if (charge == 0) {
       throw std::domain_error("The proton charge found for period number " +
                               std::to_string(periodNumber) +
-                              " in the input workspace "
-                              "run information is zero. When applying "
+                              " in the input workspace (" + inputWS->getName() +
+                              ") run information is zero. When applying "
                               "NormaliseByCurrent on multiperiod data, a "
                               "non-zero value is required for every period in "
                               "the proton_charge_by_period log.");
@@ -100,13 +101,15 @@ double NormaliseByCurrent::extractCharge(
       charge = inputWS->run().getProtonCharge();
     } catch (Exception::NotFoundError &) {
       g_log.error() << "The proton charge is not set for the run attached to "
-                       "this workspace\n";
+                       "the workspace(" +
+                           inputWS->getName() + ")\n";
       throw;
     }
 
     if (charge == 0) {
-      throw std::domain_error("The proton charge found in the input workspace "
-                              "run information is zero");
+      throw std::domain_error(
+          "The proton charge found in the input workspace (" +
+          inputWS->getName() + ") run information is zero");
     }
   }
   return charge;


### PR DESCRIPTION
For powder diffraction workflows, exceptions that come from `NormaliseByCurrent` are deep in the workflow. It is helpful to add the workspace name so people can tell which workspace didn't have a proton charge.

**To test:**

A code review is sufficient.

*There is no associated issue.*

*This does not require release notes* because it is only adding details to exceptions.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
