### PR TITLE
Load current run in muon GUIs

### DIFF
--- a/docs/source/release/v3.14.0/muon.rst
+++ b/docs/source/release/v3.14.0/muon.rst
@@ -22,6 +22,7 @@ Bugfixes
 - When turning TF Asymmetry mode off it no longer resets the global options.
 - Results table will produce correct values for co-added runs.
 - The x limits on the settings tab will now correct themselves if bad values are entered. 
+- The `load current run` button now works for CHRONUS in muon analysis.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -749,7 +749,7 @@ void MuonAnalysis::runLoadCurrent() {
 
   if (instname == "EMU" || instname == "HIFI" || instname == "MUSR" ||
       instname == "CHRONUS" || instname == "ARGUS") {
-    const QString instDirectory = instname == "CHRONUS" ? "NDW1030" : instname;
+    const QString instDirectory = instname;
     std::string autosavePointsTo = "";
     const std::string autosaveFile =
         "\\\\" + instDirectory.toStdString() + "\\data\\autosave.run";

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -89,7 +89,7 @@ class GroupingTablePresenter(object):
     def add_group_to_view(self, group):
         self._view.disable_updates()
         assert isinstance(group, MuonGroup)
-        entry = [str(group.name), ",".join(str(det) for det in group.detectors), str(group.n_detectors)]
+        entry = [str(group.name), run_utils.run_list_to_string(group.detectors,False), str(group.n_detectors)]
         self._view.add_entry_to_table(entry)
         self._view.enable_updates()
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -58,7 +58,7 @@ class GroupingTablePresenter(object):
         return True
 
     def validate_detector_ids(self, text):
-        if re.match(run_utils.run_string_regex, text) and max(run_utils.run_string_to_list(text)) <= self._model._data.num_detectors:
+        if re.match(run_utils.run_string_regex, text) and max(run_utils.run_string_to_list(text, False)) <= self._model._data.num_detectors:
             return True
         self._view.warning_popup("Invalid detector list.")
         return False
@@ -89,7 +89,7 @@ class GroupingTablePresenter(object):
     def add_group_to_view(self, group):
         self._view.disable_updates()
         assert isinstance(group, MuonGroup)
-        entry = [str(group.name), run_utils.run_list_to_string(group.detectors), str(group.n_detectors)]
+        entry = [str(group.name), ",".join(str(det) for det in group.detectors), str(group.n_detectors)]
         self._view.add_entry_to_table(entry)
         self._view.enable_updates()
 
@@ -137,7 +137,7 @@ class GroupingTablePresenter(object):
         table = self._view.get_table_contents()
         self._model.clear_groups()
         for entry in table:
-            detector_list = run_utils.run_string_to_list(str(entry[1]))
+            detector_list = run_utils.run_string_to_list(str(entry[1]),False)
             group = MuonGroup(group_name=str(entry[0]), detector_ids=detector_list)
             self._model.add_group(group)
 

--- a/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import os
 
-allowed_instruments = ["EMU", "MUSR", "CHRONUS", "HIFI"]
+allowed_instruments = ["EMU", "MUSR", "CHRONUS", "HIFI", "ARGUS"]
 allowed_extensions = ["nxs"]
 FILE_SEP = os.sep
 
@@ -26,8 +26,6 @@ def get_instrument_directory(instrument):
     """
     if instrument in allowed_instruments:
         instrument_directory = instrument
-        if instrument == "CHRONUS":
-            instrument_directory = "NDW1030"
         return instrument_directory
     else:
         raise RuntimeError('Instrument {} not in list of allowed instruments'.format(instrument))

--- a/scripts/Muon/GUI/Common/utilities/run_string_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/run_string_utils.py
@@ -37,7 +37,7 @@ def lambda_tuple_unpacking(lam):
     return f_inner
 
 
-def run_list_to_string(run_list):
+def run_list_to_string(run_list, max_value = True):
     """
     Converts a list of runs into a formatted string using a delimiter/range separator
     :param run_list: list of integers
@@ -48,7 +48,7 @@ def run_list_to_string(run_list):
     run_list = _remove_duplicates_from_list(run_list)
     run_list = [i for i in run_list if i >= 0]
     run_list.sort()
-    if len(run_list) > max_run_list_size:
+    if max_value and len(run_list) > max_run_list_size:
         raise IndexError("Too many runs ({}) must be <{}".format(len(run_list), max_run_list_size))
 
     range_list = []

--- a/scripts/Muon/GUI/Common/utilities/run_string_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/run_string_utils.py
@@ -76,11 +76,12 @@ def validate_run_string(run_string):
     return False
 
 
-def run_string_to_list(run_string):
+def run_string_to_list(run_string, max_value = True):
     """
     Does the opposite of run_list_to_string(), taking a string representation of a series of runs
     and producing an ordered list of unique runs. Calls validate_run_string().
     :param run_string: string, a series of runs
+    :max_value: if to use the max number of runs
     :return: list of integers
     """
     if not validate_run_string(run_string):
@@ -103,7 +104,7 @@ def run_string_to_list(run_string):
 
             range_max = int(range_max)
             range_min = int(range_min)
-            if (range_max - range_min) > max_run_list_size:
+            if max_value and (range_max - range_min) > max_run_list_size:
                 raise IndexError(
                     "Too many runs ({}) must be <{}".format(range_max - range_min, max_run_list_size))
             else:


### PR DESCRIPTION
The load current run option did not work in Muon Analysis for the CHRONUS instrument. This PR fixes that, in addition it adds the CHRONUS and ARGUS instruments to the new muon GUI.

**To test:**
- Go to https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template#L23 and add `Muon/Muon_Analysis_2.py` to the list of interfaces
- Compile the code
- Open Muon Analysis and change the instrument to `CHRONUS`
- Click load current run and some data will be loaded
- Close Muon Analysis

- Open Muon Analysis 2
- Change the instrument to `CHRONUS` and click load current run
- In the ADS some new data will be added
- Change the instrument to `ARGUS` and click load current run
- In the ADS some new data will be added


<!-- Instructions for testing. -->

Fixes #24837. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
