### PR TITLE
Open H5 files read-only to fix failing SANS tests

### DIFF
--- a/scripts/SANS/SANSUtility.py
+++ b/scripts/SANS/SANSUtility.py
@@ -707,7 +707,7 @@ def get_number_of_periods_from_file(file_name):
     if hasattr(full_file_path, '__iter__'):
         full_file_path = full_file_path[0]
     try:
-        with h5.File(full_file_path) as h5_file:
+        with h5.File(full_file_path, 'r') as h5_file:
             first_entry = h5_file["raw_data_1"]
             period_group = first_entry["periods"]
             proton_charge_data_set = period_group["proton_charge"]
@@ -728,7 +728,7 @@ def check_if_is_event_data(file_name):
     full_file_path = FileFinder.findRuns(file_name)
     if hasattr(full_file_path, '__iter__'):
         file_name = full_file_path[0]
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         first_entry = h5_file[keys[0]]
@@ -754,7 +754,7 @@ def is_nexus_file(file_name):
         file_name = full_file_path[0]
     is_nexus = True
     try:
-        with h5.File(file_name) as h5_file:
+        with h5.File(file_name, 'r') as h5_file:
             keys = list(h5_file.keys())
             nexus_test = "raw_data_1" in keys or "mantid_workspace_1" in keys
             is_nexus = True if nexus_test else False
@@ -1548,7 +1548,7 @@ def can_load_as_event_workspace(filename):
         try:
             # We only check the first entry in the root
             # and check for event_eventworkspace in the next level
-            with h5.File(filename) as h5f:
+            with h5.File(filename, 'r') as h5f:
                 try:
                     rootKeys = list(h5f.keys()) # python3 fix
                     entry0 = h5f[rootKeys[0]]
@@ -1773,7 +1773,7 @@ class MeasurementTimeFromNexusFileExtractor(object):
     def get_measurement_time(self, filename_full):
         measurement_time = ''
         try:
-            with h5.File(filename_full) as h5f:
+            with h5.File(filename_full, 'r') as h5f:
                 try:
                     rootKeys =  list(h5f.keys())
                     entry0 = h5f[rootKeys[0]]

--- a/scripts/SANS/sans/common/file_information.py
+++ b/scripts/SANS/sans/common/file_information.py
@@ -302,7 +302,7 @@ def get_isis_nexus_info(file_name):
     :return: if the file was a Nexus file and the number of periods.
     """
     try:
-        with h5.File(file_name) as h5_file:
+        with h5.File(file_name, 'r') as h5_file:
             keys = list(h5_file.keys())
             is_isis_nexus = RAW_DATA_1 in keys
             if is_isis_nexus:
@@ -338,7 +338,7 @@ def get_instrument_name_for_isis_nexus(file_name):
                                         |--instrument|
                                                      |--name
     """
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         first_entry = h5_file[keys[0]]
@@ -359,7 +359,7 @@ def get_top_level_nexus_entry(file_name, entry_name):
     :param entry_name: the entry name
     :return:
     """
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         top_level = h5_file[keys[0]]
@@ -385,7 +385,7 @@ def get_event_mode_information(file_name):
                                     |--some_group|
                                                  |--Attribute: NX_class = NXevent_data
     """
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         first_entry = h5_file[keys[0]]
@@ -405,7 +405,7 @@ def get_geometry_information_isis_nexus(file_name):
     :param file_name:
     :return: height, width, thickness, shape
     """
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         top_level = h5_file[keys[0]]
@@ -438,7 +438,7 @@ def get_geometry_information_isis_nexus(file_name):
 
 
 def get_date_and_run_number_added_nexus(file_name):
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         keys = list(h5_file.keys())
         first_entry = h5_file[keys[0]]
         logs = first_entry["logs"]
@@ -534,7 +534,7 @@ def get_added_nexus_information(file_name):  # noqa
 
     if has_added_suffix(file_name):
         try:
-            with h5.File(file_name) as h5_file:
+            with h5.File(file_name, 'r') as h5_file:
                 # Get all mantid_workspace_X keys
                 keys = list(h5_file.keys())
                 top_level_keys = get_all_keys_for_top_level(keys)
@@ -594,7 +594,7 @@ def get_geometry_information_isis_added_nexus(file_name):
     :param file_name: the file name
     :return: height, width, thickness, shape
     """
-    with h5.File(file_name) as h5_file:
+    with h5.File(file_name, 'r') as h5_file:
         # Open first entry
         keys = list(h5_file.keys())
         top_level = h5_file[keys[0]]


### PR DESCRIPTION
**Description of work.**
This PR fixes the failing SANS tests on ISIS-MAC-PRO jenkins build by opening H5 files in read-only (the default is read-write).

**To test:**
`ctest -R "crop_helper_test|command_interface_state_director_test" -j8 --repeat-until-fail 100`
All tests should pass

Fixes #24937 

*This does not require release notes* because **change to fix internal testing**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
