### PR TITLE
Suppress remaining flake8 warnings

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/DPDFreduction.py
@@ -123,7 +123,7 @@ class DPDFreduction(api.PythonAlgorithm):
         return issues
 
     #pylint: disable=too-many-locals, too-many-branches
-    def PyExec(self):
+    def PyExec(self): # noqa
         self._runs = self.getProperty('RunNumbers').value
         self._vanfile = self.getProperty('Vanadium').value
         self._ecruns = self.getProperty('EmptyCanRunNumbers').value

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -80,7 +80,7 @@ class LRReflectivityOutput(PythonAlgorithm):
         return normalization_available
 
     #pylint: disable=too-many-locals,too-many-branches
-    def average_points_for_single_q(self, scaled_ws_list):
+    def average_points_for_single_q(self, scaled_ws_list): # noqa
         """
             Take the point with the smalled error when multiple points are
             at the same q-value.

--- a/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LiquidsReflectometryReduction.py
@@ -102,7 +102,7 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
                              "Pixel range to use for calculating the primary fraction correction.")
 
     #pylint: disable=too-many-locals,too-many-branches
-    def PyExec(self):
+    def PyExec(self): # noqa
         # The old reduction code had a tolerance value for matching the
         # slit parameters to get the scaling factors
         self.TOLERANCE = self.getProperty("SlitTolerance").value
@@ -443,7 +443,7 @@ class LiquidsReflectometryReduction(PythonAlgorithm):
         return cropped
 
     #pylint: disable=too-many-locals,too-many-branches
-    def apply_scaling_factor(self, workspace):
+    def apply_scaling_factor(self, workspace): # noqa
         """
             Apply scaling factor from reference scaling data
             @param workspace: Mantid workspace

--- a/scripts/reduction/reducer.py
+++ b/scripts/reduction/reducer.py
@@ -43,7 +43,7 @@ from reduction.find_data import find_data
 __version__ = '1.0'
 
 
-def validate_loader(func):
+def validate_loader(func): # noqa
     def validated_f(reducer, algorithm, *args, **kwargs):
         if issubclass(algorithm.__class__, ReductionStep) or algorithm is None:
             # If we have a ReductionStep object, just use it.
@@ -181,7 +181,7 @@ def validate_loader(func):
     return validated_f
 
 
-def validate_step(func):
+def validate_step(func): # noqa
     """
         Decorator for Reducer methods that need a ReductionStep
         object as its first argument.


### PR DESCRIPTION
They are all complexity warnings. This will allow us to set the flake8 warning threshold to 0.


**To test:**
Check the flake8 build goes to zero warnings.


*This does not require release notes* because it's for internal use only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
