### PR TITLE
Adding rebinning to new Muon GUI

### DIFF
--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -240,7 +240,7 @@ MuonPreProcess::applyRebinning(MatrixWorkspace_sptr ws,
     IAlgorithm_sptr rebin = createChildAlgorithm("Rebin");
     rebin->setProperty("InputWorkspace", ws);
     rebin->setProperty("Params", rebinArgs);
-    rebin->setProperty("FullBinsOnly", false);
+    rebin->setProperty("FullBinsOnly", true);
     rebin->execute();
     return rebin->getProperty("OutputWorkspace");
   } else {

--- a/Framework/Muon/src/MuonPreProcess.cpp
+++ b/Framework/Muon/src/MuonPreProcess.cpp
@@ -240,7 +240,7 @@ MuonPreProcess::applyRebinning(MatrixWorkspace_sptr ws,
     IAlgorithm_sptr rebin = createChildAlgorithm("Rebin");
     rebin->setProperty("InputWorkspace", ws);
     rebin->setProperty("Params", rebinArgs);
-    rebin->setProperty("FullBinsOnly", true);
+    rebin->setProperty("FullBinsOnly", false);
     rebin->execute();
     return rebin->getProperty("OutputWorkspace");
   } else {

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -11,27 +11,48 @@ def get_raw_data_workspace_name(context, run):
     return context._base_run_name(run) + "_raw_data"
 
 
-def get_group_data_workspace_name(context, group_name, run):
+def get_group_data_workspace_name(context, group_name, run, rebin):
     if context.is_multi_period():
-        return context._base_run_name(run) + "; Group; " + group_name + \
-               "; Counts; Periods; " + context.period_string(run) + "; #1"
+        name = context._base_run_name(run) + "; Group; " + group_name + \
+               "; Counts; Periods; " + context.period_string(run) + ";"
     else:
-        return context._base_run_name(run) + "; Group; " + group_name + "; Counts; #1"
+        name = context._base_run_name(run) + "; Group; " + group_name + "; Counts;"
+
+    if rebin:
+        name += ' Rebin;'
+
+    name += ' #1'
+
+    return name
 
 
-def get_group_asymmetry_name(context, group_name, run):
+def get_group_asymmetry_name(context, group_name, run, rebin):
     if context.is_multi_period():
-        return context._base_run_name(run) + "; Group; " + group_name + \
-               "; Asymmetry; Periods; " + context.period_string(run) + "; #1"
+        name =  context._base_run_name(run) + "; Group; " + group_name + \
+               "; Asymmetry; Periods; " + context.period_string(run) + ";"
     else:
-        return context._base_run_name(run) + "; Group; " + group_name + "; Asymmetry; #1"
+        name = context._base_run_name(run) + "; Group; " + group_name + "; Asymmetry;"
+
+    if rebin:
+        name += ' Rebin;'
+
+    name += ' #1'
+
+    return name
 
 
-def get_pair_data_workspace_name(context, pair_name, run):
+def get_pair_data_workspace_name(context, pair_name, run, rebin):
     if context.is_multi_period():
-        return context._base_run_name(run) + "; Pair Asym; " + pair_name + "; Periods; " + context.period_string(run) + "; #1"
+        name = context._base_run_name(run) + "; Pair Asym; " + pair_name + "; Periods; " + context.period_string(run) + ";"
     else:
-        return context._base_run_name(run) + "; Pair Asym; " + pair_name + "; #1"
+        name = context._base_run_name(run) + "; Pair Asym; " + pair_name + ";"
+
+    if rebin:
+        name += ' Rebin;'
+
+    name += ' #1'
+
+    return name
 
 
 def get_base_data_directory(context, run):

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -7,8 +7,8 @@
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
 
 
-def calculate_group_data(context, group_name, run):
-    processed_data = _run_pre_processing(context, run)
+def calculate_group_data(context, group_name, run, rebin):
+    processed_data = _run_pre_processing(context, run, rebin)
 
     params = _get_MuonGroupingCounts_parameters(context, group_name, run)
     params["InputWorkspace"] = processed_data
@@ -17,8 +17,8 @@ def calculate_group_data(context, group_name, run):
     return group_data
 
 
-def calculate_pair_data(context, pair_name, run):
-    processed_data = _run_pre_processing(context, run)
+def calculate_pair_data(context, pair_name, run, rebin):
+    processed_data = _run_pre_processing(context, run, rebin)
 
     params = _get_MuonPairingAsymmetry_parameters(context, pair_name, run)
     params["InputWorkspace"] = processed_data
@@ -27,8 +27,8 @@ def calculate_pair_data(context, pair_name, run):
     return pair_data
 
 
-def estimate_group_asymmetry_data(context, group_name, run):
-    processed_data = _run_pre_processing(context, run)
+def estimate_group_asymmetry_data(context, group_name, run, rebin):
+    processed_data = _run_pre_processing(context, run, rebin)
 
     params = _get_MuonGroupingAsymmetry_parameters(context, group_name, run)
     params["InputWorkspace"] = processed_data
@@ -37,14 +37,14 @@ def estimate_group_asymmetry_data(context, group_name, run):
     return group_asymmetry
 
 
-def _run_pre_processing(context, run):
-    params = _get_pre_processing_params(context, run)
+def _run_pre_processing(context, run, rebin):
+    params = _get_pre_processing_params(context, run, rebin)
     params["InputWorkspace"] = context.loaded_workspace_as_group(run)
     processed_data = algorithm_utils.run_MuonPreProcess(params)
     return processed_data
 
 
-def _get_pre_processing_params(context, run):
+def _get_pre_processing_params(context, run, rebin):
     pre_process_params = {}
 
     try:
@@ -65,11 +65,20 @@ def _get_pre_processing_params(context, run):
     except KeyError:
         pass
 
-    try:
-        rebin_args = context.gui_variables["Rebin"]
-        pre_process_params["RebinArgs"] = rebin_args
-    except KeyError:
-        pass
+    if rebin:
+        try:
+            if context.gui_variables['RebinType'] == 'Variable' and context.gui_variables["RebinVariable"]:
+                pre_process_params["RebinArgs"] = context.gui_variables["RebinVariable"]
+        except KeyError:
+            pass
+
+        try:
+            if context.gui_variables['RebinType'] == 'Fixed' and context.gui_variables["RebinFixed"]:
+                x_data = context._loaded_data.get_data(run=run, instrument=context.instrument)['workspace']['OutputWorkspace'][0].workspace.dataX(0)
+                original_step = x_data[1] - x_data[0]
+                pre_process_params["RebinArgs"] = float(context.gui_variables["RebinFixed"]) * original_step
+        except KeyError:
+            pass
 
     try:
         if context.gui_variables['DeadTimeSource'] == 'FromFile':

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -74,7 +74,8 @@ def _get_pre_processing_params(context, run, rebin):
 
         try:
             if context.gui_variables['RebinType'] == 'Fixed' and context.gui_variables["RebinFixed"]:
-                x_data = context._loaded_data.get_data(run=run, instrument=context.instrument)['workspace']['OutputWorkspace'][0].workspace.dataX(0)
+                x_data = context._loaded_data.get_data(run=run, instrument=context.instrument
+                                                       )['workspace']['OutputWorkspace'][0].workspace.dataX(0)
                 original_step = x_data[1] - x_data[0]
                 pre_process_params["RebinArgs"] = float(context.gui_variables["RebinFixed"]) * original_step
         except KeyError:

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -159,6 +159,7 @@ class GroupingTablePresenter(object):
 
             self._view.group_range_min.setEnabled(False)
             if 'GroupRangeMin' in self._model._data.gui_variables:
+                # Remove variable from model if value from file is to be used
                 self._model._data.gui_variables.pop('GroupRangeMin')
         else:
             self._view.group_range_min.setEnabled(True)
@@ -173,6 +174,7 @@ class GroupingTablePresenter(object):
 
             self._view.group_range_max.setEnabled(False)
             if 'GroupRangeMax' in self._model._data.gui_variables:
+                # Remove variable from model if value from file is to be used
                 self._model._data.gui_variables.pop('GroupRangeMax')
         else:
             self._view.group_range_max.setEnabled(True)

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from mantid.api import ITableWorkspace
 from mantid import api
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 
 
 class InstrumentWidgetModel(object):
@@ -122,7 +122,7 @@ class InstrumentWidgetModel(object):
         variable_rebin_list = variable_rebin_string.split(',')
         try:
             variable_rebin_list = [Decimal(x) for x in variable_rebin_list]
-        except ValueError:
+        except (ValueError, InvalidOperation):
             return (False, 'Rebin entries must be numbers')
 
         if len(variable_rebin_list) == 0:

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -23,6 +23,7 @@ class InstrumentWidgetModel(object):
 
     def __init__(self, muon_data=MuonDataContext()):
         self._data = muon_data
+        self._data.gui_variables['RebinType'] = 'None'
 
     def clear_data(self):
         """When e.g. instrument changed"""
@@ -71,10 +72,13 @@ class InstrumentWidgetModel(object):
         return self._data.dead_time_table
 
     def add_fixed_binning(self, fixed_bin_size):
-        self._data.gui_variables["Rebin"] = str(fixed_bin_size)
+        self._data.gui_variables["RebinFixed"] = str(fixed_bin_size)
 
     def add_variable_binning(self, rebin_params):
-        self._data.gui_variables["Rebin"] = str(rebin_params)
+        self._data.gui_variables["RebinVariable"] = str(rebin_params)
+
+    def update_binning_type(self, rebin_type):
+        self._data.gui_variables['RebinType'] = rebin_type
 
     # ------------------------------------------------------------------------------------------------------------------
     # Dead Time

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from mantid.api import ITableWorkspace
 from mantid import api
+from decimal import Decimal
 
 
 class InstrumentWidgetModel(object):
@@ -120,9 +121,9 @@ class InstrumentWidgetModel(object):
     def validate_variable_rebin_string(self, variable_rebin_string):
         variable_rebin_list = variable_rebin_string.split(',')
         try:
-            variable_rebin_list = [float(x) for x in variable_rebin_list]
+            variable_rebin_list = [Decimal(x) for x in variable_rebin_list]
         except ValueError:
-            return (False, 'Rebin entries must be floats')
+            return (False, 'Rebin entries must be numbers')
 
         if len(variable_rebin_list) == 0:
             return (False, 'Rebin list must be non-empty')

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -150,4 +150,3 @@ class InstrumentWidgetModel(object):
             return (True, '')
         else:
             return (False, 'Variable rebin string must have 2 or an odd number of entires')
-

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -77,6 +77,12 @@ class InstrumentWidgetModel(object):
     def add_variable_binning(self, rebin_params):
         self._data.gui_variables["RebinVariable"] = str(rebin_params)
 
+    def get_variable_binning(self):
+        if 'RebinVariable' in self._data.gui_variables:
+            return self._data.gui_variables['RebinVariable']
+        else:
+            return ''
+
     def update_binning_type(self, rebin_type):
         self._data.gui_variables['RebinType'] = rebin_type
 
@@ -110,3 +116,38 @@ class InstrumentWidgetModel(object):
         self._data.gui_variables['DeadTimeSource'] = 'FromADS'
         dtc = api.AnalysisDataService.retrieve(str(name))
         self._data.gui_variables["DeadTimeTable"] = dtc
+
+    def validate_variable_rebin_string(self, variable_rebin_string):
+        variable_rebin_list = variable_rebin_string.split(',')
+        try:
+            variable_rebin_list = [float(x) for x in variable_rebin_list]
+        except ValueError:
+            return (False, 'Rebin entries must be floats')
+
+        if len(variable_rebin_list) == 0:
+            return (False, 'Rebin list must be non-empty')
+
+        if len(variable_rebin_list) == 1:
+            return (True, '')
+
+        if len(variable_rebin_list) == 2:
+            if variable_rebin_list[1] > variable_rebin_list[0]:
+                return (True, '')
+            else:
+                return (False, 'End of range must be greater than start of range')
+
+        while len(variable_rebin_list) >= 3:
+            # We don't do any additional checking of logarithmic binning so just return true in this instance
+            if variable_rebin_list[1] <= 0:
+                return (True, '')
+
+            if (variable_rebin_list[2] - variable_rebin_list[0])%variable_rebin_list[1] != 0:
+                return (False, 'Step and bin boundaries must line up')
+
+            variable_rebin_list = variable_rebin_list[2:]
+
+        if len(variable_rebin_list) == 1:
+            return (True, '')
+        else:
+            return (False, 'Variable rebin string must have 2 or an odd number of entires')
+

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -38,6 +38,8 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
         self._view.on_dead_time_from_file_selected(self.handle_dead_time_from_table_workspace_selected)
         self._view.on_dead_time_file_option_changed(self.handle_dead_time_table_workspace_selector_changed)
 
+        self._view.on_rebin_type_changed(self.handle_rebin_type_changed)
+
         self._view.on_instrument_changed(self.handle_instrument_changed)
 
         self.handle_loaded_time_zero_checkState_change()
@@ -105,6 +107,10 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
     def handle_variable_rebin_changed(self):
         variable_bin_size = self._view.get_variable_bin_text()
         self._model.add_variable_binning(variable_bin_size)
+
+    def handle_rebin_type_changed(self):
+        rebin_type = self._view.rebin_selector.currentText()
+        self._model.update_binning_type(rebin_type)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Instrument

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -106,7 +106,12 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
 
     def handle_variable_rebin_changed(self):
         variable_bin_size = self._view.get_variable_bin_text()
-        self._model.add_variable_binning(variable_bin_size)
+        valid, message = self._model.validate_variable_rebin_string(variable_bin_size)
+        if not valid:
+            self._view.rebin_variable_edit.setText(self._model.get_variable_binning())
+            self._view.warning_popup(message)
+        else:
+            self._model.add_variable_binning(variable_bin_size)
 
     def handle_rebin_type_changed(self):
         rebin_type = self._view.rebin_selector.currentText()

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -470,10 +470,14 @@ class InstrumentWidgetView(QtGui.QWidget):
         self.rebin_steps_label.setText("Steps : ")
 
         self.rebin_steps_edit = QtGui.QLineEdit(self)
+        int_validator = QtGui.QIntValidator()
+        self.rebin_steps_edit.setValidator(int_validator)
 
         self.rebin_variable_label = QtGui.QLabel(self)
         self.rebin_variable_label.setText("Bin Boundaries : ")
         self.rebin_variable_edit = QtGui.QLineEdit(self)
+        variable_validator = QtGui.QRegExpValidator(QtCore.QRegExp('^[0-9]+(,[0-9]+)*$'))
+        self.rebin_variable_edit.setValidator(variable_validator)
 
         self.rebin_help_button = QtGui.QPushButton(self)
         size_policy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
@@ -538,6 +542,9 @@ class InstrumentWidgetView(QtGui.QWidget):
 
     def on_variable_rebin_edit_changed(self, slot):
         self.rebin_variable_edit.editingFinished.connect(slot)
+
+    def on_rebin_type_changed(self, slot):
+        self.rebin_selector.currentIndexChanged.connect(slot)
 
     def get_fixed_bin_text(self):
         return self.rebin_steps_edit.text()

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -479,17 +479,6 @@ class InstrumentWidgetView(QtGui.QWidget):
         variable_validator = QtGui.QRegExpValidator(QtCore.QRegExp('^[0-9]+(,[0-9]+)*$'))
         self.rebin_variable_edit.setValidator(variable_validator)
 
-        self.rebin_help_button = QtGui.QPushButton(self)
-        size_policy = QtGui.QSizePolicy(QtGui.QSizePolicy.Fixed, QtGui.QSizePolicy.Fixed)
-        size_policy.setHorizontalStretch(0)
-        size_policy.setVerticalStretch(0)
-        size_policy.setHeightForWidth(self.rebin_help_button.sizePolicy().hasHeightForWidth())
-        self.rebin_help_button.setSizePolicy(size_policy)
-        self.rebin_help_button.setMinimumSize(QtCore.QSize(40, 40))
-        self.rebin_help_button.setMaximumSize(QtCore.QSize(40, 40))
-        self.rebin_help_button.setObjectName("rebinHelpButton")
-        self.rebin_help_button.setText("?")
-
         self.horizontal_layout_5 = QtGui.QHBoxLayout()
         self.horizontal_layout_5.setObjectName("horizontalLayout3")
         self.horizontal_layout_5.addSpacing(10)
@@ -503,7 +492,6 @@ class InstrumentWidgetView(QtGui.QWidget):
         self.horizontal_layout_5.addWidget(self.rebin_variable_edit)
         self.horizontal_layout_5.addStretch(0)
         self.horizontal_layout_5.addSpacing(10)
-        self.horizontal_layout_5.addWidget(self.rebin_help_button)
 
         self.rebin_steps_label.hide()
         self.rebin_steps_edit.hide()

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -470,12 +470,20 @@ class InstrumentWidgetView(QtGui.QWidget):
         self.rebin_steps_label.setText("Steps : ")
 
         self.rebin_steps_edit = QtGui.QLineEdit(self)
-        int_validator = QtGui.QIntValidator()
+        int_validator = QtGui.QDoubleValidator()
         self.rebin_steps_edit.setValidator(int_validator)
+        self.rebin_steps_edit.setToolTip('Value to scale current bin width by.')
 
         self.rebin_variable_label = QtGui.QLabel(self)
         self.rebin_variable_label.setText("Bin Boundaries : ")
         self.rebin_variable_edit = QtGui.QLineEdit(self)
+        self.rebin_variable_edit.setToolTip('A comma separated list of first bin boundary, width, last bin boundary.\n'
+                                            'Optionally this can be followed by a comma and more widths and last boundary pairs.\n'
+                                            'Optionally this can also be a single number, which is the bin width.\n'
+                                            'Negative width values indicate logarithmic binning.\n\n'
+                                            'For example:\n'
+                                            '2,-0.035,10: from 2 rebin in Logarithmic bins of 0.035 up to 10;\n'
+                                            '0,100,10000,200,20000: from 0 rebin in steps of 100 to 10,000 then steps of 200 to 20,000')
         variable_validator = QtGui.QRegExpValidator(QtCore.QRegExp('^[0-9]+(,[0-9]+)*$'))
         self.rebin_variable_edit.setValidator(variable_validator)
 

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -484,7 +484,7 @@ class InstrumentWidgetView(QtGui.QWidget):
                                             'For example:\n'
                                             '2,-0.035,10: from 2 rebin in Logarithmic bins of 0.035 up to 10;\n'
                                             '0,100,10000,200,20000: from 0 rebin in steps of 100 to 10,000 then steps of 200 to 20,000')
-        variable_validator = QtGui.QRegExpValidator(QtCore.QRegExp('^[0-9]+(,[0-9]+)*$'))
+        variable_validator = QtGui.QRegExpValidator(QtCore.QRegExp('^(\s*-?\d+(\.\d+)?)(\s*,\s*-?\d+(\.\d+)?)*$'))
         self.rebin_variable_edit.setValidator(variable_validator)
 
         self.horizontal_layout_5 = QtGui.QHBoxLayout()

--- a/scripts/Muon/GUI/Common/muon_data_context.py
+++ b/scripts/Muon/GUI/Common/muon_data_context.py
@@ -334,35 +334,55 @@ class MuonDataContext(object):
         for group_name in self._groups.keys():
             self.show_group_data(group_name)
 
-    def show_group_data(self, group_name, show=True):
+        if self.gui_variables['RebinType'] != 'None':
+            for group_name in self._groups.keys():
+                self.show_group_data(group_name, rebin=True)
+
+    def show_group_data(self, group_name, show=True, rebin=False):
         for run in self.current_runs:
             run_as_string = run_list_to_string(run)
-            group_workspace = calculate_group_data(self, group_name, run)
-            group_asymmetry = estimate_group_asymmetry_data(self, group_name, run)
+            group_workspace = calculate_group_data(self, group_name, run, rebin)
+            group_asymmetry = estimate_group_asymmetry_data(self, group_name, run, rebin)
             directory = get_base_data_directory(self, run_as_string) + get_group_data_directory(self, run_as_string)
-            name = get_group_data_workspace_name(self, group_name, run_as_string)
-            asym_name = get_group_asymmetry_name(self, group_name, run_as_string)
+            name = get_group_data_workspace_name(self, group_name, run_as_string, rebin)
+            asym_name = get_group_asymmetry_name(self, group_name, run_as_string, rebin)
 
-            self._groups[group_name]._workspace[str(run)] = MuonWorkspaceWrapper(group_workspace)
-            self._groups[group_name]._asymmetry_estimate[str(run)] = MuonWorkspaceWrapper(group_asymmetry)
-            if show:
-                self._groups[group_name].workspace[str(run)].show(directory + name)
-                self._groups[group_name]._asymmetry_estimate[str(run)].show(directory + asym_name)
+            if not rebin:
+                self._groups[group_name]._workspace[str(run)] = MuonWorkspaceWrapper(group_workspace)
+                self._groups[group_name]._asymmetry_estimate[str(run)] = MuonWorkspaceWrapper(group_asymmetry)
+                if show:
+                    self._groups[group_name].workspace[str(run)].show(directory + name)
+                    self._groups[group_name]._asymmetry_estimate[str(run)].show(directory + asym_name)
+            else:
+                self._groups[group_name]._workspace_rebin[str(run)] = MuonWorkspaceWrapper(group_workspace)
+                self._groups[group_name]._asymmetry_estimate_rebin[str(run)] = MuonWorkspaceWrapper(group_asymmetry)
+                if show:
+                    self._groups[group_name]._workspace_rebin[str(run)].show(directory + name)
+                    self._groups[group_name]._asymmetry_estimate_rebin[str(run)].show(directory + asym_name)
 
     def show_all_pairs(self):
         for pair_name in self._pairs.keys():
             self.show_pair_data(pair_name)
 
-    def show_pair_data(self, pair_name, show=True):
+        if self.gui_variables['RebinType'] != 'None':
+            for pair_name in self._pairs.keys():
+                self.show_pair_data(pair_name, rebin=True)
+
+    def show_pair_data(self, pair_name, show=True, rebin=False):
         for run in self.current_runs:
             run_as_string = run_list_to_string(run)
-            name = get_pair_data_workspace_name(self, pair_name, run_as_string)
+            name = get_pair_data_workspace_name(self, pair_name, run_as_string, rebin)
             directory = get_base_data_directory(self, run_as_string) + get_pair_data_directory(self, run_as_string)
-            pair_workspace = calculate_pair_data(self, pair_name, run)
+            pair_workspace = calculate_pair_data(self, pair_name, run, rebin)
 
-            self._pairs[pair_name].workspace[str(run)] = MuonWorkspaceWrapper(pair_workspace)
-            if show:
-                self._pairs[pair_name].workspace[str(run)].show(directory + name)
+            if not rebin:
+                self._pairs[pair_name].workspace[str(run)] = MuonWorkspaceWrapper(pair_workspace)
+                if show:
+                    self._pairs[pair_name].workspace[str(run)].show(directory + name)
+            else:
+                self._pairs[pair_name].workspace_rebin[str(run)] = MuonWorkspaceWrapper(pair_workspace)
+                if show:
+                    self._pairs[pair_name].workspace_rebin[str(run)].show(directory + name)
 
     def calculate_all_groups(self):
         for group_name in self._groups.keys():

--- a/scripts/Muon/GUI/Common/muon_data_context.py
+++ b/scripts/Muon/GUI/Common/muon_data_context.py
@@ -334,7 +334,7 @@ class MuonDataContext(object):
         for group_name in self._groups.keys():
             self.show_group_data(group_name)
 
-        if self.gui_variables['RebinType'] != 'None':
+        if self.do_rebin():
             for group_name in self._groups.keys():
                 self.show_group_data(group_name, rebin=True)
 
@@ -364,7 +364,7 @@ class MuonDataContext(object):
         for pair_name in self._pairs.keys():
             self.show_pair_data(pair_name)
 
-        if self.gui_variables['RebinType'] != 'None':
+        if self.do_rebin():
             for pair_name in self._pairs.keys():
                 self.show_pair_data(pair_name, rebin=True)
 
@@ -404,6 +404,12 @@ class MuonDataContext(object):
             return False
         else:
             return True
+
+    def do_rebin(self):
+        return (self.gui_variables['RebinType'] == 'Fixed' and
+                'RebinFixed' in self.gui_variables and self.gui_variables['RebinFixed']) or\
+               (self.gui_variables['RebinType'] == 'Variable' and
+                'RebinVariable' in self.gui_variables and self.gui_variables['RebinVariable'])
 
     class InstrumentNotifier(Observable):
         def __init__(self, outer):

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -28,6 +28,8 @@ class MuonGroup(object):
         self.detectors = detector_ids
         self._workspace = {}
         self._asymmetry_estimate = {}
+        self._workspace_rebin = {}
+        self._asymmetry_estimate_rebin = {}
 
     @property
     def workspace(self):

--- a/scripts/Muon/GUI/Common/muon_pair.py
+++ b/scripts/Muon/GUI/Common/muon_pair.py
@@ -30,6 +30,7 @@ class MuonPair(object):
         self._backward_group_name = backward_group_name
         self._alpha = float(alpha)
         self._workspace = {}
+        self.workspace_rebin = {}
 
     @property
     def workspace(self):

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -34,6 +34,7 @@ set ( TEST_PY_FILES
    LoadWidgetView_test.py
    MaxEntModel_test.py
    MaxEntPresenter_test.py
+   muon_data_context_test.py
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
    PlottingPresenter_test.py

--- a/scripts/test/Muon/home_grouping_widget_test.py
+++ b/scripts/test/Muon/home_grouping_widget_test.py
@@ -32,6 +32,7 @@ class HomeTabGroupingPresenterTest(unittest.TestCase):
         self.obj = QtGui.QWidget()
         ConfigService['default.instrument'] = 'MUSR'
         self.context = MuonDataContext()
+        self.context.gui_variables['RebinType'] = 'None'
         self.view = HomeGroupingWidgetView(self.obj)
         self.model = HomeGroupingWidgetModel(self.context)
         self.presenter = HomeGroupingWidgetPresenter(self.view, self.model)

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -121,15 +121,43 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         self.view.rebin_steps_edit.setText('50')
         self.view.rebin_steps_edit.editingFinished.emit()
 
-        self.assertEqual(self.model._data.gui_variables['Rebin'], '50')
+        self.assertEqual(self.model._data.gui_variables['RebinFixed'], '50')
 
     def test_that_changeing_variable_rebin_updates_fixed_binning_in_model(self):
         self.view.rebin_variable_edit.setText('1,5,8,150')
         self.view.rebin_variable_edit.editingFinished.emit()
 
-        self.assertEqual(self.model._data.gui_variables['Rebin'], '1,5,8,150')
+        self.assertEqual(self.model._data.gui_variables['RebinVariable'], '1,5,8,150')
 
-    # TODO Need to add validation to rebin input strings once I've worked out what they should be
+    def test_that_steps_only_accepts_a_single_integer(self):
+        self.view.rebin_steps_edit.insert('1,0.1,70')
+        self.view.rebin_steps_edit.editingFinished.emit()
+
+        self.assertEqual(self.view.rebin_steps_edit.text(), '')
+        self.assertEqual(self.model._data.gui_variables['RebinFixed'], '')
+
+    def test_that_variable_rebin_only_accepts_a_valid_rebin_string(self):
+        self.view.rebin_variable_edit.insert('1-0.1-80')
+        self.view.rebin_variable_edit.editingFinished.emit()
+
+        self.assertEqual(self.view.rebin_variable_edit.text(), '')
+        self.assertEqual(self.model._data.gui_variables['RebinVariable'], '')
+
+    def test_that_rebin_type_starts_as_none(self):
+        self.assertEqual(self.model._data.gui_variables['RebinType'], 'None')
+
+    def test_that_updating_rebin_combobox_updates_context(self):
+        self.view.rebin_selector.setCurrentIndex(1)
+
+        self.assertEqual(self.model._data.gui_variables['RebinType'], 'Fixed')
+
+        self.view.rebin_selector.setCurrentIndex(2)
+
+        self.assertEqual(self.model._data.gui_variables['RebinType'], 'Variable')
+
+        self.view.rebin_selector.setCurrentIndex(0)
+
+        self.assertEqual(self.model._data.gui_variables['RebinType'], 'None')
 
     def test_that_on_dead_time_unselected_deadtime_model_set_to_none(self):
         self.view.deadtime_selector.setCurrentIndex(1)

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -123,11 +123,11 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
 
         self.assertEqual(self.model._data.gui_variables['RebinFixed'], '50')
 
-    def test_that_changeing_variable_rebin_updates_fixed_binning_in_model(self):
-        self.view.rebin_variable_edit.setText('1,5,8,150')
+    def test_that_changeing_variable_rebin_updates_variable_binning_in_model(self):
+        self.view.rebin_variable_edit.setText('1,5,21')
         self.view.rebin_variable_edit.editingFinished.emit()
 
-        self.assertEqual(self.model._data.gui_variables['RebinVariable'], '1,5,8,150')
+        self.assertEqual(self.model._data.gui_variables['RebinVariable'], '1,5,21')
 
     def test_that_steps_only_accepts_a_single_integer(self):
         self.view.rebin_steps_edit.insert('1,0.1,70')
@@ -141,7 +141,6 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         self.view.rebin_variable_edit.editingFinished.emit()
 
         self.assertEqual(self.view.rebin_variable_edit.text(), '')
-        self.assertEqual(self.model._data.gui_variables['RebinVariable'], '')
 
     def test_that_rebin_type_starts_as_none(self):
         self.assertEqual(self.model._data.gui_variables['RebinType'], 'None')
@@ -264,6 +263,47 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         self.view.warning_popup.assert_not_called()
         self.assertEqual(self.view.deadtime_file_selector.currentText(), 'dead_time_table_name')
         self.assertEqual(handle_table_changed_mock.call_count, 3)
+
+    def test_validate_variable_rebin_string_allows_single_number(self):
+        result, message = self.model.validate_variable_rebin_string('0.034')
+
+        self.assertTrue(result)
+
+    def test_validate_variable_rebin_string_does_not_allow_empty(self):
+        result, message = self.model.validate_variable_rebin_string('')
+
+        self.assertFalse(result)
+
+    def test_validate_variable_rebin_string_does_not_allow_non_numbers(self):
+        result, message = self.model.validate_variable_rebin_string('abc')
+
+        self.assertFalse(result)
+
+    def test_validate_variable_rebin_string_requires_second_number_of_two_to_be_greater(self):
+        result, message = self.model.validate_variable_rebin_string('4,2')
+
+        self.assertFalse(result)
+
+        result, message = self.model.validate_variable_rebin_string('2,4')
+
+        self.assertTrue(result)
+
+    def test_validate_variable_rebin_string_of_length_greater_than_three_must_have_bins_line_up(self):
+        result, messag = self.model.validate_variable_rebin_string('1,5,21')
+
+        self.assertTrue(result)
+
+        result, message = self.model.validate_variable_rebin_string('1,5,20')
+
+        self.assertFalse(result)
+
+        result, message = self.model.validate_variable_rebin_string('1,5,21,4')
+
+        self.assertFalse(result)
+
+        result, message = self.model.validate_variable_rebin_string('1,-5,19')
+
+        self.assertTrue(result)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/muon_data_context_test.py
+++ b/scripts/test/Muon/muon_data_context_test.py
@@ -1,0 +1,91 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import sys
+from Muon.GUI.Common.muon_load_data import MuonLoadData
+from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
+
+from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_model import HomeGroupingWidgetModel
+from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_presenter import HomeGroupingWidgetPresenter
+from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_view import HomeGroupingWidgetView
+from Muon.GUI.Common.muon_data_context import MuonDataContext
+from mantid.api import AnalysisDataService
+from Muon.GUI.Common import mock_widget
+import unittest
+from PyQt4 import QtGui
+from Muon.GUI.Common.observer_pattern import Observer
+from mantid.api import FileFinder
+from mantid import ConfigService
+import Muon.GUI.Common.utilities.load_utils as load_utils
+from Muon.GUI.Common.muon_pair import MuonPair
+
+
+if sys.version_info.major < 2:
+    from unittest import mock
+else:
+    import mock
+
+
+class MuonDataContextTest(unittest.TestCase):
+    def setUp(self):
+        self.loaded_data = MuonLoadData()
+        self.context = MuonDataContext(self.loaded_data)
+
+        filepath = FileFinder.findRuns('EMU00019489.nxs')[0]
+
+        load_result, run, filename = load_workspace_from_filename(filepath)
+
+        self.loaded_data.add_data(workspace=load_result, run=[run], filename=filename, instrument='EMU')
+        self.context.current_runs = [[run]]
+        self.context.update_current_data()
+
+    def tearDown(self):
+        AnalysisDataService.clear()
+
+    def test_that_setting_a_fixed_rebin_step_calculates_all_groups_and_pairs_twice(self):
+        self.context.gui_variables['RebinType'] = 'Fixed'
+        self.context.gui_variables['RebinFixed'] = '2'
+
+        self.context.show_all_groups()
+
+        expected_workspaces = ['EMU19489', 'EMU19489 Groups', 'EMU19489; Group; bwd; Asymmetry; #1', 'EMU19489; Group; bwd; Asymmetry; Rebin; #1',
+                               'EMU19489; Group; bwd; Counts; #1', 'EMU19489; Group; bwd; Counts; Rebin; #1', 'EMU19489; Group; fwd; Asymmetry; #1',
+                               'EMU19489; Group; fwd; Asymmetry; Rebin; #1', 'EMU19489; Group; fwd; Counts; #1', 'EMU19489; Group; fwd; Counts; Rebin; #1',
+                               'Muon Data']
+
+
+        self.assertEqual(AnalysisDataService.getObjectNames(), expected_workspaces)
+
+    def test_that_setting_no_rebinning_calculates_groups_and_pairs_once(self):
+        self.context.gui_variables['RebinType'] = 'None'
+        self.context.show_all_groups()
+
+        expected_workspaces = ['EMU19489', 'EMU19489 Groups',
+                               'EMU19489; Group; bwd; Asymmetry; #1',
+                               'EMU19489; Group; bwd; Counts; #1',
+                               'EMU19489; Group; fwd; Asymmetry; #1',
+                               'EMU19489; Group; fwd; Counts; #1',
+                               'Muon Data']
+
+        self.assertEqual(AnalysisDataService.getObjectNames(), expected_workspaces)
+
+    def test_that_setting_a_variable_rebin_step_calculates_all_groups_and_pairs_twice(self):
+        self.context.gui_variables['RebinType'] = 'Variable'
+        self.context.gui_variables['RebinVariable'] = '1,0.1,2'
+
+        self.context.show_all_groups()
+
+        expected_workspaces = ['EMU19489', 'EMU19489 Groups', 'EMU19489; Group; bwd; Asymmetry; #1', 'EMU19489; Group; bwd; Asymmetry; Rebin; #1',
+                               'EMU19489; Group; bwd; Counts; #1', 'EMU19489; Group; bwd; Counts; Rebin; #1', 'EMU19489; Group; fwd; Asymmetry; #1',
+                               'EMU19489; Group; fwd; Asymmetry; Rebin; #1', 'EMU19489; Group; fwd; Counts; #1', 'EMU19489; Group; fwd; Counts; Rebin; #1',
+                               'Muon Data']
+
+
+        self.assertEqual(AnalysisDataService.getObjectNames(), expected_workspaces)
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/muon_data_context_test.py
+++ b/scripts/test/Muon/muon_data_context_test.py
@@ -33,6 +33,7 @@ class MuonDataContextTest(unittest.TestCase):
     def setUp(self):
         self.loaded_data = MuonLoadData()
         self.context = MuonDataContext(self.loaded_data)
+        self.context.instrument = 'EMU'
 
         filepath = FileFinder.findRuns('EMU00019489.nxs')[0]
 


### PR DESCRIPTION
**Description of work.**

This adds in handling of the rebinning in the new Muon GUI so it matches that in the old GUI. The calculations are also updated so that when a rebinning is specified the groups and pairs are calculated for both the binned and unbinned input workspaces.

**Report to:** anthony <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Open the new Muon GUI change the binning and click update all. Check that the results match with the old GUI

<!-- Instructions for testing. -->

Fixes #24803 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
