### PR TITLE
ILL direct geometry & reflectometry: move duplicate code into a separate module

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -9,43 +9,34 @@
 from __future__ import (absolute_import, division, print_function)
 
 import DirectILL_common as common
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, FileAction, InstrumentValidator,
                         ITableWorkspaceProperty, MatrixWorkspaceProperty, MultipleFileProperty, Progress, PropertyMode,
                         WorkspaceProperty, WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direct, Direction, FloatBoundedValidator, IntBoundedValidator, IntArrayBoundedValidator,
                            IntMandatoryValidator, Property, StringListValidator, UnitConversion)
-from mantid.simpleapi import (AddSampleLog, CalculateFlatBackground, CloneWorkspace, CorrectTOFAxis, CreateEPP,
-                              CreateSingleValuedWorkspace, CreateWorkspace, CropWorkspace, DeleteWorkspace, Divide, ExtractMonitors,
+from mantid.simpleapi import (AddSampleLog, CalculateFlatBackground, CorrectTOFAxis, CreateEPP,
+                              CreateSingleValuedWorkspace, CreateWorkspace, CropWorkspace, DeleteWorkspace, ExtractMonitors,
                               FindEPP, GetEiMonDet, LoadAndMerge, Minus, NormaliseToMonitor, Scale)
 import numpy
 
 _MONSUM_LIMIT = 100
 
 
-def _applyIncidentEnergyCalibration(ws, wsType, eiWS, wsNames, report,
-                                    algorithmLogging):
+def _applyIncidentEnergyCalibration(ws, eiWS, wsNames, report, algorithmLogging):
     """Update incident energy and wavelength in the sample logs."""
     originalEnergy = ws.getRun().getLogData('Ei').value
     originalWavelength = ws.getRun().getLogData('wavelength').value
     energy = eiWS.readY(0)[0]
     wavelength = UnitConversion.run('Energy', 'Wavelength', energy, 0, 0, 0, Direct, 5)
-    if wsType == common.WS_CONTENT_DETS:
-        calibratedWSName = wsNames.withSuffix('incident_energy_calibrated_detectors')
-    elif wsType == common.WS_CONTENT_MONS:
-        calibratedWSName = wsNames.withSuffix('incident_energy_calibrated_monitors')
-    else:
-        raise RuntimeError('Unknown workspace content type')
-    calibratedWS = CloneWorkspace(InputWorkspace=ws,
-                                  OutputWorkspace=calibratedWSName,
-                                  EnableLogging=algorithmLogging)
-    AddSampleLog(Workspace=calibratedWS,
+    AddSampleLog(Workspace=ws,
                  LogName='Ei',
                  LogText=str(energy),
                  LogType='Number',
                  NumberType='Double',
                  LogUnit='meV',
                  EnableLogging=algorithmLogging)
-    AddSampleLog(Workspace=calibratedWS,
+    AddSampleLog(Workspace=ws,
                  Logname='wavelength',
                  LogText=str(wavelength),
                  LogType='Number',
@@ -55,7 +46,7 @@ def _applyIncidentEnergyCalibration(ws, wsType, eiWS, wsNames, report,
     report.notice("Applied Ei calibration to '" + str(ws) + "'.")
     report.notice('Original Ei: {} new Ei: {}.'.format(originalEnergy, energy))
     report.notice('Original wavelength: {} new wavelength {}.'.format(originalWavelength, wavelength))
-    return calibratedWS
+    return ws
 
 
 def _calculateEPP(ws, sigma, wsNames, algorithmLogging):
@@ -198,15 +189,10 @@ def _normalizeToTime(ws, wsNames, wsCleanup, algorithmLogging):
     if time < 0:
         raise RuntimeError("Cannot normalise to acquisition time: time is negative.")
     normalizedWSName = wsNames.withSuffix('normalized_to_time')
-    normalizationFactorWsName = wsNames.withSuffix('normalization_factor_time')
-    normalizationFactorWS = CreateSingleValuedWorkspace(OutputWorkspace=normalizationFactorWsName,
-                                                        DataValue=time,
-                                                        EnableLogging=algorithmLogging)
-    normalizedWS = Divide(LHSWorkspace=ws,
-                          RHSWorkspace=normalizationFactorWS,
-                          OutputWorkspace=normalizedWSName,
-                          EnableLogging=algorithmLogging)
-    wsCleanup.cleanup(normalizationFactorWS)
+    normalizedWS = Scale(InputWorkspace=ws,
+                         Factor=1./time,
+                         OutputWorkspace=normalizedWSName,
+                         EnableLogging=algorithmLogging)
     return normalizedWS
 
 
@@ -227,8 +213,7 @@ def _scaleAfterMonitorNormalization(ws, wsNames, wsCleanup, algorithmLogging):
     return scaledWS
 
 
-def _subtractFlatBkg(ws, wsType, bkgWorkspace, bkgScaling, wsNames,
-                     wsCleanup, algorithmLogging):
+def _subtractFlatBkg(ws, wsType, bkgWorkspace, bkgScaling, wsNames, wsCleanup, algorithmLogging):
     """Subtract a scaled flat background from a workspace."""
     if wsType == common.WS_CONTENT_DETS:
         subtractedWSName = wsNames.withSuffix('flat_bkg_subtracted_detectors')
@@ -293,54 +278,54 @@ class DirectILLCollectData(DataProcessorAlgorithm):
     def PyExec(self):
         """Execute the data collection workflow."""
         progress = Progress(self, 0.0, 1.0, 9)
-        report = common.Report()
-        subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
-        wsNamePrefix = self.getProperty(common.PROP_OUTPUT_WS).valueAsStr
+        self._report = utils.Report()
+        self._subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
+        namePrefix = self.getProperty(common.PROP_OUTPUT_WS).valueAsStr
         cleanupMode = self.getProperty(common.PROP_CLEANUP_MODE).value
-        wsNames = common.NameSource(wsNamePrefix, cleanupMode)
-        wsCleanup = common.IntermediateWSCleanup(cleanupMode, subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
+        self._names = utils.NameSource(namePrefix, cleanupMode)
 
         # The variables 'mainWS' and 'monWS shall hold the current main
         # data throughout the algorithm.
 
         # Get input workspace.
         progress.report('Loading inputs')
-        mainWS = self._inputWS(wsNames, wsCleanup, subalgLogging)
+        mainWS = self._inputWS()
 
         # Extract monitors to a separate workspace.
         progress.report('Extracting monitors')
-        mainWS, monWS = self._separateMons(mainWS, wsNames, wsCleanup, subalgLogging)
+        mainWS, monWS = self._separateMons(mainWS)
 
         # Save the main workspace for later use, if needed.
         rawWS = None
         if not self.getProperty(common.PROP_OUTPUT_RAW_WS).isDefault:
             rawWS = mainWS
-            wsCleanup.protect(rawWS)
+            self._cleanup.protect(rawWS)
 
         # Normalisation to monitor/time, if requested.
         progress.report('Normalising to monitor/time')
-        monWS = self._flatBkgMon(monWS, wsNames, wsCleanup, subalgLogging)
-        monEPPWS = self._createEPPWSMon(monWS, wsNames, wsCleanup, subalgLogging)
-        mainWS = self._normalize(mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging)
+        monWS = self._flatBkgMon(monWS)
+        monEPPWS = self._createEPPWSMon(monWS)
+        mainWS = self._normalize(mainWS, monWS, monEPPWS)
 
         # Time-independent background.
         progress.report('Calculating backgrounds')
-        mainWS = self._flatBkgDet(mainWS, wsNames, wsCleanup, report, subalgLogging)
+        mainWS = self._flatBkgDet(mainWS)
 
         # Calibrate incident energy, if requested.
         progress.report('Calibrating incident energy')
-        mainWS, monWS = self._calibrateEi(mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging)
-        wsCleanup.cleanup(monWS, monEPPWS)
+        mainWS, monWS = self._calibrateEi(mainWS, monWS, monEPPWS)
+        self._cleanup.cleanup(monWS, monEPPWS)
 
         progress.report('Correcting TOF')
-        mainWS = self._correctTOFAxis(mainWS, wsNames, wsCleanup, report, subalgLogging)
-        self._outputRaw(mainWS, rawWS, subalgLogging)
+        mainWS = self._correctTOFAxis(mainWS)
+        self._outputRaw(mainWS, rawWS)
 
         # Find elastic peak positions.
         progress.report('Calculating EPPs')
-        self._outputDetEPPWS(mainWS, wsNames, wsCleanup, report, subalgLogging)
+        self._outputDetEPPWS(mainWS)
 
-        self._finalize(mainWS, wsCleanup, report)
+        self._finalize(mainWS)
         progress.report('Done')
 
     def PyInit(self):
@@ -377,10 +362,10 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                                                direction=Direction.Output),
                              doc='A flux normalized and background subtracted workspace.')
         self.declareProperty(name=common.PROP_CLEANUP_MODE,
-                             defaultValue=common.CLEANUP_ON,
+                             defaultValue=utils.Cleanup.ON,
                              validator=StringListValidator([
-                                 common.CLEANUP_ON,
-                                 common.CLEANUP_OFF]),
+                                 utils.Cleanup.ON,
+                                 utils.Cleanup.OFF]),
                              direction=Direction.Input,
                              doc='What to do with intermediate workspaces.')
         self.declareProperty(name=common.PROP_SUBALG_LOGGING,
@@ -546,78 +531,74 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                 'List of runs is given without summing. Consider giving summed runs (+) or summed ranges (-).'
         return issues
 
-    def _calibrateEi(self, mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging):
+    def _calibrateEi(self, mainWS, monWS, monEPPWS):
         """Perform and apply incident energy calibration."""
         eiCalibrationWS = None
-        if self._eiCalibrationEnabled(mainWS, report):
+        if self._eiCalibrationEnabled(mainWS):
             if self.getProperty(common.PROP_INCIDENT_ENERGY_WS).isDefault:
                 monIndex = self._monitorIndex(monWS)
-                eiCalibrationWS = _calibratedIncidentEnergy(mainWS, monWS, monEPPWS, monIndex, wsNames,
-                                                            self.log(), subalgLogging)
+                eiCalibrationWS = _calibratedIncidentEnergy(mainWS, monWS, monEPPWS, monIndex, self._names,
+                                                            self.log(), self._subalgLogging)
             else:
                 eiCalibrationWS = self.getProperty(common.PROP_INCIDENT_ENERGY_WS).value
-                wsCleanup.protect(eiCalibrationWS)
+                self._cleanup.protect(eiCalibrationWS)
             if eiCalibrationWS:
-                eiCalibratedDetWS = _applyIncidentEnergyCalibration(mainWS, common.WS_CONTENT_DETS, eiCalibrationWS, wsNames,
-                                                                    report, subalgLogging)
-                wsCleanup.cleanup(mainWS)
-                mainWS = eiCalibratedDetWS
-                eiCalibratedMonWS = _applyIncidentEnergyCalibration(monWS, common.WS_CONTENT_MONS, eiCalibrationWS, wsNames, report,
-                                                                    subalgLogging)
-                wsCleanup.cleanup(monWS)
-                monWS = eiCalibratedMonWS
+                mainWS = _applyIncidentEnergyCalibration(mainWS, eiCalibrationWS, self._names,
+                                                         self._report, self._subalgLogging)
+                monWS = _applyIncidentEnergyCalibration(monWS, eiCalibrationWS, self._names, self._report,
+                                                        self._subalgLogging)
         if not self.getProperty(common.PROP_OUTPUT_INCIDENT_ENERGY_WS).isDefault:
             if eiCalibrationWS is None:
-                eiCalibrationWSName = wsNames.withSuffix('incident_energy_from_logs')
+                eiCalibrationWSName = self._names.withSuffix('incident_energy_from_logs')
                 Ei = mainWS.run().getProperty('Ei').value
                 eiCalibrationWS = CreateSingleValuedWorkspace(OutputWorkspace=eiCalibrationWSName,
                                                               DataValue=Ei,
-                                                              EnableLogging=subalgLogging)
+                                                              EnableLogging=self._subalgLogging)
             self.setProperty(common.PROP_OUTPUT_INCIDENT_ENERGY_WS, eiCalibrationWS)
-        wsCleanup.cleanup(eiCalibrationWS)
+        self._cleanup.cleanup(eiCalibrationWS)
         return mainWS, monWS
 
-    def _chooseElasticChannelMode(self, mainWS, report):
+    def _chooseElasticChannelMode(self, mainWS):
         """Return suitable elastic channel mode."""
         mode = self.getProperty(common.PROP_ELASTIC_CHANNEL_MODE).value
         if mode == common.ELASTIC_CHANNEL_AUTO:
             instrument = mainWS.getInstrument()
             if instrument.hasParameter('enable_elastic_channel_fitting'):
                 if instrument.getBoolParameter('enable_elastic_channel_fitting')[0]:
-                    report.notice(common.PROP_ELASTIC_CHANNEL_MODE + ' set to '
-                                  + common.ELASTIC_CHANNEL_FIT + ' by the IPF.')
+                    self._report.notice(common.PROP_ELASTIC_CHANNEL_MODE + ' set to '
+                                        + common.ELASTIC_CHANNEL_FIT + ' by the IPF.')
                     return common.ELASTIC_CHANNEL_FIT
                 else:
-                    report.notice(common.PROP_ELASTIC_CHANNEL_MODE + ' set to '
-                                  + common.ELASTIC_CHANNEL_SAMPLE_LOG + ' by the IPF.')
+                    self._report.notice(common.PROP_ELASTIC_CHANNEL_MODE + ' set to '
+                                        + common.ELASTIC_CHANNEL_SAMPLE_LOG + ' by the IPF.')
                     return common.ELASTIC_CHANNEL_SAMPLE_LOG
             else:
-                report.notice('Defaulted ' + common.PROP_ELASTIC_CHANNEL_MODE + ' to '
-                              + common.ELASTIC_CHANNEL_SAMPLE_LOG + '.')
+                self._report.notice('Defaulted ' + common.PROP_ELASTIC_CHANNEL_MODE + ' to '
+                                    + common.ELASTIC_CHANNEL_SAMPLE_LOG + '.')
                 return common.ELASTIC_CHANNEL_SAMPLE_LOG
         return mode
 
-    def _chooseEPPMethod(self, mainWS, report):
+    def _chooseEPPMethod(self, mainWS):
         """Return a suitable EPP method."""
         eppMethod = self.getProperty(common.PROP_EPP_METHOD).value
         if eppMethod == common.EPP_METHOD_AUTO:
             instrument = mainWS.getInstrument()
             if instrument.hasParameter('enable_elastic_peak_fitting'):
                 if instrument.getBoolParameter('enable_elastic_peak_fitting')[0]:
-                    report.notice(common.PROP_EPP_METHOD + ' set to '
-                                  + common.EPP_METHOD_FIT + ' by the IPF.')
+                    self._report.notice(common.PROP_EPP_METHOD + ' set to '
+                                        + common.EPP_METHOD_FIT + ' by the IPF.')
                     return common.EPP_METHOD_FIT
                 else:
-                    report.notice(common.PROP_EPP_METHOD + ' set to '
-                                  + common.EPP_METHOD_CALCULATE + ' by the IPF.')
+                    self._report.notice(common.PROP_EPP_METHOD + ' set to '
+                                        + common.EPP_METHOD_CALCULATE + ' by the IPF.')
                     return common.EPP_METHOD_CALCULATE
             else:
-                report.notice('Defaulted ' + common.PROP_EPP_METHOD + ' to '
-                              + common.EPP_METHOD_FIT + '.')
+                self._report.notice('Defaulted ' + common.PROP_EPP_METHOD + ' to '
+                                    + common.EPP_METHOD_FIT + '.')
                 return common.EPP_METHOD_FIT
         return eppMethod
 
-    def _correctTOFAxis(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _correctTOFAxis(self, mainWS):
         """Adjust the TOF axis to get the elastic channel correct."""
         try:
             l2 = float(mainWS.getInstrument().getStringParameter('l2')[0])
@@ -628,7 +609,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
             indexWS = self.getProperty(common.PROP_ELASTIC_CHANNEL_WS).value
             index = int(indexWS.readY(0)[0])
         else:
-            mode = self._chooseElasticChannelMode(mainWS, report)
+            mode = self._chooseElasticChannelMode(mainWS)
             if mode == common.ELASTIC_CHANNEL_SAMPLE_LOG:
                 if not mainWS.run().hasProperty('Detector.elasticpeak'):
                     self.log().warning('No ' + common.PROP_ELASTIC_CHANNEL_WS +
@@ -637,51 +618,51 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                 index = mainWS.run().getLogData('Detector.elasticpeak').value
             else:
                 ys = _sumDetectorsAtDistance(mainWS, l2, 1e-5)
-                index = _fitElasticChannel(ys, wsNames, wsCleanup, subalgLogging)
-        correctedWSName = wsNames.withSuffix('tof_axis_corrected')
+                index = _fitElasticChannel(ys, self._names, self._cleanup, self._subalgLogging)
+        correctedWSName = self._names.withSuffix('tof_axis_corrected')
         correctedWS = CorrectTOFAxis(InputWorkspace=mainWS,
                                      OutputWorkspace=correctedWSName,
                                      IndexType='Workspace Index',
                                      ElasticBinIndex=index,
                                      L2=l2,
-                                     EnableLogging=subalgLogging)
-        report.notice('Elastic channel index {0} was used for TOF axis adjustment.'.format(index))
+                                     EnableLogging=self._subalgLogging)
+        self._report.notice('Elastic channel index {0} was used for TOF axis adjustment.'.format(index))
         if not self.getProperty(common.PROP_OUTPUT_ELASTIC_CHANNEL_WS).isDefault:
-            indexOutputWSName = wsNames.withSuffix('elastic_channel_output')
+            indexOutputWSName = self._names.withSuffix('elastic_channel_output')
             indexOutputWS = CreateSingleValuedWorkspace(OutputWorkspace=indexOutputWSName,
                                                         DataValue=index,
-                                                        EnableLogging=subalgLogging)
+                                                        EnableLogging=self._subalgLogging)
             self.setProperty(common.PROP_OUTPUT_ELASTIC_CHANNEL_WS, indexOutputWS)
-            wsCleanup.cleanup(indexOutputWS)
-        wsCleanup.cleanup(mainWS)
+            self._cleanup.cleanup(indexOutputWS)
+        self._cleanup.cleanup(mainWS)
         return correctedWS
 
-    def _createEPPWSDet(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _createEPPWSDet(self, mainWS):
         """Create an EPP table for a detector workspace."""
-        eppMethod = self._chooseEPPMethod(mainWS, report)
+        eppMethod = self._chooseEPPMethod(mainWS)
         if eppMethod == common.EPP_METHOD_FIT:
-            detEPPWS = _fitEPP(mainWS, common.WS_CONTENT_DETS, wsNames, subalgLogging)
+            detEPPWS = _fitEPP(mainWS, common.WS_CONTENT_DETS, self._names, self._subalgLogging)
         else:
             sigma = self.getProperty(common.PROP_EPP_SIGMA).value
             if sigma == Property.EMPTY_DBL:
                 sigma = 10.0 * (mainWS.readX(0)[1] - mainWS.readX(0)[0])
-            detEPPWS = _calculateEPP(mainWS, sigma, wsNames, subalgLogging)
-        wsCleanup.cleanupLater(detEPPWS)
+            detEPPWS = _calculateEPP(mainWS, sigma, self._names, self._subalgLogging)
+        self._cleanup.cleanupLater(detEPPWS)
         return detEPPWS
 
-    def _createEPPWSMon(self, monWS, wsNames, wsCleanup, subalgLogging):
+    def _createEPPWSMon(self, monWS):
         """Create an EPP table for a monitor workspace."""
-        monEPPWS = _fitEPP(monWS, common.WS_CONTENT_MONS, wsNames, subalgLogging)
+        monEPPWS = _fitEPP(monWS, common.WS_CONTENT_MONS, self._names, self._subalgLogging)
         return monEPPWS
 
-    def _finalize(self, outWS, wsCleanup, report):
+    def _finalize(self, outWS):
         """Do final cleanup and set the output property."""
         self.setProperty(common.PROP_OUTPUT_WS, outWS)
-        wsCleanup.cleanup(outWS)
-        wsCleanup.finalCleanup()
-        report.toLog(self.log())
+        self._cleanup.cleanup(outWS)
+        self._cleanup.finalCleanup()
+        self._report.toLog(self.log())
 
-    def _eiCalibrationEnabled(self, mainWS, report):
+    def _eiCalibrationEnabled(self, mainWS):
         """Return true if incident energy calibration should be perfomed, false if not."""
         calibration = self.getProperty(common.PROP_INCIDENT_ENERGY_CALIBRATION).value
         state = None
@@ -693,38 +674,38 @@ class DirectILLCollectData(DataProcessorAlgorithm):
             if instrument.hasParameter('enable_incident_energy_calibration'):
                 enabled = instrument.getBoolParameter('enable_incident_energy_calibration')[0]
                 if not enabled:
-                    report.notice('Incident energy calibration disabled by the IPF.')
+                    self._report.notice('Incident energy calibration disabled by the IPF.')
                     return False
                 else:
                     state = ENABLED_AUTOMATICALLY
         monitorCounts = _monitorCounts(mainWS)
         if monitorCounts < _MONSUM_LIMIT:
-            report.warning("'monsum' less than {}. Disabling incident energy calibration.".format(_MONSUM_LIMIT))
+            self._report.warning("'monsum' less than {}. Disabling incident energy calibration.".format(_MONSUM_LIMIT))
             return False
         if state == ENABLED_AUTOMATICALLY:
-            report.notice('Incident energy calibration enabled.')
+            self._report.notice('Incident energy calibration enabled.')
         return True
 
-    def _flatBkgDet(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _flatBkgDet(self, mainWS):
         """Subtract flat background from a detector workspace."""
-        if not self._flatBgkEnabled(mainWS, report):
+        if not self._flatBgkEnabled(mainWS):
             return mainWS
         if not self.getProperty(common.PROP_FLAT_BKG_WS).isDefault:
             bkgWS = self.getProperty(common.PROP_FLAT_BKG_WS).value
-            wsCleanup.protect(bkgWS)
+            self._cleanup.protect(bkgWS)
         else:
             windowWidth = self.getProperty(common.PROP_FLAT_BKG_WINDOW).value
-            bkgWS = _createFlatBkg(mainWS, common.WS_CONTENT_DETS, windowWidth, wsNames, subalgLogging)
+            bkgWS = _createFlatBkg(mainWS, common.WS_CONTENT_DETS, windowWidth, self._names, self._subalgLogging)
         if not self.getProperty(common.PROP_OUTPUT_FLAT_BKG_WS).isDefault:
             self.setProperty(common.PROP_OUTPUT_FLAT_BKG_WS, bkgWS)
         bkgScaling = self.getProperty(common.PROP_FLAT_BKG_SCALING).value
-        bkgSubtractedWS = _subtractFlatBkg(mainWS, common.WS_CONTENT_DETS, bkgWS, bkgScaling, wsNames,
-                                           wsCleanup, subalgLogging)
-        wsCleanup.cleanup(mainWS)
-        wsCleanup.cleanup(bkgWS)
+        bkgSubtractedWS = _subtractFlatBkg(mainWS, common.WS_CONTENT_DETS, bkgWS, bkgScaling, self._names,
+                                           self._cleanup, self._subalgLogging)
+        self._cleanup.cleanup(mainWS)
+        self._cleanup.cleanup(bkgWS)
         return bkgSubtractedWS
 
-    def _flatBgkEnabled(self, mainWS, report):
+    def _flatBgkEnabled(self, mainWS):
         """Returns true if flat background subtraction is enabled, false otherwise."""
         flatBkgOption = self.getProperty(common.PROP_FLAT_BKG).value
         if flatBkgOption == common.BKG_AUTO:
@@ -732,33 +713,33 @@ class DirectILLCollectData(DataProcessorAlgorithm):
             if instrument.hasParameter('enable_flat_background_subtraction'):
                 enabled = instrument.getBoolParameter('enable_flat_background_subtraction')[0]
                 if not enabled:
-                    report.notice('Flat background subtraction disabled by the IPF.')
+                    self._report.notice('Flat background subtraction disabled by the IPF.')
                     return False
-            report.notice('Flat background subtraction enabled.')
+            self._report.notice('Flat background subtraction enabled.')
             return True
         return flatBkgOption != common.BKG_OFF
 
-    def _flatBkgMon(self, monWS, wsNames, wsCleanup, subalgLogging):
+    def _flatBkgMon(self, monWS):
         """Subtract flat background from a monitor workspace."""
         windowWidth = self.getProperty(common.PROP_FLAT_BKG_WINDOW).value
-        monBkgWS = _createFlatBkg(monWS, common.WS_CONTENT_MONS, windowWidth, wsNames, subalgLogging)
+        monBkgWS = _createFlatBkg(monWS, common.WS_CONTENT_MONS, windowWidth, self._names, self._subalgLogging)
         monBkgScaling = 1
-        bkgSubtractedMonWS = _subtractFlatBkg(monWS, common.WS_CONTENT_MONS, monBkgWS, monBkgScaling, wsNames,
-                                              wsCleanup, subalgLogging)
-        wsCleanup.cleanup(monBkgWS)
-        wsCleanup.cleanup(monWS)
+        bkgSubtractedMonWS = _subtractFlatBkg(monWS, common.WS_CONTENT_MONS, monBkgWS, monBkgScaling, self._names,
+                                              self._cleanup, self._subalgLogging)
+        self._cleanup.cleanup(monBkgWS)
+        self._cleanup.cleanup(monWS)
         return bkgSubtractedMonWS
 
-    def _inputWS(self, wsNames, wsCleanup, subalgLogging):
+    def _inputWS(self):
         """Return the raw input workspace."""
         inputFiles = self.getPropertyValue(common.PROP_INPUT_FILE)
         if inputFiles:
-            mergedWSName = wsNames.withSuffix('merged')
+            mergedWSName = self._names.withSuffix('merged')
             mainWS = LoadAndMerge(Filename=inputFiles, OutputWorkspace=mergedWSName,
-                                  LoaderName='LoadILLTOF', EnableLogging=subalgLogging)
+                                  LoaderName='LoadILLTOF', EnableLogging=self._subalgLogging)
         else:
             mainWS = self.getProperty(common.PROP_INPUT_WS).value
-            wsCleanup.protect(mainWS)
+            self._cleanup.protect(mainWS)
         return mainWS
 
     def _monitorIndex(self, monWS):
@@ -775,7 +756,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
             monIndex = common.convertToWorkspaceIndex(monIndex, monWS)
         return monIndex
 
-    def _normalize(self, mainWS, monWS, monEPPWS, wsNames, wsCleanup, report, subalgLogging):
+    def _normalize(self, mainWS, monWS, monEPPWS):
         """Normalize to monitor or measurement time."""
         normalisationMethod = self.getProperty(common.PROP_NORMALISATION).value
         if normalisationMethod == common.NORM_METHOD_OFF:
@@ -783,7 +764,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
         if normalisationMethod == common.NORM_METHOD_MON:
             monitorCounts = _monitorCounts(monWS)
             if monitorCounts < _MONSUM_LIMIT:
-                report.warning("'monsum' less than {}. Disabling normalization to monitor.".format(_MONSUM_LIMIT))
+                self._report.warning("'monsum' less than {}. Disabling normalization to monitor.".format(_MONSUM_LIMIT))
                 normalisationMethod = common.NORM_METHOD_TIME
             else:
                 sigmaMultiplier = \
@@ -800,42 +781,41 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                     centre = eppRow['PeakCentre']
                     begin = centre - sigmaMultiplier * sigma
                     end = centre + sigmaMultiplier * sigma
-                normalizedWS = _normalizeToMonitor(mainWS, monWS, monIndex, begin, end, wsNames, wsCleanup,
-                                                   subalgLogging)
-                normalizedWS = _scaleAfterMonitorNormalization(normalizedWS, wsNames, wsCleanup,
-                                                               subalgLogging)
+                normalizedWS = _normalizeToMonitor(mainWS, monWS, monIndex, begin, end, self._names, self._cleanup,
+                                                   self._subalgLogging)
+                normalizedWS = _scaleAfterMonitorNormalization(normalizedWS, self._names, self._cleanup, self._subalgLogging)
         if normalisationMethod == common.NORM_METHOD_TIME:
-            normalizedWS = _normalizeToTime(mainWS, wsNames, wsCleanup, subalgLogging)
-        wsCleanup.cleanup(mainWS)
+            normalizedWS = _normalizeToTime(mainWS, self._names, self._cleanup, self._subalgLogging)
+        self._cleanup.cleanup(mainWS)
         return normalizedWS
 
-    def _outputDetEPPWS(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _outputDetEPPWS(self, mainWS):
         """Set the output epp workspace property, if needed."""
         if not self.getProperty(common.PROP_OUTPUT_DET_EPP_WS).isDefault:
-            eppWS = self._createEPPWSDet(mainWS, wsNames, wsCleanup, report, subalgLogging)
+            eppWS = self._createEPPWSDet(mainWS)
             self.setProperty(common.PROP_OUTPUT_DET_EPP_WS, eppWS)
-            wsCleanup.cleanup(eppWS)
+            self._cleanup.cleanup(eppWS)
 
-    def _outputRaw(self, mainWS, rawWS, subalgLogging):
+    def _outputRaw(self, mainWS, rawWS):
         """Optionally set mainWS as the raw output workspace."""
         if not self.getProperty(common.PROP_OUTPUT_RAW_WS).isDefault:
             CorrectTOFAxis(InputWorkspace=rawWS,
                            OutputWorkspace=rawWS,
                            ReferenceWorkspace=mainWS,
-                           EnableLogging=subalgLogging)
+                           EnableLogging=self._subalgLogging)
             self.setProperty(common.PROP_OUTPUT_RAW_WS, rawWS)
             DeleteWorkspace(Workspace=rawWS,
-                            EnableLogging=subalgLogging)
+                            EnableLogging=self._subalgLogging)
 
-    def _separateMons(self, mainWS, wsNames, wsCleanup, subalgLogging):
+    def _separateMons(self, mainWS):
         """Extract monitors to a separate workspace."""
-        detWSName = wsNames.withSuffix('extracted_detectors')
-        monWSName = wsNames.withSuffix('extracted_monitors')
+        detWSName = self._names.withSuffix('extracted_detectors')
+        monWSName = self._names.withSuffix('extracted_monitors')
         detWS, monWS = ExtractMonitors(InputWorkspace=mainWS,
                                        DetectorWorkspace=detWSName,
                                        MonitorWorkspace=monWSName,
-                                       EnableLogging=subalgLogging)
-        wsCleanup.cleanup(mainWS)
+                                       EnableLogging=self._subalgLogging)
+        self._cleanup.cleanup(mainWS)
         return detWS, monWS
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
@@ -9,14 +9,15 @@
 from __future__ import (absolute_import, division, print_function)
 
 import DirectILL_common as common
+import ILL_utilities as utils
 import mantid
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, InstrumentValidator,
                         ITableWorkspaceProperty, MatrixWorkspaceProperty, mtd, Progress, PropertyMode,
                         WorkspaceProperty, WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, FloatBoundedValidator, IntArrayBoundedValidator,
                            IntArrayProperty, Property, StringArrayProperty, StringListValidator)
-from mantid.simpleapi import (ClearMaskFlag, CloneWorkspace, CreateEmptyTableWorkspace, CreateSingleValuedWorkspace, Divide,
-                              ExtractMask, Integration, LoadMask, MaskDetectors, MedianDetectorTest, Multiply, Plus, SolidAngle)
+from mantid.simpleapi import (ClearMaskFlag, CreateEmptyTableWorkspace, Divide, ExtractMask, Integration, LoadMask, MaskDetectors,
+                              MedianDetectorTest, Plus, Scale, SolidAngle)
 import numpy
 import os.path
 
@@ -92,14 +93,10 @@ def _createMaskWS(ws, name, algorithmLogging):
     extractResult = ExtractMask(InputWorkspace=ws,
                                 OutputWorkspace=name,
                                 EnableLogging=algorithmLogging)
-    zeroWS = CreateSingleValuedWorkspace(DataValue=0.,
-                                         ErrorValue=0.,
-                                         EnableLogging=algorithmLogging,
-                                         StoreInADS=False)
-    maskWS = Multiply(LHSWorkspace=extractResult.OutputWorkspace,
-                      RHSWorkspace=zeroWS,
-                      OutputWorkspace=name,
-                      EnableLogging=algorithmLogging)
+    maskWS = Scale(InputWorkspace=extractResult.OutputWorkspace,
+                   Factor=0.,
+                   OutputWorkspace=name,
+                   EnableLogging=algorithmLogging)
     return maskWS
 
 
@@ -202,18 +199,6 @@ def _integrateElasticPeaks(ws, eppWS, sigmaMultiplier, wsNames, wsCleanup, algor
     wsCleanup.cleanup(integratedElasticPeaksWS)
     wsCleanup.cleanup(solidAngleWS)
     return solidAngleCorrectedElasticPeaksWS
-
-
-def _maskDiagnosedDetectors(ws, diagnosticsWS, wsNames, algorithmLogging):
-    """Mask detectors according to diagnostics."""
-    maskedWSName = wsNames.withSuffix('diagnostics_applied')
-    maskedWS = CloneWorkspace(InputWorkspace=ws,
-                              OutputWorkspace=maskedWSName,
-                              EnableLogging=algorithmLogging)
-    MaskDetectors(Workspace=maskedWS,
-                  MaskedWorkspace=diagnosticsWS,
-                  EnableLogging=algorithmLogging)
-    return maskedWS
 
 
 def _maskedListToStr(masked):
@@ -335,78 +320,78 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
     def PyExec(self):
         """Executes the data reduction workflow."""
         progress = Progress(self, 0.0, 1.0, 7)
-        report = common.Report()
-        subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
+        self._report = utils.Report()
+        self._subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
         wsNamePrefix = self.getProperty(common.PROP_OUTPUT_WS).valueAsStr
         cleanupMode = self.getProperty(common.PROP_CLEANUP_MODE).value
-        wsNames = common.NameSource(wsNamePrefix, cleanupMode)
-        wsCleanup = common.IntermediateWSCleanup(cleanupMode, subalgLogging)
+        self._names = utils.NameSource(wsNamePrefix, cleanupMode)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
 
         progress.report('Loading inputs')
-        mainWS = self._inputWS(wsNames, wsCleanup, subalgLogging)
+        mainWS = self._inputWS()
 
-        maskWSName = wsNames.withSuffix('combined_mask')
-        maskWS = _createMaskWS(mainWS, maskWSName, subalgLogging)
-        wsCleanup.cleanupLater(maskWS)
+        maskWSName = self._names.withSuffix('combined_mask')
+        maskWS = _createMaskWS(mainWS, maskWSName, self._subalgLogging)
+        self._cleanup.cleanupLater(maskWS)
 
         reportWS = None
         if not self.getProperty(common.PROP_OUTPUT_DIAGNOSTICS_REPORT_WS).isDefault:
             reportWSName = self.getProperty(common.PROP_OUTPUT_DIAGNOSTICS_REPORT_WS).valueAsStr
-            reportWS = _createDiagnosticsReportTable(reportWSName, mainWS.getNumberHistograms(), subalgLogging)
+            reportWS = _createDiagnosticsReportTable(reportWSName, mainWS.getNumberHistograms(), self._subalgLogging)
 
         progress.report('Loading default mask')
-        defaultMaskWS = self._defaultMask(mainWS, wsNames, wsCleanup, report, subalgLogging)
+        defaultMaskWS = self._defaultMask(mainWS)
         defaultMaskedSpectra = set()
         if defaultMaskWS is not None:
             defaultMaskedSpectra = _reportDefaultMask(reportWS, defaultMaskWS)
             maskWS = Plus(LHSWorkspace=maskWS,
                           RHSWorkspace=defaultMaskWS,
-                          EnableLogging=subalgLogging)
-            wsCleanup.cleanup(defaultMaskWS)
+                          EnableLogging=self._subalgLogging)
+            self._cleanup.cleanup(defaultMaskWS)
 
         progress.report('User-defined mask')
-        userMaskWS = self._userMask(mainWS, wsNames, wsCleanup, subalgLogging)
+        userMaskWS = self._userMask(mainWS)
         maskWS = Plus(LHSWorkspace=maskWS,
                       RHSWorkspace=userMaskWS,
-                      EnableLogging=subalgLogging)
-        wsCleanup.cleanup(userMaskWS)
+                      EnableLogging=self._subalgLogging)
+        self._cleanup.cleanup(userMaskWS)
 
         beamStopMaskedSpectra = set()
-        if self._beamStopDiagnosticsEnabled(mainWS, report):
+        if self._beamStopDiagnosticsEnabled(mainWS):
             progress.report('Diagnosing beam stop')
-            beamStopMaskWS = self._beamStopDiagnostics(mainWS, maskWS, wsNames, wsCleanup, report, subalgLogging)
+            beamStopMaskWS = self._beamStopDiagnostics(mainWS, maskWS)
             beamStopMaskedSpectra = _reportBeamStopMask(reportWS, beamStopMaskWS)
             maskWS = Plus(LHSWorkspace=maskWS,
                           RHSWorkspace=beamStopMaskWS,
-                          EnableLogging=subalgLogging)
-            wsCleanup.cleanup(beamStopMaskWS)
+                          EnableLogging=self._subalgLogging)
+            self._cleanup.cleanup(beamStopMaskWS)
 
         bkgMaskedSpectra = set()
-        if self._bkgDiagnosticsEnabled(mainWS, report):
+        if self._bkgDiagnosticsEnabled(mainWS):
             progress.report('Diagnosing backgrounds')
-            bkgMaskWS, bkgWS = self._bkgDiagnostics(mainWS, wsNames, wsCleanup, report, subalgLogging)
+            bkgMaskWS, bkgWS = self._bkgDiagnostics(mainWS)
             bkgMaskedSpectra = _reportBkgDiagnostics(reportWS, bkgWS, bkgMaskWS)
             maskWS = Plus(LHSWorkspace=maskWS,
                           RHSWorkspace=bkgMaskWS,
-                          EnableLogging=subalgLogging)
-            wsCleanup.cleanup(bkgMaskWS)
-            wsCleanup.cleanup(bkgWS)
+                          EnableLogging=self._subalgLogging)
+            self._cleanup.cleanup(bkgMaskWS)
+            self._cleanup.cleanup(bkgWS)
 
         peakMaskedSpectra = set()
-        if self._peakDiagnosticsEnabled(mainWS, report):
+        if self._peakDiagnosticsEnabled(mainWS):
             progress.report('Diagnosing peaks')
-            peakMaskWS, peakIntensityWS = self._peakDiagnostics(mainWS, wsNames, wsCleanup, report, subalgLogging)
+            peakMaskWS, peakIntensityWS = self._peakDiagnostics(mainWS)
             peakMaskedSpectra = _reportPeakDiagnostics(reportWS, peakIntensityWS, peakMaskWS)
             maskWS = Plus(LHSWorkspace=maskWS,
                           RHSWorkspace=peakMaskWS,
-                          EnableLogging=subalgLogging)
-            wsCleanup.cleanup(peakMaskWS)
-            wsCleanup.cleanup(peakIntensityWS)
+                          EnableLogging=self._subalgLogging)
+            self._cleanup.cleanup(peakMaskWS)
+            self._cleanup.cleanup(peakIntensityWS)
 
         self._outputReports(reportWS, defaultMaskedSpectra, beamStopMaskedSpectra,
                             peakMaskedSpectra, bkgMaskedSpectra)
 
-        self._finalize(maskWS, wsCleanup, report)
+        self._finalize(maskWS)
         progress.report('Done')
 
     def PyInit(self):
@@ -436,10 +421,10 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
                                                direction=Direction.Output),
                              doc='A diagnostics mask workspace.')
         self.declareProperty(name=common.PROP_CLEANUP_MODE,
-                             defaultValue=common.CLEANUP_ON,
+                             defaultValue=utils.Cleanup.ON,
                              validator=StringListValidator([
-                                 common.CLEANUP_ON,
-                                 common.CLEANUP_OFF]),
+                                 utils.Cleanup.ON,
+                                 utils.Cleanup.OFF]),
                              direction=Direction.Input,
                              doc='What to do with intermediate workspaces.')
         self.declareProperty(name=common.PROP_SUBALG_LOGGING,
@@ -604,7 +589,7 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
                     issues[propName] = 'The low threshold cannot equal or exceed 1.'
         return issues
 
-    def _beamStopDiagnostics(self, mainWS, maskWS, wsNames, wsCleanup, report, algorithmLogging):
+    def _beamStopDiagnostics(self, mainWS, maskWS):
         """Diagnose beam stop and return a mask workspace."""
         import operator
 
@@ -631,8 +616,8 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
                     return i
                 i += step
             return i
-        beamStopDiagnosticsWSName = wsNames.withSuffix('beam_stop_diagnostics')
-        beamStopDiagnosticsWS = _createMaskWS(mainWS, beamStopDiagnosticsWSName, algorithmLogging)
+        beamStopDiagnosticsWSName = self._names.withSuffix('beam_stop_diagnostics')
+        beamStopDiagnosticsWS = _createMaskWS(mainWS, beamStopDiagnosticsWSName, self._subalgLogging)
         threshold = self.getProperty(common.PROP_BEAM_STOP_THRESHOLD).value
         beginIndices, endIndices = _beamStopRanges(mainWS)
         for i in range(len(beginIndices)):
@@ -647,7 +632,7 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
                     ys[0] = 1.0
         return beamStopDiagnosticsWS
 
-    def _beamStopDiagnosticsEnabled(self, mainWS, report):
+    def _beamStopDiagnosticsEnabled(self, mainWS):
         """Return true if beam stop diagnostics are enabled, false otherwise."""
         beamStopDiagnostics = self.getProperty(common.PROP_BEAM_STOP_DIAGNOSTICS).value
         if beamStopDiagnostics == common.BEAM_STOP_DIAGNOSTICS_AUTO:
@@ -658,28 +643,28 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         elif beamStopDiagnostics == common.BEAM_STOP_DIAGNOSTICS_ON:
             instrument = mainWS.getInstrument()
             if not instrument.hasParameter('beam_stop_diagnostics_spectra'):
-                report.error("'beam_stop_diagnostics_spectra' missing from instrument parameters. "
-                             + "Beam stop diagnostics disabled.")
+                self._report.error("'beam_stop_diagnostics_spectra' missing from instrument parameters. "
+                                   + "Beam stop diagnostics disabled.")
                 return False
             return True
         return False
 
-    def _bkgDiagnostics(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _bkgDiagnostics(self, mainWS):
         """Perform background diagnostics."""
         if self.getProperty(common.PROP_EPP_WS).isDefault:
             # With the AUTO option validateInputs might let missing EPPWorkspace pass.
             raise RuntimeError('Missing ' + common.PROP_EPP_WS + '. Elastic peak positions are needed for background diagnostics.')
         eppWS = self.getProperty(common.PROP_EPP_WS).value
         sigmaMultiplier = self.getProperty(common.PROP_BKG_SIGMA_MULTIPLIER).value
-        integratedBkgs = _integrateBkgs(mainWS, eppWS, sigmaMultiplier, wsNames, wsCleanup, subalgLogging)
+        integratedBkgs = _integrateBkgs(mainWS, eppWS, sigmaMultiplier, self._names, self._cleanup, self._subalgLogging)
         lowThreshold = self._bkgDiagnosticsLowThreshold(mainWS)
         highThreshold = self._bkgDiagnosticsHighThreshold(mainWS)
         significanceTest = self._bkgDiagnosticsSignificanceTest(mainWS)
         settings = _DiagnosticsSettings(lowThreshold, highThreshold, significanceTest)
-        bkgDiagnosticsWS = _bkgDiagnostics(integratedBkgs, settings, wsNames, subalgLogging)
+        bkgDiagnosticsWS = _bkgDiagnostics(integratedBkgs, settings, self._names, self._subalgLogging)
         return (bkgDiagnosticsWS, integratedBkgs)
 
-    def _bkgDiagnosticsEnabled(self, mainWS, report):
+    def _bkgDiagnosticsEnabled(self, mainWS):
         """Return true if background diagnostics are enabled, false otherwise."""
         bkgDiagnostics = self.getProperty(common.PROP_BKG_DIAGNOSTICS).value
         if bkgDiagnostics == common.BKG_DIAGNOSTICS_AUTO:
@@ -687,9 +672,9 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
             if instrument.hasParameter('enable_background_diagnostics'):
                 enabled = instrument.getBoolParameter('enable_background_diagnostics')[0]
                 if not enabled:
-                    report.notice('Background diagnostics disable by the IPF.')
+                    self._report.notice('Background diagnostics disable by the IPF.')
                     return False
-            report.notice('Background diagnostics enabled.')
+            self._report.notice('Background diagnostics enabled.')
             return True
         return bkgDiagnostics == common.BKG_DIAGNOSTICS_ON
 
@@ -705,7 +690,7 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         """Return a suitable value for the significance test."""
         return self._value(ws, common.PROP_BKG_DIAGNOSTICS_SIGNIFICANCE_TEST, 'background_diagnostics_significance_test', 3.3)
 
-    def _defaultMask(self, mainWS, wsNames, wsCleanup, report, algorithmLogging):
+    def _defaultMask(self, mainWS):
         """Load instrument specific default mask or return None if not available."""
         option = self.getProperty(common.PROP_DEFAULT_MASK).value
         if option == common.DEFAULT_MASK_OFF:
@@ -713,30 +698,30 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         instrument = mainWS.getInstrument()
         instrumentName = instrument.getName()
         if not instrument.hasParameter('Workflow.MaskFile'):
-            report.notice('No default mask available for ' + instrumentName + '.')
+            self._report.notice('No default mask available for ' + instrumentName + '.')
             return None
         maskFilename = instrument.getStringParameter('Workflow.MaskFile')[0]
         maskFile = os.path.join(mantid.config.getInstrumentDirectory(), 'masks', maskFilename)
-        defaultMaskWSName = wsNames.withSuffix('default_mask')
+        defaultMaskWSName = self._names.withSuffix('default_mask')
         defaultMaskWS = LoadMask(Instrument=instrumentName,
                                  InputFile=maskFile,
                                  RefWorkspace=mainWS,
                                  OutputWorkspace=defaultMaskWSName,
-                                 EnableLogging=algorithmLogging)
-        report.notice('Default mask loaded from ' + maskFilename)
+                                 EnableLogging=self._subalgLogging)
+        self._report.notice('Default mask loaded from ' + maskFilename)
         return defaultMaskWS
 
-    def _finalize(self, outWS, wsCleanup, report):
+    def _finalize(self, outWS):
         """Do final cleanup and set the output property."""
         self.setProperty(common.PROP_OUTPUT_WS, outWS)
-        wsCleanup.cleanup(outWS)
-        wsCleanup.finalCleanup()
-        report.toLog(self.log())
+        self._cleanup.cleanup(outWS)
+        self._cleanup.finalCleanup()
+        self._report.toLog(self.log())
 
-    def _inputWS(self, wsNames, wsCleanup, subalgLogging):
+    def _inputWS(self):
         """Return the raw input workspace."""
         mainWS = self.getProperty(common.PROP_INPUT_WS).value
-        wsCleanup.protect(mainWS)
+        self._cleanup.protect(mainWS)
         return mainWS
 
     def _outputReports(self, reportWS, defaultMaskedSpectra, directBeamMaskedSpectra,
@@ -755,22 +740,22 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         report += _maskedListToStr(bkgMaskedSpectra - hardMasking)
         self.setProperty(common.PROP_OUTPUT_DIAGNOSTICS_REPORT, report)
 
-    def _peakDiagnostics(self, mainWS, wsNames, wsCleanup, report, subalgLogging):
+    def _peakDiagnostics(self, mainWS):
         """Perform elastic peak diagnostics."""
         if self.getProperty(common.PROP_EPP_WS).isDefault:
             # With the AUTO option validateInputs might let missing EPPWorkspace pass.
             raise RuntimeError('Missing ' + common.PROP_EPP_WS + '. Elastic peak positions are needed for peak diagnostics.')
         eppWS = self.getProperty(common.PROP_EPP_WS).value
         sigmaMultiplier = self.getProperty(common.PROP_ELASTIC_PEAK_SIGMA_MULTIPLIER).value
-        integratedPeaksWS = _integrateElasticPeaks(mainWS, eppWS, sigmaMultiplier, wsNames, wsCleanup, subalgLogging)
+        integratedPeaksWS = _integrateElasticPeaks(mainWS, eppWS, sigmaMultiplier, self._names, self._cleanup, self._subalgLogging)
         lowThreshold = self._peakDiagnosticsLowThreshold(mainWS)
         highThreshold = self._peakDiagnosticsHighThreshold(mainWS)
         significanceTest = self._peakDiagnosticsSignificanceTest(mainWS)
         settings = _DiagnosticsSettings(lowThreshold, highThreshold, significanceTest)
-        peakDiagnosticsWS = _elasticPeakDiagnostics(integratedPeaksWS, settings, wsNames, subalgLogging)
+        peakDiagnosticsWS = _elasticPeakDiagnostics(integratedPeaksWS, settings, self._names, self._subalgLogging)
         return (peakDiagnosticsWS, integratedPeaksWS)
 
-    def _peakDiagnosticsEnabled(self, mainWS, report):
+    def _peakDiagnosticsEnabled(self, mainWS):
         """Return true if elastic peak diagnostics are enabled, false otherwise."""
         peakDiagnostics = self.getProperty(common.PROP_ELASTIC_PEAK_DIAGNOSTICS).value
         if peakDiagnostics == common.ELASTIC_PEAK_DIAGNOSTICS_AUTO:
@@ -778,9 +763,9 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
             if instrument.hasParameter('enable_elastic_peak_diagnostics'):
                 enabled = instrument.getBoolParameter('enable_elastic_peak_diagnostics')[0]
                 if not enabled:
-                    report.notice('Elastic peak diagnostics disabled by the IPF.')
+                    self._report.notice('Elastic peak diagnostics disabled by the IPF.')
                     return False
-            report.notice('Elastic peak diagnostics enabled.')
+            self._report.notice('Elastic peak diagnostics enabled.')
             return True
         return peakDiagnostics == common.ELASTIC_PEAK_DIAGNOSTICS_ON
 
@@ -796,19 +781,19 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         """Return a suitable value for the significance test."""
         return self._value(ws, common.PROP_PEAK_DIAGNOSTICS_SIGNIFICANCE_TEST, 'elastic_peak_diagnostics_significance_test', 3.3)
 
-    def _userMask(self, mainWS, wsNames, wsCleanup, algorithmLogging):
+    def _userMask(self, mainWS):
         """Return combined masked spectra and components."""
         userMask = self.getProperty(common.PROP_USER_MASK).value
         maskComponents = self.getProperty(common.PROP_USER_MASK_COMPONENTS).value
-        maskWSName = wsNames.withSuffix('user_mask')
-        maskWS = _createMaskWS(mainWS, maskWSName, algorithmLogging)
+        maskWSName = self._names.withSuffix('user_mask')
+        maskWS = _createMaskWS(mainWS, maskWSName, self._subalgLogging)
         MaskDetectors(Workspace=maskWS,
                       DetectorList=userMask,
                       ComponentList=maskComponents,
-                      EnableLogging=algorithmLogging)
+                      EnableLogging=self._subalgLogging)
         extractResult = ExtractMask(InputWorkspace=maskWS,
                                     OutputWorkspace=maskWSName,
-                                    EnableLogging=algorithmLogging)
+                                    EnableLogging=self._subalgLogging)
         return extractResult.OutputWorkspace
 
     def _value(self, ws, propertyName, instrumentParameterName, defaultValue):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLIntegrateVanadium.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLIntegrateVanadium.py
@@ -9,6 +9,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import DirectILL_common as common
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, InstrumentValidator, ITableWorkspaceProperty,
                         MatrixWorkspaceProperty, Progress, PropertyMode, WorkspaceProperty, WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, EnabledWhenProperty, FloatBoundedValidator, Property,
@@ -45,20 +46,20 @@ class DirectILLIntegrateVanadium(DataProcessorAlgorithm):
     def PyExec(self):
         """Executes the data reduction workflow."""
         progress = Progress(self, 0.0, 1.0, 4)
-        subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
+        self._subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
         cleanupMode = self.getProperty(common.PROP_CLEANUP_MODE).value
-        wsCleanup = common.IntermediateWSCleanup(cleanupMode, subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
 
         progress.report('Loading inputs')
-        mainWS = self._inputWS(wsCleanup)
+        mainWS = self._inputWS()
 
         progress.report('Integrating')
-        mainWS = self._integrate(mainWS, wsCleanup, subalgLogging)
+        mainWS = self._integrate(mainWS)
 
         progress.report('Masking zeros')
-        mainWS = self._maskZeros(mainWS, subalgLogging)
+        mainWS = self._maskZeros(mainWS)
 
-        self._finalize(mainWS, wsCleanup)
+        self._finalize(mainWS)
         progress.report('Done')
 
     def PyInit(self):
@@ -79,10 +80,10 @@ class DirectILLIntegrateVanadium(DataProcessorAlgorithm):
                                                direction=Direction.Output),
                              doc='The integrated workspace.')
         self.declareProperty(name=common.PROP_CLEANUP_MODE,
-                             defaultValue=common.CLEANUP_ON,
+                             defaultValue=utils.Cleanup.ON,
                              validator=StringListValidator([
-                                 common.CLEANUP_ON,
-                                 common.CLEANUP_OFF]),
+                                 utils.Cleanup.ON,
+                                 utils.Cleanup.OFF]),
                              direction=Direction.Input,
                              doc='What to do with intermediate workspaces.')
         self.declareProperty(name=common.PROP_SUBALG_LOGGING,
@@ -115,19 +116,19 @@ class DirectILLIntegrateVanadium(DataProcessorAlgorithm):
         self.setPropertySettings(common.PROP_TEMPERATURE, EnabledWhenProperty(common.PROP_DWF_CORRECTION,
                                                                               PropertyCriterion.IsDefault))
 
-    def _inputWS(self, wsCleanup):
+    def _inputWS(self):
         """Return the raw input workspace."""
         mainWS = self.getProperty(common.PROP_INPUT_WS).value
-        wsCleanup.protect(mainWS)
+        self._cleanup.protect(mainWS)
         return mainWS
 
-    def _finalize(self, outWS, wsCleanup):
+    def _finalize(self, outWS):
         """Do final cleanup and set the output property."""
         self.setProperty(common.PROP_OUTPUT_WS, outWS)
-        wsCleanup.cleanup(outWS)
-        wsCleanup.finalCleanup()
+        self._cleanup.cleanup(outWS)
+        self._cleanup.finalCleanup()
 
-    def _integrate(self, mainWS, wsCleanup, subalgLogging):
+    def _integrate(self, mainWS):
         """Integrate mainWS applying Debye-Waller correction, if requested."""
         eppWS = self.getProperty(common.PROP_EPP_WS).value
         calibrationWS = self.getProperty(common.PROP_OUTPUT_WS).value
@@ -138,18 +139,18 @@ class DirectILLIntegrateVanadium(DataProcessorAlgorithm):
                                                   OutputWorkspace=calibrationWS,
                                                   Temperature=temperature,
                                                   EnableDWF=dwfEnabled,
-                                                  EnableLogging=subalgLogging)
-        wsCleanup.cleanup(mainWS)
+                                                  EnableLogging=self._subalgLogging)
+        self._cleanup.cleanup(mainWS)
         return calibrationWS
 
-    def _maskZeros(self, mainWS, subalgLogging):
+    def _maskZeros(self, mainWS):
         """Mask zero integrals in mainWS."""
         mainWS = MaskDetectorsIf(InputWorkspace=mainWS,
                                  OutputWorkspace=mainWS,
                                  Mode='SelectIf',
                                  Operator='Equal',
                                  Value=0.,
-                                 EnableLogging=subalgLogging)
+                                 EnableLogging=self._subalgLogging)
         return mainWS
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShielding.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShielding.py
@@ -9,6 +9,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import DirectILL_common as common
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, InstrumentValidator,
                         MatrixWorkspaceProperty, PropertyMode, WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, EnabledWhenProperty, IntBoundedValidator,
@@ -44,19 +45,19 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
 
     def PyExec(self):
         """Execute the algorithm."""
-        subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
+        self._subalgLogging = self.getProperty(common.PROP_SUBALG_LOGGING).value == common.SUBALG_LOGGING_ON
         wsNamePrefix = self.getProperty(common.PROP_OUTPUT_WS).valueAsStr
         cleanupMode = self.getProperty(common.PROP_CLEANUP_MODE).value
-        wsNames = common.NameSource(wsNamePrefix, cleanupMode)
-        wsCleanup = common.IntermediateWSCleanup(cleanupMode, subalgLogging)
+        self._names = utils.NameSource(wsNamePrefix, cleanupMode)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
 
         # Get input workspace.
-        mainWS = self._inputWS(wsNames, wsCleanup, subalgLogging)
+        mainWS = self._inputWS()
 
         # Self shielding and empty container subtraction, if requested.
-        correctionWS = self._selfShielding(mainWS, wsNames, wsCleanup, subalgLogging)
+        correctionWS = self._selfShielding(mainWS)
 
-        self._finalize(correctionWS, wsCleanup)
+        self._finalize(correctionWS)
 
     def PyInit(self):
         """Initialize the algorithm's input and output properties."""
@@ -80,10 +81,10 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
                                                      direction=Direction.Output),
                              doc='A workspace containing the self shielding correction factors.')
         self.declareProperty(name=common.PROP_CLEANUP_MODE,
-                             defaultValue=common.CLEANUP_ON,
+                             defaultValue=utils.Cleanup.ON,
                              validator=StringListValidator([
-                                 common.CLEANUP_ON,
-                                 common.CLEANUP_OFF]),
+                                 utils.Cleanup.ON,
+                                 utils.Cleanup.OFF]),
                              direction=Direction.Input,
                              doc='What to do with intermediate workspaces.')
         self.declareProperty(name=common.PROP_SUBALG_LOGGING,
@@ -128,28 +129,28 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
         """Check for issues with user input."""
         return dict()
 
-    def _finalize(self, outWS, wsCleanup):
+    def _finalize(self, outWS):
         """Do final cleanup and set the output property."""
         self.setProperty(common.PROP_OUTPUT_WS, outWS)
-        wsCleanup.cleanup(outWS)
-        wsCleanup.finalCleanup()
+        self._cleanup.cleanup(outWS)
+        self._cleanup.finalCleanup()
 
-    def _inputWS(self, wsNames, wsCleanup, subalgLogging):
+    def _inputWS(self):
         """Return the raw input workspace."""
         mainWS = self.getProperty(common.PROP_INPUT_WS).value
-        wsCleanup.protect(mainWS)
+        self._cleanup.protect(mainWS)
         return mainWS
 
-    def _selfShielding(self, mainWS, wsNames, wsCleanup, subalgLogging):
+    def _selfShielding(self, mainWS):
         """Return the self shielding corrections."""
-        wavelengthWSName = wsNames.withSuffix('input_in_wavelength')
+        wavelengthWSName = self._names.withSuffix('input_in_wavelength')
         wavelengthWS = ConvertUnits(InputWorkspace=mainWS,
                                     OutputWorkspace=wavelengthWSName,
                                     Target='Wavelength',
                                     EMode='Direct',
-                                    EnableLogging=subalgLogging)
+                                    EnableLogging=self._subalgLogging)
         wavelengthPoints = self.getProperty(common.PROP_NUMBER_OF_SIMULATION_WAVELENGTHS).value
-        correctionWSName = wsNames.withSuffix('correction')
+        correctionWSName = self._names.withSuffix('correction')
         useFullInstrument = self.getProperty(common.PROP_SIMULATION_INSTRUMENT).value == common.SIMULATION_INSTRUMENT_FULL
         if useFullInstrument:
             correctionWS = MonteCarloAbsorption(InputWorkspace=wavelengthWS,
@@ -157,7 +158,7 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
                                                 SparseInstrument=False,
                                                 NumberOfWavelengthPoints=wavelengthPoints,
                                                 Interpolation='CSpline',
-                                                EnableLogging=subalgLogging)
+                                                EnableLogging=self._subalgLogging)
         else:
             rows = self.getProperty(common.PROP_SPARSE_INSTRUMENT_ROWS).value
             columns = self.getProperty(common.PROP_SPARSE_INSTRUMENT_COLUMNS).value
@@ -168,13 +169,13 @@ class DirectILLSelfShielding(DataProcessorAlgorithm):
                                                 NumberOfDetectorColumns=columns,
                                                 NumberOfWavelengthPoints=wavelengthPoints,
                                                 Interpolation='CSpline',
-                                                EnableLogging=subalgLogging)
-        wsCleanup.cleanup(wavelengthWS)
+                                                EnableLogging=self._subalgLogging)
+        self._cleanup.cleanup(wavelengthWS)
         correctionWS = ConvertUnits(InputWorkspace=correctionWS,
                                     OutputWorkspace=correctionWSName,
                                     Target='TOF',
                                     EMode='Direct',
-                                    EnableLogging=subalgLogging)
+                                    EnableLogging=self._subalgLogging)
         return correctionWS
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILL_common.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILL_common.py
@@ -8,10 +8,6 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.api import mtd
-from mantid.simpleapi import DeleteWorkspace
-
-
 ABSOLUTE_UNITS_OFF = 'Absolute Units OFF'
 ABSOLUTE_UNITS_ON = 'Absolute Units ON'
 
@@ -28,9 +24,6 @@ BKG_DIAGNOSTICS_OFF = 'Bkg Diagnostics OFF'
 BKG_DIAGNOSTICS_ON = 'Bkg Diagnostics ON'
 
 CATEGORIES = 'ILL\\Direct;Inelastic\\Reduction;Workflow\\Inelastic'
-
-CLEANUP_OFF = 'Cleanup OFF'
-CLEANUP_ON = 'Cleanup ON'
 
 DEFAULT_MASK_OFF = 'Default Mask OFF'
 DEFAULT_MASK_ON = 'Default Mask ON'
@@ -138,116 +131,6 @@ TRANSPOSING_ON = 'Transposing ON'
 
 WS_CONTENT_DETS = 0
 WS_CONTENT_MONS = 1
-
-
-class IntermediateWSCleanup:
-    """A class to manage intermediate workspace cleanup."""
-
-    def __init__(self, cleanupMode, deleteAlgorithmLogging):
-        """Initialize an instance of the class."""
-        self._deleteAlgorithmLogging = deleteAlgorithmLogging
-        self._doDelete = cleanupMode == CLEANUP_ON
-        self._protected = set()
-        self._toBeDeleted = set()
-
-    def cleanup(self, *args):
-        """Delete the workspaces listed in *args."""
-        for ws in args:
-            self._delete(ws)
-
-    def cleanupLater(self, *args):
-        """Mark the workspaces listed in *args to be cleaned up later."""
-        for arg in args:
-            self._toBeDeleted.add(str(arg))
-
-    def finalCleanup(self):
-        """Delete all workspaces marked to be cleaned up later."""
-        for ws in self._toBeDeleted:
-            self._delete(ws)
-
-    def protect(self, *args):
-        """Mark the workspaces listed in *args to be never deleted."""
-        for arg in args:
-            self._protected.add(str(arg))
-
-    def _delete(self, ws):
-        """Delete the given workspace in ws if it is not protected, and
-        deletion is actually turned on.
-        """
-        if not self._doDelete:
-            return
-        try:
-            ws = str(ws)
-        except RuntimeError:
-            return
-        if ws not in self._protected and mtd.doesExist(ws):
-            DeleteWorkspace(Workspace=ws, EnableLogging=self._deleteAlgorithmLogging)
-
-
-class NameSource:
-    """A class to provide names for intermediate workspaces."""
-
-    def __init__(self, prefix, cleanupMode):
-        """Initialize an instance of the class."""
-        self._names = set()
-        self._prefix = prefix
-        if cleanupMode == CLEANUP_ON:
-            self._prefix = '__' + prefix
-
-    def withSuffix(self, suffix):
-        """Returns a workspace name with given suffix applied."""
-        return self._prefix + '_' + suffix + '_'
-
-
-class Report:
-    """A logger for final report generation."""
-
-    _LEVEL_NOTICE = 0
-    _LEVEL_WARNING = 1
-    _LEVEL_ERROR = 2
-
-    class _Entry:
-        """A private class for report entries."""
-
-        def __init__(self, text, loggingLevel):
-            """Initialize an entry."""
-            self._text = text
-            self._loggingLevel = loggingLevel
-
-        def contents(self):
-            """Return the contents of this entry."""
-            return self._text
-
-        def level(self):
-            """Return the logging level of this entry."""
-            return self._loggingLevel
-
-    def __init__(self):
-        """Initialize a report."""
-        self._entries = list()
-
-    def error(self, text):
-        """Add an error entry to this report."""
-        self._entries.append(Report._Entry(text, Report._LEVEL_ERROR))
-
-    def notice(self, text):
-        """Add an information entry to this report."""
-        self._entries.append(Report._Entry(text, Report._LEVEL_NOTICE))
-
-    def warning(self, text):
-        """Add a warning entry to this report."""
-        self._entries.append(Report._Entry(text, Report._LEVEL_WARNING))
-
-    def toLog(self, log):
-        """Write this report to a log."""
-        for entry in self._entries:
-            loggingLevel = entry.level()
-            if loggingLevel == Report._LEVEL_NOTICE:
-                log.notice(entry.contents())
-            elif loggingLevel == Report._LEVEL_WARNING:
-                log.warning(entry.contents())
-            elif loggingLevel == Report._LEVEL_ERROR:
-                log.error(entry.contents())
 
 
 def convertToWorkspaceIndex(i, ws, indexType=INDEX_TYPE_DET_ID):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ILL_utilities.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ILL_utilities.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+from __future__ import (absolute_import, division, print_function)
+
+from mantid import mtd
+from mantid.simpleapi import DeleteWorkspace
+
+
+class Cleanup:
+    """A class to manage intermediate workspace cleanup."""
+
+    OFF = 'Cleanup OFF'
+    ON = 'Cleanup ON'
+
+    def __init__(self, cleanupMode, deleteAlgorithmLogging):
+        """Initialize an instance of the class."""
+        self._deleteAlgorithmLogging = deleteAlgorithmLogging
+        self._doDelete = cleanupMode == self.ON
+        self._protected = set()
+        self._toBeDeleted = set()
+
+    def cleanup(self, *args):
+        """Delete the workspaces listed in *args."""
+        for ws in args:
+            self._delete(ws)
+
+    def cleanupLater(self, *args):
+        """Mark the workspaces listed in *args to be cleaned up later."""
+        for arg in args:
+            self._toBeDeleted.add(str(arg))
+
+    def finalCleanup(self):
+        """Delete all workspaces marked to be cleaned up later."""
+        for ws in self._toBeDeleted:
+            self._delete(ws)
+
+    def protect(self, *args):
+        """Mark the workspaces listed in *args to be never deleted."""
+        for arg in args:
+            self._protected.add(str(arg))
+
+    def _delete(self, ws):
+        """Delete the given workspace in ws if it is not protected, and
+        deletion is actually turned on.
+        """
+        if not self._doDelete:
+            return
+        try:
+            ws = str(ws)
+        except RuntimeError:
+            return
+        if ws not in self._protected and mtd.doesExist(ws):
+            DeleteWorkspace(Workspace=ws, EnableLogging=self._deleteAlgorithmLogging)
+
+
+class NameSource:
+    """A class to provide names for intermediate workspaces."""
+
+    def __init__(self, prefix, cleanupMode):
+        """Initialize an instance of the class."""
+        self._names = set()
+        self._prefix = '__' + prefix if cleanupMode == Cleanup.ON else prefix
+
+    def withSuffix(self, suffix):
+        """Returns a workspace name with given suffix applied."""
+        return self._prefix + '_' + suffix + '_'
+
+
+class Report:
+    """A logger for final report generation."""
+
+    _LEVEL_NOTICE = 0
+    _LEVEL_WARNING = 1
+    _LEVEL_ERROR = 2
+
+    class _Entry:
+        """A private class for report entries."""
+
+        def __init__(self, text, loggingLevel):
+            """Initialize an entry."""
+            self._text = text
+            self._loggingLevel = loggingLevel
+
+        def contents(self):
+            """Return the contents of this entry."""
+            return self._text
+
+        def level(self):
+            """Return the logging level of this entry."""
+            return self._loggingLevel
+
+    def __init__(self):
+        """Initialize a report."""
+        self._entries = list()
+
+    def error(self, text):
+        """Add an error entry to this report."""
+        self._entries.append(Report._Entry(text, Report._LEVEL_ERROR))
+
+    def notice(self, text):
+        """Add an information entry to this report."""
+        self._entries.append(Report._Entry(text, Report._LEVEL_NOTICE))
+
+    def warning(self, text):
+        """Add a warning entry to this report."""
+        self._entries.append(Report._Entry(text, Report._LEVEL_WARNING))
+
+    def toLog(self, log):
+        """Write this report to a log."""
+        for entry in self._entries:
+            loggingLevel = entry.level()
+            if loggingLevel == Report._LEVEL_NOTICE:
+                log.notice(entry.contents())
+            elif loggingLevel == Report._LEVEL_WARNING:
+                log.warning(entry.contents())
+            elif loggingLevel == Report._LEVEL_ERROR:
+                log.error(entry.contents())

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLConvertToQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLConvertToQ.py
@@ -8,6 +8,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspaceProperty, WorkspaceUnitValidator)
 from mantid.kernel import (Direction, FloatBoundedValidator, Property, StringListValidator)
 from mantid.simpleapi import (ConvertToPointData, CreateWorkspace, Divide, GroupToXResolution, ReflectometryMomentumTransfer)
@@ -55,9 +56,9 @@ class ReflectometryILLConvertToQ(DataProcessorAlgorithm):
         """Execute the algorithm."""
         self._subalgLogging = self.getProperty(Prop.SUBALG_LOGGING).value == SubalgLogging.ON
         cleanupMode = self.getProperty(Prop.CLEANUP).value
-        self._cleanup = common.WSCleanup(cleanupMode, self._subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
         wsPrefix = self.getPropertyValue(Prop.OUTPUT_WS)
-        self._names = common.WSNameSource(wsPrefix, cleanupMode)
+        self._names = utils.NameSource(wsPrefix, cleanupMode)
 
         ws, directWS = self._inputWS()
 
@@ -100,8 +101,8 @@ class ReflectometryILLConvertToQ(DataProcessorAlgorithm):
             doc='Enable or disable child algorithm logging.')
         self.declareProperty(
             Prop.CLEANUP,
-            defaultValue=common.WSCleanup.ON,
-            validator=StringListValidator([common.WSCleanup.ON, common.WSCleanup.OFF]),
+            defaultValue=utils.Cleanup.ON,
+            validator=StringListValidator([utils.Cleanup.ON, utils.Cleanup.OFF]),
             doc='Enable or disable intermediate workspace cleanup.')
         self.declareProperty(
             MatrixWorkspaceProperty(

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPolarizationCor.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPolarizationCor.py
@@ -8,11 +8,11 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, FileAction, FileProperty, mtd, WorkspaceGroupProperty)
 from mantid.kernel import (CompositeValidator, Direction, StringArrayLengthValidator, StringArrayMandatoryValidator, StringArrayProperty,
                            StringListValidator)
 from mantid.simpleapi import (LoadILLPolarizationFactors, PolarizationEfficiencyCor, RebinToWorkspace)
-import ReflectometryILL_common as common
 
 
 class Prop:
@@ -54,9 +54,9 @@ class ReflectometryILLPolarizationCor(DataProcessorAlgorithm):
         """Execute the algorithm."""
         self._subalgLogging = self.getProperty(Prop.SUBALG_LOGGING).value == SubalgLogging.ON
         cleanupMode = self.getProperty(Prop.CLEANUP).value
-        self._cleanup = common.WSCleanup(cleanupMode, self._subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
         wsPrefix = self.getPropertyValue(Prop.OUTPUT_WS)
-        self._names = common.WSNameSource(wsPrefix, cleanupMode)
+        self._names = utils.NameSource(wsPrefix, cleanupMode)
 
         wss = self._inputWS()
 
@@ -86,8 +86,8 @@ class ReflectometryILLPolarizationCor(DataProcessorAlgorithm):
                              validator=StringListValidator([SubalgLogging.OFF, SubalgLogging.ON]),
                              doc='Enable or disable child algorithm logging.')
         self.declareProperty(Prop.CLEANUP,
-                             defaultValue=common.WSCleanup.ON,
-                             validator=StringListValidator([common.WSCleanup.ON, common.WSCleanup.OFF]),
+                             defaultValue=utils.Cleanup.ON,
+                             validator=StringListValidator([utils.Cleanup.ON, utils.Cleanup.OFF]),
                              doc='Enable or disable intermediate workspace cleanup.')
         self.declareProperty(FileProperty(Prop.EFFICIENCY_FILE,
                                           defaultValue='',

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
@@ -8,6 +8,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory,
                         DataProcessorAlgorithm,
                         FileAction,
@@ -106,9 +107,9 @@ class ReflectometryILLPreprocess(DataProcessorAlgorithm):
         """Execute the algorithm."""
         self._subalgLogging = self.getProperty(Prop.SUBALG_LOGGING).value == SubalgLogging.ON
         cleanupMode = self.getProperty(Prop.CLEANUP).value
-        self._cleanup = common.WSCleanup(cleanupMode, self._subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
         wsPrefix = self.getPropertyValue(Prop.OUTPUT_WS)
-        self._names = common.WSNameSource(wsPrefix, cleanupMode)
+        self._names = utils.NameSource(wsPrefix, cleanupMode)
 
         ws = self._inputWS()
 
@@ -176,8 +177,8 @@ class ReflectometryILLPreprocess(DataProcessorAlgorithm):
                              validator=StringListValidator([SubalgLogging.OFF, SubalgLogging.ON]),
                              doc='Enable or disable child algorithm logging.')
         self.declareProperty(Prop.CLEANUP,
-                             defaultValue=common.WSCleanup.ON,
-                             validator=StringListValidator([common.WSCleanup.ON, common.WSCleanup.OFF]),
+                             defaultValue=utils.Cleanup.ON,
+                             validator=StringListValidator([utils.Cleanup.ON, utils.Cleanup.OFF]),
                              doc='Enable or disable intermediate workspace cleanup.')
         self.declareProperty(MatrixWorkspaceProperty(Prop.WATER_REFERENCE,
                                                      defaultValue='',

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
@@ -8,6 +8,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import ILL_utilities as utils
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, MatrixWorkspaceProperty, PropertyMode,
                         WorkspaceUnitValidator)
 from mantid.kernel import (CompositeValidator, Direction, FloatArrayBoundedValidator, FloatArrayProperty,
@@ -67,9 +68,9 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
         """Execute the algorithm."""
         self._subalgLogging = self.getProperty(Prop.SUBALG_LOGGING).value == SubalgLogging.ON
         cleanupMode = self.getProperty(Prop.CLEANUP).value
-        self._cleanup = common.WSCleanup(cleanupMode, self._subalgLogging)
+        self._cleanup = utils.Cleanup(cleanupMode, self._subalgLogging)
         wsPrefix = self.getPropertyValue(Prop.OUTPUT_WS)
-        self._names = common.WSNameSource(wsPrefix, cleanupMode)
+        self._names = utils.NameSource(wsPrefix, cleanupMode)
 
         ws = self._inputWS()
         processReflected = not self._directOnly()
@@ -120,8 +121,8 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
             doc='Enable or disable child algorithm logging.')
         self.declareProperty(
             Prop.CLEANUP,
-            defaultValue=common.WSCleanup.ON,
-            validator=StringListValidator([common.WSCleanup.ON, common.WSCleanup.OFF]),
+            defaultValue=utils.Cleanup.ON,
+            validator=StringListValidator([utils.Cleanup.ON, utils.Cleanup.OFF]),
             doc='Enable or disable intermediate workspace cleanup.')
         self.declareProperty(
             Prop.SUM_TYPE,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_common.py
@@ -9,7 +9,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mantid.kernel import UnitConversion, DeltaEModeType
-from mantid.simpleapi import (CreateWorkspace, DeleteWorkspace, mtd, Multiply)
+from mantid.simpleapi import CreateWorkspace, Multiply
 import scipy.constants as constants
 
 
@@ -137,63 +137,3 @@ class SampleLogs:
     LINE_POSITION = 'reduction.line_position'
     SUM_TYPE = 'reduction.foreground.summation_type'
     TWO_THETA = 'loader.two_theta'
-
-
-class WSCleanup:
-    """A class to manage intermediate workspace cleanup."""
-
-    OFF = 'Cleanup OFF'
-    ON = 'Cleanup ON'
-
-    def __init__(self, cleanupMode, deleteAlgorithmLogging):
-        """Initialize an instance of the class."""
-        self._deleteAlgorithmLogging = deleteAlgorithmLogging
-        self._doDelete = cleanupMode == self.ON
-        self._protected = set()
-        self._toBeDeleted = set()
-
-    def cleanup(self, *args):
-        """Delete the workspaces listed in *args."""
-        for ws in args:
-            self._delete(ws)
-
-    def cleanupLater(self, *args):
-        """Mark the workspaces listed in *args to be cleaned up later."""
-        for arg in args:
-            self._toBeDeleted.add(str(arg))
-
-    def finalCleanup(self):
-        """Delete all workspaces marked to be cleaned up later."""
-        for ws in self._toBeDeleted:
-            self._delete(ws)
-
-    def protect(self, *args):
-        """Mark the workspaces listed in *args to be never deleted."""
-        for arg in args:
-            self._protected.add(str(arg))
-
-    def _delete(self, ws):
-        """Delete the given workspace in ws if it is not protected, and
-        deletion is actually turned on.
-        """
-        if not self._doDelete:
-            return
-        try:
-            ws = str(ws)
-        except RuntimeError:
-            return
-        if ws not in self._protected and mtd.doesExist(ws):
-            DeleteWorkspace(Workspace=ws, EnableLogging=self._deleteAlgorithmLogging)
-
-
-class WSNameSource:
-    """A class to provide names for intermediate workspaces."""
-
-    def __init__(self, prefix, cleanupMode):
-        """Initialize an instance of the class."""
-        self._names = set()
-        self._prefix = '__' + prefix if cleanupMode == WSCleanup.ON else prefix
-
-    def withSuffix(self, suffix):
-        """Returns a workspace name with given suffix applied."""
-        return self._prefix + '_' + suffix + '_'


### PR DESCRIPTION
The `DirectILL*` and `ReflectometryILL` workflow algorithms are using the same machinery for workspace naming and cleanup as well as for reporting. This PR combines the two implementations into a single shared Python module to reduce code duplication. Also, a lot of code cleanup in the `DirectILL*` algorithms is included.

**To test:**

Code review.

Fixes #25010.

*This does not require release notes* because this is an internal change only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
