### PR TITLE
Set matplotlib backend for test

### DIFF
--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -7,6 +7,8 @@
 #  This file is part of the mantid workbench.
 from qtpy.QtWidgets import QApplication
 
+import matplotlib as mpl
+mpl.use('Agg')  # noqa
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.utils.qt.test import GuiTest
 from mantidqt.utils.qt.test.qt_widget_finder import QtWidgetFinder


### PR DESCRIPTION
**Description of work.**

Sets the backend for matplotlib in the sample log viewer unit test to `Agg`. The default tkinter is not always available. Fixes a [builder issue](http://builds.mantidproject.org/job/pull_requests-ubuntu-python3/15550/consoleFull).

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Code review. Test this locally on Ubuntu by removing the `python-tk` package.

*There is no associated issue.*

*This does not require release notes* because **it fixes a unit test on certain build nodes.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
