### PR TITLE
Fix workbench running tab-indented scripts

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -221,6 +221,10 @@ def code_blocks(code_str):
     isp = InputSplitter()
     for line in lines:
         lineno_cur += 1
+        # IPython InputSplitter assumes that indentation is 4 spaces, not tabs.
+        # Accounting for that here, rather than using script-level "tabs to spaces"
+        # allows the user to keep tabs in their script if they wish.
+        line = line.replace("\t", " "*4)
         isp.push(line)
         # If we need more input to form a complete statement
         # or we are not at the end of the code then keep


### PR DESCRIPTION
**Description of work.**
This PR replaces tabs with spaces in each line before they are sent to the InputSplitter to split a script into executable code blocks. The IPython InputSplitter, upon which Mantid's is based, assumes that spaces are used instead of tabs: while it searches for tabs as a whitespace character, it hard-codes each indentation level to be made up of four whitespace characters i.e. a tab has been converted to spaces

**Report to:** James Lord

**To test:**
In workbench, open [AnalyseThresholdScans9.py](https://github.com/mantidproject/scriptrepository/blob/master/muon/AnalyseThresholdScans9.py). Click options -> whitespace visible. Notice that the current script contains tabs.
Run the script. It should run without issue.
See that the script still contains tabs i.e. we haven't changed the tabs to spaces permanently.
Click options -> tabs to spaces and see that the script still runs

Fixes #25140 

*This does not require release notes* because **bug fix to issue in workbench - not yet released**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
