### PR TITLE
Fix for workbench hard crash on project overwrite save

### DIFF
--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -77,19 +77,14 @@ class Project(AnalysisDataServiceObserver):
             # Cancel close dialogs
             return
 
-        overwriting = False
         # If the selected path is a project directory ask if overwrite is required?
         if os.path.exists(os.path.join(path, (os.path.basename(path) + self.project_file_ext))):
             answer = self._offer_overwriting_gui()
             if answer == QMessageBox.No:
                 return
             elif answer == QMessageBox.Yes:
-                overwriting = True
-
-        if not overwriting and os.path.exists(path) and os.listdir(path) != []:
-            QMessageBox.warning(None, "Empty directory or project required!",
-                                "Please choose either an new directory or an already saved project", QMessageBox.Ok)
-            return
+                # Just continue on
+                pass
 
         # todo: get a list of workspaces but to be implemented on GUI implementation
         self.last_project_location = path


### PR DESCRIPTION
**Description of work.**
Workbench is currently crashing due to an oversight when reimplementing project save to mimic the MantidPlot windows saving behaviour. This occurs when attempting to overwrite some left over code assumes it is a directory that is still being passed instead of a project file, so when `os.listdir` it raises an uncaught exception. 

**To test:**

- open existing project
- save project as...
- Select the existing project
- Click yes to replace it
- see that workbench no longer crashes

Partial fix for: #24972

<!-- Instructions for testing. -->

*There is no associated issue.*
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
