### PR TITLE
VSI crash fixed.

### DIFF
--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/PeaksTabWidget.cpp
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/src/PeaksTabWidget.cpp
@@ -138,7 +138,7 @@ void PeaksTabWidget::updateTab(const std::vector<bool> &visiblePeaks,
 void PeaksTabWidget::addNewPeaksWorkspace(
     Mantid::API::IPeaksWorkspace_sptr peaksWorkspace,
     std::vector<bool> visiblePeaks) {
-  m_ws.push_back(std::move(peaksWorkspace));
+  m_ws.push_back(peaksWorkspace);
   addNewTab(peaksWorkspace, peaksWorkspace->getName(), std::move(visiblePeaks));
 }
 } // namespace SimpleGui


### PR DESCRIPTION
**Description of work.**
A shared pointer was referenced after it was moved. Copy the pointer instead.

**To test:**
Follow the instructions in the issue description and after that drag and drop the other peaks workspace. This way it always crashes (without the fix).

Fixes #24996.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
