### PR TITLE
Remove incorrect Qt libs from macOS workbench/MantidPlot packages

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -166,17 +166,11 @@ add_custom_target( Framework DEPENDS ${FRAMEWORK_LIBS} )
 ###########################################################################
 
 # Create instrument directory
-if(APPLE)
-    set(_BUNDLES ${INBUNDLE} MantidWorkbench.app/)
-else()
-    set(_BUNDLES "./")
-endif()
-
-foreach ( _bundle ${_BUNDLES} )
+foreach ( _bundle ${BUNDLES} )
     install ( DIRECTORY ../instrument/ DESTINATION ${_bundle}instrument
         PATTERN "*UNIT_TESTING*" EXCLUDE
         PATTERN ".gitignore" EXCLUDE
-        )
+    )
     # Ships .py files but only ship compiled pyd files for supported platforms.
     if ( WIN32 ) # General windows environment
         if ( CMAKE_SIZEOF_VOID_P EQUAL 8 ) # Recommended way of detecting 64- vs 32-bit build

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -364,7 +364,7 @@ end
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
                "certifi","tornado","markupsafe","matplotlib","mpl_toolkits", "jinja2","jsonschema","functools32",
                "ptyprocess","CifFile","yaml","requests","networkx","PIL","dateutil","pytz",
-               "pywt","skimage"]
+               "skimage"]
 directories.each do |directory|
   module_dir = "#{pip_site_packages}/#{directory}"
   if !File.exist?(module_dir)

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -350,8 +350,17 @@ end
 
 #Copy over python libraries not included with OSX.
 #currently missing epics
+python_exe = `which python`
 system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
-pip_site_packages = "/Library/Python/2.7/site-packages"
+homebrew_pip_site_packages = "/usr/local/lib/python2.7/site-packages"
+if python_exe.start_with?("/usr/local")
+  pip_site_packages = homebrew_pip_site_packages
+elsif python_exe.start_with?("/usr/bin")
+  pip_site_packages = "/Library/Python/2.7/site-packages"
+else
+  p "Unknown python distribution at #{python_exe}"
+end
+
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
                "certifi","tornado","markupsafe","matplotlib","mpl_toolkits", "jinja2","jsonschema","functools32",
                "ptyprocess","CifFile","yaml","requests","networkx","PIL","dateutil","pytz",
@@ -375,6 +384,13 @@ if !File.exist?(mpltoolkit_init)
   `touch #{mpltoolkit_init}`
 end
 
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
+files.each do |file|
+  copyFile("#{pip_site_packages}/#{file}")
+end
+
+# mistune.so isn't present in v0.7
+copyOptionalFile("#{pip_site_packages}/mistune.so")
 
 if( "@MAKE_VATES@" == "ON" )
   addPythonLibrariesInDirectory("#{ParaView_dir}/lib/site-packages","Contents/Python/")
@@ -383,7 +399,7 @@ end
 # ---------------------------------------------
 # H5Py section
 # ---------------------------------------------
-h5py_path = "/usr/local/lib/python2.7/site-packages"
+h5py_path = homebrew_pip_site_packages
 h5py_directories = ["h5py"]
 h5py_directories.each do |directory|
   addPythonLibrary("#{h5py_path}/#{directory}","Contents/MacOS/")
@@ -412,14 +428,6 @@ h5py_patterns.each do |pattern|
     end
   end
 end
-
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
-files.each do |file|
-  copyFile("#{pip_site_packages}/#{file}")
-end
-
-# mistune.so isn't present in v0.7
-copyOptionalFile("#{pip_site_packages}/mistune.so")
 
 `mkdir Contents/MacOS/bin`
 `cp /usr/local/bin/ipython@PYTHON_VERSION_MAJOR@ Contents/MacOS/bin/`

--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -237,9 +237,13 @@ search_patterns.each do |pattern|
   end
 end
 
-#We'll use macdeployqt to fix qt dependencies.
+# We'll use macdeployqt to fix qt dependencies.
+# Remove the qt5 libraries in the mantidqt package
+#`rm Contents/MacOS/mantidqt/_commonqt5.so`
+#`rm Contents/MacOS/mantidqt/widgets/instrumentview/_instrumentviewqt5.so`
 Qt_Executables = "-executable=Contents/MacOS/mantidqtpython.so -executable=Contents/MacOS/libqwtplot3d.dylib -executable=Contents/MacOS/libqwt.dylib "
-Qt_Executables << "-executable=Contents/MacOS/#{findQScintilla2(lib_dir)}"
+Qt_Executables << "-executable=Contents/MacOS/#{findQScintilla2(lib_dir)} "
+Qt_Executables << "-executable=Contents/MacOS/mantidqt/_commonqt4.so "
 
 if( "@MAKE_VATES@" == "ON" )
   list = ["Contents/Libraries/vtkParaViewWebCorePython.so",

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -338,6 +338,14 @@ if ( CMAKE_COMPILER_IS_GNUCXX )
 endif()
 
 ###########################################################################
+# Bundles setting used for install commands if not set by something else
+# e.g. Darwin
+###########################################################################
+if ( NOT BUNDLES )
+  set ( BUNDLES "./" )
+endif()
+
+###########################################################################
 # Set a flag to indicate that this script has been called
 ###########################################################################
 

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -119,6 +119,7 @@ if ( ENABLE_MANTIDPLOT )
 set ( CMAKE_INSTALL_PREFIX "" )
 set ( CPACK_PACKAGE_EXECUTABLES MantidPlot )
 set ( INBUNDLE MantidPlot.app/ )
+set ( BUNDLES ${INBUNDLE} MantidWorkbench.app/)
 
 # Copy the launcher script to the correct location
 configure_file ( ${CMAKE_MODULE_PATH}/Packaging/osx/Mantid_osx_launcher.in

--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -92,5 +92,7 @@ file(WRITE ${_PyStoG_scripts_dir}/__init__.py
            ${_PyStoG_INIT_CONTENTS})
 
 # install the results
-install ( DIRECTORY ${_PyStoG_scripts_dir}
-          DESTINATION ${INBUNDLE}scripts )
+foreach ( _bundle ${BUNDLES} )
+  install ( DIRECTORY ${_PyStoG_scripts_dir}
+            DESTINATION ${_bundle}scripts )
+endforeach ()

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -63,7 +63,6 @@ CustomInstallLib = patch_setuptools_command('install_lib')
     DEPENDS ${_outputs}
   )
 
-
   if ( ${ENABLE_WORKBENCH} )
     # setuptools by default wants to build into a directory called 'build' relative the to the working directory. We have overridden
     # commands in setup.py.in to force the build directory to take place out of source. The install directory is specified here and then
@@ -88,6 +87,16 @@ CustomInstallLib = patch_setuptools_command('install_lib')
     install(DIRECTORY ${_package_source_directory}
             DESTINATION ${_package_install_destination}
             PATTERN "test" EXCLUDE )
+
+    if (APPLE AND "${pkg_name}" STREQUAL "mantidqt")
+      # Horrible hack to get mantidqt into the MantidPlot.app bundle too.
+      # Remove this when MantidPlot is removed!!
+      set ( _package_install_destination ${BIN_DIR} )
+      # Registers the "installed" components with CMake so it will carry them over
+      install(DIRECTORY ${_package_source_directory}
+              DESTINATION ${_package_install_destination}
+              PATTERN "test" EXCLUDE )
+    endif()
 
     # install the generated executable - only tested with "workbench"
     if ( ARGC GREATER 1 AND "${ARGN}" STREQUAL "EXECUTABLE" )

--- a/qt/applications/workbench/make_package.rb.in
+++ b/qt/applications/workbench/make_package.rb.in
@@ -302,7 +302,7 @@ end
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
                "certifi","tornado","markupsafe","matplotlib","mpl_toolkits", "jinja2","jsonschema","functools32",
                "ptyprocess","CifFile","yaml","requests","networkx","PIL","dateutil","pytz",
-               "pywt","skimage"]
+               "skimage"]
 directories.each do |directory|
   module_dir = "#{pip_site_packages}/#{directory}"
   if !File.exist?(module_dir)

--- a/qt/applications/workbench/make_package.rb.in
+++ b/qt/applications/workbench/make_package.rb.in
@@ -178,6 +178,7 @@ search_patterns.each do |pattern|
 end
 
 #We'll use macdeployqt to fix qt dependencies.
+# Remove the qt4 libraries in the mantidqt package
 Qt_Executables = "-executable=Contents/MacOS/#{File.basename(qscintilla2_lib)} "
 Qt_Executables << "-executable=Contents/MacOS/mantidqt/_commonqt5.so "
 Qt_Executables << "-executable=Contents/MacOS/mantidqt/widgets/instrumentview/_instrumentviewqt5.so "

--- a/qt/applications/workbench/make_package.rb.in
+++ b/qt/applications/workbench/make_package.rb.in
@@ -288,8 +288,17 @@ end
 
 #Copy over python libraries not included with OSX.
 #currently missing epics
+python_exe = `which python`
 system_python_extras = "/System/Library/Frameworks/Python.framework/Versions/2.7/Extras/lib/python"
-pip_site_packages = "/Library/Python/2.7/site-packages"
+homebrew_pip_site_packages = "/usr/local/lib/python2.7/site-packages"
+if python_exe.start_with?("/usr/local")
+  pip_site_packages = homebrew_pip_site_packages
+elsif python_exe.start_with?("/usr/bin")
+  pip_site_packages = "/Library/Python/2.7/site-packages"
+else
+  p "Unknown python distribution at #{python_exe}"
+end
+
 directories = ["sphinx","sphinx_bootstrap_theme","IPython","zmq","pygments","backports", "qtawesome", "qtpy",
                "certifi","tornado","markupsafe","matplotlib","mpl_toolkits", "jinja2","jsonschema","functools32",
                "ptyprocess","CifFile","yaml","requests","networkx","PIL","dateutil","pytz",
@@ -313,11 +322,18 @@ if !File.exist?(mpltoolkit_init)
   `touch #{mpltoolkit_init}`
 end
 
+files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
+files.each do |file|
+  copyFile("#{pip_site_packages}/#{file}")
+end
+
+# mistune.so isn't present in v0.7
+copyOptionalFile("#{pip_site_packages}/mistune.so")
 
 # ---------------------------------------------
 # H5Py section
 # ---------------------------------------------
-h5py_path = "/usr/local/lib/python2.7/site-packages"
+h5py_path = homebrew_pip_site_packages
 h5py_directories = ["h5py"]
 h5py_directories.each do |directory|
   addPythonLibrary("#{h5py_path}/#{directory}","Contents/MacOS/")
@@ -346,14 +362,6 @@ h5py_patterns.each do |pattern|
     end
   end
 end
-
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","six.py"]
-files.each do |file|
-  copyFile("#{pip_site_packages}/#{file}")
-end
-
-# mistune.so isn't present in v0.7
-copyOptionalFile("#{pip_site_packages}/mistune.so")
 
 `mkdir Contents/MacOS/bin`
 `cp /usr/local/bin/ipython@PYTHON_VERSION_MAJOR@ Contents/MacOS/bin/`

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -50,7 +50,7 @@ mtd_add_sip_module (
     ${Boost_LIBRARIES}
     API
   INSTALL_DIR
-    ${WORKBENCH_LIB_DIR}/mantidqt
+    ${LIB_DIR}/mantidqt
   LINUX_INSTALL_RPATH
     "\$ORIGIN/.."
   OSX_INSTALL_RPATH
@@ -79,7 +79,7 @@ mtd_add_sip_module (
     MantidQtWidgetsCommonQt5
     Qt5::Core
     Qt5::Gui
-Qt5::Widgets
+    Qt5::Widgets
     Qt5::Qscintilla
     ${Boost_LIBRARIES}
     API

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -30,6 +30,8 @@ endif()
 set ( MSLICE_DEV ${_mslice_external_root}/src/mslice PARENT_SCOPE )
 
 # Installation
-# MSLICE_DEV is only set in PARENT_SCOPE!
-install ( DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
-          DESTINATION ${INBUNDLE}scripts/ExternalInterfaces/mslice )
+# MSLICE_DEV is only set in PARENT_SCOPE! so don't use it here
+foreach ( _bundle ${BUNDLES} )
+  install ( DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
+            DESTINATION ${_bundle}scripts/ExternalInterfaces/mslice )
+endforeach()


### PR DESCRIPTION
**Description of work.**

Removes the `_commonqt4`  library from the workbench package and the `_commonqt5` package from MantidPlot to ensure each only depend on Qt4 or Qt5.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

Fixes #24817

**To test:**

Install the package built by the builders.

*There is no associated issue.*

*This does not require release notes* because **packaging has been broekn this cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
