### PR TITLE
Workbench: Project Save update file save behaviour

### DIFF
--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -100,16 +100,16 @@ class Project(AnalysisDataServiceObserver):
                                     "Would you like to overwrite the selected project?",
                                     QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
-    @staticmethod
-    def _save_file_dialog():
-        return open_a_file_dialog(accept_mode=QFileDialog.AcceptSave, file_mode=QFileDialog.Directory)
+    def _save_file_dialog(self):
+        return open_a_file_dialog(accept_mode=QFileDialog.AcceptSave, file_mode=QFileDialog.AnyFile,
+                                  file_filter="Project files ( *" + self.project_file_ext + ")")
 
     def _save(self):
         workspaces_to_save = AnalysisDataService.getObjectNames()
         plots_to_save = self.plot_gfm.figs
         interfaces_to_save = self.interface_populating_function()
         project_saver = ProjectSaver(self.project_file_ext)
-        project_saver.save_project(directory=self.last_project_location, workspace_to_save=workspaces_to_save,
+        project_saver.save_project(file_name=self.last_project_location, workspace_to_save=workspaces_to_save,
                                    plots_to_save=plots_to_save, interfaces_to_save=interfaces_to_save)
         self.__saved = True
 
@@ -129,11 +129,9 @@ class Project(AnalysisDataServiceObserver):
         if file_ext != ".mtdproj":
             QMessageBox.warning(None, "Wrong file type!", "Please select a valid project file", QMessageBox.Ok)
 
-        directory = os.path.dirname(file_name)
-
         project_loader = ProjectLoader(self.project_file_ext)
-        project_loader.load_project(directory)
-        self.last_project_location = directory
+        project_loader.load_project(file_name)
+        self.last_project_location = file_name
         self.__saved = True
 
     def _load_file_dialog(self):

--- a/qt/python/mantidqt/project/projectloader.py
+++ b/qt/python/mantidqt/project/projectloader.py
@@ -37,20 +37,21 @@ class ProjectLoader(object):
         self.decoder_factory = DecoderFactory()
         self.project_file_ext = project_file_ext
 
-    def load_project(self, directory):
+    def load_project(self, file_name):
         """
-        Will load the project in the given directory
-        :param directory: String or string castable object; the directory of the project
+        Will load the project in the given file_name
+        :param file_name: String or string castable object; the file_name of the project
         :return: Bool; True if all workspace loaded successfully, False if not loaded successfully.
         """
         # It can be expected that if at this point it is NoneType that it's an error
-        if directory is None:
+        if file_name is None:
             return
 
         # Read project
-        self.project_reader.read_project(directory)
+        self.project_reader.read_project(file_name)
 
         # Load in the workspaces
+        directory = os.path.dirname(file_name)
         self.workspace_loader.load_workspaces(directory=directory,
                                               workspaces_to_load=self.project_reader.workspace_names)
         workspace_success = _confirm_all_workspaces_loaded(workspaces_to_confirm=self.project_reader.workspace_names)
@@ -89,14 +90,14 @@ class ProjectReader(object):
         self.interface_list = None
         self.project_file_ext = project_file_ext
 
-    def read_project(self, directory):
+    def read_project(self, file_name):
         """
-        :param directory: String or string castable object; the directory of the project
-        Will read the project file in from the directory that is given.
+        :param file_name: String or string castable object; the file_name of the project
+        Will read the project file in from the file_name that is given.
         try:
         """
         try:
-            with open(os.path.join(directory, (os.path.basename(directory) + self.project_file_ext))) as f:
+            with open(file_name) as f:
                 json_data = json.load(f)
                 self.workspace_names = json_data["workspaces"]
                 self.plot_list = json_data["plots"]

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -71,15 +71,17 @@ class ProjectTest(unittest.TestCase):
 
     def test_save_as_saves_project_successfully(self):
         working_file = os.path.join(tempfile.mkdtemp(), "temp" + ".mtdproj")
+        working_directory = os.path.dirname(working_file)
         self.project._save_file_dialog = mock.MagicMock(return_value=working_file)
         CreateSampleWorkspace(OutputWorkspace="ws1")
 
         self.project.save_as()
 
         self.assertEqual(self.project._save_file_dialog.call_count, 1)
-        self.assertTrue(os.path.isdir(working_file))
-        file_list = os.listdir(working_file)
-        self.assertTrue(os.path.basename(working_file) + ".mtdproj" in file_list)
+        self.assertTrue(os.path.isfile(working_file))
+        self.assertTrue(os.path.isdir(working_directory))
+        file_list = os.listdir(working_directory)
+        self.assertTrue(os.path.basename(working_file) in file_list)
         self.assertTrue("ws1.nxs" in file_list)
 
     def test_load_calls_loads_successfully(self):

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -56,36 +56,36 @@ class ProjectTest(unittest.TestCase):
         self.assertEqual(self.project.save_as.call_count, 0)
 
     def test_save_saves_project_successfully(self):
-        working_directory = tempfile.mkdtemp()
-        self.project.last_project_location = working_directory
+        working_file = os.path.join(tempfile.mkdtemp(), "temp" + ".mtdproj")
+        self.project.last_project_location = working_file
         CreateSampleWorkspace(OutputWorkspace="ws1")
         self.project._offer_overwriting_gui = mock.MagicMock(return_value=QMessageBox.Yes)
 
         self.project.save()
 
-        self.assertTrue(os.path.isdir(working_directory))
-        file_list = os.listdir(working_directory)
-        self.assertTrue(os.path.basename(working_directory) + ".mtdproj" in file_list)
+        self.assertTrue(os.path.isfile(working_file))
+        file_list = os.listdir(os.path.dirname(working_file))
+        self.assertTrue(os.path.basename(working_file) in file_list)
         self.assertTrue("ws1.nxs" in file_list)
         self.assertEqual(self.project._offer_overwriting_gui.call_count, 1)
 
     def test_save_as_saves_project_successfully(self):
-        working_directory = tempfile.mkdtemp()
-        self.project._save_file_dialog = mock.MagicMock(return_value=working_directory)
+        working_file = os.path.join(tempfile.mkdtemp(), "temp" + ".mtdproj")
+        self.project._save_file_dialog = mock.MagicMock(return_value=working_file)
         CreateSampleWorkspace(OutputWorkspace="ws1")
 
         self.project.save_as()
 
         self.assertEqual(self.project._save_file_dialog.call_count, 1)
-        self.assertTrue(os.path.isdir(working_directory))
-        file_list = os.listdir(working_directory)
-        self.assertTrue(os.path.basename(working_directory) + ".mtdproj" in file_list)
+        self.assertTrue(os.path.isdir(working_file))
+        file_list = os.listdir(working_file)
+        self.assertTrue(os.path.basename(working_file) + ".mtdproj" in file_list)
         self.assertTrue("ws1.nxs" in file_list)
 
     def test_load_calls_loads_successfully(self):
         working_directory = tempfile.mkdtemp()
         return_value_for_load = os.path.join(working_directory, os.path.basename(working_directory) + ".mtdproj")
-        self.project._save_file_dialog = mock.MagicMock(return_value=working_directory)
+        self.project._save_file_dialog = mock.MagicMock(return_value=return_value_for_load)
         CreateSampleWorkspace(OutputWorkspace="ws1")
         self.project.save_as()
 

--- a/qt/python/mantidqt/project/test/test_projectloader.py
+++ b/qt/python/mantidqt/project/test/test_projectloader.py
@@ -12,7 +12,7 @@ import unittest
 import matplotlib
 matplotlib.use('AGG')
 
-from os.path import isdir  # noqa
+from os.path import isdir, join  # noqa
 from shutil import rmtree  # noqa
 import tempfile  # noqa
 
@@ -23,6 +23,7 @@ from mantidqt.project import projectloader, projectsaver  # noqa
 
 project_file_ext = ".mtdproj"
 working_directory = tempfile.mkdtemp()
+working_project_file = join(working_directory, "temp" + project_file_ext)
 
 
 class ProjectLoaderTest(unittest.TestCase):
@@ -30,7 +31,7 @@ class ProjectLoaderTest(unittest.TestCase):
         ws1_name = "ws1"
         ADS.addOrReplace(ws1_name, CreateSampleWorkspace(OutputWorkspace=ws1_name))
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        project_saver.save_project(workspace_to_save=[ws1_name], directory=working_directory)
+        project_saver.save_project(workspace_to_save=[ws1_name], file_name=working_project_file)
 
     def tearDown(self):
         ADS.clear()
@@ -46,7 +47,7 @@ class ProjectLoaderTest(unittest.TestCase):
     def test_project_loading(self):
         project_loader = projectloader.ProjectLoader(project_file_ext)
 
-        self.assertTrue(project_loader.load_project(working_directory))
+        self.assertTrue(project_loader.load_project(working_project_file))
 
         self.assertEqual(ADS.getObjectNames(), ["ws1"])
 
@@ -61,7 +62,7 @@ class ProjectReaderTest(unittest.TestCase):
         ws1_name = "ws1"
         ADS.addOrReplace(ws1_name, CreateSampleWorkspace(OutputWorkspace=ws1_name))
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        project_saver.save_project(workspace_to_save=[ws1_name], directory=working_directory)
+        project_saver.save_project(workspace_to_save=[ws1_name], file_name=working_project_file)
 
     def tearDown(self):
         ADS.clear()
@@ -70,7 +71,7 @@ class ProjectReaderTest(unittest.TestCase):
 
     def test_project_reading(self):
         project_reader = projectloader.ProjectReader(project_file_ext)
-        project_reader.read_project(working_directory)
+        project_reader.read_project(working_project_file)
         self.assertEqual(["ws1"], project_reader.workspace_names)
 
 

--- a/qt/python/mantidqt/project/test/test_projectsaver.py
+++ b/qt/python/mantidqt/project/test/test_projectsaver.py
@@ -119,6 +119,7 @@ class ProjectSaverTest(unittest.TestCase):
         self.assertTrue(ws1_name + ".nxs" in list_of_files)
 
     def test_saving_plots_when_plots_are_passed(self):
+        os.makedirs(working_directory)
         fig = matplotlib.figure.Figure(dpi=100, figsize=(6.4, 4.8))
         fig_manager = matplotlib.backend_bases.FigureManagerBase(matplotlib.backend_bases.FigureCanvasBase(fig), 1)
         matplotlib.axes.Axes(fig=fig, rect=[0, 0, 0, 0])
@@ -146,13 +147,13 @@ class ProjectWriterTest(unittest.TestCase):
         if os.path.isdir(working_directory):
             rmtree(working_directory)
 
-        self.file_name = os.path.join(working_directory, os.path.basename(working_directory) + project_file_ext)
+        os.makedirs(working_directory)
 
     def test_write_out_empty_workspaces(self):
         workspace_list = []
         plots_to_save = []
         interfaces_to_save = []
-        project_writer = projectsaver.ProjectWriter(save_location=working_directory, workspace_names=workspace_list,
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
                                                     project_file_ext=project_file_ext, plots_to_save=plots_to_save,
                                                     interfaces_to_save=interfaces_to_save)
         workspaces_string = "\"workspaces\": []"
@@ -160,7 +161,7 @@ class ProjectWriterTest(unittest.TestCase):
 
         project_writer.write_out()
 
-        with open(self.file_name, 'r') as f:
+        with open(working_project_file, 'r') as f:
             file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -169,14 +170,14 @@ class ProjectWriterTest(unittest.TestCase):
         plots_to_save = []
         workspace_list = ["ws1", "ws2", "ws3", "ws4"]
         interfaces_to_save = []
-        project_writer = projectsaver.ProjectWriter(save_location=working_directory, workspace_names=workspace_list,
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
                                                     project_file_ext=project_file_ext, plots_to_save=plots_to_save,
                                                     interfaces_to_save=interfaces_to_save)
         workspaces_string = "\"workspaces\": [\"ws1\", \"ws2\", \"ws3\", \"ws4\"]"
         plots_string = "\"plots\": []"
 
         project_writer.write_out()
-        with open(self.file_name, 'r') as f:
+        with open(working_project_file, 'r') as f:
             file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -185,7 +186,7 @@ class ProjectWriterTest(unittest.TestCase):
         plots_to_save = [{"plots1": {"plot-information": "axes data"}}]
         workspace_list = []
         interfaces_to_save = []
-        project_writer = projectsaver.ProjectWriter(save_location=working_directory, workspace_names=workspace_list,
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
                                                     project_file_ext=project_file_ext, plots_to_save=plots_to_save,
                                                     interfaces_to_save=interfaces_to_save)
         workspaces_string = "\"workspaces\": []"
@@ -193,7 +194,7 @@ class ProjectWriterTest(unittest.TestCase):
 
         project_writer.write_out()
 
-        with open(self.file_name, 'r') as f:
+        with open(working_project_file, 'r') as f:
             file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -202,7 +203,7 @@ class ProjectWriterTest(unittest.TestCase):
         plots_to_save = [{"plots1": {"plot-information": "axes data"}}]
         workspace_list = ["ws1", "ws2", "ws3", "ws4"]
         interfaces_to_save = []
-        project_writer = projectsaver.ProjectWriter(save_location=working_directory, workspace_names=workspace_list,
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
                                                     project_file_ext=project_file_ext, plots_to_save=plots_to_save,
                                                     interfaces_to_save=interfaces_to_save)
         workspaces_string = "\"workspaces\": [\"ws1\", \"ws2\", \"ws3\", \"ws4\"]"
@@ -210,7 +211,7 @@ class ProjectWriterTest(unittest.TestCase):
 
         project_writer.write_out()
 
-        with open(self.file_name, 'r') as f:
+        with open(working_project_file, 'r') as f:
             file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -219,7 +220,7 @@ class ProjectWriterTest(unittest.TestCase):
         plots_to_save = []
         workspace_list = []
         interfaces_to_save = [{"interface1": {"interface data": "data"}}]
-        project_writer = projectsaver.ProjectWriter(save_location=working_directory, workspace_names=workspace_list,
+        project_writer = projectsaver.ProjectWriter(save_location=working_project_file, workspace_names=workspace_list,
                                                     project_file_ext=project_file_ext, plots_to_save=plots_to_save,
                                                     interfaces_to_save=interfaces_to_save)
         workspaces_string = "\"workspaces\": []"
@@ -228,7 +229,7 @@ class ProjectWriterTest(unittest.TestCase):
 
         project_writer.write_out()
 
-        with open(self.file_name, 'r') as f:
+        with open(working_project_file, 'r') as f:
             file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)

--- a/qt/python/mantidqt/project/test/test_projectsaver.py
+++ b/qt/python/mantidqt/project/test/test_projectsaver.py
@@ -23,6 +23,7 @@ from mantidqt.project import projectsaver
 
 project_file_ext = ".mtdproj"
 working_directory = tempfile.mkdtemp()
+working_project_file = os.path.join(working_directory, "temp" + project_file_ext)
 
 
 class ProjectSaverTest(unittest.TestCase):
@@ -38,15 +39,14 @@ class ProjectSaverTest(unittest.TestCase):
         ws1_name = "ws1"
         ADS.addOrReplace(ws1_name, CreateSampleWorkspace(OutputWorkspace=ws1_name))
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        file_name = working_directory + "/" + os.path.basename(working_directory) + project_file_ext
 
         workspaces_string = "\"workspaces\": [\"ws1\"]"
         plots_string = "\"plots\": []"
 
-        project_saver.save_project(workspace_to_save=[ws1_name], directory=working_directory)
+        project_saver.save_project(workspace_to_save=[ws1_name], file_name=working_project_file)
 
         # Check project file is saved correctly
-        f = open(file_name, "r")
+        f = open(working_project_file, "r")
         file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -54,7 +54,7 @@ class ProjectSaverTest(unittest.TestCase):
         # Check workspace is saved
         list_of_files = os.listdir(working_directory)
         self.assertEqual(len(list_of_files), 2)
-        self.assertTrue(os.path.basename(working_directory) + project_file_ext in list_of_files)
+        self.assertTrue(os.path.basename(working_project_file) in list_of_files)
         self.assertTrue(ws1_name + ".nxs" in list_of_files)
 
     def test_only_multiple_workspaces_saving(self):
@@ -69,16 +69,15 @@ class ProjectSaverTest(unittest.TestCase):
         CreateSampleWorkspace(OutputWorkspace=ws4_name)
         CreateSampleWorkspace(OutputWorkspace=ws5_name)
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        file_name = working_directory + "/" + os.path.basename(working_directory) + project_file_ext
 
         workspaces_string = "\"workspaces\": [\"ws1\", \"ws2\", \"ws3\", \"ws4\", \"ws5\"]"
         plots_string = "\"plots\": []"
 
         project_saver.save_project(workspace_to_save=[ws1_name, ws2_name, ws3_name, ws4_name, ws5_name],
-                                   directory=working_directory)
+                                   file_name=working_project_file)
 
         # Check project file is saved correctly
-        f = open(file_name, "r")
+        f = open(working_project_file, "r")
         file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -86,7 +85,7 @@ class ProjectSaverTest(unittest.TestCase):
         # Check workspace is saved
         list_of_files = os.listdir(working_directory)
         self.assertEqual(len(list_of_files), 6)
-        self.assertTrue(os.path.basename(working_directory) + project_file_ext in list_of_files)
+        self.assertTrue(os.path.basename(working_project_file) in list_of_files)
         self.assertTrue(ws1_name + ".nxs" in list_of_files)
         self.assertTrue(ws2_name + ".nxs" in list_of_files)
         self.assertTrue(ws3_name + ".nxs" in list_of_files)
@@ -101,15 +100,14 @@ class ProjectSaverTest(unittest.TestCase):
         CreateSampleWorkspace(OutputWorkspace=ws2_name)
         CreateSampleWorkspace(OutputWorkspace=ws3_name)
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        file_name = working_directory + "/" + os.path.basename(working_directory) + project_file_ext
 
         workspaces_string = "\"workspaces\": [\"ws1\"]"
         plots_string = "\"plots\": []"
 
-        project_saver.save_project(workspace_to_save=[ws1_name], directory=working_directory)
+        project_saver.save_project(workspace_to_save=[ws1_name], file_name=working_project_file)
 
         # Check project file is saved correctly
-        f = open(file_name, "r")
+        f = open(working_project_file, "r")
         file_string = f.read()
         self.assertTrue(workspaces_string in file_string)
         self.assertTrue(plots_string in file_string)
@@ -117,7 +115,7 @@ class ProjectSaverTest(unittest.TestCase):
         # Check workspace is saved
         list_of_files = os.listdir(working_directory)
         self.assertEqual(len(list_of_files), 2)
-        self.assertTrue(os.path.basename(working_directory) + project_file_ext in list_of_files)
+        self.assertTrue(os.path.basename(working_project_file) in list_of_files)
         self.assertTrue(ws1_name + ".nxs" in list_of_files)
 
     def test_saving_plots_when_plots_are_passed(self):
@@ -126,16 +124,15 @@ class ProjectSaverTest(unittest.TestCase):
         matplotlib.axes.Axes(fig=fig, rect=[0, 0, 0, 0])
 
         project_saver = projectsaver.ProjectSaver(project_file_ext)
-        file_name = working_directory + "/" + os.path.basename(working_directory) + project_file_ext
 
-        project_saver.save_project(directory=working_directory,
+        project_saver.save_project(file_name=working_project_file,
                                    plots_to_save={1: fig_manager})
 
         plots_dict = {u"creationArguments": [], u"axes": [], u"label": u"", u"properties": {u"figWidth": 6.4,
                                                                                             u"figHeight": 4.8,
                                                                                             u"dpi": 100.0}}
 
-        f = open(file_name, "r")
+        f = open(working_project_file, "r")
         file_dict = json.load(f)
         self.assertDictEqual(plots_dict, file_dict["plots"][0])
 

--- a/qt/python/mantidqt/project/test/test_workspaceloader.py
+++ b/qt/python/mantidqt/project/test/test_workspaceloader.py
@@ -25,7 +25,7 @@ class WorkspaceLoaderTest(unittest.TestCase):
         self.project_ext = ".mtdproj"
         ADS.addOrReplace(self.ws1_name, CreateSampleWorkspace(OutputWorkspace=self.ws1_name))
         project_saver = projectsaver.ProjectSaver(self.project_ext)
-        project_saver.save_project(workspace_to_save=[self.ws1_name], directory=self.working_directory)
+        project_saver.save_project(workspace_to_save=[self.ws1_name], file_name=self.working_directory)
 
     def tearDown(self):
         ADS.clear()


### PR DESCRIPTION
**Description of work.**
Project Save in Workbench originally followed MantidPlot behavior in Linux variations. However this update intends to update it to follow original Windows behavior for all platforms.

**To test:**
The exact behavior should be that:
- You choose a place to save a file and it saved the project file there
- Whatever directory you save the project file in the workspaces should be saved there
- Anything else saved by project save should also be put in that folder

To actually test:
- Open Workbench
- Load a workspace
- Open a MatrixWorkspaceDisplay or TableWorkspaceDisplay (Show data on the workspace)
- File->Save Project as...
- Choose a place to save your project
- Ensure that all behavior is as stated previously.
- Close Workbench
- Open Workbench
- File->Open Project
- Select your project file (file ending in .mtdproj)
- Ensure you load back in the workspace and interface as they were previously.

<!-- Instructions for testing. -->

Fixes #24793 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
