### PR TITLE
Workbench: Plot legend draggability - Project Loading and Fitting

### DIFF
--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -236,6 +236,9 @@ class PlotsLoader(object):
             return
         ax.legend().set_visible(legend["visible"])
 
+        # Ensure that legend is draggable
+        ax.get_legend().draggable()
+
     def update_properties(self, ax, properties):
         ax.set_position(properties["bounds"])
         ax.set_navigate(properties["dynamic"])

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -258,7 +258,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             new_line.update_from(old_line)
 
         # Now update the legend to make sure it changes to the old properties
-        self.get_axes().legend()
+        self.get_axes().legend().draggable()
 
     @Slot(int, float, float, float)
     def peak_added_slot(self, peak_id, centre, height, fwhm):


### PR DESCRIPTION
**Description of work.**
Loading from a project would not make the legend of a plot draggable, neither would a fit. This PR does that.

**To test:**
- Load Workbench
- Load a 1D plottable workspace
- Do a fit of the plot and check that the legend can be dragged
- Save a project
- Open that project
- Check you can still drag the legend on the popped up plot window

<!-- Instructions for testing. -->

Fixes #25060 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
