### PR TITLE
Ensure beam centre max radius is larger than min radius

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -128,7 +128,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         self.declareProperty('Centre2', 0.0, direction=Direction.Output,
                              doc="The centre position found in the second dimension")
 
-    def PyExec(self):
+    def PyExec(self): # noqa: C901
         state = self._get_state()
         state_serialized = state.property_manager
         self.logger = Logger("CentreFinder")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -10,6 +10,8 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+import numpy as np
+
 from mantid import AnalysisDataService
 from mantid.api import (DataProcessorAlgorithm, MatrixWorkspaceProperty, AlgorithmFactory, PropertyMode, Progress)
 from mantid.kernel import (Direction, PropertyManagerProperty, StringListValidator, Logger)
@@ -129,8 +131,8 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
     def PyExec(self):
         state = self._get_state()
         state_serialized = state.property_manager
-        logger = Logger("CentreFinder")
-        logger.notice("Starting centre finder routine...")
+        self.logger = Logger("CentreFinder")
+        self.logger.notice("Starting centre finder routine...")
         progress = self._get_progress()
         self.scale_1 = 1000
         self.scale_2 = 1000
@@ -205,13 +207,20 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
                                                        sample_quartiles[MaskingQuadrant.Right]))
             residueTB.append(self._calculate_residuals(sample_quartiles[MaskingQuadrant.Top],
                                                        sample_quartiles[MaskingQuadrant.Bottom]))
-            if(j == 0):
-                logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
-                              format(j, self.scale_1 * centre1, self.scale_2 * centre2, residueLR[j], residueTB[j]))
-                if not PYQT4:
-                    self._plot_quartiles_matplotlib(output_workspaces, state.data.sample_scatter)
-                elif IN_MANTIDPLOT:
-                    self._plot_quartiles(output_workspaces, state.data.sample_scatter)
+            if j == 0:
+                self.logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
+                                   format(j, self.scale_1 * centre1,
+                                          self.scale_2 * centre2, residueLR[j], residueTB[j]))
+                try:
+                    output_workspaces_matplotlib = self._validate_workspaces(output_workspaces)
+                except ValueError as e:
+                    self.logger.notice("Stopping process: {}. Check radius limits.".format(str(e)))
+                    break
+                else:
+                    if not PYQT4:
+                        self._plot_quartiles_matplotlib(output_workspaces_matplotlib, state.data.sample_scatter)
+                    elif IN_MANTIDPLOT:
+                        self._plot_quartiles(output_workspaces, state.data.sample_scatter)
 
             else:
                 # have we stepped across the y-axis that goes through the beam center?
@@ -221,25 +230,27 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
                 if residueTB[j] > residueTB[j-1]:
                     position_2_step = - position_2_step / 2
 
-                logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
-                              format(j, self.scale_1 * centre1, self.scale_2 * centre2, residueLR[j], residueTB[j]))
+                self.logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
+                                   format(j, self.scale_1 * centre1,
+                                          self.scale_2 * centre2, residueLR[j], residueTB[j]))
 
-                if (residueLR[j]+residueTB[j]) < (residueLR[j-1]+residueTB[j-1]) or state.compatibility.use_compatibility_mode:
+                if (residueLR[j]+residueTB[j]) < (residueLR[j-1]+residueTB[j-1]) or \
+                        state.compatibility.use_compatibility_mode:
                     centre_1_hold = centre1
                     centre_2_hold = centre2
 
                 if abs(position_1_step) < tolerance and abs(position_2_step) < tolerance:
                     # this is the success criteria, we've close enough to the center
-                    logger.notice("Converged - check if stuck in local minimum! ")
+                    self.logger.notice("Converged - check if stuck in local minimum! ")
                     break
 
             if j == max_iterations:
-                logger.notice("Out of iterations, new coordinates may not be the best")
+                self.logger.notice("Out of iterations, new coordinates may not be the best")
 
         self.setProperty("Centre1", centre_1_hold)
         self.setProperty("Centre2", centre_2_hold)
 
-        logger.notice("Centre coordinates updated: [{}, {}]".format(centre_1_hold*self.scale_1, centre_2_hold*self.scale_2))
+        self.logger.notice("Centre coordinates updated: [{}, {}]".format(centre_1_hold*self.scale_1, centre_2_hold*self.scale_2))
 
     def _rename_and_group_workspaces(self, index, output_workspaces):
         to_group = []
@@ -278,6 +289,21 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         if not WITHOUT_GUI:
             plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
                  plot_kwargs=plot_kwargs, window_title=title)
+
+    @staticmethod
+    def _validate_workspaces(workspaces):
+        """
+        This method checks if any of the workspaces to plot contain NaN values.
+        :param workspaces: A list of workspace names
+        :return: A list of workspaces (used in matplotlib plotting). Raises if NaN values present.
+        """
+        workspaces = AnalysisDataService.Instance().retrieveWorkspaces(workspaces, unrollGroups=True)
+        for ws in workspaces:
+            if np.isnan(ws.readY(0)).any():
+                # All data can be NaN if bounds are too close together
+                # this makes the data unplottable
+                raise ValueError("Workspace contains NaN values.")
+        return workspaces
 
     def _get_cloned_workspace(self, workspace_name):
         workspace = self.getProperty(workspace_name).value

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -37,6 +37,8 @@ def create_mock_masking_table():
 
 def create_mock_beam_centre_tab():
     view = mock.create_autospec(BeamCentre, spec_set=False)
+    view.r_min_line_edit = mock.Mock()
+    view.r_max_line_edit = mock.Mock()
     return view
 
 

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -29,6 +29,7 @@ class BeamCentrePresenterTest(unittest.TestCase):
         self.SANSCentreFinder = mock.MagicMock()
         self.presenter = BeamCentrePresenter(self.parent_presenter, self.WorkHandler, self.BeamCentreModel,
                                              self.SANSCentreFinder)
+        self.presenter.connect_signals = mock.Mock()
 
     def test_that_on_run_clicked_calls_find_beam_centre(self):
         self.presenter.set_view(self.view)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where ISIS SANS beam centre finder could run with mininum radius larger than maximum radius, which would cause an error.
The fix is to disable the run button while min >= max

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Load attached user and batch file
3. In the beam centre tab, play around with the radius min and radius max tooltips. When min > max the run button should be disabled

For issue #25081, check that attempting to find beam centre with bounds close together (e.g. 60 and 70) will attempt to find the first set of coordinates, then stop the process. Using further apart bounds (e.g. 60 and 200) should allow the beam centre to be found.

**data**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/2942045/loqPRData.zip)

Fixes #25011 
Fixes #25081 

*This does not require release notes* because **small change picked up in manual testing, not raised by a user.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
