### PR TITLE
Catch possible exceptions from by V3D::normalize in instrument view

### DIFF
--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -294,17 +294,19 @@ void Projection3D::componentSelected(size_t componentIndex) {
   }
 
   auto pos = componentInfo.position(componentIndex);
-
   auto compDir = pos - componentInfo.samplePosition();
-  compDir.normalize();
-  V3D up(0, 0, 1);
-  V3D x = up.cross_prod(compDir);
-  up = compDir.cross_prod(x);
   Quat rot;
-  InstrumentActor::BasisRotation(x, up, compDir, V3D(-1, 0, 0), V3D(0, 1, 0),
-                                 V3D(0, 0, -1), rot);
+  try {
+    compDir.normalize();
+    V3D up(0, 0, 1);
+    V3D x = up.cross_prod(compDir);
+    up = compDir.cross_prod(x);
+    InstrumentActor::BasisRotation(x, up, compDir, V3D(-1, 0, 0), V3D(0, 1, 0),
+                                   V3D(0, 0, -1), rot);
 
-  rot.rotate(pos);
+    rot.rotate(pos);
+  } catch (std::runtime_error &) {
+  }
   m_viewport.setTranslation(-pos.X(), -pos.Y());
   m_viewport.setRotation(rot);
 }


### PR DESCRIPTION
**Description of work.**

`V3D::normalize` can [now throw](https://github.com/mantidproject/mantid/commit/228d48192ae76427dc5ac678a8d27d233672301d) in the case of zero-length vectors. This catches these exceptions in the instrument view if they happen.

**To test:**

Follow the instructions in the issue.

Fixes #25046.

*This does not require release notes* because **it fixes an issue introduced in this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
