### PR TITLE
Workbench: Project Saver fix an issue where instrument view will save data in the a subdir of the project

### DIFF
--- a/qt/python/mantidqt/project/projectloader.py
+++ b/qt/python/mantidqt/project/projectloader.py
@@ -51,9 +51,9 @@ class ProjectLoader(object):
         # Read project
         self.project_reader.read_project(file_name)
 
+        directory = os.path.dirname(file_name)
         # Load in the workspaces
         if load_workspaces:
-            directory = os.path.dirname(file_name)
             self.workspace_loader.load_workspaces(directory=directory,
                                                   workspaces_to_load=self.project_reader.workspace_names)
 
@@ -66,18 +66,18 @@ class ProjectLoader(object):
 
             # Load interfaces
             if self.project_reader.interface_list is not None:
-                self.load_interfaces(file_name)
+                self.load_interfaces(directory=directory)
 
         return workspace_success
 
-    def load_interfaces(self, file_name):
+    def load_interfaces(self, directory):
         for interface in self.project_reader.interface_list:
             # Find decoder
             decoder = self.decoder_factory.find_decoder(interface["tag"])
 
             # Decode and Show the interface
             try:
-                decoded_interface = decoder.decode(interface, file_name)
+                decoded_interface = decoder.decode(interface, directory)
                 decoded_interface.show()
             except Exception as e:
                 # Catch any exception and log it for the encoder

--- a/qt/python/mantidqt/project/projectsaver.py
+++ b/qt/python/mantidqt/project/projectsaver.py
@@ -43,9 +43,9 @@ class ProjectSaver(object):
             logger.warning("Can not save an empty project")
             return
 
+        directory = os.path.dirname(file_name)
         # Save workspaces to that location
         if project_recovery:
-            directory = os.path.dirname(file_name)
             workspace_saver = WorkspaceSaver(directory=directory)
             workspace_saver.save_workspaces(workspaces_to_save=workspace_to_save)
             saved_workspaces = workspace_saver.get_output_list()
@@ -60,7 +60,7 @@ class ProjectSaver(object):
         if interfaces_to_save is None:
             interfaces_to_save = []
 
-        interfaces = self._return_interfaces_dicts(file_name=file_name, interfaces_to_save=interfaces_to_save)
+        interfaces = self._return_interfaces_dicts(directory=directory, interfaces_to_save=interfaces_to_save)
 
         # Pass dicts to Project Writer
         writer = ProjectWriter(workspace_names=saved_workspaces,
@@ -71,13 +71,13 @@ class ProjectSaver(object):
         writer.write_out()
 
     @staticmethod
-    def _return_interfaces_dicts(file_name, interfaces_to_save):
+    def _return_interfaces_dicts(directory, interfaces_to_save):
         interfaces = []
         for interface, encoder in interfaces_to_save:
             # Add to the dictionary encoded data with the key as the first tag in the list on the encoder attributes
             try:
                 tag = encoder.tags[0]
-                encoded_dict = encoder.encode(interface, file_name)
+                encoded_dict = encoder.encode(interface, directory)
                 encoded_dict["tag"] = tag
                 interfaces.append(encoded_dict)
             except Exception as e:


### PR DESCRIPTION
**Description of work.**
Project Saver will now save the instrument excess data in it's actual directory opposed to a subdir.

**To test:**
- Open Workbench
- Load a workspace with an instrument
- Open instrument view
- Save your project or wait for project recovery
- Check the directory you saved your project to or recovery did, ensure that a file is present named `YOURWORKSPACENAMEMaskView.xml` and not present in a subdir that contains this file.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because it is an unreleased piece of code that has the bug.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
