### PR TITLE
Fix path to CRT dlls for VS2017

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -4,6 +4,9 @@
 # dlls
 ###########################################################################
 set (SYSTEM_PACKAGE_TARGET RUNTIME)
+# Also include MSVC runtime libraries when running install commands
+set(CMAKE_INSTALL_OPENMP_LIBRARIES TRUE)
+include (InstallRequiredSystemLibraries)
 
 ###########################################################################
 # Compiler options.

--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -57,22 +57,6 @@ mark_as_advanced(WINDOWS_DEPLOYMENT_TYPE)
 ###########################################################################
 # External dependency DLLs
 ###########################################################################
-# MSVC runtime & openmp libs for Visual Studio
-# They are in the locations defined by the VS***COMNTOOLS environment variable
-set ( _RT 140 )
-file ( TO_CMAKE_PATH $ENV{VS${_RT}COMNTOOLS}../../VC/redist/x64 X64_REDIST_DIR )
-# CRT libraries
-set ( CRT_DLLS concrt${_RT}.dll msvcp${_RT}.dll vccorlib${_RT}.dll vcruntime${_RT}.dll )
-foreach( DLL ${CRT_DLLS} )
-  install ( FILES ${X64_REDIST_DIR}/Microsoft.VC${_RT}.CRT/${DLL} DESTINATION bin )
-endforeach()
-# OpenMP
-set ( OMP_DLLS vcomp${_RT}.dll )
-foreach( DLL ${OMP_DLLS} )
-    install ( FILES ${X64_REDIST_DIR}/Microsoft.VC${_RT}.OpenMP/${DLL} DESTINATION bin )
-endforeach()
-
-# Other third party dependencies
 set ( BOOST_DIST_DLLS
     boost_date_time-mt.dll
     boost_filesystem-mt.dll


### PR DESCRIPTION
This PR fixes a problem with cpack finding DLLs in VS2017

This needs further investigation into the new hard-coded relative path used (`../../VC/Redist/MSVC/14.16.27012/x64`) as we're not currently sure whether this is likely to change.

**To test:**

Build the package on Windows 10 on a machine with VS2017 only. Check the installer builds and runs ok.

Fixes #23037

*This does not require release notes* because it only concerns the build system

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
