### PR TITLE
Update FFT PhaseQuad to cope with multiple CHRONUS grouping files

### DIFF
--- a/Framework/Muon/src/CalMuonDetectorPhases.cpp
+++ b/Framework/Muon/src/CalMuonDetectorPhases.cpp
@@ -398,7 +398,7 @@ void CalMuonDetectorPhases::getGroupingFromInstrument(
   const auto instrument = ws->getInstrument();
   auto loader = Kernel::make_unique<API::GroupingLoader>(instrument);
 
-  if (instrument->getName() == "MUSR") {
+  if (instrument->getName() == "MUSR" || instrument->getName() == "CHRONUS") {
     // Two possibilities for grouping - use workspace log
     auto fieldDir = ws->run().getLogData("main_field_direction");
     if (fieldDir) {

--- a/docs/source/release/v4.0.0/muon.rst
+++ b/docs/source/release/v4.0.0/muon.rst
@@ -20,6 +20,7 @@ Improvements
 - ALC interface now sorts the data into ascending order.
 - Muon Analysis now includes number of event per frame and number of events per frame per detector in the run info box on the home tab.
 - Frequency Domain Analysis now lets the user select the phase table in MaxEnt mode.
+- CHRONUS now has a transverse and longitudanal default grouping table, the main field direction is read from the file to determine which to use.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

After a transverse and longitudanal grouping table was added for CHRONUS the phase quad FFT transform ceased to work. This PR resolves this issue.

**Report to:** James Lord (Remind me to ask him to check the change once it is on nightly) <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
* Open frequency domain analysis, select CHRONUS as the instrument and load run 7873 (If you don't have access to the ISIS data archive contact me and I can send you the file)
* Go to the transform tab select CHRONUS7873_raw_data (PhaseQuad) as the workspace.
* Change last good data to 10
* Change the Apodization function to Lorenz and the decay constant to 4.4 
* You should hopefully get no errors and a workspace should be produced in Muon Data->CHRONUS7873.


<!-- Instructions for testing. -->

Fixes #25101  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->




---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
