### PR TITLE
Restore workbench editor tabs with the same font as used on first construction 

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -133,15 +133,16 @@ class MultiPythonFileInterpreter(QWidget):
         :return: True if all tabs are closed, False if cancelled
         """
         for idx in reversed(range(self.editor_count)):
-            if not self.close_tab(idx):
+            if not self.close_tab(idx, allow_zero_tabs=True):
                 return False
 
         return True
 
-    def close_tab(self, idx):
+    def close_tab(self, idx, allow_zero_tabs=False):
         """
         Close the tab at the given index.
         :param idx: The tab index
+        :param allow_zero_tabs: If True then closing the last tab does not add a new empty tab.
         :return: True if tab is to be closed, False if cancelled
         """
         if idx >= self.editor_count:
@@ -157,8 +158,7 @@ class MultiPythonFileInterpreter(QWidget):
         else:
             return False
 
-        # we never want an empty widget
-        if self.editor_count == 0:
+        if (not allow_zero_tabs) and self.editor_count == 0:
             self.append_new_editor()
 
         return True

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -47,6 +47,7 @@ class MultiPythonFileInterpreter(QWidget):
 
         # attributes
         self.default_content = default_content
+        self.default_font = font
         self.prev_session_tabs = None
         self.whitespace_visible = False
         self.setAttribute(Qt.WA_DeleteOnClose, True)
@@ -59,7 +60,7 @@ class MultiPythonFileInterpreter(QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
 
         # add a single editor by default
-        self.append_new_editor(font=font)
+        self.append_new_editor()
 
         # setting defaults
         self.confirm_on_save = True
@@ -87,7 +88,8 @@ class MultiPythonFileInterpreter(QWidget):
     def append_new_editor(self, font=None, content=None, filename=None):
         """
         Appends a new editor the tabbed widget
-        :param font: A reference to the font to be used by the editor
+        :param font: A reference to the font to be used by the editor. If None is given
+        then self.default_font is used
         :param content: An optional string containing content to be placed
         into the editor on opening. If None then self.default_content is used
         :param filename: An optional string containing the filename of the editor
@@ -96,6 +98,8 @@ class MultiPythonFileInterpreter(QWidget):
         """
         if content is None:
             content = self.default_content
+        if font is None:
+            font = self.default_font
 
         interpreter = PythonFileInterpreter(font, content, filename=filename,
                                             parent=self)

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
@@ -9,6 +9,8 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 
+import unittest
+
 from qtpy.QtWidgets import QApplication
 
 from mantidqt.utils.qt.testing import GuiTest
@@ -37,8 +39,8 @@ class MultiPythonFileInterpreterDeletionTest(GuiTest, QtWidgetFinder):
         widget.close_all()
 
         QApplication.processEvents()
-        # there will always be 1, because we never allow an empty editor widget
-        self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 1)
+        # there should be zero interpreters
+        self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
 
         # close the whole widget, this should delete everything from the QApplication
         widget.close()
@@ -86,3 +88,7 @@ class MultiPythonFileInterpreterDeletionTest(GuiTest, QtWidgetFinder):
         QApplication.processEvents()
         self.assert_number_of_widgets_matching(".interpreter.PythonFileInterpreter", 0)
         self.assert_no_toplevel_widgets()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

Fixes issue with restored code editor tabs not using a fixed-width font.

**To test:**

* Start workbench
* Editor font should be fixed width
* Try opening new tabs and closing all of them and ensure the font is always the same

* Save a file, close and reopen workbench to check the font is restored for the opened files.

Fixes #25048 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because **workbench is not yet released**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
