### PR TITLE
Cache Beamline in InstrumentDefinitionParser

### DIFF
--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1430,6 +1430,14 @@ void ExperimentInfo::setInstumentFromXML(const std::string &nxFilename,
     } else {
       // Really create the instrument
       instr = parser.parseXML(nullptr);
+      // Parse the instrument tree (internally create ComponentInfo and
+      // DetectorInfo). This is an optimization that avoids duplicate parsing
+      // of the instrument tree when loading multiple workspaces with the same
+      // instrument. As a consequence less time is spent and less memory is
+      // used. Note that this is only possible since the tree in `instrument`
+      // will not be modified once we add it to the IDS.
+      instr->parseTreeAndCacheBeamline();
+
       // Add to data service for later retrieval
       InstrumentDataService::Instance().add(instrumentNameMangled, instr);
     }

--- a/docs/source/release/v4.0.0/framework.rst
+++ b/docs/source/release/v4.0.0/framework.rst
@@ -24,7 +24,11 @@ Nexus Geometry Loading
 ----------------------
 - :ref:`LoadEmptyInstrument <algm-LoadEmptyInstrument>` will now load instrument geometry from hdf5 `NeXus <https://www.nexusformat.org/>`_ format files. Files consistent with the standard following the introduction of `NXoff_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXoff_geometry.html>`_ and `NXcylindrical_geometry <http://download.nexusformat.org/sphinx/classes/base_classes/NXcylindrical_geometry.html>`_ will be used to build the entire in-memory instrument geometry within Mantid. This IDF-free route is primarily envisioned for the ESS. While dependent on the instrument, we are overall seeing significant improvements in instrument load times over loading from equivalent IDF based implementations. :ref:`LoadInstrument <algm-LoadInstrument>` also supports the nexus geometry format in the same was as LoadEmptyInstrument.
 - The changes above have also been incorporated directly into :ref:`LoadEventNexus <algm-LoadEventNexus>`, so it is possible to store data and geometry together for the first time in a NeXus compliant format for Mantid. These changes have made it possible to load experimental ESS event data files directly into Mantid.
+
+Instruments
+-----------
 - New helper function `ExperimentInfo.getResourceFilenames` returns a list of instrument definition files and/or parameter files in accordance to a query time stamp.
+- A bug has been fixed that caused each workspace to hold a separate copy of the instrument. In the case of large instruments such as WISH this added 200MB to each workspace, even in the case of a single spectrum workspace.
 
 Archive Searching
 -----------------


### PR DESCRIPTION
**Description of work.**

In the `LoadNexusProcessed` case instrument loading is performed by [ExperimentInfo](https://github.com/mantidproject/mantid/blob/master/Framework/API/src/ExperimentInfo.cpp#L1432) and this was missing the line to cache Beamline objects in the instrument that was added to the IDS. This caused a new Beamline object to be created for each workspace. For WISH, in the case where they loaded a single spectrum from a process file, this adds 200MB to each workspace and hits the memory limit on the 32GB VMs much quicker than it should.

These changes move the caching to the `InstrumentDefinitionParser` so that the client of that code does not have to remember to call this method. 

**To test:**

The following script demonstrates the problem. On `master` the memory usage goes up with each loop but after this fix the memory usage stays roughly constant.

```python
from __future__ import print_function
from mantid.simpleapi import *

MB = 1024*1024

def display_memory_usage():
    import psutil
    proc = psutil.Process()
    usage = proc.memory_info().rss/MB
    print("Mem Usage: {} MiB".format(usage))
    return usage


filename = 'ExternalData/Testing/Data/SystemTest/WishAnalysis.nxs'

for i in range(3):
    Load(filename, LoadHistory=False, OutputWorkspace='out-'+str(i))
    display_memory_usage()

raw_input("Press a key to exit")
```


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
