### PR TITLE
Move linker lines to mtd_add_qt_library function call in spectrum viewer widget

### DIFF
--- a/qt/widgets/spectrumviewer/CMakeLists.txt
+++ b/qt/widgets/spectrumviewer/CMakeLists.txt
@@ -76,10 +76,9 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsSpectrumViewer
     MantidQtWidgetsLegacyQwt
   INSTALL_DIR
     ${LIB_DIR}
+  OSX_INSTALL_RPATH
+    @loader_path/../MacOS
+    @loader_path/../Libraries
+  LINUX_INSTALL_RPATH
+    "\$ORIGIN/../${LIB_DIR}"
 )
-
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidQtWidgetsSpectrumViewerQt4 PROPERTIES INSTALL_RPATH "@loader_path/../MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidQtWidgetsSpectrumViewerQt4 PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
-endif ()


### PR DESCRIPTION
**Description of work.**

Moves "left over" code for linkers to the `mtd_add_qt_library` function call for spectrum viewer widget.

**Report to:** @martyngigg @peterfpeterson 

**To test:**
I built with `ENABLE_CPACK=ON` and ran `ninja package` to make sure no error for my own test.

*There is no associated issue.*

*This does not require release notes* because related to code cleanup for building

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
