### PR TITLE
Updated decrement/increment to display one value 

### DIFF
--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -141,7 +141,8 @@ class LoadRunWidgetPresenter(object):
     # ------------------------------------------------------------------------------------------------------------------
 
     def handle_increment_run(self):
-        self.run_list = self.get_incremented_run_list()
+        incremented_run_list = self.get_incremented_run_list()
+        self.run_list = [max(incremented_run_list)] if incremented_run_list else []
         if not self.run_list:
             return
         new_run = max(self.run_list)
@@ -154,7 +155,8 @@ class LoadRunWidgetPresenter(object):
         self.load_runs([file_name])
 
     def handle_decrement_run(self):
-        self.run_list = self.get_decremented_run_list()
+        decremented_run_list = self.get_decremented_run_list()
+        self.run_list = [min(decremented_run_list)] if decremented_run_list else []
         if not self.run_list:
             return
         new_run = min(self.run_list)

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -129,7 +129,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         self.assertEqual(self.presenter.runs, [[self._loaded_run], [new_run]])
         self.assertEqual(self.presenter.workspaces, [self._loaded_workspace, {'MainFieldDirection': 'transverse'}])
 
-        self.assertEqual(self.view.get_run_edit_text(), '1233-1234')
+        self.assertEqual(self.view.get_run_edit_text(), '1233')
 
     @run_test_with_and_without_threading
     def test_that_increment_run_loads_the_data_correctly(self):
@@ -144,7 +144,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         self.assertEqual(self.presenter.runs, [[self._loaded_run], [new_run]])
         self.assertEqual(self.presenter.workspaces, [self._loaded_workspace, {'MainFieldDirection': 'transverse'}])
 
-        self.assertEqual(self.view.get_run_edit_text(), '1234-1235')
+        self.assertEqual(self.view.get_run_edit_text(), '1235')
 
     @run_test_with_and_without_threading
     def test_that_if_decrement_run_fails_the_data_are_returned_to_previous_state(self):
@@ -154,8 +154,8 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         self.wait_for_thread(self.presenter._load_thread)
 
         self.assert_model_has_not_changed()
-        self.assert_view_has_not_changed()
-#
+        self.assertEqual(self.view.get_run_edit_text(), '')
+
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_the_data_are_returned_to_previous_state(self):
         self.load_utils_patcher.load_workspace_from_filename = mock.Mock(side_effect=self.load_failure)
@@ -164,7 +164,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         self.wait_for_thread(self.presenter._load_thread)
 
         self.assert_model_has_not_changed()
-        self.assert_view_has_not_changed()
+        self.assertEqual(self.view.get_run_edit_text(), '')
 
     @run_test_with_and_without_threading
     def test_that_if_decrement_run_fails_warning_message_is_displayed(self):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -123,7 +123,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[1], [2], [3], [4]])
         six.assertCountEqual(self, self.model.loaded_runs, [[1], [2], [3], [4]])
 
-        self.assertEqual(self.view.get_run_edit_text(), "1-4")
+        self.assertEqual(self.view.get_run_edit_text(), "1")
 
     @run_test_with_and_without_threading
     def test_that_increment_run_increments_the_lower_end_of_the_range_of_loaded_runs(self):
@@ -137,7 +137,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[2], [3], [4], [5]])
         six.assertCountEqual(self, self.model.loaded_runs, [[2], [3], [4], [5]])
 
-        self.assertEqual(self.view.get_run_edit_text(), "2-5")
+        self.assertEqual(self.view.get_run_edit_text(), "5")
 
     @run_test_with_and_without_threading
     def test_that_if_decrement_run_fails_the_data_are_returned_to_previous_state(self):
@@ -152,7 +152,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[2], [3], [4]])
         six.assertCountEqual(self, self.model.loaded_runs, [[2], [3], [4]])
 
-        self.assertEqual(self.view.get_run_edit_text(), "2-4")
+        self.assertEqual(self.view.get_run_edit_text(), "")
 
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_the_data_are_returned_to_previous_state(self):
@@ -167,7 +167,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[2], [3], [4]])
         six.assertCountEqual(self, self.model.loaded_runs, [[2], [3], [4]])
 
-        self.assertEqual(self.view.get_run_edit_text(), "2-4")
+        self.assertEqual(self.view.get_run_edit_text(), "")
 
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_warning_message_is_displayed(self):


### PR DESCRIPTION
**Description of work.**

Currently the increment and decrement buttons on the frequency domain analysis GUI increase the range of runs selected in the runs box. They should instead switch to a single run.

**Report to:** James Lord <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
* You need to have access to the ISIS data archive to test this issue
* Open frequency domain analysis, select HIFI and load run 74447, Click back and forth on the increment and decrement buttons and check that it switches to one current run each time. 
* Try with a range or comma seperated list of runs and check that it always ends up with one run which is one higher or lower than the previous extreme value.

<!-- Instructions for testing. -->

Fixes #25105  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because this is a change to a new GUI


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
