### PR TITLE
Prevent TableWorkspaceDisplay error when the data is being reloaded

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -15,8 +15,8 @@ from qtpy.QtCore import Qt
 
 from mantid.kernel import logger
 from mantidqt.widgets.observers.ads_observer import WorkspaceDisplayADSObserver
-from mantidqt.widgets.workspacedisplay.data_copier import DataCopier
 from mantidqt.widgets.observers.observing_presenter import ObservingPresenter
+from mantidqt.widgets.workspacedisplay.data_copier import DataCopier
 from mantidqt.widgets.workspacedisplay.status_bar_view import StatusBarView
 from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.model import TableWorkspaceDisplayModel
@@ -76,7 +76,6 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         self.load_data(self.view)
 
         # connect to cellChanged signal after the data has been loaded
-        # all consecutive triggers will be from user actions
         self.view.itemChanged.connect(self.handleItemChanged)
 
     def show_view(self):
@@ -93,8 +92,13 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
 
     def replace_workspace(self, workspace_name, workspace):
         if self.model.workspace_equals(workspace_name):
+            # stops triggering itemChanged signal while the data is being reloaded
+            self.view.blockSignals(True)
+
             self.model = TableWorkspaceDisplayModel(workspace)
             self.load_data(self.view)
+            self.view.blockSignals(False)
+            
             self.view.emit_repaint()
 
     def handleItemChanged(self, item):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -98,7 +98,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
             self.model = TableWorkspaceDisplayModel(workspace)
             self.load_data(self.view)
             self.view.blockSignals(False)
-            
+
             self.view.emit_repaint()
 
     def handleItemChanged(self, item):


### PR DESCRIPTION
**Description of work.**
Disables `itemChanged` signal while the view data is being reloaded. This prevents triggering the `itemChanged` signal when replacing the item widgets with new ones, containing the new data.

This only seems to happen for `IPeaksWorkspace`'s, but this fix makes it impossible to happen for any type of `ITableWorkspace`.

**To test:**
- Load a peak ws: 
- `peak = Load("SingleCrystalPeakTable.nxs")`
- Show it's data
- Save the project
- Run `SortPeaksWorkspace` in a way that changes the workspace (e.g. sort column `DetID` descending)
- Load the project with the data window still open, the workspace should be replaced, i.e. the data displayed will return to the original


<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
