### PR TITLE
Ignore unused typedef warning from Boost

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -203,6 +203,7 @@ std::size_t binIndexOfDeprecated(MatrixWorkspace &self, const double xValue,
   return self.yIndexOfX(xValue, index);
 }
 
+GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
 GNU_DIAG_OFF("conversion")
@@ -210,6 +211,7 @@ GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(binIndexOfDeprecatedOverloads,
                                 binIndexOfDeprecated, 2, 3)
 GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unused-local-typedef")
 
 /**
  * This is an anonymous wrapper around the homonym method of MatrixWorkspace.


### PR DESCRIPTION
**Description of work.**

Fixes a [compiler warning](http://builds.mantidproject.org/job/master_incremental/label=osx-10.10-build/) on OSX that has made it to master.

**To test:**

Code review.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
