### PR TITLE
Use fixed-width fonts for text areas in workbench

### DIFF
--- a/qt/applications/workbench/workbench/config/__init__.py
+++ b/qt/applications/workbench/workbench/config/__init__.py
@@ -18,9 +18,12 @@ and use it to access the settings
 """
 from __future__ import (absolute_import, unicode_literals)
 
+# third-party imports
 from qtpy.QtCore import QSettings
 
-from workbench.config.user import UserConfig
+# local imports
+from .user import UserConfig
+
 
 # -----------------------------------------------------------------------------
 # Constants

--- a/qt/applications/workbench/workbench/config/fonts.py
+++ b/qt/applications/workbench/workbench/config/fonts.py
@@ -1,0 +1,74 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+""" Utility functions to deal with fetching fonts
+"""
+from __future__ import (absolute_import, unicode_literals)
+
+# std imports
+import os
+import os.path as osp
+import sys
+
+# third-party imports
+from qtpy.QtGui import QFont, QFontDatabase
+
+
+def is_ubuntu():
+    """Return True if we're running an Ubuntu distro else return False"""
+    # platform.linux_distribution doesn't exist in Python 3.5
+    if sys.platform.startswith('linux') and osp.isfile('/etc/lsb-release'):
+        release_info = open('/etc/lsb-release').read()
+        if 'Ubuntu' in release_info:
+            return True
+        else:
+            return False
+    else:
+        return False
+
+
+# Plain-text fonts
+MONOSPACE = ['Monospace', 'DejaVu Sans Mono', 'Consolas',
+             'Bitstream Vera Sans Mono', 'Andale Mono', 'Liberation Mono',
+             'Courier New', 'Courier', 'monospace', 'Fixed', 'Terminal']
+
+
+# Define reasonable point sizes on various OSes
+if sys.platform == 'darwin':
+    MONOSPACE = ['Menlo'] + MONOSPACE
+    PT_SIZE = 12
+elif os.name == 'nt':
+    PT_SIZE = 10
+elif is_ubuntu():
+    MONOSPACE = ['Ubuntu Mono'] + MONOSPACE
+    PT_SIZE = 11
+else:
+    PT_SIZE = 9
+
+
+# Cached font for this system
+_TEXT_FONT_CACHE = None
+
+
+def text_font():
+    """Return the first monospace font for this system.
+    The font is cached on first access.
+    """
+    global _TEXT_FONT_CACHE
+    if _TEXT_FONT_CACHE is None:
+        fontdb = QFontDatabase()
+        families = fontdb.families()
+        for family in MONOSPACE:
+            if family in families:
+                _TEXT_FONT_CACHE = QFont(family)
+                break
+        _TEXT_FONT_CACHE.setPointSize(PT_SIZE)
+        _TEXT_FONT_CACHE.setFixedPitch(True)
+
+    return _TEXT_FONT_CACHE

--- a/qt/applications/workbench/workbench/config/fonts.py
+++ b/qt/applications/workbench/workbench/config/fonts.py
@@ -34,9 +34,9 @@ def is_ubuntu():
 
 
 # Plain-text fonts
-MONOSPACE = ['Monospace', 'DejaVu Sans Mono', 'Consolas',
-             'Bitstream Vera Sans Mono', 'Andale Mono', 'Liberation Mono',
-             'Courier New', 'Courier', 'monospace', 'Fixed', 'Terminal']
+MONOSPACE = ['Consolas', 'Monospace', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono',
+             'Andale Mono', 'Liberation Mono', 'Courier New',
+             'Courier', 'monospace', 'Fixed', 'Terminal']
 
 
 # Define reasonable point sizes on various OSes

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -13,14 +13,15 @@ from __future__ import (absolute_import, unicode_literals)
 import os.path as osp
 
 # third-party library imports
+from mantid.kernel import logger
+from mantidqt.utils.qt import add_actions, create_action
+from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
-from mantid.kernel import logger
-from mantidqt.utils.qt import add_actions, create_action
-from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
-from workbench.plugins.base import PluginWidget
+from ..config.fonts import text_font
+from ..plugins.base import PluginWidget
 
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
@@ -50,8 +51,9 @@ class MultiFileEditor(PluginWidget):
         super(MultiFileEditor, self).__init__(parent)
 
         # layout
-        self.editors = MultiPythonFileInterpreter(default_content=DEFAULT_CONTENT, parent=self)
-
+        self.editors = MultiPythonFileInterpreter(font=text_font(),
+                                                  default_content=DEFAULT_CONTENT,
+                                                  parent=self)
         layout = QVBoxLayout()
         layout.addWidget(self.editors)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/qt/applications/workbench/workbench/plugins/jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/jupyterconsole.py
@@ -24,7 +24,9 @@ from numpy.version import version as np_version
 from qtpy.QtWidgets import QVBoxLayout
 
 # local package imports
-from workbench.plugins.base import PluginWidget
+from ..config.fonts import text_font
+from ..plugins.base import PluginWidget
+
 # from mantidqt.utils.qt import toQSettings when readSettings/writeSettings are implemented
 
 DEFAULT_BANNER_PARTS = [
@@ -53,8 +55,9 @@ class JupyterConsole(PluginWidget):
         super(JupyterConsole, self).__init__(parent)
 
         # layout
-        self.console = InProcessJupyterConsole(self, banner=BANNER,
-                                               startup_code=STARTUP_CODE)
+        font = text_font()
+        self.console = InProcessJupyterConsole(self, banner=BANNER, startup_code=STARTUP_CODE,
+                                               font_family=font.family(), font_size=font.pointSize())
         layout = QVBoxLayout()
         layout.addWidget(self.console)
         self.setLayout(layout)

--- a/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
+++ b/qt/applications/workbench/workbench/plugins/logmessagedisplay.py
@@ -14,12 +14,13 @@ import sys
 
 # 3rdparty imports
 from mantidqt.utils.writetosignal import WriteToSignal
+from mantidqt.utils.qt import toQSettings
 from mantidqt.widgets.messagedisplay import MessageDisplay
 from qtpy.QtWidgets import QHBoxLayout
 
 # local imports
-from workbench.plugins.base import PluginWidget
-from mantidqt.utils.qt import toQSettings
+from ..config.fonts import text_font
+from ..plugins.base import PluginWidget
 
 # Default logs at notice
 DEFAULT_LOG_PRIORITY = 5
@@ -33,7 +34,7 @@ class LogMessageDisplay(PluginWidget):
         super(LogMessageDisplay, self).__init__(parent)
 
         # layout
-        self.display = MessageDisplay(parent)
+        self.display = MessageDisplay(text_font(), parent)
         layout = QHBoxLayout()
         layout.addWidget(self.display)
         self.setLayout(layout)

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -115,7 +115,7 @@ public:
   };
 
 public:
-  ScriptEditor(const QString & language,
+  ScriptEditor(const QString &lexer, const QFont &font = QFont(),
                QWidget *parent /TransferThis/ = 0) throw(std::invalid_argument);
 
   QString fileName() const;

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -79,6 +79,7 @@ class MessageDisplay : QWidget, Configurable {
 
 public:
   MessageDisplay(QWidget *parent = 0);
+  MessageDisplay(const QFont &font, QWidget *parent = 0);
   void attachLoggingChannel(int logLevel = -1);
 
   void appendFatal(const QString &text);

--- a/qt/python/mantidqt/widgets/codeeditor/editor.py
+++ b/qt/python/mantidqt/widgets/codeeditor/editor.py
@@ -14,5 +14,4 @@ from __future__ import (absolute_import, unicode_literals)
 # local imports
 from mantidqt.utils.qt import import_qt
 
-# Import single-file editor from C++ wrapping
-CodeEditor = import_qt('.._common', 'mantidqt.widgets', 'ScriptEditor')
+CodeEditor = import_qt('..._common', 'mantidqt.widgets.codeeditor', 'ScriptEditor')

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -35,7 +35,13 @@ def _tab_title_and_toolip(filename):
 class MultiPythonFileInterpreter(QWidget):
     """Provides a tabbed widget for editing multiple files"""
 
-    def __init__(self, default_content=None, parent=None):
+    def __init__(self, font=None, default_content=None, parent=None):
+        """
+
+        :param font: An optional font to override the default editor font
+        :param default_content: str, if provided this will populate any new editor that is created
+        :param parent: An optional parent widget
+        """
         super(MultiPythonFileInterpreter, self).__init__(parent)
 
         # attributes
@@ -51,7 +57,7 @@ class MultiPythonFileInterpreter(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # add a single editor by default
-        self.append_new_editor()
+        self.append_new_editor(font=font)
 
         # setting defaults
         self.confirm_on_save = True
@@ -72,10 +78,20 @@ class MultiPythonFileInterpreter(QWidget):
                 file_paths.append(file_path)
         return file_paths
 
-    def append_new_editor(self, content=None, filename=None):
+    def append_new_editor(self, font=None, content=None, filename=None):
+        """
+        Appends a new editor the tabbed widget
+        :param font: A reference to the font to be used by the editor
+        :param content: An optional string containing content to be placed
+        into the editor on opening. If None then self.default_content is used
+        :param filename: An optional string containing the filename of the editor
+        if applicable.
+        :return:
+        """
         if content is None:
             content = self.default_content
-        interpreter = PythonFileInterpreter(content, filename=filename, parent=self)
+        interpreter = PythonFileInterpreter(font, content, filename=filename,
+                                            parent=self)
         if self.whitespace_visible:
             interpreter.set_whitespace_visible()
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
@@ -10,12 +10,18 @@
 #include <Qsci/qscilexerpython.h>
 
 /**
- * Defines a Pytho lexer with a different colour scheme
+ * Defines a Python lexer with a alternative colour scheme
+ * to the standard one provided by QsciLexerPython.
  */
 class AlternateCSPythonLexer : public QsciLexerPython {
 public:
+  AlternateCSPythonLexer(const QFont &font);
+
   QColor defaultColor(int style) const override;
   QFont defaultFont(int style) const override;
+
+private:
+  QFont m_font;
 };
 
 #endif // MANTIDQT_WIDGETS_ALTERNATECSPYTHONLEXER_H

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MessageDisplay.h
@@ -53,6 +53,8 @@ public:
 public:
   /// Default constructor with optional parent
   MessageDisplay(QWidget *parent = nullptr);
+  /// Constructor accepting a QFont
+  MessageDisplay(const QFont &font, QWidget *parent = nullptr);
   MessageDisplay(const MessageDisplay &) = delete;
   MessageDisplay &operator=(const MessageDisplay &) = delete;
   /// Destructor
@@ -117,7 +119,7 @@ private:
   /// Initialize the text formats
   void initFormats();
   /// Set the properties of the text display
-  void setupTextArea();
+  void setupTextArea(const QFont &font);
   /// Return format for given log level
   QTextCharFormat format(const Message::Priority priority) const;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
@@ -54,7 +54,8 @@ public:
   };
 
 public:
-  ScriptEditor(const QString &lexerName, QWidget *parent = nullptr);
+  ScriptEditor(const QString &lexerName, const QFont &font = QFont(),
+               QWidget *parent = nullptr);
   ScriptEditor(QWidget *parent = nullptr, QsciLexer *lexer = nullptr,
                const QString &settingsGroup = "");
   /// Destructor

--- a/qt/widgets/common/src/AlternateCSPythonLexer.cpp
+++ b/qt/widgets/common/src/AlternateCSPythonLexer.cpp
@@ -5,7 +5,13 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AlternateCSPythonLexer.h"
-#include <QApplication>
+
+/**
+ * Construct a lexer with a font to be used for all text styles
+ * @param font A font to used for the text
+ */
+AlternateCSPythonLexer::AlternateCSPythonLexer(const QFont &font)
+    : QsciLexerPython(), m_font(font) {}
 
 /**
  * Returns the foreground colour of the text for a style.
@@ -61,11 +67,11 @@ QColor AlternateCSPythonLexer::defaultColor(int style) const {
 }
 
 /**
- *  Returns the font of the text for a style.
- * @param style An enum defining the type of element encountered
+ * Returns the font of the text.
+ * @param style Unused.
  * @return A QFont for this element type
  */
 QFont AlternateCSPythonLexer::defaultFont(int style) const {
   Q_UNUSED(style);
-  return QApplication::font();
+  return m_font;
 }

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -73,9 +73,18 @@ void MessageDisplay::writeSettings(QSettings &storage) const {
 }
 
 /**
+ * Construct a MessageDisplay with the default font
  * @param parent An optional parent widget
  */
 MessageDisplay::MessageDisplay(QWidget *parent)
+    : MessageDisplay(QFont(), parent) {}
+
+/**
+ * Construct a MessageDisplay using the given font
+ * @param font A reference to a font object
+ * @param parent An optional parent widget
+ */
+MessageDisplay::MessageDisplay(const QFont &font, QWidget *parent)
     : QWidget(parent), m_logChannel(new QtSignalChannel),
       m_textDisplay(new QPlainTextEdit(this)), m_formats(),
       m_loglevels(new QActionGroup(this)),
@@ -87,7 +96,7 @@ MessageDisplay::MessageDisplay(QWidget *parent)
       m_debug(new QAction(tr("&Debug"), this)) {
   initActions();
   initFormats();
-  setupTextArea();
+  setupTextArea(font);
 }
 
 /**
@@ -383,8 +392,10 @@ void MessageDisplay::initFormats() {
 /**
  * Set the properties of the text display, i.e read-only
  * and make it occupy the whole widget
+ * @param font A reference to the font for the text area
  */
-void MessageDisplay::setupTextArea() {
+void MessageDisplay::setupTextArea(const QFont &font) {
+  m_textDisplay->setFont(font);
   m_textDisplay->setReadOnly(true);
   m_textDisplay->ensureCursorVisible();
   setMaximumLineCount(DEFAULT_LINE_COUNT_MAX);

--- a/qt/widgets/common/src/ScriptEditor.cpp
+++ b/qt/widgets/common/src/ScriptEditor.cpp
@@ -44,16 +44,18 @@ namespace {
  * Return a new instance of a lexer based on the given language
  * @param lexerName A string defining the language. Currently hardcoded to
  * Python.
+ * @param font A font used for the AlternateCSPythonLexer
  * @return A new QsciLexer instance
  */
-QsciLexer *createLexerFromName(const QString &lexerName) {
+QsciLexer *createLexerFromName(const QString &lexerName, const QFont &font) {
   if (lexerName == "Python") {
     return new QsciLexerPython;
-  } else if (lexerName == "AlternateCSPythonLexer") {
-    return new AlternateCSPythonLexer;
+  } else if (lexerName == "AlternateCSPython") {
+    return new AlternateCSPythonLexer(font);
   } else {
-    throw std::invalid_argument("createLexerFromLanguage: Unsupported "
-                                "name. Supported names=Python, ");
+    throw std::invalid_argument(
+        "createLexerFromLanguage: Unsupported "
+        "name. Supported names=Python, AlternateCSPython");
   }
 }
 } // namespace
@@ -70,10 +72,12 @@ QColor ScriptEditor::g_error_colour = QColor("red");
  * Construction based on a string defining the langauge used
  * for syntax highlighting
  * @param lexerName A string choosing the name of a lexer
+ * @param font A reference to the initial font to be used in the editor
  * @param parent Parent widget
  */
-ScriptEditor::ScriptEditor(const QString &lexerName, QWidget *parent)
-    : ScriptEditor(parent, createLexerFromName(lexerName)) {}
+ScriptEditor::ScriptEditor(const QString &lexerName, const QFont &font,
+                           QWidget *parent)
+    : ScriptEditor(parent, createLexerFromName(lexerName, font)) {}
 
 /**
  * Constructor


### PR DESCRIPTION
**Description of work.**

The code editor was not using a monospace font as one would expect for a editing code. This has been fixed here along with using the same font for other text areas like IPython and the messages display so that there is not a visual jar between widgets.

**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* Start the workbench
* See that each character in the editor now uses a the same amount of width on the screen.
* Confirm the fonts look the same in the Messages display and in IPython

Fixes #24743.

*This does not require release notes* because **the workbench is not yet released.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
