### PR TITLE
Updated Group to use spectrum not workspace index

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -21,7 +21,7 @@ Q.convention = Inelastic
 
 # Set of PyQt interfaces to add to the Interfaces menu, separated by a space.  Interfaces are seperated from their respective categories by a "/".
 
-mantidqt.python_interfaces = Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry_Old.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS.py Muon/Frequency_Domain_Analysis.py Muon/Elemental_Analysis.py Muon/Frequency_Domain_Analysis_Old.py  Muon/Elemental_Analysis_old.py
+mantidqt.python_interfaces = Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry_Old.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS.py Muon/Frequency_Domain_Analysis.py Muon/Elemental_Analysis.py Muon/Frequency_Domain_Analysis_Old.py Muon/Elemental_Analysis_old.py
 
 # Directory containing the above startup scripts
 mantidqt.python_interfaces_directory = @MANTID_ROOT@/scripts

--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -126,6 +126,7 @@ Bugfixes
   in order to avoid these large file sizes.
 - A bug where using a cropped calibration file (from a previous run) on the ISISEnergyTransfer interface would cause an 
   error has been fixed.
+- A bug where specifying a custom detector grouping for Osiris was not working has been fixed.
 
 Bayes Interface
 ---------------

--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -126,7 +126,7 @@ Bugfixes
   in order to avoid these large file sizes.
 - A bug where using a cropped calibration file (from a previous run) on the ISISEnergyTransfer interface would cause an 
   error has been fixed.
-- A bug where specifying a custom detector grouping for Osiris was not working has been fixed.
+- A bug where specifying a custom detector grouping for OSIRIS was not working has been fixed.
 
 Bayes Interface
 ---------------

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -41,8 +41,10 @@ std::string createGroupString(std::size_t const &start,
 std::string createGroupingString(std::size_t const &groupSize,
                                  std::size_t const &numberOfGroups,
                                  std::size_t const &spectraMin) {
-  auto groupingString = createRangeString(spectraMin, spectraMin + groupSize - 1);
-  for (auto i = spectraMin + groupSize; i < spectraMin + groupSize * numberOfGroups; i += groupSize)
+  auto groupingString =
+      createRangeString(spectraMin, spectraMin + groupSize - 1);
+  for (auto i = spectraMin + groupSize;
+       i < spectraMin + groupSize * numberOfGroups; i += groupSize)
     groupingString += "," + createGroupString(i, groupSize);
   return groupingString;
 }
@@ -51,7 +53,8 @@ std::string createDetectorGroupingString(std::size_t const &groupSize,
                                          std::size_t const &numberOfGroups,
                                          std::size_t const &numberOfDetectors,
                                          std::size_t const &spectraMin) {
-  const auto groupingString = createGroupingString(groupSize, numberOfGroups, spectraMin);
+  const auto groupingString =
+      createGroupingString(groupSize, numberOfGroups, spectraMin);
   const auto remainder = numberOfDetectors % numberOfGroups;
   if (remainder == 0)
     return groupingString;
@@ -617,8 +620,7 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
 std::string ISISEnergyTransfer::getDetectorGroupingString() const {
   const unsigned int nGroups = m_uiForm.spNumberGroups->value();
   const unsigned int spectraMin = m_uiForm.spSpectraMin->value();
-  const unsigned int nSpectra =
-      1 + m_uiForm.spSpectraMax->value() - spectraMin;
+  const unsigned int nSpectra = 1 + m_uiForm.spSpectraMax->value() - spectraMin;
   return createDetectorGroupingString(static_cast<std::size_t>(nSpectra),
                                       static_cast<std::size_t>(nGroups),
                                       static_cast<std::size_t>(spectraMin));

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -39,32 +39,35 @@ std::string createGroupString(std::size_t const &start,
 }
 
 std::string createGroupingString(std::size_t const &groupSize,
-                                 std::size_t const &numberOfGroups) {
-  auto groupingString = createRangeString(0, groupSize - 1);
-  for (auto i = groupSize; i < groupSize * numberOfGroups; i += groupSize)
+                                 std::size_t const &numberOfGroups,
+                                 std::size_t const &spectraMin) {
+  auto groupingString = createRangeString(spectraMin, spectraMin + groupSize - 1);
+  for (auto i = spectraMin + groupSize; i < spectraMin + groupSize * numberOfGroups; i += groupSize)
     groupingString += "," + createGroupString(i, groupSize);
   return groupingString;
 }
 
 std::string createDetectorGroupingString(std::size_t const &groupSize,
                                          std::size_t const &numberOfGroups,
-                                         std::size_t const &numberOfDetectors) {
-  const auto groupingString = createGroupingString(groupSize, numberOfGroups);
+                                         std::size_t const &numberOfDetectors,
+                                         std::size_t const &spectraMin) {
+  const auto groupingString = createGroupingString(groupSize, numberOfGroups, spectraMin);
   const auto remainder = numberOfDetectors % numberOfGroups;
   if (remainder == 0)
     return groupingString;
   return groupingString + "," +
-         createRangeString(numberOfDetectors - remainder,
-                           numberOfDetectors - 1);
+         createRangeString(spectraMin + numberOfDetectors - remainder,
+                           spectraMin + numberOfDetectors - 1);
 }
 
 std::string createDetectorGroupingString(std::size_t const &numberOfDetectors,
-                                         std::size_t const &numberOfGroups) {
+                                         std::size_t const &numberOfGroups,
+                                         std::size_t const &spectraMin) {
   const auto groupSize = numberOfDetectors / numberOfGroups;
   if (groupSize == 0)
-    return createRangeString(0, numberOfDetectors - 1);
+    return createRangeString(spectraMin, spectraMin + numberOfDetectors - 1);
   return createDetectorGroupingString(groupSize, numberOfGroups,
-                                      numberOfDetectors);
+                                      numberOfDetectors, spectraMin);
 }
 
 std::vector<std::size_t>
@@ -613,10 +616,12 @@ ISISEnergyTransfer::createMapFile(const std::string &groupType) {
 
 std::string ISISEnergyTransfer::getDetectorGroupingString() const {
   const unsigned int nGroups = m_uiForm.spNumberGroups->value();
+  const unsigned int spectraMin = m_uiForm.spSpectraMin->value();
   const unsigned int nSpectra =
-      1 + m_uiForm.spSpectraMax->value() - m_uiForm.spSpectraMin->value();
+      1 + m_uiForm.spSpectraMax->value() - spectraMin;
   return createDetectorGroupingString(static_cast<std::size_t>(nSpectra),
-                                      static_cast<std::size_t>(nGroups));
+                                      static_cast<std::size_t>(nGroups),
+                                      static_cast<std::size_t>(spectraMin));
 }
 
 /**

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -593,7 +593,7 @@ def get_group_from_string(grouping_string):
 
 
 def create_group_from_string(group_detectors, grouping_string):
-    group_detectors.setProperty("WorkspaceIndexList", get_group_from_string(grouping_string))
+    group_detectors.setProperty("SpectraList", get_group_from_string(grouping_string))
     group_detectors.setProperty("OutputWorkspace", "__temp")
     group_detectors.execute()
     return group_detectors.getProperty("OutputWorkspace").value


### PR DESCRIPTION
**Description of work.**

The issue here appears to be that the code was taking a spectra list and treating it like a workspace index which led to issues on OSIRIS where these two lists are offset by a large number. I have I think corrected the issue by getting the relevant algorithm to treat the list as a spectrum list rather than a workspace index list. This may produce some change in the data for other instruments however as the spectrum number is offset by one from the workspace index for them as well.

**To test:**

Check that the issue described in #25073 is resolved

<!-- Instructions for testing. -->

Fixes #25073  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
