### PR TITLE
Fix EnginX systemtests for python3

### DIFF
--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -11,6 +11,7 @@ import os
 import csv
 from platform import system
 from shutil import copy2
+from six import u
 
 
 def main(vanadium_run, user, focus_run, **kwargs):
@@ -523,7 +524,7 @@ def _save_out(run_number, focus_directory, focus_general, output, join_string, b
     # work out where to save the files
     filename = os.path.join(focus_directory, join_string.format(run_number, bank_id))
     hdf5_name = os.path.join(focus_directory, run_number + ".hdf5")
-    if not unicode(bank_id).isnumeric():
+    if not u(bank_id).isnumeric():
         bank_id = 0
     # save the files out to the user directory
     simple.SaveFocusedXYE(InputWorkspace=output, Filename=filename + ".dat", SplitFiles=False,


### PR DESCRIPTION
`unicode` doesn't exist in python 3, use `six.u` instead

The currently failing tests can be seen [here](http://builds.mantidproject.org/job/master_systemtests-ubuntu-16.04-python3/639/testReport/)

**To test:**
See that the systemtests now pass with python 3 (`./systemtest -R EnginXScriptTest`)

*There is no associated issue.*


*This does not require release notes* because it fixes a bug only added this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
