### PR TITLE
Add exclusive bounds to ArrayBoundedValidator

### DIFF
--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -190,9 +190,7 @@ void SaveGSS::init() {
 
   auto must_be_3 = boost::make_shared<Kernel::ArrayLengthValidator<int>>(3);
   auto precision_range =
-      boost::make_shared<Kernel::ArrayBoundedValidator<int>>();
-  precision_range->setLower(0);
-  precision_range->setUpper(10);
+      boost::make_shared<Kernel::ArrayBoundedValidator<int>>(0, 10);
 
   auto precision_validator = boost::make_shared<Kernel::CompositeValidator>();
   precision_validator->add(must_be_3);

--- a/Framework/Kernel/inc/MantidKernel/ArrayBoundedValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayBoundedValidator.h
@@ -8,9 +8,6 @@
 #define MANTID_KERNEL_ARRAYBOUNDEDVALIDATOR_H_
 
 #include "MantidKernel/BoundedValidator.h"
-#include "MantidKernel/DllConfig.h"
-#include <string>
-#include <vector>
 
 namespace Mantid {
 namespace Kernel {

--- a/Framework/Kernel/inc/MantidKernel/ArrayBoundedValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/ArrayBoundedValidator.h
@@ -9,8 +9,6 @@
 
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/DllConfig.h"
-#include "MantidKernel/IValidator.h"
-#include "MantidKernel/TypedValidator.h"
 #include <string>
 #include <vector>
 
@@ -26,42 +24,49 @@ namespace Kernel {
     @date 09/11/2010
 */
 template <typename TYPE>
-class MANTID_KERNEL_DLL ArrayBoundedValidator
+class MANTID_KERNEL_DLL ArrayBoundedValidator final
     : public TypedValidator<std::vector<TYPE>> {
 public:
-  ArrayBoundedValidator();
-  ArrayBoundedValidator(const ArrayBoundedValidator<TYPE> &abv);
-  ArrayBoundedValidator(const TYPE lowerBound, const TYPE upperBound);
-  ArrayBoundedValidator(BoundedValidator<TYPE> &bv);
-  ~ArrayBoundedValidator() override;
+  ArrayBoundedValidator() = default;
+  ArrayBoundedValidator(const ArrayBoundedValidator<TYPE> &abv) noexcept;
+  ArrayBoundedValidator(const TYPE lowerBound, const TYPE upperBound) noexcept;
+  ArrayBoundedValidator(TYPE lowerBound, TYPE upperBound,
+                        bool exclusive) noexcept;
+  ArrayBoundedValidator(BoundedValidator<TYPE> &bv) noexcept;
   /// Clone the current state
   IValidator_sptr clone() const override;
-  /// Return the object that checks the bounds
-  boost::shared_ptr<BoundedValidator<TYPE>> getValidator() const;
-
   /// Return if it has a lower bound
-  bool hasLower() const;
+  bool hasLower() const noexcept;
   /// Return if it has a lower bound
-  bool hasUpper() const;
+  bool hasUpper() const noexcept;
   /// Return the lower bound value
-  const TYPE &lower() const;
+  TYPE lower() const noexcept;
   /// Return the upper bound value
-  const TYPE &upper() const;
+  TYPE upper() const noexcept;
+  bool isLowerExclusive() const noexcept;
+  /// Check if upper bound is exclusive
+  bool isUpperExclusive() const noexcept;
+  /// Set the lower bound to be exclusive
+  void setLowerExclusive(const bool exclusive) noexcept;
+  /// Set the upper bound to be exclusive
+  void setUpperExclusive(const bool exclusive) noexcept;
+
+  /// Set both the upper and lower bounds to be exclusive
+  void setExclusive(const bool exclusive) noexcept;
 
   /// Set lower bound value
-  void setLower(const TYPE &value);
+  void setLower(const TYPE &value) noexcept;
   /// Set upper bound value
-  void setUpper(const TYPE &value);
+  void setUpper(const TYPE &value) noexcept;
   /// Clear lower bound value
-  void clearLower();
+  void clearLower() noexcept;
   /// Clear upper bound value
-  void clearUpper();
+  void clearUpper() noexcept;
 
 private:
   std::string checkValidity(const std::vector<TYPE> &value) const override;
 
-  /// The object used to do the actual validation
-  boost::shared_ptr<BoundedValidator<TYPE>> boundVal;
+  BoundedValidator<TYPE> m_actualValidator;
 };
 
 } // namespace Kernel

--- a/Framework/Kernel/inc/MantidKernel/BoundedValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/BoundedValidator.h
@@ -25,10 +25,10 @@ namespace Kernel {
     @date 28/11/2007
 */
 template <class TYPE>
-class DLLExport BoundedValidator : public TypedValidator<TYPE> {
+class DLLExport BoundedValidator final : public TypedValidator<TYPE> {
 public:
   /// No-arg Constructor
-  BoundedValidator()
+  BoundedValidator() noexcept
       : TypedValidator<TYPE>(), m_hasLowerBound(false), m_hasUpperBound(false),
         m_lowerExclusive(false), m_upperExclusive(false), m_lowerBound(TYPE()),
         m_upperBound(TYPE()) {}
@@ -39,65 +39,69 @@ public:
    * @param exclusive :: make bounds exclusive (default inclusive)
    */
   BoundedValidator(const TYPE lowerBound, const TYPE upperBound,
-                   bool exclusive = false)
+                   bool exclusive = false) noexcept
       : TypedValidator<TYPE>(), m_hasLowerBound(true), m_hasUpperBound(true),
         m_lowerExclusive(exclusive), m_upperExclusive(exclusive),
         m_lowerBound(lowerBound), m_upperBound(upperBound) {}
 
   /// Return if it has a lower bound
-  bool hasLower() const { return m_hasLowerBound; }
+  bool hasLower() const noexcept { return m_hasLowerBound; }
   /// Return if it has a lower bound
-  bool hasUpper() const { return m_hasUpperBound; }
+  bool hasUpper() const noexcept { return m_hasUpperBound; }
   /// Return the lower bound value
-  const TYPE &lower() const { return m_lowerBound; }
+  TYPE lower() const noexcept { return m_lowerBound; }
   /// Return the upper bound value
-  const TYPE &upper() const { return m_upperBound; }
+  TYPE upper() const noexcept { return m_upperBound; }
   /// Check if lower bound is exclusive
-  bool isLowerExclusive() const { return m_lowerExclusive; }
+  bool isLowerExclusive() const noexcept { return m_lowerExclusive; }
   /// Check if upper bound is exclusive
-  bool isUpperExclusive() const { return m_upperExclusive; }
+  bool isUpperExclusive() const noexcept { return m_upperExclusive; }
   /// Set the lower bound to be exclusive
-  void setLowerExclusive(const bool exclusive) { m_lowerExclusive = exclusive; }
+  void setLowerExclusive(const bool exclusive) noexcept {
+    m_lowerExclusive = exclusive;
+  }
   /// Set the upper bound to be exclusive
-  void setUpperExclusive(const bool exclusive) { m_upperExclusive = exclusive; }
+  void setUpperExclusive(const bool exclusive) noexcept {
+    m_upperExclusive = exclusive;
+  }
 
   /// Set both the upper and lower bounds to be exclusive
-  void setExclusive(const bool exclusive) {
+  void setExclusive(const bool exclusive) noexcept {
     setLowerExclusive(exclusive);
     setUpperExclusive(exclusive);
   }
 
   /// Set lower bound value
-  void setLower(const TYPE &value) {
+  void setLower(const TYPE &value) noexcept {
     m_hasLowerBound = true;
     m_lowerBound = value;
   }
 
   /// Set upper bound value
-  void setUpper(const TYPE &value) {
+  void setUpper(const TYPE &value) noexcept {
     m_hasUpperBound = true;
     m_upperBound = value;
   }
 
   /// Clear lower bound value
-  void clearLower() {
+  void clearLower() noexcept {
     m_hasLowerBound = false;
     m_lowerBound = TYPE();
   }
   /// Clear upper bound value
-  void clearUpper() {
+  void clearUpper() noexcept {
     m_hasUpperBound = false;
     m_upperBound = TYPE();
   }
 
   /// Set both bounds (lower and upper) at the same time
-  void setBounds(const TYPE &lower, const TYPE &upper) {
+  void setBounds(const TYPE &lower, const TYPE &upper) noexcept {
     setLower(lower);
     setUpper(upper);
   }
 
   /// Clear both bounds (lower and upper) at the same time
-  void clearBounds() {
+  void clearBounds() noexcept {
     clearLower();
     clearUpper();
   }

--- a/Framework/Kernel/inc/MantidKernel/IValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/IValidator.h
@@ -15,7 +15,6 @@
 #include <boost/shared_ptr.hpp>
 #endif
 #include <stdexcept>
-#include <string>
 #include <vector>
 
 namespace Mantid {

--- a/Framework/Kernel/inc/MantidKernel/TypedValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/TypedValidator.h
@@ -10,7 +10,6 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidKernel/IValidator.h"
-#include <stdexcept>
 #include <typeinfo>
 
 namespace Mantid {

--- a/Framework/Kernel/test/ArrayBoundedValidatorTest.h
+++ b/Framework/Kernel/test/ArrayBoundedValidatorTest.h
@@ -8,6 +8,7 @@
 #define ARRAYBOUNDEDVALIDATORTEST_H_
 
 #include "MantidKernel/ArrayBoundedValidator.h"
+#include <array>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::Kernel;

--- a/Framework/Kernel/test/ArrayBoundedValidatorTest.h
+++ b/Framework/Kernel/test/ArrayBoundedValidatorTest.h
@@ -8,10 +8,7 @@
 #define ARRAYBOUNDEDVALIDATORTEST_H_
 
 #include "MantidKernel/ArrayBoundedValidator.h"
-#include "MantidKernel/BoundedValidator.h"
 #include <cxxtest/TestSuite.h>
-#include <string>
-#include <vector>
 
 using namespace Mantid::Kernel;
 using namespace std;
@@ -32,38 +29,99 @@ public:
 
   void testDoubleParamConstructor() {
     ArrayBoundedValidator<double> v(2, 5);
-    // Test that all the base class member variables are correctly assigned to
-    TS_ASSERT_EQUALS(v.getValidator()->hasLower(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->hasUpper(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->lower(), 2);
-    TS_ASSERT_EQUALS(v.getValidator()->upper(), 5);
+    TS_ASSERT_EQUALS(v.hasLower(), true);
+    TS_ASSERT_EQUALS(v.hasUpper(), true);
+    TS_ASSERT_EQUALS(v.lower(), 2);
+    TS_ASSERT_EQUALS(v.upper(), 5);
   }
 
   void testIntParamConstructor() {
     ArrayBoundedValidator<int> v(1, 8);
     // Test that all the base class member variables are correctly assigned to
-    TS_ASSERT_EQUALS(v.getValidator()->hasLower(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->hasUpper(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->lower(), 1);
-    TS_ASSERT_EQUALS(v.getValidator()->upper(), 8);
+    TS_ASSERT_EQUALS(v.hasLower(), true);
+    TS_ASSERT_EQUALS(v.hasUpper(), true);
+    TS_ASSERT_EQUALS(v.lower(), 1);
+    TS_ASSERT_EQUALS(v.upper(), 8);
+  }
+
+  void testExclusiveConstructor() {
+    const std::array<bool, 2> exclusives{{true, false}};
+    for (const auto exclusive : exclusives) {
+      ArrayBoundedValidator<int> v(1, 8, exclusive);
+      TS_ASSERT_EQUALS(v.hasLower(), true);
+      TS_ASSERT_EQUALS(v.hasUpper(), true);
+      TS_ASSERT_EQUALS(v.lower(), 1);
+      TS_ASSERT_EQUALS(v.upper(), 8);
+      TS_ASSERT_EQUALS(v.isLowerExclusive(), exclusive)
+      TS_ASSERT_EQUALS(v.isUpperExclusive(), exclusive)
+    }
   }
 
   void testDoubleBoundedValidatorConstructor() {
     BoundedValidator<double> bv(3, 9);
     ArrayBoundedValidator<double> v(bv);
-    TS_ASSERT_EQUALS(v.getValidator()->hasLower(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->hasUpper(), true);
-    TS_ASSERT_EQUALS(v.getValidator()->lower(), 3);
-    TS_ASSERT_EQUALS(v.getValidator()->upper(), 9);
+    TS_ASSERT_EQUALS(v.hasLower(), true);
+    TS_ASSERT_EQUALS(v.hasUpper(), true);
+    TS_ASSERT_EQUALS(v.lower(), 3);
+    TS_ASSERT_EQUALS(v.upper(), 9);
+  }
+
+  void testSetLowerSetUpper() {
+    BoundedValidator<int> v;
+    TS_ASSERT(!v.hasLower())
+    TS_ASSERT(!v.hasUpper())
+    v.setLower(3);
+    TS_ASSERT_EQUALS(v.lower(), 3)
+    v.setUpper(9);
+    TS_ASSERT_EQUALS(v.upper(), 9)
+  }
+
+  void testHasLowerHasUpper() {
+    BoundedValidator<int> v;
+    TS_ASSERT(!v.hasLower())
+    TS_ASSERT(!v.hasUpper())
+    v.setLower(1);
+    TS_ASSERT(v.hasLower())
+    TS_ASSERT(!v.hasUpper())
+    v.clearLower();
+    v.setUpper(9);
+    TS_ASSERT(!v.hasLower())
+    TS_ASSERT(v.hasUpper())
+  }
+
+  void testClearLowerClearUpper() {
+    BoundedValidator<int> v(2, 9);
+    TS_ASSERT(v.hasLower())
+    TS_ASSERT(v.hasUpper())
+    v.clearLower();
+    TS_ASSERT(!v.hasLower())
+    TS_ASSERT(v.hasUpper())
+    v.setLower(2);
+    v.clearUpper();
+    TS_ASSERT(v.hasLower())
+    TS_ASSERT(!v.hasUpper())
+  }
+
+  void testSetExclusive() {
+    BoundedValidator<int> v;
+    TS_ASSERT(!v.isLowerExclusive())
+    TS_ASSERT(!v.isUpperExclusive())
+    v.setLowerExclusive(true);
+    TS_ASSERT(v.isLowerExclusive())
+    v.setUpperExclusive(true);
+    TS_ASSERT(v.isUpperExclusive())
+    v.setExclusive(false);
+    TS_ASSERT(!v.isLowerExclusive())
+    TS_ASSERT(!v.isUpperExclusive())
   }
 
   void testArrayValidation() {
-    string index_start("At index ");
-    string index_end(": ");
-    string start("Selected value ");
-    string end(")");
-    string greaterThan(" is > the upper bound (");
-    string lessThan(" is < the lower bound (");
+    const string index_start("At index ");
+    const string index_end(": ");
+    const string start("Selected value ");
+    const string end(")");
+    const string greaterThan(" is > the upper bound (");
+    const string lessThan(" is < the lower bound (");
 
     ArrayBoundedValidator<int> vi(0, 10);
     vector<int> ai{10, 3, -1, 2, 11, 0};
@@ -73,11 +131,11 @@ public:
                                          index_start + "4" + index_end + start +
                                          "11" + greaterThan + "10" + end);
 
-    vi.getValidator()->clearLower();
+    vi.clearLower();
     TS_ASSERT_EQUALS(vi.isValid(ai), index_start + "4" + index_end + start +
                                          "11" + greaterThan + "10" + end);
 
-    vi.getValidator()->clearUpper();
+    vi.clearUpper();
     TS_ASSERT_EQUALS(vi.isValid(ai), "");
 
     ArrayBoundedValidator<double> vd(0, 10);
@@ -91,13 +149,13 @@ public:
                          greaterThan + "10" + end + index_start + "5" +
                          index_end + start + "-0.01" + lessThan + "0" + end);
 
-    vd.getValidator()->clearUpper();
+    vd.clearUpper();
     TS_ASSERT_EQUALS(vd.isValid(ad), index_start + "2" + index_end + start +
                                          "-1" + lessThan + "0" + end +
                                          index_start + "5" + index_end + start +
                                          "-0.01" + lessThan + "0" + end);
 
-    vd.getValidator()->clearLower();
+    vd.clearLower();
     TS_ASSERT_EQUALS(vd.isValid(ad), "");
   }
 };

--- a/Framework/MDAlgorithms/src/SetMDFrame.cpp
+++ b/Framework/MDAlgorithms/src/SetMDFrame.cpp
@@ -85,7 +85,6 @@ void SetMDFrame::init() {
 
   auto axisValidator =
       boost::make_shared<Mantid::Kernel::ArrayBoundedValidator<int>>();
-  axisValidator->clearUpper();
   axisValidator->setLower(0);
   declareProperty(
       Kernel::make_unique<Kernel::ArrayProperty<int>>(

--- a/Framework/MDAlgorithms/src/TransposeMD.cpp
+++ b/Framework/MDAlgorithms/src/TransposeMD.cpp
@@ -62,7 +62,6 @@ void TransposeMD::init() {
                   "An input workspace.");
 
   auto axisValidator = boost::make_shared<ArrayBoundedValidator<int>>();
-  axisValidator->clearUpper();
   axisValidator->setLower(0);
 
   declareProperty(

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ArrayBoundedValidator.cpp
@@ -5,8 +5,11 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/ArrayBoundedValidator.h"
+#include "MantidKernel/make_unique.h"
 #include <boost/python/class.hpp>
-#include <boost/python/copy_const_reference.hpp>
+#include <boost/python/default_call_policies.hpp>
+#include <boost/python/make_constructor.hpp>
+#include <boost/python/overloads.hpp>
 #include <boost/python/return_value_policy.hpp>
 
 using Mantid::Kernel::ArrayBoundedValidator;
@@ -14,31 +17,73 @@ using Mantid::Kernel::IValidator;
 using namespace boost::python;
 
 namespace {
+
+/**
+ * Factory function to allow more flexibility in the constructor
+ * @param lower An optional lower bound
+ * @param upper An optional upper bound
+ * @param exclusive Optional argument specifiying if the bounds are exclusive
+ * @returns A pointer to a new BoundedValidator object
+ */
+template <typename T>
+ArrayBoundedValidator<T> *
+createExclusiveArrayBoundedValidator(object lower = object(),
+                                     object upper = object(),
+                                     const bool exclusive = false) {
+  auto validator = Mantid::Kernel::make_unique<ArrayBoundedValidator<T>>();
+  if (lower.ptr() != Py_None) {
+    validator->setLower(extract<T>(lower));
+    validator->setLowerExclusive(exclusive);
+  }
+  if (upper.ptr() != Py_None) {
+    validator->setUpper(extract<T>(upper));
+    validator->setUpperExclusive(exclusive);
+  }
+  return validator.release();
+}
+
 #define EXPORT_ARRAYBOUNDEDVALIDATOR(type, prefix)                             \
   class_<ArrayBoundedValidator<type>, bases<IValidator>, boost::noncopyable>(  \
       #prefix "ArrayBoundedValidator")                                         \
       .def(init<type, type>(                                                   \
           (arg("self"), arg("lowerBound"), arg("upperBound")),                 \
-          "A validator to ensure each value is in the given range"))           \
+          "Construct a validator to ensure each value is in the given range")) \
+      .def("__init__",                                                         \
+           make_constructor(&createExclusiveArrayBoundedValidator<type>,       \
+                            default_call_policies(),                           \
+                            (arg("lower") = object(), arg("upper") = object(), \
+                             arg("exclusive") = false)))                       \
       .def("hasLower", &ArrayBoundedValidator<type>::hasLower, arg("self"),    \
-           "Returns true if a lower bound has been set")                       \
+           "Return true if a lower bound has been set")                        \
       .def("hasUpper", &ArrayBoundedValidator<type>::hasUpper, arg("self"),    \
-           "Returns true if an upper bound has been set")                      \
+           "Return true if an upper bound has been set")                       \
       .def("lower", &ArrayBoundedValidator<type>::lower, arg("self"),          \
-           return_value_policy<copy_const_reference>(),                        \
-           "Returns the lower bound")                                          \
+           "Return the lower bound")                                           \
       .def("upper", &ArrayBoundedValidator<type>::upper, arg("self"),          \
-           return_value_policy<copy_const_reference>(),                        \
-           "Returns the upper bound")                                          \
+           "Return the upper bound")                                           \
+      .def("setLowerExclusive",                                                \
+           &ArrayBoundedValidator<type>::setLowerExclusive,                    \
+           (arg("self"), arg("exclusive")),                                    \
+           "Set if the lower bound is exclusive")                              \
+      .def("setUpperExclusive",                                                \
+           &ArrayBoundedValidator<type>::setUpperExclusive,                    \
+           (arg("self"), arg("exclusive")),                                    \
+           "Set if the upper bound is exclusive")                              \
+      .def("setExclusive", &ArrayBoundedValidator<type>::setExclusive,         \
+           (arg("self"), arg("exclusive")), "Set if the bounds are exclusive") \
+      .def("isLowerExclusive", &ArrayBoundedValidator<type>::isLowerExclusive, \
+           arg("self"), "Return True if the lower bound is exclusive")         \
+      .def("isUpperExclusive", &ArrayBoundedValidator<type>::isUpperExclusive, \
+           arg("self"), "Return True if the upper bound is exclusive")         \
       .def("setLower", &ArrayBoundedValidator<type>::setLower,                 \
-           (arg("self"), arg("lower")), "Sets the lower bound")                \
+           (arg("self"), arg("lower")), "Set the lower bound")                 \
       .def("setUpper", &ArrayBoundedValidator<type>::setUpper,                 \
-           (arg("self"), arg("upper")), "Sets the upper bound")                \
+           (arg("self"), arg("upper")), "Set the upper bound")                 \
       .def("clearLower", &ArrayBoundedValidator<type>::clearLower,             \
            arg("self"), "Clear any set lower bound")                           \
       .def("clearUpper", &ArrayBoundedValidator<type>::clearUpper,             \
            arg("self"), "Clear any set upper bound");
-}
+} // namespace
 
 void export_ArrayBoundedValidator() {
   EXPORT_ARRAYBOUNDEDVALIDATOR(double, Float);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/BoundedValidator.cpp
@@ -7,7 +7,6 @@
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidPythonInterface/kernel/IsNone.h"
 #include <boost/python/class.hpp>
-#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/default_call_policies.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/overloads.hpp>
@@ -89,10 +88,8 @@ createExclusiveBoundedValidator(object lower = object(),
            (arg("self"), arg("exclusive")),                                    \
            "Sets both bounds to be inclusive/exclusive")                       \
       .def("lower", &BoundedValidator<ElementType>::lower, arg("self"),        \
-           return_value_policy<copy_const_reference>(),                        \
            "Returns the lower bound")                                          \
       .def("upper", &BoundedValidator<ElementType>::upper, arg("self"),        \
-           return_value_policy<copy_const_reference>(),                        \
            "Returns the upper bound")                                          \
       .def("setBounds", &BoundedValidator<ElementType>::setBounds,             \
            (arg("self"), arg("lower"), arg("upper")), "Set both bounds")       \

--- a/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
@@ -71,8 +71,7 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
         self.declareProperty(MultipleFileProperty(name="RunNumber",
                                                   extensions=EXTENSIONS_NXS),
                              "Event file")
-        validator = IntArrayBoundedValidator()
-        validator.setLower(0)
+        validator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("Background", values=[0], direction=Direction.Input,
                                               validator=validator))
         self.declareProperty("XPixelSum", 1,
@@ -91,8 +90,7 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
                              "Maximum absolute value of offsets; default is 1")
         self.declareProperty("CrossCorrelation", True,
                              "CrossCorrelation if True; minimize using many peaks if False.")
-        validator = FloatArrayBoundedValidator()
-        validator.setLower(0.)
+        validator = FloatArrayBoundedValidator(lower=0.)
         self.declareProperty(FloatArrayProperty("PeakPositions", []),
                              "Comma delimited d-space positions of reference peaks.  Use 1-3 for Cross Correlation.  "+
                              "Unlimited for many peaks option.")

--- a/Framework/PythonInterface/plugins/algorithms/ConjoinFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConjoinFiles.py
@@ -44,8 +44,7 @@ class ConjoinFiles(PythonAlgorithm):
         raise RuntimeError("Failed to load run %s from file %s" % (str(run), filename))
 
     def PyInit(self):
-        greaterThanZero = IntArrayBoundedValidator()
-        greaterThanZero.setLower(0)
+        greaterThanZero = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("RunNumbers",values=[0],validator=greaterThanZero), doc="Run numbers")
         self.declareProperty(WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
         self.declareProperty(FileProperty("Directory", "", FileAction.OptionalDirectory))

--- a/Framework/PythonInterface/plugins/algorithms/CreateLeBailFitInput.py
+++ b/Framework/PythonInterface/plugins/algorithms/CreateLeBailFitInput.py
@@ -47,8 +47,7 @@ class CreateLeBailFitInput(PythonAlgorithm):
         self.declareProperty("GenerateBraggReflections", False,
                              "Generate Bragg reflections other than reading a Fullprof .irf file. ")
 
-        arrvalidator = IntArrayBoundedValidator()
-        arrvalidator.setLower(0)
+        arrvalidator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("MaxHKL", values=[12, 12, 12], validator=arrvalidator,
                                               direction=Direction.Input), "Maximum reflection (HKL) to generate")
 

--- a/Framework/PythonInterface/plugins/algorithms/DeltaPDF3D.py
+++ b/Framework/PythonInterface/plugins/algorithms/DeltaPDF3D.py
@@ -43,8 +43,7 @@ class DeltaPDF3D(PythonAlgorithm):
         self.declareProperty("Shape", "sphere", doc="Shape to cut out reflections",
                              validator=StringListValidator(['sphere', 'cube']))
         self.setPropertySettings("Shape", condition)
-        val_min_zero = FloatArrayBoundedValidator()
-        val_min_zero.setLower(0.)
+        val_min_zero = FloatArrayBoundedValidator(lower=0.)
         self.declareProperty(FloatArrayProperty("Size", [0.2], validator=val_min_zero),
                              "Width of cube/diameter of sphere used to remove reflections, in (HKL) (one or three values)")
         self.setPropertySettings("Size", condition)

--- a/Framework/PythonInterface/plugins/algorithms/ExaminePowderDiffProfile.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExaminePowderDiffProfile.py
@@ -86,8 +86,7 @@ class ExaminePowderDiffProfile(PythonAlgorithm):
         self.declareProperty("ProcessBackground", False, "Option to process background from input data file.")
         backgroundtypes = ["Polynomial", "Chebyshev", "FullprofPolynomial"]
         self.declareProperty("BackgroundType", "Polynomial", StringListValidator(backgroundtypes), "Type of background.")
-        arrvalidator = FloatArrayBoundedValidator()
-        arrvalidator.setLower(0.)
+        arrvalidator = FloatArrayBoundedValidator(lower=0.)
         self.declareProperty(FloatArrayProperty("BackgroundPoints", values=[], validator=arrvalidator, direction=Direction.Input),
                              "User specified X/TOF values of the data points to calculate background.")
         self.declareProperty(MatrixWorkspaceProperty("BackgroundWorkspace", "", Direction.Output, PropertyMode.Optional),

--- a/Framework/PythonInterface/plugins/algorithms/LoadMultipleGSS.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadMultipleGSS.py
@@ -46,8 +46,7 @@ class LoadMultipleGSS(PythonAlgorithm):
 
     def PyInit(self):
         self.declareProperty("FilePrefix","")
-        intArrayValidator = IntArrayBoundedValidator()
-        intArrayValidator.setLower(0)
+        intArrayValidator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("RunNumbers",[0], validator=intArrayValidator))
         self.declareProperty(FileProperty("Directory", "", action=FileAction.OptionalDirectory))
 

--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -113,8 +113,7 @@ class SNAPReduce(DataProcessorAlgorithm):
         return "Diffraction\\Reduction"
 
     def PyInit(self):
-        validator = IntArrayBoundedValidator()
-        validator.setLower(0)
+        validator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("RunNumbers", values=[0], direction=Direction.Input,
                                               validator=validator),
                              "Run numbers to process, comma separated")

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -164,20 +164,13 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self.declareProperty("PushDataPositive", "None",
                              StringListValidator(["None", "ResetToZero", "AddMinimum"]),
                              "Add a constant to the data that makes it positive over the whole range.")
-        arrvalidatorBack = IntArrayBoundedValidator()
-        arrvalidatorBack.setLower(-1)
-        self.declareProperty(IntArrayProperty("BackgroundNumber", values=[0], validator=arrvalidatorBack),
+        arrvalidator = IntArrayBoundedValidator(lower=-1)
+        self.declareProperty(IntArrayProperty("BackgroundNumber", values=[0], validator=arrvalidator),
                              doc="If specified overrides value in CharacterizationRunsFile If -1 turns off correction.")
-        arrvalidatorVan = IntArrayBoundedValidator()
-        arrvalidatorVan.setLower(-1)
-        self.declareProperty(IntArrayProperty("VanadiumNumber", values=[0], validator=arrvalidatorVan),
-                             doc="If specified overrides value in CharacterizationRunsFile. If -1 turns off correction."
-                                 "")
-        arrvalidatorVanBack = IntArrayBoundedValidator()
-        arrvalidatorVanBack.setLower(-1)
-        self.declareProperty(IntArrayProperty("VanadiumBackgroundNumber", values=[0], validator=arrvalidatorVanBack),
-                             doc="If specified overrides value in CharacterizationRunsFile. If -1 turns off correction."
-                                 "")
+        self.declareProperty(IntArrayProperty("VanadiumNumber", values=[0], validator=arrvalidator),
+                             doc="If specified overrides value in CharacterizationRunsFile. If -1 turns off correction.")
+        self.declareProperty(IntArrayProperty("VanadiumBackgroundNumber", values=[0], validator=arrvalidator),
+                             doc="If specified overrides value in CharacterizationRunsFile. If -1 turns off correction.")
         self.declareProperty(FileProperty(name="CalibrationFile",defaultValue="",action=FileAction.OptionalLoad,
                                           extensions=[".h5", ".hd5", ".hdf", ".cal"]))  # CalFileName
         self.declareProperty(FileProperty(name="GroupingFile",defaultValue="",action=FileAction.OptionalLoad,

--- a/Framework/PythonInterface/plugins/algorithms/StatisticsOfTableWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/StatisticsOfTableWorkspace.py
@@ -45,8 +45,7 @@ class StatisticsOfTableWorkspace(PythonAlgorithm):
     def PyInit(self):
         self.declareProperty(ITableWorkspaceProperty('InputWorkspace', '', Direction.Input),
                              doc='Input table workspace.')
-        validator = IntArrayBoundedValidator()
-        validator.setLower(0)
+        validator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(
             IntArrayProperty('ColumnIndices', values=[], direction=Direction.Input, validator=validator),
             'Comma separated list of column indices for which statistics will be separated')

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioPeakPrediction.py
@@ -38,8 +38,7 @@ class VesuvioPeakPrediction(VesuvioBase):
                              validator=StringListValidator(['Debye', 'Einstein']),
                              doc='Model used to make predictions')
 
-        arrvalid = FloatArrayBoundedValidator()
-        arrvalid.setLower(0.0)
+        arrvalid = FloatArrayBoundedValidator(lower=0.)
 
         self.declareProperty(FloatArrayProperty(name='Temperature', validator=arrvalid),
                              doc='Temperature (K)')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeighting.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeighting.py
@@ -35,8 +35,7 @@ class DetectorFloodWeighting(DataProcessorAlgorithm):
                                                      validator=WorkspaceUnitValidator("Wavelength")),
                              doc='Flood weighting measurement')
 
-        validator = FloatArrayBoundedValidator()
-        validator.setLower(0.)
+        validator = FloatArrayBoundedValidator(lower=0.)
         self.declareProperty(FloatArrayProperty('Bands', [], direction=Direction.Input, validator=validator),
                              doc='Wavelength bands to use. Single pair min to max.')
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -12,7 +12,7 @@ import DirectILL_common as common
 from mantid.api import (AlgorithmFactory, DataProcessorAlgorithm, FileAction, InstrumentValidator,
                         ITableWorkspaceProperty, MatrixWorkspaceProperty, MultipleFileProperty, Progress, PropertyMode,
                         WorkspaceProperty, WorkspaceUnitValidator)
-from mantid.kernel import (CompositeValidator, Direct, Direction, FloatBoundedValidator, IntBoundedValidator, IntArrayBoundedValidator,
+from mantid.kernel import (CompositeValidator, Direct, Direction, FloatBoundedValidator, IntBoundedValidator,
                            IntMandatoryValidator, Property, StringListValidator, UnitConversion)
 from mantid.simpleapi import (AddSampleLog, CalculateFlatBackground, CloneWorkspace, CorrectTOFAxis, CreateEPP,
                               CreateSingleValuedWorkspace, CreateWorkspace, CropWorkspace, DeleteWorkspace, Divide, ExtractMonitors,
@@ -354,8 +354,6 @@ class DirectILLCollectData(DataProcessorAlgorithm):
         mandatoryPositiveInt.add(IntBoundedValidator(lower=0))
         positiveFloat = FloatBoundedValidator(lower=0)
         positiveInt = IntBoundedValidator(lower=0)
-        positiveIntArray = IntArrayBoundedValidator()
-        positiveIntArray.setLower(0)
         inputWorkspaceValidator = CompositeValidator()
         inputWorkspaceValidator.add(InstrumentValidator())
         inputWorkspaceValidator.add(WorkspaceUnitValidator('TOF'))

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLDiagnostics.py
@@ -420,8 +420,7 @@ class DirectILLDiagnostics(DataProcessorAlgorithm):
         inputWorkspaceValidator.add(InstrumentValidator())
         inputWorkspaceValidator.add(WorkspaceUnitValidator('TOF'))
         positiveFloat = FloatBoundedValidator(lower=0)
-        positiveIntArray = IntArrayBoundedValidator()
-        positiveIntArray.setLower(0)
+        positiveIntArray = IntArrayBoundedValidator(lower=0)
         scalingFactor = FloatBoundedValidator(lower=0, upper=1)
 
         # Properties.

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
@@ -60,8 +60,7 @@ class IndirectDiffScan(DataProcessorAlgorithm):
                              validator=StringListValidator(['IRIS', 'OSIRIS']),
                              doc='Instrument used during run.')
 
-        int_arr_valid = IntArrayBoundedValidator()
-        int_arr_valid.setLower(0)
+        int_arr_valid = IntArrayBoundedValidator(lower=0)
 
         self.declareProperty(IntArrayProperty(name='SpectraRange', values=[0, 1],
                                               validator=int_arr_valid),

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLEfficiency.py
@@ -128,8 +128,7 @@ class PowderILLEfficiency(PythonAlgorithm):
                                  'relative calibration constants; for example, the beam stop [degrees]. ')
 
         pixelRangeValidator = CompositeValidator()
-        greaterThanOne = IntArrayBoundedValidator()
-        greaterThanOne.setLower(1)
+        greaterThanOne = IntArrayBoundedValidator(lower=1)
         lengthTwo = IntArrayLengthValidator()
         lengthTwo.setLength(2)
         orderedPairsValidator = IntArrayOrderedPairsValidator()

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
@@ -141,8 +141,7 @@ class ReflectometryILLPreprocess(DataProcessorAlgorithm):
         """Initialize the input and output properties of the algorithm."""
         nonnegativeInt = IntBoundedValidator(lower=0)
         wsIndexRange = IntBoundedValidator(lower=0, upper=255)
-        nonnegativeIntArray = IntArrayBoundedValidator()
-        nonnegativeIntArray.setLower(0)
+        nonnegativeIntArray = IntArrayBoundedValidator(lower=0)
         maxTwoNonnegativeInts = CompositeValidator()
         maxTwoNonnegativeInts.add(IntArrayLengthValidator(lenmin=0, lenmax=2))
         maxTwoNonnegativeInts.add(nonnegativeIntArray)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLSumForeground.py
@@ -94,11 +94,9 @@ class ReflectometryILLSumForeground(DataProcessorAlgorithm):
         """Initialize the input and output properties of the algorithm."""
         threeNonnegativeInts = CompositeValidator()
         threeNonnegativeInts.add(IntArrayLengthValidator(3))
-        nonnegativeInts = IntArrayBoundedValidator()
-        nonnegativeInts.setLower(0)
+        nonnegativeInts = IntArrayBoundedValidator(lower=0)
         threeNonnegativeInts.add(nonnegativeInts)
-        nonnegativeFloatArray = FloatArrayBoundedValidator()
-        nonnegativeFloatArray.setLower(0.)
+        nonnegativeFloatArray = FloatArrayBoundedValidator(lower=0.)
         inWavelength = WorkspaceUnitValidator('Wavelength')
         self.declareProperty(
             MatrixWorkspaceProperty(

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrection.py
@@ -41,8 +41,7 @@ class SANSDarkRunBackgroundCorrection(PythonAlgorithm):
         self.declareProperty("ApplyToDetectors", True, "If True then we apply the correction to the detector pixels")
         self.declareProperty("ApplyToMonitors", False, "If True then we apply the correction to the monitors")
 
-        arrvalidator = IntArrayBoundedValidator()
-        arrvalidator.setLower(0)
+        arrvalidator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("SelectedMonitors", values=[],
                                               validator=arrvalidator,
                                               direction=Direction.Input),

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/USANSReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/USANSReduction.py
@@ -39,8 +39,7 @@ class USANSReduction(PythonAlgorithm):
         return "Perform USANS data reduction"
 
     def PyInit(self):
-        arrvalidator = IntArrayBoundedValidator()
-        arrvalidator.setLower(0)
+        arrvalidator = IntArrayBoundedValidator(lower=0)
         self.declareProperty(IntArrayProperty("RunNumbers", values=[0], validator=arrvalidator,
                                               direction=Direction.Input), "Runs to reduce")
         self.declareProperty("EmptyRun", '', "Run number for the empty run")

--- a/Framework/PythonInterface/test/python/mantid/kernel/ArrayBoundedValidatorTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ArrayBoundedValidatorTest.py
@@ -19,6 +19,13 @@ class ArrayBoundedValidatorTest(unittest.TestCase):
         self.assertFalse(validator.hasLower())
         self.assertFalse(validator.hasUpper())
 
+    def test_exclusive_constructor(self):
+        validator = FloatArrayBoundedValidator(lower=-1., upper=3., exclusive=True)
+        self.assertEquals(validator.lower(), -1.)
+        self.assertEquals(validator.upper(), 3.)
+        self.assertTrue(validator.isLowerExclusive())
+        self.assertTrue(validator.isUpperExclusive())
+
     def test_set_members_alter_bounds(self):
         validator = FloatArrayBoundedValidator()
         self.assertFalse(validator.hasLower())


### PR DESCRIPTION
This PR tries to bring `ArrayBoundedValidator` more consistent with `BoundedValidator`. This allows for a new constructor in Python enabling one to write
```python
validator = IntArrayValidator(lower=0.)
```

This PR also updates some algorithms to use the new feature.


**To test:**

Try out the new `ArrayBoundedValidator` constructor with named parameters: `v = FloatArrayBoundedValidator(lower=-0.3, upper=0.7, True)` and the new methods from Python.

Check also that this does not break the old behavior: `v = IntArrayBoundedValidator(lowerBound=4, upperBound=8)` should still work.

Fixes #9777. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
