### PR TITLE
Prevent __future__ imports being inherited by the CodeEditor execute environment

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -9,18 +9,15 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 
-# std imports
 import ctypes
 import inspect
 import time
 
-# 3rdparty imports
 from qtpy.QtCore import QObject, Signal
 from six import PY2, iteritems
 
-# local imports
-from mantidqt.widgets.codeeditor.inputsplitter import InputSplitter
 from mantidqt.utils.asynchronous import AsyncTask
+from mantidqt.widgets.codeeditor.inputsplitter import InputSplitter
 
 if PY2:
     from inspect import getargspec as getfullargspec
@@ -151,14 +148,14 @@ class PythonCodeExecution(QObject):
         :raises: Any error that the code generates
         """
         filename = '<string>' if filename is None else filename
-        compile(code_str, filename, mode='exec')
+        compile(code_str, filename, mode='exec', dont_inherit=True)
 
         sig_progress = self.sig_exec_progress
         for block in code_blocks(code_str):
             sig_progress.emit(block.lineno)
             # compile so we can set the filename
-            code_obj = compile(block.code_str, filename, mode='exec')
-            exec(code_obj, self.globals_ns, self.globals_ns)
+            code_obj = compile(block.code_str, filename, mode='exec', dont_inherit=True)
+            exec (code_obj, self.globals_ns, self.globals_ns)
 
     def generate_calltips(self):
         """
@@ -230,4 +227,4 @@ def code_blocks(code_str):
             # consistent each executed block needs to have the statements
             # on the same line as they are in the real code so we prepend
             # blank lines to make this so
-            isp.push('\n'*lineno_cur)
+            isp.push('\n' * lineno_cur)


### PR DESCRIPTION
**Description of work.**
Adds the `dont_inherit` flag to `compile` which specifies to _not_ inherit any `__future__` imports from the calling environment.

This fixes an issue preventing ProjectRecovery to execute the generated `ordered_recovery.py`.

**To test:**
- Run `print(type("\ua"))`.
- It should show error: "SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 0-2: truncated \uXXXX escape"
- Remove `unicode_literals` from `__future__` import
- Run again, it should run without an error and show: `<type 'str'>`

Fixes #24819

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
