### PR TITLE
PDDetermineCharacterizations throws a meaningful exception

### DIFF
--- a/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
+++ b/Framework/Algorithms/src/PDDetermineCharacterizations.cpp
@@ -309,8 +309,15 @@ double PDDetermineCharacterizations::getLogValue(API::Run &run,
       }
     }
   }
-  g_log.warning("Failed to determine " + label);
-  return 0.;
+
+  // generate an exception if it gets here because the log wasn't found
+  std::stringstream msg;
+  msg << "Failed to determine " << label << " because none of the logs ";
+  for (auto &name : names) {
+    msg << "\"" << name << "\" ";
+  }
+  msg << "exist";
+  throw std::runtime_error(msg.str());
 }
 
 /// Set the default values in the property manager

--- a/docs/source/release/v4.0.0/diffraction.rst
+++ b/docs/source/release/v4.0.0/diffraction.rst
@@ -85,6 +85,7 @@ Improvements
 - Focus on Pearl now has a focused_bin_widths parameter in pearl_advanced_config.py to allow setting default rebin values.
 - Focus on Pearl now saves out xye_tof files.
 - :ref:`PDLoadCharacterizations <algm-PDLoadCharacterizations>` now sets the same run numbers for all rows when using an ``exp.ini`` file.
+- :ref:`PDDetermineCharacterizations <algm-PDDetermineCharacterizations>` will generate an exception if it cannot determine the frequency or wavelength
 - Focus now checks if the vanadium for a run is already loaded before loading it in to prevent reloading the same vanadium multiple times.
 - :ref:`SaveReflections <algm-SaveReflections>` now supports saving indexed modulated peaks in the Jana format.
 - `PyStoG <https://pystog.readthedocs.io/en/latest/>`_ has been added as an external project.


### PR DESCRIPTION
Rather than silently return that things are ok, throw an exception when the frequency or wavelength isn't determined. This was discovered when testing with random names for the logs.

**To test:**

Run `PDDetermineCharacterizations` (or `AlignAndFocusPowderFromFiles`, or `SNSPowderReduction`) with log names that don't exist in the file. The algorithm should now give an exception rather than log a warning.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
