### PR TITLE
Add logging to resource loading

### DIFF
--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -51,7 +51,11 @@ def import_qt(modulename, package, attr=None):
         try:
             lib = import_module(modulename + LIB_SUFFIX, package)
         except ImportError:
-            lib = import_module(modulename.lstrip('.') + LIB_SUFFIX)
+            try:
+                lib = import_module(modulename.lstrip('.') + LIB_SUFFIX)
+            except ImportError:
+                raise ImportError('No module named {} or {}'.format(modulename + LIB_SUFFIX,
+                                                                    modulename.lstrip('.') + LIB_SUFFIX))
     else:
         lib = import_module(modulename + LIB_SUFFIX)
 

--- a/qt/python/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/utils/qt/__init__.py
@@ -50,12 +50,14 @@ def import_qt(modulename, package, attr=None):
     if modulename.startswith('.'):
         try:
             lib = import_module(modulename + LIB_SUFFIX, package)
-        except ImportError:
+        except ImportError as e1:
             try:
                 lib = import_module(modulename.lstrip('.') + LIB_SUFFIX)
-            except ImportError:
-                raise ImportError('No module named {} or {}'.format(modulename + LIB_SUFFIX,
-                                                                    modulename.lstrip('.') + LIB_SUFFIX))
+            except ImportError as e2:
+                msg = 'import of "{}" failed with "{}"'
+                msg = 'First ' + msg.format(modulename + LIB_SUFFIX, e1) \
+                    + '. Second ' + msg.format(modulename.lstrip('.') + LIB_SUFFIX, e2)
+                raise ImportError(msg)
     else:
         lib = import_module(modulename + LIB_SUFFIX)
 


### PR DESCRIPTION
Since this is a frequent enough issue, add logging to aid in tracking down issues in production.

**To test:**

Turn up logging to `debug` and see that you can see what is being loaded.

*There is no associated issue.*

*This does not require release notes* because it for developers to debug installation issues.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
