### PR TITLE
System tests: rename tolerance_is_reller to tolerance_is_rel_err

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -303,8 +303,8 @@ class MantidSystemTest(unittest.TestCase):
         checker.setPropertyValue("Workspace1", valNames[0])
         checker.setPropertyValue("Workspace2", valNames[1])
         checker.setProperty("Tolerance", float(self.tolerance))
-        if hasattr(self, 'tolerance_is_relerr') and self.tolerance_is_relerr:
-            checker.setProperty("ToleranceRelerr", True)
+        if hasattr(self, 'tolerance_is_rel_err') and self.tolerance_is_rel_err:
+            checker.setProperty("ToleranceRelErr", True)
         for d in self.disableChecking:
             checker.setProperty("Check"+d, False)
         checker.execute()

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -303,7 +303,7 @@ class MantidSystemTest(unittest.TestCase):
         checker.setPropertyValue("Workspace1", valNames[0])
         checker.setPropertyValue("Workspace2", valNames[1])
         checker.setProperty("Tolerance", float(self.tolerance))
-        if hasattr(self, 'tolerance_is_reller') and self.tolerance_is_reller:
+        if hasattr(self, 'tolerance_is_relerr') and self.tolerance_is_relerr:
             checker.setProperty("ToleranceRelerr", True)
         for d in self.disableChecking:
             checker.setProperty("Check"+d, False)

--- a/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
@@ -36,7 +36,7 @@ class ISISDirectInelasticReduction(with_metaclass(ABCMeta, systemtesting.MantidS
         - hard_mask: An hard mask file or None
     """
     tolerance = 0.
-    tolerance_is_relerr = True
+    tolerance_is_rel_err = True
 
     @abstractmethod
     def get_reference_file(self):
@@ -56,7 +56,7 @@ class ISISDirectInelasticReduction(with_metaclass(ABCMeta, systemtesting.MantidS
     def validate(self):
         """Returns the name of the workspace & file to compare"""
         self.tolerance = 1e-6
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         self.disableChecking.append('Sample')
@@ -465,7 +465,7 @@ class MERLINReduction(ISISDirectInelasticReduction):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         result = self.get_result_workspace()
@@ -478,7 +478,7 @@ class MERLINReduction(ISISDirectInelasticReduction):
 
 class LETReduction(systemtesting.MantidSystemTest):
     tolerance = 1e-6
-    tolerance_is_relerr=True
+    tolerance_is_rel_err=True
 
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places. Requires 2Gb"""
@@ -500,7 +500,7 @@ class LETReduction(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
 
@@ -512,7 +512,7 @@ class LETReductionEvent2015Multirep(systemtesting.MantidSystemTest):
     written in a hope that most of the stuff find here will eventually find its way into main reduction routines
     """
     tolerance = 1e-6
-    tolerance_is_relerr = True
+    tolerance_is_rel_err = True
 
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places. Requires 20Gb"""
@@ -539,7 +539,7 @@ class LETReductionEvent2015Multirep(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_relerr = False
+        self.tolerance_is_rel_err = False
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
 

--- a/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectInelastic.py
@@ -35,8 +35,8 @@ class ISISDirectInelasticReduction(with_metaclass(ABCMeta, systemtesting.MantidS
         - sample_rmm: A float value for the sample rmm or None
         - hard_mask: An hard mask file or None
     """
-    tolerance=0.
-    tolerance_is_reller=True
+    tolerance = 0.
+    tolerance_is_relerr = True
 
     @abstractmethod
     def get_reference_file(self):
@@ -56,7 +56,7 @@ class ISISDirectInelasticReduction(with_metaclass(ABCMeta, systemtesting.MantidS
     def validate(self):
         """Returns the name of the workspace & file to compare"""
         self.tolerance = 1e-6
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         self.disableChecking.append('Sample')
@@ -465,7 +465,7 @@ class MERLINReduction(ISISDirectInelasticReduction):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         result = self.get_result_workspace()
@@ -478,7 +478,7 @@ class MERLINReduction(ISISDirectInelasticReduction):
 
 class LETReduction(systemtesting.MantidSystemTest):
     tolerance = 1e-6
-    tolerance_is_reller=True
+    tolerance_is_relerr=True
 
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places. Requires 2Gb"""
@@ -500,7 +500,7 @@ class LETReduction(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
 
@@ -512,7 +512,7 @@ class LETReductionEvent2015Multirep(systemtesting.MantidSystemTest):
     written in a hope that most of the stuff find here will eventually find its way into main reduction routines
     """
     tolerance = 1e-6
-    tolerance_is_reller=True
+    tolerance_is_relerr = True
 
     def requiredMemoryMB(self):
         """Far too slow for managed workspaces. They're tested in other places. Requires 20Gb"""
@@ -539,7 +539,7 @@ class LETReductionEvent2015Multirep(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 1e-6
-        self.tolerance_is_reller=False
+        self.tolerance_is_relerr = False
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
 

--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -79,9 +79,9 @@ class ISIS_ReductionWebLike(systemtesting.MantidSystemTest):
         # tolerance defined outside of init
 #pylint: disable=W0201
         self.tolerance = 1e-6
-        # tolerance_is_reller defined outside of init
+        # tolerance_is_relerr defined outside of init
 #pylint: disable=W0201
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         self.disableChecking.append('Sample')

--- a/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
+++ b/Testing/SystemTests/tests/analysis/ISISDirectReductionComponents.py
@@ -79,9 +79,9 @@ class ISIS_ReductionWebLike(systemtesting.MantidSystemTest):
         # tolerance defined outside of init
 #pylint: disable=W0201
         self.tolerance = 1e-6
-        # tolerance_is_relerr defined outside of init
+        # tolerance_is_rel_err defined outside of init
 #pylint: disable=W0201
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')
         self.disableChecking.append('Sample')

--- a/Testing/SystemTests/tests/analysis/SANS2DBatch.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatch.py
@@ -67,7 +67,7 @@ class SANS2DNewSettingsCarriedAcrossInBatchMode(systemtesting.MantidSystemTest):
         BatchReduce(csv_file, 'nxs', plotresults=False)
 
     def validate(self):
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "iteration_2", "SANS2DNewSettingsCarriedAcross.nxs"
@@ -100,7 +100,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrection(systemtesting.MantidSystemTest):
         Load(Filename = self._final_output, OutputWorkspace=self._final_workspace)
 
     def validate(self):
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')

--- a/Testing/SystemTests/tests/analysis/SANS2DBatch.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatch.py
@@ -67,7 +67,7 @@ class SANS2DNewSettingsCarriedAcrossInBatchMode(systemtesting.MantidSystemTest):
         BatchReduce(csv_file, 'nxs', plotresults=False)
 
     def validate(self):
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "iteration_2", "SANS2DNewSettingsCarriedAcross.nxs"
@@ -100,7 +100,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrection(systemtesting.MantidSystemTest):
         Load(Filename = self._final_output, OutputWorkspace=self._final_workspace)
 
     def validate(self):
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')

--- a/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
@@ -71,7 +71,7 @@ class SANS2DNewSettingsCarriedAcrossInBatchModeTest_V2(systemtesting.MantidSyste
             os.remove(path2)
 
     def validate(self):
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "iteration_2", "SANS2DNewSettingsCarriedAcross.nxs"
@@ -105,7 +105,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrectionTest_V2(systemtesting.MantidSystemT
         Load(Filename=self._final_output, OutputWorkspace=self._final_workspace)
 
     def validate(self):
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')

--- a/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DBatchTest_V2.py
@@ -71,7 +71,7 @@ class SANS2DNewSettingsCarriedAcrossInBatchModeTest_V2(systemtesting.MantidSyste
             os.remove(path2)
 
     def validate(self):
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "iteration_2", "SANS2DNewSettingsCarriedAcross.nxs"
@@ -105,7 +105,7 @@ class SANS2DTUBESBatchWithZeroErrorCorrectionTest_V2(systemtesting.MantidSystemT
         Load(Filename=self._final_output, OutputWorkspace=self._final_workspace)
 
     def validate(self):
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('SpectraMap')
         self.disableChecking.append('Instrument')

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
@@ -43,7 +43,7 @@ class SANS2DMinimalBatchReduction(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalBatchReduction, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -202,7 +202,7 @@ class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
         self.checkFittingSettings(fit_settings)
 
     def validate(self):
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "trans_test_rear_1D_1.5_12.5","SANSReductionGUI.nxs"

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI.py
@@ -43,7 +43,7 @@ class SANS2DMinimalBatchReduction(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalBatchReduction, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -202,7 +202,7 @@ class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
         self.checkFittingSettings(fit_settings)
 
     def validate(self):
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
         self.disableChecking.append('Instrument')
         return "trans_test_rear_1D_1.5_12.5","SANSReductionGUI.nxs"

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
@@ -54,7 +54,7 @@ class SANS2DReductionGUIAddedFiles(sansgui.SANS2DGUIReduction):
     def validate(self):
         # we have double the sample and the can, this means that the reduced data will be
         # almost the same
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 0.35
         self.disableChecking.append('Instrument')
         return "trans_test_rear","SANSReductionGUI.nxs"

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUIAdded.py
@@ -54,7 +54,7 @@ class SANS2DReductionGUIAddedFiles(sansgui.SANS2DGUIReduction):
     def validate(self):
         # we have double the sample and the can, this means that the reduced data will be
         # almost the same
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 0.35
         self.disableChecking.append('Instrument')
         return "trans_test_rear","SANSReductionGUI.nxs"

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI_V2.py
@@ -29,7 +29,7 @@ class SANS2DMinimalBatchReductionTest_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalBatchReductionTest_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -49,7 +49,7 @@ class SANS2DMinimalSingleReductionTest_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalSingleReductionTest_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -74,7 +74,7 @@ class SANS2DSearchCentreGUI_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DSearchCentreGUI_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_reller = True
+        self.tolerance_is_relerr = True
         self.tolerance = 1.0e-2
 
     def runTest(self):

--- a/Testing/SystemTests/tests/analysis/SANS2DReductionGUI_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DReductionGUI_V2.py
@@ -29,7 +29,7 @@ class SANS2DMinimalBatchReductionTest_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalBatchReductionTest_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -49,7 +49,7 @@ class SANS2DMinimalSingleReductionTest_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DMinimalSingleReductionTest_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
 
     def runTest(self):
@@ -74,7 +74,7 @@ class SANS2DSearchCentreGUI_V2(systemtesting.MantidSystemTest):
     def __init__(self):
         super(SANS2DSearchCentreGUI_V2, self).__init__()
         config['default.instrument'] = 'SANS2D'
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.tolerance = 1.0e-2
 
     def runTest(self):

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
@@ -30,7 +30,7 @@ class SANS2DMinimalBatchReductionSliced(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('Instrument')
         return str(mtd['trans_test_rear_1D_1.5_12.5'][0]), 'SANSReductionGUI.nxs'
 

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicing.py
@@ -30,7 +30,7 @@ class SANS2DMinimalBatchReductionSliced(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('Instrument')
         return str(mtd['trans_test_rear_1D_1.5_12.5'][0]), 'SANSReductionGUI.nxs'
 

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicingTest_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicingTest_V2.py
@@ -31,7 +31,7 @@ class SANS2DMinimalBatchReductionSlicedTest_V2(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('Instrument')
         try:
             return str(AnalysisDataService['trans_test_rear'][0]), 'SANSReductionGUI.nxs'
@@ -57,7 +57,7 @@ class SANS2DMinimalSingleReductionSlicedTest_V2(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_reller=True
+        self.tolerance_is_relerr = True
         self.disableChecking.append('Instrument')
         return str(AnalysisDataService['trans_test_rear'][0]), 'SANSReductionGUI.nxs'
 

--- a/Testing/SystemTests/tests/analysis/SANS2DSlicingTest_V2.py
+++ b/Testing/SystemTests/tests/analysis/SANS2DSlicingTest_V2.py
@@ -31,7 +31,7 @@ class SANS2DMinimalBatchReductionSlicedTest_V2(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('Instrument')
         try:
             return str(AnalysisDataService['trans_test_rear'][0]), 'SANSReductionGUI.nxs'
@@ -57,7 +57,7 @@ class SANS2DMinimalSingleReductionSlicedTest_V2(systemtesting.MantidSystemTest):
 
     def validate(self):
         self.tolerance = 0.02
-        self.tolerance_is_relerr = True
+        self.tolerance_is_rel_err = True
         self.disableChecking.append('Instrument')
         return str(AnalysisDataService['trans_test_rear'][0]), 'SANSReductionGUI.nxs'
 

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -126,6 +126,13 @@ system test.
 
    self.tolerance = 0.00000001
 
+By default the tolerance is absolute. It can be changed to relative by another
+flag in the :class:`systemtesting.MantidSystemTest` class.
+
+.. code-block:: python
+
+   self.tolerance_relerr = True
+
 Disable Some Checks
 -------------------
 

--- a/dev-docs/source/SystemTests.rst
+++ b/dev-docs/source/SystemTests.rst
@@ -131,7 +131,7 @@ flag in the :class:`systemtesting.MantidSystemTest` class.
 
 .. code-block:: python
 
-   self.tolerance_relerr = True
+   self.tolerance_rel_err = True
 
 Disable Some Checks
 -------------------


### PR DESCRIPTION
This PR renames the `tolerance_is_reller` flag in `MantidSystemTest` class to `tolerance_is_rel_err` which is in line with `CompareWorkspaces`. Also, a note about the absoluteness/relativeness of tolerances in system tests has been added to the dev-docs.

**Report to:** [nobody].

**To test:**

Build the `dev-docs` target and check that the System Tests page looks OK.

*There is no associated issue.*


*This does not require release notes* because this is an internal developer facing change.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
