### PR TITLE
Workbench/MantidPlot: Project Recovery - Remove file dumping from the logging

### DIFF
--- a/Framework/DataHandling/src/SaveMask.cpp
+++ b/Framework/DataHandling/src/SaveMask.cpp
@@ -57,6 +57,7 @@ void SaveMask::exec() {
         this->createChildAlgorithm("ExtractMask", 0.0, 0.5, false);
     emAlg->setProperty("InputWorkspace", userInputWS);
     emAlg->setPropertyValue("OutputWorkspace", "tmp");
+    emAlg->setLogging(this->isLogging());
     emAlg->execute();
     API::MatrixWorkspace_sptr ws = emAlg->getProperty("OutputWorkspace");
     inpWS = boost::dynamic_pointer_cast<DataObjects::SpecialWorkspace2D>(ws);

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -342,7 +342,7 @@ public:
       }
     }
     lock.unlock();
-    g_log.information("Data Object '" + oldName + "' renamed to '" + newName +
+    g_log.debug("Data Object '" + oldName + "' renamed to '" + newName +
                       "'");
     notificationCenter.postNotification(
         new RenameNotification(oldName, newName));

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -342,8 +342,7 @@ public:
       }
     }
     lock.unlock();
-    g_log.debug("Data Object '" + oldName + "' renamed to '" + newName +
-                      "'");
+    g_log.debug("Data Object '" + oldName + "' renamed to '" + newName + "'");
     notificationCenter.postNotification(
         new RenameNotification(oldName, newName));
   }

--- a/Framework/Kernel/inc/MantidKernel/DataService.h
+++ b/Framework/Kernel/inc/MantidKernel/DataService.h
@@ -287,7 +287,7 @@ public:
     lock.unlock();
     notificationCenter.postNotification(new PreDeleteNotification(name, data));
     data.reset(); // DataService now has no references to the object
-    g_log.information("Data Object '" + name + "' deleted from data service.");
+    g_log.debug("Data Object '" + name + "' deleted from data service.");
     notificationCenter.postNotification(new PostDeleteNotification(name));
   }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -1387,7 +1387,8 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(
       return false; // no mask workspace was found
 
     // save mask to file inside project folder
-    auto alg = AlgorithmManager::Instance().create("SaveMask", -1);
+    auto alg = AlgorithmManager::Instance().createUnmanaged("SaveMask", -1);
+    alg->setChild(true);
     alg->setProperty("InputWorkspace",
                      boost::dynamic_pointer_cast<Workspace>(outputWS));
     alg->setPropertyValue("OutputFile", fileName);


### PR DESCRIPTION
**Description of work.**
Everytime project recovery ran in Workbench/MantidPlot and Instrument View was open it would dump the masked workspace.

**To test:**
- Open MantidPlot
- Load a workspace with an instrument
- Open Instrument View
- Run mantidplot.app.saveRecoveryCheckpoint()
- It should not dump something similar to the following, in the console:
```
<detector-masking>
    <group>
        <detids/>
    </group>
</detector-masking>
```

Testing on MantidPlot should be sufficient as both use the same code (Feel free to repeat on Workbench, you will have to wait for recovery).
<!-- Instructions for testing. -->

*There is no associated issue.*

It's already got a suitable thing in the MantidPlot release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
