### PR TITLE
Fix phase bug in FDA

### DIFF
--- a/docs/source/release/v4.0.0/muon.rst
+++ b/docs/source/release/v4.0.0/muon.rst
@@ -41,6 +41,7 @@ Bugfixes
 - The `load current run` button now works for CHRONUS in muon analysis.
 - ALC interface now removes all of the fitting regions for the baseline modelling when the data changes.
 - ALC interface now produces a warning if the custom grouping is not valid.
+- Frequency Domain Analysis will ignore the fix phases option if phase table is not used.
 
 Algorithms
 ----------

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -225,7 +225,6 @@ class MaxEntView(QtGui.QWidget):
 
         inputs["Npts"] = int(self.N_points.currentText())
         inputs["MaxField"] = float(self.max_field.text())
-        inputs["FixPhases"] = self.fix_phase_box.checkState()
         inputs["FitDeadTime"] = self.dead_box.checkState()
         inputs["DoublePulse"] = self.double_pulse_box.checkState()
         inputs["OuterIterations"] = int(self.inner_loop.text())
@@ -240,6 +239,7 @@ class MaxEntView(QtGui.QWidget):
         return inputs
 
     def addPhaseTable(self, inputs):
+        inputs["FixPhases"] = self.fix_phase_box.checkState()
         if self.usePhases():
             inputs['InputPhaseTable'] = "PhaseTable"
         else:

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_view.py
@@ -225,8 +225,8 @@ class MaxEntView(QtGui.QWidget):
 
         inputs["Npts"] = int(self.N_points.currentText())
         inputs["MaxField"] = float(self.max_field.text())
-        inputs["FitDeadTime"] = self.dead_box.checkState()
-        inputs["DoublePulse"] = self.double_pulse_box.checkState()
+        inputs["FitDeadTime"] = self.dead_box.checkState() == QtCore.Qt.Checked
+        inputs["DoublePulse"] = self.double_pulse_box.checkState() == QtCore.Qt.Checked
         inputs["OuterIterations"] = int(self.inner_loop.text())
         inputs["InnerIterations"] = int(self.outer_loop.text())
         inputs["DefaultLevel"] = float(self.AConst.text())
@@ -239,10 +239,10 @@ class MaxEntView(QtGui.QWidget):
         return inputs
 
     def addPhaseTable(self, inputs):
-        inputs["FixPhases"] = self.fix_phase_box.checkState()
-        if self.usePhases():
+        inputs["FixPhases"] = self.fix_phase_box.checkState() == QtCore.Qt.Checked
+        if self.usePhases() and self.phaseTable_box.currentText() == construct:
             inputs['InputPhaseTable'] = "PhaseTable"
-        else:
+        elif self.usePhases():
             inputs['InputPhaseTable'] = self.phaseTable_box.currentText()
 
     def outputPhases(self):


### PR DESCRIPTION
Open frequency domain analysis (muon)
Set instrument to MUSR
Enter run 62260
Go to transform tab and change it to maxent
Click `use phase table`
change start time to 1
make sure 'fix phases` and `output phase table` is ticked
press calculate button

Open the MUSR62260_raw_data;PhaseTable;MaxEnt table
Change the phase column to be editable
Change the first phase value to 0.3
Change the run to 62261

In the FDA GUI change the `select phase table` to MUSR62260_raw_data;PhaseTable;MaxEnt
press calculate again
Look in the new output for the phases and the old phases (the phases should match)

Turn off the use phases
Press calculate
The phase table will change

<!-- Instructions for testing. -->

Fixes #25160. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
