### PR TITLE
Add option to ignore nexus instrument xml

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -699,8 +699,9 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
 }
 
 //-----------------------------------------------------------------------------
-/** Load the instrument from the nexus file or if not found from the IDF file
- *  specified by the info in the Nexus file
+/** Load the instrument from the nexus file if property LoadNexusInstrumentXML
+ *  is set to true. If instrument XML not found from the IDF file
+ *  (specified by the info in the Nexus file) load the IDF.
  *
  *  @param nexusfilename :: The Nexus file name
  *  @param localWorkspace :: templated workspace in which to put the
@@ -714,8 +715,13 @@ bool LoadEventNexus::loadInstrument(const std::string &nexusfilename,
                                     T localWorkspace,
                                     const std::string &top_entry_name,
                                     Algorithm *alg) {
-  bool foundInstrument = runLoadIDFFromNexus<T>(nexusfilename, localWorkspace,
-                                                top_entry_name, alg);
+
+  bool loadNexusInstrumentXML = alg->getProperty("LoadNexusInstrumentXML");
+  bool foundInstrument = false;
+
+  if (loadNexusInstrumentXML)
+    foundInstrument = runLoadIDFFromNexus<T>(nexusfilename, localWorkspace,
+                                             top_entry_name, alg);
   if (!foundInstrument)
     foundInstrument = runLoadInstrument<T>(nexusfilename, localWorkspace,
                                            top_entry_name, alg);

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -716,9 +716,11 @@ bool LoadEventNexus::loadInstrument(const std::string &nexusfilename,
                                     const std::string &top_entry_name,
                                     Algorithm *alg) {
 
-  bool loadNexusInstrumentXML = alg->getProperty("LoadNexusInstrumentXML");
-  bool foundInstrument = false;
+  bool loadNexusInstrumentXML = true;
+  if (alg->existsProperty("LoadNexusInstrumentXML"))
+    loadNexusInstrumentXML = alg->getProperty("LoadNexusInstrumentXML");
 
+  bool foundInstrument = false;
   if (loadNexusInstrumentXML)
     foundInstrument = runLoadIDFFromNexus<T>(nexusfilename, localWorkspace,
                                              top_entry_name, alg);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -281,6 +281,11 @@ void LoadEventNexus::init() {
                   "Set type of loader. 2 options {Default, Multiproceess},"
                   "'Multiprocess' should work faster for big files and it is "
                   "experimental, available only in Linux");
+
+  declareProperty(make_unique<PropertyWithValue<bool>>("LoadNexusInstrumentXML",
+                                                       true, Direction::Input),
+                  "Reads the embedded Instrument XML from the NeXus file "
+                  "(optional, default True). ");
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
+++ b/Framework/WorkflowAlgorithms/src/EQSANSLoad.cpp
@@ -109,6 +109,9 @@ void EQSANSLoad::init() {
       "using the distance found in the meta data), in mm");
   declareProperty("LoadMonitors", true,
                   "If true, the monitor workspace will be loaded");
+  declareProperty("LoadNexusInstrumentXML", true,
+                  "Reads the embedded Instrument XML from the NeXus file "
+                  "(optional, default True). ");
   declareProperty("OutputMessage", "", Direction::Output);
   declareProperty("ReductionProperties", "__sans_reduction_properties",
                   Direction::Input);
@@ -524,9 +527,11 @@ void EQSANSLoad::exec() {
   // Check whether we need to load the data
   if (!inputEventWS) {
     const bool loadMonitors = getProperty("LoadMonitors");
+    const bool loadNexusInstrumentXML = getProperty("LoadNexusInstrumentXML");
     IAlgorithm_sptr loadAlg = createChildAlgorithm("LoadEventNexus", 0, 0.2);
     loadAlg->setProperty("LoadMonitors", loadMonitors);
     loadAlg->setProperty("Filename", fileName);
+    loadAlg->setProperty("LoadNexusInstrumentXML", loadNexusInstrumentXML);
     if (skipTOFCorrection) {
       if (m_low_TOF_cut > 0.0)
         loadAlg->setProperty("FilterByTofMin", m_low_TOF_cut);

--- a/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/SetupEQSANSReduction.cpp
@@ -82,6 +82,10 @@ void SetupEQSANSReduction::init() {
       "DetectorTubes", false,
       "If true, the solid angle correction for tube detectors will be applied");
 
+  declareProperty("LoadNexusInstrumentXML", true,
+                  "Reads the embedded Instrument XML from the NeXus file "
+                  "(optional, default True). ");
+
   // -- Define group --
   setPropertyGroup("UseConfigTOFCuts", load_grp);
   setPropertyGroup("LowTOFCut", load_grp);
@@ -102,6 +106,7 @@ void SetupEQSANSReduction::init() {
   setPropertyGroup("DetectorOffset", load_grp);
   setPropertyGroup("SolidAngleCorrection", load_grp);
   setPropertyGroup("DetectorTubes", load_grp);
+  setPropertyGroup("LoadNexusInstrumentXML", load_grp);
 
   // Beam center
   std::string center_grp = "Beam Center";
@@ -693,6 +698,8 @@ void SetupEQSANSReduction::exec() {
   loadAlg->setProperty("UseConfig", useConfig);
   const bool useConfigMask = getProperty("UseConfigMask");
   loadAlg->setProperty("UseConfigMask", useConfigMask);
+  const bool loadNexusInstrumentXML = getProperty("LoadNexusInstrumentXML");
+  loadAlg->setProperty("LoadNexusInstrumentXML", loadNexusInstrumentXML);
   auto loadAlgProp = make_unique<AlgorithmProperty>("LoadAlgorithm");
   loadAlgProp->setValue(loadAlg->toString());
   reductionManager->declareProperty(std::move(loadAlgProp));

--- a/docs/source/concepts/ORNL_SANS_Reduction.rst
+++ b/docs/source/concepts/ORNL_SANS_Reduction.rst
@@ -499,4 +499,7 @@ General commands
 ``Resolution(sample_aperture_diameter=10.0)``
     Specifies that we want to q-resolution to be computed.
 
+``LoadNexusInstrumentXML(True)``
+    By default if the instrument definition is present in the NeXus file it is read. However one can pass ``LoadNexusInstrumentXML(False)`` to make sure the local IDF is read.
+
 .. categories:: Concepts

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -15,6 +15,11 @@ Concepts
 Algorithms
 ----------
 
+Improvements
+############
+
+- :ref:`LoadEventNexus <algm-LoadEventNexus>` has an additional option `LoadNexusInstrumentXML` = `{Default, True}`,  which controls whether or not the embedded instrument definition is read from the NeXus file.
+
 Data Objects
 ------------
 

--- a/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
+++ b/scripts/reduction_workflow/instruments/sans/sns_command_interface.py
@@ -139,3 +139,7 @@ def SetDetectorOffset(distance):
 
 def SetSampleOffset(distance):
     ReductionSingleton().reduction_properties["SampleOffset"] = distance
+
+
+def LoadNexusInstrumentXML(value=True):
+    ReductionSingleton().reduction_properties["LoadNexusInstrumentXML"] = value


### PR DESCRIPTION
**Description of work.**

Issue #24785

Create a `LoadNexusInstrumentXML` property in the `LoadEventNexus`.
If `LoadNexusInstrumentXML = True` (default) reads the nexus embedded instrument XML.
If `LoadNexusInstrumentXML = False` reads the local IDF.

**To test:**

- Tests should pass.
- However one can read an event Nexus file and click the option `LoadNexusInstrumentXML` and see if the local IDF was read. In Debug log level, after the Logs were read, this is clear.
- For the SANS part (this only works for EQSANS) in a regular EQSANS script use `LoadNexusInstrumentXML(False)` to ignore the embedded IDF.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
