### PR TITLE
Workbench/Matplotlib in mantidqt: Make legends draggable

### DIFF
--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -209,7 +209,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
             plot_kwargs[kw] = num
             plot_fn(ws, **plot_kwargs)
 
-    ax.legend()
+    ax.legend().draggable()
     if not overplot:
         title = workspaces[0].name()
         ax.set_title(title)


### PR DESCRIPTION
**Description of work.**
Matplotlib graphs will now be draggable on plot creation.

**To test:**
- Open Workbench
- Load Workspace
- Plot graph
- Try to move the legend!

<!-- Instructions for testing. -->

Fixes #24912 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
