### PR TITLE
Separate Save Directory for Added Runs

### DIFF
--- a/docs/source/release/v3.14.0/sans.rst
+++ b/docs/source/release/v3.14.0/sans.rst
@@ -41,6 +41,7 @@ Improved
 * If loading of user file fails, user file field will remain empty to make it clear it has not be loaded successfully.
 * Workspaces are centred upon loading.
 * All limit strings in the user file (L/ ) are now space-separable to allow for uniform structure in the user file. For backwards compatibility, any string which was comma separable remains comma separable as well.
+* Added a sum runs directory selection button. This is separate from default save directory and only determines where summed runs are saved.
 
 Bug fixes
 #########

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -17,6 +17,7 @@ Ui_AddRunsPage, _ = load_ui(__file__, "add_runs_page.ui")
 class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     sum = Signal()
     outFileChanged = Signal()
+    saveDirectoryClicked = Signal()
 
     def __init__(self, parent=None):
         super(AddRunsPage, self).__init__(parent)
@@ -26,6 +27,7 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
     def _connect_signals(self):
         self.sumButton.pressed.connect(self.sum)
         self.fileNameEdit.editingFinished.connect(self.outFileChanged)
+        self.saveDirectoryButton.clicked.connect(self.saveDirectoryClicked)
 
     def run_selector_view(self):
         return self.run_selector
@@ -57,6 +59,11 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
 
     def disable_summation_settings(self):
         self.summation_settings_view().setEnabled(False)
+
+    def display_save_directory_box(self, title, default_path):
+        filename = QtWidgets.QFileDialog.getExistingDirectory(self, title, default_path,
+                                                              QtWidgets.QFileDialog.ShowDirsOnly)
+        return filename
 
     def setupUi(self, other):
         Ui_AddRunsPage.setupUi(self, other)

--- a/scripts/Interface/ui/sans_isis/add_runs_page.ui
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.ui
@@ -91,6 +91,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="saveDirectoryButton">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a directory to save summed runs into. This directory is different to Mantid's default save directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
            <string>Select Save Directory</string>
           </property>

--- a/scripts/Interface/ui/sans_isis/add_runs_page.ui
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.ui
@@ -62,11 +62,41 @@
        <number>6</number>
       </property>
       <item>
-       <widget class="QLabel" name="outputDirectoryLabel">
-        <property name="text">
-         <string>Save Directory:</string>
-        </property>
-       </widget>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="outputDirectoryLabel">
+          <property name="maximumSize">
+           <size>
+            <width>937</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Save Directory:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="saveDirectoryButton">
+          <property name="text">
+           <string>Select Save Directory</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QLineEdit" name="fileNameEdit"/>

--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -35,7 +35,8 @@ def add_runs(runs, # noqa: C901
              isOverlay=False,
              time_shifts=None,
              outFile=None,
-             outFile_monitors=None):
+             outFile_monitors=None,
+             save_directory=None):
     if inst.upper() == "SANS2DTUBES":
         inst = "SANS2D"
   #check if there is at least one file in the list
@@ -138,6 +139,9 @@ def add_runs(runs, # noqa: C901
     # now save the added file
         outFile = lastFile+'-add.'+'nxs' if outFile is None else outFile
         outFile_monitors = lastFile+'-add_monitors.'+'nxs' if outFile_monitors is None else outFile_monitors
+        if save_directory:
+            outFile = save_directory + outFile
+            outFile_monitors = save_directory + outFile_monitors
         sanslog.notice('writing file:   '+outFile)
 
         if period == 1 or period == _NO_INDIVIDUAL_PERIODS:
@@ -177,7 +181,8 @@ def add_runs(runs, # noqa: C901
     path,base = os.path.split(outFile)
     if path == '' or base not in os.listdir(path):
         # Try the default save directory
-        path = config['defaultsave.directory'] + path
+        path_prefix = save_directory if save_directory else config["defaultsave.directory"]
+        path = path_prefix + path
         # If the path is still an empty string check in the current working directory
         if path == '':
             path = os.getcwd()

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -200,6 +200,15 @@ def load_default_file(line_edit_field, q_settings_group_key, q_settings_key):
     line_edit_field.setText(default_file)
 
 
+def load_property(q_settings_group_key, q_settings_key):
+    settings = QSettings()
+    settings.beginGroup(q_settings_group_key)
+    default_property = settings.value(q_settings_key, "", type=str)
+    settings.endGroup()
+
+    return default_property
+
+
 def set_setting(q_settings_group_key, q_settings_key, value):
     settings = QSettings()
     settings.beginGroup(q_settings_group_key)

--- a/scripts/SANS/sans/gui_logic/models/run_summation.py
+++ b/scripts/SANS/sans/gui_logic/models/run_summation.py
@@ -37,6 +37,7 @@ class RunSummation(object):
         save_as_event = self._should_save_as_event_workspaces(settings)
 
         file_name = base_file_name + '.nxs'
+        print(file_name)
         monitors_file_name = base_file_name + '_monitors.nxs'
 
         SANSadd2.add_runs(
@@ -48,7 +49,8 @@ class RunSummation(object):
             saveAsEvent=save_as_event,
             time_shifts=additional_time_shifts,
             outFile=file_name,
-            outFile_monitors=monitors_file_name)
+            outFile_monitors=monitors_file_name,
+            save_directory=settings.save_directory)
 
     def _run_selection_as_path_list(self, run_selection):
         return [run.file_path() for run in run_selection]

--- a/scripts/SANS/sans/gui_logic/models/run_summation.py
+++ b/scripts/SANS/sans/gui_logic/models/run_summation.py
@@ -37,7 +37,6 @@ class RunSummation(object):
         save_as_event = self._should_save_as_event_workspaces(settings)
 
         file_name = base_file_name + '.nxs'
-        print(file_name)
         monitors_file_name = base_file_name + '_monitors.nxs'
 
         SANSadd2.add_runs(

--- a/scripts/SANS/sans/gui_logic/models/summation_settings.py
+++ b/scripts/SANS/sans/gui_logic/models/summation_settings.py
@@ -84,12 +84,18 @@ class SummationSettings(object):
         self._save_as_event_data = SaveAsEventData()
         self._custom_binning = CustomBinning()
         self._settings = self._settings_from_type(initial_type)
+        self._save_directory = ConfigService.getString('defaultsave.directory')
 
     def instrument(self):
         return ConfigService.getString('default.instrument')
 
+    @property
     def save_directory(self):
-        return ConfigService.getString('defaultsave.directory')
+        return self._save_directory
+
+    @save_directory.setter
+    def save_directory(self, directory):
+        self._save_directory = directory
 
     def set_histogram_binning_type(self, type):
         self._settings = self._settings_from_type(type)

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -4,10 +4,13 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+import os
+
 from mantid import config
 from mantid.kernel import ConfigService, ConfigPropertyObserver
 
 from sans.common.enums import SANSInstrument
+from sans.gui_logic.gui_common import GENERIC_SETTINGS, load_property, set_setting
 from sans.gui_logic.models.run_selection import has_any_event_data
 
 
@@ -68,6 +71,8 @@ class AddRunsPagePresenter(object):
                  view,
                  parent_view):
 
+        self.__generic_settings = GENERIC_SETTINGS
+        self.__output_directory_key = "add_runs_output_directory"
         self._view = view
         self._parent_view = parent_view
         self._sum_runs = sum_runs
@@ -80,8 +85,6 @@ class AddRunsPagePresenter(object):
                                          view)
 
         self._connect_to_view(view)
-        self._output_directory_observer = \
-            OutputDirectoryObserver(self._handle_output_directory_changed)
 
     def _get_filename_manager(self):
         # Separate call so AddRunsFilesnameManager can be mocked out.
@@ -94,7 +97,10 @@ class AddRunsPagePresenter(object):
     def _connect_to_view(self, view):
         view.sum.connect(self._handle_sum)
         view.outFileChanged.connect(self._handle_out_file_changed)
-        self._view.set_out_file_directory(ConfigService.Instance().getString("defaultsave.directory"))
+        view.saveDirectoryClicked.connect(self._handle_output_directory_changed)
+
+        self._summation_settings_presenter.settings().save_directory = self._get_default_output_directory()
+        self._view.set_out_file_directory(self._summation_settings_presenter.settings().save_directory)
 
     def _make_base_file_name_from_selection(self, run_selection):
         filename_manager = self._get_filename_manager()
@@ -134,10 +140,13 @@ class AddRunsPagePresenter(object):
         self._use_generated_file_name = False
 
     def _output_directory_is_not_empty(self, settings):
-        return settings.save_directory() != ''
+        return settings.save_directory != ''
 
-    def _handle_output_directory_changed(self, new_directory):
-        self._view.set_out_file_directory(new_directory)
+    def _handle_output_directory_changed(self):
+        directory = self._display_save_directory_box("Save sum runs",
+                                                     self._summation_settings_presenter.settings().save_directory)
+        self._update_output_directory(directory)
+        self._view.set_out_file_directory(self._summation_settings_presenter.settings().save_directory)
 
     def _handle_sum(self):
         run_selection = self._run_selector_presenter.run_selection()
@@ -149,3 +158,28 @@ class AddRunsPagePresenter(object):
                            self._sum_base_file_name(run_selection))
         else:
             self._view.no_save_directory()
+
+    def _display_save_directory_box(self, title, default_path):
+        filename = self._view.display_save_directory_box(title, default_path)
+        return filename
+
+    def _get_default_output_directory(self):
+        directory = load_property(self.__generic_settings, self.__output_directory_key)
+        if not directory:
+            return ConfigService.Instance().getString("defaultsave.directory")
+        else:
+            return directory
+
+    def _update_output_directory(self, directory):
+        """
+        Get the output directory. This method is called after a directory dialog box has been navigated.
+        If we do not pass in a directory e.g. directory dialog cancelled
+        then do nothing.
+        Otherwise update our settings
+        :param directory: a string - a directory path
+        :return: Nothing
+        """
+        if directory is None:
+            return
+        set_setting(self.__generic_settings, self.__output_directory_key, directory)
+        self._summation_settings_presenter.settings().save_directory = directory

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -142,7 +142,7 @@ class AddRunsPagePresenter(object):
         return settings.save_directory != ''
 
     def _handle_output_directory_changed(self):
-        directory = self._display_save_directory_box("Save sum runs", self.save_directory)
+        directory = self._view.display_save_directory_box("Save sum runs", self.save_directory)
         self._update_output_directory(directory)
         self._view.set_out_file_directory(self.save_directory)
 
@@ -158,10 +158,6 @@ class AddRunsPagePresenter(object):
                            self._sum_base_file_name(run_selection))
         else:
             self._view.no_save_directory()
-
-    def _display_save_directory_box(self, title, default_path):
-        filename = self._view.display_save_directory_box(title, default_path)
-        return filename
 
     def _get_default_output_directory(self):
         directory = load_property(self.__generic_settings, self.__output_directory_key)

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -165,7 +165,7 @@ class AddRunsPagePresenter(object):
 
     def _get_default_output_directory(self):
         directory = load_property(self.__generic_settings, self.__output_directory_key)
-        if not directory:
+        if directory == "":
             return ConfigService.Instance().getString("defaultsave.directory")
         else:
             return directory

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -7,7 +7,6 @@
 import os
 
 from mantid.kernel import ConfigService, ConfigPropertyObserver
-from mantid.simpleapi import config
 
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.gui_common import GENERIC_SETTINGS, load_property, set_setting

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -165,7 +165,7 @@ class AddRunsPagePresenter(object):
 
     def _get_default_output_directory(self):
         directory = load_property(self.__generic_settings, self.__output_directory_key)
-        if directory == "":
+        if not directory:
             return ConfigService.Instance().getString("defaultsave.directory")
         else:
             return directory
@@ -179,9 +179,7 @@ class AddRunsPagePresenter(object):
         :param directory: a string - a directory path
         :return: Nothing
         """
-        if directory == "":
-            return None
-        else:
+        if directory:
             directory = os.path.join(directory, '')  # Add an OS specific trailing slash if it doesn't already exist
             set_setting(self.__generic_settings, self.__output_directory_key, directory)
             self.save_directory = directory

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -243,6 +243,7 @@ class SummationConfigurationTest(SelectionMockingTestCase):
         return self._just_use(self._summation_settings_presenter)
 
     def test_passes_correct_config_when_summation_requested(self):
+        ConfigService["defaultsave.directory"] = "someDir/"
         run_summation = mock.Mock()
 
         self.presenter = self._make_presenter(
@@ -259,8 +260,7 @@ class SummationConfigurationTest(SelectionMockingTestCase):
                                          'LOQ00003-add')
 
     def test_shows_error_when_empty_default_directory(self):
-        old_default_save = ConfigService["defaultsave.directory"]
-        ConfigService["defaultsave.directory"] = ''
+        ConfigService["defaultsave.directory"] = ""
         summation_settings_model = self._summation_settings_with_save_directory('')
         self._summation_settings_presenter.settings.return_value = summation_settings_model
         self.presenter = self._make_presenter(
@@ -270,7 +270,6 @@ class SummationConfigurationTest(SelectionMockingTestCase):
 
         self.view.sum.emit()
         assert_called(self.view.no_save_directory)
-        ConfigService["defaultsave.directory"] = old_default_save
 
 
 class BaseFileNameTest(SelectionMockingTestCase):
@@ -278,6 +277,10 @@ class BaseFileNameTest(SelectionMockingTestCase):
         self.setUpMockChildPresentersWithDefaultSummationSettings()
         self.view = self._make_mock_view()
         self.parent_view = self._make_mock_parent_view()
+        ConfigService["defaultsave.directory"] = "someDir/"
+
+    def tearDown(self):
+        ConfigService["defaultsave.directory"] = ""
 
     def _make_presenter(self,
                         run_summation):

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -6,24 +6,26 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import sys
-from ui.sans_isis.add_runs_page import AddRunsPage
-from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
+
 from mantid.kernel import ConfigService
-from sans.gui_logic.presenter.add_runs_presenter import AddRunsPagePresenter, AddRunsFilenameManager
+from sans.common.enums import SANSInstrument
 from sans.gui_logic.models.run_summation import RunSummation
 from sans.gui_logic.models.run_file import SummableRunFile
 from sans.gui_logic.models.run_selection import RunSelection
 from sans.gui_logic.models.summation_settings import SummationSettings
-from sans.gui_logic.presenter.summation_settings_presenter import SummationSettingsPresenter
+from sans.gui_logic.presenter.add_runs_presenter import AddRunsPagePresenter, AddRunsFilenameManager
 from sans.gui_logic.presenter.run_selector_presenter import RunSelectorPresenter
+from sans.gui_logic.presenter.summation_settings_presenter import SummationSettingsPresenter
+from ui.sans_isis.add_runs_page import AddRunsPage
+from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from fake_signal import FakeSignal
 from assert_called import assert_called
-from sans.common.enums import SANSInstrument
 
 if sys.version_info.major == 2:
     import mock
 else:
     from unittest import mock
+
 
 class MockedOutAddRunsFilenameManager(AddRunsFilenameManager):
     def __init__(self):
@@ -43,6 +45,7 @@ class AddRunsPagePresenterTestCase(unittest.TestCase):
         mock_view = mock.create_autospec(AddRunsPage, spec_set=True)
         mock_view.sum = FakeSignal()
         mock_view.outFileChanged = FakeSignal()
+        mock_view.saveDirectoryClicked = FakeSignal()
         return mock_view
 
     def _make_mock_parent_view(self):
@@ -99,7 +102,7 @@ class AddRunsPagePresenterTestCase(unittest.TestCase):
 
     def _summation_settings_with_save_directory(self, directory):
         mock_summation_settings = mock.create_autospec(SummationSettings, spec_set=True)
-        mock_summation_settings.save_directory.return_value = directory
+        mock_summation_settings.save_directory = directory
         return mock_summation_settings
 
 
@@ -191,7 +194,7 @@ class SummationSettingsViewEnablednessTest(SelectionMockingTestCase):
         return self._just_use(self._summation_settings_presenter)
 
     def _make_presenter(self):
-        presenter =  AddRunsPagePresenter(mock.Mock(),
+        presenter = AddRunsPagePresenter(mock.Mock(),
                                          self._capture_on_change_callback(self.run_selector_presenter),
                                          self._just_use_summation_settings_presenter(),
                                          self._view,
@@ -256,6 +259,7 @@ class SummationConfigurationTest(SelectionMockingTestCase):
                                          'LOQ00003-add')
 
     def test_shows_error_when_empty_default_directory(self):
+        ConfigService["defaultsave.directory"] = ''
         summation_settings_model = self._summation_settings_with_save_directory('')
         self._summation_settings_presenter.settings.return_value = summation_settings_model
         self.presenter = self._make_presenter(

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -259,6 +259,7 @@ class SummationConfigurationTest(SelectionMockingTestCase):
                                          'LOQ00003-add')
 
     def test_shows_error_when_empty_default_directory(self):
+        old_default_save = ConfigService["defaultsave.directory"]
         ConfigService["defaultsave.directory"] = ''
         summation_settings_model = self._summation_settings_with_save_directory('')
         self._summation_settings_presenter.settings.return_value = summation_settings_model
@@ -269,6 +270,7 @@ class SummationConfigurationTest(SelectionMockingTestCase):
 
         self.view.sum.emit()
         assert_called(self.view.no_save_directory)
+        ConfigService["defaultsave.directory"] = old_default_save
 
 
 class BaseFileNameTest(SelectionMockingTestCase):
@@ -297,6 +299,7 @@ class BaseFileNameTest(SelectionMockingTestCase):
 
     def _base_file_name_arg(self, run_summation_mock):
         first_call = 0
+        print(run_summation_mock.call_args)
         return run_summation_mock.call_args[first_call][2]
 
     def _retrieve_generated_name_for(self, run_paths):


### PR DESCRIPTION
**Description of work.**
This PR introduces a button in the add runs tab of the SANS v2 GUI which selects an output directory for added runs, separate from the default save directory

**Report to:** Steve King ISIS

**To test:**
1. Interfaces -> SANS -> SANS v2. Load the attached user file
2. Click manage directories and select an output directory
3. Click the add runs tab on the LHS, there should be a line of text "Save Directory:      ". That should be populated with your default save directory as you have not selected a separate directory yet.
4. Click the *Select Save Director* button and select a different directory
5. This should update the save directory in the add runs page but *not* in the run (first) page
6. Click the button again but this time click cancel. The add runs save directory should not change
7. Close mantid and relaunch. The save directory in the add runs tab of the GUI should initialise to the directory you last selected
8. In the add runs page, type "56799, 56806" at the top and click add
9. When this has processed (you should see a new file name pop up lower down the page) click sum
10. Check that the file has been added to your add runs save directory and not your default save directory

Fixes #24855 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
