### PR TITLE
ILL powder reduce single run

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
@@ -75,8 +75,8 @@ class PowderILLParameterScanTest(unittest.TestCase):
     def test_normalise_time(self):
         red = PowderILLParameterScan(Run=self._runs,NormaliseTo='Time')
         self.assertTrue(red)
-        self.assertAlmostEquals(red.readY(0)[1400],9532/300,4)
-        self.assertAlmostEquals(red.readY(1)[2100],9789/300,2)
+        self.assertAlmostEquals(red.readY(0)[1400],9532/300.,4)
+        self.assertAlmostEquals(red.readY(1)[2100],9789/300.,2)
 
     def test_normalise_roi(self):
         red = PowderILLParameterScan(Run=self._runs,NormaliseTo='ROI',ROI='0,100')
@@ -97,7 +97,7 @@ class PowderILLParameterScanTest(unittest.TestCase):
     def test_normalise_time_single(self):
         red = PowderILLParameterScan(Run='967087',NormaliseTo='Time')
         self.assertTrue(red)
-        self.assertAlmostEquals(red.readY(0)[1400],9532/300,4)
+        self.assertAlmostEquals(red.readY(0)[1400],9532/300.,4)
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/PowderILLParameterScanTest.py
@@ -94,5 +94,10 @@ class PowderILLParameterScanTest(unittest.TestCase):
         self.assertEquals(red.getNumberHistograms(), 1)
         self.assertAlmostEqual(red.getAxis(1).extractValues()[0], 248.372, 5)
 
+    def test_normalise_time_single(self):
+        red = PowderILLParameterScan(Run='967087',NormaliseTo='Time')
+        self.assertTrue(red)
+        self.assertAlmostEquals(red.readY(0)[1400],9532/300,4)
+
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v4.0.0/diffraction.rst
+++ b/docs/source/release/v4.0.0/diffraction.rst
@@ -100,6 +100,7 @@ Bugfixes
 - The Powder Diffraction GUI now remembers whether linear or logarithmic binning was selected between uses.
 - Fixed a bug in :ref:`GenerateGroupingPowder <algm-GenerateGroupingPowder>` which caused detectors without corresponding spectrum to get included in grouping.
 - :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` now does not use cache file when the grouping has changed.
+- :ref:`PowderILLParameterScan <algm-PowderILLParameterScan>` will now accept also single run, when the time normalisation is enabled.
 
 New Algorithms
 ##############


### PR DESCRIPTION
**Description of work.**
Fixes the algorithm to take also single run, when the loaded entity is not a workspace group, but a workspace.

**To test:**
Should run with no errors.

```
red = PowderILLParameterScan(Run='ILL/D20/967087.nxs',NormaliseTo='Time')
```

<!-- Instructions for testing. -->

Fixes #25183 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.