### PR TITLE
Revert "Add uncertainties tag to NXcanSASAlgorithm"

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -18,6 +18,7 @@ enum class WorkspaceDimensionality { oneD, twoD, other };
 
 // NXcanSAS Tag Definitions
 const std::string sasUnitAttr = "units";
+const std::string sasUncertaintyAttr = "uncertainty";
 const std::string sasSignal = "signal";
 const std::string sasSeparator = ",";
 const std::string sasAngstrom = "A";
@@ -26,15 +27,6 @@ const std::string sasIntensity = "1/cm";
 const std::string sasMomentumTransfer = "1/A";
 const std::string sasNxclass = "NX_class";
 const std::string sasCanSASclass = "canSAS_class";
-
-/**
- * Standards state that "uncertainties" should be used, however different
- * facilities interpret the standards differently.
- * At time of writing, 01/19, both "uncertainty" and "uncertainties" are needed
- * so that Mantid NXcanSAS output is compatible with all other NXcanSAS files.
- **/
-const std::string sasUncertaintyAttr = "uncertainty";
-const std::string sasUncertaintiesAttr = "uncertainties";
 
 // SASentry
 const std::string sasEntryClassAttr = "SASentry";
@@ -54,10 +46,8 @@ const std::string nxDataClassAttr = "NXdata";
 const std::string sasDataGroupName = "sasdata";
 const std::string sasDataIAxesAttr = "I_axes";
 const std::string sasDataIUncertaintyAttr = "I_uncertainty";
-const std::string sasDataIUncertaintiesAttr = "I_uncertainties";
 const std::string sasDataQIndicesAttr = "Q_indices";
 const std::string sasDataQUncertaintyAttr = "Q_uncertainty";
-const std::string sasDataQUncertaintiesAttr = "Q_uncertainties";
 const std::string sasDataMaskIndicesAttr = "Mask_indices";
 
 const std::string sasDataQ = "Q";
@@ -120,7 +110,6 @@ const std::string nxTransmissionSpectrumClassAttr = "NXdata";
 const std::string sasTransmissionSpectrumGroupName = "sastransmission_spectrum";
 const std::string sasTransmissionSpectrumTIndices = "T_indices";
 const std::string sasTransmissionSpectrumTUncertainty = "T_uncertainty";
-const std::string sasTransmissionSpectrumTUncertainties = "T_uncertainties";
 const std::string sasTransmissionSpectrumNameAttr = "name";
 const std::string sasTransmissionSpectrumNameSampleAttrValue = "sample";
 const std::string sasTransmissionSpectrumNameCanAttrValue = "can";

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -419,16 +419,12 @@ void addData1D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
                                                   sasDataQ);
   Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataIUncertaintyAttr,
                                                   sasDataIdev);
-  Mantid::DataHandling::H5Util::writeStrAttribute(
-      data, sasDataIUncertaintiesAttr, sasDataIdev);
   Mantid::DataHandling::H5Util::writeNumAttribute(data, sasDataQIndicesAttr,
                                                   std::vector<int>{0});
 
   if (workspace->hasDx(0)) {
     Mantid::DataHandling::H5Util::writeStrAttribute(
         data, sasDataQUncertaintyAttr, sasDataQdev);
-    Mantid::DataHandling::H5Util::writeStrAttribute(
-        data, sasDataQUncertaintiesAttr, sasDataQdev);
   }
 
   //-----------------------------------------
@@ -440,7 +436,6 @@ void addData1D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
   qAttributes.emplace(sasUnitAttr, qUnit);
   if (workspace->hasDx(0)) {
     qAttributes.emplace(sasUncertaintyAttr, sasDataQdev);
-    qAttributes.emplace(sasUncertaintiesAttr, sasDataQdev);
   }
 
   writeArray1DWithStrAttributes(data, sasDataQ, qValue.rawData(), qAttributes);
@@ -453,7 +448,6 @@ void addData1D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
   iUnit = getIntensityUnitLabel(iUnit);
   iAttributes.emplace(sasUnitAttr, iUnit);
   iAttributes.emplace(sasUncertaintyAttr, sasDataIdev);
-  iAttributes.emplace(sasUncertaintiesAttr, sasDataIdev);
 
   writeArray1DWithStrAttributes(data, sasDataI, intensity.rawData(),
                                 iAttributes);
@@ -600,8 +594,6 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
                                                   sasDataIAxesAttr2D);
   Mantid::DataHandling::H5Util::writeStrAttribute(data, sasDataIUncertaintyAttr,
                                                   sasDataIdev);
-  Mantid::DataHandling::H5Util::writeStrAttribute(
-      data, sasDataIUncertaintiesAttr, sasDataIdev);
   // Write the Q Indices as Int Array
   Mantid::DataHandling::H5Util::writeNumAttribute(data, sasDataQIndicesAttr,
                                                   std::vector<int>{0, 1});
@@ -630,7 +622,6 @@ void addData2D(H5::Group &data, Mantid::API::MatrixWorkspace_sptr workspace) {
   iUnit = getIntensityUnitLabel(iUnit);
   iAttributes.emplace(sasUnitAttr, iUnit);
   iAttributes.emplace(sasUncertaintyAttr, sasDataIdev);
-  iAttributes.emplace(sasUncertaintiesAttr, sasDataIdev);
 
   auto iExtractor = [](Mantid::API::MatrixWorkspace_sptr ws, int index) {
     return ws->dataY(index).data();
@@ -678,17 +669,14 @@ void addTransmission(H5::Group &group,
       group, sasTransmissionName, nxTransmissionSpectrumClassAttr,
       sasTransmissionSpectrumClassAttr);
 
-  // Add attributes for @signal, @T_axes, @T_indices, @T_uncertainty,
-  // @T_uncertainties, @name, @timestamp
+  // Add attributes for @signal, @T_axes, @T_indices, @T_uncertainty, @name,
+  // @timestamp
   Mantid::DataHandling::H5Util::writeStrAttribute(transmission, sasSignal,
                                                   sasTransmissionSpectrumT);
   Mantid::DataHandling::H5Util::writeStrAttribute(
       transmission, sasTransmissionSpectrumTIndices, sasTransmissionSpectrumT);
   Mantid::DataHandling::H5Util::writeStrAttribute(
       transmission, sasTransmissionSpectrumTUncertainty,
-      sasTransmissionSpectrumTdev);
-  Mantid::DataHandling::H5Util::writeStrAttribute(
-      transmission, sasTransmissionSpectrumTUncertainties,
       sasTransmissionSpectrumTdev);
   Mantid::DataHandling::H5Util::writeStrAttribute(
       transmission, sasTransmissionSpectrumNameAttr, transmissionName);
@@ -707,8 +695,6 @@ void addTransmission(H5::Group &group,
   }
   transmissionAttributes.emplace(sasUnitAttr, unit);
   transmissionAttributes.emplace(sasUncertaintyAttr,
-                                 sasTransmissionSpectrumTdev);
-  transmissionAttributes.emplace(sasUncertaintiesAttr,
                                  sasTransmissionSpectrumTdev);
 
   writeArray1DWithStrAttributes(transmission, sasTransmissionSpectrumT,

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -490,15 +490,6 @@ private:
     TSM_ASSERT("Should not have a Q_uncertainty attribute",
                missingQUncertaintyAttribute);
 
-    bool missingQUncertaintiesAttribute = false;
-    try {
-      data.openAttribute(sasDataQUncertaintiesAttr);
-    } catch (H5::AttributeIException &) {
-      missingQUncertaintiesAttribute = true;
-    }
-    TSM_ASSERT("Should not have a Q_uncertainties attribute",
-               missingQUncertaintiesAttribute);
-
     // Check that Qdev data set does not exist
     bool missingQDevDataSet = false;
     try {
@@ -520,26 +511,16 @@ private:
     }
     TSM_ASSERT("Data set should not have an uncertainty",
                missingQUncertaintyOnQDataSet);
-
-    bool missingQUncertaintiesOnQDataSet = false;
-    try {
-      auto qDataSet = data.openDataSet(sasDataQ);
-      auto uncertainties = qDataSet.openAttribute(sasUncertaintiesAttr);
-    } catch (H5::AttributeIException &) {
-      missingQUncertaintiesOnQDataSet = true;
-    }
-    TSM_ASSERT("Data set should not have uncertainties",
-               missingQUncertaintiesOnQDataSet);
   }
 
   void do_assert_data(H5::Group &data, int size, double value, double error,
                       double xmin, double xmax, double xerror, bool hasDx) {
     auto numAttributes = data.getNumAttrs();
     if (hasDx) {
-      TSM_ASSERT_EQUALS("Should have 9 attributes", 9, numAttributes);
+      TSM_ASSERT_EQUALS("Should have 7 attribute", 7, numAttributes);
     } else {
       TSM_ASSERT_EQUALS(
-          "Should have 7 attributes, since Q_uncertainty is not present", 7,
+          "Should have 6 attribute, since Q_uncertainty is not present", 6,
           numAttributes);
     }
 
@@ -564,13 +545,6 @@ private:
         data, sasDataIUncertaintyAttr);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
 
-    // I_uncertainties attribute
-    auto errorAlternativeAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(
-            data, sasDataIUncertaintiesAttr);
-    TSM_ASSERT_EQUALS("Should be just Idev", errorAlternativeAttribute,
-                      sasDataIdev);
-
     // Q_indices attribute
     auto qAttribute =
         Mantid::DataHandling::H5Util::readNumArrayAttributeCoerce<int>(
@@ -593,13 +567,6 @@ private:
     TSM_ASSERT_EQUALS("Should be just Idev", uncertaintyIAttribute,
                       sasDataIdev);
 
-    // I data set uncertainties attribute
-    auto uncertaintiesIAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(
-            intensityDataSet, sasUncertaintiesAttr);
-    TSM_ASSERT_EQUALS("Should be just Idev", uncertaintiesIAttribute,
-                      sasDataIdev);
-
     // I dev data set
     auto errorDataSet = data.openDataSet(sasDataIdev);
     do_assert_1D_vector_with_same_entries(errorDataSet, error, size);
@@ -618,13 +585,6 @@ private:
       TSM_ASSERT_EQUALS("Should be just Qdev", uncertaintyQAttribute,
                         sasDataQdev);
 
-      // Q data set uncertainties attribute
-      auto uncertaintiesQAttribute =
-          Mantid::DataHandling::H5Util::readAttributeAsString(
-              qDataSet, sasUncertaintiesAttr);
-      TSM_ASSERT_EQUALS("Should be just Qdev", uncertaintiesQAttribute,
-                        sasDataQdev);
-
       // Q error data set
       auto xErrorDataSet = data.openDataSet(sasDataQdev);
       do_assert_1D_vector_with_same_entries(xErrorDataSet, xerror, size);
@@ -634,13 +594,6 @@ private:
           Mantid::DataHandling::H5Util::readAttributeAsString(
               data, sasDataQUncertaintyAttr);
       TSM_ASSERT_EQUALS("Should be just Qdev", qErrorAttribute, sasDataQdev);
-
-      // Q_uncertainties attribute on the SASdata group
-      auto qErrorAlternativeAttribute =
-          Mantid::DataHandling::H5Util::readAttributeAsString(
-              data, sasDataQUncertaintiesAttr);
-      TSM_ASSERT_EQUALS("Should be just Qdev", qErrorAlternativeAttribute,
-                        sasDataQdev);
     } else {
       do_assert_that_Q_dev_information_is_not_present(data);
     }
@@ -649,7 +602,7 @@ private:
   void do_assert_2D_data(H5::Group &data) {
     auto numAttributes = data.getNumAttrs();
     TSM_ASSERT_EQUALS(
-        "Should have 7 attributes, since Q_uncertainty is not present", 7,
+        "Should have 6 attributes, since Q_uncertainty is not present", 6,
         numAttributes);
 
     // canSAS_class and NX_class attribute
@@ -673,13 +626,6 @@ private:
     auto errorAttribute = Mantid::DataHandling::H5Util::readAttributeAsString(
         data, sasDataIUncertaintyAttr);
     TSM_ASSERT_EQUALS("Should be just Idev", errorAttribute, sasDataIdev);
-
-    // I_uncertainties attribute
-    auto errorAlternativeAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(
-            data, sasDataIUncertaintiesAttr);
-    TSM_ASSERT_EQUALS("Should be just Idev", errorAlternativeAttribute,
-                      sasDataIdev);
 
     // Q_indices attribute
     auto qAttribute =
@@ -734,13 +680,6 @@ private:
         Mantid::DataHandling::H5Util::readAttributeAsString(
             transmission, sasTransmissionSpectrumTUncertainty);
     TSM_ASSERT_EQUALS("Should be Tdev", tUncertaintyIndicesAttribute,
-                      sasTransmissionSpectrumTdev);
-
-    // T uncertainties attribute
-    auto tUncertaintiesIndicesAttribute =
-        Mantid::DataHandling::H5Util::readAttributeAsString(
-            transmission, sasTransmissionSpectrumTUncertainties);
-    TSM_ASSERT_EQUALS("Should be Tdev", tUncertaintiesIndicesAttribute,
                       sasTransmissionSpectrumTdev);
 
     // Signal attribute

--- a/docs/source/release/v3.14.0/framework.rst
+++ b/docs/source/release/v3.14.0/framework.rst
@@ -89,7 +89,6 @@ Improvements
   version of algorithm, `Indexed` provide the new one with better performance and some restrictions
   (see :ref:`ConvertToMD <algm-ConvertToMD>` Notes)
 - :ref:`FitPeaks <algm-FitPeaks>` can output parameters' uncertainty (fitting error) in an optional workspace.
-- :ref:`SaveNXcanSAS <algm-SaveNXcanSAS>` now has "uncertainties" parameter as well as "uncertainty". They point to the same data, but move file output inline with standards whilst keeping compatibility with old output.
 - The documentation in :ref:`EventFiltering` and :ref:`FilterEvents <algm-FilterEvents>` have been extensively rewritten to aid in understanding what the code does.
 - All of the numerical integration based absorption corrections which use :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` will generate an exception when they fail to generate a gauge volume. Previously, they would silently generate a correction workspace that was all not-a-number (``NAN``). If the sample shape is a cylinder it will use the specialized code for rasterizing it.
 - :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now will check the workspace's sample object for geometry


### PR DESCRIPTION
This might be the fix to the failing system OS system tests on ISIS-MAC-PRO, which are failing when trying to load HDF files.
This PR reversion will take away the "uncertainties" tag from NXCanSas files. 

To test:
System tests pass (repeatedly) on ISIS-MAC-PRO