### PR TITLE
Fix crash upon running enginX's gui calibrate with no calibration directory selected

### DIFF
--- a/docs/source/release/v4.0.0/diffraction.rst
+++ b/docs/source/release/v4.0.0/diffraction.rst
@@ -114,4 +114,9 @@ New
 
 - Scripts added that produce the same results as the ISIS engineering GUI (supports ENGINX and IMAT), this is to allow use with ISIS autoreduction.
 
+Bugfixes
+########
+
+- Fixed a crash in the gui caused by running a calibration without setting a calibration directory.
+
 :ref:`Release 4.0.0 <v4.0.0>`

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -969,10 +969,10 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
   }
 
   try {
-    m_calibFinishedOK = false;
-    doCalib(cs, vanNo, ceriaNo, outFilename, specNos);
     m_calibFinishedOK = true;
+    doCalib(cs, vanNo, ceriaNo, outFilename, specNos);
   } catch (std::runtime_error &rexc) {
+    m_calibFinishedOK = false;
     g_log.error()
         << "The calibration calculations failed. One of the "
            "algorithms did not execute correctly. See log messages for "
@@ -1071,6 +1071,7 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
     m_view->userWarning("No calibration directory selected",
                         "Please select a calibration directory in Settings. "
                         "This will be used to cache Vanadium calibration data");
+    m_calibFinishedOK = false;
     return;
   }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "EnggDiffractionPresenter.h"
 #include "EnggDiffractionPresWorker.h"
+#include "EnggDiffractionViewQtGUI.h"
 #include "EnggVanadiumCorrectionsModel.h"
 #include "IEnggDiffractionView.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -27,6 +28,9 @@
 #include <Poco/Path.h>
 
 #include <QThread>
+
+// Delete these
+#include <QMetaObject>
 
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;
@@ -1068,9 +1072,9 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
                                        const std::string &outFilename,
                                        const std::string &specNos) {
   if (cs.m_inputDirCalib.empty()) {
-    m_view->userWarning("No calibration directory selected",
-                        "Please select a calibration directory in Settings. "
-                        "This will be used to cache Vanadium calibration data");
+    g_log.warning("No calibration directory selected. Please select a "
+                  "calibration directory in Settings. This will be used to "
+                  "cache Vanadium calibration data");
     m_calibFinishedOK = false;
     return;
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "EnggDiffractionPresenter.h"
 #include "EnggDiffractionPresWorker.h"
-#include "EnggDiffractionViewQtGUI.h"
 #include "EnggVanadiumCorrectionsModel.h"
 #include "IEnggDiffractionView.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -28,9 +27,6 @@
 #include <Poco/Path.h>
 
 #include <QThread>
-
-// Delete these
-#include <QMetaObject>
 
 using namespace Mantid::API;
 using namespace MantidQt::CustomInterfaces;


### PR DESCRIPTION
**Description of work.**
The crash occurred due to  trying to call the message-box stating that a calibration folder was not set, not being called on the gui thread, changing to `invokeMethod` lead to the crash no longer happening, but the message-box also not appearing, to fix the crash the message-box has been replaced with a warning in the logger.

**To test:**
Check that the settings tab on the enginX gui does not have any path set in `Calibration settings->Input directories/folder:->calibration`
go back to the calibration tab, click browse and navigate to these files ENGINX00236516 for the vanadium and ENGINX00241391 for the calibration sample(message me on slack so i can send the files, there too big to send over github), then click calibrate. the calibration should fail without crashing, a warning should print to the results log stating "No calibration directory selected. Please select a calibration directory in Settings. This will be used to cache Vanadium calibration data"


Fixes #24992 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
