### PR TITLE
ILL powder detector scan copy logs from input

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -111,6 +111,7 @@ public:
   /// Writable version of the run object
   Run &mutableRun();
   void setSharedRun(Kernel::cow_ptr<Run> run);
+  Kernel::cow_ptr<Run> sharedRun();
 
   /// Access a log for this experiment.
   Kernel::Property *getLog(const std::string &log) const;

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -675,6 +675,9 @@ void ExperimentInfo::setSharedRun(Kernel::cow_ptr<Run> run) {
   m_run = std::move(run);
 }
 
+/// Return the cow ptr of the run
+Kernel::cow_ptr<Run> ExperimentInfo::sharedRun() { return m_run; }
+
 /**
  * Get an experimental log either by log name or by type, e.g.
  *   - temperature_log

--- a/Framework/Algorithms/src/SumOverlappingTubes.cpp
+++ b/Framework/Algorithms/src/SumOverlappingTubes.cpp
@@ -109,7 +109,8 @@ void SumOverlappingTubes::exec() {
       m_numPoints + 1,
       LinearGenerator(m_startScatteringAngle, m_stepScatteringAngle));
 
-  MatrixWorkspace_sptr outputWS = create<Workspace2D>(m_numHistograms, x);
+  MatrixWorkspace_sptr outputWS =
+      create<Workspace2D>(*m_workspaceList.front(), m_numHistograms, x);
   outputWS->setDistribution(false);
 
   const auto newAxis = new NumericAxis(m_heightAxis);

--- a/Framework/Algorithms/src/SumOverlappingTubes.cpp
+++ b/Framework/Algorithms/src/SumOverlappingTubes.cpp
@@ -109,9 +109,9 @@ void SumOverlappingTubes::exec() {
       m_numPoints + 1,
       LinearGenerator(m_startScatteringAngle, m_stepScatteringAngle));
 
-  MatrixWorkspace_sptr outputWS =
-      create<Workspace2D>(*m_workspaceList.front(), m_numHistograms, x);
+  MatrixWorkspace_sptr outputWS = create<Workspace2D>(m_numHistograms, x);
   outputWS->setDistribution(false);
+  outputWS->setSharedRun(m_workspaceList.front()->sharedRun());
 
   const auto newAxis = new NumericAxis(m_heightAxis);
   newAxis->setUnit("Label");

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScanTest.py
@@ -43,6 +43,8 @@ class PowderILLDetectorScanTest(unittest.TestCase):
         self.assertAlmostEqual(xaxis[-1],148.721,3)
         spectrumaxis = item.getAxis(1).extractValues()
         self.assertEquals(spectrumaxis[0],0)
+        self.assertTrue(item.getRun())
+        self.assertTrue(item.getRun().hasProperty('run_number'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Carries along the logs of the first input.

**To test:**
<!-- Instructions for testing. -->
```
ws = PowderILLDetectorScan(Run='ILL/D2B/508093.nxs')
```
Make sure the output has sample logs.

In future this should do the same as `MergeRuns` for properly merging the logs from all the inputs.

Fixes #25035 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.