### PR TITLE
Indirect Diffraction - Re-sizeable interface

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -17,6 +17,15 @@ from mantid.kernel import *
 from mantid import config
 
 
+def contains_invalid_number_range(list_of_ranges):
+    for element in list_of_ranges:
+        if "-" in element:
+            range_limits = element.split("-")
+            if int(range_limits[0]) >= int(range_limits[1]):
+                return True
+    return False
+
+
 class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
     _workspace_names = None
     _cal_file = None
@@ -113,8 +122,12 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
 
         # Validate input files
         input_files = self.getProperty('InputFiles').value
+
         if len(input_files) == 0:
             issues['InputFiles'] = 'InputFiles must contain at least one filename'
+
+        if contains_invalid_number_range(input_files):
+            issues['InputFiles'] = 'Run number ranges must go from low to high'
 
         # Validate detector range
         detector_range = self.getProperty('SpectraRange').value

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -17,12 +17,16 @@ from mantid.kernel import *
 from mantid import config
 
 
-def contains_invalid_number_range(list_of_ranges):
-    for element in list_of_ranges:
-        if "-" in element:
-            range_limits = element.split("-")
-            if int(range_limits[0]) >= int(range_limits[1]):
-                return True
+def is_range_ascending(range_string, delimiter):
+    range_limits = tuple(map(int, range_string.split(delimiter)))
+    return range_limits[0] < range_limits[1]
+
+
+def contains_non_ascending_range(strings, delimiter):
+    range_strings = list(filter(lambda x: delimiter in x, strings))
+    for range_string in range_strings:
+        if not is_range_ascending(range_string, delimiter):
+            return True
     return False
 
 
@@ -126,7 +130,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
         if len(input_files) == 0:
             issues['InputFiles'] = 'InputFiles must contain at least one filename'
 
-        if contains_invalid_number_range(input_files):
+        if contains_non_ascending_range(input_files, '-'):
             issues['InputFiles'] = 'Run number ranges must go from low to high'
 
         # Validate detector range

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
@@ -248,6 +248,7 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         self.assertEqual(red_ws.getNumberHistograms(), 196)
 
     # ------------------------------------------Failure cases------------------------------------------
+
     def test_reduction_with_cal_file_osiris_diffonly_fails(self):
         """
         Test to ensure cal file can not be used in diffonly mode
@@ -269,6 +270,20 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
                           CalFile='osi_041_RES10.cal',
                           OutputWorkspace='wks',
                           SpectraRange=[105, 112])
+
+    def test_that_reduction_fails_if_provided_a_range_of_run_numbers_which_goes_from_high_to_low(self):
+        with self.assertRaises(RuntimeError):
+            ISISIndirectDiffractionReduction(InputFiles=['137793-137796', '137813-814'],
+                                             Instrument='OSIRIS',
+                                             Mode='diffspec',
+                                             SpectraRange=[105, 112])
+
+    def test_that_reduction_fails_if_provided_a_range_of_run_numbers_which_is_not_a_range(self):
+        with self.assertRaises(RuntimeError):
+            ISISIndirectDiffractionReduction(InputFiles=['137793-137796', '137813-137813'],
+                                             Instrument='OSIRIS',
+                                             Mode='diffspec',
+                                             SpectraRange=[105, 112])
 
 
 if __name__ == '__main__':

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
@@ -15,382 +15,721 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QVBoxLayout" name="verticalLayout_2">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
     <item>
-     <widget class="QGroupBox" name="gbInstrument">
-      <property name="title">
-       <string>Instrument</string>
+     <widget class="QScrollArea" name="scrollArea">
+      <property name="frameShape">
+       <enum>QFrame::Box</enum>
       </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_6">
-       <item>
-        <widget class="MantidQt::MantidWidgets::IndirectInstrumentConfig" name="iicInstrumentConfiguration">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="techniques" stdset="0">
-          <stringlist>
-           <string>TOF Indirect Geometry Spectroscopy</string>
-           <string>TOF Indirect Geometry Diffraction</string>
-          </stringlist>
-         </property>
-         <property name="disabledInstruments" stdset="0">
-          <stringlist>
-           <string>TFXA</string>
-          </stringlist>
-         </property>
-         <property name="facility" stdset="0">
-          <string>ISIS</string>
-         </property>
-         <property name="forceDiffraction" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="showInstrumentLabel" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="gbInput">
-      <property name="title">
-       <string>Input</string>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
       </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>6</number>
-       </property>
-       <item row="2" column="0">
-        <widget class="QLabel" name="lbSpecMin">
-         <property name="text">
-          <string>Spectra Min:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="QSpinBox" name="spSpecMin">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>5000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QCheckBox" name="ckUseCan">
-         <property name="text">
-          <string>Use Container:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="lbSpecMax">
-         <property name="text">
-          <string>Spectra Max:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QCheckBox" name="ckSumFiles">
-         <property name="text">
-          <string>Sum Sample Files</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QSpinBox" name="spSpecMax">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>5000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QCheckBox" name="ckLoadLogs">
-         <property name="text">
-          <string>Load Log Files</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1" colspan="2">
-        <widget class="MantidQt::API::MWRunFiles" name="rfCanFiles" native="true">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="label" stdset="0">
-          <string/>
-         </property>
-         <property name="multipleFiles" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="MantidQt::API::MWRunFiles" name="rfSampleFiles" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>41</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="label" stdset="0">
-          <string>Run Numbers</string>
-         </property>
-         <property name="multipleFiles" stdset="0">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QCheckBox" name="ckCanScale">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Scale Container:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QDoubleSpinBox" name="spCanScale">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="singleStep">
-          <double>0.100000000000000</double>
-         </property>
-         <property name="value">
-          <double>1.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QStackedWidget" name="swVanadium">
-      <property name="currentIndex">
-       <number>0</number>
+      <property name="widgetResizable">
+       <bool>true</bool>
       </property>
-      <widget class="QWidget" name="pageCalibration">
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
+      <widget class="QWidget" name="scrollAreaWidgetContents">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>530</width>
+         <height>586</height>
+        </rect>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
         <item>
-         <widget class="QGroupBox" name="gbCalibration">
+         <widget class="QGroupBox" name="gbInstrument">
           <property name="title">
-           <string>Calibration</string>
+           <string>Instrument</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-           <property name="leftMargin">
-            <number>6</number>
-           </property>
-           <property name="topMargin">
-            <number>6</number>
-           </property>
-           <property name="rightMargin">
-            <number>6</number>
-           </property>
-           <property name="bottomMargin">
-            <number>6</number>
-           </property>
-           <item row="4" column="0" colspan="2">
-            <widget class="MantidQt::API::MWRunFiles" name="rfVanadiumFile" native="true">
-             <property name="enabled">
-              <bool>true</bool>
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <item>
+            <widget class="MantidQt::MantidWidgets::IndirectInstrumentConfig" name="iicInstrumentConfiguration">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
              </property>
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="label" stdset="0">
-              <string>Vanadium Runs</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="instrumentOverride" stdset="0">
-              <string>OSIRIS</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0" colspan="2">
-            <widget class="MantidQt::API::MWRunFiles" name="rfCalFile" native="true">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="label" stdset="0">
-              <string>Cal File</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="optional" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="fileExtensions" stdset="0">
+             <property name="techniques" stdset="0">
               <stringlist>
-               <string>.cal</string>
+               <string>TOF Indirect Geometry Spectroscopy</string>
+               <string>TOF Indirect Geometry Diffraction</string>
               </stringlist>
              </property>
+             <property name="disabledInstruments" stdset="0">
+              <stringlist>
+               <string>TFXA</string>
+              </stringlist>
+             </property>
+             <property name="facility" stdset="0">
+              <string>ISIS</string>
+             </property>
+             <property name="forceDiffraction" stdset="0">
+              <bool>true</bool>
+             </property>
+             <property name="showInstrumentLabel" stdset="0">
+              <bool>false</bool>
+             </property>
             </widget>
            </item>
           </layout>
          </widget>
         </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pageCalibOnly">
-       <layout class="QVBoxLayout" name="verticalLayout_8">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
         <item>
-         <widget class="QGroupBox" name="gbCalibOnly">
+         <widget class="QGroupBox" name="gbInput">
           <property name="title">
-           <string>Calibration</string>
+           <string>Input</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-           <item row="1" column="0">
-            <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>41</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="findRunFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="label" stdset="0">
-              <string>Vanadium File</string>
-             </property>
-             <property name="multipleFiles" stdset="0">
-              <bool>true</bool>
-             </property>
-             <property name="optional" stdset="0">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="0">
-            <widget class="QCheckBox" name="ckUseVanadium">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Use Vanadium File</string>
-             </property>
-            </widget>
-           </item>
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="leftMargin">
+            <number>6</number>
+           </property>
+           <property name="topMargin">
+            <number>6</number>
+           </property>
+           <property name="rightMargin">
+            <number>6</number>
+           </property>
+           <property name="bottomMargin">
+            <number>6</number>
+           </property>
            <item row="2" column="0">
-            <widget class="QCheckBox" name="ckUseCalib">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>22</height>
-              </size>
-             </property>
+            <widget class="QLabel" name="lbSpecMin">
              <property name="text">
-              <string>Use Calibration File</string>
+              <string>Spectra Min:</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
+           <item row="2" column="1">
+            <widget class="QSpinBox" name="spSpecMin">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>5000</number>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <widget class="QCheckBox" name="ckUseCan">
+             <property name="text">
+              <string>Use Container:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="lbSpecMax">
+             <property name="text">
+              <string>Spectra Max:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="2">
+            <widget class="QCheckBox" name="ckSumFiles">
+             <property name="text">
+              <string>Sum Sample Files</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QSpinBox" name="spSpecMax">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>5000</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="2">
+            <widget class="QCheckBox" name="ckLoadLogs">
+             <property name="text">
+              <string>Load Log Files</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="5" column="1" colspan="2">
+            <widget class="MantidQt::API::MWRunFiles" name="rfCanFiles" native="true">
              <property name="enabled">
               <bool>false</bool>
              </property>
+             <property name="label" stdset="0">
+              <string/>
+             </property>
+             <property name="multipleFiles" stdset="0">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0" colspan="3">
+            <widget class="MantidQt::API::MWRunFiles" name="rfSampleFiles" native="true">
              <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                <horstretch>0</horstretch>
                <verstretch>41</verstretch>
               </sizepolicy>
              </property>
-             <property name="findRunFiles" stdset="0">
-              <bool>false</bool>
-             </property>
              <property name="label" stdset="0">
-              <string>Cal File</string>
+              <string>Run Numbers</string>
              </property>
              <property name="multipleFiles" stdset="0">
-              <bool>false</bool>
-             </property>
-             <property name="optional" stdset="0">
               <bool>true</bool>
              </property>
-             <property name="fileExtensions" stdset="0">
-              <string>.cal</string>
+            </widget>
+           </item>
+           <item row="6" column="0">
+            <widget class="QCheckBox" name="ckCanScale">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Scale Container:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="6" column="1">
+            <widget class="QDoubleSpinBox" name="spCanScale">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="singleStep">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.000000000000000</double>
              </property>
             </widget>
            </item>
           </layout>
-          <zorder>ckUseCalib</zorder>
-          <zorder>rfCalFile_only</zorder>
-          <zorder>rfVanFile_only</zorder>
-          <zorder>ckUseVanadium</zorder>
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="gbDspaceRebinCalibOnly">
-          <property name="title">
-           <string>Rebin in D-Spacing (optional)</string>
+         <widget class="QStackedWidget" name="swVanadium">
+          <property name="currentIndex">
+           <number>0</number>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_9">
-           <property name="spacing">
-            <number>6</number>
+          <widget class="QWidget" name="pageCalibration">
+           <layout class="QVBoxLayout" name="verticalLayout_3">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="gbCalibration">
+              <property name="title">
+               <string>Calibration</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_2">
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>6</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <property name="bottomMargin">
+                <number>6</number>
+               </property>
+               <item row="4" column="0" colspan="2">
+                <widget class="MantidQt::API::MWRunFiles" name="rfVanadiumFile" native="true">
+                 <property name="enabled">
+                  <bool>true</bool>
+                 </property>
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="label" stdset="0">
+                  <string>Vanadium Runs</string>
+                 </property>
+                 <property name="multipleFiles" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <property name="instrumentOverride" stdset="0">
+                  <string>OSIRIS</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0" colspan="2">
+                <widget class="MantidQt::API::MWRunFiles" name="rfCalFile" native="true">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="label" stdset="0">
+                  <string>Cal File</string>
+                 </property>
+                 <property name="multipleFiles" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                 <property name="optional" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                 <property name="fileExtensions" stdset="0">
+                  <stringlist>
+                   <string>.cal</string>
+                  </stringlist>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="pageCalibOnly">
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="gbCalibOnly">
+              <property name="title">
+               <string>Calibration</string>
+              </property>
+              <layout class="QGridLayout" name="gridLayout_3">
+               <item row="1" column="0">
+                <widget class="MantidQt::API::MWRunFiles" name="rfVanFile_only" native="true">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>41</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="findRunFiles" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <property name="label" stdset="0">
+                  <string>Vanadium File</string>
+                 </property>
+                 <property name="multipleFiles" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <property name="optional" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="ckUseVanadium">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Use Vanadium File</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="ckUseCalib">
+                 <property name="minimumSize">
+                  <size>
+                   <width>0</width>
+                   <height>22</height>
+                  </size>
+                 </property>
+                 <property name="text">
+                  <string>Use Calibration File</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="3" column="0">
+                <widget class="MantidQt::API::MWRunFiles" name="rfCalFile_only" native="true">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>41</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="findRunFiles" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                 <property name="label" stdset="0">
+                  <string>Cal File</string>
+                 </property>
+                 <property name="multipleFiles" stdset="0">
+                  <bool>false</bool>
+                 </property>
+                 <property name="optional" stdset="0">
+                  <bool>true</bool>
+                 </property>
+                 <property name="fileExtensions" stdset="0">
+                  <string>.cal</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+              <zorder>ckUseCalib</zorder>
+              <zorder>rfCalFile_only</zorder>
+              <zorder>rfVanFile_only</zorder>
+              <zorder>ckUseVanadium</zorder>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="gbDspaceRebinCalibOnly">
+              <property name="title">
+               <string>Rebin in D-Spacing (optional)</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_9">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>6</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <property name="bottomMargin">
+                <number>6</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="lbRebinStart_calibOnly">
+                 <property name="text">
+                  <string>Start:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinStart_CalibOnly"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinStart_CalibOnly">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="lbRebinWidth_CalibOnly">
+                 <property name="text">
+                  <string>Width:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinWidth_CalibOnly"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinWidth_CalibOnly">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="lbRebinEnd_CalibOnly">
+                 <property name="text">
+                  <string>End:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinEnd_CalibOnly"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinEnd_CalibOnly">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="pageDSpaceRebin">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="gbRebin">
+              <property name="title">
+               <string>Rebin in D-Spacing (optional)</string>
+              </property>
+              <layout class="QHBoxLayout" name="horizontalLayout_7">
+               <property name="spacing">
+                <number>6</number>
+               </property>
+               <property name="leftMargin">
+                <number>6</number>
+               </property>
+               <property name="topMargin">
+                <number>6</number>
+               </property>
+               <property name="rightMargin">
+                <number>6</number>
+               </property>
+               <property name="bottomMargin">
+                <number>6</number>
+               </property>
+               <item>
+                <widget class="QLabel" name="lbRebinStart">
+                 <property name="text">
+                  <string>Start:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinStart"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinStart">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="lbRebinWidth">
+                 <property name="text">
+                  <string>Width:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinWidth"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinWidth">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="lbRebinEnd">
+                 <property name="text">
+                  <string>End:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="leRebinEnd"/>
+               </item>
+               <item>
+                <widget class="QLabel" name="valRebinEnd">
+                 <property name="styleSheet">
+                  <string notr="true">color: rgb(170, 0, 0);</string>
+                 </property>
+                 <property name="text">
+                  <string>*</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gbGeneralOptions">
+          <property name="title">
+           <string>Options</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <item>
+            <widget class="QCheckBox" name="ckManualGrouping">
+             <property name="text">
+              <string>Use Manual Grouping</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="lbNoGroups">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Number of Groups:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spNumberGroups">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="groupBox">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>50</height>
+           </size>
+          </property>
+          <property name="title">
+           <string>Run</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <property name="spacing">
+            <number>0</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>7</number>
+           </property>
+           <item>
+            <spacer name="horizontalSpacer_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pbRun">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="text">
+              <string>Run</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="gbOutput">
+          <property name="title">
+           <string>Output</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout">
            <property name="leftMargin">
             <number>6</number>
            </property>
@@ -404,99 +743,46 @@
             <number>6</number>
            </property>
            <item>
-            <widget class="QLabel" name="lbRebinStart_calibOnly">
+            <widget class="QLabel" name="lbPlotType">
              <property name="text">
-              <string>Start:</string>
+              <string>Plot Type:</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="leRebinStart_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinStart_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
+            <widget class="QComboBox" name="cbPlotType">
+             <property name="enabled">
+              <bool>false</bool>
              </property>
-             <property name="text">
-              <string>*</string>
-             </property>
+             <item>
+              <property name="text">
+               <string>Spectra</string>
+              </property>
+             </item>
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="lbRebinWidth_CalibOnly">
-             <property name="text">
-              <string>Width:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinWidth_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinWidth_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
+            <widget class="QPushButton" name="pbPlot">
+             <property name="enabled">
+              <bool>false</bool>
              </property>
              <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinEnd_CalibOnly">
-             <property name="text">
-              <string>End:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinEnd_CalibOnly"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinEnd_CalibOnly">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
+              <string>Plot</string>
              </property>
             </widget>
            </item>
           </layout>
          </widget>
         </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="pageDSpaceRebin">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
         <item>
-         <widget class="QGroupBox" name="gbRebin">
-          <property name="title">
-           <string>Rebin in D-Spacing (optional)</string>
+         <widget class="QGroupBox" name="gbSave">
+          <property name="toolTip">
+           <string>Select which file formats the data should be saved in.</string>
           </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
-           <property name="spacing">
-            <number>6</number>
-           </property>
+          <property name="title">
+           <string>Save Formats</string>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
            <property name="leftMargin">
             <number>6</number>
            </property>
@@ -510,62 +796,42 @@
             <number>6</number>
            </property>
            <item>
-            <widget class="QLabel" name="lbRebinStart">
+            <widget class="QCheckBox" name="ckGSS">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="text">
-              <string>Start:</string>
+              <string>GSS</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="leRebinStart"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinStart">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
+            <widget class="QCheckBox" name="ckNexus">
+             <property name="enabled">
+              <bool>false</bool>
              </property>
              <property name="text">
-              <string>*</string>
+              <string>Nexus</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QLabel" name="lbRebinWidth">
+            <widget class="QCheckBox" name="ckAscii">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
              <property name="text">
-              <string>Width:</string>
+              <string>ASCII (DAT)</string>
              </property>
             </widget>
            </item>
            <item>
-            <widget class="QLineEdit" name="leRebinWidth"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinWidth">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
+            <widget class="QPushButton" name="pbSave">
+             <property name="enabled">
+              <bool>false</bool>
              </property>
              <property name="text">
-              <string>*</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="lbRebinEnd">
-             <property name="text">
-              <string>End:</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLineEdit" name="leRebinEnd"/>
-           </item>
-           <item>
-            <widget class="QLabel" name="valRebinEnd">
-             <property name="styleSheet">
-              <string notr="true">color: rgb(170, 0, 0);</string>
-             </property>
-             <property name="text">
-              <string>*</string>
+              <string>Save</string>
              </property>
             </widget>
            </item>
@@ -574,242 +840,16 @@
         </item>
        </layout>
       </widget>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="gbGeneralOptions">
-      <property name="title">
-       <string>Options</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="ckManualGrouping">
-         <property name="text">
-          <string>Use Manual Grouping</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="lbNoGroups">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Number of Groups:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSpinBox" name="spNumberGroups">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="groupBox">
-      <property name="minimumSize">
-       <size>
-        <width>0</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>16777215</width>
-        <height>50</height>
-       </size>
-      </property>
-      <property name="title">
-       <string>Run</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_5">
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>7</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pbRun">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>Run</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="gbOutput">
-      <property name="title">
-       <string>Output</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>6</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="lbPlotType">
-         <property name="text">
-          <string>Plot Type:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="cbPlotType">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <item>
-          <property name="text">
-           <string>Spectra</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pbPlot">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Plot</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="gbSave">
-      <property name="toolTip">
-       <string>Select which file formats the data should be saved in.</string>
-      </property>
-      <property name="title">
-       <string>Save Formats</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="leftMargin">
-        <number>6</number>
-       </property>
-       <property name="topMargin">
-        <number>6</number>
-       </property>
-       <property name="rightMargin">
-        <number>6</number>
-       </property>
-       <property name="bottomMargin">
-        <number>6</number>
-       </property>
-       <item>
-        <widget class="QCheckBox" name="ckGSS">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>GSS</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="ckNexus">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Nexus</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="ckAscii">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>ASCII (DAT)</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pbSave">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Save</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
      </widget>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout_10">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
+      <property name="rightMargin">
+       <number>9</number>
+      </property>
       <item>
        <widget class="QPushButton" name="pbHelp">
         <property name="enabled">


### PR DESCRIPTION
**Description of work.**
This PR ensures you can re-size the Indirect diffraction interface. This is useful as the diffraction interface was previously difficult to use on devices with smaller screens.

**To test:**
1.`Interfaces`->`Indirect`->`Diffraction`
2. Try to resize the interface by making it smaller

*No Release notes required I think as this is a minor change*

Fixes #24921

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
