### PR TITLE
Use qtpy in ISISCommandInterface

### DIFF
--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -35,11 +35,11 @@ except (Exception, Warning):
     # the result is that attempting to plot will raise an exception
 
 try:
-    from PyQt4.QtGui import qApp
+    from qtpy.QtWidgets import qApp
 
     def appwidgets():
         return qApp.allWidgets()
-except ImportError:
+except (ImportError, RuntimeError):
     def appwidgets():
         return []
 


### PR DESCRIPTION
**Description of work.**

Stops issues with mixing up Qt4/Qt5 when importing the SANS `ISISCommandInterface` on the command line.

The [macOS system tests](http://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-osx/714/console) are failing due to a SANS test mixing up Qt4/Qt5. Using `qtpy` in 

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Code review should suffice.

*There is no associated issue.*

*This does not require release notes* because **it is an internal issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
