### PR TITLE
Workbench: Saving a workspace now correctly selects the workspace that was clicked

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -215,8 +215,8 @@ set ( QT5_INC_FILES
   inc/MantidQtWidgets/Common/Batch/BuildSubtreeItems.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/ADSAdapter.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
-  inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/ViewNotifiable.h
+  inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspacePresenter.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceProvider.h
   inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceProviderNotifiable.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
@@ -9,10 +9,10 @@
 
 #include <MantidAPI/IAlgorithm_fwd.h>
 #include <MantidAPI/Workspace_fwd.h>
+#include <QString>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <map>
-
 namespace MantidQt {
 namespace MantidWidgets {
 
@@ -57,7 +57,8 @@ public:
   virtual void sortWorkspaces(SortCriteria criteria,
                               SortDirection direction) = 0;
   virtual SaveFileType getSaveFileType() const = 0;
-  virtual void saveWorkspace(SaveFileType type) = 0;
+  virtual void saveWorkspace(const std::string &wsName,
+                             const SaveFileType type) = 0;
   virtual void saveWorkspaces(const StringList &wsNames) = 0;
   virtual std::string getFilterText() const = 0;
   virtual void filterWorkspaces(const std::string &filterText) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/IWorkspaceDockView.h
@@ -9,7 +9,6 @@
 
 #include <MantidAPI/IAlgorithm_fwd.h>
 #include <MantidAPI/Workspace_fwd.h>
-#include <QString>
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <map>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceDockMockObjects.h
@@ -51,7 +51,8 @@ public:
                void(IWorkspaceDockView::SortCriteria criteria,
                     IWorkspaceDockView::SortDirection direction));
   MOCK_CONST_METHOD0(getSaveFileType, SaveFileType());
-  MOCK_METHOD1(saveWorkspace, void(SaveFileType type));
+  MOCK_METHOD2(saveWorkspace,
+               void(const std::string &wsName, SaveFileType type));
   MOCK_METHOD1(saveWorkspaces, void(const StringList &wsNames));
   MOCK_METHOD1(
       updateTree,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -98,7 +98,7 @@ public:
   void clearView() override;
   std::string getFilterText() const override;
   SaveFileType getSaveFileType() const override;
-  void saveWorkspace(SaveFileType type) override;
+  void saveWorkspace(const std::string &wsName, SaveFileType type) override;
   void
   saveWorkspaces(const MantidQt::MantidWidgets::StringList &wsNames) override;
   void filterWorkspaces(const std::string &filterText) override;

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspacePresenter.cpp
@@ -264,7 +264,8 @@ void WorkspacePresenter::deleteWorkspaces() {
 }
 
 void WorkspacePresenter::saveSingleWorkspace() {
-  m_view->saveWorkspace(m_view->getSaveFileType());
+  m_view->saveWorkspace(m_view->getSelectedWorkspace()->getName(),
+                        m_view->getSaveFileType());
 }
 
 void WorkspacePresenter::saveWorkspaceCollection() {

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -420,7 +420,12 @@ WorkspaceTreeWidget::SaveFileType WorkspaceTreeWidget::getSaveFileType() const {
   return m_saveFileType;
 }
 
-void WorkspaceTreeWidget::saveWorkspace(SaveFileType type) {
+void WorkspaceTreeWidget::saveWorkspace(const std::string &wsName,
+                                        const SaveFileType type) {
+  QHash<QString, QString> presets;
+  if (!wsName.empty()) {
+    presets["InputWorkspace"] = QString::fromStdString(wsName);
+  }
   int version = -1;
   std::string algorithmName;
 
@@ -436,7 +441,7 @@ void WorkspaceTreeWidget::saveWorkspace(SaveFileType type) {
   }
 
   m_mantidDisplayModel->showAlgorithmDialog(
-      QString::fromStdString(algorithmName), version);
+      QString::fromStdString(algorithmName), presets, nullptr, version);
 }
 
 void WorkspaceTreeWidget::saveWorkspaces(const StringList &wsNames) {

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -421,7 +421,7 @@ WorkspaceTreeWidget::SaveFileType WorkspaceTreeWidget::getSaveFileType() const {
 }
 
 void WorkspaceTreeWidget::saveWorkspace(const std::string &wsName,
-                                        const SaveFileType type) {
+                                        SaveFileType type) {
   QHash<QString, QString> presets;
   if (!wsName.empty()) {
     presets["InputWorkspace"] = QString::fromStdString(wsName);

--- a/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
+++ b/qt/widgets/common/test/WorkspacePresenter/WorkspacePresenterTest.h
@@ -445,8 +445,12 @@ public:
     using SaveFileType = IWorkspaceDockView::SaveFileType;
     ::testing::DefaultValue<SaveFileType>::Set(SaveFileType::Nexus);
 
+    auto ws1 = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+
+    EXPECT_CALL(*mockView.get(), getSelectedWorkspace()).WillOnce(Return(ws1));
     EXPECT_CALL(*mockView.get(), getSaveFileType()).Times(Exactly(1));
-    EXPECT_CALL(*mockView.get(), saveWorkspace(SaveFileType::Nexus))
+    EXPECT_CALL(*mockView.get(),
+                saveWorkspace(ws1->getName(), SaveFileType::Nexus))
         .Times(Exactly(1));
 
     presenter->notifyFromView(ViewNotifiable::Flag::SaveSingleWorkspace);
@@ -457,9 +461,12 @@ public:
   void testSaveSingleWorkspaceASCIIv1() {
     using SaveFileType = IWorkspaceDockView::SaveFileType;
     ::testing::DefaultValue<SaveFileType>::Set(SaveFileType::ASCIIv1);
+    auto ws1 = WorkspaceCreationHelper::create2DWorkspace(10, 10);
 
+    EXPECT_CALL(*mockView.get(), getSelectedWorkspace()).WillOnce(Return(ws1));
     EXPECT_CALL(*mockView.get(), getSaveFileType()).Times(Exactly(1));
-    EXPECT_CALL(*mockView.get(), saveWorkspace(SaveFileType::ASCIIv1))
+    EXPECT_CALL(*mockView.get(),
+                saveWorkspace(ws1->getName(), SaveFileType::ASCIIv1))
         .Times(Exactly(1));
 
     presenter->notifyFromView(ViewNotifiable::Flag::SaveSingleWorkspace);
@@ -471,8 +478,12 @@ public:
     using SaveFileType = IWorkspaceDockView::SaveFileType;
     ::testing::DefaultValue<SaveFileType>::Set(SaveFileType::ASCII);
 
+    auto ws1 = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+
+    EXPECT_CALL(*mockView.get(), getSelectedWorkspace()).WillOnce(Return(ws1));
     EXPECT_CALL(*mockView.get(), getSaveFileType()).Times(Exactly(1));
-    EXPECT_CALL(*mockView.get(), saveWorkspace(SaveFileType::ASCII))
+    EXPECT_CALL(*mockView.get(),
+                saveWorkspace(ws1->getName(), SaveFileType::ASCII))
         .Times(Exactly(1));
 
     presenter->notifyFromView(ViewNotifiable::Flag::SaveSingleWorkspace);


### PR DESCRIPTION
**Description of work.**
Passes in the name to the Algorithm Dialog so that the clicked workspace is selected when being saved. This should make the clicked workspace be selected for saving when Save Nexus is clicked.

**To test:**
- Open multiple workspaces.
- Right click > Save Nexus on different ones
- The clicked workspace should be selected for saving in the dialog.

Fixes #24750

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
