### PR TITLE
Change deprecation date for old reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -52,7 +52,7 @@ class ReflGui(QtGui.QMainWindow, Ui_windowRefl):
 
     def show_deprecation_warning(self):
         logger.warning("""
-The ISIS Reflectometry (Old) interface has been deprecated and will be removed from Mantid in March 2019
+The ISIS Reflectometry (Old) interface has been deprecated and will be removed from Mantid in July 2019
 We recommend you use ISIS Reflectometry instead, If this is not possible contact the development team using the "Help->Ask For Help" menu.
 """)
 


### PR DESCRIPTION
This PR is a minor change to push back the date in the deprecation warning when you open the old reflectometry GUI. We'd like to delay removing the old GUI because the new GUI is undergoing restructuring.

**To test:**

Open the `ISIS Reflectometry Old` GUI and check the date in the warning in the log is July rather than March.

*There is no associated issue.*

*This does not require release notes* because it is a minor change to warning text.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
