### PR TITLE
Remove Tk dependence from workbench unit test

### DIFF
--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -20,6 +20,8 @@ from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateWorkspace,
                               GroupWorkspaces)
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+import matplotlib as mpl
+mpl.use('Agg')  # noqa
 from workbench.plugins.workspacewidget import WorkspaceWidget
 
 


### PR DESCRIPTION
**Description of work.**

Sets the matplotlib backend before the pyplot import happens as we do in many other tests. Ubuntu separates out the `python-tk` package so it may not be installed and tests can fail due to [this](http://builds.mantidproject.org/job/pull_requests-ubuntu/28259/console).

**To test:**

Code review.

*This does not require release notes* because **it fixes internal tests.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
