### PR TITLE
Fix warning on MacOS.

### DIFF
--- a/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Framework/Kernel/test/ArrayPropertyTest.h
@@ -247,7 +247,7 @@ public:
   }
 
   void test_SetValueFromJson_Accepts_ArrayValues() {
-    const std::array<int, 3> testValues{1, 2, 3};
+    const std::array<int, 3> testValues{{1, 2, 3}};
     Json::Value arrayValue{Json::arrayValue};
     for (const auto &elem : testValues) {
       arrayValue.append(elem);


### PR DESCRIPTION
**Description of work.**

**Report to:** [@peterfpeterson]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

Fixes the following warning:

```
13:34:34 [772/1927] Building CXX object Framework/Kernel/test/CMakeFiles/KernelTest.dir/ArrayPropertyTest.cpp.o
13:34:34 In file included from Framework/Kernel/test/ArrayPropertyTest.cpp:17:
13:34:34 /Users/builder/Jenkins/workspace/master_incremental/label/osx-10.10-build/Framework/Kernel/test/ArrayPropertyTest.h:250:41: warning: suggest braces around initialization of subobject [-Wmissing-braces]
13:34:34     const std::array<int, 3> testValues{1, 2, 3};
13:34:34                                         ^~~~~~~
13:34:34                                         {      }
13:34:34 1 warning generated.
```

**To test:**

<!-- Instructions for testing. -->

* Code review
* Check MacOS build server

*There is no associated issue.*

*This does not require release notes* because recently added compiler warning

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
