### PR TITLE
Group and pair names unchangeable after creation

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
@@ -1,7 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 from Muon.GUI.Common.muon_data_context import MuonDataContext, construct_empty_group
-from PyQt4 import QtGui
 
 class GroupingTableModel(object):
     """

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from Muon.GUI.Common.muon_data_context import MuonDataContext, construct_empty_group
 
+
 class GroupingTableModel(object):
     """
     Model used when grouping table is not part of the grouping tab. When the

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_model.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from Muon.GUI.Common.muon_data_context import MuonDataContext, construct_empty_group
-
+from PyQt4 import QtGui
 
 class GroupingTableModel(object):
     """

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -96,11 +96,14 @@ class GroupingTablePresenter(object):
 
     def handle_add_group_button_clicked(self):
         new_group_name = self._view.enter_group_name()
+        if new_group_name is None:
+            return
         if new_group_name in self._model.group_and_pair_names:
             self._view.warning_popup("Groups and pairs must have unique names")
         elif self.validate_group_name(new_group_name):
             group = MuonGroup(group_name=str(new_group_name), detector_ids=[1])
             self.add_group(group)
+
 
     def handle_remove_group_button_clicked(self):
         group_names = self._view.get_selected_group_names()

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -104,7 +104,6 @@ class GroupingTablePresenter(object):
             group = MuonGroup(group_name=str(new_group_name), detector_ids=[1])
             self.add_group(group)
 
-
     def handle_remove_group_button_clicked(self):
         group_names = self._view.get_selected_group_names()
         if not group_names:

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -1,9 +1,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import re
-
+from PyQt4 import QtGui
 from Muon.GUI.Common.utilities import run_string_utils as run_utils
 from Muon.GUI.Common.muon_group import MuonGroup
+
 
 maximum_number_of_groups = 20
 
@@ -95,8 +96,10 @@ class GroupingTablePresenter(object):
         self._view.enable_updates()
 
     def handle_add_group_button_clicked(self):
-        group = self._model.construct_empty_group(self._view.num_rows() + 1)
-        self.add_group(group)
+        new_group_name = self._view.enter_group_name()
+        if self.validate_group_name(new_group_name):
+            group = MuonGroup(group_name=str(new_group_name), detector_ids=[1])
+            self.add_group(group)
 
     def handle_remove_group_button_clicked(self):
         group_names = self._view.get_selected_group_names()
@@ -129,7 +132,6 @@ class GroupingTablePresenter(object):
                 self.update_model_from_view()
             except ValueError as error:
                 self._view.warning_popup(error)
-
         self.update_view_from_model()
         self._view.notify_data_changed()
         self.notify_data_changed()

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -1,10 +1,9 @@
 from __future__ import (absolute_import, division, print_function)
 
 import re
-from PyQt4 import QtGui
+
 from Muon.GUI.Common.utilities import run_string_utils as run_utils
 from Muon.GUI.Common.muon_group import MuonGroup
-
 
 maximum_number_of_groups = 20
 
@@ -132,6 +131,7 @@ class GroupingTablePresenter(object):
                 self.update_model_from_view()
             except ValueError as error:
                 self._view.warning_popup(error)
+
         self.update_view_from_model()
         self._view.notify_data_changed()
         self.notify_data_changed()

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -96,7 +96,9 @@ class GroupingTablePresenter(object):
 
     def handle_add_group_button_clicked(self):
         new_group_name = self._view.enter_group_name()
-        if self.validate_group_name(new_group_name):
+        if new_group_name in self._model.group_and_pair_names:
+            self._view.warning_popup("Groups and pairs must have unique names")
+        elif self.validate_group_name(new_group_name):
             group = MuonGroup(group_name=str(new_group_name), detector_ids=[1])
             self.add_group(group)
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -153,10 +153,8 @@ class GroupingTableView(QtGui.QWidget):
             item = QtGui.QTableWidgetItem(entry)
             if group_table_columns[i] == group_table_columns[0]:
                 # column 0 : group name
-                group_name_widget = table_utils.ValidatedTableItem(self._validate_group_name_entry)
-                group_name_widget.setText(entry)
-                self.grouping_table.setItem(row_position, 0, group_name_widget)
-                self.grouping_table.item(row_position, 0).setToolTip(entry)
+                item.setFlags(QtCore.Qt.ItemIsEnabled)
+                item.setFlags(QtCore.Qt.ItemIsSelectable)
             if group_table_columns[i] == group_table_columns[1]:
                 # column 1 : detector IDs
                 detector_widget = table_utils.ValidatedTableItem(self._validate_detector_ID_entry)
@@ -358,12 +356,12 @@ class GroupingTableView(QtGui.QWidget):
         for row in range(self.num_rows()):
             for col in range(self.num_cols()):
                 item = self.grouping_table.item(row, col)
-                if group_table_columns[col] != 'number_of_detectors':
+                if group_table_columns[col] == 'detector_ids':
                     item.setFlags(QtCore.Qt.ItemIsSelectable |
                                   QtCore.Qt.ItemIsEditable |
                                   QtCore.Qt.ItemIsEnabled)
                 else:
-                    # number of detectors should remain un-editable
+                    # Group name and number of detectors should remain un-editable
                     item.setFlags(QtCore.Qt.ItemIsSelectable)
 
     def get_group_range(self):

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -190,7 +190,6 @@ class GroupingTableView(QtGui.QWidget):
 
     def enter_group_name(self):
         new_group_name, ok = QtGui.QInputDialog.getText(self, 'Group Name', 'Enter name of new group:')
-        group_index = 1
         if ok:
             return new_group_name
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -153,6 +153,10 @@ class GroupingTableView(QtGui.QWidget):
             item = QtGui.QTableWidgetItem(entry)
             if group_table_columns[i] == group_table_columns[0]:
                 # column 0 : group name
+                group_name_widget = table_utils.ValidatedTableItem(self._validate_group_name_entry)
+                group_name_widget.setText(entry)
+                self.grouping_table.setItem(row_position, 0, group_name_widget)
+                self.grouping_table.item(row_position, 0).setToolTip(entry)
                 item.setFlags(QtCore.Qt.ItemIsEnabled)
                 item.setFlags(QtCore.Qt.ItemIsSelectable)
             if group_table_columns[i] == group_table_columns[1]:
@@ -183,6 +187,11 @@ class GroupingTableView(QtGui.QWidget):
         last_row = self.grouping_table.rowCount() - 1
         if last_row >= 0:
             self.grouping_table.removeRow(last_row)
+
+    def enter_group_name(self):
+        new_group_name, ok = QtGui.QInputDialog.getText(None, 'Group Name', 'Enter name of new group:')
+        if ok:
+            return new_group_name
 
     # ------------------------------------------------------------------------------------------------------------------
     # Context menu on right-click in the table

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_view.py
@@ -189,7 +189,8 @@ class GroupingTableView(QtGui.QWidget):
             self.grouping_table.removeRow(last_row)
 
     def enter_group_name(self):
-        new_group_name, ok = QtGui.QInputDialog.getText(None, 'Group Name', 'Enter name of new group:')
+        new_group_name, ok = QtGui.QInputDialog.getText(self, 'Group Name', 'Enter name of new group:')
+        group_index = 1
         if ok:
             return new_group_name
 

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -126,9 +126,21 @@ class PairingTablePresenter(object):
         self._view.enable_updates()
 
     def handle_add_pair_button_clicked(self):
-        pair = self._model.construct_empty_pair(self._view.num_rows() + 1)
-        self.add_pair(pair)
-        self.notify_data_changed()
+        new_pair_name = self._view.enter_pair_name()
+        if self.validate_pair_name(new_pair_name):
+            if len(self._model.group_names) == 1:
+                group1 = self._model.group_names[0]
+                group2 = self._model.group_names[0]
+            elif len(self._model.group_names) >= 2:
+                group1 = self._model.group_names[0]
+                group2 = self._model.group_names[1]
+            else:
+                group1 = None
+                group2 = None
+            pair = MuonPair(pair_name=new_pair_name,
+                            forward_group_name=group1, backward_group_name=group2, alpha=1.0)
+            self.add_pair(pair)
+            self.notify_data_changed()
 
     def handle_remove_pair_button_clicked(self):
         pair_names = self._view.get_selected_pair_names()

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -135,12 +135,8 @@ class PairingTablePresenter(object):
             elif new_pair_name in self._model.group_and_pair_names:
                 self._view.warning_popup("Groups and pairs must have unique names")
             elif self.validate_pair_name(new_pair_name):
-                if len(self._model.group_names) >= 2:
-                    group1 = self._model.group_names[0]
-                    group2 = self._model.group_names[1]
-                else:
-                    group1 = None
-                    group2 = None
+                group1 = self._model.group_names[0]
+                group2 = self._model.group_names[1]
                 pair = MuonPair(pair_name=str(new_pair_name),
                                 forward_group_name=group1, backward_group_name=group2, alpha=1.0)
                 self.add_pair(pair)

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -127,7 +127,9 @@ class PairingTablePresenter(object):
 
     def handle_add_pair_button_clicked(self):
         new_pair_name = self._view.enter_pair_name()
-        if self.validate_pair_name(new_pair_name):
+        if new_pair_name in self._model.group_and_pair_names:
+            self._view.warning_popup("Groups and pairs must have unique names")
+        elif self.validate_pair_name(new_pair_name):
             if len(self._model.group_names) == 1:
                 group1 = self._model.group_names[0]
                 group2 = self._model.group_names[0]
@@ -137,7 +139,7 @@ class PairingTablePresenter(object):
             else:
                 group1 = None
                 group2 = None
-            pair = MuonPair(pair_name=new_pair_name,
+            pair = MuonPair(pair_name=str(new_pair_name),
                             forward_group_name=group1, backward_group_name=group2, alpha=1.0)
             self.add_pair(pair)
             self.notify_data_changed()

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -126,15 +126,14 @@ class PairingTablePresenter(object):
         self._view.enable_updates()
 
     def handle_add_pair_button_clicked(self):
-        if len(self._model.group_names) == 1:
-            self._view.warning_popup("Two groups are required to create a pair")
+        if len(self._model.group_names) == 0 or len(self._model.group_names) == 1:
+            self._view.warning_popup("At least two groups are required to create a pair")
         else:
             new_pair_name = self._view.enter_pair_name()
             if new_pair_name is None:
                 return
-            if new_pair_name in self._model.group_and_pair_names:
+            elif new_pair_name in self._model.group_and_pair_names:
                 self._view.warning_popup("Groups and pairs must have unique names")
-
             elif self.validate_pair_name(new_pair_name):
                 if len(self._model.group_names) >= 2:
                     group1 = self._model.group_names[0]

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -126,23 +126,26 @@ class PairingTablePresenter(object):
         self._view.enable_updates()
 
     def handle_add_pair_button_clicked(self):
-        new_pair_name = self._view.enter_pair_name()
-        if new_pair_name in self._model.group_and_pair_names:
-            self._view.warning_popup("Groups and pairs must have unique names")
-        elif self.validate_pair_name(new_pair_name):
-            if len(self._model.group_names) == 1:
-                group1 = self._model.group_names[0]
-                group2 = self._model.group_names[0]
-            elif len(self._model.group_names) >= 2:
-                group1 = self._model.group_names[0]
-                group2 = self._model.group_names[1]
-            else:
-                group1 = None
-                group2 = None
-            pair = MuonPair(pair_name=str(new_pair_name),
-                            forward_group_name=group1, backward_group_name=group2, alpha=1.0)
-            self.add_pair(pair)
-            self.notify_data_changed()
+        if len(self._model.group_names) == 1:
+            self._view.warning_popup("Two groups are required to create a pair")
+        else:
+            new_pair_name = self._view.enter_pair_name()
+            if new_pair_name is None:
+                return
+            if new_pair_name in self._model.group_and_pair_names:
+                self._view.warning_popup("Groups and pairs must have unique names")
+
+            elif self.validate_pair_name(new_pair_name):
+                if len(self._model.group_names) >= 2:
+                    group1 = self._model.group_names[0]
+                    group2 = self._model.group_names[1]
+                else:
+                    group1 = None
+                    group2 = None
+                pair = MuonPair(pair_name=str(new_pair_name),
+                                forward_group_name=group1, backward_group_name=group2, alpha=1.0)
+                self.add_pair(pair)
+                self.notify_data_changed()
 
     def handle_remove_pair_button_clicked(self):
         pair_names = self._view.get_selected_pair_names()

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -293,7 +293,7 @@ class PairingTableView(QtGui.QWidget):
             self.pairing_table.removeRow(last_row)
 
     def enter_pair_name(self):
-        new_pair_name, ok = QtGui.QInputDialog.getText(None, 'Group Name', 'Enter name of new group:')
+        new_pair_name, ok = QtGui.QInputDialog.getText(None, 'Pair Name', 'Enter name of new pair:')
         if ok:
             return new_pair_name
 

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -138,6 +138,9 @@ class PairingTableView(QtGui.QWidget):
         for i, entry in enumerate(row_entries):
             item = QtGui.QTableWidgetItem(entry)
             if pair_columns[i] == 'pair_name':
+                pair_name_widget = table_utils.ValidatedTableItem(self._validate_pair_name_entry)
+                pair_name_widget.setText(entry)
+                self.pairing_table.setItem(row_position, i, pair_name_widget)
                 item.setFlags(QtCore.Qt.ItemIsEnabled)
                 item.setFlags(QtCore.Qt.ItemIsSelectable)
             if pair_columns[i] == 'group_1':
@@ -288,6 +291,11 @@ class PairingTableView(QtGui.QWidget):
         last_row = self.pairing_table.rowCount() - 1
         if last_row >= 0:
             self.pairing_table.removeRow(last_row)
+
+    def enter_pair_name(self):
+        new_pair_name, ok = QtGui.QInputDialog.getText(None, 'Group Name', 'Enter name of new group:')
+        if ok:
+            return new_pair_name
 
     # ------------------------------------------------------------------------------------------------------------------
     # Enabling / Disabling the table

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -293,7 +293,7 @@ class PairingTableView(QtGui.QWidget):
             self.pairing_table.removeRow(last_row)
 
     def enter_pair_name(self):
-        new_pair_name, ok = QtGui.QInputDialog.getText(None, 'Pair Name', 'Enter name of new pair:')
+        new_pair_name, ok = QtGui.QInputDialog.getText(self, 'Pair Name', 'Enter name of new pair:')
         if ok:
             return new_pair_name
 

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_view.py
@@ -138,9 +138,8 @@ class PairingTableView(QtGui.QWidget):
         for i, entry in enumerate(row_entries):
             item = QtGui.QTableWidgetItem(entry)
             if pair_columns[i] == 'pair_name':
-                pair_name_widget = table_utils.ValidatedTableItem(self._validate_pair_name_entry)
-                pair_name_widget.setText(entry)
-                self.pairing_table.setItem(row_position, i, pair_name_widget)
+                item.setFlags(QtCore.Qt.ItemIsEnabled)
+                item.setFlags(QtCore.Qt.ItemIsSelectable)
             if pair_columns[i] == 'group_1':
                 group1_selector_widget = self._group_selection_cell_widget()
                 # ensure changing the selection sends an update signal
@@ -332,6 +331,9 @@ class PairingTableView(QtGui.QWidget):
                 if col == 1 or col == 2 or col == 4:
                     item = self.pairing_table.cellWidget(row, col)
                     item.setEnabled(True)
+                elif col == 0:
+                    item = self.pairing_table.item(row, col)
+                    item.setFlags(QtCore.Qt.ItemIsSelectable)
                 else:
                     item = self.pairing_table.item(row, col)
                     item.setFlags(QtCore.Qt.ItemIsSelectable |

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -264,7 +264,6 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
         self.assertEqual(self.view.get_table_item_text(0, 1), "1-5,10,20-25")
         self.assertEqual(self.model._data._groups["group_0"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
-        self.assertEqual(self.model._data._groups["group_0"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
 
     def test_that_if_detector_list_changed_that_number_of_detectors_updates(self):
         self.presenter.handle_add_group_button_clicked()

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -33,6 +33,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
         self.view = GroupingTableView(parent=self.obj)
         self.presenter = GroupingTablePresenter(self.view, self.model)
 
+        self.view.enter_group_name = mock.Mock(return_value="group")
         self.view.warning_popup = mock.Mock()
         self.gui_variable_observer.update = mock.MagicMock()
 
@@ -113,6 +114,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
     def test_that_cannot_add_more_than_20_rows(self):
         for i in range(maximum_number_of_groups + 1):
+            self.view.enter_group_name = mock.Mock(return_value="group_" + str(i))
             self.presenter.handle_add_group_button_clicked()
 
         self.assertEqual(self.view.num_rows(), maximum_number_of_groups)
@@ -120,6 +122,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
     def test_that_trying_to_add_a_20th_row_gives_warning_message(self):
         for i in range(maximum_number_of_groups + 1):
+            self.view.enter_group_name = mock.Mock(return_value="group_" + str(i))
             self.presenter.handle_add_group_button_clicked()
 
         self.assertEqual(self.view.warning_popup.call_count, 1)
@@ -134,9 +137,11 @@ class GroupingTablePresenterTest(unittest.TestCase):
     # ------------------------------------------------------------------------------------------------------------------
 
     def test_context_menu_add_grouping_with_no_rows_selected_adds_group_to_end_of_table(self):
+        self.view.enter_group_name = mock.Mock(return_value="group_1")
         self.presenter.handle_add_group_button_clicked()
 
         self.view.contextMenuEvent(0)
+        self.view.enter_group_name = mock.Mock(return_value="group_2")
         self.view.add_group_action.triggered.emit(True)
 
         self.assertEqual(len(self.model.groups), 2)
@@ -220,38 +225,13 @@ class GroupingTablePresenterTest(unittest.TestCase):
             self.assertEqual(str(self.view.get_table_item_text(0, 0)), valid_name)
             self.assertIn(valid_name, self.model.group_names)
 
-    def test_that_renaming_group_to_duplicate_fails_and_reverts_to_previous_value(self):
-        self.add_three_groups_to_table()
-
-        self.view.grouping_table.setCurrentCell(0, 0)
-        self.view.grouping_table.item(0, 0).setText("my_group_1")
-
-        self.assertEqual(str(self.view.get_table_item_text(0, 0)), "my_group_0")
-        self.assertIn("my_group_0", self.model.group_names)
-
     def test_that_warning_shown_if_duplicated_group_name_used(self):
         self.add_three_groups_to_table()
 
-        self.view.grouping_table.setCurrentCell(0, 0)
-        self.view.grouping_table.item(0, 0).setText("my_group_1")
+        self.view.enter_group_name = mock.Mock(return_value="my_group_1")
+        self.presenter.handle_add_group_button_clicked()
 
         self.assertEqual(self.view.warning_popup.call_count, 1)
-
-    def test_that_default_group_name_is_group_1(self):
-        self.presenter.handle_add_group_button_clicked()
-
-        self.assertEqual(str(self.view.get_table_item_text(0, 0)), "group_1")
-        self.assertIn("group_1", self.model.group_names)
-
-    def test_that_adding_new_group_creates_incremented_default_name(self):
-        self.presenter.handle_add_group_button_clicked()
-        self.presenter.handle_add_group_button_clicked()
-        self.presenter.handle_add_group_button_clicked()
-
-        self.assertEqual(str(self.view.get_table_item_text(0, 0)), "group_1")
-        self.assertEqual(str(self.view.get_table_item_text(1, 0)), "group_2")
-        self.assertEqual(str(self.view.get_table_item_text(2, 0)), "group_3")
-        six.assertCountEqual(self, self.model.group_names, ["group_1", "group_2", "group_3"])
 
     # ------------------------------------------------------------------------------------------------------------------
     # detector ID validation
@@ -281,7 +261,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
         self.view.grouping_table.item(0, 1).setText("20-25,10,5,4,3,2,1")
 
         self.assertEqual(self.view.get_table_item_text(0, 1), "1-5,10,20-25")
-        self.assertEqual(self.model._data._groups["group_1"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
+        self.assertEqual(self.model._data._groups["group"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
 
     def test_that_if_detector_list_changed_that_number_of_detectors_updates(self):
         self.presenter.handle_add_group_button_clicked()

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -17,6 +17,12 @@ else:
 
 maximum_number_of_groups = 20
 
+def group_name():
+    name = []
+    for i in range(maximum_number_of_groups + 1):
+        name.append("group_" + str(i))
+    return name
+
 
 class GroupingTablePresenterTest(unittest.TestCase):
 
@@ -33,7 +39,7 @@ class GroupingTablePresenterTest(unittest.TestCase):
         self.view = GroupingTableView(parent=self.obj)
         self.presenter = GroupingTablePresenter(self.view, self.model)
 
-        self.view.enter_group_name = mock.Mock(return_value="group")
+        self.view.enter_group_name = mock.Mock(side_effect=group_name())
         self.view.warning_popup = mock.Mock()
         self.gui_variable_observer.update = mock.MagicMock()
 
@@ -114,7 +120,6 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
     def test_that_cannot_add_more_than_20_rows(self):
         for i in range(maximum_number_of_groups + 1):
-            self.view.enter_group_name = mock.Mock(return_value="group_" + str(i))
             self.presenter.handle_add_group_button_clicked()
 
         self.assertEqual(self.view.num_rows(), maximum_number_of_groups)
@@ -122,7 +127,6 @@ class GroupingTablePresenterTest(unittest.TestCase):
 
     def test_that_trying_to_add_a_20th_row_gives_warning_message(self):
         for i in range(maximum_number_of_groups + 1):
-            self.view.enter_group_name = mock.Mock(return_value="group_" + str(i))
             self.presenter.handle_add_group_button_clicked()
 
         self.assertEqual(self.view.warning_popup.call_count, 1)
@@ -137,16 +141,14 @@ class GroupingTablePresenterTest(unittest.TestCase):
     # ------------------------------------------------------------------------------------------------------------------
 
     def test_context_menu_add_grouping_with_no_rows_selected_adds_group_to_end_of_table(self):
-        self.view.enter_group_name = mock.Mock(return_value="group_1")
         self.presenter.handle_add_group_button_clicked()
 
         self.view.contextMenuEvent(0)
-        self.view.enter_group_name = mock.Mock(return_value="group_2")
         self.view.add_group_action.triggered.emit(True)
 
         self.assertEqual(len(self.model.groups), 2)
         self.assertEqual(self.view.num_rows(), 2)
-        self.assertEqual(self.view.get_table_item_text(1, 0), "group_2")
+        self.assertEqual(self.view.get_table_item_text(1, 0), "group_1")
 
     def test_context_menu_add_grouping_with_rows_selected_does_not_add_group(self):
         self.presenter.handle_add_group_button_clicked()
@@ -261,7 +263,8 @@ class GroupingTablePresenterTest(unittest.TestCase):
         self.view.grouping_table.item(0, 1).setText("20-25,10,5,4,3,2,1")
 
         self.assertEqual(self.view.get_table_item_text(0, 1), "1-5,10,20-25")
-        self.assertEqual(self.model._data._groups["group"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
+        self.assertEqual(self.model._data._groups["group_0"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
+        self.assertEqual(self.model._data._groups["group_0"].detectors, [1, 2, 3, 4, 5, 10, 20, 21, 22, 23, 24, 25])
 
     def test_that_if_detector_list_changed_that_number_of_detectors_updates(self):
         self.presenter.handle_add_group_button_clicked()

--- a/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
@@ -17,6 +17,11 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
 
+def pair_name():
+    name = []
+    for i in range(21):
+        name.append("pair_" + str(i+1))
+    return name
 
 class AlphaTest(unittest.TestCase):
 
@@ -32,6 +37,7 @@ class AlphaTest(unittest.TestCase):
         self.presenter = PairingTablePresenter(self.view, self.model)
 
         self.view.warning_popup = mock.Mock()
+        self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
 
     def tearDown(self):
         self.obj = None

--- a/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
@@ -36,6 +36,8 @@ class AlphaTest(unittest.TestCase):
         self.view = PairingTableView(parent=self.obj)
         self.presenter = PairingTablePresenter(self.view, self.model)
 
+        self.add_three_groups_to_model()
+
         self.view.warning_popup = mock.Mock()
         self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
 
@@ -154,7 +156,7 @@ class AlphaTest(unittest.TestCase):
 
         self.assertEqual(self.presenter.guessAlphaNotifier.notify_subscribers.call_count, 1)
         self.assertEqual(self.presenter.guessAlphaNotifier.notify_subscribers.call_args_list[0][0][0],
-                         ["pair_2", "", ""])
+                         ["pair_2", "my_group_0", "my_group_1"])
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
@@ -16,6 +16,11 @@ if sys.version_info.major > 2:
 else:
     import mock
 
+def pair_name():
+    name = []
+    for i in range(21):
+        name.append("pair_" + str(i+1))
+    return name
 
 class GroupSelectorTest(unittest.TestCase):
 
@@ -31,6 +36,7 @@ class GroupSelectorTest(unittest.TestCase):
         self.presenter = PairingTablePresenter(self.view, self.model)
 
         self.view.warning_popup = mock.Mock()
+        self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
 
     def tearDown(self):
         self.obj = None

--- a/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
@@ -35,6 +35,8 @@ class GroupSelectorTest(unittest.TestCase):
         self.view = PairingTableView(parent=self.obj)
         self.presenter = PairingTablePresenter(self.view, self.model)
 
+        self.add_three_groups_to_model()
+
         self.view.warning_popup = mock.Mock()
         self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
 
@@ -73,40 +75,13 @@ class GroupSelectorTest(unittest.TestCase):
     #         together make the muon pair.
     # ------------------------------------------------------------------------------------------------------------------
 
-    def test_that_adding_pair_when_no_groups_exist_leaves_combo_boxes_empty(self):
-        self.presenter.handle_add_pair_button_clicked()
-
-        self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 0)
-        self.assertEqual(self.get_group_2_selector_from_pair(0).count(), 0)
-        self.assertEqual(self.get_group_1_selector_from_pair(0).currentText(), "")
-        self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), "")
-
-    def test_that_adding_pair_then_adding_group_puts_group_in_combos(self):
-        self.presenter.handle_add_pair_button_clicked()
-        self.data.add_group(MuonGroup(group_name="my_group_0", detector_ids=[1]))
-        self.presenter.update_view_from_model()
-
-        self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 1)
-        self.assertEqual(self.get_group_2_selector_from_pair(0).count(), 1)
-
-    def test_that_adding_pair_then_adding_group_sets_combo_to_added_group(self):
-        self.presenter.handle_add_pair_button_clicked()
-        self.data.add_group(MuonGroup(group_name="my_group_0", detector_ids=[1]))
-        self.presenter.update_view_from_model()
-
-        self.assertEqual(self.get_group_1_selector_from_pair(0).currentText(), "my_group_0")
-        self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), "my_group_0")
-
     def test_that_adding_two_groups_and_then_pair_sets_combo_to_added_groups(self):
-        self.data.add_group(MuonGroup(group_name="my_group_0", detector_ids=[1]))
-        self.data.add_group(MuonGroup(group_name="my_group_1", detector_ids=[2]))
         self.presenter.handle_add_pair_button_clicked()
 
         self.assertEqual(self.get_group_1_selector_from_pair(0).currentText(), "my_group_0")
         self.assertEqual(self.get_group_2_selector_from_pair(0).currentText(), "my_group_1")
 
     def test_that_added_groups_appear_in_group_combo_boxes_in_new_pairs(self):
-        self.add_three_groups_to_model()
         self.presenter.handle_add_pair_button_clicked()
 
         self.assertEqual(self.get_group_1_selector_from_pair(0).count(), 3)
@@ -164,7 +139,7 @@ class GroupSelectorTest(unittest.TestCase):
         self.assertNotEqual(self.get_group_1_selector_from_pair(0).findText("my_group_0"), -1)
         self.assertNotEqual(self.get_group_2_selector_from_pair(0).findText("my_group_0"), -1)
 
-    def test_adding_new_group_does_not_change_pair_slection(self):
+    def test_adding_new_group_does_not_change_pair_selection(self):
         self.add_three_groups_to_model()
         self.presenter.handle_add_pair_button_clicked()
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -18,6 +18,11 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
 
+def pair_name():
+    name = []
+    for i in range(21):
+        name.append("pair_" + str(i+1))
+    return name
 
 class PairingTablePresenterTest(unittest.TestCase):
 
@@ -34,6 +39,7 @@ class PairingTablePresenterTest(unittest.TestCase):
         self.presenter = PairingTablePresenter(self.view, self.model)
 
         self.view.warning_popup = mock.Mock()
+        self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
 
     def tearDown(self):
         self.obj = None
@@ -229,20 +235,11 @@ class PairingTablePresenterTest(unittest.TestCase):
             self.assertEqual(str(self.view.get_table_item_text(0, 0)), valid_name)
             self.assertIn(valid_name, self.model.pair_names)
 
-    def test_that_renaming_group_to_duplicate_fails_and_reverts_to_previous_value(self):
-        self.add_two_pairs_to_table()
-
-        self.view.pairing_table.setCurrentCell(0, 0)
-        self.view.pairing_table.item(0, 0).setText("my_pair_1")
-
-        self.assertEqual(str(self.view.get_table_item_text(0, 0)), "my_pair_0")
-        self.assertIn("my_pair_0", self.model.pair_names)
-
     def test_that_warning_shown_if_duplicated_pair_name_used(self):
         self.add_two_pairs_to_table()
 
-        self.view.pairing_table.setCurrentCell(0, 0)
-        self.view.pairing_table.item(0, 0).setText("my_group_1")
+        self.view.enter_pair_name = mock.Mock(return_value="my_group_1")
+        self.presenter.handle_add_pair_button_clicked()
 
         self.assertEqual(self.view.warning_popup.call_count, 1)
 


### PR DESCRIPTION
**Description of work.**
This PR removes the ability for the user to edit the group names and pair names from the frequency domain analysis GUI. When a group or pair is added it allows the user to set a name which once set cannot be changed

**To test:**

Open the frequency domain analysis GUI and load some data.
Go to the grouping tab
Try to change the group name of an existing group. You should not be able to do this.
Add a new group by clicking the + button. It should let you enter the name of the group and create a new group with that name - check once it is created that the name cannot be changed.
Create a new group by right clicking and pressing Add Group and this should do the same as above.
Repeat the above with the pair name.
Ensure you cannot add groups or pairs with the same name or invalid characters

Fixes #25168.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
