### PR TITLE
Specify QT4 before running the error reporter

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat
@@ -43,5 +43,5 @@ start "MantidPlot" /B /WAIT %_BIN_DIR%\MantidPlot.exe %*
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if %errorlevel% NEQ 0 (
 set QT_API=pyqt4
-python %_INSTALL_DIR%\scripts\ErrorReporter\error_dialog_app.py --exitcode=%1 --directory=%_BIN_DIR%
+python %_INSTALL_DIR%\scripts\ErrorReporter\error_dialog_app.py --exitcode=%errorlevel% --directory=%_BIN_DIR%
 )

--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat
@@ -42,5 +42,6 @@ start "MantidPlot" /B /WAIT %_BIN_DIR%\MantidPlot.exe %*
 :: If not launch the error reporter
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if %errorlevel% NEQ 0 (
+set QT_API=pyqt4
 python %_INSTALL_DIR%\scripts\ErrorReporter\error_dialog_app.py --exitcode=%1 --directory=%_BIN_DIR%
 )

--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -6,8 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, print_function)
 
-import sys
 import argparse
+import sys
 
 parser = argparse.ArgumentParser(description='Pass in exit_code')
 parser.add_argument('--exitcode', dest='exit_code')
@@ -18,21 +18,26 @@ command_line_args = parser.parse_args()
 
 sys.path.insert(0, command_line_args.directory)
 
-from qtpy import QtGui, QtWidgets # noqa
+import mantid  # noqa
 
-import mantid # noqa
-try:
-    from ErrorReporter import resources_qt5 # noqa
-except ImportError:
-    from ErrorReporter import resources_qt4 # noqa
-from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
-from ErrorReporter.errorreport import CrashReportPage # noqa
+import qtpy  # noqa
+if qtpy.PYQT5:
+    from ErrorReporter import resources_qt5  # noqa
+elif qtpy.PYQT4:
+    from ErrorReporter import resources_qt4  # noqa
+else:
+    raise RuntimeError("Unknown QT version: {}".format(qtpy.QT_VERSION))
+
+from qtpy import QtWidgets  # noqa
+
+from ErrorReporter.error_report_presenter import ErrorReporterPresenter  # noqa
+from ErrorReporter.errorreport import CrashReportPage  # noqa
+
 # Set path to look for package qt libraries
 if command_line_args.qtdir is not None:
     from qtpy.QtCore import QCoreApplication
-    QCoreApplication.addLibraryPath(
-        command_line_args.qtdir
-    )
+
+    QCoreApplication.addLibraryPath(command_line_args.qtdir)
 
 
 def main():
@@ -46,5 +51,5 @@ def main():
     return int(command_line_args.exit_code)
 
 
-if __name__ == '__main__':              # if we're running file directly and not importing it
-    sys.exit(main())                              # run the main function
+if __name__ == '__main__':  # if we're running file directly and not importing it
+    sys.exit(main())  # run the main function


### PR DESCRIPTION
**Description of work.**
Specifies which version of QT to use before starting the error reporter for Mantid Plot. In `error_dialog_app.py` the `resource_qtX` is imported based on QT version.

Fixes the exit code being passed to the error reporter.

**To test:**
Build & install package. 
Open MantidPlot. 
Segfault it, error reporter should open.

<!-- Instructions for testing. -->

Fixes #25017 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
