### PR TITLE
Fix instrument view exception on 3D rotate

### DIFF
--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -392,9 +392,12 @@ void Projection3D::initRotation(int x, int y) {
  * @param y :: The y screen coord of the mouse pointer.
  */
 void Projection3D::rotate(int x, int y) {
-  m_viewport.generateRotationTo(x, y);
-  m_viewport.initRotationFrom(x, y);
-  updateView(false);
+  try {
+    m_viewport.generateRotationTo(x, y);
+    m_viewport.initRotationFrom(x, y);
+    updateView(false);
+  } catch (std::runtime_error &) {
+  }
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

Introduces a try catch in `Projection3D::rotate` to handle the throw in `V3D::normalise` for 0 vectors (see PR #24893) 

**To test:**

Load the `D33_mask.nxs` from system tests ILL/D33.
Open the instrument view (3D) and rotate it generously, it should never throw an unhandled exception, unlike current `release-next` branch.

*There is no associated issue, neither release notes, since the regression has been introduced recently.*

<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.