### PR TITLE
Fix power scale on workbench instrument view

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -198,6 +198,7 @@ public slots:
   void changeColorMapRange(double minValue, double maxValue); // Deprecated
   void setIntegrationRange(double, double);
   void setBinRange(double, double);
+  void disableColorMapAutoscaling(); // Deprecated
   void setColorMapAutoscaling(bool); // Deprecated
 
   void setViewDirection(const QString &);

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -807,7 +807,6 @@ void InstrumentWidget::changeNthPower(double nth_power) {
 }
 
 void InstrumentWidget::changeColorMapMinValue(double minValue) {
-  m_instrumentActor->setAutoscaling(false);
   m_instrumentActor->setMinValue(minValue);
   setupColorMap();
   updateInstrumentView();
@@ -815,7 +814,6 @@ void InstrumentWidget::changeColorMapMinValue(double minValue) {
 
 /// Set the maximumu value of the colour map
 void InstrumentWidget::changeColorMapMaxValue(double maxValue) {
-  m_instrumentActor->setAutoscaling(false);
   m_instrumentActor->setMaxValue(maxValue);
   setupColorMap();
   updateInstrumentView();
@@ -960,6 +958,13 @@ bool InstrumentWidget::eventFilter(QObject *obj, QEvent *ev) {
     return true;
   }
   return QWidget::eventFilter(obj, ev);
+}
+
+/**
+ * Disable colormap autoscaling
+ */
+void InstrumentWidget::disableColorMapAutoscaling() {
+  setColorMapAutoscaling(false);
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -239,8 +239,12 @@ void InstrumentWidgetRenderTab::setupColorMapWidget() {
           SLOT(changeNthPower(double)));
   connect(m_colorBarWidget, SIGNAL(minValueChanged(double)), m_instrWidget,
           SLOT(changeColorMapMinValue(double)));
+  connect(m_colorBarWidget, SIGNAL(minValueEdited(double)), m_instrWidget,
+          SLOT(disableColorMapAutoscaling()));
   connect(m_colorBarWidget, SIGNAL(maxValueChanged(double)), m_instrWidget,
           SLOT(changeColorMapMaxValue(double)));
+  connect(m_colorBarWidget, SIGNAL(maxValueEdited(double)), m_instrWidget,
+          SLOT(disableColorMapAutoscaling()));
 }
 
 void InstrumentWidgetRenderTab::setupUnwrappedControls(

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/DraggableColorBarWidget.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/DraggableColorBarWidget.h
@@ -51,6 +51,11 @@ signals:
   void maxValueChanged(double);
   void nthPowerChanged(double);
 
+  // Edited signals only emitted when manual editing of that field
+  // occurs
+  void minValueEdited(double);
+  void maxValueEdited(double);
+
 protected:
   void mousePressEvent(QMouseEvent *) override;
   void mouseMoveEvent(QMouseEvent *) override;

--- a/qt/widgets/legacyqwt/src/DraggableColorBarWidget.cpp
+++ b/qt/widgets/legacyqwt/src/DraggableColorBarWidget.cpp
@@ -157,12 +157,16 @@ void DraggableColorBarWidget::setupColorBarScaling(
 
 /// Send the minValueChanged signal
 void DraggableColorBarWidget::minValueChanged() {
-  emit minValueChanged(m_minValueBox->text().toDouble());
+  const auto value = m_minValueBox->text().toDouble();
+  emit minValueEdited(value);
+  emit minValueChanged(value);
 }
 
 /// Send the maxValueChanged signal
 void DraggableColorBarWidget::maxValueChanged() {
-  emit maxValueChanged(m_maxValueBox->text().toDouble());
+  const auto value = m_maxValueBox->text().toDouble();
+  emit maxValueEdited(value);
+  emit maxValueChanged(value);
 }
 
 /**

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
@@ -53,10 +53,16 @@ public:
   void loadFromProject(const std::string &) {}
   std::string saveToProject() const { return ""; }
 signals:
+  // Changed signals emitted for any change
   void scaleTypeChanged(int);
   void minValueChanged(double);
   void maxValueChanged(double);
   void nthPowerChanged(double);
+
+  // Edited signals only emitted when manual editing of that field
+  // occurs
+  void minValueEdited(double);
+  void maxValueEdited(double);
   ///@}
 
 private slots:

--- a/qt/widgets/mplcpp/src/ColorbarWidget.cpp
+++ b/qt/widgets/mplcpp/src/ColorbarWidget.cpp
@@ -233,7 +233,11 @@ void ColorbarWidget::scaleTypeSelectionChanged(int index) {
 /**
  * Called when the power exponent input has been edited
  */
-void ColorbarWidget::powerExponentEdited() { setScaleType(2); }
+void ColorbarWidget::powerExponentEdited() {
+  setScaleType(2);
+  // power edit has double validator so this should always be valid
+  emit nthPowerChanged(m_ui.powerEdit->text().toDouble());
+}
 
 // --------------------------- Private methods --------------------------------
 

--- a/qt/widgets/mplcpp/src/ColorbarWidget.cpp
+++ b/qt/widgets/mplcpp/src/ColorbarWidget.cpp
@@ -205,7 +205,9 @@ void ColorbarWidget::setNthPower(double gamma) {
  */
 void ColorbarWidget::scaleMinimumEdited() {
   // The validator ensures the text is a double
-  setClim(m_ui.scaleMinEdit->text().toDouble(), boost::none);
+  const double value = m_ui.scaleMinEdit->text().toDouble();
+  emit minValueEdited(value);
+  setClim(value, boost::none);
 }
 
 /**
@@ -213,7 +215,9 @@ void ColorbarWidget::scaleMinimumEdited() {
  */
 void ColorbarWidget::scaleMaximumEdited() {
   // The validator ensures the text is a double
-  setClim(boost::none, m_ui.scaleMaxEdit->text().toDouble());
+  const double value = m_ui.scaleMaxEdit->text().toDouble();
+  emit maxValueEdited(value);
+  setClim(boost::none, value);
 }
 
 /**

--- a/qt/widgets/mplcpp/src/MantidColorMap.cpp
+++ b/qt/widgets/mplcpp/src/MantidColorMap.cpp
@@ -115,7 +115,10 @@ MantidColorMap::ScaleType MantidColorMap::getScaleType() const {
  * @brief Set the value of the exponent for the power scale
  * @param gamma The value of the exponent
  */
-void MantidColorMap::setNthPower(double gamma) { m_gamma = gamma; }
+void MantidColorMap::setNthPower(double gamma) {
+  m_gamma = gamma;
+  m_mappable.setNorm(PowerNorm(m_gamma, 0, 1));
+}
 
 /**
  * @brief Compute an RGB color value on the current scale type for the given


### PR DESCRIPTION
**Description of work.**

Changing the value of the power on the power scale of the instrument view was broken at some point. This fixes it.

**Report to:** Steve King, ISIS <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Needs to be tested on both Workbench and MantidPlot.

* Load some data, e.g. `LOQ54431.raw` in the `SystemTestData`
* Show the instrument view
* Switch to the power scale
* Alter the power and confirm the changes alter the instrument view as well as the colour bar scale.
* Also confirm that editing the min/max values disables the autoscaling checkbox. 

Fixes #25122. 

*This does not require release notes* because **it fixes an issue in the unreleased workbench.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
