### PR TITLE
Indirect Update Data Analysis Model when workspace changes

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -37,6 +37,8 @@ Bug Fixes
 #########
 - Fixed an error caused by loading a Sample into ConvFit which does not have a resolution parameter for the analyser.
 - Fixed a crash caused by changing the Preview Spectrum on Elwin after clicking Run.
+- Fixed a bug where the loaded workspace in Data Analysis doesn't update after being changed on a different
+  interface.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -161,7 +161,6 @@ set ( MOC_FILES
     Elwin.h
     IAddWorkspaceDialog.h
     IIndirectFitDataView.h
-    IIndirectFitOutputOptionsModel.h
     IIndirectFitOutputOptionsView.h
     IIndirectFitPlotView.h
     ILLEnergyTransfer.h

--- a/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.cpp
@@ -123,6 +123,12 @@ void ConvFitAddWorkspaceDialog::setResolutionFBSuffices(
   m_uiForm.dsResolution->setFBSuffixes(suffices);
 }
 
+void ConvFitAddWorkspaceDialog::updateSelectedSpectra() {
+  auto const state =
+      m_uiForm.ckAllSpectra->isChecked() ? Qt::Checked : Qt::Unchecked;
+  selectAllSpectra(state);
+}
+
 void ConvFitAddWorkspaceDialog::selectAllSpectra(int state) {
   auto const name = workspaceName();
   if (validWorkspace(name) && state == Qt::Checked) {

--- a/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitAddWorkspaceDialog.h
@@ -28,6 +28,8 @@ public:
   void setResolutionWSSuffices(const QStringList &suffices);
   void setResolutionFBSuffices(const QStringList &suffices);
 
+  void updateSelectedSpectra() override;
+
 private slots:
   void selectAllSpectra(int state);
   void workspaceChanged(const QString &workspaceName);

--- a/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IAddWorkspaceDialog.h
@@ -22,6 +22,8 @@ public:
   virtual void setWSSuffices(const QStringList &suffices) = 0;
   virtual void setFBSuffices(const QStringList &suffices) = 0;
 
+  virtual void updateSelectedSpectra() = 0;
+
 signals:
   void addData();
   void closeDialog();

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -44,7 +44,9 @@ public:
   virtual void setResolutionWSSuffices(QStringList const &suffices) = 0;
   virtual void setResolutionFBSuffices(QStringList const &suffices) = 0;
 
-  virtual void setWorkspaceSelectorIndex(QString const &workspaceName) = 0;
+  virtual bool isSampleWorkspaceSelectorVisible() const = 0;
+  virtual void
+  setSampleWorkspaceSelectorIndex(QString const &workspaceName) = 0;
 
   virtual void readSettings(QSettings const &settings) = 0;
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -44,6 +44,8 @@ public:
   virtual void setResolutionWSSuffices(QStringList const &suffices) = 0;
   virtual void setResolutionFBSuffices(QStringList const &suffices) = 0;
 
+  virtual void setWorkspaceSelectorIndex(QString const &workspaceName) = 0;
+
   virtual void readSettings(QSettings const &settings) = 0;
   virtual UserInputValidator &validate(UserInputValidator &validator) = 0;
 

--- a/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.cpp
@@ -109,6 +109,12 @@ void AddWorkspaceDialog::setFBSuffices(const QStringList &suffices) {
   m_uiForm.dsWorkspace->setFBSuffixes(suffices);
 }
 
+void AddWorkspaceDialog::updateSelectedSpectra() {
+  auto const state =
+      m_uiForm.ckAllSpectra->isChecked() ? Qt::Checked : Qt::Unchecked;
+  selectAllSpectra(state);
+}
+
 void AddWorkspaceDialog::selectAllSpectra(int state) {
   auto const name = workspaceName();
   if (validWorkspace(name) && state == Qt::Checked) {

--- a/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/IndirectAddWorkspaceDialog.h
@@ -25,6 +25,8 @@ public:
   void setWSSuffices(const QStringList &suffices) override;
   void setFBSuffices(const QStringList &suffices) override;
 
+  void updateSelectedSpectra() override;
+
 private slots:
   void selectAllSpectra(int state);
   void workspaceChanged(const QString &workspaceName);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -38,8 +38,6 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SLOT(setModelWorkspace(const QString &)));
   connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
-          SIGNAL(singleSampleLoaded()));
-  connect(m_view, SIGNAL(sampleLoaded(const QString &)), this,
           SIGNAL(dataChanged()));
 
   connect(m_view, SIGNAL(addClicked()), this,

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -25,6 +25,8 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
     std::unique_ptr<IndirectDataTablePresenter> tablePresenter)
     : m_model(model), m_view(view),
       m_tablePresenter(std::move(tablePresenter)) {
+  observeReplace(true);
+
   connect(m_view, SIGNAL(singleDataViewSelected()), this,
           SLOT(setModelFromSingleData()));
   connect(m_view, SIGNAL(multipleDataViewSelected()), this,
@@ -139,6 +141,29 @@ void IndirectFitDataPresenter::loadSettings(const QSettings &settings) {
   m_view->readSettings(settings);
 }
 
+void IndirectFitDataPresenter::replaceHandle(const std::string &workspaceName,
+                                             const Workspace_sptr &workspace) {
+  UNUSED_ARG(workspace)
+  const auto names = m_model->getWorkspaceNames();
+  const auto iter = std::find(names.begin(), names.end(), workspaceName);
+  if (iter != names.end()) {
+    setModelWorkspace(QString::fromStdString(workspaceName));
+
+    //if (m_view->isMultipleDataTabSelected()) {
+    //  setModelFromSingleData();
+    //  setModelWorkspace(QString::fromStdString(workspaceName));
+    //  setModelFromMultipleData();
+    //  setModelWorkspace(QString::fromStdString(workspaceName));
+    //} else {
+    //  setModelFromMultipleData();
+    //  setModelWorkspace(QString::fromStdString(workspaceName));
+    //  setModelFromSingleData();
+    //  setModelWorkspace(QString::fromStdString(workspaceName));
+    //}
+    emit dataChanged();
+  }
+}
+
 UserInputValidator &
 IndirectFitDataPresenter::validate(UserInputValidator &validator) {
   return m_view->validate(validator);
@@ -149,6 +174,7 @@ void IndirectFitDataPresenter::showAddWorkspaceDialog() {
     m_addWorkspaceDialog = getAddWorkspaceDialog(m_view->parentWidget());
   m_addWorkspaceDialog->setWSSuffices(m_view->getSampleWSSuffices());
   m_addWorkspaceDialog->setFBSuffices(m_view->getSampleFBSuffices());
+  m_addWorkspaceDialog->updateSelectedSpectra();
   m_addWorkspaceDialog->show();
   connect(m_addWorkspaceDialog.get(), SIGNAL(addData()), this, SLOT(addData()));
   connect(m_addWorkspaceDialog.get(), SIGNAL(closeDialog()), this,

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -65,6 +65,8 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(
                                       std::size_t)));
 }
 
+IndirectFitDataPresenter::~IndirectFitDataPresenter() { observeReplace(false); }
+
 IIndirectFitDataView const *IndirectFitDataPresenter::getView() const {
   return m_view;
 }
@@ -144,10 +146,18 @@ void IndirectFitDataPresenter::loadSettings(const QSettings &settings) {
 void IndirectFitDataPresenter::replaceHandle(const std::string &workspaceName,
                                              const Workspace_sptr &workspace) {
   UNUSED_ARG(workspace)
-  const auto names = m_model->getWorkspaceNames();
-  const auto iter = std::find(names.begin(), names.end(), workspaceName);
-  if (iter != names.end() && !m_view->isMultipleDataTabSelected())
-    m_view->setWorkspaceSelectorIndex(QString::fromStdString(workspaceName));
+  if (m_model->hasWorkspace(workspaceName) &&
+      !m_view->isMultipleDataTabSelected())
+    selectReplacedWorkspace(QString::fromStdString(workspaceName));
+}
+
+void IndirectFitDataPresenter::selectReplacedWorkspace(
+    const QString &workspaceName) {
+  if (m_view->isSampleWorkspaceSelectorVisible()) {
+    setModelWorkspace(workspaceName);
+    emit dataChanged();
+  } else
+    m_view->setSampleWorkspaceSelectorIndex(workspaceName);
 }
 
 UserInputValidator &

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -146,22 +146,8 @@ void IndirectFitDataPresenter::replaceHandle(const std::string &workspaceName,
   UNUSED_ARG(workspace)
   const auto names = m_model->getWorkspaceNames();
   const auto iter = std::find(names.begin(), names.end(), workspaceName);
-  if (iter != names.end()) {
-    setModelWorkspace(QString::fromStdString(workspaceName));
-
-    //if (m_view->isMultipleDataTabSelected()) {
-    //  setModelFromSingleData();
-    //  setModelWorkspace(QString::fromStdString(workspaceName));
-    //  setModelFromMultipleData();
-    //  setModelWorkspace(QString::fromStdString(workspaceName));
-    //} else {
-    //  setModelFromMultipleData();
-    //  setModelWorkspace(QString::fromStdString(workspaceName));
-    //  setModelFromSingleData();
-    //  setModelWorkspace(QString::fromStdString(workspaceName));
-    //}
-    emit dataChanged();
-  }
+  if (iter != names.end() && !m_view->isMultipleDataTabSelected())
+    m_view->setWorkspaceSelectorIndex(QString::fromStdString(workspaceName));
 }
 
 UserInputValidator &

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -32,7 +32,7 @@ public:
   IndirectFitDataPresenter(
       IndirectFittingModel *model, IIndirectFitDataView *view,
       std::unique_ptr<IndirectDataTablePresenter> tablePresenter);
-  ~IndirectFitDataPresenter() { observeReplace(false); }
+  ~IndirectFitDataPresenter();
 
   void setSampleWSSuffices(const QStringList &suffices);
   void setSampleFBSuffices(const QStringList &suffices);
@@ -91,6 +91,8 @@ private:
   virtual std::unique_ptr<IAddWorkspaceDialog>
   getAddWorkspaceDialog(QWidget *parent) const;
   void updateDataInTable(std::size_t dataIndex);
+
+  void selectReplacedWorkspace(const QString &workspaceName);
 
   std::unique_ptr<IAddWorkspaceDialog> m_addWorkspaceDialog;
   IndirectFittingModel *m_model;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -56,7 +56,6 @@ protected slots:
   virtual void closeDialog();
 
 signals:
-  void singleSampleLoaded();
   void singleResolutionLoaded();
   void dataAdded();
   void dataRemoved();

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -13,6 +13,7 @@
 #include "IndirectFittingModel.h"
 
 #include "DllConfig.h"
+#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <QObject>
@@ -21,15 +22,17 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class MANTIDQT_INDIRECT_DLL IndirectFitDataPresenter : public QObject {
+class MANTIDQT_INDIRECT_DLL IndirectFitDataPresenter
+    : public QObject,
+      public AnalysisDataServiceObserver {
   Q_OBJECT
 public:
   IndirectFitDataPresenter(IndirectFittingModel *model,
                            IIndirectFitDataView *view);
-
   IndirectFitDataPresenter(
       IndirectFittingModel *model, IIndirectFitDataView *view,
       std::unique_ptr<IndirectDataTablePresenter> tablePresenter);
+  ~IndirectFitDataPresenter() { observeReplace(false); }
 
   void setSampleWSSuffices(const QStringList &suffices);
   void setSampleFBSuffices(const QStringList &suffices);
@@ -43,6 +46,9 @@ public:
 
   void loadSettings(const QSettings &settings);
   UserInputValidator &validate(UserInputValidator &validator);
+
+  void replaceHandle(const std::string &workspaceName,
+                     const Workspace_sptr &workspace) override;
 
 public slots:
   void updateSpectraInTable(std::size_t dataIndex);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -97,6 +97,12 @@ void IndirectFitDataView::setResolutionFBSuffices(const QStringList &suffices) {
   m_dataForm->dsResolution->setFBSuffixes(suffices);
 }
 
+void IndirectFitDataView::setWorkspaceSelectorIndex(
+    const QString &workspaceName) {
+  m_dataForm->dsSample->setWorkspaceSelectorIndex(workspaceName);
+  m_dataForm->dsSample->setSelectorIndex(1);
+}
+
 UserInputValidator &
 IndirectFitDataView::validate(UserInputValidator &validator) {
   if (currentIndex() == 0)

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -97,7 +97,11 @@ void IndirectFitDataView::setResolutionFBSuffices(const QStringList &suffices) {
   m_dataForm->dsResolution->setFBSuffixes(suffices);
 }
 
-void IndirectFitDataView::setWorkspaceSelectorIndex(
+bool IndirectFitDataView::isSampleWorkspaceSelectorVisible() const {
+  return m_dataForm->dsSample->isWorkspaceSelectorVisible();
+}
+
+void IndirectFitDataView::setSampleWorkspaceSelectorIndex(
     const QString &workspaceName) {
   m_dataForm->dsSample->setWorkspaceSelectorIndex(workspaceName);
   m_dataForm->dsSample->setSelectorIndex(1);

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -45,6 +45,8 @@ public:
   virtual void setResolutionWSSuffices(const QStringList &suffices) override;
   virtual void setResolutionFBSuffices(const QStringList &suffices) override;
 
+	void setWorkspaceSelectorIndex(const QString &workspaceName);
+
   void readSettings(const QSettings &settings) override;
   UserInputValidator &validate(UserInputValidator &validator) override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -45,7 +45,8 @@ public:
   virtual void setResolutionWSSuffices(const QStringList &suffices) override;
   virtual void setResolutionFBSuffices(const QStringList &suffices) override;
 
-	void setWorkspaceSelectorIndex(const QString &workspaceName);
+  bool isSampleWorkspaceSelectorVisible() const override;
+  void setSampleWorkspaceSelectorIndex(const QString &workspaceName) override;
 
   void readSettings(const QSettings &settings) override;
   UserInputValidator &validate(UserInputValidator &validator) override;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -337,13 +337,21 @@ operator=(PrivateFittingData &&fittingData) {
 }
 
 IndirectFittingModel::IndirectFittingModel()
-    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {}
+    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {observeReplace(true);}
 
 MatrixWorkspace_sptr
 IndirectFittingModel::getWorkspace(std::size_t index) const {
   if (index < m_fittingData.size())
     return m_fittingData[index]->workspace();
   return nullptr;
+}
+
+std::vector<std::string> IndirectFittingModel::getWorkspaceNames() const {
+  std::vector<std::string> names;
+  for(size_t i = 0;i<m_fittingData.size();i++){
+    names.emplace_back(m_fittingData[i]->workspace()->getName());
+  }
+  return names;
 }
 
 Spectra IndirectFittingModel::getSpectra(std::size_t index) const {
@@ -445,6 +453,17 @@ std::vector<std::string> IndirectFittingModel::getFitParameterNames() const {
 
 Mantid::API::IFunction_sptr IndirectFittingModel::getFittingFunction() const {
   return m_activeFunction;
+}
+
+void IndirectFittingModel::replaceHandle(const std::string &wsName,
+                                         const Workspace_sptr &ws) {
+  const auto names = getWorkspaceNames();
+  const auto location = std::find(names.begin(), names.end(), wsName);
+  if (location != names.end()) {
+    const std::size_t index = std::distance(names.begin(), location);
+    removeWorkspace(index);
+    addWorkspace(wsName);
+  }
 }
 
 void IndirectFittingModel::setFittingData(PrivateFittingData &&fittingData) {

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -330,8 +330,8 @@ PrivateFittingData::PrivateFittingData(
     std::vector<std::unique_ptr<IndirectFitData>> &&data)
     : m_data(std::move(data)) {}
 
-PrivateFittingData &
-PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
+PrivateFittingData &PrivateFittingData::
+operator=(PrivateFittingData &&fittingData) {
   m_data = std::move(fittingData.m_data);
   return *this;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -581,7 +581,8 @@ void IndirectFittingModel::removeFittingData(std::size_t index) {
   if (m_fitOutput)
     m_fitOutput->removeOutput(m_fittingData[index].get());
   m_fittingData.erase(m_fittingData.begin() + index);
-  m_defaultParameters.erase(m_defaultParameters.begin() + index);
+  if (m_defaultParameters.size() > index)
+    m_defaultParameters.erase(m_defaultParameters.begin() + index);
 }
 
 PrivateFittingData IndirectFittingModel::clearWorkspaces() {

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -330,16 +330,14 @@ PrivateFittingData::PrivateFittingData(
     std::vector<std::unique_ptr<IndirectFitData>> &&data)
     : m_data(std::move(data)) {}
 
-PrivateFittingData &PrivateFittingData::
-operator=(PrivateFittingData &&fittingData) {
+PrivateFittingData &
+PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
   m_data = std::move(fittingData.m_data);
   return *this;
 }
 
 IndirectFittingModel::IndirectFittingModel()
-    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {
-  observeReplace(true);
-}
+    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {}
 
 MatrixWorkspace_sptr
 IndirectFittingModel::getWorkspace(std::size_t index) const {
@@ -350,9 +348,9 @@ IndirectFittingModel::getWorkspace(std::size_t index) const {
 
 std::vector<std::string> IndirectFittingModel::getWorkspaceNames() const {
   std::vector<std::string> names;
-  for (auto i = 0u; i < m_fittingData.size(); ++i) {
+  names.reserve(m_fittingData.size());
+  for (auto i = 0u; i < m_fittingData.size(); ++i)
     names.emplace_back(m_fittingData[i]->workspace()->getName());
-  }
   return names;
 }
 
@@ -455,18 +453,6 @@ std::vector<std::string> IndirectFittingModel::getFitParameterNames() const {
 
 Mantid::API::IFunction_sptr IndirectFittingModel::getFittingFunction() const {
   return m_activeFunction;
-}
-
-void IndirectFittingModel::replaceHandle(const std::string &workspaceName,
-                                         const Workspace_sptr &workspace) {
-  UNUSED_ARG(workspace)
-  const auto names = getWorkspaceNames();
-  const auto location = std::find(names.begin(), names.end(), workspaceName);
-  if (location != names.end()) {
-    const std::size_t index = std::distance(names.begin(), location);
-    removeWorkspace(index);
-    addWorkspace(workspaceName);
-  }
 }
 
 void IndirectFittingModel::setFittingData(PrivateFittingData &&fittingData) {

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -350,7 +350,7 @@ IndirectFittingModel::getWorkspace(std::size_t index) const {
 
 std::vector<std::string> IndirectFittingModel::getWorkspaceNames() const {
   std::vector<std::string> names;
-  for (size_t i = 0; i < m_fittingData.size(); i++) {
+  for (auto i = 0u; i < m_fittingData.size(); ++i) {
     names.emplace_back(m_fittingData[i]->workspace()->getName());
   }
   return names;
@@ -457,14 +457,15 @@ Mantid::API::IFunction_sptr IndirectFittingModel::getFittingFunction() const {
   return m_activeFunction;
 }
 
-void IndirectFittingModel::replaceHandle(const std::string &wsName,
-                                         const Workspace_sptr &ws) {
+void IndirectFittingModel::replaceHandle(const std::string &workspaceName,
+                                         const Workspace_sptr &workspace) {
+  UNUSED_ARG(workspace)
   const auto names = getWorkspaceNames();
-  const auto location = std::find(names.begin(), names.end(), wsName);
+  const auto location = std::find(names.begin(), names.end(), workspaceName);
   if (location != names.end()) {
     const std::size_t index = std::distance(names.begin(), location);
     removeWorkspace(index);
-    addWorkspace(wsName);
+    addWorkspace(workspaceName);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -337,7 +337,9 @@ operator=(PrivateFittingData &&fittingData) {
 }
 
 IndirectFittingModel::IndirectFittingModel()
-    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {observeReplace(true);}
+    : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {
+  observeReplace(true);
+}
 
 MatrixWorkspace_sptr
 IndirectFittingModel::getWorkspace(std::size_t index) const {
@@ -348,7 +350,7 @@ IndirectFittingModel::getWorkspace(std::size_t index) const {
 
 std::vector<std::string> IndirectFittingModel::getWorkspaceNames() const {
   std::vector<std::string> names;
-  for(size_t i = 0;i<m_fittingData.size();i++){
+  for (size_t i = 0; i < m_fittingData.size(); i++) {
     names.emplace_back(m_fittingData[i]->workspace()->getName());
   }
   return names;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -339,6 +339,13 @@ PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
 IndirectFittingModel::IndirectFittingModel()
     : m_previousModelSelected(false), m_fittingMode(FittingMode::SEQUENTIAL) {}
 
+bool IndirectFittingModel::hasWorkspace(
+    std::string const &workspaceName) const {
+  auto const names = getWorkspaceNames();
+  auto const iter = std::find(names.begin(), names.end(), workspaceName);
+  return iter != names.end();
+}
+
 MatrixWorkspace_sptr
 IndirectFittingModel::getWorkspace(std::size_t index) const {
   if (index < m_fittingData.size())

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -47,6 +47,7 @@ public:
   IndirectFittingModel();
   virtual ~IndirectFittingModel() = default;
 
+  bool hasWorkspace(std::string const &workspaceName) const;
   virtual Mantid::API::MatrixWorkspace_sptr
   getWorkspace(std::size_t index) const;
   Spectra getSpectra(std::size_t index) const;
@@ -117,8 +118,6 @@ public:
                                             std::size_t spectrum) const;
   std::string getOutputBasename() const;
 
-  std::vector<std::string> getWorkspaceNames() const;
-
   void cleanFailedRun(Mantid::API::IAlgorithm_sptr fittingAlgorithm);
   void cleanFailedSingleRun(Mantid::API::IAlgorithm_sptr fittingAlgorithm,
                             std::size_t index);
@@ -142,6 +141,8 @@ protected:
   void removeFittingData(std::size_t index);
 
 private:
+  std::vector<std::string> getWorkspaceNames() const;
+
   void removeWorkspaceFromFittingData(std::size_t const &index);
 
   Mantid::API::IAlgorithm_sptr

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -47,7 +47,7 @@ public:
   IndirectFittingModel();
   virtual ~IndirectFittingModel() = default;
 
-  bool hasWorkspace(std::string const &workspaceName) const;
+  virtual bool hasWorkspace(std::string const &workspaceName) const;
   virtual Mantid::API::MatrixWorkspace_sptr
   getWorkspace(std::size_t index) const;
   Spectra getSpectra(std::size_t index) const;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -43,10 +43,11 @@ private:
     IndirectFittingModel - Provides methods for specifying and
     performing a QENS fit, as well as accessing the results of the fit.
 */
-class MANTIDQT_INDIRECT_DLL IndirectFittingModel : public AnalysisDataServiceObserver {
+class MANTIDQT_INDIRECT_DLL IndirectFittingModel
+    : public AnalysisDataServiceObserver {
 public:
   IndirectFittingModel();
-  virtual ~IndirectFittingModel() {observeReplace(false);}
+  virtual ~IndirectFittingModel() { observeReplace(false); }
 
   virtual Mantid::API::MatrixWorkspace_sptr
   getWorkspace(std::size_t index) const;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -72,8 +72,8 @@ public:
   virtual Mantid::API::IFunction_sptr getFittingFunction() const;
 
   virtual std::vector<std::string> getSpectrumDependentAttributes() const = 0;
-  void replaceHandle(const std::string &wsName,
-                     const Workspace_sptr &ws) override;
+  void replaceHandle(const std::string &workspaceName,
+                     const Workspace_sptr &workspace) override;
   void setFittingData(PrivateFittingData &&fittingData);
   void setSpectra(const std::string &spectra, std::size_t dataIndex);
   void setSpectra(Spectra &&spectra, std::size_t dataIndex);

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -11,6 +11,7 @@
 #include "IndirectFitOutput.h"
 
 #include "DllConfig.h"
+#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IAlgorithm.h"
 
@@ -42,10 +43,10 @@ private:
     IndirectFittingModel - Provides methods for specifying and
     performing a QENS fit, as well as accessing the results of the fit.
 */
-class MANTIDQT_INDIRECT_DLL IndirectFittingModel {
+class MANTIDQT_INDIRECT_DLL IndirectFittingModel : public AnalysisDataServiceObserver {
 public:
   IndirectFittingModel();
-  virtual ~IndirectFittingModel() = default;
+  virtual ~IndirectFittingModel() {observeReplace(false);}
 
   virtual Mantid::API::MatrixWorkspace_sptr
   getWorkspace(std::size_t index) const;
@@ -70,7 +71,8 @@ public:
   virtual Mantid::API::IFunction_sptr getFittingFunction() const;
 
   virtual std::vector<std::string> getSpectrumDependentAttributes() const = 0;
-
+  void replaceHandle(const std::string &wsName,
+                     const Workspace_sptr &ws) override;
   void setFittingData(PrivateFittingData &&fittingData);
   void setSpectra(const std::string &spectra, std::size_t dataIndex);
   void setSpectra(Spectra &&spectra, std::size_t dataIndex);
@@ -116,6 +118,8 @@ public:
   Mantid::API::IAlgorithm_sptr getSingleFit(std::size_t dataIndex,
                                             std::size_t spectrum) const;
   std::string getOutputBasename() const;
+
+  std::vector<std::string> getWorkspaceNames() const;
 
   void cleanFailedRun(Mantid::API::IAlgorithm_sptr fittingAlgorithm);
   void cleanFailedSingleRun(Mantid::API::IAlgorithm_sptr fittingAlgorithm,

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -11,7 +11,6 @@
 #include "IndirectFitOutput.h"
 
 #include "DllConfig.h"
-#include "MantidAPI/AnalysisDataServiceObserver.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IAlgorithm.h"
 
@@ -43,11 +42,10 @@ private:
     IndirectFittingModel - Provides methods for specifying and
     performing a QENS fit, as well as accessing the results of the fit.
 */
-class MANTIDQT_INDIRECT_DLL IndirectFittingModel
-    : public AnalysisDataServiceObserver {
+class MANTIDQT_INDIRECT_DLL IndirectFittingModel {
 public:
   IndirectFittingModel();
-  virtual ~IndirectFittingModel() { observeReplace(false); }
+  virtual ~IndirectFittingModel() = default;
 
   virtual Mantid::API::MatrixWorkspace_sptr
   getWorkspace(std::size_t index) const;
@@ -72,8 +70,7 @@ public:
   virtual Mantid::API::IFunction_sptr getFittingFunction() const;
 
   virtual std::vector<std::string> getSpectrumDependentAttributes() const = 0;
-  void replaceHandle(const std::string &workspaceName,
-                     const Workspace_sptr &workspace) override;
+
   void setFittingData(PrivateFittingData &&fittingData);
   void setSpectra(const std::string &spectra, std::size_t dataIndex);
   void setSpectra(Spectra &&spectra, std::size_t dataIndex);

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -257,8 +257,9 @@ IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
       m_model->getWorkspace(m_activeIndex)->getNumberHistograms() - 1;
   const auto expected = m_view->maximumSpectrum() - m_view->minimumSpectrum();
   if (hist < expected) {
-    validator.addErrorMessage(QString::fromStdString(
-        "Spectra range entered is greater than spectra range of sample workspace"));
+    validator.addErrorMessage(
+        QString::fromStdString("Spectra range entered is greater than spectra "
+                               "range of sample workspace"));
   }
   return m_view->validateMaskBinsString(validator);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -255,7 +255,8 @@ IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
 
   const auto numberOfHistograms =
       m_model->getWorkspace(m_activeIndex)->getNumberHistograms();
-  const auto expected = m_view->maximumSpectrum() - m_view->minimumSpectrum()+1;
+  const auto expected =
+      m_view->maximumSpectrum() - m_view->minimumSpectrum() + 1;
   if (hist < expected) {
     validator.addErrorMessage(
         QString::fromStdString("Spectra range entered is greater than spectra "

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -253,9 +253,9 @@ UserInputValidator &
 IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
   validator = validateSpectraString(validator);
 
-  const auto hist =
-      m_model->getWorkspace(m_activeIndex)->getNumberHistograms() - 1;
-  const auto expected = m_view->maximumSpectrum() - m_view->minimumSpectrum();
+  const auto numberOfHistograms =
+      m_model->getWorkspace(m_activeIndex)->getNumberHistograms();
+  const auto expected = m_view->maximumSpectrum() - m_view->minimumSpectrum()+1;
   if (hist < expected) {
     validator.addErrorMessage(
         QString::fromStdString("Spectra range entered is greater than spectra "

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -252,6 +252,14 @@ void IndirectSpectrumSelectionPresenter::displayBinMask() {
 UserInputValidator &
 IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
   validator = validateSpectraString(validator);
+
+  const auto hist =
+      m_model->getWorkspace(m_activeIndex)->getNumberHistograms() - 1;
+  const auto expected = m_view->maximumSpectrum() - m_view->minimumSpectrum();
+  if (hist < expected) {
+    validator.addErrorMessage(QString::fromStdString(
+        "Spectra range entered is greater than spectra range of sample workspace"));
+  }
   return m_view->validateMaskBinsString(validator);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -252,16 +252,6 @@ void IndirectSpectrumSelectionPresenter::displayBinMask() {
 UserInputValidator &
 IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
   validator = validateSpectraString(validator);
-
-  const auto numberOfHistograms =
-      m_model->getWorkspace(m_activeIndex)->getNumberHistograms();
-  const auto expected =
-      m_view->maximumSpectrum() - m_view->minimumSpectrum() + 1;
-  if (numberOfHistograms < expected)
-    validator.addErrorMessage(
-        QString::fromStdString("Spectra range entered is greater than spectra "
-                               "range of sample workspace"));
-
   return m_view->validateMaskBinsString(validator);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.cpp
@@ -257,11 +257,11 @@ IndirectSpectrumSelectionPresenter::validate(UserInputValidator &validator) {
       m_model->getWorkspace(m_activeIndex)->getNumberHistograms();
   const auto expected =
       m_view->maximumSpectrum() - m_view->minimumSpectrum() + 1;
-  if (hist < expected) {
+  if (numberOfHistograms < expected)
     validator.addErrorMessage(
         QString::fromStdString("Spectra range entered is greater than spectra "
                                "range of sample workspace"));
-  }
+
   return m_view->validateMaskBinsString(validator);
 }
 

--- a/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitAddWorkspaceDialog.h
@@ -31,6 +31,8 @@ public:
   void enableParameterSelection();
   void disableParameterSelection();
 
+  void updateSelectedSpectra() override{};
+
 public slots:
   void emitWorkspaceChanged(const QString &name);
   void emitParameterTypeChanged(const QString &index);

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -66,6 +66,10 @@ public:
   MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
   MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
 
+  MOCK_CONST_METHOD0(isSampleWorkspaceSelectorVisible, bool());
+  MOCK_METHOD1(setSampleWorkspaceSelectorIndex,
+               void(QString const &workspaceName));
+
   MOCK_METHOD1(readSettings, void(QSettings const &settings));
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -82,6 +82,10 @@ public:
   MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
   MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
 
+  MOCK_CONST_METHOD0(isSampleWorkspaceSelectorVisible, bool());
+  MOCK_METHOD1(setSampleWorkspaceSelectorIndex,
+               void(QString const &workspaceName));
+
   MOCK_METHOD1(readSettings, void(QSettings const &settings));
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
 
@@ -95,6 +99,8 @@ public:
   using IndirectFittingModel::addWorkspace;
 
   /// Public Methods
+  MOCK_CONST_METHOD1(hasWorkspace, bool(std::string const &workspaceName));
+
   MOCK_CONST_METHOD0(isMultiFit, bool());
   MOCK_CONST_METHOD0(numberOfWorkspaces, std::size_t());
 
@@ -275,6 +281,14 @@ public:
     EXPECT_CALL(*m_view, readSettings(_)).Times(Exactly(1));
 
     m_presenter->loadSettings(settings);
+  }
+
+  void test_that_replaceHandle_will_check_if_the_model_has_a_workspace() {
+    std::string const workspacename("DummyName");
+
+    EXPECT_CALL(*m_model, hasWorkspace(workspacename)).Times(Exactly(1));
+
+    m_presenter->replaceHandle(workspacename, createWorkspace(5));
   }
 
 private:

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -234,6 +234,18 @@ public:
   }
 
   void
+  test_that_hasWorkspace_returns_true_when_the_model_contains_a_workspace() {
+    auto const model = createModelWithSingleWorkspace("WorkspaceName", 3);
+    TS_ASSERT(model->hasWorkspace("WorkspaceName"));
+  }
+
+  void
+  test_that_hasWorkspace_returns_false_when_the_model_does_not_contain_a_workspace() {
+    auto const model = createModelWithSingleWorkspace("WorkspaceName", 3);
+    TS_ASSERT(!model->hasWorkspace("WrongName"));
+  }
+
+  void
   test_that_getWorkspace_returns_a_nullptr_when_getWorkspace_is_provided_an_out_of_range_index() {
     auto const model = createModelWithSingleWorkspace("WorkspaceName", 3);
     TS_ASSERT_EQUALS(model->getWorkspace(1), nullptr);

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -92,6 +92,10 @@ public:
   MOCK_METHOD1(setResolutionWSSuffices, void(QStringList const &suffices));
   MOCK_METHOD1(setResolutionFBSuffices, void(QStringList const &suffices));
 
+  MOCK_CONST_METHOD0(isSampleWorkspaceSelectorVisible, bool());
+  MOCK_METHOD1(setSampleWorkspaceSelectorIndex,
+               void(QString const &workspaceName));
+
   MOCK_METHOD1(readSettings, void(QSettings const &settings));
   MOCK_METHOD1(validate, UserInputValidator &(UserInputValidator &validator));
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -84,6 +84,10 @@ public:
   QString getWsNameFromFiles() const;
   /// Get the currently available file or workspace name
   QString getCurrentDataName() const;
+  /// Sets which selector (file or workspace) is visible
+  void setSelectorIndex(int index);
+  /// Set the index of the combobox containing the loaded workspace
+  void setWorkspaceSelectorIndex(QString const &workspaceName);
   /// Get whether the file selector is currently being shown
   bool isFileSelectorVisible() const;
   /// Get whether the workspace selector is currently being shown
@@ -420,8 +424,6 @@ private slots:
 private:
   /// Attempt to automatically load a file
   void autoLoadFile(const QString &filenames);
-  /// Set the index of the combobox containing the loaded workspace
-  void setWorkspaceSelectorIndex(QString const &workspaceName);
   /// Member containing the widgets child widgets.
   Ui::DataSelector m_uiForm;
   /// Algorithm Runner used to run the load algorithm

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -125,6 +125,13 @@ void DataSelector::handleFileInput() {
 }
 
 /**
+ * Sets whether the file or workspace selector is visible
+ */
+void DataSelector::setSelectorIndex(int index) {
+  m_uiForm.cbInputType->setCurrentIndex(index);
+}
+
+/**
  * Get if the file selector is currently being shown.
  *
  * @return :: true if it is visible, otherwise false


### PR DESCRIPTION
**Description of work.**
This PR updates the Data Analysis Model when a workspace stored within the model has changed. This prevents a spectra out of range error.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit`
2. Load the data below 
3. Choose `One Lorentzian` as Fit Type (the `Fit Spectra` should be between 0 and 17)
4. Click `Run` and wait. A fit should be produced
5. `Interfaces`->`Indirect`->`Data Reduction`->`ISISEnergyTransfer` (Keep Data Analysis Open)
6. The instrument should be `IRIS`
7. The detector grouping should be `Individual`
8. Enter the run number 26176
9. Click `Run` and wait
10. Go back to `Data Analysis`. The `Fit Spectra` should have changed to be 0 to 50.
11. Click `Run`. A Fit should be produced

**Data Files**
Sample: 
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3083751/iris26176_graphite002_red.zip)
Resolution:
[iris26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/3083752/iris26173_graphite002_res.zip)

Fixes #25074 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
