### PR TITLE
Windows catalog tooltip fix

### DIFF
--- a/docs/source/release/v4.0.0/ui.rst
+++ b/docs/source/release/v4.0.0/ui.rst
@@ -87,6 +87,7 @@ BugFixes
 - Fixed issue where an open set of data from ITableWorkspace wouldn't update if the data was changed via python.
 - Fixed an issue where MantidPlot would crash when renaming workspaces.
 - Fixed issue with filenames containing spaces that are passed to Mantid when launched from the command line.
+- The catalog search error tooltips now display properly on windows.
 
 MantidWorkbench
 ---------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/CatalogSearch.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/CatalogSearch.h
@@ -197,6 +197,9 @@ private:
   QString m_downloadSaveDir;
   /// The current page the user is on in the results window. Used for paging.
   int m_currentPageNumber;
+
+  void correctedToolTip(std::string toolTip, QLabel *label);
+
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/CatalogSearch.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/CatalogSearch.h
@@ -197,9 +197,8 @@ private:
   QString m_downloadSaveDir;
   /// The current page the user is on in the results window. Used for paging.
   int m_currentPageNumber;
-
+  // Ensure tooltip uses visible color on current OS
   void correctedToolTip(std::string toolTip, QLabel *label);
-
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/CatalogSearch.cpp
+++ b/qt/widgets/common/src/CatalogSearch.cpp
@@ -582,7 +582,7 @@ void CatalogSearch::correctedToolTip(std::string text, QLabel *label) {
       QString::fromStdString("<span style=\"color: black;\">"+text+"</span>"));
   #else
   label->setToolTip(
-      QString::fromStdString("<span style=\"color: white;\">"+toolTip+"</span>"));
+      QString::fromStdString("<span style=\"color: white;\">"+text+"</span>"));
 #endif
 
 }

--- a/qt/widgets/common/src/CatalogSearch.cpp
+++ b/qt/widgets/common/src/CatalogSearch.cpp
@@ -566,15 +566,25 @@ bool CatalogSearch::validateDates() {
   // If startDate > endDate we want to throw an error and inform the user (red
   // star(*)).
   if (ret) {
-    m_icatUiForm.StartDate_err->setToolTip(
-        QString::fromStdString("<span style=\"color: white;\">Start date "
-                               "cannot be greater than end date.</span>"));
+    correctedToolTip("Start date cannot be greater than end date.",
+                     m_icatUiForm.StartDate_err);
     m_icatUiForm.StartDate_err->show();
   } else {
     m_icatUiForm.StartDate_err->hide();
   }
 
   return ret;
+}
+
+void CatalogSearch::correctedToolTip(std::string text, QLabel *label) {
+  #ifdef Q_OS_WIN
+  label->setToolTip(
+      QString::fromStdString("<span style=\"color: black;\">"+text+"</span>"));
+  #else
+  label->setToolTip(
+      QString::fromStdString("<span style=\"color: white;\">"+toolTip+"</span>"));
+#endif
+
 }
 
 /**
@@ -699,8 +709,7 @@ void CatalogSearch::showErrorLabels(
 
     if (label) {
       // Update the tooltip of the element and then show it.
-      label->setToolTip(QString::fromStdString(
-          "<span style=\"color: white;\">" + iter->second + "</span>"));
+      correctedToolTip(iter->second, label);
       label->show();
     }
   }

--- a/qt/widgets/common/src/CatalogSearch.cpp
+++ b/qt/widgets/common/src/CatalogSearch.cpp
@@ -577,14 +577,13 @@ bool CatalogSearch::validateDates() {
 }
 
 void CatalogSearch::correctedToolTip(std::string text, QLabel *label) {
-  #ifdef Q_OS_WIN
-  label->setToolTip(
-      QString::fromStdString("<span style=\"color: black;\">"+text+"</span>"));
-  #else
-  label->setToolTip(
-      QString::fromStdString("<span style=\"color: white;\">"+text+"</span>"));
+#ifdef Q_OS_WIN
+  label->setToolTip(QString::fromStdString("<span style=\"color: black;\">" +
+                                           text + "</span>"));
+#else
+  label->setToolTip(QString::fromStdString("<span style=\"color: white;\">" +
+                                           text + "</span>"));
 #endif
-
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
The Tooltips from mistakes in date entries in the catalog search were unreadable on windows, due to being white text on a white background, this change checks if the operating system is windows, so that the text of the tooltip is not set to white on windows.
**To test:**
login to the catalog, and enter date in an incorrect format, e.g. `  / 1/ 10` into either start or end date, click search, then mouse over the asterisk next to the data you entered, the tooltip displayed should contain visible text, this should also be check with entering a start date greater than the entered end date.


*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
