### PR TITLE
Workbench: Fit property browser lines now keep all settings from one fit to another.

### DIFF
--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -241,8 +241,8 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
         # Add properties back to the lines
         new_lines = self.get_lines()
-        for ii, old_line in enumerate(original_lines):
-            new_lines[ii].update_from(old_line)
+        for new_line, old_line in zip(new_lines, original_lines):
+            new_line.update_from(old_line)
 
         # Now update the legend to make sure it changes to the old properties
         self.get_axes().legend()

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -228,12 +228,24 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         from mantidqt.plotting.functions import plot
         ws = mtd[name]
+
+        # Keep local copy of the original lines
+        original_lines = self.get_lines()
+
         self.clear_fit_result_lines()
         plot([ws], wksp_indices=[1, 2], fig=self.canvas.figure, overplot=True)
         name += ':'
         for lin in self.get_lines():
             if lin.get_label().startswith(name):
                 self.fit_result_lines.append(lin)
+
+        # Add properties back to the lines
+        new_lines = self.get_lines()
+        for ii, old_line in enumerate(original_lines):
+            new_lines[ii].update_from(old_line)
+
+        # Now update the legend to make sure it changes to the old properties
+        self.get_axes().legend()
 
     @Slot(int, float, float, float)
     def peak_added_slot(self, peak_id, centre, height, fwhm):


### PR DESCRIPTION
REQUIRES ~~#24562~~ TO BE MERGED FIRST

**Description of work.**
Previously when performing a fit it would remove the old settings from a previous line and create a completely new line. Whilst it still does this, it keeps a reference to the old lines and updates the new ones with the old's settings.

**To test:**
- Open Workbench
- Load a workspace capable of plotting a 1D graph (line graph)
- Open a plot of a single spectrum as a 1D graph
- Perform a fit (Any will do)
- The resulting lines should have some settings
- Perform another fit (Any will do)
- The resulting lines should have the same settings as the previous lines (i.e. the colour does not change)

<!-- Instructions for testing. -->

Fixes #24902 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

_*No release notes* Because this is a bug in unreleased code._

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
