### PR TITLE
Updated Facilities.xml with MARI event live data source

### DIFF
--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -138,6 +138,9 @@
     <technique>Neutron Spectroscopy</technique>
     <technique>TOF Direct Geometry Spectroscopy</technique>
     <livedata>
+      <connection name="kafka_event" address="livedata.isis.cclrc.ac.uk:9092" listener="KafkaEventListener" />
+    </livedata>
+    <livedata>
       <connection name="histo" address="NDXMARI:6789" listener="ISISHistoDataListener" />
     </livedata>
   </instrument>


### PR DESCRIPTION
**Description of work.**

The MARI instrument at ISIS has recently had its data acquisition electronics upgraded and can now use event mode data collection. The plan is that this will be the standard run mode from now on. This PR updates the `Facilities.xml` file to add the event mode live data as the default listener for MARI (the histogram mode listener is still retained).

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

<!-- Instructions for testing. -->
This test needs to be run within the STFC firewall: run the `StartLiveData` algorithm and select `MARI` as the instrument. Check that the `Connection` is set to `kafka_event` and the address is correctly set as `livedata.isis.cclrc.ac.uk:9092`. Put a value in `Output Workspace` and `Run` the algorithm. Check that it produces an `EventWorkspace` with 922 spectra. 

*There is no associated issue.*

*This does not require release notes* because it's only small backend change affecting one instrument.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
