### PR TITLE
Fix Workbench startup when switching Python versions

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -532,10 +532,7 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-            try:
-                self.restoreState(settings.get('MainWindow/state'))
-            except:
-                self.setWindowState(Qt.WindowMaximized)
+            self.restoreState(settings.get('MainWindow/state'))
         else:
             self.setWindowState(Qt.WindowMaximized)
 

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -532,10 +532,10 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-			try:
+            try:
                 self.restoreState(settings.get('MainWindow/state'))
-			except:
-				self.setWindowState(Qt.WindowMaximized)
+            except:
+                self.setWindowState(Qt.WindowMaximized)
         else:
             self.setWindowState(Qt.WindowMaximized)
 

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -532,7 +532,10 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-            self.restoreState(settings.get('MainWindow/state'))
+			try:
+                self.restoreState(settings.get('MainWindow/state'))
+			except:
+				self.setWindowState(Qt.WindowMaximized)
         else:
             self.setWindowState(Qt.WindowMaximized)
 

--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -41,10 +41,12 @@ class UserConfig(object):
         default_settings = self._flatten_defaults(defaults)
 
         # put defaults into qsettings if they weren't there already
-        configFileKeys = self.qsettings.allKeys()
-        for key in default_settings.keys():
-            if key not in configFileKeys:
-                self.qsettings.setValue(key, default_settings[key])
+        try:
+            self.set_qsettings_values(default_settings)
+        # the editors/sessiontabs are pickled in config so need to remove them
+        except ValueError:
+            self.qsettings.remove('Editors/SessionTabs')
+            self.set_qsettings_values(default_settings)
 
         # fixup the values of booleans - they do not evaluate correctly when read from the config file
         for key in self.all_keys():
@@ -56,6 +58,12 @@ class UserConfig(object):
                 self.set(key, True)
             elif value == 'false':
                 self.set(key, False)
+
+    def set_qsettings_values(self, default_settings):
+        configFileKeys = self.qsettings.allKeys()
+        for key in default_settings.keys():
+            if key not in configFileKeys:
+                self.qsettings.setValue(key, default_settings[key])
 
     def all_keys(self, group=None):
         if group is not None:


### PR DESCRIPTION
**Description of work.**

Adds try-except to skip a pickle issue between Python 2 and Python 3 for the cached state variable for the workbench. will default to behavior if not cached state was found.

**Report to:** @TTitcombe 

**To test:**
Build both python 2 and python 3 variants of the workbench. Open one and then the other, ensure no `ValueError: unsupported pickle protocol` is raised.

Fixes #25146
*This does not require release notes* because deals with non-User case of two workbench installs for different Python versions.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
