### PR TITLE
Set __file__ attribute in workbench script execution

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -72,6 +72,18 @@ class PythonCodeExecutionTest(GuiTest):
         user_globals = self._verify_async_execution_successful(code)
         self.assertEqual(100, user_globals['_local'])
 
+    def test_filename_sets__file__attr(self):
+        executor = PythonCodeExecution()
+        test_filename = 'script.py'
+        executor.execute('x=1', filename=test_filename)
+        self.assertTrue('__file__' in executor.globals_ns)
+        self.assertEqual(test_filename, executor.globals_ns['__file__'])
+
+    def test_empty_filename_does_not_set__file__attr(self):
+        executor = PythonCodeExecution()
+        executor.execute('x=1')
+        self.assertTrue('__file__' not in executor.globals_ns)
+
     def test_execute_async_calls_success_signal_on_completion(self):
         code = "x=1+2"
         executor, recv = self._run_async_code(code)


### PR DESCRIPTION
**Description of work.**

The vanilla Python interpreter sets the `__file__` attribute when files are executed, as does MantidPlot. This behaviour is now replicated in the workbench script editor.

**Report to:** [nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Open workbench with default content and add `print(__file__)`. Executing this should give a `RuntimeError`. Save the file and then rerun the code. It should now print the `__file__` attribute value as the path to the file.

Fixes #24753 

*This does not require release notes* because **the workbench is not yet released.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
