### PR TITLE
Pack six.py from pip on macOS

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -364,6 +364,14 @@ directories.each do |directory|
   addPythonLibrary(module_dir,"Contents/MacOS/")
 end
 
+# we need to pack new version of six from pip
+six_file = "#{pip_site_packages}/six.py"
+if !File.exist?(six_file)
+  p "Failed to copy six from pip site-packages!"
+  exit 1
+end
+copyFile(six_file)
+
 # Some versions of mpltool_kits are missing their __init__ file
 mpltoolkit_init = "Contents/MacOS/mpl_toolkits/__init__.py"
 if !File.exist?(mpltoolkit_init)

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -409,7 +409,7 @@ h5py_patterns.each do |pattern|
   end
 end
 
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py", "six.py"]
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
 files.each do |file|
   copyFile("#{pip_site_packages}/#{file}")
 end

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -364,14 +364,6 @@ directories.each do |directory|
   addPythonLibrary(module_dir,"Contents/MacOS/")
 end
 
-# we need to pack new version of six from pip
-six_file = "#{pip_site_packages}/six.py"
-if !File.exist?(six_file)
-  p "Failed to copy six from pip site-packages!"
-  exit 1
-end
-copyFile(six_file)
-
 # Some versions of mpltool_kits are missing their __init__ file
 mpltoolkit_init = "Contents/MacOS/mpl_toolkits/__init__.py"
 if !File.exist?(mpltoolkit_init)
@@ -417,7 +409,7 @@ h5py_patterns.each do |pattern|
   end
 end
 
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py"]
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py", "six.py"]
 files.each do |file|
   copyFile("#{pip_site_packages}/#{file}")
 end

--- a/qt/applications/workbench/make_package.rb.in
+++ b/qt/applications/workbench/make_package.rb.in
@@ -346,7 +346,7 @@ h5py_patterns.each do |pattern|
   end
 end
 
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py"]
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","six.py"]
 files.each do |file|
   copyFile("#{pip_site_packages}/#{file}")
 end


### PR DESCRIPTION
**Description of work.**

Packs `six.py` with the macOS bundle. The one shipped from the system has a too old version, which causes some import to fail, and MantidPlot fail to start up.

**Report to:** [ILL]/[Bjorn]. 

**To test:**

Download the .dmg from the mac build artefacts. Install on a clean (i.e. that does not have the build time dependencies for mantid) macOS machine. Make sure MantidPlot starts up normally.

<!-- Instructions for testing. -->

Fixes #24816 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.