### PR TITLE
Workbench: Ship styles/qtwindowsvistastyle.dll for Windows Vista Style

### DIFF
--- a/buildconfig/CMake/WindowsNSISQt5.cmake
+++ b/buildconfig/CMake/WindowsNSISQt5.cmake
@@ -26,4 +26,6 @@ endforeach()
 
 install ( FILES ${QT5_PLUGIN_DIR}/platforms/qwindows.dll DESTINATION plugins/qt5/platforms )
 install ( FILES ${QT5_PLUGIN_DIR}/sqldrivers/qsqlite.dll DESTINATION plugins/qt5/sqldrivers )
+install ( FILES ${QT5_PLUGIN_DIR}/styles/qwindowsvistastyle.dll DESTINATION plugins/qt5/styles )
+
 install ( FILES ${QT5_INSTALL_PREFIX}/lib/qscintilla2_qt5.dll DESTINATION bin )


### PR DESCRIPTION
**Description of work.**
Adds `styles/qtwindowsvistastyle.dll` to DLLs shipped on Windows. This fixes the Workbench defaulting to "Windows" theme instead of "Windows Vista"

**To test:**
Build package, it should contain & install `qt5\plugins\styles\qwindowsvistastyle.dll` into `plugins\qt5\styles\qwindowsvistastyle.dll`

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
