### PR TITLE
Fixes to Kernel::Material

### DIFF
--- a/Framework/DataHandling/test/SetSampleMaterialTest.h
+++ b/Framework/DataHandling/test/SetSampleMaterialTest.h
@@ -179,7 +179,7 @@ public:
     TS_ASSERT_DELTA(sampleMaterial.absorbXSection(NeutronAtom::ReferenceLambda),
                     1.4381, 0.0001);
     TS_ASSERT_DELTA(
-        sampleMaterial.cohScatterLength(NeutronAtom::ReferenceLambda), 5.1834,
+        sampleMaterial.cohScatterLength(NeutronAtom::ReferenceLambda), 3.8082,
         0.0001);
     TS_ASSERT_DELTA(
         sampleMaterial.totalScatterLengthSqrd(NeutronAtom::ReferenceLambda),

--- a/Framework/Kernel/inc/MantidKernel/Material.h
+++ b/Framework/Kernel/inc/MantidKernel/Material.h
@@ -38,6 +38,10 @@ namespace Kernel {
     <LI>number density (nAtoms / Angstrom^3)</LI>
   </UL>
 
+  To understand how the effective scattering information is calculated, see
+  Sears, Varley F. "Neutron scattering lengths and cross sections." Neutron
+  news 3.3 (1992): 26-37. To highlight a point that may be missed, the
+  absorption is the only quantity that is wavelength dependent.
 */
 class MANTID_KERNEL_DLL Material final {
 public:

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -51,7 +51,7 @@ inline double scatteringXS(const double realLength, const double imagLength) {
     return .04 * M_PI * lengthSqrd;
   }
 }
-} // anonymous
+} // namespace
 
 Mantid::Kernel::Material::FormulaUnit::FormulaUnit(
     const boost::shared_ptr<PhysicalConstants::Atom> &atom,
@@ -230,9 +230,9 @@ double Material::absorbXSection(const double lambda) const {
         std::accumulate(std::begin(m_chemicalFormula),
                         std::end(m_chemicalFormula), 0.,
                         [](double subtotal, const FormulaUnit &right) {
-          return subtotal +
-                 right.atom->neutron.abs_scatt_xs * right.multiplicity;
-        }) /
+                          return subtotal + right.atom->neutron.abs_scatt_xs *
+                                                right.multiplicity;
+                        }) /
         m_atomTotal;
   }
 

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -24,7 +24,34 @@ using PhysicalConstants::getAtom;
 
 namespace {
 const double INV_FOUR_PI = 1. / (4. * M_PI);
+
+inline double scatteringLength(const double real, const double imag) {
+  double length;
+  if (imag == 0.) {
+    length = std::abs(real);
+  } else if (real == 0.) {
+    length = std::abs(imag);
+  } else {
+    length = std::sqrt(real * real + imag * imag);
+  }
+
+  if (!std::isnormal(length)) {
+    return 0.;
+  } else {
+    return length;
+  }
 }
+
+inline double scatteringXS(const double realLength, const double imagLength) {
+  double lengthSqrd = (realLength * realLength) + (imagLength * imagLength);
+
+  if (!std::isnormal(lengthSqrd)) {
+    return 0.;
+  } else {
+    return .04 * M_PI * lengthSqrd;
+  }
+}
+} // anonymous
 
 Mantid::Kernel::Material::FormulaUnit::FormulaUnit(
     const boost::shared_ptr<PhysicalConstants::Atom> &atom,
@@ -77,12 +104,13 @@ Material::Material(const std::string &name,
       m_pressure(pressure) {
   if (atom.z_number == 0) { // user specified atom
     m_chemicalFormula.emplace_back(atom, 1.);
-  } else if (atom.z_number > 0) { // single isotope
+  } else if (atom.a_number > 0) { // single isotope
     m_chemicalFormula.emplace_back(getAtom(atom.z_number, atom.a_number), 1.);
   } else { // isotopic average
     m_chemicalFormula.emplace_back(atom, 1.);
   }
 }
+
 // update the total atom count
 void Material::countAtoms() {
   m_atomTotal = std::accumulate(std::begin(m_chemicalFormula),
@@ -121,8 +149,8 @@ double Material::temperature() const { return m_temperature; }
 double Material::pressure() const { return m_pressure; }
 
 /**
- * Get the coherent scattering cross section for a given wavelength.
- * CURRENTLY this simply returns the value for the underlying element
+ * Get the coherent scattering cross section according to Sears eqn 7.
+ *
  * @param lambda :: The wavelength to evaluate the cross section
  * @returns The value of the coherent scattering cross section at
  * the given wavelength
@@ -130,25 +158,15 @@ double Material::pressure() const { return m_pressure; }
 double Material::cohScatterXSection(const double lambda) const {
   UNUSED_ARG(lambda);
 
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.coh_scatt_xs *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.coh_scatt_xs;
 
-  if (!std::isnormal(weightedTotal)) {
-    return 0.;
-  } else {
-    return weightedTotal;
-  }
+  return scatteringXS(cohScatterLengthReal(), cohScatterLengthImg());
 }
 
 /**
- * Get the incoherent scattering cross section for a given wavelength
- * CURRENTLY this simply returns the value for the underlying element
+ * Get the incoherent scattering cross section according to Sears eqn 16
+ *
  * @param lambda :: The wavelength to evaluate the cross section
  * @returns The value of the coherent scattering cross section at
  * the given wavelength
@@ -156,32 +174,24 @@ double Material::cohScatterXSection(const double lambda) const {
 double Material::incohScatterXSection(const double lambda) const {
   UNUSED_ARG(lambda);
 
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.inc_scatt_xs *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.inc_scatt_xs;
 
-  if (!std::isnormal(weightedTotal)) {
-    return 0.;
-  } else {
-    return weightedTotal;
-  }
+  return totalScatterXSection() - cohScatterXSection();
 }
 
 /**
- * Get the total scattering cross section for a given wavelength
- * CURRENTLY this simply returns the value for sum of the incoherent
- * and coherent scattering cross sections.
+ * Get the total scattering cross section following Sears eqn 13.
+ *
  * @param lambda :: The wavelength to evaluate the cross section
  * @returns The value of the total scattering cross section at
  * the given wavelength
  */
 double Material::totalScatterXSection(const double lambda) const {
   UNUSED_ARG(lambda);
+
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.tot_scatt_xs;
 
   const double weightedTotal =
       std::accumulate(std::begin(m_chemicalFormula),
@@ -200,23 +210,31 @@ double Material::totalScatterXSection(const double lambda) const {
 }
 
 /**
- * Get the absorption cross section for a given wavelength.
+ * Get the absorption cross section for a given wavelength
+ * according to Sears eqn 14
+ *
  * CURRENTLY This assumes a linear dependence on the wavelength with the
- * reference
- * wavelength = NeutronAtom::ReferenceLambda angstroms.
+ * reference wavelength = NeutronAtom::ReferenceLambda angstroms.
+ *
  * @param lambda :: The wavelength to evaluate the cross section
  * @returns The value of the absoprtion cross section at
  * the given wavelength
  */
 double Material::absorbXSection(const double lambda) const {
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.abs_scatt_xs *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  double weightedTotal;
+
+  if (m_chemicalFormula.size() == 1) {
+    weightedTotal = m_chemicalFormula.begin()->atom->neutron.abs_scatt_xs;
+  } else {
+    weightedTotal =
+        std::accumulate(std::begin(m_chemicalFormula),
+                        std::end(m_chemicalFormula), 0.,
+                        [](double subtotal, const FormulaUnit &right) {
+          return subtotal +
+                 right.atom->neutron.abs_scatt_xs * right.multiplicity;
+        }) /
+        m_atomTotal;
+  }
 
   if (!std::isnormal(weightedTotal)) {
     return 0.;
@@ -225,46 +243,31 @@ double Material::absorbXSection(const double lambda) const {
   }
 }
 
+/// According to Sears eqn 12
 double Material::cohScatterLength(const double lambda) const {
   UNUSED_ARG(lambda);
 
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.coh_scatt_length *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.coh_scatt_length;
 
-  if (!std::isnormal(weightedTotal)) {
-    return 0.;
-  } else {
-    return weightedTotal;
-  }
+  return scatteringLength(cohScatterLengthReal(), cohScatterLengthImg());
 }
 
+/// According to Sears eqn 7
 double Material::incohScatterLength(const double lambda) const {
   UNUSED_ARG(lambda);
 
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.inc_scatt_length *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.inc_scatt_length;
 
-  if (!std::isnormal(weightedTotal)) {
-    return 0.;
-  } else {
-    return weightedTotal;
-  }
+  return scatteringLength(incohScatterLengthReal(), incohScatterLengthImg());
 }
 
+/// Sears eqn 12
 double Material::cohScatterLengthReal(const double lambda) const {
   UNUSED_ARG(lambda);
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.coh_scatt_length_real;
 
   const double weightedTotal =
       std::accumulate(
@@ -282,8 +285,12 @@ double Material::cohScatterLengthReal(const double lambda) const {
   }
 }
 
+/// Sears eqn 12
 double Material::cohScatterLengthImg(const double lambda) const {
   UNUSED_ARG(lambda);
+
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.coh_scatt_length_img;
 
   const double weightedTotal =
       std::accumulate(
@@ -301,8 +308,12 @@ double Material::cohScatterLengthImg(const double lambda) const {
   }
 }
 
+/// Not explicitly in Sears, but following eqn 12
 double Material::incohScatterLengthReal(const double lambda) const {
   UNUSED_ARG(lambda);
+
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.inc_scatt_length_real;
 
   const double weightedTotal =
       std::accumulate(
@@ -320,8 +331,12 @@ double Material::incohScatterLengthReal(const double lambda) const {
   }
 }
 
+/// Not explicitly in Sears, but following eqn 12
 double Material::incohScatterLengthImg(const double lambda) const {
   UNUSED_ARG(lambda);
+
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.inc_scatt_length_img;
 
   const double weightedTotal =
       std::accumulate(
@@ -339,52 +354,42 @@ double Material::incohScatterLengthImg(const double lambda) const {
   }
 }
 
+/// Sears eqn 13
 double Material::totalScatterLength(const double lambda) const {
   UNUSED_ARG(lambda);
 
-  const double weightedTotal =
-      std::accumulate(std::begin(m_chemicalFormula),
-                      std::end(m_chemicalFormula), 0.,
-                      [](double subtotal, const FormulaUnit &right) {
-                        return subtotal + right.atom->neutron.tot_scatt_length *
-                                              right.multiplicity;
-                      }) /
-      m_atomTotal;
+  if (m_chemicalFormula.size() == 1)
+    return m_chemicalFormula.begin()->atom->neutron.tot_scatt_length;
 
-  if (!std::isnormal(weightedTotal)) {
-    return 0.;
-  } else {
-    return weightedTotal;
-  }
+  const double crossSection = totalScatterXSection();
+  return 10. * std::sqrt(crossSection) * INV_FOUR_PI;
 }
 
 double Material::cohScatterLengthSqrd(const double lambda) const {
-  const double weightedTotalReal = this->cohScatterLengthReal(lambda);
-  const double weightedTotalImg = this->cohScatterLengthImg();
+  UNUSED_ARG(lambda);
 
-  if (!std::isnormal(weightedTotalReal)) {
-    return 0.;
-  } else {
-    return (weightedTotalReal * weightedTotalReal) +
-           (weightedTotalImg * weightedTotalImg);
-  }
+  // these have already acconted for single atom case
+  const double cohReal = this->cohScatterLengthReal();
+  const double cohImag = this->cohScatterLengthImg();
+
+  return (cohReal * cohReal + cohImag * cohImag);
 }
 
 double Material::incohScatterLengthSqrd(const double lambda) const {
-  const double weightedTotalReal = this->incohScatterLengthReal(lambda);
-  const double weightedTotalImg = this->incohScatterLengthImg(lambda);
+  UNUSED_ARG(lambda);
 
-  if (!std::isnormal(weightedTotalReal)) {
-    return 0.;
-  } else {
-    return (weightedTotalReal * weightedTotalReal) +
-           (weightedTotalImg * weightedTotalImg);
-  }
+  // cross section has this properly averaged already
+  const double crossSection = incohScatterXSection();
+
+  // 1 barn = 100 fm^2
+  return 100. * crossSection * INV_FOUR_PI;
 }
 
 double Material::totalScatterLengthSqrd(const double lambda) const {
+  UNUSED_ARG(lambda);
+
   // cross section has this properly averaged already
-  double crossSection = totalScatterXSection(lambda);
+  const double crossSection = totalScatterXSection();
 
   // 1 barn = 100 fm^2
   return 100. * crossSection * INV_FOUR_PI;

--- a/Framework/Kernel/src/NeutronAtom.cpp
+++ b/Framework/Kernel/src/NeutronAtom.cpp
@@ -31,12 +31,12 @@ void calculateScatteringLengths(NeutronAtom &atom) {
   atom.tot_scatt_length = 10. * std::sqrt(atom.tot_scatt_xs * INV_FOUR_PI);
 
   if (atom.coh_scatt_length_img == 0.)
-    atom.coh_scatt_length = fabs(atom.coh_scatt_length_real);
+    atom.coh_scatt_length = std::abs(atom.coh_scatt_length_real);
   else
     atom.coh_scatt_length = 10. * std::sqrt(atom.coh_scatt_xs * INV_FOUR_PI);
 
   if (atom.inc_scatt_length_img == 0.)
-    atom.inc_scatt_length = fabs(atom.inc_scatt_length_real);
+    atom.inc_scatt_length = std::abs(atom.inc_scatt_length_real);
   else
     atom.inc_scatt_length = 10. * std::sqrt(atom.inc_scatt_xs * INV_FOUR_PI);
 }

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -9,8 +9,8 @@
 
 #include <cmath>
 #include <cxxtest/TestSuite.h>
-#include <stdexcept>
 #include <iostream>
+#include <stdexcept>
 
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/Material.h"
@@ -82,8 +82,10 @@ public:
 
     // check everything against another wavelength, only affects absorption
     const double lambda(2.1);
-    TS_ASSERT_DELTA(material.cohScatterXSection(lambda), material.cohScatterXSection(), 1e-04);
-    TS_ASSERT_DELTA(material.incohScatterXSection(lambda), material.incohScatterXSection(), 1e-04);
+    TS_ASSERT_DELTA(material.cohScatterXSection(lambda),
+                    material.cohScatterXSection(), 1e-04);
+    TS_ASSERT_DELTA(material.incohScatterXSection(lambda),
+                    material.incohScatterXSection(), 1e-04);
     TS_ASSERT_DELTA(material.absorbXSection(lambda), 5.93, 1e-02);
   }
 
@@ -98,8 +100,8 @@ public:
     // check everything with (default) reference wavelength
     checkMatching(material, atom);
     const double totLength = material.totalScatterLength();
-    TS_ASSERT_DELTA(.04 * M_PI * totLength * totLength, material.totalScatterXSection(), 1.e-4);
-
+    TS_ASSERT_DELTA(.04 * M_PI * totLength * totLength,
+                    material.totalScatterXSection(), 1.e-4);
   }
 
   // "null scatterer" has only incoherent scattering

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cxxtest/TestSuite.h>
 #include <stdexcept>
+#include <iostream>
 
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/Material.h"
@@ -17,6 +18,8 @@
 #include "MantidTestHelpers/NexusTestHelper.h"
 
 using Mantid::Kernel::Material;
+using Mantid::PhysicalConstants::NeutronAtom;
+using Mantid::PhysicalConstants::getNeutronAtom;
 
 class MaterialTest : public CxxTest::TestSuite {
 public:
@@ -33,20 +36,96 @@ public:
     TS_ASSERT_EQUALS(empty.absorbXSection(lambda), 0.0);
   }
 
-  void test_That_Construction_By_Known_Element_Gives_Expected_Values() {
-    Material vanBlock("vanBlock",
-                      Mantid::PhysicalConstants::getNeutronAtom(23, 0), 0.072);
+  // common code for comparing scattering information for material made of a
+  // single atom
+  void checkMatching(const Material &material, const NeutronAtom &atom) {
+    TS_ASSERT_DELTA(material.cohScatterXSection(), atom.coh_scatt_xs, 1.e-4);
+    TS_ASSERT_DELTA(material.incohScatterXSection(), atom.inc_scatt_xs, 1.e-4);
+    TS_ASSERT_DELTA(material.totalScatterXSection(), atom.tot_scatt_xs, 1.e-4);
+    TS_ASSERT_DELTA(material.absorbXSection(), atom.abs_scatt_xs, 1.e-4);
+    TS_ASSERT_DELTA(material.cohScatterLength(), atom.coh_scatt_length, 1.e-4);
+    TS_ASSERT_DELTA(material.incohScatterLength(), atom.inc_scatt_length,
+                    1.e-4);
+    TS_ASSERT_DELTA(material.totalScatterLength(), atom.tot_scatt_length,
+                    1.e-4);
+    TS_ASSERT_DELTA(material.cohScatterLengthReal(), atom.coh_scatt_length_real,
+                    1.e-4);
+    TS_ASSERT_DELTA(material.cohScatterLengthImg(), atom.coh_scatt_length_img,
+                    1.e-4);
+    TS_ASSERT_DELTA(material.incohScatterLengthReal(),
+                    atom.inc_scatt_length_real, 1.e-4);
+    TS_ASSERT_DELTA(material.incohScatterLengthImg(), atom.inc_scatt_length_img,
+                    1.e-4);
+    const double cohReal = atom.coh_scatt_length_real;
+    const double cohImag = atom.coh_scatt_length_img;
+    TS_ASSERT_DELTA(material.cohScatterLengthSqrd(),
+                    cohReal * cohReal + cohImag * cohImag, 1.e-4);
+    const double totXS = atom.tot_scatt_xs;
+    TS_ASSERT_DELTA(material.totalScatterLengthSqrd(), 25. * totXS / M_PI,
+                    1.e-4);
+  }
 
-    TS_ASSERT_EQUALS(vanBlock.name(), "vanBlock");
-    TS_ASSERT_EQUALS(vanBlock.numberDensity(), 0.072);
-    TS_ASSERT_EQUALS(vanBlock.temperature(), 300);
-    TS_ASSERT_EQUALS(vanBlock.pressure(),
+  void test_Vanadium() {
+    const std::string name("Vanadium");
+    NeutronAtom atom = getNeutronAtom(23);
+    std::cout << "--->>> " << name << ": " << atom << std::endl;
+    Material material(name, atom, 0.072);
+
+    TS_ASSERT_EQUALS(material.name(), name);
+    TS_ASSERT_EQUALS(material.numberDensity(), 0.072);
+    TS_ASSERT_EQUALS(material.temperature(), 300);
+    TS_ASSERT_EQUALS(material.pressure(),
                      Mantid::PhysicalConstants::StandardAtmosphere);
 
+    // check everything with (default) reference wavelength
+    checkMatching(material, atom);
+
+    // check everything against another wavelength, only affects absorption
     const double lambda(2.1);
-    TS_ASSERT_DELTA(vanBlock.cohScatterXSection(lambda), 0.0184, 1e-02);
-    TS_ASSERT_DELTA(vanBlock.incohScatterXSection(lambda), 5.08, 1e-02);
-    TS_ASSERT_DELTA(vanBlock.absorbXSection(lambda), 5.93, 1e-02);
+    TS_ASSERT_DELTA(material.cohScatterXSection(lambda), material.cohScatterXSection(), 1e-04);
+    TS_ASSERT_DELTA(material.incohScatterXSection(lambda), material.incohScatterXSection(), 1e-04);
+    TS_ASSERT_DELTA(material.absorbXSection(lambda), 5.93, 1e-02);
+  }
+
+  // highly absorbing material
+  void test_Gadolinium() {
+    const std::string name("Gadolinium");
+    NeutronAtom atom = getNeutronAtom(64);
+    std::cout << "--->>> " << name << ": " << atom << std::endl;
+    Material material(name, atom, 0.072); // TODO mass density is 7.90 g/cm3
+    TS_ASSERT_EQUALS(material.name(), name);
+
+    // check everything with (default) reference wavelength
+    checkMatching(material, atom);
+    const double totLength = material.totalScatterLength();
+    TS_ASSERT_DELTA(.04 * M_PI * totLength * totLength, material.totalScatterXSection(), 1.e-4);
+
+  }
+
+  // "null scatterer" has only incoherent scattering
+  void test_TiZr() {
+    Material TiZr("TiZr", Material::parseChemicalFormula("Ti2.082605 Zr"),
+                  0.542);
+    std::cout << "--->>> TiZr" << std::endl;
+
+    TS_ASSERT_EQUALS(TiZr.cohScatterLengthImg(), 0.);
+    TS_ASSERT_DELTA(TiZr.cohScatterLengthReal(), 0., 1.e-5);
+    TS_ASSERT_EQUALS(
+        TiZr.cohScatterLength(),
+        TiZr.cohScatterLengthReal()); // there  is no imaginary part
+    TS_ASSERT_DELTA(TiZr.cohScatterXSection(), 0., 1.e-5);
+
+    TS_ASSERT_DELTA(TiZr.totalScatterXSection(),
+                    TiZr.cohScatterXSection() + TiZr.incohScatterXSection(),
+                    1.e-5);
+
+    const double cohReal = TiZr.cohScatterLengthReal();
+    const double cohImag = TiZr.cohScatterLengthImg();
+    TS_ASSERT_DELTA(TiZr.cohScatterLengthSqrd(),
+                    cohReal * cohReal + cohImag * cohImag, 1.e-4);
+
+    const double totXS = TiZr.totalScatterXSection();
+    TS_ASSERT_DELTA(TiZr.totalScatterLengthSqrd(), 25. * totXS / M_PI, 1.e-4);
   }
 
   /** Save then re-load from a NXS file */

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -68,7 +68,6 @@ public:
   void test_Vanadium() {
     const std::string name("Vanadium");
     NeutronAtom atom = getNeutronAtom(23);
-    std::cout << "--->>> " << name << ": " << atom << std::endl;
     Material material(name, atom, 0.072);
 
     TS_ASSERT_EQUALS(material.name(), name);
@@ -93,8 +92,7 @@ public:
   void test_Gadolinium() {
     const std::string name("Gadolinium");
     NeutronAtom atom = getNeutronAtom(64);
-    std::cout << "--->>> " << name << ": " << atom << std::endl;
-    Material material(name, atom, 0.072); // TODO mass density is 7.90 g/cm3
+    Material material(name, atom, 0.0768); // mass density is 7.90 g/cm3
     TS_ASSERT_EQUALS(material.name(), name);
 
     // check everything with (default) reference wavelength
@@ -108,7 +106,6 @@ public:
   void test_TiZr() {
     Material TiZr("TiZr", Material::parseChemicalFormula("Ti2.082605 Zr"),
                   0.542);
-    std::cout << "--->>> TiZr" << std::endl;
 
     TS_ASSERT_EQUALS(TiZr.cohScatterLengthImg(), 0.);
     TS_ASSERT_DELTA(TiZr.cohScatterLengthReal(), 0., 1.e-5);

--- a/Framework/Kernel/test/NeutronAtomTest.h
+++ b/Framework/Kernel/test/NeutronAtomTest.h
@@ -29,6 +29,34 @@ public:
     TS_ASSERT_EQUALS(curium.coh_scatt_length_real, 7.7);
   }
 
+  void testVanadium() {
+    NeutronAtom atom = getNeutronAtom(23);
+    TS_ASSERT_EQUALS(atom.z_number, 23);
+    TS_ASSERT_EQUALS(atom.a_number, 0);
+    TS_ASSERT_EQUALS(atom.coh_scatt_length_real, -0.3824);
+    TS_ASSERT_EQUALS(atom.coh_scatt_length_img, 0.);
+    TS_ASSERT_EQUALS(atom.inc_scatt_length_real, 0);
+    TS_ASSERT_EQUALS(atom.inc_scatt_length_img, 0.);
+    TS_ASSERT_EQUALS(atom.coh_scatt_xs,  0.0184);
+    TS_ASSERT_EQUALS(atom.inc_scatt_xs, 5.08);
+    TS_ASSERT_EQUALS(atom.tot_scatt_xs, 5.1);
+    TS_ASSERT_EQUALS(atom.abs_scatt_xs, 5.08);
+  }
+
+  void testGadolinium() {
+    NeutronAtom atom = getNeutronAtom(64);
+    TS_ASSERT_EQUALS(atom.z_number, 64);
+    TS_ASSERT_EQUALS(atom.a_number, 0);
+    TS_ASSERT_EQUALS(atom.coh_scatt_length_real, 6.5);
+    TS_ASSERT_EQUALS(atom.coh_scatt_length_img, -13.82);
+    TS_ASSERT_EQUALS(atom.inc_scatt_length_real, 0);
+    TS_ASSERT_EQUALS(atom.inc_scatt_length_img, 0);
+    TS_ASSERT_EQUALS(atom.coh_scatt_xs,  29.3);
+    TS_ASSERT_EQUALS(atom.inc_scatt_xs, 151.);
+    TS_ASSERT_EQUALS(atom.tot_scatt_xs, 180.);
+    TS_ASSERT_EQUALS(atom.abs_scatt_xs, 49700.);
+  }
+
   void testError() {
     TS_ASSERT_THROWS(getNeutronAtom(1, 15), std::runtime_error);
     TS_ASSERT_THROWS(getNeutronAtom(97), std::runtime_error);

--- a/Framework/Kernel/test/NeutronAtomTest.h
+++ b/Framework/Kernel/test/NeutronAtomTest.h
@@ -37,7 +37,7 @@ public:
     TS_ASSERT_EQUALS(atom.coh_scatt_length_img, 0.);
     TS_ASSERT_EQUALS(atom.inc_scatt_length_real, 0);
     TS_ASSERT_EQUALS(atom.inc_scatt_length_img, 0.);
-    TS_ASSERT_EQUALS(atom.coh_scatt_xs,  0.0184);
+    TS_ASSERT_EQUALS(atom.coh_scatt_xs, 0.0184);
     TS_ASSERT_EQUALS(atom.inc_scatt_xs, 5.08);
     TS_ASSERT_EQUALS(atom.tot_scatt_xs, 5.1);
     TS_ASSERT_EQUALS(atom.abs_scatt_xs, 5.08);
@@ -51,7 +51,7 @@ public:
     TS_ASSERT_EQUALS(atom.coh_scatt_length_img, -13.82);
     TS_ASSERT_EQUALS(atom.inc_scatt_length_real, 0);
     TS_ASSERT_EQUALS(atom.inc_scatt_length_img, 0);
-    TS_ASSERT_EQUALS(atom.coh_scatt_xs,  29.3);
+    TS_ASSERT_EQUALS(atom.coh_scatt_xs, 29.3);
     TS_ASSERT_EQUALS(atom.inc_scatt_xs, 151.);
     TS_ASSERT_EQUALS(atom.tot_scatt_xs, 180.);
     TS_ASSERT_EQUALS(atom.abs_scatt_xs, 49700.);

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -7,11 +7,11 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-from mantid.api import Sample
 from mantid.simpleapi import CreateWorkspace
 from mantid.simpleapi import SetSampleMaterial
 from mantid.geometry import CrystalStructure
 from mantid.geometry import CSGObject
+from numpy import pi
 
 class SampleTest(unittest.TestCase):
 
@@ -71,7 +71,11 @@ class SampleTest(unittest.TestCase):
 
         xs0 = atoms[0].neutron()
         xs1 = atoms[1].neutron()
-        xs = ( xs0['coh_scatt_xs']*2 + xs1['coh_scatt_xs']*3 ) / 5
+        # the correct way to calculate for coherent cross section
+        # is to average the scattering lengths then convert to a cross section
+        b_real = (xs0['coh_scatt_length_real']*2 + xs1['coh_scatt_length_real']*3) / 5
+        b_imag = (xs0['coh_scatt_length_img']*2 + xs1['coh_scatt_length_img']*3) / 5
+        xs = .04 * pi * (b_real * b_real + b_imag * b_imag)
         self.assertAlmostEquals(material.cohScatterXSection(), xs, places=4)
 
     def test_get_shape(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
@@ -12,7 +12,6 @@ from mantid.simpleapi import IndirectTransmission
 
 
 class IndirectTransmissionTest(unittest.TestCase):
-    
     def test_indirect_transmission_iris_graphite_002(self):
         """
         Test a transmission calculation using IRIS, graphite, 002.
@@ -31,7 +30,7 @@ class IndirectTransmissionTest(unittest.TestCase):
                                   ChemicalFormula=formula, DensityType='Number Density', Density=density, Thickness=thickness)
 
         # Expected values from table
-        ref_result = [6.658, 0.821223, 2.58187, 53.5069, 56.0888, 0.1, 0.1, 0.566035, 0.429298]
+        ref_result = [6.65800, 0.82122, 0.039174, 56.05149, 56.09067, 0.1, 0.1, 0.56602, 0.42931]
         values = ws.column(1)
         np.testing.assert_array_almost_equal(values, ref_result, decimal=4)
 
@@ -53,10 +52,10 @@ class IndirectTransmissionTest(unittest.TestCase):
                                   ChemicalFormula=formula, DensityType='Number Density', Density=density, Thickness=thickness)
 
         # Expected values from table
-        ref_result = [5.5137, 0.680081, 2.58187, 53.5069, 56.0888, 0.1, 0.1, 0.566834, 0.429298]
+        ref_result = [5.5137, 0.680081, 0.039174, 56.05149, 56.09067,   0.1, 0.1, 0.56682, 0.42931]
         values = ws.column(1)
         np.testing.assert_array_almost_equal(values, ref_result, decimal=4)
-    
+
     def test_indirect_transmission_basis_silicon_111(self):
         """
         Test a transmission calculation using BASIS, silicon 111.
@@ -75,13 +74,11 @@ class IndirectTransmissionTest(unittest.TestCase):
                                   ChemicalFormula=formula, DensityType='Number Density', Density=density, Thickness=thickness)
 
         # Expected values from table
-        ref_result = [6.2676, 0.7731, 2.5819, 53.5069, 56.0888, 0.1, 0.1, 0.5663, 0.4293]
+        ref_result = [6.2676, 0.7731, 0.03917, 56.0515, 56.0907, 0.1, 0.1, 0.56630, 0.42931]
 
         values = ws.column(1)
-        print(ref_result)
-        print(values)
         np.testing.assert_array_almost_equal(values, ref_result, decimal=4)
-    
+
     def test_indirect_transmission_analyser_validation(self):
         """
         Verifies analyser validation based on instrument is working.
@@ -129,7 +126,7 @@ class IndirectTransmissionTest(unittest.TestCase):
         ws = IndirectTransmission(Instrument=instrument, Analyser=analyser, Reflection=reflection,
                                   ChemicalFormula=formula, DensityType='Mass Density', Density=density, Thickness=thickness)
 
-        ref_result = [6.65800, 0.82122, 2.58186, 53.50693, 56.08880, 0.100272, 0.1, 0.56512, 0.43021]
+        ref_result = [6.65800, 0.82122, 0.0391739, 56.051493, 56.09067, 0.100283900, 0.1, 0.56511, 0.43022]
         mass_values = ws.column(1)
         np.testing.assert_array_almost_equal(mass_values, ref_result, decimal=4)
 

--- a/docs/source/release/v4.0.0/framework.rst
+++ b/docs/source/release/v4.0.0/framework.rst
@@ -5,6 +5,8 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+The calculations for :py:obj:`mantid.kernel.Material` have been changed to match the equations in Sears, Varley F. "Neutron scattering lengths and cross sections." Neutron News 3.3 (1992): 26-37
+
 Logging
 -------
 


### PR DESCRIPTION
It was discovered that `Material` and `NeutronAtom` weren't giving the same results when using a single atom. Also, comparing values for the null scatterer TiZr pointed out that not all the calculations were being done according to Sears. This was fixed, lots of consistency tests were added, and references to the exact equations implemented from literature are in the code. This way, if you find an error, you can get published!

**To test:**

Look that the tests are reasonable and that the code implements the equations they suggest they are.

Fixes #8134 and #25047.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
