### PR TITLE
Further distinguish deprecated ISIS sans gui from new gui

### DIFF
--- a/docs/source/release/v4.0.0/sans.rst
+++ b/docs/source/release/v4.0.0/sans.rst
@@ -27,7 +27,7 @@ This release sees the "new" ISIS SANS interface becoming the primary interface, 
 Active development will only be carried out on the new interface and only major bugs will be fixed in the deprecated interface.
 This change does not affect the functionality of either of the interfaces.
 
-To signify this change, the "ISIS SANS" interface has been renamed "ISIS SANS (Deprecated)" and the "ISIS SANS v2 experimental" interface has been renamed "ISIS SANS".
+To signify this change, the "ISIS SANS" interface has been renamed "Old ISIS SANS (Deprecated)" and the "ISIS SANS v2 experimental" interface has been renamed "ISIS SANS".
 The old interface will be removed in a later release.
 
 .. figure:: ../../images/sans_isis_interface_4.0.png

--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
@@ -51,7 +51,7 @@ class SANSRunWindow : public MantidQt::API::UserSubWindow {
 
 public:
   /// Name of the interface
-  static std::string name() { return "ISIS SANS (Deprecated)"; }
+  static std::string name() { return "Old ISIS SANS (Deprecated)"; }
   // This interface's categories.
   static QString categoryInfo() { return "SANS"; }
 


### PR DESCRIPTION
**Description of work.**
The SANS scientists requested that the name of the old gui, which was recently changed to `ISIS SANS (deprecated)` was made more distinct from the main gui name to avoid accidentally using the wrong gui.

This PR changes the old gui's name to `Old ISIS SANS (deprecated)`

**To test:**
In mantidplot, check that SANS -> ISIS SANS opens up the new gui and SANS -> Old ISIS SANS (deprecated) opens up the old gui

*There is no associated issue.*

*This does not require release notes* because **minor change to interface name not seen in release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
