### PR TITLE
Fix ISIS SANS in packaged Mantid

### DIFF
--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -29,8 +29,7 @@ list ( APPEND common_link_libs
   ${PYTHON_LIBRARIES}
 )
 
-# Wrapper module linked against Qt4 - not currently installed until required for backward compatability
-# with MantidPlot
+# Wrapper module linked against Qt4
 mtd_add_sip_module (
   MODULE_NAME _commonqt4
   TARGET_NAME mantidqt_commonqt4
@@ -50,6 +49,12 @@ mtd_add_sip_module (
     Qt4::Qscintilla
     ${Boost_LIBRARIES}
     API
+  INSTALL_DIR
+    ${WORKBENCH_LIB_DIR}/mantidqt
+  LINUX_INSTALL_RPATH
+    "\$ORIGIN/.."
+  OSX_INSTALL_RPATH
+    "@loader_path/.."
   FOLDER Qt4
 )
 

--- a/qt/python/mantidqt/widgets/jobtreeview/__init__.py
+++ b/qt/python/mantidqt/widgets/jobtreeview/__init__.py
@@ -11,9 +11,9 @@ from __future__ import (absolute_import)
 
 from mantidqt.utils.qt import import_qt
 
-Cell = import_qt('.._common', 'mantidqt.widgets.jobtreeview', 'Cell')
-JobTreeView = import_qt('.._common', 'mantidqt.widgets.jobtreeview', 'JobTreeView')
-JobTreeViewSignalAdapter = import_qt('.._common', 'mantidqt.widgets.jobtreeview', 'JobTreeViewSignalAdapter')
+Cell = import_qt('..._common', 'mantidqt.widgets.jobtreeview', 'Cell')
+JobTreeView = import_qt('..._common', 'mantidqt.widgets.jobtreeview', 'JobTreeView')
+JobTreeViewSignalAdapter = import_qt('..._common', 'mantidqt.widgets.jobtreeview', 'JobTreeViewSignalAdapter')
 
 # RowLocation must be accessed differently as it is wrapped in a SIP namespace class
-RowLocation = import_qt('.._common', 'mantidqt.widgets.jobtreeview').MantidQt.MantidWidgets.Batch.RowLocation
+RowLocation = import_qt('..._common', 'mantidqt.widgets.jobtreeview').MantidQt.MantidWidgets.Batch.RowLocation


### PR DESCRIPTION
**Description of work.**
Fixes the relative import paths for _commonqt5 .so file so that ISIS SANS can open in workbench
Actually generates the _commonqt4 .so so ISIS SANS can open in mantidplot 

**Report to:** nobody

**To test:**
Package this PR. Open up MantidPlot and Workbench. Then open up Interfaces -> SANS -> SANS v2 experimental. If the GUI has opened, this has worked.

Fixes #24827 

*This does not require release notes* because **fix to very recent bug - not seen by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
