### PR TITLE
Upgrade bundled version of IPython on Windows

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 22bf373a4055d85b6793a34f6c823719d482a229 )
+  set ( THIRD_PARTY_GIT_SHA1 3284b21de6bf3642286797a4f22b3d3dd8e45fc5 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -18,7 +18,7 @@ set PYTHONPATH=%_BIN_DIR%;%PYTHONPATH%@PARAVIEW_PYTHON_PATHS@
 
 :: Python drivers
 set _PYTHON_EXE=%PYTHONHOME%\python.exe
-set _IPYTHON_CMD=%PYTHONHOME%\Scripts\ipython.cmd
+set _JUPYTER_CMD=%PYTHONHOME%\Scripts\jupyter.cmd
 
 :: QtPy should use Qt4 by unless specified
 if "%QT_API%"=="" (
@@ -42,7 +42,7 @@ if "%1"=="--classic" (
 )
 
 :: Start ipython and pass through all arguments to it
-start "Mantid Python" /B /WAIT %_IPYTHON_CMD% %*
+start "Mantid Python" /B /WAIT %_JUPYTER_CMD% %*
 if %ERRORLEVEL% NEQ 0 exit /B %ERRORLEVEL%
 goto TheEnd
 

--- a/docs/source/release/v4.0.0/framework.rst
+++ b/docs/source/release/v4.0.0/framework.rst
@@ -167,6 +167,7 @@ Improvements
 - It is now possible to build custom materials with :class:`mantid.kernel.MaterialBuilder` without setting a formula or atomic number. In this case, all cross sections and number density have to be given.
 - Python plotting now handles `twinx` and `twiny` axes for workspaces.
 - :py:obj:`mantid.kernel.MaterialBuilder` now supports number densities in formula units per cubic Ångström.
+- IPython on Windows has been upgraded to v5.8.0. This is the last version that supports Python 2.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -10,17 +10,9 @@
 from __future__ import (absolute_import, unicode_literals)
 
 # system imports
-import sys
 
 # third-party library imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
-try:
-    from IPython.core.usage import quick_guide
-except ImportError:  # quick_guide was removed in IPython 6.0
-    quick_guide = ''
-from IPython.core.usage import release as ipy_release
-from matplotlib import __version__ as mpl_version
-from numpy.version import version as np_version
 from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
@@ -28,17 +20,6 @@ from ..config.fonts import text_font
 from ..plugins.base import PluginWidget
 
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
-
-DEFAULT_BANNER_PARTS = [
-    'IPython {version} -- An enhanced Interactive Python.\n'.format(
-        version=ipy_release.version,
-        ),
-    quick_guide,
-    '\nPython {}, numpy {}, matplotlib {}\n'.format(sys.version.split('\n')[0].strip(), np_version, mpl_version),
-    'Type "copyright", "credits" or "license" for more information.\n',
-]
-
-BANNER = ''.join(DEFAULT_BANNER_PARTS)
 
 # should we share this with plugins.editor?
 STARTUP_CODE = """from __future__ import (absolute_import, division, print_function, unicode_literals)
@@ -56,7 +37,7 @@ class JupyterConsole(PluginWidget):
 
         # layout
         font = text_font()
-        self.console = InProcessJupyterConsole(self, banner=BANNER, startup_code=STARTUP_CODE,
+        self.console = InProcessJupyterConsole(self, startup_code=STARTUP_CODE,
                                                font_family=font.family(), font_size=font.pointSize())
         layout = QVBoxLayout()
         layout.addWidget(self.console)

--- a/qt/python/mantidqt/widgets/jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/jupyterconsole.py
@@ -37,29 +37,12 @@ class InProcessJupyterConsole(RichJupyterWidget):
         :param args: Positional arguments passed directly to RichJupyterWidget
         :param kwargs: Keyword arguments. The following keywords are understood by this widget:
 
-          - banner: Replace the default banner with this text
-          - startup_code: A code snippet to run on startup. It is also added to the banner to inform the user.
+          - startup_code: A code snippet to run on startup.
 
         the rest are passed to RichJupyterWidget
         """
-        banner = kwargs.pop("banner", "")
         startup_code = kwargs.pop("startup_code", "")
         super(InProcessJupyterConsole, self).__init__(*args, **kwargs)
-
-        # adjust startup banner accordingly
-        # newer ipython has banner1 & banner2 and not just banner
-        two_ptr_banner = hasattr(self, 'banner1')
-        if not banner:
-            banner = self.banner1 if two_ptr_banner else self.banner
-        if startup_code:
-            banner += "\n" + \
-                "The following code has been executed at startup:\n\n" + \
-                startup_code
-        if two_ptr_banner:
-            self.banner1 = banner
-            self.banner2 = ''
-        else:
-            self.banner = banner
 
         # create an in-process kernel
         kernel_manager = QtInProcessKernelManager()
@@ -71,7 +54,7 @@ class InProcessJupyterConsole(RichJupyterWidget):
         shell = kernel.shell
         shell.run_code = async_wrapper(shell.run_code, shell)
 
-        # attach channels, start kenel and run any startup code
+        # attach channels, start kernel and run any startup code
         kernel_client = kernel_manager.client()
         kernel_client.start_channels()
         if startup_code:

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -10,25 +10,19 @@
 from __future__ import (absolute_import)
 
 # system imports
-import sys
+# import readline before QApplication starts to avoid segfault with IPython 5 and Python 3
+import readline  # noqa
 import unittest
 
 # third-party library imports
-import IPython
-from qtpy import QT_VERSION
 
 # local package imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
 from mantidqt.utils.qt.testing import GuiTest
 
 
-PRE_IPY5_PY3_QT5 = (sys.version_info.major == 3 and IPython.version_info[0] < 5 and int(QT_VERSION[0]) == 5)
-SKIP_REASON = "Segfault within readline for IPython < 5 and Python 3"
-
-
 class InProcessJupyterConsoleTest(GuiTest):
 
-    @unittest.skipIf(PRE_IPY5_PY3_QT5, SKIP_REASON)
     def test_construction_raises_no_errors(self):
         widget = InProcessJupyterConsole()
         self.assertTrue(hasattr(widget, "kernel_manager"))
@@ -36,16 +30,12 @@ class InProcessJupyterConsoleTest(GuiTest):
         self.assertTrue(len(widget.banner) > 0)
         del widget
 
-    @unittest.skipIf(PRE_IPY5_PY3_QT5, SKIP_REASON)
     def test_construction_with_banner_replaces_default(self):
-        widget = InProcessJupyterConsole(banner="Hello!")
-        self.assertEquals("Hello!", widget.banner)
+        widget = InProcessJupyterConsole()
         del widget
 
-    @unittest.skipIf(PRE_IPY5_PY3_QT5, SKIP_REASON)
     def test_construction_with_startup_code_adds_to_banner_and_executes(self):
         widget = InProcessJupyterConsole(startup_code="x = 1")
-        self.assertTrue("x = 1" in widget.banner)
         self.assertEquals(1, widget.kernel_manager.kernel.shell.user_ns['x'])
         del widget
 


### PR DESCRIPTION
**Description of work.**

This now ships the most recent version of IPython 5.x as this is the last version to support Python 2. We also include the `qtconsole` package that is now required to provide the Qt console widget.

This was requested by the Reflectometry group at ISIS in order to access the latest and greatest features possible from the IPython notebooks.

When this is merged please also merge mantidproject/thirdparty-msvc2015#42.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Build on Windows and ensure the IPython console in MantidPlot and workbench still works.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
