### PR TITLE
Catch Exception on saving files with event slices

### DIFF
--- a/docs/source/release/v4.0.0/sans.rst
+++ b/docs/source/release/v4.0.0/sans.rst
@@ -62,6 +62,7 @@ Bug fixes
 * Removed option to process in non-compatibility mode to avoid calculation issues.
 * Default name for added runs has correct number of digits.
 * RKH files no longer append to existing files, but overwrite instead.
+* Reductions with event slices can save output files. However, transmission workspaces are not included in these files.
 
 Improvements
 ############

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 from copy import deepcopy
 from mantid.api import AnalysisDataService, WorkspaceGroup
+from mantid.kernel import Logger
 from sans.common.general_functions import (create_managed_non_child_algorithm, create_unmanaged_algorithm,
                                            get_output_name, get_base_name_from_multi_period_name, get_transmission_output_name)
 from sans.common.enums import (SANSDataType, SaveType, OutputMode, ISISReductionMode, DataType)
@@ -1134,8 +1135,20 @@ def get_all_names_to_save(reduction_packages, save_can):
 
         transmission = reduction_package.unfitted_transmission
         transmission_can = reduction_package.unfitted_transmission_can
-        trans_name = '' if not transmission else transmission.name()
-        transCan_name = '' if not transmission_can else transmission_can.name()
+        try:
+            # Does not always work for event slice data as transmission
+            # workspaces can get deleted.
+            # This is a temporary fix to allow file saving with
+            # event sliced data.
+            trans_name = '' if not transmission else transmission.name()
+        except Exception:
+            trans_name = ''
+            Logger("SANS").notice("Transmission run not found. Not saving to file.")
+        try:
+            transCan_name = '' if not transmission_can else transmission_can.name()
+        except Exception:
+            transCan_name = ''
+            Logger("SANS").notice("Can transmission run not found. Not saving to file.")
 
         if save_can:
             if reduced_merged:

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1141,12 +1141,12 @@ def get_all_names_to_save(reduction_packages, save_can):
             # This is a temporary fix to allow file saving with
             # event sliced data.
             trans_name = '' if not transmission else transmission.name()
-        except Exception:
+        except RuntimeError:
             trans_name = ''
             Logger("SANS").notice("Transmission run not found. Not saving to file.")
         try:
             transCan_name = '' if not transmission_can else transmission_can.name()
-        except Exception:
+        except RuntimeError:
             transCan_name = ''
             Logger("SANS").notice("Can transmission run not found. Not saving to file.")
 


### PR DESCRIPTION
**Description of work.**
This PR provides a temporary fix to a bug which stops users from saving files when they have reduced data with an event slice.

This is a temporary fix put in place for the next release, as this fix stops transmission workspaces from being saved out with the reduced data. 
Issue #24929  tracks the underlying issue

**Report to:** Sarah SANS2D ISIS

**To test:**
1. Interfaces -> SANS -> SANS v2
2. Load the attached user file
3. In the table, enter the following in the first 6 columns:
57290 | 57295 | 57283 | 57284 | 57284 | 57283
4. In settings, set event slice to `0:300:600`
5. On the main run page, click the `both` radio button at the bottom and select a directory in `manage directories`. Then click all three file type buttons (CanSAS, RKH etc.)
6. Click process all

This should not result in any error (the row should turn green, not blue). In your selected output directory, check that three files have been created - one for each of the file buttons you selected).

Fixes #24916 

*Data*
[USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT_Compatibility_On.txt](https://github.com/mantidproject/mantid/files/2919778/USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT_Compatibility_On.txt)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
