### PR TITLE
Add a context menu to plots in the workbench

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -29,9 +29,9 @@ from .propertiesdialog import LabelEditor, XAxisEditor, YAxisEditor
 # Map canvas context-menu string labels to a pair of matplotlib scale-type strings
 AXES_SCALE_MENU_OPTS = OrderedDict([
     ("Lin x/Lin y", ("linear", "linear")),
-    ("Log x/Log y", ("symlog", "symlog")),
-    ("Lin x/Log y", ("linear", "symlog")),
-    ("Log x/Lin y", ("symlog", "linear"))]
+    ("Log x/Log y", ("log", "log")),
+    ("Lin x/Log y", ("linear", "log")),
+    ("Log x/Lin y", ("log", "linear"))]
 )
 
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -157,6 +157,12 @@ class FigureInteraction(object):
         :param scale_types: A 2-tuple of strings giving matplotlib axes scale types
         """
         for axes in self.canvas.figure.get_axes():
+            # Recompute the limits of the data. If the scale is set to log
+            # on either axis, Fit enabled & then disabled, then the axes are
+            # not rescaled properly because the vertical marker artists were
+            # included in the last computation of the data limits and
+            # set_xscale/set_yscale only autoscale the view
+            axes.relim()
             axes.set_xscale(scale_types[0])
             axes.set_yscale(scale_types[1])
 

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -1,0 +1,163 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+"""
+Defines interaction behaviour for plotting.
+"""
+from __future__ import (absolute_import, unicode_literals)
+
+# std imports
+from collections import OrderedDict
+from functools import partial
+
+# third party imports
+from mantid.py3compat import iteritems
+from mantidqt.plotting.figuretype import FigureType, figure_type
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QCursor
+from qtpy.QtWidgets import QActionGroup, QMenu
+
+# local imports
+from .propertiesdialog import LabelEditor, XAxisEditor, YAxisEditor
+
+
+# Map canvas context-menu string labels to a pair of matplotlib scale-type strings
+AXES_SCALE_MENU_OPTS = OrderedDict([
+    ("Lin x/Lin y", ("linear", "linear")),
+    ("Log x/Log y", ("symlog", "symlog")),
+    ("Lin x/Log y", ("linear", "symlog")),
+    ("Log x/Lin y", ("symlog", "linear"))]
+)
+
+
+class FigureInteraction(object):
+    """
+    Defines the behaviour of interaction events on a figure canvas. Note that
+    this currently only works with Qt canvas types.
+    """
+
+    def __init__(self, fig_manager):
+        """
+        Registers handlers for events of interest
+        :param fig_manager: A reference to the figure manager containing the
+        canvas that receives the events
+        """
+        # Check it looks like a FigureCanvasQT
+        if not hasattr(fig_manager.canvas, "buttond"):
+            raise RuntimeError("Figure canvas does not look like a Qt canvas.")
+
+        canvas = fig_manager.canvas
+        self._cids = []
+        self._cids.append(canvas.mpl_connect('button_press_event',
+                                             self.on_mouse_button_press))
+
+        self.canvas = canvas
+        self.fit_browser = fig_manager.fit_browser
+
+    @property
+    def nevents(self):
+        return len(self._cids)
+
+    def disconnect(self):
+        """
+        Disconnects all registered event handers
+        """
+        for id in self._cids:
+            self.canvas.mpl_disconnect(id)
+
+    # ------------------------ Handlers --------------------
+    def on_mouse_button_press(self, event):
+        """Respond to a MouseEvent where a button was pressed"""
+        # local variables to avoid constant self lookup
+        canvas = self.canvas
+        if event.button == canvas.buttond[Qt.RightButton]:
+            self._show_context_menu(event)
+            return
+        elif event.dblclick and event.button == canvas.buttond[Qt.LeftButton]:
+            self._show_axis_editor(event)
+
+    def _show_axis_editor(self, event):
+        # We assume this is used for editing axis information e.g. labels
+        # which are outside of the axes so event.inaxes is no use.
+        canvas = self.canvas
+        figure = canvas.figure
+        axes = figure.get_axes()
+
+        def move_and_show(editor):
+            editor.move(QCursor.pos())
+            editor.exec_()
+
+        for ax in axes:
+            if ax.title.contains(event)[0]:
+                move_and_show(LabelEditor(canvas, ax.title))
+            elif ax.xaxis.label.contains(event)[0]:
+                move_and_show(LabelEditor(canvas, ax.xaxis.label))
+            elif ax.yaxis.label.contains(event)[0]:
+                move_and_show(LabelEditor(canvas, ax.yaxis.label))
+            elif ax.xaxis.contains(event)[0]:
+                move_and_show(XAxisEditor(canvas, ax))
+            elif ax.yaxis.contains(event)[0]:
+                move_and_show(YAxisEditor(canvas, ax))
+
+    def _show_context_menu(self, event):
+        """Display a relevant context menu on the canvas
+        :param event: The MouseEvent that generated this call
+        """
+        if not event.inaxes:
+            # the current context menus are ony relevant for axes
+            return
+
+        fig_type = figure_type(self.canvas.figure)
+        if fig_type == FigureType.Empty or fig_type == FigureType.Image:
+            # Fitting or changing scale types does not make sense in
+            # these cases
+            return
+
+        menu = QMenu()
+        if self.fit_browser.tool is not None:
+            self.fit_browser.add_to_menu(menu)
+            menu.addSeparator()
+        self._add_axes_scale_menu(menu)
+        menu.exec_(QCursor.pos())
+
+    def _add_axes_scale_menu(self, menu):
+        """Add the Axes scale options menu to the given menu"""
+        axes_menu = QMenu("Axes", menu)
+        axes_actions = QActionGroup(axes_menu)
+        current_scale_types = self._get_axes_scale_types()
+        for label, scale_types in iteritems(AXES_SCALE_MENU_OPTS):
+            action = axes_menu.addAction(label, partial(self._quick_change_axes, scale_types))
+            if current_scale_types == scale_types:
+                action.setCheckable(True)
+                action.setChecked(True)
+            axes_actions.addAction(action)
+        menu.addMenu(axes_menu)
+
+    def _get_axes_scale_types(self):
+        """Return a 2-tuple containing the axis scale types if all Axes on the figure are the same
+         otherwise we return None. It assumes a figure with atleast 1 Axes object"""
+        all_axes = self.canvas.figure.get_axes()
+        scale_types = (all_axes[0].get_xscale(), all_axes[0].get_yscale())
+        for axes in all_axes[1:]:
+            other_scales = (axes.get_xscale(), axes.get_yscale())
+            if scale_types != other_scales:
+                scale_types = None
+                break
+
+        return scale_types
+
+    def _quick_change_axes(self, scale_types):
+        """
+        Perform a change of axes on the figure to that given by the option
+        :param scale_types: A 2-tuple of strings giving matplotlib axes scale types
+        """
+        for axes in self.canvas.figure.get_axes():
+            axes.set_xscale(scale_types[0])
+            axes.set_yscale(scale_types[1])
+
+        self.canvas.draw_idle()

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -8,27 +8,30 @@
 #
 #
 """Provides our custom figure manager to wrap the canvas, window and our custom toolbar"""
+from __future__ import  (absolute_import, unicode_literals)
+
+from collections import OrderedDict
+from functools import partial, wraps
 import sys
-from functools import wraps
 
 # 3rdparty imports
+from mantid.api import AnalysisDataServiceObserver
+from mantid.plots import MantidAxes
+from mantid.py3compat import text_type
+from mantidqt.plotting.figuretype import FigureType, figure_type
+from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import FigureManagerBase, MouseEvent
 from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg)  # noqa
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtWidgets import QApplication, QLabel
-from six import text_type
 
 # local imports
-from mantid.api import AnalysisDataServiceObserver
-from mantid.plots import MantidAxes
-from mantidqt.plotting.figuretype import FigureType, figure_type
-from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
-from workbench.plotting.figurewindow import FigureWindow
-from workbench.plotting.propertiesdialog import LabelEditor, XAxisEditor, YAxisEditor
-from workbench.plotting.qappthreadcall import QAppThreadCall
-from workbench.plotting.toolbar import WorkbenchNavigationToolbar, ToolbarStateChecker
+from .figureinteraction import FigureInteraction
+from .figurewindow import FigureWindow
+from .qappthreadcall import QAppThreadCall
+from .toolbar import WorkbenchNavigationToolbar, ToolbarStateChecker
 
 
 def _catch_exceptions(func):
@@ -122,7 +125,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         The qt.QMainWindow
 
     """
-
     def __init__(self, canvas, num):
         QObject.__init__(self)
         FigureManagerBase.__init__(self, canvas, num)
@@ -184,7 +186,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         self.fit_browser = FitPropertyBrowser(canvas, ToolbarStateChecker(self.toolbar))
         self.fit_browser.closing.connect(self.handle_fit_browser_close)
-        self.window.show_context_menu.connect(self.fit_browser.show_canvas_context_menu, Qt.QueuedConnection)
         self.window.setCentralWidget(canvas)
         self.window.addDockWidget(Qt.LeftDockWidgetArea, self.fit_browser)
         self.fit_browser.hide()
@@ -197,12 +198,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             # This will be called whenever the current axes is changed
             if self.toolbar is not None:
                 self.toolbar.update()
-
         canvas.figure.add_axobserver(notify_axes_change)
 
         # Register canvas observers
-        self._cids = []
-        self._cids.append(self.canvas.mpl_connect('button_press_event', self.on_button_press))
+        self._fig_interation = FigureInteraction(self)
         self._ads_observer = FigureManagerADSObserver(self)
 
         self.window.raise_()
@@ -258,8 +257,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.destroy()
         self._ads_observer.observeAll(False)
         del self._ads_observer
-        for id in self._cids:
-            self.canvas.mpl_disconnect(id)
+        self._fig_interation.disconnect()
         self.window.close()
 
         try:
@@ -322,45 +320,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         class so that it can be wrapped in a QAppThreadCall.
         """
         Gcf.figure_visibility_changed(self.num)
-
-    # ------------------------ Interaction events --------------------
-    def on_button_press(self, event):
-        class MouseButton:
-            # Based on the matplotlib MouseEvent click buttons
-            right_click = 3
-            middle_click = 2
-            left_click = 1
-
-        # If right-click then emit a QContextMenuEvent
-        if isinstance(event, MouseEvent) and event.button == MouseButton.right_click:
-            self.window.show_context_menu.emit()
-
-        if not event.dblclick:
-            # shortcut
-            return
-
-        # We assume this is used for editing axis information e.g. labels
-        # which are outside of the axes so event.inaxes is no use.
-        canvas = self.canvas
-        figure = canvas.figure
-        axes = figure.get_axes()
-
-        def move_and_show(editor):
-            editor.move(event.x, figure.bbox.height - event.y + self.window.y())
-            editor.exec_()
-
-        for ax in axes:
-            if ax.title.contains(event)[0]:
-                move_and_show(LabelEditor(canvas, ax.title))
-            elif ax.xaxis.label.contains(event)[0]:
-                move_and_show(LabelEditor(canvas, ax.xaxis.label))
-            elif ax.yaxis.label.contains(event)[0]:
-                move_and_show(LabelEditor(canvas, ax.yaxis.label))
-            elif ax.xaxis.contains(event)[0]:
-                move_and_show(XAxisEditor(canvas, ax))
-            elif ax.yaxis.contains(event)[0]:
-                move_and_show(YAxisEditor(canvas, ax))
-
 
 # -----------------------------------------------------------------------------
 # Figure control

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -10,8 +10,7 @@
 """Provides our custom figure manager to wrap the canvas, window and our custom toolbar"""
 from __future__ import  (absolute_import, unicode_literals)
 
-from collections import OrderedDict
-from functools import partial, wraps
+from functools import wraps
 import sys
 
 # 3rdparty imports
@@ -22,7 +21,7 @@ from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
 import matplotlib
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_bases import FigureManagerBase, MouseEvent
+from matplotlib.backend_bases import FigureManagerBase
 from matplotlib.backends.backend_qt5agg import (FigureCanvasQTAgg)  # noqa
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtWidgets import QApplication, QLabel
@@ -320,6 +319,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         class so that it can be wrapped in a QAppThreadCall.
         """
         Gcf.figure_visibility_changed(self.num)
+
 
 # -----------------------------------------------------------------------------
 # Figure control

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, unicode_literals)
 # std imports
 
 # 3rdparty imports
+from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 from qtpy.QtGui import QDoubleValidator
 from qtpy.QtWidgets import QDialog
@@ -112,6 +113,9 @@ class AxisEditor(PropertiesEditorBase):
         # Ensure that only floats can be entered
         self.ui.editor_min.setValidator(QDoubleValidator())
         self.ui.editor_max.setValidator(QDoubleValidator())
+        if figure_type(canvas.figure) == FigureType.Image:
+            self.ui.logBox.hide()
+            self.ui.gridBox.hide()
 
         self.axes = axes
         self.axis_id = axis_id

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+# system imports
+import unittest
+
+# third-party library imports
+from mantid.py3compat.mock import MagicMock
+
+# local package imports
+from workbench.plotting.figureinteraction import FigureInteraction
+
+
+class FigureInteractionTest(unittest.TestCase):
+
+    # Success tests
+
+    def test_construction_registers_handler_for_button_press_event(self):
+        fig_manager = MagicMock()
+        fig_manager.canvas = MagicMock()
+        interactor = FigureInteraction(fig_manager)
+        fig_manager.canvas.mpl_connect.assert_called_once_with('button_press_event',
+                                                               interactor.on_mouse_button_press)
+
+    def test_disconnect_called_for_each_registered_handler(self):
+        fig_manager = MagicMock()
+        canvas = MagicMock()
+        fig_manager.canvas = canvas
+        interactor = FigureInteraction(fig_manager)
+        interactor.disconnect()
+        self.assertEqual(interactor.nevents, canvas.mpl_disconnect.call_count)
+
+    # Failure tests
+
+    def test_construction_with_non_qt_canvas_raises_exception(self):
+        class NotQtCanvas(object):
+            pass
+
+        class FigureManager(object):
+            def __init__(self):
+                self.canvas = NotQtCanvas()
+
+        self.assertRaises(RuntimeError, FigureInteraction, FigureManager())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -13,7 +13,9 @@ from __future__ import (absolute_import, division, print_function,
 import unittest
 
 # third-party library imports
-from mantid.py3compat.mock import MagicMock
+from mantid.py3compat.mock import MagicMock, PropertyMock, call, patch
+from mantidqt.plotting.figuretype import FigureType
+from qtpy.QtCore import Qt
 
 # local package imports
 from workbench.plotting.figureinteraction import FigureInteraction
@@ -22,7 +24,6 @@ from workbench.plotting.figureinteraction import FigureInteraction
 class FigureInteractionTest(unittest.TestCase):
 
     # Success tests
-
     def test_construction_registers_handler_for_button_press_event(self):
         fig_manager = MagicMock()
         fig_manager.canvas = MagicMock()
@@ -38,6 +39,61 @@ class FigureInteractionTest(unittest.TestCase):
         interactor.disconnect()
         self.assertEqual(interactor.nevents, canvas.mpl_disconnect.call_count)
 
+    @patch('workbench.plotting.figureinteraction.QMenu',
+           autospec=True)
+    @patch('workbench.plotting.figureinteraction.figure_type',
+           autospec=True)
+    def test_right_click_gives_no_context_menu_for_empty_figure(self, mocked_figure_type,
+                                                                mocked_qmenu):
+        fig_manager = self._create_mock_fig_manager_to_accept_right_click()
+        interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_right_click()
+        mocked_figure_type.return_value = FigureType.Empty
+
+        interactor.on_mouse_button_press(mouse_event)
+        mocked_qmenu.assert_not_called()
+
+    @patch('workbench.plotting.figureinteraction.QMenu',
+           autospec=True)
+    @patch('workbench.plotting.figureinteraction.figure_type',
+           autospec=True)
+    def test_right_click_gives_no_context_menu_for_color_plot(self, mocked_figure_type,
+                                                              mocked_qmenu):
+        fig_manager = self._create_mock_fig_manager_to_accept_right_click()
+        interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_right_click()
+        mocked_figure_type.return_value = FigureType.Image
+
+        interactor.on_mouse_button_press(mouse_event)
+        mocked_qmenu.assert_not_called()
+
+    @patch('workbench.plotting.figureinteraction.QMenu',
+           autospec=True)
+    @patch('workbench.plotting.figureinteraction.figure_type',
+           autospec=True)
+    def test_right_click_gives_context_menu_for_plot_without_fit_enabled(self, mocked_figure_type,
+                                                                         mocked_qmenu_cls):
+        fig_manager = self._create_mock_fig_manager_to_accept_right_click()
+        fig_manager.fit_browser.tool = None
+        interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_right_click()
+        mocked_figure_type.return_value = FigureType.Line
+
+        # Expect a call to QMenu() for the outer menu followed by a call with the first
+        # as its parent to generate the Axes menu.
+        qmenu_call1 = MagicMock()
+        qmenu_call2 = MagicMock()
+        mocked_qmenu_cls.side_effect = [qmenu_call1, qmenu_call2]
+
+        with patch('workbench.plotting.figureinteraction.QActionGroup',
+                   autospec=True):
+            interactor.on_mouse_button_press(mouse_event)
+            self.assertEqual(0, qmenu_call1.addSeparator.call_count)
+            self.assertEqual(0, qmenu_call1.addAction.call_count)
+            expected_qmenu_calls = [call(), call("Axes", qmenu_call1)]
+            self.assertEqual(expected_qmenu_calls, mocked_qmenu_cls.call_args_list)
+            self.assertEqual(4, qmenu_call2.addAction.call_count)
+
     # Failure tests
 
     def test_construction_with_non_qt_canvas_raises_exception(self):
@@ -49,6 +105,19 @@ class FigureInteractionTest(unittest.TestCase):
                 self.canvas = NotQtCanvas()
 
         self.assertRaises(RuntimeError, FigureInteraction, FigureManager())
+
+    # Private methods
+    def _create_mock_fig_manager_to_accept_right_click(self):
+        fig_manager = MagicMock()
+        canvas = MagicMock()
+        type(canvas).buttond = PropertyMock(return_value={Qt.RightButton: 3})
+        fig_manager.canvas = canvas
+        return fig_manager
+
+    def _create_mock_right_click(self):
+        mouse_event = MagicMock()
+        type(mouse_event).button = PropertyMock(return_value=3)
+        return mouse_event
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -211,6 +211,19 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         self.remove_guess()
         self.plot_guess()
 
+    def add_to_menu(self, menu):
+        """
+        Add the relevant actions to a menu
+        :param menu: A menu to hold the actions
+        :return: The menu passed to us
+        """
+        if self.tool is not None:
+            self.tool.add_to_menu(menu, peak_names=self.registeredPeaks(),
+                                  current_peak_type=self.defaultPeakType(),
+                                  background_names=self.registeredBackgrounds(),
+                                  other_names=self.registeredOthers())
+        return menu
+
     @Slot()
     def clear_fit_result_lines_slot(self):
         """
@@ -307,17 +320,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         :param fun_name: A registered name of a fit function
         """
         self.addFunction(fun_name)
-
-    @Slot()
-    def show_canvas_context_menu(self):
-        """
-        Show plot's context menu
-        """
-        if self.tool is not None:
-            self.tool.show_context_menu(peak_names=self.registeredPeaks(),
-                                        current_peak_type=self.defaultPeakType(),
-                                        background_names=self.registeredBackgrounds(),
-                                        other_names=self.registeredOthers())
 
     @Slot()
     def plot_guess_slot(self):

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -4,9 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, unicode_literals)
+
 from qtpy.QtCore import QObject, Signal, Slot
-from qtpy.QtGui import QCursor
-from qtpy.QtWidgets import QApplication, QMenu, QInputDialog
+from qtpy.QtWidgets import QApplication,  QInputDialog
 
 from .markers import VerticalMarker, PeakMarker
 from .mouse_state_machine import StateMachine
@@ -403,9 +404,12 @@ class FitInteractiveTool(QObject):
         """
         return self.fit_start_x.patch.get_transform()
 
-    def show_context_menu(self, peak_names, current_peak_type, background_names, other_names):
+    def add_to_menu(self, menu, peak_names, current_peak_type, background_names,
+                    other_names):
         """
-        Show the context menu.
+        Adds the fit tool menu actions to the given menu and returns the menu
+
+        :param menu: A reference to a menu that will accept the actions
         :param peak_names: A list of registered fit function peak names to be offered to choose from by the "Add a peak"
             dialog.
         :param current_peak_type:
@@ -413,15 +417,16 @@ class FitInteractiveTool(QObject):
             "Add a background" dialog.
         :param other_names:  A list of other registered fit functions to be offered to choose from by the
             "Add other function" dialog.
+        :returns: The menu reference passed in
         """
         self.peak_names = peak_names
         self.current_peak_type = current_peak_type
         self.background_names = background_names
         self.other_names = other_names
         if not self.toolbar_state_checker.is_tool_active():
-            menu = QMenu()
             menu.addAction("Add peak", self.add_default_peak)
             menu.addAction("Select peak type", self.add_peak_dialog)
             menu.addAction("Add background", self.add_background_dialog)
             menu.addAction("Add other function", self.add_other_dialog)
-            menu.exec_(QCursor.pos())
+
+        return menu


### PR DESCRIPTION
**Description of work.**

The new context menu will allow quick access to change certain properties of the plot. Only one option exist so far - the option to change the axes type. 

**To test:**

* build and start the workbench
* create a line plot
* right click and try the axes options.
* enable fitting and check the fit options still work and the axes options also work too

Refs #24483 

*This does not require release notes* because **it is part of the unreleased workbench.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
