### PR TITLE
Remove Show Transmission Button

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSCreateAdjustmentWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSCreateAdjustmentWorkspacesTest.py
@@ -175,11 +175,10 @@ class SANSCreateAdjustmentWorkspacesTest(unittest.TestCase):
             self.assertTrue(calculated_transmission)
             self.assertTrue(unfitted_transmisison)
 
-    def test_that_when_show_transmission_is_true_transmission_runs_are_output(self):
+    def test_that_transmission_runs_are_output(self):
         # Arrange
         state = SANSCreateAdjustmentWorkspacesTest._get_state()
         state.adjustment.wide_angle_correction = True
-        state.adjustment.show_transmission = True
         serialized_state = state.property_manager
         sample_data = SANSCreateAdjustmentWorkspacesTest._get_sample_data()
         sample_monitor_data = SANSCreateAdjustmentWorkspacesTest._get_sample_monitor_data(3.)
@@ -200,7 +199,7 @@ class SANSCreateAdjustmentWorkspacesTest(unittest.TestCase):
             # We expect a wavelength and pixel adjustment workspace since we set the flag to true and provided a
             # sample data set
             self.assertTrue(wavelength_and_pixel_adjustment)
-            # We expect transmission workspaces since show_transmission was set to true
+            # We expect transmission workspaces
             self.assertTrue(calculated_transmission)
             self.assertTrue(unfitted_transmisison)
         except:  # noqa

--- a/Testing/SystemTests/tests/analysis/SANSReductionCoreTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSReductionCoreTest.py
@@ -165,7 +165,6 @@ class SANSReductionCoreTest(unittest.TestCase):
 
         # Construct the final state
         state = user_file_director.construct()
-        state.adjustment.show_transmission = True
 
         # Load the sample workspaces
         workspace, workspace_monitor, transmission_workspace, direct_workspace = self._load_workspace(state)

--- a/Testing/SystemTests/tests/analysis/SANSSingleReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSSingleReductionTest.py
@@ -161,7 +161,6 @@ class SANSSingleReductionTest(unittest.TestCase):
         # COMPATIBILITY END
         # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
         state = user_file_director.construct()
-        state.adjustment.show_transmission = True
 
         # Load the sample workspaces
         sample, sample_monitor, transmission_workspace, direct_workspace, can, can_monitor, \

--- a/docs/source/release/v4.0.0/sans.rst
+++ b/docs/source/release/v4.0.0/sans.rst
@@ -46,6 +46,7 @@ Improved
 * The gui will remember which output mode (Memory, File, Both) you last used and set that as your default when on the SANS interface.
 * The gui will check *save can* by default if it was checked when the gui was last used.
 * Default adding mode is set to Event for all instruments except for LOQ, which defaults to Custom.
+* Removed the show transmission check box. Transmission workspaces are always added to output files regardless of output mode, and are always added to ADS if "memory" or "both" output mode is selected.
 
 Bug fixes
 #########

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1055,14 +1055,6 @@ class SANSDataProcessorGui(QMainWindow,
             self._on_compatibility_unchecked()
 
     @property
-    def show_transmission(self):
-        return self.show_transmission_view.isChecked()
-
-    @show_transmission.setter
-    def show_transmission(self, value):
-        self.show_transmission_view.setChecked(value)
-
-    @property
     def instrument(self):
         return get_instrument_from_gui_selection(self.instrument_type.text())
 
@@ -1989,8 +1981,6 @@ class SANSDataProcessorGui(QMainWindow,
         self.fit_can_wavelength_combo_box.setChecked(False)
         self.fit_can_wavelength_min_line_edit.setText("")
         self.fit_can_wavelength_max_line_edit.setText("")
-
-        self.show_transmission_view.setChecked(True)
 
         self.pixel_adjustment_det_1_line_edit.setText("")
         self.pixel_adjustment_det_2_line_edit.setText("")

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -1440,13 +1440,6 @@ QGroupBox::title {
                           </property>
                          </widget>
                         </item>
-                        <item row="2" column="0">
-                         <widget class="QCheckBox" name="show_transmission_view">
-                          <property name="text">
-                           <string>Show Transmission</string>
-                          </property>
-                         </widget>
-                        </item>
                        </layout>
                       </widget>
                      </item>
@@ -2325,7 +2318,6 @@ QGroupBox::title {
   <tabstop>fit_sample_wavelength_combo_box</tabstop>
   <tabstop>fit_sample_wavelength_min_line_edit</tabstop>
   <tabstop>fit_sample_wavelength_max_line_edit</tabstop>
-  <tabstop>show_transmission_view</tabstop>
   <tabstop>fit_can_use_fit_check_box</tabstop>
   <tabstop>fit_can_fit_type_combo_box</tabstop>
   <tabstop>fit_can_polynomial_order_spin_box</tabstop>

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -149,10 +149,6 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
     elif output_mode is OutputMode.Both:
         save_to_file(reduction_packages, save_can)
 
-    if output_mode is not OutputMode.SaveToFile and not state.adjustment.show_transmission:
-        # Remove transmission workspaces from ADS only
-        delete_reduced_workspaces(reduction_packages, include_non_transmission=False)
-
     # -----------------------------------------------------------------------
     # Clean up other workspaces if the optimizations have not been turned on.
     # -----------------------------------------------------------------------

--- a/scripts/SANS/sans/algorithm_detail/single_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/single_execution.py
@@ -251,8 +251,7 @@ def run_optimized_for_can(reduction_alg, reduction_setting_bundle):
                                      (output_parts_bundle.output_workspace_count is not None and
                                       output_parts_bundle.output_workspace_norm is None))
     is_invalid_transmission_workspaces = (output_transmission_bundle.calculated_transmission_workspace is None
-                                          or output_transmission_bundle.unfitted_transmission_workspace is None) \
-        and state.adjustment.show_transmission
+                                          or output_transmission_bundle.unfitted_transmission_workspace is None)
     partial_output_require_reload = output_parts and is_invalid_partial_workspaces
 
     must_reload = output_bundle.output_workspace is None or partial_output_require_reload or is_invalid_transmission_workspaces

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -770,14 +770,6 @@ class StateGuiModel(object):
     def transmission_can_wavelength_max(self, value):
         self._set_transmission_fit(data_type=DataType.Can, stop=value)
 
-    @property
-    def show_transmission(self):
-        return self.get_simple_element(element_id=OtherId.show_transmission, default_value=True)
-
-    @show_transmission.setter
-    def show_transmission(self, value):
-        self.set_simple_element(element_id=OtherId.show_transmission, value=value)
-
     # ------------------------------------------------------------------------------------------------------------------
     # Wavelength- and pixel-adjustment files
     # ------------------------------------------------------------------------------------------------------------------

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -319,8 +319,7 @@ class RunTabPresenter(object):
                     " has been specified.".format(user_file_path))
         except RuntimeError as path_error:
             # This exception block runs if user file does not exist
-            self._view.on_user_file_load_failure()
-            self.display_errors(path_error, error_msg + " when finding file.")
+            self._on_user_file_load_failure(path_error, error_msg + " when finding file.")
         else:
             try:
                 self._table_model.user_file = user_file_path
@@ -332,8 +331,7 @@ class RunTabPresenter(object):
                 user_file_items = user_file_reader.read_user_file()
             except (RuntimeError, ValueError) as e:
                 # It is in this exception block that loading fails if the file is invalid (e.g. a csv)
-                self._view.on_user_file_load_failure()
-                self.display_errors(e, error_msg + " when reading file.", use_error_name=True)
+                self._on_user_file_load_failure(e, error_msg + " when reading file.", use_error_name=True)
             else:
                 try:
                     # 4. Populate the model
@@ -352,14 +350,19 @@ class RunTabPresenter(object):
 
                 except RuntimeError as instrument_e:
                     # This exception block runs if the user file does not contain an parsable instrument
-                    self._view.on_user_file_load_failure()
-                    self.display_errors(instrument_e, error_msg + " when reading instrument.")
+                    self._on_user_file_load_failure(instrument_e, error_msg + " when reading instrument.")
                 except Exception as other_error:
                     # If we don't catch all exceptions, SANS can fail to open if last loaded
                     # user file contains an error that would not otherwise be caught
                     traceback.print_exc()
-                    self._view.on_user_file_load_failure()
-                    self.display_errors(other_error, "Unknown error in loading user file.", use_error_name=True)
+                    self._on_user_file_load_failure(other_error, "Unknown error in loading user file.",
+                                                    use_error_name=True)
+
+    def _on_user_file_load_failure(self, e, message, use_error_name=False):
+        self._setup_instrument_specific_settings(SANSInstrument.NoInstrument)
+        self._view.instrument = SANSInstrument.NoInstrument
+        self._view.on_user_file_load_failure()
+        self.display_errors(e, message, use_error_name)
 
     def on_batch_file_load(self):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -931,7 +931,6 @@ class RunTabPresenter(object):
         self._set_on_view("transmission_radius")
         self._set_on_view("transmission_monitor")
         self._set_on_view("transmission_mn_shift")
-        self._set_on_view("show_transmission")
 
         self._set_on_view_transmission_fit()
 
@@ -1120,7 +1119,6 @@ class RunTabPresenter(object):
         self._set_on_state_model("transmission_radius", state_model)
         self._set_on_state_model("transmission_monitor", state_model)
         self._set_on_state_model("transmission_mn_shift", state_model)
-        self._set_on_state_model("show_transmission", state_model)
 
         self._set_on_state_model_transmission_fit(state_model)
 

--- a/scripts/SANS/sans/state/adjustment.py
+++ b/scripts/SANS/sans/state/adjustment.py
@@ -29,12 +29,10 @@ class StateAdjustment(StateBase):
     normalize_to_monitor = TypedParameter(StateNormalizeToMonitor, validator_sub_state)
     wavelength_and_pixel_adjustment = TypedParameter(StateWavelengthAndPixelAdjustment, validator_sub_state)
     wide_angle_correction = BoolParameter()
-    show_transmission = BoolParameter()
 
     def __init__(self):
         super(StateAdjustment, self).__init__()
         self.wide_angle_correction = False
-        self.show_transmission = False
 
     def validate(self):
         is_invalid = {}

--- a/scripts/SANS/sans/user_file/settings_tags.py
+++ b/scripts/SANS/sans/user_file/settings_tags.py
@@ -143,7 +143,6 @@ class BackId(object):
 @serializable_enum("reduction_dimensionality", "use_full_wavelength_range", "event_slices",
                    "use_compatibility_mode", "save_types", "save_as_zero_error_free", "user_specified_output_name",
                    "user_specified_output_name_suffix", "use_reduction_mode_as_suffix", "sample_width", "sample_height",
-                   "sample_thickness", "sample_shape", "merge_mask", "merge_min", "merge_max", "show_transmission",
-                   "wavelength_range")
+                   "sample_thickness", "sample_shape", "merge_mask", "merge_min", "merge_max", "wavelength_range")
 class OtherId(object):
     pass

--- a/scripts/SANS/sans/user_file/state_director.py
+++ b/scripts/SANS/sans/user_file/state_director.py
@@ -279,7 +279,6 @@ class StateDirectorISIS(object):
         self._set_up_normalize_to_monitor_state(user_file_items)
         self._set_up_calculate_transmission(user_file_items)
         self._set_up_wavelength_and_pixel_adjustment(user_file_items)
-        self._set_up_show_transmission(user_file_items)
 
         # Convert to Q state
         self._set_up_convert_to_q_state(user_file_items)
@@ -1281,15 +1280,6 @@ class StateDirectorISIS(object):
             check_if_contains_only_one_element(use_compatibility_mode, OtherId.use_compatibility_mode)
             use_compatibility_mode = use_compatibility_mode[-1]
             self._compatibility_builder.set_use_compatibility_mode(use_compatibility_mode)
-
-    def _set_up_show_transmission(self, user_file_items):
-        if OtherId.show_transmission in user_file_items:
-            show_transmission = user_file_items[OtherId.show_transmission]
-            check_if_contains_only_one_element(show_transmission, OtherId.show_transmission)
-            show_transmission = show_transmission[-1]
-            self._adjustment_builder.set_show_transmission(show_transmission)
-        else:
-            self._adjustment_builder.set_show_transmission(True)
 
     def _set_up_save(self, user_file_items):
         if OtherId.save_types in user_file_items:

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -153,7 +153,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertTrue(view.radius_limit_min == 12.)
         self.assertTrue(view.radius_limit_max == 15.)
         self.assertTrue(view.compatibility_mode)
-        self.assertTrue(view.show_transmission)
 
         # Assert that Beam Centre View is updated correctly
         self.assertEqual(view.beam_centre.lab_pos_1, 155.45)

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -413,15 +413,6 @@ class StateGuiModelTest(unittest.TestCase):
         self.assertTrue(state_gui_model.transmission_can_wavelength_min == 1.3)
         self.assertTrue(state_gui_model.transmission_can_wavelength_max == 10.3)
 
-    def test_that_default_show_transmission_is_true(self):
-        state_gui_model = StateGuiModel({"test": [1]})
-        self.assertTrue(state_gui_model.show_transmission)
-
-    def test_that_can_set_show_transmission(self):
-        state_gui_model = StateGuiModel({"test": [1]})
-        state_gui_model.show_transmission = True
-        self.assertTrue(state_gui_model.show_transmission)
-
     # ==================================================================================================================
     # ==================================================================================================================
     # Q TAB

--- a/scripts/test/SANS/state/adjustment_test.py
+++ b/scripts/test/SANS/state/adjustment_test.py
@@ -90,12 +90,10 @@ class StateAdjustmentBuilderTest(unittest.TestCase):
         builder.set_normalize_to_monitor(MockStateNormalizeToMonitor())
         builder.set_wavelength_and_pixel_adjustment(MockStateWavelengthAndPixelAdjustment())
         builder.set_wide_angle_correction(False)
-        builder.set_show_transmission(False)
         state = builder.build()
 
         # # Assert
         self.assertTrue(not state.wide_angle_correction)
-        self.assertTrue(not state.show_transmission)
         try:
             state.validate()
             is_valid = True

--- a/scripts/test/SANS/user_file/state_director_test.py
+++ b/scripts/test/SANS/user_file/state_director_test.py
@@ -157,7 +157,6 @@ class UserFileStateDirectorISISTest(unittest.TestCase):
         self.assertTrue(calculate_transmission.fit[DataType.to_string(DataType.Can)].wavelength_low == 1.5)
         self.assertTrue(calculate_transmission.fit[DataType.to_string(DataType.Can)].wavelength_high == 12.5)
         self.assertTrue(calculate_transmission.fit[DataType.to_string(DataType.Can)].polynomial_order == 0)
-        self.assertTrue(adjustment.show_transmission)
 
         # Wavelength and Pixel Adjustment
         wavelength_and_pixel_adjustment = adjustment.wavelength_and_pixel_adjustment


### PR DESCRIPTION
**Description of work.**
This PR removes the unused "show transmission" button from the SANS v2 GUI, which determines whether or not transmission workspaces are output to the ADS. In this PR transmission workspaces are always output.
This PR also makes sure that the instrument is reset to "NoInstrument" if a user file load has failed.

**Report to:** nobody

**Data**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/2904713/loqPRData.zip)


**To test:**
1. Load the attached user file and batch file
2. In `Manage Directories` select an output directory
3. In the main GUI tab click process all
4. Check that the ADS contains `first_time_trans` and `second_time_trans` group workspaces, which contain the sample and can transmission workspaces

5. Click load user file and attempt to load the batch file. You should have a warning dialog, the user file line edit should be empty, and the instrument should be *NoInstrument*

Fixes #24853 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
