### PR TITLE
 basis paramfiles

### DIFF
--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -19,6 +19,12 @@ New Algorithms
 - :ref:`IndirectReplaceFitResult <algm-IndirectReplaceFitResult>` will replace the *_Result* fit data found in one workspace with the 
   single fit data provided within a second workspace.
 
+Improvements
+############
+
+- :ref:`BASISReduction <algm-BASISReduction>` user interface contains slightly different naming convention for selection of reflection and works for old and new DAS.
+
+
 :ref:`Release 4.0.0 <v4.0.0>`
 
 Data Analysis Interface

--- a/instrument/BASIS_silicon_111_Parameters.xml
+++ b/instrument/BASIS_silicon_111_Parameters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2010-07-15T00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="11.967"/>
+    <value val="12.925"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="-5.0"/>
+    <value val="0.0"/>
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_111_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_111_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -37,15 +37,15 @@
   </parameter>
 
   <parameter name="reflection" type="string">
-    <value val="333" />
+    <value val="111" />
   </parameter>
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>
@@ -53,11 +53,11 @@
 <component-link name="silicon">
 
   <parameter name="Efixed">
-    <value val="18.7434" />
+    <value val="2.082" />
   </parameter>
 
   <parameter name="resolution">
-    <value val="0.0315" />
+    <value val="0.0035" />
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_311_Parameters.xml
+++ b/instrument/BASIS_silicon_311_Parameters.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2010-07-15T00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="11.967"/>
+    <value val="12.9257"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="-5.0"/>
+    <value val="8.7"/>
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_311_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_311_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -31,21 +31,21 @@
   <parameter name="back-end">
     <value val="138000" />
   </parameter>
-
+ 
   <parameter name="analyser" type="string">
     <value val="silicon" />
   </parameter>
 
   <parameter name="reflection" type="string">
-    <value val="333" />
+    <value val="311" />
   </parameter>
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>
@@ -53,11 +53,11 @@
 <component-link name="silicon">
 
   <parameter name="Efixed">
-    <value val="18.7434" />
+    <value val="7.6368" />
   </parameter>
 
   <parameter name="resolution">
-    <value val="0.0315" />
+    <value val="0.015" />
   </parameter>
 
 </component-link>

--- a/instrument/BASIS_silicon_333_Parameters_2010_2018.xml
+++ b/instrument/BASIS_silicon_333_Parameters_2010_2018.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<parameter-file instrument = "BASIS" valid-from = "2019-01-01 00:00:00">
+<parameter-file instrument = "BASIS" valid-from = "2010-07-15 00:00:00" valid-to = "2018-12-31 23:59:59">
 
 <component-link name = "BASIS">
 
@@ -42,10 +42,10 @@
 
   <!-- Moderator Tzero/LambdaZero Parameters  -->
   <parameter name="Moderator.TimeZero.Gradient">
-    <value val="12.925"/>
+    <value val="11.967"/>
   </parameter>
   <parameter name="Moderator.TimeZero.Intercept">
-    <value val="0.0"/>
+    <value val="-5.0"/>
   </parameter>
 
 </component-link>


### PR DESCRIPTION
**Description of work.**
- [x] New parameter file for each silicon reflection (updated delayed time parameters for the moderator)
- [x] Update `BASISReduction` to select parameter files based on run's timestamp
- [x] Updated [release notes](https://github.com/mantidproject/mantid/blob/c281071e117317777dd03069be80ad06fdf4d3ed/docs/source/release/v4.0.0/indirect_inelastic.rst#improvements)

**Report to:** [nobody]

**To test:**
Run the following script. It will reduce an old run and a new run. The parameter file will be different in each case
```
common_args=dict(MonitorNorm=False, ReflectionType='silicon_111', EnergyBins=[-100, 0.4, 100], MomentumTransferBins=[0.3, 0.2, 1.9])
for run in ('55555', '90177'):
    BASISReduction(RunNumbers=run, **common_args)
    print(mtd['BSS_{}_sqw'.format(run)].getRun().getProperty('reflParmFile').value)
# Printout lines, in this order:
#     BASIS_silicon_111_Parameters_2010_2018.xml
#     BASIS_silicon_111_Parameters.xml
```
Fixes #24881
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
