### PR TITLE
Small bug fix in loader_path call for OSX

### DIFF
--- a/qt/widgets/sliceviewer/CMakeLists.txt
+++ b/qt/widgets/sliceviewer/CMakeLists.txt
@@ -141,7 +141,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsSliceViewer
   INSTALL_DIR
     ${LIB_DIR}
   OSX_INSTALL_RPATH
-    loader_path/../MacOS
+    @loader_path/../MacOS
   LINUX_INSTALL_RPATH
     "\$ORIGIN/../${LIB_DIR}"
 )


### PR DESCRIPTION
**Description of work.**

Small bug fix for `@loader_path` call on OSX for slice viewer.

**To test:**

Will need OSX. 

*There is no associated issue.*
*No release note* 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
