### PR TITLE
ReflectometryILLSumForeground: better line position for SumInQ

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
@@ -328,14 +328,14 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
         """Sum the foreground region into a single histogram using the coherent method."""
         foreground = self._foregroundIndices(ws)
         sumIndices = [i for i in range(foreground[0], foreground[2] + 1)]
-        beamPosIndex = foreground[1]
+        linePosition = ws.run().getProperty(common.SampleLogs.LINE_POSITION).value
         isFlatSample = not ws.run().getProperty('beam_stats.bent_sample').value
         sumWSName = self._names.withSuffix('summed_in_Q')
         sumWS = ReflectometrySumInQ(
             InputWorkspace=ws,
             OutputWorkspace=sumWSName,
             InputWorkspaceIndexSet=sumIndices,
-            BeamCentre=beamPosIndex,
+            BeamCentre=linePosition,
             FlatSample=isFlatSample,
             EnableLogging=self._subalgLogging)
         self._cleanup.cleanup(ws)


### PR DESCRIPTION
`ReflectometrySumInQ` supports fractional `BeamCentre`. However, `ReflectometryILLSumForeground` was supplying an integral foreground centre to the algorithm. This PR changes the algorithm to use the correct beam centre from the sample logs instead.

**Report to:** [nobody].

**To test:**

Code review.

Fixes #24788.

*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
