### PR TITLE
MR: leave points with big error

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -505,10 +505,10 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
         data_e = q_rebin.dataE(0)
 
         # Values < 1e-12 and values where the error is greater than the value are replaced by 0+-1
-        for i in range(len(data_y)):
-            if data_y[i] < 1e-12 or data_e[i]>data_y[i]:
-                data_y[i]=0.0
-                data_e[i]=1.0
+        #for i in range(len(data_y)):
+        #    if data_y[i] < 1e-12 or data_e[i]>data_y[i]:
+        #        data_y[i]=0.0
+        #        data_e[i]=1.0
 
         # Sanity check
         if sum(data_y) == 0:

--- a/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/MagnetismReflectometryReduction.py
@@ -502,13 +502,6 @@ class MagnetismReflectometryReduction(PythonAlgorithm):
 
         # Clean up the workspace for backward compatibility
         data_y = q_rebin.dataY(0)
-        data_e = q_rebin.dataE(0)
-
-        # Values < 1e-12 and values where the error is greater than the value are replaced by 0+-1
-        #for i in range(len(data_y)):
-        #    if data_y[i] < 1e-12 or data_e[i]>data_y[i]:
-        #        data_y[i]=0.0
-        #        data_e[i]=1.0
 
         # Sanity check
         if sum(data_y) == 0:


### PR DESCRIPTION
A carry-over feature from LR has been to trim points where the error bar is larger than the reflectivity value. Those points were replaced by 0 +- 1.

That feature should be removed from MR (it should probably be removed from LR too).

**Report to:** mathieu

**To test:**

- make sure tests pass
- inspect code

*There is no associated issue.*

This does not require release notes.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
