### PR TITLE
Change alg landing page to categories, not full index.

### DIFF
--- a/docs/source/_templates/algorithmcategories.html
+++ b/docs/source/_templates/algorithmcategories.html
@@ -1,0 +1,43 @@
+{# Generates a better view for category pages #}
+
+{% extends "layout.html" %}
+
+{% macro list_to_definition_list(item_list) -%}
+{# Output a list in a single column #}
+{# It currently assumes the items in the list are mantiddoc.directives.categories.PageRef classes #}
+  <dl><ul>
+  {% for item in item_list %}
+    <li><dt><a href="{{ item.link(outpath) }}">{{ item.name }}</a></dt><dd> <ul> {{ item.additional_text }}</ul></dd></li>
+  {%- endfor -%}
+  </ul></dl>
+{%- endmacro %}
+
+{%- block body -%}
+    <h1> {{ title }} </h1>
+    {% set header_file = text_page %}
+    {% include header_file ignore missing %}
+    <p>Mantid contains many algorithms for loading, saving and performing operations on a wide variety of data.  The categories below should help you find the algorithm you need.  To help with ensuring the Algorithms are found in the most sensible places, they can be in more than one category.  If you prefer to search, or know the name you can use the <a href='categories/Algorithm Index.html'>Algorithms Index</a>.</p>
+    {% if parentcategory %}
+    <p> {{ parentcategory }} </p>
+    {% endif %}
+    {% if generalcategories %}
+    <h2> General Algorithms </h2>
+    {{ list_to_definition_list(generalcategories) }}
+    <hr>
+    {% endif %}
+    
+    {% if techniquecategories %}
+    <h2> Technique Specific Algorithms  </h2>
+    {{ list_to_definition_list(techniquecategories) }}
+    <hr>
+    {% endif %}    
+    
+    {% if facilitycategories %}
+    <h2> Facility Specific Algorithms  </h2>
+    {{ list_to_definition_list(facilitycategories) }}
+    <hr>
+    {% endif %}
+    
+    <p><b>Complete Index:</b> <a href='categories/Algorithm Index.html'>Algorithms Index</a></p>
+
+{%- endblock -%}

--- a/docs/source/_templates/category.html
+++ b/docs/source/_templates/category.html
@@ -31,18 +31,38 @@
     </div>
 {%- endmacro %}
 
+{% macro list_to_single_column(item_list) -%}
+{# Output a list in a single column #}
+{# It currently assumes the items in the list are mantiddoc.directives.categories.PageRef classes #}
+  <ul>
+  {% for item in item_list %}
+    <li><a href="{{ item.link(outpath) }}">{{ item.name }}</a></li>
+  {%- endfor -%}
+  </ul>
+{%- endmacro %}
+
 {%- block body -%}
     <h1> Category: {{ title }} </h1>
+    {% set header_file = text_page %}
+    {% include header_file ignore missing %}
     {% if subcategories %}
     <br>
     <h2> Subcategories </h2>
-    {{ split_to_three_columns(subcategories) }}
+    {% if subcategories|length > 10 %}
+      {{ split_to_three_columns(subcategories) }}
+    {% else %}
+      {{ list_to_single_column(subcategories) }}
+    {% endif %}
     <hr>
     {% endif %}
 
     {% if pages %}
-    <h2> Pages </h2>
-    {{ split_to_three_columns(pages) }}
+    <h2>  Pages  </h2>
+      {% if pages|length > 10 %}
+        {{ split_to_three_columns(pages) }}
+      {% else %}
+        {{ list_to_single_column(pages) }}
+      {% endif %}
     {% endif %}
     
     {% if parentcategory %}

--- a/docs/source/algorithms/categories/Arithmetic.txt
+++ b/docs/source/algorithms/categories/Arithmetic.txt
@@ -1,0 +1,1 @@
+Generic mathematical operations on workspaces, including fast fourier transforms.

--- a/docs/source/algorithms/categories/CorrectionFunctions.txt
+++ b/docs/source/algorithms/categories/CorrectionFunctions.txt
@@ -1,0 +1,1 @@
+Various correction functions including absorption and multiple scattering corrections.

--- a/docs/source/algorithms/categories/Crystal.txt
+++ b/docs/source/algorithms/categories/Crystal.txt
@@ -1,0 +1,1 @@
+Algorithms specifically for single crystal experiments.

--- a/docs/source/algorithms/categories/DataHandling.txt
+++ b/docs/source/algorithms/categories/DataHandling.txt
@@ -1,0 +1,1 @@
+For loading and saving data from a wide variety of formats.

--- a/docs/source/algorithms/categories/Deprecated.txt
+++ b/docs/source/algorithms/categories/Deprecated.txt
@@ -1,0 +1,1 @@
+Algorithms in this category are planned for removal in future releases, alternatives are in the algorithm pages.

--- a/docs/source/algorithms/categories/Diagnostics.txt
+++ b/docs/source/algorithms/categories/Diagnostics.txt
@@ -1,0 +1,1 @@
+Algorithms for performing diagnostics on workspaces.

--- a/docs/source/algorithms/categories/Diffraction.txt
+++ b/docs/source/algorithms/categories/Diffraction.txt
@@ -1,0 +1,1 @@
+Algorithms to support single crystal, powder and total diffraction.

--- a/docs/source/algorithms/categories/Events.txt
+++ b/docs/source/algorithms/categories/Events.txt
@@ -1,0 +1,1 @@
+Algorithms for manipulating event based data, including filtering, compressing and sorting event workspaces.

--- a/docs/source/algorithms/categories/Inelastic.txt
+++ b/docs/source/algorithms/categories/Inelastic.txt
@@ -1,0 +1,1 @@
+Algorithms to support direct and indirect neutron spectroscopy.

--- a/docs/source/algorithms/categories/MDAlgorithms.txt
+++ b/docs/source/algorithms/categories/MDAlgorithms.txt
@@ -1,0 +1,1 @@
+Algorithms for creating and manipulating multi-dimensional workspaces.

--- a/docs/source/algorithms/categories/Optimization.txt
+++ b/docs/source/algorithms/categories/Optimization.txt
@@ -1,0 +1,1 @@
+Support for fitting splines, peaks and other models to data. Including  peak finding, as stripping peaks from data.

--- a/docs/source/algorithms/categories/Remote.txt
+++ b/docs/source/algorithms/categories/Remote.txt
@@ -1,0 +1,1 @@
+Support for launching job on remote computing resources.

--- a/docs/source/algorithms/categories/Sample.txt
+++ b/docs/source/algorithms/categories/Sample.txt
@@ -1,0 +1,1 @@
+Sample shape and material definition, manipulation and sample transmission calculation.

--- a/docs/source/algorithms/categories/Simulation.txt
+++ b/docs/source/algorithms/categories/Simulation.txt
@@ -1,0 +1,1 @@
+Algorithms to load and operate on data from external simulation packages.

--- a/docs/source/algorithms/categories/Transforms.txt
+++ b/docs/source/algorithms/categories/Transforms.txt
@@ -1,0 +1,1 @@
+Algorithms for transforming data and other workspace axes such as axes, grouping, masking rebinning, units etc.

--- a/docs/source/algorithms/categories/Utility.txt
+++ b/docs/source/algorithms/categories/Utility.txt
@@ -1,0 +1,1 @@
+Various algorithms for operations like cloning, deleting, renaming and comparing workspaces, extracting monitors and generating python from a workspace.

--- a/docs/source/algorithms/categories/Workflow.txt
+++ b/docs/source/algorithms/categories/Workflow.txt
@@ -1,0 +1,1 @@
+Internal algorithms decribing complete, and partial workflows for data.  Most of these are not planned for direct use by users.

--- a/docs/source/algorithms/categories/facilitycategories.txt
+++ b/docs/source/algorithms/categories/facilitycategories.txt
@@ -1,0 +1,3 @@
+ILL
+ISIS
+SINQ

--- a/docs/source/algorithms/categories/hiddencategories.txt
+++ b/docs/source/algorithms/categories/hiddencategories.txt
@@ -1,0 +1,1 @@
+Algorithm Index

--- a/docs/source/algorithms/categories/techniquecategories.txt
+++ b/docs/source/algorithms/categories/techniquecategories.txt
@@ -1,0 +1,6 @@
+Crystal
+Diffraction
+Inelastic
+Muon
+Reflectometry
+SANS

--- a/docs/source/release/v4.0.0/ui.rst
+++ b/docs/source/release/v4.0.0/ui.rst
@@ -20,6 +20,11 @@ The following changes have been made _only_ on Windows, bringing it in line with
 - The Mantid Nightly build will now be installed in a different directory by default, to avoid overwriting the release Mantid installation.
 - The Mantid Nightly build desktop and start menu shortcuts will have the "Nightly" suffix appended, to distinguish from the release Mantid installation.
 
+Documentation
+-------------
+- The entry pages for he Mantid documentation have been improved, both the welcome page, and the Algorithms reference section.
+- The algorithms references section is now based around the algorithm categories, rather than the complete alphabetical list, although the full list is still available for those that remember it with fond memories.
+
 Project Recovery
 ----------------
 New


### PR DESCRIPTION

**Description of work.**
See changes in the to test section

**Report to:** nobody. 

**To test:**

1. Open the algorithms page from a variety of links (e.g. mantid home->documentation, mantidplot help page, anywhere else you can think of.)
1. Consider the changes below and check that they work (apart from perhaps the last one.)
1. Make sure that you test with the offline help as well as the generated html pages.
1. It would be worth testing on a non winodws build as there is a certain amount of path manipulation involved in this.

Changes:
- the first algorithms index page to be based on the categories, and be a bit prettier.  This is in the same location as the previous full list so all previous link should direct to there.
- the full list is linked from this page and is still acceptable
- Also changes the categories pages for small categories to use a single column when there are less than 10 pages.
- Fixes the broken code that allows links between parent and child categories
- Makes the world a better place

Fixes #22254

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
