### PR TITLE
Fix mplcpp Axes::text for python3

### DIFF
--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -131,7 +131,7 @@ Artist Axes::text(double x, double y, QString text,
   auto args =
       Python::NewRef(Py_BuildValue("(ffs)", x, y, text.toLatin1().constData()));
   auto kwargs = Python::NewRef(
-      Py_BuildValue("(ss)", "horizontalalignment", horizontalAlignment));
+      Py_BuildValue("{ss}", "horizontalalignment", horizontalAlignment));
   return Artist(pyobj().attr("text")(*args, **kwargs));
 }
 


### PR DESCRIPTION
[MantidQtWidgetsMplCppTestQt5.AxesTest currently fails on Ubuntu 18.04 with python3](http://builds.mantidproject.org/job/master_clean-ubuntu-18.04-python3/270/testReport/). `kwargs` should be a dict instead of tuple.


**To test:**
See that `ctest -R MantidQtWidgetsMplCppTestQt5_AxesTest` now passes on Ubuntu 18.04 with python3.


*There is no associated issue.*


*This does not require release notes* because it just fixes an internally failing test


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
