### PR TITLE
SNAPReduce error with wrong output workspace names

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -492,9 +492,9 @@ class SNAPReduce(DataProcessorAlgorithm):
             # put together output names
             new_Tag = Tag
             if len(prefix) > 0:
-                new_Tag += '_' + prefix
+                new_Tag = prefix + '_' + new_Tag
             basename = '%s_%s_%s' % (new_Tag, runnumber, self.alignAndFocusArgs['GroupingWorkspace'])
-
+            self.log().warning('{}:{}:{}'.format(i, new_Tag, basename))
             redWS, unfocussedWksp = self._alignAndFocus('SNAP_{}'.format(runnumber),
                                                         basename + '_red',
                                                         detCalFilename=detcalFile,
@@ -570,8 +570,8 @@ class SNAPReduce(DataProcessorAlgorithm):
 
             # declare some things as extra outputs in set-up
             if Process_Mode != "Production":
-                prefix = 'OutputWorkspace_{:d}_'.format(i)
-                propNames = [prefix + it for it in ['d', 'norm', 'normalizer']]
+                propprefix = 'OutputWorkspace_{:d}_'.format(i)
+                propNames = [propprefix + it for it in ['d', 'norm', 'normalizer']]
                 wkspNames = ['%s_%s_d' % (new_Tag, runnumber),
                              basename + '_red',
                              '%s_%s_normalizer' % (new_Tag, runnumber)]


### PR DESCRIPTION
The issue was a re-used variable name in `PyExec`.

**Description of work.**

**Report to:** Antonio

**To test:**

The issue doesn't happen when reducing a single run, but with multiple runs. 
```python
SNAPReduce(RunNumbers='42610-42611', Binning='1.,-.0012,3.5', Calibration='Convert Units',
    Normalization='Extracted from Data', GroupDetectorsBy='All', ProcessingMode='Set-Up',
    OptionalPrefix='S4_X')
```

*There is no associated issue.*

*This does not require release notes* because it is a bug introduced during the release cycle on functionality that was already noted.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
