### PR TITLE
Workbench: Project recovery progress bar fix

### DIFF
--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
@@ -100,8 +100,6 @@ class ProjectRecoveryModel(QObject):
         try:
             self._start_recovery_of_checkpoint(checkpoint)
         except Exception as e:
-            if isinstance(e, KeyboardInterrupt):
-                raise
             # Fail "Silently" by setting failed run to true, setting checkpoint to tried and closing the view.
             logger.debug("Project Recovery: " + str(e))
             self.has_failed_run = True

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/projectrecoverymodel.py
@@ -15,7 +15,7 @@ import six
 from qtpy.QtCore import Slot, QObject
 
 from mantid.api import AnalysisDataService as ADS
-from mantid.kernel import ConfigService
+from mantid.kernel import ConfigService, logger
 
 
 DEFAULT_NUM_CHECKPOINTS = 5
@@ -103,6 +103,7 @@ class ProjectRecoveryModel(QObject):
             if isinstance(e, KeyboardInterrupt):
                 raise
             # Fail "Silently" by setting failed run to true, setting checkpoint to tried and closing the view.
+            logger.debug("Project Recovery: " + str(e))
             self.has_failed_run = True
             self._update_checkpoint_tried(selected)
             self.presenter.close_view()

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -138,6 +138,11 @@ class PythonFileInterpreter(QWidget):
 
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
+        # Connect the model signals to the view's signals so they can be accessed from outside the MVP
+        self._presenter.model.sig_exec_progress.connect(self.sig_progress)
+        self._presenter.model.sig_exec_error.connect(self.sig_exec_error)
+        self._presenter.model.sig_exec_success.connect(self.sig_exec_success)
+
     def closeEvent(self, event):
         self.deleteLater()
         if self.find_replace_dialog:
@@ -154,11 +159,6 @@ class PythonFileInterpreter(QWidget):
     def hide_find_replace_dialog(self):
         if self.find_replace_dialog is not None:
             self.find_replace_dialog.hide()
-
-        # Connect the model signals to the view's signals so they can be accessed from outside the MVP
-        self._presenter.model.sig_exec_progress.connect(self.sig_progress)
-        self._presenter.model.sig_exec_error.connect(self.sig_exec_error)
-        self._presenter.model.sig_exec_success.connect(self.sig_exec_success)
 
     @property
     def filename(self):
@@ -342,7 +342,7 @@ class PythonFileInterpreterPresenter(QObject):
     def req_execute_async_blocking(self):
         self._req_execute_impl(blocking=True)
 
-    def _req_execute_impl(self, blocking, ignore_selection):
+    def _req_execute_impl(self, blocking, ignore_selection=False):
         if self.is_executing:
             return
         code_str, self._code_start_offset = self._get_code_for_execution(ignore_selection)


### PR DESCRIPTION
**Description of work.**
Due to git merging some code poorly, the connections between the model and view of the PythonFileInterpreter were not being made, this in turn lead to the recovery view never being called by the emit.

**To test:**
- Open Workbench
- Run this script:
```python
for ii in range(0, 1000):
    CreateSampleWorkspace(OutputWorkspace=str(ii))
```
- Wait for recovery to save (Shown in the messages tab as `Project Recovery: Saving finished`)
- Run: `Segfault(0)`
- Open Workbench
- Recovery last checkpoint
- Notice the progress bar works.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
