### PR TITLE
EnginX stopped unnecessarily creating vanadium files

### DIFF
--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -109,7 +109,6 @@ def run(ceria_run, do_cal, do_van, van_run, calibration_directory, calibration_g
 
     # check whether creating a vanadium is required or requested
     if (not os.path.isfile(_get_van_names(van_run, calibration_directory)[0])) or do_van:
-        print("create vanadium")
         create_vanadium(van_run, calibration_directory)
 
     # find the file names of calibration files that would be created by this run
@@ -123,7 +122,6 @@ def run(ceria_run, do_cal, do_van, van_run, calibration_directory, calibration_g
     # if the calibration files that this run would create are not present, or the user has requested it, create the
     # calibration files
     if not all(expected_cals_present) or do_cal:
-        print("create calibration")
         create_calibration(ceria_run, van_run, calibration_directory, calibration_general, cropped, crop_name, crop_on)
 
     # if a focus is requested, run the focus

--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -108,8 +108,8 @@ def run(ceria_run, do_cal, do_van, van_run, calibration_directory, calibration_g
     """
 
     # check whether creating a vanadium is required or requested
-    vanadium = _gen_filename(van_run)
-    if not os.path.isfile(vanadium) or do_van:
+    if (not os.path.isfile(_get_van_names(van_run, calibration_directory)[0])) or do_van:
+        print("create vanadium")
         create_vanadium(van_run, calibration_directory)
 
     # find the file names of calibration files that would be created by this run
@@ -123,6 +123,7 @@ def run(ceria_run, do_cal, do_van, van_run, calibration_directory, calibration_g
     # if the calibration files that this run would create are not present, or the user has requested it, create the
     # calibration files
     if not all(expected_cals_present) or do_cal:
+        print("create calibration")
         create_calibration(ceria_run, van_run, calibration_directory, calibration_general, cropped, crop_name, crop_on)
 
     # if a focus is requested, run the focus


### PR DESCRIPTION
**Description of work.**
Calibration and Vanadium should only created when forced to, or when the files they generate are not present, however vanadium was always being created, this change to the script fixes that, and prints to the script window when these are being created.

**To test:**
run the following script twice 
```
import Engineering.EnginX as Enginx
Enginx.main(vanadium_run="236516", user="test", focus_run="299080")
```
the first time should generate the vanadium and calibration, and state as such in the script window, the second time it should find the files, and thus not bother creating them

Fixes #24850 


*This does not require release notes* because **it fixes a bug not present in a release build of mantid**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
