### PR TITLE
 Input parameters for ModeratorTzeroLinear

### DIFF
--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -59,6 +59,12 @@ void ModeratorTzeroLinear::init() {
                       boost::make_shared<WorkspaceUnitValidator>("TOF")),
                   "The name of the input workspace, containing events and/or "
                   "histogram data, in units of time-of-flight");
+  declareProperty("Gradient", EMPTY_DBL(),
+                  "Wavelength dependent TOF shift, units in microsec/Angstrom. "
+                  "Overrides the value stored in the instrument object");
+  declareProperty("Intercept", EMPTY_DBL(),
+                  "TOF shift, units in microseconds. Overrides the value"
+                  "stored in the instrument object");
   // declare the output workspace
   declareProperty(make_unique<WorkspaceProperty<MatrixWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
@@ -95,24 +101,39 @@ void ModeratorTzeroLinear::exec() {
 
   // gradient, intercept constants
   try {
+
+      // determine which Gradient to use
     const std::vector<double> gradientParam =
         m_instrument->getNumberParameter("Moderator.TimeZero.gradient");
-    if (gradientParam.empty())
+    const double gradientParamManual = getProperty("Gradient");
+    if (gradientParam.empty() && gradientParamManual == EMPTY_DBL())
       throw Exception::InstrumentDefinitionError(
           "Unable to retrieve Moderator Time Zero parameters (gradient)",
           inputWS->getTitle());
-    m_gradient = gradientParam[0]; //[gradient]=microsecond/Angstrom
+    if (gradientParamManual != EMPTY_DBL()){
+        m_gradient = gradientParamManual;
+    } else {
+        m_gradient = gradientParam[0]; //[gradient]=microsecond/Angstrom
+    }
     // conversion factor for gradient from microsecond/Angstrom to meters
     double convfactor =
         1.0e4 * PhysicalConstants::h / PhysicalConstants::NeutronMass;
     m_gradient *= convfactor; //[gradient] = meter
+
+    // determine which Intercept to use
     const std::vector<double> interceptParam =
         m_instrument->getNumberParameter("Moderator.TimeZero.intercept");
-    if (interceptParam.empty())
+    const double interceptParamManual = getProperty("Intercept");
+    if (interceptParam.empty() && interceptParamManual == EMPTY_DBL())
       throw Exception::InstrumentDefinitionError(
           "Unable to retrieve Moderator Time Zero parameters (intercept)",
           inputWS->getTitle());
-    m_intercept = interceptParam[0]; //[intercept]=microsecond
+    if (interceptParamManual != EMPTY_DBL()){
+        m_intercept = interceptParamManual;
+    } else {
+        m_intercept = interceptParam[0]; //[intercept]=microsecond
+    }
+
     g_log.debug() << "Moderator Time Zero: gradient=" << m_gradient
                   << "intercept=" << m_intercept << '\n';
   } catch (Exception::NotFoundError &) {

--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -102,7 +102,7 @@ void ModeratorTzeroLinear::exec() {
   // gradient, intercept constants
   try {
 
-      // determine which Gradient to use
+    // determine which Gradient to use
     const std::vector<double> gradientParam =
         m_instrument->getNumberParameter("Moderator.TimeZero.gradient");
     const double gradientParamManual = getProperty("Gradient");
@@ -110,10 +110,10 @@ void ModeratorTzeroLinear::exec() {
       throw Exception::InstrumentDefinitionError(
           "Unable to retrieve Moderator Time Zero parameters (gradient)",
           inputWS->getTitle());
-    if (gradientParamManual != EMPTY_DBL()){
-        m_gradient = gradientParamManual;
+    if (gradientParamManual != EMPTY_DBL()) {
+      m_gradient = gradientParamManual;
     } else {
-        m_gradient = gradientParam[0]; //[gradient]=microsecond/Angstrom
+      m_gradient = gradientParam[0]; //[gradient]=microsecond/Angstrom
     }
     // conversion factor for gradient from microsecond/Angstrom to meters
     double convfactor =
@@ -128,10 +128,10 @@ void ModeratorTzeroLinear::exec() {
       throw Exception::InstrumentDefinitionError(
           "Unable to retrieve Moderator Time Zero parameters (intercept)",
           inputWS->getTitle());
-    if (interceptParamManual != EMPTY_DBL()){
-        m_intercept = interceptParamManual;
+    if (interceptParamManual != EMPTY_DBL()) {
+      m_intercept = interceptParamManual;
     } else {
-        m_intercept = interceptParam[0]; //[intercept]=microsecond
+      m_intercept = interceptParam[0]; //[intercept]=microsecond
     }
 
     g_log.debug() << "Moderator Time Zero: gradient=" << m_gradient

--- a/Framework/Algorithms/test/ModeratorTzeroLinearTest.h
+++ b/Framework/Algorithms/test/ModeratorTzeroLinearTest.h
@@ -13,6 +13,8 @@
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidAPI/AlgorithmManager.h"
+
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid;
@@ -99,6 +101,50 @@ public:
                            // exceptions and not return them
     TS_ASSERT_THROWS(alg.execute(), Exception::InstrumentDefinitionError);
     AnalysisDataService::Instance().remove("testWS");
+  }
+
+  void testExecManualOverride() {
+    // Workspace with indirect instrument
+    MatrixWorkspace_sptr testWS = CreateHistogramWorkspace();
+    AnalysisDataService::Instance().add("testWS", testWS);
+    const bool add_deltaE_mode = true;
+    addToInstrument(testWS, add_deltaE_mode);
+
+    // Pass input parameters to the algorithm. Algorithm will execute
+    // even though the instrument lacks parameter Gradient and Intercept
+    alg.initialize();
+    alg.setProperty("InputWorkspace", testWS);
+    alg.setProperty("Gradient", 24.0);
+    alg.setProperty("Intercept", 42.0);
+    alg.setProperty("OutputWorkspace", "outWS1");
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Add parameters to the instrument. Parameter values (11.0 and -5.0)
+    // are different than the manual values (24.0 and 42.0)
+    const bool add_t0_formula = true;
+    addToInstrument(testWS, add_deltaE_mode, add_t0_formula);
+    alg.setProperty("OutputWorkspace", "outWS2");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    // Instrument parameters are not used because the manual values override
+    // Thus, TOFs in outWS2 should be the same as outWS1.
+    // Note: instruments will be different
+    auto checkAlg =
+        AlgorithmManager::Instance().createUnmanaged("CompareWorkspaces");
+    checkAlg->initialize();
+    checkAlg->setChild(true);
+    checkAlg->setProperty("Workspace1", "outWS1");
+    checkAlg->setProperty("Workspace2", "outWS2");
+    checkAlg->setProperty("CheckInstrument", false);
+    checkAlg->setProperty("Tolerance", 1.0e-9);
+    checkAlg->execute();
+    TS_ASSERT(checkAlg->getProperty("Result"));
+
+    AnalysisDataService::Instance().remove("testWS");
+    AnalysisDataService::Instance().remove("outWS1");
+    AnalysisDataService::Instance().remove("outWS2");
+
   }
 
   /*

--- a/Framework/Algorithms/test/ModeratorTzeroLinearTest.h
+++ b/Framework/Algorithms/test/ModeratorTzeroLinearTest.h
@@ -7,13 +7,13 @@
 #ifndef MANTID_ALGORITHMS_MODERATORTZEROLINEARTEST_H_
 #define MANTID_ALGORITHMS_MODERATORTZEROLINEARTEST_H_
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAlgorithms/ModeratorTzeroLinear.h"
 #include "MantidHistogramData/LinearGenerator.h"
 #include "MantidKernel/UnitFactory.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
-#include "MantidAPI/AlgorithmManager.h"
 
 #include <cxxtest/TestSuite.h>
 
@@ -144,7 +144,6 @@ public:
     AnalysisDataService::Instance().remove("testWS");
     AnalysisDataService::Instance().remove("outWS1");
     AnalysisDataService::Instance().remove("outWS2");
-
   }
 
   /*

--- a/docs/source/algorithms/ModeratorTzeroLinear-v1.rst
+++ b/docs/source/algorithms/ModeratorTzeroLinear-v1.rst
@@ -16,8 +16,8 @@ This algorithm is suitable to data reduction of indirect instruments
 featuring a neutron flux with a narrow distribution of wavelengths. A
 empirical formula for the correction, stored in the instrument
 definition file, is taken as linear on the initial neutron wavelength
-:math:`\lambda_i`: :math:`t_0 = a * \lambda_i + b`,
-(:math:`a` is in units of microsec/Angstrom and :math:`a` is in units 
+:math:`\lambda_i`: :math:`t_0 = a * \lambda_i + b`. Gradient :math:`a` is
+in units of microsec/Angstrom and Intercept :math:`b` is in units
 of microsec. Below is the example XML code included in BASIS beamline 
 parameters file.
 

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -10,3 +10,11 @@ Indirect Geometry Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 4.1.0 <v4.1.0>`
+
+Algorithms
+----------
+
+Improvements
+############
+
+- :ref:`ModeratorTzeroLinear <algm-ModeratorTzeroLinear>` permits now passing parameter values as input properties.


### PR DESCRIPTION
**Description of work.**
- [x] added/modified Algorithm source code
- [x] unit test for the new features
- [x] updated [release notes](https://github.com/mantidproject/mantid/blob/8611310ad03e8fe615111e621fe08de3b03f4871/docs/source/release/v4.1.0/indirect_geometry.rst#improvements)
- [x] python test script for reviewer

**To test:**

Run the following python script:

```
w = Load('BSS_84646', BankName='bank1')
h = Rebin(w, Params=[0,100,150000], PreserveEvents=False)
h = SumSpectra(h)

# Shift 100000 microseconds
tof_shift = 100000
w2 = ModeratorTzeroLinear(w, Gradient=0.0, Intercept=tof_shift)
h2 = Rebin(w2, Params=[0,100,150000], PreserveEvents=False)
h2 = SumSpectra(h2)

# Assert the maximum has shifted 1000000 microseconds
import numpy as np
i = np.argmax(h.dataY(0))
i2 = np.argmax(h2.dataY(0))
assert h.dataX(0)[i] - h2.dataX(0)[i2] == tof_shift
```
Description of the script: we load an events file and sum all events to produce a histogram of time-of-flights (workspace `h`). We redo this step but shift the TOFs by 100 micro-seconds (workspace `h2`). Finally, we assert that the peak maximum of `h2` is shifted 100 micro-seconds with respect the peak maximum of `h`.

Fixes #25132

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
