### PR TITLE
PDLoadCharacterizations bug

### DIFF
--- a/Framework/DataHandling/src/PDLoadCharacterizations.cpp
+++ b/Framework/DataHandling/src/PDLoadCharacterizations.cpp
@@ -397,6 +397,7 @@ void PDLoadCharacterizations::readCharInfo(std::ifstream &file,
       continue;
     if (line.substr(0, 1) == "#")
       continue;
+    g_log.debug(line);
     // parse the line
     std::vector<std::string> splitted;
     boost::split(splitted, line, boost::is_any_of("\t "),
@@ -539,10 +540,12 @@ void PDLoadCharacterizations::readVersion1(const std::string &filename,
   for (Strings::getLine(file, line); !file.eof();
        Strings::getLine(file, line)) {
     linenum += 1;
+    line = Strings::strip(line);
     if (line.empty())
       continue;
     if (line.substr(0, 1) == "#")
       continue;
+    g_log.debug(line);
 
     boost::smatch result;
     // all instances of table headers


### PR DESCRIPTION
Strip whitespace from v1 file

**To test:**

Copy an existing pair of characterization files and add some lines that consist of only whitespace then try to load them into `PDCalibration`. It will work now.
* `/SNS/PG3/shared/CALIBRATION/2019_1_11A_CAL/PG3_char_2019_01_21-HighRes.txt`
* `/SNS/PG3/shared/CALIBRATION/2019_1_11A_CAL/PG3_char_2019_01_24.txt`

*There is no associated issue.*

*This does not require release notes* because it is a minor issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
