### PR TITLE
SANS GUI user preferences and tooltips

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -22,12 +22,12 @@ Improved
 * Added shortcut keys to delete or add rows.
 * Added tabbing support to table.
 * Added error notifications on a row by row basis.
-* Updated file adding to prefix the instrument name
-* Updated file finding to be able to find added runs without instrument name prefix
+* Updated file adding to prefix the instrument name.
+* Updated file finding to be able to find added runs without instrument name prefix.
 * Updated GUI code so calculated merge scale and shift are shown after reduction.
 * Removed instrument selection box. Instrument is now determined by user file.
-* Automatically remembers last loaded user file
-* Added display of current save directory
+* Automatically remembers last loaded user file.
+* Added display of current save directory.
 * Added a "process all" and "process selected" button to the batch table in place of "process" button.
 * Added a load button to load selected workspaces without processing.
 * Added save_can option to output unsubtracted can and sample workspaces.
@@ -37,16 +37,18 @@ Improved
 * Autocomplete for Sample shape column in the table.
 * Can separate items in variable q binning with commas or spaces. E.g. L/Q 0.0, 0.02 0.3 0.05, 0.8
 * Can export table as a csv, which can be re-loaded as a batch file.
-* File path to batch file will be added to your directories automatically upon loading
+* File path to batch file will be added to your directories automatically upon loading.
 * If loading of user file fails, user file field will remain empty to make it clear it has not be loaded successfully.
 * Workspaces are centred upon loading.
 * All limit strings in the user file (L/ ) are now space-separable to allow for uniform structure in the user file. For backwards compatibility, any string which was comma separable remains comma separable as well.
 * Added a sum runs directory selection button. This is separate from default save directory and only determines where summed runs are saved.
+* The gui will remember which output mode (Memory, File, Both) you last used and set that as your default when on the SANS interface.
+* Default adding mode is set to Event for all instruments except for LOQ, which defaults to Custom.
 
 Bug fixes
 #########
 * Fixed an issue where the run tab was difficult to select.
-* Changed the geometry names from CylinderAxisUP, Cuboid and CylinderAxisAlong to Cylinder, FlatPlate and Disc
+* Changed the geometry names from CylinderAxisUP, Cuboid and CylinderAxisAlong to Cylinder, FlatPlate and Disc.
 * The GUI now correctly resets to default values when a new user file is loaded.
 * The GUI no longer hangs whilst searching the archive for files.
 * Updated the options and units displayed in wavelength and momentum range combo boxes.

--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -43,6 +43,7 @@ Improved
 * All limit strings in the user file (L/ ) are now space-separable to allow for uniform structure in the user file. For backwards compatibility, any string which was comma separable remains comma separable as well.
 * Added a sum runs directory selection button. This is separate from default save directory and only determines where summed runs are saved.
 * The gui will remember which output mode (Memory, File, Both) you last used and set that as your default when on the SANS interface.
+* The gui will check *save can* by default if it was checked when the gui was last used.
 * Default adding mode is set to Event for all instruments except for LOQ, which defaults to Custom.
 
 Bug fixes

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -197,6 +197,7 @@ class SANSDataProcessorGui(QMainWindow,
         self.__user_file_key = "user_file"
         self.__mask_file_input_path_key = "mask_files"
         self.__output_mode_key = "output_mode"
+        self.__save_can_key = "save_can"
 
         # Logger
         self.gui_logger = Logger("SANS GUI LOGGER")
@@ -225,6 +226,8 @@ class SANSDataProcessorGui(QMainWindow,
         self.delete_row_button.clicked.connect(self._remove_rows_requested_from_button)
         self.insert_row_button.clicked.connect(self._on_insert_button_pressed)
         self.save_other_pushButton.clicked.connect(self._on_save_other_button_pressed)
+
+        self.save_can_checkBox.clicked.connect(self._on_save_can_clicked)
 
         # Attach validators
         self._attach_validators()
@@ -538,6 +541,10 @@ class SANSDataProcessorGui(QMainWindow,
             output_mode = None
         set_setting(self.__generic_settings, self.__output_mode_key, output_mode)
 
+    def _on_save_can_clicked(self, value):
+        self.save_can_checkBox.setChecked(value)
+        set_setting(self.__generic_settings, self.__save_can_key, value)
+
     def _on_user_file_load(self):
         """
         Load the user file
@@ -580,6 +587,14 @@ class SANSDataProcessorGui(QMainWindow,
             self.output_mode_file_radio_button.setChecked(True)
         elif value is OutputMode.Both:
             self.output_mode_both_radio_button.setChecked(True)
+
+    def set_out_default_save_can(self):
+        try:
+            default_save_can = load_property(self.__generic_settings, self.__save_can_key, type=bool)
+        except RuntimeError:
+            pass
+        else:
+            self._on_save_can_clicked(default_save_can)
 
     def _on_batch_file_load(self):
         """
@@ -954,7 +969,7 @@ class SANSDataProcessorGui(QMainWindow,
 
     @save_can.setter
     def save_can(self, value):
-        self.save_can_checkBox.setChecked(value)
+        self._on_save_can_clicked.setChecked(value)
 
     @property
     def progress_bar_minimum(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -73,8 +73,12 @@ class RunSelectorPresenterFactory(object):
                                     parent_view)
 
 
-def _make_run_summation_settings_presenter(summation_settings_view, parent_view):
-    summation_settings = SummationSettings(BinningType.Custom)
+def _make_run_summation_settings_presenter(summation_settings_view, parent_view, instrument):
+    if instrument != "LOQ":
+        binning_type = BinningType.SaveAsEventData
+    else:
+        binning_type = BinningType.Custom
+    summation_settings = SummationSettings(binning_type)
     summation_settings.bin_settings = DEFAULT_BIN_SETTINGS
     return SummationSettingsPresenter(summation_settings,
                                       summation_settings_view,

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -632,7 +632,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>2</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -156,6 +156,9 @@ QGroupBox::title {
               </item>
               <item row="0" column="6">
                <widget class="QPushButton" name="manage_directories_button">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add directories to search for data, set your output directory, and manage data archvie searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="text">
                  <string>Manage Directories</string>
                 </property>
@@ -271,7 +274,7 @@ QGroupBox::title {
               <item>
                <widget class="QToolButton" name="delete_row_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;delete selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delete selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -294,7 +297,7 @@ QGroupBox::title {
               <item>
                <widget class="QToolButton" name="copy_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;copy selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Copy selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -310,7 +313,7 @@ QGroupBox::title {
               <item>
                <widget class="QToolButton" name="cut_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;cut selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Cut selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -326,7 +329,7 @@ QGroupBox::title {
               <item>
                <widget class="QToolButton" name="paste_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;paste rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Paste rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -342,7 +345,7 @@ QGroupBox::title {
               <item>
                <widget class="QToolButton" name="erase_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;erase contents of selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Erase contents of selected rows&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>...</string>
@@ -485,6 +488,9 @@ QGroupBox::title {
                      </item>
                      <item>
                       <widget class="QCheckBox" name="save_can_checkBox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, save the unsubtracted Can and Sam workspaces separately.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>Save Can</string>
                        </property>
@@ -564,7 +570,7 @@ QGroupBox::title {
                         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When enabled it will replace all entries with zero-valued errors with errors of magnitude 1e6. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                        </property>
                        <property name="text">
-                        <string>zero error free</string>
+                        <string>Zero Error Free</string>
                        </property>
                        <property name="checked">
                         <bool>true</bool>
@@ -573,6 +579,9 @@ QGroupBox::title {
                      </item>
                      <item row="2" column="0">
                       <widget class="QCheckBox" name="plot_results_checkbox">
+                       <property name="toolTip">
+                        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, the 0th spectrum of each reduced workspace will be plotted as it is reduced.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                       </property>
                        <property name="text">
                         <string>Plot Results</string>
                        </property>
@@ -623,7 +632,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>2</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">
@@ -1037,7 +1046,7 @@ QGroupBox::title {
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="title">
-                     <string>Monitor Normalization</string>
+                     <string>Monitor Scattering</string>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_8">
                      <item row="0" column="0">
@@ -1513,7 +1522,7 @@ QGroupBox::title {
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The wavelength adjustment files.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="title">
-                     <string>Wavelength adjustment files</string>
+                     <string>Wavelength efficiency files</string>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_11">
                      <item row="0" column="1">

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -1046,7 +1046,7 @@ QGroupBox::title {
                      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Settings for the monitor normalization.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                     <property name="title">
-                     <string>Monitor Scattering</string>
+                     <string>Scattering</string>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_8">
                      <item row="0" column="0">

--- a/scripts/Interface/ui/sans_isis/summation_settings_widget.py
+++ b/scripts/Interface/ui/sans_isis/summation_settings_widget.py
@@ -74,6 +74,7 @@ class SummationSettingsWidget(QtWidgets.QWidget, Ui_SummationSettingsWidget):
         self.preserveEventsChanged.emit(state != 0)
 
     def draw_settings(self, settings):
+        self._draw_binning_type(settings)
         self._draw_bin_settings(settings)
         self._draw_additional_time_shifts(settings)
         self._draw_overlay_event_workspaces(settings)
@@ -94,6 +95,11 @@ class SummationSettingsWidget(QtWidgets.QWidget, Ui_SummationSettingsWidget):
             set_checked_without_signal(
                 self.overlayEventWorkspacesCheckbox, False)
             self.overlayEventWorkspacesCheckbox.setVisible(False)
+
+    def _draw_binning_type(self, settings):
+        index = settings.get_index_from_type()
+        if index:
+            self.binningType.setCurrentIndex(index)
 
     def _draw_bin_settings(self, settings):
         if settings.has_bin_settings():

--- a/scripts/Interface/ui/sans_isis/summation_settings_widget.py
+++ b/scripts/Interface/ui/sans_isis/summation_settings_widget.py
@@ -59,6 +59,15 @@ class SummationSettingsWidget(QtWidgets.QWidget, Ui_SummationSettingsWidget):
         elif index == 2:
             return BinningType.SaveAsEventData
 
+    @staticmethod
+    def _binning_type_to_index(bin_type):
+        if bin_type == BinningType.Custom:
+            return 0
+        elif bin_type == BinningType.FromMonitors:
+            return 1
+        elif bin_type == BinningType.SaveAsEventData:
+            return 2
+
     def _handle_binning_type_changed(self, index):
         binning_type = self._binning_type_index_to_type(index)
         self.binningTypeChanged.emit(binning_type)
@@ -97,8 +106,8 @@ class SummationSettingsWidget(QtWidgets.QWidget, Ui_SummationSettingsWidget):
             self.overlayEventWorkspacesCheckbox.setVisible(False)
 
     def _draw_binning_type(self, settings):
-        index = settings.get_index_from_type()
-        if index:
+        index = self._binning_type_to_index(settings.type)
+        if index is not None:
             self.binningType.setCurrentIndex(index)
 
     def _draw_bin_settings(self, settings):

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -200,10 +200,11 @@ def load_default_file(line_edit_field, q_settings_group_key, q_settings_key):
     line_edit_field.setText(default_file)
 
 
-def load_property(q_settings_group_key, q_settings_key):
+def load_property(q_settings_group_key, q_settings_key, type=str):
     settings = QSettings()
     settings.beginGroup(q_settings_group_key)
-    default_property = settings.value(q_settings_key, "", type=str)
+    default = False if type == bool else ""
+    default_property = settings.value(q_settings_key, default, type=type)
     settings.endGroup()
 
     return default_property

--- a/scripts/SANS/sans/gui_logic/models/summation_settings.py
+++ b/scripts/SANS/sans/gui_logic/models/summation_settings.py
@@ -113,6 +113,10 @@ class SummationSettings(object):
         return isinstance(self._settings, SaveAsEventData)
 
     @property
+    def type(self):
+        return self._type
+
+    @property
     def additional_time_shifts(self):
         return self._settings.additional_time_shifts
 
@@ -136,14 +140,6 @@ class SummationSettings(object):
     @bin_settings.setter
     def bin_settings(self, bin_settings):
         self._settings.bin_settings = bin_settings
-
-    def get_index_from_type(self):
-        if self._type == BinningType.Custom:
-            return 0
-        elif self._type == BinningType.FromMonitors:
-            return 1
-        elif self._type == BinningType.SaveAsEventData:
-            return 2
 
     def _settings_from_type(self, type):
         try:

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -10,7 +10,6 @@ from mantid.kernel import ConfigService, ConfigPropertyObserver
 
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.gui_common import GENERIC_SETTINGS, load_property, set_setting
-#from sans.gui_logic.models.run_selection import has_any_event_data
 
 
 class OutputDirectoryObserver(ConfigPropertyObserver):
@@ -127,17 +126,6 @@ class AddRunsPagePresenter(object):
             self._view.set_out_file_name(self._generated_output_file_name)
 
     def _update_histogram_binning(self, run_selection):
-        """
-        if has_any_event_data(run_selection):
-            self._view.enable_summation_settings()
-        else:
-            self._view.disable_summation_settings()
-        """
-        # Previously we have only enabled the summation settings
-        # if runs contain event data.
-        # We are now setting the summation settings
-        # to enabled by default while we confirm if this
-        # is behaviour the users want
         self._view.enable_summation_settings()
 
     def _handle_selection_changed(self, run_selection):

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -81,7 +81,7 @@ class AddRunsPagePresenter(object):
                                         self._handle_selection_changed, view)
         self._summation_settings_presenter = \
             make_run_summation_presenter(view.summation_settings_view(),
-                                         view)
+                                         view, ConfigService.Instance().getString("default.instrument"))
 
         self._connect_to_view(view)
 

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -127,10 +127,18 @@ class AddRunsPagePresenter(object):
             self._view.set_out_file_name(self._generated_output_file_name)
 
     def _update_histogram_binning(self, run_selection):
+        """
         if has_any_event_data(run_selection):
             self._view.enable_summation_settings()
         else:
             self._view.disable_summation_settings()
+        """
+        # Previously we have only enabled the summation settings
+        # if runs contain event data.
+        # We are now setting the summation settings
+        # to enabled by default while we confirm if this
+        # is behaviour the users want
+        self._view.enable_summation_settings()
 
     def _handle_selection_changed(self, run_selection):
         self._refresh_view(run_selection)

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -10,7 +10,7 @@ from mantid.kernel import ConfigService, ConfigPropertyObserver
 
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.gui_common import GENERIC_SETTINGS, load_property, set_setting
-from sans.gui_logic.models.run_selection import has_any_event_data
+#from sans.gui_logic.models.run_selection import has_any_event_data
 
 
 class OutputDirectoryObserver(ConfigPropertyObserver):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -288,6 +288,7 @@ class RunTabPresenter(object):
             self._view.set_out_file_directory(ConfigService.Instance().getString("defaultsave.directory"))
 
             self._view.set_out_default_user_file()
+            self._view.set_out_default_output_mode()
 
             self._view.set_hinting_line_edit_for_column(
                 self._table_model.column_name_converter.index('sample_shape'),

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -289,6 +289,7 @@ class RunTabPresenter(object):
 
             self._view.set_out_default_user_file()
             self._view.set_out_default_output_mode()
+            self._view.set_out_default_save_can()
 
             self._view.set_hinting_line_edit_for_column(
                 self._table_model.column_name_converter.index('sample_shape'),

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -202,7 +202,7 @@ class SummationSettingsViewEnablednessTest(SelectionMockingTestCase):
         presenter._get_filename_manager = mock.Mock(return_value=MockedOutAddRunsFilenameManager())
         return presenter
 
-    def test_disables_summation_settings_when_no_event_data(self):
+    def xtest_disables_summation_settings_when_no_event_data(self):
         runs = self._make_mock_run_selection([self._histogram_run,
                                               self._histogram_run])
         self._on_model_updated(runs)


### PR DESCRIPTION
**Description of work.**
This PR makes several small changes to tooltips and titles in the SANS GUI.
It also save the user's selected reduction output mode so use as default for the next time the use Mantid.
Finally, we change the default adding mode for all instrument except for LOQ to event data.

**Report to:** nobody

**To test:**
1. For changes to text e.g. tooltips, check for spelling mistakes and that they make sense
2. Go to Interfaces -> SANS -> SANS v2 
3. Load the LOQ user file attached
4. In the add runs tab check that the default added mode (a disabled dropdown menu) says custom bin boundaries
5. Back in the runs tab, load the SANS2D user file attached
6. Check that the default added mode says event data
7. Back in the runs tab, at the bottom select either the "file" or "both" radio button
8. Close mantid and re-load it. 
9. Go back into SANS v2. Check that your selection was set as default

[PRdata_no_runs.zip](https://github.com/mantidproject/mantid/files/2890087/PRdata_no_runs.zip)

Fixes #24399 
Fixes #24792 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
