### PR TITLE
Fix SANSSaveOther

### DIFF
--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -259,6 +259,7 @@ class WorkspaceTreeWidget : QWidget {
 public:
   WorkspaceTreeWidget(MantidDisplayBase *mdb /Transfer/, bool viewOnly=false,
                       QWidget *parent /TransferThis/ = nullptr);
+  std::vector<std::string> getSelectedWorkspaceNames() const;
 };
 
 // Implementation to override context menu

--- a/scripts/Interface/ui/sans_isis/settings_diagnostic_tab.py
+++ b/scripts/Interface/ui/sans_isis/settings_diagnostic_tab.py
@@ -15,7 +15,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractmethod
 import os
-from qtpy import QtGui, QtWidgets
+from qtpy import QtWidgets
 from six import with_metaclass, PY3
 
 from mantidqt.utils.qt import load_ui
@@ -134,17 +134,17 @@ class SettingsDiagnosticTab(QtWidgets.QWidget, Ui_SettingsDiagnosticTab):
             for key, val in sorted(value.iteritems()):
                 if key in self.excluded:
                     continue
-                child = QtGui.QTreeWidgetItem()
+                child = QtWidgets.QTreeWidgetItem()
                 child.setText(0, unicode(key))
                 item.addChild(child)
                 self.fill_tree_widget(child, val)
         elif type(value) is list:
             for val in value:
-                child = QtGui.QTreeWidgetItem()
+                child = QtWidgets.QTreeWidgetItem()
                 child.setText(1, unicode(val))
                 item.addChild(child)
         else:
-            child = QtGui.QTreeWidgetItem()
+            child = QtWidgets.QTreeWidgetItem()
             value = self.clean_class_type(value)
             child.setText(1, unicode(value))
             item.addChild(child)

--- a/scripts/Interface/ui/sans_isis/settings_diagnostic_tab.py
+++ b/scripts/Interface/ui/sans_isis/settings_diagnostic_tab.py
@@ -131,7 +131,7 @@ class SettingsDiagnosticTab(QtWidgets.QWidget, Ui_SettingsDiagnosticTab):
     def fill_tree_widget(self, item, value):
         item.setExpanded(True)
         if type(value) is dict:
-            for key, val in sorted(value.iteritems()):
+            for key, val in sorted(value.items()):
                 if key in self.excluded:
                     continue
                 child = QtWidgets.QTreeWidgetItem()


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug introduced in the porting of ISIS SANS over to workbench caused by a method not being exposed in `__common.sip`

**To test:**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/2931282/loqPRData.zip)
1. Interfaces -> SANS -> SANS v2
2. Load the attached user (mask) file and batch file
3. Click process all
4. Once the workspaces have been added to the ADS, click `Save Other` on the SANS gui
5. Provide an output directory, output name, and select a workspace, then click save
6. Check that the file has been saved out and no errors have been posted to the mantid logger

Fixes #25000 


*This does not require release notes* because **fix to bug introduced in a recent nightly not reported by any users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
