### PR TITLE
Grouping tab should automatically update upon changes to tables

### DIFF
--- a/docs/source/interfaces/muon_grouping_tab.rst
+++ b/docs/source/interfaces/muon_grouping_tab.rst
@@ -15,15 +15,12 @@ Grouping Tab
 
 **Default** Loads in the default groups and pairs for the instrument
 
-**Update All** Recalculates all groups and pairs putting the result in the ADS. New or modified groups
-and pairs are not automatically recalculated.
-
 Grouping Table
 ^^^^^^^^^^^^^^
 
 **Plus and Minus** Add or remove groups
 
-**Group Asymmetry Range** Controls the range to use when estimating the group asymmetry. By default this range is the first good data and end time value from the file
+**Group Asymmetry Range** Controls the range to use when estimating the group asymmetry. The values are used as ``StartX`` and ``EndX`` in :ref:`EstimateMuonAsymmetryFromCounts <algm-EstimateMuonAsymmetryFromCounts>`. By default this range is the first good data and end time value from the file
 but may be overridden here if required.
 
 

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from Muon.GUI.Common.observer_pattern import Observer, Observable
-
+from functools import partial
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
 import Muon.GUI.Common.utilities.xml_utils as xml_utils
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
@@ -86,6 +86,16 @@ class GroupingTabPresenter(object):
         """
         Calculate alpha for the pair for which "Guess Alpha" button was clicked.
         """
+        self.input_prepopulated_callback = partial(self.handle_guess_alpha_after_update, pair_name, group1_name, group2_name)
+
+        self.update_thread = self.create_update_thread()
+        self.update_thread.threadWrapperSetUp(self.disable_editing,
+                                              self.input_prepopulated_callback,
+                                              self._view.display_warning_box)
+        self.update_thread.start()
+
+    def handle_guess_alpha_after_update(self, pair_name, group1_name, group2_name):
+        self.enable_editing()
         if len(self._model._data.current_runs) > 1:
             run, index, ok_clicked = RunSelectionDialog.get_run(self._model._data.current_runs, self._model._data.instrument, self._view)
             if not ok_clicked:
@@ -194,10 +204,10 @@ class GroupingTabPresenter(object):
     # ------------------------------------------------------------------------------------------------------------------
 
     def group_table_changed(self):
-        pass
+        self.handle_update_all_clicked()
 
     def pair_table_changed(self):
-        pass
+        self.handle_update_all_clicked()
 
     class LoadObserver(Observer):
 

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 from Muon.GUI.Common.observer_pattern import Observer, Observable
-from functools import partial
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
 import Muon.GUI.Common.utilities.xml_utils as xml_utils
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
@@ -32,7 +31,6 @@ class GroupingTabPresenter(object):
         self._view.set_description_text(self.text_for_description())
         self._view.on_add_pair_requested(self.add_pair_from_grouping_table)
         self._view.on_clear_grouping_button_clicked(self.on_clear_requested)
-        self._view.on_update_button_clicked(self.handle_update_all_clicked)
         self._view.on_load_grouping_button_clicked(self.handle_load_grouping_from_file)
         self._view.on_save_grouping_button_clicked(self.handle_save_grouping_file)
         self._view.on_default_grouping_button_clicked(self.handle_default_grouping_button_clicked)
@@ -86,16 +84,6 @@ class GroupingTabPresenter(object):
         """
         Calculate alpha for the pair for which "Guess Alpha" button was clicked.
         """
-        self.input_prepopulated_callback = partial(self.handle_guess_alpha_after_update, pair_name, group1_name, group2_name)
-
-        self.update_thread = self.create_update_thread()
-        self.update_thread.threadWrapperSetUp(self.disable_editing,
-                                              self.input_prepopulated_callback,
-                                              self._view.display_warning_box)
-        self.update_thread.start()
-
-    def handle_guess_alpha_after_update(self, pair_name, group1_name, group2_name):
-        self.enable_editing()
         if len(self._model._data.current_runs) > 1:
             run, index, ok_clicked = RunSelectionDialog.get_run(self._model._data.current_runs, self._model._data.instrument, self._view)
             if not ok_clicked:

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_view.py
@@ -18,7 +18,6 @@ class GroupingTabView(QtGui.QWidget):
         self.default_grouping_button = None
         self.vertical_layout = None
         self.horizontal_layout_base = None
-        self.update_button = None
         self.horizontal_layout_description = None
         self.description_label = None
         self.description_edit = None
@@ -58,10 +57,6 @@ class GroupingTabView(QtGui.QWidget):
         self.horizontal_layout.addWidget(self.default_grouping_button)
 
         self.horizontal_layout_base = QtGui.QHBoxLayout()
-        self.update_button = QtGui.QPushButton(self)
-        self.update_button.setText("Update All")
-        self.update_button.setToolTip("Calculate group counts and pair asymmetries from the tables and store the data.")
-        self.horizontal_layout_base.addWidget(self.update_button)
 
         self.vertical_layout = QtGui.QVBoxLayout(self)
         self.vertical_layout.setObjectName("verticalLayout")
@@ -101,7 +96,6 @@ class GroupingTabView(QtGui.QWidget):
         self.save_grouping_button.setEnabled(enabled)
         self.clear_grouping_button.setEnabled(enabled)
         self.default_grouping_button.setEnabled(enabled)
-        self.update_button.setEnabled(enabled)
 
     def set_grouping_table(self, table):
         self._grouping_table = table
@@ -163,9 +157,6 @@ class GroupingTabView(QtGui.QWidget):
 
     def on_default_grouping_button_clicked(self, slot):
         self.default_grouping_button.clicked.connect(slot)
-
-    def on_update_button_clicked(self, slot):
-        self.update_button.clicked.connect(slot)
 
     def on_load_grouping_button_clicked(self, slot):
         self.load_grouping_button.clicked.connect(slot)

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -157,7 +157,7 @@ class GroupingTabPresenterTest(unittest.TestCase):
 
     def test_update_all_calculates_groups_and_pairs(self):
         self.presenter.create_update_thread = mock.MagicMock(return_value=mock.MagicMock())
-        self.view.update_button.clicked.emit(True)
+        self.presenter.handle_update_all_clicked()
 
         self.presenter.update_thread.threadWrapperSetUp.assert_called_once_with(self.presenter.disable_editing,
                                                                                 self.presenter.handle_update_finished,


### PR DESCRIPTION
**Description of work.**

This updates the new GUI so that when the group or pair tables are changed the data is automatically recalculated. As this then removes the need for the update all button this is removed.

**Report to:** James Lord <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
* Open FrequencyDomainAnalysis, select MUSR as the instrument and load a run. If you are not at ISIS 22725 is in the unit test directory
* Go to the grouping tab, make some changes to the groups and pairs table and check that the group and pair workspaces in the ADS are automatically updated.

<!-- Instructions for testing. -->

Fixes #25111  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it is a change a new GUI


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
