### PR TITLE
Fix Windows warning in MDNorm for possible type narrowing data loss

### DIFF
--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -52,8 +52,10 @@ constexpr double energyToK = 8.0 * M_PI * M_PI *
                              PhysicalConstants::meV * 1e-20 /
                              (PhysicalConstants::h * PhysicalConstants::h);
 
-// compare absolute values of integers
-static bool abs_compare(int a, int b) { return (std::abs(a) < std::abs(b)); }
+// compare absolute values of doubles
+static bool abs_compare(double a, double b) {
+  return (std::fabs(a) < std::fabs(b));
+}
 } // namespace
 
 // Register the algorithm into the AlgorithmFactory


### PR DESCRIPTION
**Description of work.**
Changes the parameters of 'abs_compare' to be doubles, uses std::fabs. The [function](https://github.com/mantidproject/mantid/blob/7386a8d6b79861b38fca64cffaca4411862f85cc/Framework/MDAlgorithms/src/MDNorm.cpp#L477) is used only once with a `vector<double>`.

**To test:**
See that builds/tests pass.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
