### PR TITLE
Workbench: Instrument view mini peak pick plot will now zoom out on new peak selection

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -255,6 +255,8 @@ public:
   QString getTubeXUnitsUnits() const;
   QString getPlotCaption() const;
 
+  void zoomOutOnPlot();
+
 private slots:
 
   void addPeak(double x, double y);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotMpl.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotMpl.h
@@ -44,6 +44,7 @@ public:
   QColor getCurveColor(const QString &label) const;
   bool isYLogScale() const;
   void replot();
+
 public slots:
   void clearCurve();
   void setYLogScale();
@@ -52,6 +53,8 @@ public slots:
   // Required to match the interface with MiniPlotQwt but matplotlib
   // handles this for us so it is a noop
   void recalcAxisDivs() {}
+  void zoomOutOnPlot();
+
 signals:
   void showContextMenu();
   void clickedAt(double, double);
@@ -63,10 +66,6 @@ private:
   bool handleMousePressEvent(QMouseEvent *evt);
   bool handleMouseReleaseEvent(QMouseEvent *evt);
 
-private slots:
-  void onHomeClicked();
-
-private: // data
   Widgets::MplCpp::FigureCanvasQt *m_canvas;
   QPushButton *m_homeBtn;
   std::list<Widgets::MplCpp::Line2D> m_lines;

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1814,11 +1814,11 @@ void DetectorPlotController::addPeak(double x, double y) {
  * Zoom out back to the natural home of the mini plot
  */
 void DetectorPlotController::zoomOutOnPlot() {
-  #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    // Do nothing if in Qt4 or below.
-  #else
-    m_plot->zoomOutOnPlot();
-  #endif
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+// Do nothing if in Qt4 or below.
+#else
+  m_plot->zoomOutOnPlot();
+#endif
 }
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -706,6 +706,7 @@ void InstrumentWidgetPickTab::singleComponentTouched(size_t pickID) {
 void InstrumentWidgetPickTab::singleComponentPicked(size_t pickID) {
   m_infoController->displayInfo(pickID);
   m_plotController->setPlotData(pickID);
+  m_plotController->zoomOutOnPlot();
   m_plotController->updatePlot();
 }
 
@@ -1809,5 +1810,15 @@ void DetectorPlotController::addPeak(double x, double y) {
   }
 }
 
+/**
+ * Zoom out back to the natural home of the mini plot
+ */
+void DetectorPlotController::zoomOutOnPlot() {
+  #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+    // Do nothing if in Qt4 or below.
+  #else
+    m_plot->zoomOutOnPlot();
+  #endif
+}
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
+++ b/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
@@ -96,7 +96,7 @@ MiniPlotMpl::MiniPlotMpl(QWidget *parent)
   // Mouse events cause zooming by default. See mouseReleaseEvent
   // for exceptions
   m_zoomer.enableZoom(true);
-  connect(m_homeBtn, SIGNAL(clicked()), this, SLOT(onHomeClicked()));
+  connect(m_homeBtn, SIGNAL(clicked()), this, SLOT(zoomOutOnPlot()));
 }
 
 /**
@@ -340,7 +340,7 @@ bool MiniPlotMpl::handleMouseReleaseEvent(QMouseEvent *evt) {
 /**
  * Wire to the home button click
  */
-void MiniPlotMpl::onHomeClicked() { m_zoomer.zoomOut(); }
+void MiniPlotMpl::zoomOutOnPlot() { m_zoomer.zoomOut(); }
 
 } // namespace MantidWidgets
 } // namespace MantidQt


### PR DESCRIPTION
**Description of work.**
Picking a peak using the instrument view didn't reset the zoom back so that you can see the whole spectrum after a peak has been selected. It now does.

**To test:**
- Load some SX data
- Select a peak
- Zoom in on the peak in the miniplot
- Click on another peak in the main view
<!-- Instructions for testing. -->

Fixes #24054 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
