### PR TITLE
AlignFocusPowderFromFiles small fixes

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -125,9 +125,10 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 linearizedRuns.append(item)
         return linearizedRuns
 
-    def __createLoader(self, filename, wkspname, progstart=None, progstop=None):
+    def __createLoader(self, filename, wkspname, progstart=None, progstop=None, skipLoadingLogs=False, **kwargs):
         # load a chunk - this is a bit crazy long because we need to get an output property from `Load` when it
         # is run and the algorithm history doesn't exist until the parent algorithm (this) has finished
+        # the kwargs are extra things to be supplied to the loader
         if progstart is None or progstop is None:
             loader = self.createChildAlgorithm(self.__loaderName)
         else:
@@ -138,14 +139,23 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         loader.initialize()
         loader.setPropertyValue('Filename', filename)
         loader.setPropertyValue('OutputWorkspace', wkspname)
+        if skipLoadingLogs:
+            if self.__loaderName != 'LoadEventNexus':
+                raise RuntimeError('Cannot set LoadLogs=False in {}'.format(self.__loaderName))
+            loader.setProperty('LoadLogs', False)
+        for key, value in kwargs.items():
+            if isinstance(value, str):
+                loader.setPropertyValue(key, value)
+            else:
+                loader.setProperty(key, value)
         return loader
 
     def __getAlignAndFocusArgs(self):
         # always put these in since they are loaded in __setupCalibration
         # this requires that function to be called before this one
-        args = {CAL_WKSP:self.__calWksp,
-                GRP_WKSP:self.__grpWksp,
-                MASK_WKSP:self.__mskWksp}
+        args = {CAL_WKSP:  self.__calWksp,
+                GRP_WKSP:  self.__grpWksp,
+                MASK_WKSP: self.__mskWksp}
 
         for name in PROPS_FOR_ALIGN:
             prop = self.getProperty(name)
@@ -172,8 +182,8 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if useCharac or useCal:
                 tempname = '__%s_temp' % wkspname
                 # set the loader for this file
-                loader = self.__createLoader(filename, tempname)
-                loader.setProperty('MetaDataOnly', True)  # this is only supported by LoadEventNexus
+                # MetaDataOnly=True is only supported by LoadEventNexus
+                loader = self.__createLoader(filename, tempname, MetaDataOnly=True)
                 loader.execute()
 
                 # get the underlying loader name if we used the generic one
@@ -275,33 +285,35 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         # inner loop is over chunks
         for (j, chunk) in enumerate(chunks):
             prog_start = file_prog_start + float(j) * float(numSteps - 1) * prog_per_chunk_step
-            chunkname = '{}_c{:d}'.format(wkspname, j)
-            if unfocusname :  # only create unfocus chunk if needed
-                unfocusname_chunk = '{}_c{:d}'.format(unfocusname, j)
+
+            # if reading all at once, put the data into the final name directly
+            if len(chunks) == 1:
+                chunkname = wkspname
+                unfocusname_chunk = unfocusname
+            else:
+                chunkname = '{}_c{:d}'.format(wkspname, j)
+                if unfocusname:  # only create unfocus chunk if needed
+                    unfocusname_chunk = '{}_c{:d}'.format(unfocusname, j)
 
             # load a chunk - this is a bit crazy long because we need to get an output property from `Load` when it
             # is run and the algorithm history doesn't exist until the parent algorithm (this) has finished
             loader = self.__createLoader(filename, chunkname,
-                                         progstart=prog_start, progstop=prog_start + prog_per_chunk_step)
-            if canSkipLoadingLogs:
-                loader.setProperty('LoadLogs', False)
-            for key, value in chunk.items():
-                if isinstance(value, str):
-                    loader.setPropertyValue(key, value)
-                else:
-                    loader.setProperty(key, value)
+                                         skipLoadingLogs=(len(chunks) > 1 and canSkipLoadingLogs),
+                                         progstart=prog_start, progstop=prog_start + prog_per_chunk_step,
+                                         **chunk)
             loader.execute()
             if j == 0:
                 self.__setupCalibration(chunkname)
 
             # copy the necessary logs onto the workspace
-            if canSkipLoadingLogs:
+            if len(chunks) > 1 and canSkipLoadingLogs:
                 CopyLogs(InputWorkspace=wkspname, OutputWorkspace=chunkname, MergeStrategy='WipeExisting')
 
             # get the underlying loader name if we used the generic one
             if self.__loaderName == 'Load':
                 self.__loaderName = loader.getPropertyValue('LoaderName')
-            # only LoadEventNexus can turn off loading logs, but FilterBadPulses requires them to be loaded from the file
+            # only LoadEventNexus can turn off loading logs, but FilterBadPulses
+            # requires them to be loaded from the file
             canSkipLoadingLogs = self.__loaderName == 'LoadEventNexus' and self.filterBadPulses <= 0.
 
             if determineCharacterizations and j == 0:
@@ -335,12 +347,14 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if self.kwargs is None:
                 raise RuntimeError('Somehow arguments for "AlignAndFocusPowder" aren\'t set')
 
-            AlignAndFocusPowder(InputWorkspace=chunkname, OutputWorkspace=chunkname, UnfocussedWorkspace=unfocusname_chunk,
+            AlignAndFocusPowder(InputWorkspace=chunkname,
+                                OutputWorkspace=chunkname, UnfocussedWorkspace=unfocusname_chunk,
                                 startProgress=prog_start, endProgress=prog_start+2.*prog_per_chunk_step,
                                 **self.kwargs)
             prog_start += 2. * prog_per_chunk_step  # AlignAndFocusPowder counts for two steps
 
-            self.__accumulate(chunkname, wkspname, unfocusname_chunk, unfocusname, j == 0, removelogs=canSkipLoadingLogs)
+            self.__accumulate(chunkname, wkspname, unfocusname_chunk, unfocusname, j == 0,
+                              removelogs=canSkipLoadingLogs)
         # end of inner loop
 
         # write out the cachefile for the main reduced data independent of whether
@@ -362,6 +376,8 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         # the first call to accumulate to a specific target should be a simple rename
         self.log().debug('__accumulate({}, {}, {}, {}, {})'.format(chunkname, sumname, chunkunfocusname,
                                                                    sumuunfocusname, firstrun))
+        if chunkname == sumname:
+            return  # there is nothing to be done
 
         if not firstrun:
             # if the sum workspace doesn't already exist, just rename
@@ -493,7 +509,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             notcached = self.__findAndLoadCachefiles(self._filenames, finalname, firstTime=True)
         else:
             notcached = self._filenames[:]  # make a copy
-        self.log().notice('Files to process: {}'.format(notcached,))
+        self.log().notice('Files to process: {}'.format(notcached))
 
         # process not-cached files
         if notcached:
@@ -598,14 +614,16 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 partialsum_unfocusname = partialsum_wkspname + '_unfocused'
             else:
                 partialsum_unfocusname = ''
-            self.__accumulate(wkspname, partialsum_wkspname, unfocusname, partialsum_unfocusname, (not hasAccumulated) or i == 0)
+            self.__accumulate(wkspname, partialsum_wkspname, unfocusname, partialsum_unfocusname,
+                              (not hasAccumulated) or i == 0)
             hasAccumulated = True
             if i == grain_end - 1:
                 if self.useCaching and len(grain) > 1:
                     # save partial cache
                     self.__saveSummedGroupToCache(grain, partialsum_wkspname)
                 # accumulate into final sum
-                self.__accumulate(partialsum_wkspname, finalname, partialsum_unfocusname, finalunfocusname, (not hasAccumulated) or i==0)
+                self.__accumulate(partialsum_wkspname, finalname, partialsum_unfocusname, finalunfocusname,
+                                  (not hasAccumulated) or i == 0)
 
     def __saveSummedGroupToCache(self, group, wkspname):
         cache_file = self.__getGroupCacheName(group)

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -313,6 +313,13 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 FilterBadPulses(InputWorkspace=chunkname, OutputWorkspace=chunkname,
                                 LowerCutoff=self.filterBadPulses,
                                 startProgress=prog_start, endProgress=prog_start+prog_per_chunk_step)
+                if mtd[chunkname].getNumberEvents() == 0:
+                    msg = 'FilterBadPulses removed all events from '
+                    if len(chunks) == 1:
+                        raise RuntimeError(msg + filename)
+                    else:
+                        raise RuntimeError(msg + 'chunk {} of {} in {}'.format(j, len(chunks), filename))
+
             prog_start += prog_per_chunk_step
 
             # absorption correction workspace

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -203,6 +203,11 @@ std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
     }
   }
 
+  m_inputW = getProperty("InputWorkspace");
+  m_inputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_inputW);
+  if (m_inputEW && m_inputEW->getNumberEvents() <= 0)
+    result["InputWorkspace"] = "Cannot process empty event workspace";
+
   return result;
 }
 


### PR DESCRIPTION
There are two things done here:
1. For files being read in a single chunk, just read them in and process without extra renaming of workspaces.
2. Generate errors when empty event workspaces are provided/occur. This makes it significantly easier to find out what has gone wrong, generally from `FilterBadPulses`.

**To test:**

Try out a variety of files to see that things continue to work.

*There is no associated issue.*

*This does not require release notes* because it is small optimizations that are minor compared to the other changes in this area during the release cycle.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
