### PR TITLE
Fix bug finding workspace in old Reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -1072,6 +1072,7 @@ We recommend you use ISIS Reflectometry instead, If this is not possible contact
 
                     alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
                     alg.initialize()
+                    alg.setProperty("Debug", True)
                     alg.setProperty("InputWorkspace", ws[i])
                     if group_trans_ws:
                         alg.setProperty("FirstTransmissionRun", group_trans_ws)
@@ -1105,6 +1106,7 @@ We recommend you use ISIS Reflectometry instead, If this is not possible contact
             else:
                 alg = AlgorithmManager.create("ReflectometryReductionOneAuto")
                 alg.initialize()
+                alg.setProperty("Debug", True)
                 alg.setProperty("InputWorkspace", ws)
                 if transmission_ws:
                     alg.setProperty("FirstTransmissionRun", transmission_ws)


### PR DESCRIPTION
The old reflectometry GUI assumes the IvsLam workspace is available after running `ReflectometryReductionOneAuto`, but since the introduction of the `Debug` flag this workspace is no longer output by default. This PR sets `Debug=True` to fix this.

Re #24977

**To test:**

- Open the `ISIS Reflectometry Old` GUI
- Set the instrument to `INTER` and in the first table cell enter `13460`
- Click `Process`

Fixes #24977

*This does not require release notes* because it fixes a regression in the nightly build

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
