### PR TITLE
Added tab order tracking to new Muon Gui

### DIFF
--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis_2.py
@@ -118,9 +118,9 @@ class FrequencyAnalysisGui(QtGui.QMainWindow):
         web browsers.
         """
         self.tabs = DetachableTabWidget(self)
-        self.tabs.addTab(self.home_tab.home_tab_view, 'Home')
-        self.tabs.addTab(self.grouping_tab_widget.group_tab_view, 'Grouping')
-        self.tabs.addTab(self.transform.widget, 'Transform')
+        self.tabs.addTabWithOrder(self.home_tab.home_tab_view, 'Home')
+        self.tabs.addTabWithOrder(self.grouping_tab_widget.group_tab_view, 'Grouping')
+        self.tabs.addTabWithOrder(self.transform.widget, 'Transform')
 
     def closeEvent(self, event):
         self.tabs.closeEvent(event)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -100,8 +100,8 @@ class MuonAnalysisGui(QtGui.QMainWindow):
         web browsers.
         """
         self.tabs = DetachableTabWidget(self)
-        self.tabs.addTab(self.home_tab.home_tab_view, 'Home')
-        self.tabs.addTab(self.grouping_tab_widget.group_tab_view, 'Grouping')
+        self.tabs.addTabWithOrder(self.home_tab.home_tab_view, 'Home')
+        self.tabs.addTabWithOrder(self.grouping_tab_widget.group_tab_view, 'Grouping')
 
     def closeEvent(self, event):
         self.tabs.closeEvent(event)


### PR DESCRIPTION
**Description of work.**

Currently the tabs in the new new Muon GUI can be docked and undocked. This adds tab order tracking so that they retain the same order in the GUI when docked

**Report to:** anthony <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

* In Mantid.properties.templates add Muon/Frequency_Domain_Analysis_2 to the list of interface
* Open mantid and open the new interface.
* Try docking and un-docking the tabs and and check that they retain their original order.

<!-- Instructions for testing. -->

Fixes *There is no associated issue.*

*This does not require release notes* because does not change current functionality.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
