### PR TITLE
Helper function to retrieve date-sorted filenames for IDF's or Parameter files

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -165,10 +165,9 @@ public:
                              std::string &outValidFrom,
                              std::string &outValidTo);
   /// Utility to retrieve a resource file (IDF, Parameters, ..)
-  static std::vector<std::string> getResourceFilenames(const std::string &prefix,
-                                                       const std::vector<std::string> &fileFormats,
-                                                       const std::vector<std::string> &directoryNames,
-                                                       const std::string &date);
+  static std::vector<std::string> getResourceFilenames(
+      const std::string &prefix, const std::vector<std::string> &fileFormats,
+      const std::vector<std::string> &directoryNames, const std::string &date);
   /// Get the IDF using the instrument name and date
   static std::string getInstrumentFilename(const std::string &instrumentName,
                                            const std::string &date = "");

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -164,10 +164,14 @@ public:
   static void getValidFromTo(const std::string &IDFfilename,
                              std::string &outValidFrom,
                              std::string &outValidTo);
+  /// Utility to retrieve a resource file (IDF, Parameters, ..)
+  static std::vector<std::string> resolveDatedResource(const std::string &prefix,
+    const std::vector<std::string> &fileFormats,
+    const std::vector<std::string> &directoryNames,
+    const std::string &date);
   /// Get the IDF using the instrument name and date
   static std::string getInstrumentFilename(const std::string &instrumentName,
                                            const std::string &date = "");
-
   const Geometry::DetectorInfo &detectorInfo() const;
   Geometry::DetectorInfo &mutableDetectorInfo();
 

--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -165,10 +165,10 @@ public:
                              std::string &outValidFrom,
                              std::string &outValidTo);
   /// Utility to retrieve a resource file (IDF, Parameters, ..)
-  static std::vector<std::string> resolveDatedResource(const std::string &prefix,
-    const std::vector<std::string> &fileFormats,
-    const std::vector<std::string> &directoryNames,
-    const std::string &date);
+  static std::vector<std::string> getResourceFilenames(const std::string &prefix,
+                                                       const std::vector<std::string> &fileFormats,
+                                                       const std::vector<std::string> &directoryNames,
+                                                       const std::string &date);
   /// Get the IDF using the instrument name and date
   static std::string getInstrumentFilename(const std::string &instrumentName,
                                            const std::string &date = "");

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1041,7 +1041,7 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
     for (auto elem : matchingFiles)
       pathNames.emplace_back(std::move(elem.second));
   } else {
-    pathNames.emplace_back(std::movemostRecentFile));
+    pathNames.emplace_back(std::move(mostRecentFile));
   }
 
   return pathNames;

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -935,7 +935,7 @@ void ExperimentInfo::getValidFromTo(const std::string &IDFfilename,
 }
 
 /// Utility to retrieve a list of resource files sorted by `from` date
-std::vector<std::string> ExperimentInfo::resolveDatedResource(const std::string &prefix,
+std::vector<std::string> ExperimentInfo::getResourceFilenames(const std::string &prefix,
   const std::vector<std::string> &fileFormats, const std::vector<std::string> &directoryNames,
   const std::string &date) {
 
@@ -1051,7 +1051,7 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
       Kernel::ConfigService::Instance().getInstrumentDirectories();
 
   // matching files sorted with newest files coming first
-  const std::vector<std::string> matchingFiles = resolveDatedResource(instrument + "_Definition",
+  const std::vector<std::string> matchingFiles = getResourceFilenames(instrument + "_Definition",
     validFormats, directoryNames, date);
   std::string instFile;
   if (matchingFiles.size() > 0) {

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1036,12 +1036,14 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
 
   // Retrieve the file names only
   std::vector<std::string> pathNames;
-  if (matchingFiles.size() > 0) {
+  if (!matchingFiles.empty()) {
+    pathNames.reserve(matchingFiles.size());
     for (auto elem : matchingFiles)
-      pathNames.push_back(elem.second);
+      pathNames.emplace_back(std::move(elem.second));
   } else {
-    pathNames.push_back(mostRecentFile);
+    pathNames.emplace_back(std::movemostRecentFile));
   }
+
   return pathNames;
 }
 
@@ -1074,7 +1076,7 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
   g_log.debug() << "Looking for instrument file for " << instrumentName
                 << " that is valid on '" << date << "'\n";
   // Lookup the instrument (long) name
-  std::string instrument(
+  const std::string instrument(
       Kernel::ConfigService::Instance().getInstrument(instrumentName).name());
 
   // Get the instrument directories for instrument file search
@@ -1085,7 +1087,7 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
   const std::vector<std::string> matchingFiles = getResourceFilenames(
       instrument + "_Definition", validFormats, directoryNames, date);
   std::string instFile;
-  if (matchingFiles.size() > 0) {
+  if (!matchingFiles.empty()) {
     instFile = matchingFiles[0];
     g_log.debug() << "Instrument file selected is " << instFile << '\n';
   } else {

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -80,7 +80,7 @@ public:
 class myContentHandler : public Poco::XML::ContentHandler {
   void startElement(const XMLString &, const XMLString &localName,
                     const XMLString &, const Attributes &attrList) override {
-    if (localName == "instrument") {
+    if (localName == "instrument" || localName == "parameter-file") {
       throw DummyException(
           static_cast<std::string>(attrList.getValue("", "valid-from")),
           static_cast<std::string>(attrList.getValue("", "valid-to")));

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -935,45 +935,49 @@ void ExperimentInfo::getValidFromTo(const std::string &IDFfilename,
 }
 
 /// Utility to retrieve a list of resource files sorted by `from` date
-std::vector<std::string> ExperimentInfo::getResourceFilenames(const std::string &prefix,
-  const std::vector<std::string> &fileFormats, const std::vector<std::string> &directoryNames,
-  const std::string &date) {
+std::vector<std::string> ExperimentInfo::getResourceFilenames(
+    const std::string &prefix, const std::vector<std::string> &fileFormats,
+    const std::vector<std::string> &directoryNames, const std::string &date) {
 
   if (date.empty()) {
     // Just use the current date
     g_log.debug() << "No date specified, using current date and time.\n";
     const std::string now =
-            Types::Core::DateAndTime::getCurrentTime().toISO8601String();
+        Types::Core::DateAndTime::getCurrentTime().toISO8601String();
     // Recursively call this method, but with all parameters.
-    return ExperimentInfo::resolveDatedResource(prefix, fileFormats, directoryNames, now);
+    return ExperimentInfo::resolveDatedResource(prefix, fileFormats,
+                                                directoryNames, now);
   }
 
   // Join all the file formats into a single string
   std::stringstream ss;
   ss << "(";
-  for(size_t i = 0; i < fileFormats.size(); ++i)
-  {
-    if(i != 0)
+  for (size_t i = 0; i < fileFormats.size(); ++i) {
+    if (i != 0)
       ss << "|";
     ss << fileFormats[i];
   }
   ss << ")";
   const std::string allFileFormats = ss.str();
 
-  const boost::regex regex(prefix + ".*\\." + allFileFormats, boost::regex_constants::icase);
+  const boost::regex regex(prefix + ".*\\." + allFileFormats,
+                           boost::regex_constants::icase);
   Poco::DirectoryIterator end_iter;
   DateAndTime d(date);
 
   DateAndTime refDate("1900-01-31 23:59:00"); // used to help determine the most
   // recently starting file, if none match
-  DateAndTime refDateGoodFile("1900-01-31 23:59:00"); // used to help determine the most recently
+  DateAndTime refDateGoodFile(
+      "1900-01-31 23:59:00"); // used to help determine the most recently
 
   // Two files could have the same `from` date so multimap is required.
   // Sort with newer dates placed at the beginning
-  std::multimap<DateAndTime, std::string, std::greater<DateAndTime>> matchingFiles;
+  std::multimap<DateAndTime, std::string, std::greater<DateAndTime>>
+      matchingFiles;
 
   for (const auto &directoryName : directoryNames) {
-    // Iterate over the directories from user ->etc ->install, and find the first beat file
+    // Iterate over the directories from user ->etc ->install, and find the
+    // first beat file
     for (Poco::DirectoryIterator dir_itr(directoryName); dir_itr != end_iter;
          ++dir_itr) {
 
@@ -1002,14 +1006,15 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(const std::string 
           to.setFromISO8601("2100-01-01T00:00:00");
 
         if (from <= d && d <= to)
-          matchingFiles.insert(std::pair<DateAndTime, std::string>(from, pathName));
+          matchingFiles.insert(
+              std::pair<DateAndTime, std::string>(from, pathName));
       }
     }
   }
 
   // Retrieve the file names only
   std::vector<std::string> pathNames;
-  for(auto elem : matchingFiles)
+  for (auto elem : matchingFiles)
     pathNames.push_back(elem.second);
   return pathNames;
 }
@@ -1051,14 +1056,13 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
       Kernel::ConfigService::Instance().getInstrumentDirectories();
 
   // matching files sorted with newest files coming first
-  const std::vector<std::string> matchingFiles = getResourceFilenames(instrument + "_Definition",
-    validFormats, directoryNames, date);
+  const std::vector<std::string> matchingFiles = getResourceFilenames(
+      instrument + "_Definition", validFormats, directoryNames, date);
   std::string instFile;
   if (matchingFiles.size() > 0) {
     instFile = matchingFiles[0];
     g_log.debug() << "Instrument file selected is " << instFile << '\n';
-  }
-  else {
+  } else {
     g_log.debug() << "No instrument file found\n";
   }
   return instFile;

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -945,7 +945,7 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
     const std::string now =
         Types::Core::DateAndTime::getCurrentTime().toISO8601String();
     // Recursively call this method, but with all parameters.
-    return ExperimentInfo::resolveDatedResource(prefix, fileFormats,
+    return ExperimentInfo::getResourceFilenames(prefix, fileFormats,
                                                 directoryNames, now);
   }
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -934,6 +934,86 @@ void ExperimentInfo::getValidFromTo(const std::string &IDFfilename,
   }
 }
 
+/// Utility to retrieve a list of resource files sorted by `from` date
+std::vector<std::string> ExperimentInfo::resolveDatedResource(const std::string &prefix,
+  const std::vector<std::string> &fileFormats, const std::vector<std::string> &directoryNames,
+  const std::string &date) {
+
+  if (date.empty()) {
+    // Just use the current date
+    g_log.debug() << "No date specified, using current date and time.\n";
+    const std::string now =
+            Types::Core::DateAndTime::getCurrentTime().toISO8601String();
+    // Recursively call this method, but with all parameters.
+    return ExperimentInfo::resolveDatedResource(prefix, fileFormats, directoryNames, now);
+  }
+
+  // Join all the file formats into a single string
+  std::stringstream ss;
+  ss << "(";
+  for(size_t i = 0; i < fileFormats.size(); ++i)
+  {
+    if(i != 0)
+      ss << "|";
+    ss << fileFormats[i];
+  }
+  ss << ")";
+  const std::string allFileFormats = ss.str();
+
+  const boost::regex regex(prefix + ".*\\." + allFileFormats, boost::regex_constants::icase);
+  Poco::DirectoryIterator end_iter;
+  DateAndTime d(date);
+
+  DateAndTime refDate("1900-01-31 23:59:00"); // used to help determine the most
+  // recently starting file, if none match
+  DateAndTime refDateGoodFile("1900-01-31 23:59:00"); // used to help determine the most recently
+
+  // Two files could have the same `from` date so multimap is required.
+  // Sort with newer dates placed at the beginning
+  std::multimap<DateAndTime, std::string, std::greater<DateAndTime>> matchingFiles;
+
+  for (const auto &directoryName : directoryNames) {
+    // Iterate over the directories from user ->etc ->install, and find the first beat file
+    for (Poco::DirectoryIterator dir_itr(directoryName); dir_itr != end_iter;
+         ++dir_itr) {
+
+      const auto &filePath = dir_itr.path();
+      if (!filePath.isFile())
+        continue;
+
+      const std::string &l_filenamePart = filePath.getFileName();
+      if (regex_match(l_filenamePart, regex)) {
+        const auto &pathName = filePath.toString();
+        g_log.debug() << "Found file: '" << pathName << "'\n";
+
+        std::string validFrom, validTo;
+        getValidFromTo(pathName, validFrom, validTo);
+        g_log.debug() << "File '" << pathName << " valid dates: from '"
+                      << validFrom << "' to '" << validTo << "'\n";
+        // Use default valid "from" and "to" dates if none were found.
+        DateAndTime to, from;
+        if (validFrom.length() > 0)
+          from.setFromISO8601(validFrom);
+        else
+          from = refDate;
+        if (validTo.length() > 0)
+          to.setFromISO8601(validTo);
+        else
+          to.setFromISO8601("2100-01-01T00:00:00");
+
+        if (from <= d && d <= to)
+          matchingFiles.insert(std::pair<DateAndTime, std::string>(from, pathName));
+      }
+    }
+  }
+
+  // Retrieve the file names only
+  std::vector<std::string> pathNames;
+  for(auto elem : matchingFiles)
+    pathNames.push_back(elem.second);
+  return pathNames;
+}
+
 /** A given instrument may have multiple definition files associated with it.
  *This method returns a file name which identifies a given instrument definition
  *for a given instrument.
@@ -959,15 +1039,7 @@ void ExperimentInfo::getValidFromTo(const std::string &IDFfilename,
 std::string
 ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
                                       const std::string &date) {
-  if (date.empty()) {
-    // Just use the current date
-    g_log.debug() << "No date specified, using current date and time.\n";
-    const std::string now =
-        Types::Core::DateAndTime::getCurrentTime().toISO8601String();
-    // Recursively call this method, but with both parameters.
-    return ExperimentInfo::getInstrumentFilename(instrumentName, now);
-  }
-
+  const std::vector<std::string> validFormats = {"xml", "nxs", "hdf5"};
   g_log.debug() << "Looking for instrument file for " << instrumentName
                 << " that is valid on '" << date << "'\n";
   // Lookup the instrument (long) name
@@ -978,72 +1050,18 @@ ExperimentInfo::getInstrumentFilename(const std::string &instrumentName,
   const std::vector<std::string> &directoryNames =
       Kernel::ConfigService::Instance().getInstrumentDirectories();
 
-  const boost::regex regex(instrument + "_Definition.*\\.(xml|nxs|hdf5)",
-                           boost::regex_constants::icase);
-  Poco::DirectoryIterator end_iter;
-  DateAndTime d(date);
-  bool foundGoodFile =
-      false; // True if we have found a matching file (valid at the given date)
-  std::string mostRecentInstFile; // store most recently starting matching
-                                  // instrument file if found, else most
-                                  // recently starting instrument file.
-  DateAndTime refDate("1900-01-31 23:59:00"); // used to help determine the most
-                                              // recently starting instrument
-                                              // file, if none match
-  DateAndTime refDateGoodFile("1900-01-31 23:59:00"); // used to help determine
-                                                      // the most recently
-                                                      // starting matching
-                                                      // instrument file
-  for (const auto &directoryName : directoryNames) {
-    // This will iterate around the directories from user ->etc ->install, and
-    // find the first beat file
-    for (Poco::DirectoryIterator dir_itr(directoryName); dir_itr != end_iter;
-         ++dir_itr) {
-
-      const auto &filePath = dir_itr.path();
-      if (!filePath.isFile())
-        continue;
-
-      const std::string &l_filenamePart = filePath.getFileName();
-      if (regex_match(l_filenamePart, regex)) {
-        const auto &pathName = filePath.toString();
-        g_log.debug() << "Found file: '" << pathName << "'\n";
-        std::string validFrom, validTo;
-        getValidFromTo(pathName, validFrom, validTo);
-        g_log.debug() << "File '" << pathName << " valid dates: from '"
-                      << validFrom << "' to '" << validTo << "'\n";
-
-        // Use default valid "from" and "to" dates if none were found.
-        DateAndTime to, from;
-        if (validFrom.length() > 0)
-          from.setFromISO8601(validFrom);
-        else
-          from = refDate;
-        if (validTo.length() > 0)
-          to.setFromISO8601(validTo);
-        else
-          to.setFromISO8601("2100-01-01T00:00:00");
-
-        if (from <= d && d <= to) {
-          if (from > refDateGoodFile) { // We'd found a matching file more
-                                        // recently starting than any other
-                                        // matching file found
-            foundGoodFile = true;
-            refDateGoodFile = from;
-            mostRecentInstFile = pathName;
-          }
-        }
-        if (!foundGoodFile && (from >= refDate)) { // Use most recently starting
-                                                   // file, in case we don't
-                                                   // find a matching file.
-          refDate = from;
-          mostRecentInstFile = pathName;
-        }
-      }
-    }
+  // matching files sorted with newest files coming first
+  const std::vector<std::string> matchingFiles = resolveDatedResource(instrument + "_Definition",
+    validFormats, directoryNames, date);
+  std::string instFile;
+  if (matchingFiles.size() > 0) {
+    instFile = matchingFiles[0];
+    g_log.debug() << "Instrument file selected is " << instFile << '\n';
   }
-  g_log.debug() << "Instrument file selected is " << mostRecentInstFile << '\n';
-  return mostRecentInstFile;
+  else {
+    g_log.debug() << "No instrument file found\n";
+  }
+  return instFile;
 }
 
 /** Return a const reference to the DetectorInfo object.

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -934,17 +934,19 @@ void ExperimentInfo::getValidFromTo(const std::string &IDFfilename,
   }
 }
 
-/** Compile a list of files in compliance with name pattern-matching, file format,
- * and date-stamp constraints
+/** Compile a list of files in compliance with name pattern-matching, file
+ * format, and date-stamp constraints
  *
  * Ideally, the valid-from and valid-to of any valid file should encapsulate
  * argument date. If this is not possible, then the file with the most recent
  * valid-from stamp is selected.
  *
  * @param prefix :: the name of a valid file must begin with this pattern
- * @param fileFormats :: the extension of a valid file must be one of these formats
+ * @param fileFormats :: the extension of a valid file must be one of these
+ * formats
  * @param directoryNames :: search only in these directories
- * @param date :: the valid-from and valid-to of a valid file should encapsulate this date
+ * @param date :: the valid-from and valid-to of a valid file should encapsulate
+ * this date
  * @return list of absolute paths for each valid file
  */
 std::vector<std::string> ExperimentInfo::getResourceFilenames(
@@ -987,7 +989,7 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
   std::multimap<DateAndTime, std::string, std::greater<DateAndTime>>
       matchingFiles;
   bool foundFile = false;
-  std::string mostRecentFile;  // path to the file with most recent "valid-from"
+  std::string mostRecentFile; // path to the file with most recent "valid-from"
   for (const auto &directoryName : directoryNames) {
     // Iterate over the directories from user ->etc ->install, and find the
     // first beat file
@@ -1020,13 +1022,13 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
 
         if (from <= d && d <= to) {
           foundFile = true;
-          matchingFiles.insert(std::pair<DateAndTime, std::string>(from, pathName));
-
+          matchingFiles.insert(
+              std::pair<DateAndTime, std::string>(from, pathName));
         }
         // Consider the most recent file in the absence of matching files
         if (!foundFile && (from >= refDate)) {
-            refDate = from;
-            mostRecentFile = pathName;
+          refDate = from;
+          mostRecentFile = pathName;
         }
       }
     }
@@ -1037,8 +1039,7 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
   if (matchingFiles.size() > 0) {
     for (auto elem : matchingFiles)
       pathNames.push_back(elem.second);
-  }
-  else {
+  } else {
     pathNames.push_back(mostRecentFile);
   }
   return pathNames;

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -586,6 +586,20 @@ public:
     TS_ASSERT_DIFFERS(boevs.find("TEST1_ValidDateOverlap"), std::string::npos);
     ConfigService::Instance().setString("instrumentDefinition.directory",
                                         instDir);
+
+    std::vector<std::string> formats = {"xml"};
+    std::vector<std::string> dirs;
+    dirs.push_back(testDir);
+    std::vector<std::string> fnames =
+            helper.getResourceFilenames("ARGUS", formats, dirs, "1909-01-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"), std::string::npos);
+    TS_ASSERT_EQUALS(fnames.size(), 1);
+    fnames = helper.getResourceFilenames("ARGUS", formats, dirs, "1909-03-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST2_ValidDateOverlap"), std::string::npos);
+    TS_ASSERT_DIFFERS(fnames[1].find("TEST1_ValidDateOverlap"), std::string::npos);
+    fnames = helper.getResourceFilenames("ARGUS", formats, dirs, "1909-05-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"), std::string::npos);
+    TS_ASSERT_EQUALS(fnames.size(), 1);
   }
 
   void test_nexus_geometry_getInstrumentFilename() {

--- a/Framework/API/test/ExperimentInfoTest.h
+++ b/Framework/API/test/ExperimentInfoTest.h
@@ -590,15 +590,21 @@ public:
     std::vector<std::string> formats = {"xml"};
     std::vector<std::string> dirs;
     dirs.push_back(testDir);
-    std::vector<std::string> fnames =
-            helper.getResourceFilenames("ARGUS", formats, dirs, "1909-01-31 22:59:59");
-    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"), std::string::npos);
+    std::vector<std::string> fnames = helper.getResourceFilenames(
+        "ARGUS", formats, dirs, "1909-01-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"),
+                      std::string::npos);
     TS_ASSERT_EQUALS(fnames.size(), 1);
-    fnames = helper.getResourceFilenames("ARGUS", formats, dirs, "1909-03-31 22:59:59");
-    TS_ASSERT_DIFFERS(fnames[0].find("TEST2_ValidDateOverlap"), std::string::npos);
-    TS_ASSERT_DIFFERS(fnames[1].find("TEST1_ValidDateOverlap"), std::string::npos);
-    fnames = helper.getResourceFilenames("ARGUS", formats, dirs, "1909-05-31 22:59:59");
-    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"), std::string::npos);
+    fnames = helper.getResourceFilenames("ARGUS", formats, dirs,
+                                         "1909-03-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST2_ValidDateOverlap"),
+                      std::string::npos);
+    TS_ASSERT_DIFFERS(fnames[1].find("TEST1_ValidDateOverlap"),
+                      std::string::npos);
+    fnames = helper.getResourceFilenames("ARGUS", formats, dirs,
+                                         "1909-05-31 22:59:59");
+    TS_ASSERT_DIFFERS(fnames[0].find("TEST1_ValidDateOverlap"),
+                      std::string::npos);
     TS_ASSERT_EQUALS(fnames.size(), 1);
   }
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -43,7 +43,8 @@ void export_ExperimentInfo() {
            return_value_policy<RemoveConstSharedPtr>(), args("self"),
            "Returns the :class:`~mantid.geometry.Instrument` for this run.")
       .def("getResourceFilenames", &ExperimentInfo::getResourceFilenames,
-           (arg("self"), arg("prefix"), arg("fileFormats"), arg("directoryNames"), arg("date")),
+           (arg("self"), arg("prefix"), arg("fileFormats"),
+            arg("directoryNames"), arg("date")),
            "Docstring first line"
            "Docstring second line")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -12,13 +12,13 @@
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/WarningSuppressions.h"
-#include "MantidPythonInterface/kernel/GetPointer.h"
-#include "MantidPythonInterface/kernel/Policies/RemoveConst.h"
 #include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
 #include "MantidPythonInterface/kernel/Converters/ToPyList.h"
+#include "MantidPythonInterface/kernel/GetPointer.h"
+#include "MantidPythonInterface/kernel/Policies/RemoveConst.h"
 #include <boost/python/class.hpp>
-#include <boost/python/list.hpp>
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
@@ -31,12 +31,11 @@ GET_POINTER_SPECIALIZATION(ExperimentInfo)
 
 /// Converter from C++ signature to python signature
 list getResourceFilenames(const std::string &prefix, const list &fileFormats,
-                        const list &directoryNames, const std::string &date) {
-  return Converters::ToPyList<std::string>()(ExperimentInfo::getResourceFilenames(
-          prefix,
-          Converters::PySequenceToVector<std::string>(fileFormats)(),
-          Converters::PySequenceToVector<std::string>(directoryNames)(),
-          date));
+                          const list &directoryNames, const std::string &date) {
+  return Converters::ToPyList<std::string>()(
+      ExperimentInfo::getResourceFilenames(
+          prefix, Converters::PySequenceToVector<std::string>(fileFormats)(),
+          Converters::PySequenceToVector<std::string>(directoryNames)(), date));
 }
 
 GNU_DIAG_OFF("unused-local-typedef")
@@ -56,20 +55,22 @@ void export_ExperimentInfo() {
       .def("getInstrument", &ExperimentInfo::getInstrument,
            return_value_policy<RemoveConstSharedPtr>(), args("self"),
            "Returns the :class:`~mantid.geometry.Instrument` for this run.")
-      .def("getResourceFilenames",
-              &getResourceFilenames,
-              (arg("prefix"), arg("fileFormats"), arg("directoryNames"), arg("date")),
-              "Compile a list of files in compliance with name pattern-matching,\n"
-              "file format, and date-stamp constraints\n\n"
-              "Ideally, the valid-from and valid-to of any valid file should\n"
-              "encapsulate the argument date. If this is not possible, then\n"
-              "the file with the most recent valid-from stamp is selected\n\n"
-              "prefix:         the name of a valid file must begin with this pattern\n"
-              "fileFormats:    valid file extensions\n"
-              "directoryNames: search only in these directories\n"
-              "date :          valid-from and valid-to of a valid file encapsulate date\n"
-              "\nreturns : list of absolute paths for each valid file"
-              ).staticmethod("getResourceFilenames")
+      .def("getResourceFilenames", &getResourceFilenames,
+           (arg("prefix"), arg("fileFormats"), arg("directoryNames"),
+            arg("date")),
+           "Compile a list of files in compliance with name pattern-matching,\n"
+           "file format, and date-stamp constraints\n\n"
+           "Ideally, the valid-from and valid-to of any valid file should\n"
+           "encapsulate the argument date. If this is not possible, then\n"
+           "the file with the most recent valid-from stamp is selected\n\n"
+           "prefix:         the name of a valid file must begin with this "
+           "pattern\n"
+           "fileFormats:    valid file extensions\n"
+           "directoryNames: search only in these directories\n"
+           "date :          valid-from and valid-to of a valid file "
+           "encapsulate date\n"
+           "\nreturns : list of absolute paths for each valid file")
+      .staticmethod("getResourceFilenames")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
            getInstrumentFilename_Overload(
                "Returns IDF filename", (arg("instrument"), arg("date") = "")))

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -67,10 +67,9 @@ void export_ExperimentInfo() {
            "pattern\n"
            "fileFormats:    list of valid file extensions\n"
            "directoryNames: list of directories to be searched\n"
-           "date :          valid-from and valid-to dates of a valid file\n"
-           "                (e.g '1900-01-31 23:59:00')\n"
-           "encapsulate date\n"
-           "\nreturns : list of absolute paths for each valid file")
+           "date :          the 'valid-from' and 'valid-to 'dates of a valid\n"
+           "file will encapsulate this date (e.g '1900-01-31 23:59:00')\n"
+           "\nreturns : list of absolute paths for each valid file\n")
       .staticmethod("getResourceFilenames")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
            getInstrumentFilename_Overload(

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -67,7 +67,8 @@ void export_ExperimentInfo() {
            "pattern\n"
            "fileFormats:    list of valid file extensions\n"
            "directoryNames: list of directories to be searched\n"
-           "date :          valid-from and valid-to of a valid file "
+           "date :          valid-from and valid-to dates of a valid file\n"
+           "                (e.g '1900-01-31 23:59:00')\n"
            "encapsulate date\n"
            "\nreturns : list of absolute paths for each valid file")
       .staticmethod("getResourceFilenames")
@@ -79,7 +80,7 @@ void export_ExperimentInfo() {
       .def("sample", &ExperimentInfo::sample,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return the :class:`~mantid.api.Sample` object. This cannot be "
-           "modified, use mutableSample to modify.")
+           "modified, use mutableSample to modify.")l
 
       .def("mutableSample", &ExperimentInfo::mutableSample,
            return_value_policy<reference_existing_object>(), args("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -14,16 +14,30 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/kernel/GetPointer.h"
 #include "MantidPythonInterface/kernel/Policies/RemoveConst.h"
+#include "MantidPythonInterface/kernel/Converters/PySequenceToVector.h"
+#include "MantidPythonInterface/kernel/Converters/ToPyList.h"
 #include <boost/python/class.hpp>
+#include <boost/python/list.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::ExperimentInfo;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
+using namespace Mantid::PythonInterface;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(ExperimentInfo)
+
+/// Converter from C++ signature to python signature
+list getResourceFilenames(const std::string &prefix, const list &fileFormats,
+                        const list &directoryNames, const std::string &date) {
+  return Converters::ToPyList<std::string>()(ExperimentInfo::getResourceFilenames(
+          prefix,
+          Converters::PySequenceToVector<std::string>(fileFormats)(),
+          Converters::PySequenceToVector<std::string>(directoryNames)(),
+          date));
+}
 
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
@@ -42,6 +56,20 @@ void export_ExperimentInfo() {
       .def("getInstrument", &ExperimentInfo::getInstrument,
            return_value_policy<RemoveConstSharedPtr>(), args("self"),
            "Returns the :class:`~mantid.geometry.Instrument` for this run.")
+      .def("getResourceFilenames",
+              &getResourceFilenames,
+              (arg("prefix"), arg("fileFormats"), arg("directoryNames"), arg("date")),
+              "Compile a list of files in compliance with name pattern-matching,\n"
+              "file format, and date-stamp constraints\n\n"
+              "Ideally, the valid-from and valid-to of any valid file should\n"
+              "encapsulate the argument date. If this is not possible, then\n"
+              "the file with the most recent valid-from stamp is selected\n\n"
+              "prefix:         the name of a valid file must begin with this pattern\n"
+              "fileFormats:    valid file extensions\n"
+              "directoryNames: search only in these directories\n"
+              "date :          valid-from and valid-to of a valid file encapsulate date\n"
+              "\nreturns : list of absolute paths for each valid file"
+              ).staticmethod("getResourceFilenames")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
            getInstrumentFilename_Overload(
                "Returns IDF filename", (arg("instrument"), arg("date") = "")))

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -80,7 +80,7 @@ void export_ExperimentInfo() {
       .def("sample", &ExperimentInfo::sample,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return the :class:`~mantid.api.Sample` object. This cannot be "
-           "modified, use mutableSample to modify.")l
+           "modified, use mutableSample to modify.")
 
       .def("mutableSample", &ExperimentInfo::mutableSample,
            return_value_policy<reference_existing_object>(), args("self"),

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -42,11 +42,6 @@ void export_ExperimentInfo() {
       .def("getInstrument", &ExperimentInfo::getInstrument,
            return_value_policy<RemoveConstSharedPtr>(), args("self"),
            "Returns the :class:`~mantid.geometry.Instrument` for this run.")
-      .def("getResourceFilenames", &ExperimentInfo::getResourceFilenames,
-           (arg("self"), arg("prefix"), arg("fileFormats"),
-            arg("directoryNames"), arg("date")),
-           "Docstring first line"
-           "Docstring second line")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
            getInstrumentFilename_Overload(
                "Returns IDF filename", (arg("instrument"), arg("date") = "")))

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -65,8 +65,8 @@ void export_ExperimentInfo() {
            "the file with the most recent valid-from stamp is selected\n\n"
            "prefix:         the name of a valid file must begin with this "
            "pattern\n"
-           "fileFormats:    valid file extensions\n"
-           "directoryNames: search only in these directories\n"
+           "fileFormats:    list of valid file extensions\n"
+           "directoryNames: list of directories to be searched\n"
            "date :          valid-from and valid-to of a valid file "
            "encapsulate date\n"
            "\nreturns : list of absolute paths for each valid file")

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -42,7 +42,10 @@ void export_ExperimentInfo() {
       .def("getInstrument", &ExperimentInfo::getInstrument,
            return_value_policy<RemoveConstSharedPtr>(), args("self"),
            "Returns the :class:`~mantid.geometry.Instrument` for this run.")
-
+      .def("getResourceFilenames", &ExperimentInfo::getResourceFilenames,
+           (arg("self"), arg("prefix"), arg("fileFormats"), arg("directoryNames"), arg("date")),
+           "Docstring first line"
+           "Docstring second line")
       .def("getInstrumentFilename", &ExperimentInfo::getInstrumentFilename,
            getInstrumentFilename_Overload(
                "Returns IDF filename", (arg("instrument"), arg("date") = "")))

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -27,10 +27,9 @@ Logging
 
 Nexus Geometry Loading
 ----------------------
-:ref:`LoadEmptyInstrument <algm-LoadEmptyInstrument>` will now load instrument geometry from hdf5 `NeXus <https://www.nexusformat.org/>`_ format files. Files consistent with the standard following the introduction of `NXoff_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXoff_geometry.html>`_ and `NXcylindrical_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXcylindrical_geometry.html>`_ will be used to build the entire in-memory instrument geometry within Mantid. This IDF-free route is primarily envisioned for the ESS. While dependent on the instrument, we are overall seeing significant improvements in instrument load times over loading from equivalent IDF based implementations. :ref:`LoadInstrument <algm-LoadInstrument>` also supports the nexus geometry format in the same was as LoadEmptyInstrument.
-
-The changes above have also been encorporated directly into :ref:`LoadEventNexus <algm-LoadEventNexus>`, so it is possible to store data and geometry together for the first time in a NeXus compliant format for Mantid. These changes have made it possible to load experimental ESS event data files directly into Mantid.
-
+- :ref:`LoadEmptyInstrument <algm-LoadEmptyInstrument>` will now load instrument geometry from hdf5 `NeXus <https://www.nexusformat.org/>`_ format files. Files consistent with the standard following the introduction of `NXoff_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXoff_geometry.html>`_ and `NXcylindrical_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXcylindrical_geometry.html>`_ will be used to build the entire in-memory instrument geometry within Mantid. This IDF-free route is primarily envisioned for the ESS. While dependent on the instrument, we are overall seeing significant improvements in instrument load times over loading from equivalent IDF based implementations. :ref:`LoadInstrument <algm-LoadInstrument>` also supports the nexus geometry format in the same was as LoadEmptyInstrument.
+- The changes above have also been encorporated directly into :ref:`LoadEventNexus <algm-LoadEventNexus>`, so it is possible to store data and geometry together for the first time in a NeXus compliant format for Mantid. These changes have made it possible to load experimental ESS event data files directly into Mantid.
+- New helper function `ExperimentInfo.getResourceFilenames` returns a list of instrument definition files and/or parameter files in accordance to a query time stamp.
 
 Archive Searching
 -----------------


### PR DESCRIPTION
**Description of work.**
- [x] Helper function `getResourceFilenames` returns a list of IDF's or Parameter files sorted by older `valid-from` dates
- [x] Unit test for `getResourceFilenames`
- [x] Refactor `getInstrumentFilename` to use `getResourceFilenames`
- [x] Python export of `getResourceFilenames`

**To test:**
Download and unzip [instrument.zip](https://github.com/mantidproject/mantid/files/2895477/instrument.zip)  under `/tmp`, then run the following script:
```
instrument_directories = ['/tmp/instrument']
run_number__to__filename_tail = {'BSS_55555': 'Parameters_2011_2018.xml',
                                 'BSS_90177': 'Parameters.xml'}
for run_number, tail in run_number__to__filename_tail.items():
    w = Load(Filename=run, BankName='bank1')
    start_date = str(w.getRun().startTime()).strip()
    parm_files = ExperimentInfo.getResourceFilenames('BASIS_.*Parameters',
                                                     ['xml'],
                                                     instrument_directories,
                                                     start_date)
    for file_path in parm_files:
        assert tail in file_path
```

Fixes #24797


This does not require release notes because of backend changes not exposed to the user

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
