### PR TITLE
Fix Fitting crash Enginx gui

### DIFF
--- a/docs/source/release/v4.0.0/diffraction.rst
+++ b/docs/source/release/v4.0.0/diffraction.rst
@@ -128,5 +128,6 @@ Bugfixes
 ########
 
 - Fixed a crash in the gui caused by running a calibration without setting a calibration directory.
+- Fixed a crash in the gui caused by having the EnggFitPeaks algorithm fail in the fitting tab.
 
 :ref:`Release 4.0.0 <v4.0.0>`

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -501,8 +501,7 @@ void EnggDiffFittingPresenter::doFitting(const std::vector<RunLabel> &runLabels,
     } catch (const std::runtime_error &exc) {
       g_log.error() << "Could not run the algorithm EnggFitPeaks successfully."
                     << exc.what();
-      m_view->userError("Could not run the algorithm EnggFitPeaks successfully",
-                        exc.what());
+      // A userError should be used for this message once the threading has been looked into
       return;
     }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -501,7 +501,8 @@ void EnggDiffFittingPresenter::doFitting(const std::vector<RunLabel> &runLabels,
     } catch (const std::runtime_error &exc) {
       g_log.error() << "Could not run the algorithm EnggFitPeaks successfully."
                     << exc.what();
-      // A userError should be used for this message once the threading has been looked into
+      // A userError should be used for this message once the threading has been
+      // looked into
       return;
     }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1071,7 +1071,8 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
     g_log.warning("No calibration directory selected. Please select a "
                   "calibration directory in Settings. This will be used to "
                   "cache Vanadium calibration data");
-    // This should be a userWarning once the threading problem has been dealt with
+    // This should be a userWarning once the threading problem has been dealt
+    // with
     m_calibFinishedOK = false;
     return;
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1071,6 +1071,7 @@ void EnggDiffractionPresenter::doCalib(const EnggDiffCalibSettings &cs,
     g_log.warning("No calibration directory selected. Please select a "
                   "calibration directory in Settings. This will be used to "
                   "cache Vanadium calibration data");
+    // This should be a userWarning once the threading problem has been dealt with
     m_calibFinishedOK = false;
     return;
   }


### PR DESCRIPTION
**Description of work.**
Removed `userError` from `EnggDiffractionFittingPresenter.cpp` as it caused a crash due to being called from a different thread.

**To test:**
Load this [file](https://github.com/mantidproject/mantid/files/2962693/test.zip) in the fitting window, add `23112.8405` to peaks, and then click fit. An error message should appear in the logger, but mantid should not crash.



Fixes #25157 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
