### PR TITLE
24862 integrate flux validator

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateFlux.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateFlux.cpp
@@ -7,6 +7,7 @@
 #include "MantidMDAlgorithms/IntegrateFlux.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidDataObjects/EventWorkspace.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/BoundedValidator.h"
@@ -58,8 +59,9 @@ const std::string IntegrateFlux::summary() const {
  */
 void IntegrateFlux::init() {
   declareProperty(Kernel::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input),
-                  "An input workspace.");
+                      "InputWorkspace", "", Direction::Input,
+                      boost::make_shared<API::WorkspaceUnitValidator>("Momentum")),
+                  "An input workspace. Must have units of Momentum");
   auto validator = boost::make_shared<Kernel::BoundedValidator<int>>();
   validator->setLower(2);
   declareProperty("NPoints", 1000, validator,

--- a/Framework/MDAlgorithms/src/IntegrateFlux.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateFlux.cpp
@@ -58,10 +58,11 @@ const std::string IntegrateFlux::summary() const {
 /** Initialize the algorithm's properties.
  */
 void IntegrateFlux::init() {
-  declareProperty(Kernel::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input,
-                      boost::make_shared<API::WorkspaceUnitValidator>("Momentum")),
-                  "An input workspace. Must have units of Momentum");
+  declareProperty(
+      Kernel::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+          "InputWorkspace", "", Direction::Input,
+          boost::make_shared<API::WorkspaceUnitValidator>("Momentum")),
+      "An input workspace. Must have units of Momentum");
   auto validator = boost::make_shared<Kernel::BoundedValidator<int>>();
   validator->setLower(2);
   declareProperty("NPoints", 1000, validator,

--- a/Framework/MDAlgorithms/test/IntegrateFluxTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateFluxTest.h
@@ -338,6 +338,7 @@ private:
     alg->setPropertyValue("Instrument", "CNCS");
     alg->setPropertyValue("BinParams", "0,10,100");
     alg->setProperty("OutputWorkspace", wsName);
+    alg->setPropertyValue("UnitX", "Momentum");
     alg->execute();
 
     alg = Mantid::API::AlgorithmManager::Instance().create(
@@ -357,6 +358,8 @@ private:
   void createInputWorkspaceHistogram(const std::string &wsName) {
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4,
                                                                101, 100);
+    auto axis = ws->getAxis(0);
+    axis->setUnit("Momentum");
     auto &x = ws->dataX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
@@ -376,6 +379,8 @@ private:
   void createInputWorkspaceHistogramNonUniform(const std::string &wsName) {
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4,
                                                                101, 100);
+    auto axis = ws->getAxis(0);
+    axis->setUnit("Momentum");
     auto &x = ws->dataX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
@@ -396,6 +401,8 @@ private:
   void createInputWorkspaceDistribution(const std::string &wsName) {
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4,
                                                                101, 100);
+    auto axis = ws->getAxis(0);
+    axis->setUnit("Momentum");
     auto &x = ws->dataX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
@@ -417,6 +424,8 @@ private:
   void createInputWorkspacePointData(const std::string &wsName) {
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4,
                                                                100, 100);
+    auto axis = ws->getAxis(0);
+    axis->setUnit("Momentum");
     auto &x = ws->dataX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {
@@ -436,6 +445,8 @@ private:
   void createInputWorkspacePointDataNonUniform(const std::string &wsName) {
     auto ws = Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 4,
                                                                100, 100);
+    auto axis = ws->getAxis(0);
+    axis->setUnit("Momentum");
     auto &x = ws->dataX(0);
     x[0] = 0.0;
     for (auto i = x.begin() + 1; i != x.end(); ++i) {

--- a/docs/source/algorithms/IntegrateFlux-v1.rst
+++ b/docs/source/algorithms/IntegrateFlux-v1.rst
@@ -24,7 +24,7 @@ Usage
 .. testcode:: IntegrateFluxExample
 
     # Create an event workspace
-    ws = CreateSampleWorkspace("Event")
+    ws = CreateSampleWorkspace(WorkspaceType="Event", XUnit="Momentum")
     # Integrate all spectra.
     wsOut = IntegrateFlux( ws )
     


### PR DESCRIPTION
**Description of work.**
Added a unit validator to `IntegrateFlux` and updated the tests to have correct units.

**Report to:** Andrei

**To test:**
```python
dataX = [0,1,2,3,4,5]
dataY = [1,2,3,4,5,6]

#This will work
dataWS1 = CreateWorkspace(DataX=dataX, DataY=dataY, NSpec=1, UnitX="Momentum")
IntegrateFlux(InputWorkspace=dataWS1, OutputWorkspace='out1')

#This will fail
dataWS2 = CreateWorkspace(DataX=dataX, DataY=dataY, NSpec=1, UnitX="Wavelength")
IntegrateFlux(InputWorkspace=dataWS2, OutputWorkspace='out2') #Error
```
<!-- Instructions for testing. -->

Fixes #24862 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
