### PR TITLE
BASIS reduction select parameter files by time stamp

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -28,29 +28,29 @@ DEFAULT_CONFIG_DIR = config['instrumentDefinition.directory']
 # pylint: disable=line-too-long
 REFLECTIONS_DICT = {
     'silicon_111': {'name': 'silicon_111',
-                   'energy_bins': [-150, 0.4, 500],  # micro-eV
-                   'q_bins': [0.3, 0.2, 1.9],  # inverse Angst
-                   'banks': 'bank1,bank3,bank4',
-                   'mask_file': 'BASIS_Mask_default_111.xml',
-                   'default_energy': 2.0826,  # meV
-                   'vanadium_bins': [-0.0034, 0.068, 0.0034],
-                   'vanadium_wav_range': [6.20, 6.33]},
+                    'energy_bins': [-150, 0.4, 500],  # micro-eV
+                    'q_bins': [0.3, 0.2, 1.9],  # inverse Angst
+                    'banks': 'bank1,bank3,bank4',
+                    'mask_file': 'BASIS_Mask_default_111.xml',
+                    'default_energy': 2.0826,  # meV
+                    'vanadium_bins': [-0.0034, 0.068, 0.0034],
+                    'vanadium_wav_range': [6.20, 6.33]},
     'silicon_333': {'name': 'silicon_333',
-                   'energy_bins': [-1500, 3.2, 5000],
-                   'q_bins': [0.9, 0.2, 5.7],
-                   'banks': 'bank1,bank3,bank4',
-                   'mask_file': 'BASIS_Mask_default_333.xml',
-                   'default_energy': 18.7434,
-                   'vanadium_bins': [-0.0333, 0.0666, 0.0333],
-                   'vanadium_wav_range': [2.080, 2.108]},
+                    'energy_bins': [-1500, 3.2, 5000],
+                    'q_bins': [0.9, 0.2, 5.7],
+                    'banks': 'bank1,bank3,bank4',
+                    'mask_file': 'BASIS_Mask_default_333.xml',
+                    'default_energy': 18.7434,
+                    'vanadium_bins': [-0.0333, 0.0666, 0.0333],
+                    'vanadium_wav_range': [2.080, 2.108]},
     'silicon_311': {'name': 'silicon_311',
-                   'energy_bins': [-740, 1.6, 740],
-                   'q_bins': [0.5, 0.2, 3.7],
-                   'banks': 'bank2',
-                   'mask_file': 'BASIS_Mask_default_311.xml',
-                   'default_energy': 7.6368,  # meV
-                   'vanadium_bins': [-0.015, 0.030, 0.015],
-                   'vanadium_wav_range': [3.263, 3.295]}
+                    'energy_bins': [-740, 1.6, 740],
+                    'q_bins': [0.5, 0.2, 3.7],
+                    'banks': 'bank2',
+                    'mask_file': 'BASIS_Mask_default_311.xml',
+                    'default_energy': 7.6368,  # meV
+                    'vanadium_bins': [-0.015, 0.030, 0.015],
+                    'vanadium_wav_range': [3.263, 3.295]}
 }
 
 # pylint: disable=too-many-instance-attributes
@@ -683,6 +683,7 @@ class BASISReduction(PythonAlgorithm):
         mtd[ws_name].getRun().addProperty('reflParmFile',
                                           os.path.basename(parm_file), True)
         return parm_file
+
 
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(BASISReduction)

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -7,12 +7,13 @@
 # pylint: disable=no-init
 from __future__ import (absolute_import, division, print_function)
 
+import os
 import numpy as np
 import json
 
 import mantid.simpleapi as sapi
 from mantid.api import (mtd, PythonAlgorithm, AlgorithmFactory, FileProperty,
-                        FileAction, AnalysisDataService)
+                        FileAction, AnalysisDataService, ExperimentInfo)
 from mantid.kernel import (IntArrayProperty, StringListValidator,
                            FloatArrayProperty, EnabledWhenProperty,
                            Direction, PropertyCriterion)
@@ -26,31 +27,27 @@ DEFAULT_CONFIG_DIR = config['instrumentDefinition.directory']
 # BASIS allows two possible reflections, with associated default properties
 # pylint: disable=line-too-long
 REFLECTIONS_DICT = {
-    'silicon111': {'name': 'silicon111',
+    'silicon_111': {'name': 'silicon_111',
                    'energy_bins': [-150, 0.4, 500],  # micro-eV
                    'q_bins': [0.3, 0.2, 1.9],  # inverse Angst
                    'banks': 'bank1,bank3,bank4',
                    'mask_file': 'BASIS_Mask_default_111.xml',
-                   'parameter_file': 'BASIS_silicon_111_Parameters.xml',
                    'default_energy': 2.0826,  # meV
                    'vanadium_bins': [-0.0034, 0.068, 0.0034],
                    'vanadium_wav_range': [6.20, 6.33]},
-    'silicon333': {'name': 'silicon333',
+    'silicon_333': {'name': 'silicon_333',
                    'energy_bins': [-1500, 3.2, 5000],
                    'q_bins': [0.9, 0.2, 5.7],
                    'banks': 'bank1,bank3,bank4',
                    'mask_file': 'BASIS_Mask_default_333.xml',
-                   'parameter_file': 'BASIS_silicon_333_Parameters.xml',
-                   'instrument_definition_file': 'BASIS_Definition_Si333.xml',
                    'default_energy': 18.7434,
                    'vanadium_bins': [-0.0333, 0.0666, 0.0333],
                    'vanadium_wav_range': [2.080, 2.108]},
-    'silicon311': {'name': 'silicon311',
+    'silicon_311': {'name': 'silicon_311',
                    'energy_bins': [-740, 1.6, 740],
                    'q_bins': [0.5, 0.2, 3.7],
                    'banks': 'bank2',
                    'mask_file': 'BASIS_Mask_default_311.xml',
-                   'parameter_file': 'BASIS_silicon_311_Parameters.xml',
                    'default_energy': 7.6368,  # meV
                    'vanadium_bins': [-0.015, 0.030, 0.015],
                    'vanadium_wav_range': [3.263, 3.295]}
@@ -139,7 +136,7 @@ class BASISReduction(PythonAlgorithm):
         # Properties affected by the reflection selected
         titleReflection = 'Reflection Selector'
         available_reflections = sorted(REFLECTIONS_DICT.keys())
-        default_reflection = REFLECTIONS_DICT['silicon111']
+        default_reflection = REFLECTIONS_DICT['silicon_111']
         self.declareProperty('ReflectionType', default_reflection['name'],
                              StringListValidator(available_reflections),
                              'Analyzer. Documentation lists typical \
@@ -454,8 +451,8 @@ class BASISReduction(PythonAlgorithm):
     def _calibrate_data(self, sam_ws, mon_ws):
         sapi.MaskDetectors(Workspace=sam_ws,
                            DetectorList=self._dMask)
-        p_f = pjoin(DEFAULT_CONFIG_DIR, self._reflection['parameter_file'])
-        sapi.LoadParameterFile(Workspace=sam_ws, Filename=p_f)
+        rpf = self._elucidate_reflection_parameter_file(sam_ws)
+        sapi.LoadParameterFile(Workspace=sam_ws, Filename=rpf)
         sapi.ModeratorTzeroLinear(InputWorkspace=sam_ws,
                                   OutputWorkspace=sam_ws)
         sapi.ConvertUnits(InputWorkspace=sam_ws,
@@ -464,8 +461,7 @@ class BASISReduction(PythonAlgorithm):
                           EMode='Indirect')
 
         if self._MonNorm:
-            p_f = pjoin(DEFAULT_CONFIG_DIR, self._reflection['parameter_file'])
-            sapi.LoadParameterFile(Workspace=mon_ws, Filename=p_f)
+            sapi.LoadParameterFile(Workspace=mon_ws, Filename=rpf)
             sapi.ModeratorTzeroLinear(InputWorkspace=mon_ws,
                                       OutputWorkspace=mon_ws)
             sapi.Rebin(InputWorkspace=mon_ws,
@@ -660,6 +656,33 @@ class BASISReduction(PythonAlgorithm):
         r = mtd[ws_name].mutableRun()
         r.addProperty('asString', json.dumps(self._as_json), True)
 
+    def _elucidate_reflection_parameter_file(self, ws_name):
+        r"""
+        Search a parameter file for the selected reflection and with
+        valid-from, valid-to dates framing the starting date for the run(s)
+
+        Parameters
+        ----------
+        ws_name: str
+            Name of the workspace from which to retrieve the starting date
+
+        Returns
+        -------
+        str
+            Full path to the parameter file
+        """
+        prefix = 'BASIS_{}_Parameters'.format(self._reflection['name'])
+        instr_directories = [DEFAULT_CONFIG_DIR]
+        start_date = str(mtd[ws_name].getRun().startTime()).strip()
+        parm_files = ExperimentInfo.getResourceFilenames(prefix,
+                                                         ['xml'],
+                                                         instr_directories,
+                                                         start_date)
+        parm_file = parm_files[0]  # first in the list is the most appropriate
+        # store selected parameter file in the logs
+        mtd[ws_name].getRun().addProperty('reflParmFile',
+                                          os.path.basename(parm_file), True)
+        return parm_file
 
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(BASISReduction)

--- a/instrument/BASIS_silicon_111_Parameters.xml
+++ b/instrument/BASIS_silicon_111_Parameters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2010-07-15T00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="11.967"/>
+    <value val="12.925"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="-5.0"/>
+    <value val="0.0"/>
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_111_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_111_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -37,15 +37,15 @@
   </parameter>
 
   <parameter name="reflection" type="string">
-    <value val="333" />
+    <value val="111" />
   </parameter>
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>
@@ -53,11 +53,11 @@
 <component-link name="silicon">
 
   <parameter name="Efixed">
-    <value val="18.7434" />
+    <value val="2.082" />
   </parameter>
 
   <parameter name="resolution">
-    <value val="0.0315" />
+    <value val="0.0035" />
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_311_Parameters.xml
+++ b/instrument/BASIS_silicon_311_Parameters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2010-07-15T00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="11.967"/>
+    <value val="12.9257"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="-5.0"/>
+    <value val="8.7"/>
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_311_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_311_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -31,21 +31,21 @@
   <parameter name="back-end">
     <value val="138000" />
   </parameter>
-
+ 
   <parameter name="analyser" type="string">
     <value val="silicon" />
   </parameter>
 
   <parameter name="reflection" type="string">
-    <value val="333" />
+    <value val="311" />
   </parameter>
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>
@@ -53,11 +53,11 @@
 <component-link name="silicon">
 
   <parameter name="Efixed">
-    <value val="18.7434" />
+    <value val="7.6368" />
   </parameter>
 
   <parameter name="resolution">
-    <value val="0.0315" />
+    <value val="0.015" />
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_333_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_333_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>


### PR DESCRIPTION
**Description of work.**
- [x] New parameter file for each silicon reflection (updated delayed time parameters for the moderator)
- [x] Update `BASISReduction` to select parameter files based on run's timestamp

**Report to:** [nobody]

**To test:**
Run the following script. It will reduce an old run and a new run. The parameter file will be different in each case
```
common_args=dict(MonitorNorm=False, ReflectionType='silicon_111', EnergyBins=[-100, 0.4, 100], MomentumTransferBins=[0.3, 0.2, 1.9])
for run in ('55555', '90177'):
    BASISReduction(RunNumbers=run, **common_args)
    print(mtd['BSS_{}_sqw'.format(run)].getRun().getProperty('reflParmFile').value)
# Printout lines, in this order:
#     BASIS_silicon_111_Parameters_2010_2018.xml
#     BASIS_silicon_111_Parameters.xml
```
This does not require release notes because it involves a change in the backend not exposed to users.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
