### PR TITLE
SANSBeamCentreFinder.py: make it work when there is no GUI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -26,6 +26,7 @@ from sans.state.state_base import create_deserialized_sans_state_from_property_m
 
 PYQT4 = False
 IN_MANTIDPLOT = False
+WITHOUT_GUI = False
 try:
     from qtpy import PYQT4
 except ImportError:
@@ -37,7 +38,10 @@ if PYQT4:
     except (Exception, Warning):
         pass
 else:
-    from mantidqt.plotting.functions import plot
+    try:
+        from mantidqt.plotting.functions import plot
+    except ImportError:
+        WITHOUT_GUI = True
 
 
 class SANSBeamCentreFinder(DataProcessorAlgorithm):
@@ -271,8 +275,9 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         if not isinstance(output_workspaces, list):
             output_workspaces = [output_workspaces]
 
-        plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
-             plot_kwargs=plot_kwargs, window_title=title)
+        if not WITHOUT_GUI:
+            plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
+                 plot_kwargs=plot_kwargs, window_title=title)
 
     def _get_cloned_workspace(self, workspace_name):
         workspace = self.getProperty(workspace_name).value


### PR DESCRIPTION
**Description of work.**

In framework-only builds (conda), no GUI is available. SANSBeamCentreFinder fails for now because of that. This PR fix that.

**To test:**

Make sure all system tests on jenkins pass.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
