### PR TITLE
ALC interface clears selectors and checks input

### DIFF
--- a/docs/source/release/v4.0.0/muon.rst
+++ b/docs/source/release/v4.0.0/muon.rst
@@ -27,6 +27,8 @@ Bugfixes
 - Results table will produce correct values for co-added runs.
 - The x limits on the settings tab will now correct themselves if bad values are entered. 
 - The `load current run` button now works for CHRONUS in muon analysis.
+- ALC interface now removes all of the fitting regions for the baseline modelling when the data changes.
+- ALC interface now produces a warning if the custom grouping is not valid.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
@@ -169,6 +169,11 @@ void ALCBaselineModellingPresenter::updateDataCurve() {
   assert(data);
   m_view->setDataCurve(*(QwtHelper::curveDataFromWs(data, 0)),
                        QwtHelper::curveErrorsFromWs(data, 0));
+  // Delete all section selectors
+  int noRows = m_view->noOfSectionRows() - 1;
+  for (int j = noRows; j>-1; --j) {
+    removeSection(j);
+  }
 }
 
 void ALCBaselineModellingPresenter::updateCorrectedCurve() {

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingPresenter.cpp
@@ -171,7 +171,7 @@ void ALCBaselineModellingPresenter::updateDataCurve() {
                        QwtHelper::curveErrorsFromWs(data, 0));
   // Delete all section selectors
   int noRows = m_view->noOfSectionRows() - 1;
-  for (int j = noRows; j>-1; --j) {
+  for (int j = noRows; j > -1; --j) {
     removeSection(j);
   }
 }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -329,10 +329,10 @@ bool ALCDataLoadingPresenter::checkCustomGrouping() {
     auto detectors = Mantid::Kernel::Strings::parseRange(
         isCustomGroupingValid(m_view->getForwardGrouping(), groupingOK));
     const auto backward = Mantid::Kernel::Strings::parseRange(
-        isCustomGroupingValid(m_view->getBackwardGrouping(),groupingOK));
-    if(!groupingOK){
+        isCustomGroupingValid(m_view->getBackwardGrouping(), groupingOK));
+    if (!groupingOK) {
       return groupingOK;
-	}
+    }
     detectors.insert(detectors.end(), backward.begin(), backward.end());
     for (const int det : detectors) {
       if (det < 0 || det > static_cast<int>(m_numDetectors)) {
@@ -352,8 +352,9 @@ bool ALCDataLoadingPresenter::checkCustomGrouping() {
  */
 std::string
 ALCDataLoadingPresenter::isCustomGroupingValid(const std::string &group,
-                                            bool &isValid) { 
-  if (!std::isdigit(group[0]) || std::any_of(std::begin(group), std::end(group), ::isalpha)) {
+                                               bool &isValid) {
+  if (!std::isdigit(group[0]) ||
+      std::any_of(std::begin(group), std::end(group), ::isalpha)) {
     isValid = false;
     return "";
   }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -325,10 +325,14 @@ void ALCDataLoadingPresenter::setData(MatrixWorkspace_const_sptr data) {
 bool ALCDataLoadingPresenter::checkCustomGrouping() {
   bool groupingOK = true;
   if (m_view->detectorGroupingType() == "Custom") {
-    auto detectors =
-        Mantid::Kernel::Strings::parseRange(m_view->getForwardGrouping());
-    const auto backward =
-        Mantid::Kernel::Strings::parseRange(m_view->getBackwardGrouping());
+    auto fds = m_view->getForwardGrouping();
+    auto detectors = Mantid::Kernel::Strings::parseRange(
+        isCustomGroupingValid(m_view->getForwardGrouping(), groupingOK));
+    const auto backward = Mantid::Kernel::Strings::parseRange(
+        isCustomGroupingValid(m_view->getBackwardGrouping(),groupingOK));
+    if(!groupingOK){
+      return groupingOK;
+	}
     detectors.insert(detectors.end(), backward.begin(), backward.end());
     for (const int det : detectors) {
       if (det < 0 || det > static_cast<int>(m_numDetectors)) {
@@ -339,5 +343,22 @@ bool ALCDataLoadingPresenter::checkCustomGrouping() {
   }
   return groupingOK;
 }
+/**
+ * Check basic group string is valid
+ * i.e. does not contain letters or start with , or -
+ * @param group :: the string of the grouping
+ * @param isValid :: bool to say if the string is valid
+ * @returns :: True if grouping OK, false if bad
+ */
+std::string
+ALCDataLoadingPresenter::isCustomGroupingValid(const std::string &group,
+                                            bool &isValid) { 
+  if (!std::isdigit(group[0]) || std::any_of(std::begin(group), std::end(group), ::isalpha)) {
+    isValid = false;
+    return "";
+  }
+  return group;
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -325,7 +325,6 @@ void ALCDataLoadingPresenter::setData(MatrixWorkspace_const_sptr data) {
 bool ALCDataLoadingPresenter::checkCustomGrouping() {
   bool groupingOK = true;
   if (m_view->detectorGroupingType() == "Custom") {
-    auto fds = m_view->getForwardGrouping();
     auto detectors = Mantid::Kernel::Strings::parseRange(
         isCustomGroupingValid(m_view->getForwardGrouping(), groupingOK));
     const auto backward = Mantid::Kernel::Strings::parseRange(

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.h
@@ -72,6 +72,9 @@ private:
   /// Check custom grouping is sensible
   bool checkCustomGrouping();
 
+  /// Check the group is valid
+  std::string isCustomGroupingValid(const std::string &group, bool &isValid);
+
   /// View which the object works with
   IALCDataLoadingView *const m_view;
 


### PR DESCRIPTION
Updated the muon ALC interface to handle changing of the run and to not crash when a bad group is used. 


**To test:**
Set instrument to HIFI
Open ALC
Load 149118 to 149128
Go to base line modelling and 3 regions and do a fit
Go to the next stage and fit a peak
Go back to the load page and change the last run to 149148
Go to base line modelling and check that the selectors are gone

Go back to the load page
Select `custom` group
Enter a valid pair (e.g. 1,2,3-5)
Check it loads ok
For group enter invalid examples (e.g. start with a minus sign or have characters in the list)
Check it gives a warning and does not crash
<!-- Instructions for testing. -->

Fixes #24838. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
