### PR TITLE
Removes geometry input from Indirect>Corrections>Apply Abs Corr

### DIFF
--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -27,8 +27,6 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
   m_spectra = 0;
   m_uiForm.setupUi(parent);
 
-  connect(m_uiForm.cbGeometry, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(handleGeometryChange(int)));
   connect(m_uiForm.dsSample, SIGNAL(dataReady(const QString &)), this,
           SLOT(newSample(const QString &)));
   connect(m_uiForm.dsContainer, SIGNAL(dataReady(const QString &)), this,
@@ -309,21 +307,17 @@ void ApplyAbsorptionCorrections::run() {
   if (nameCutIndex == -1)
     nameCutIndex = QStrSampleWsName.length();
 
-  QString correctionType;
-  switch (m_uiForm.cbGeometry->currentIndex()) {
-  case 0:
-    correctionType = "flt";
-    break;
-  case 1:
-    correctionType = "cyl";
-    break;
-  case 2:
-    correctionType = "anl";
-    break;
+  QString geometryType;
+  if (correctionsWsName.contains("FlatPlate")) {
+    geometryType = "_flt";
+  } else if (correctionsWsName.contains("Annulus")) {
+    geometryType = "_anl";
+  } else if (correctionsWsName.contains("Cylinder")) {
+    geometryType = "_cyl";
   }
 
   QString outputWsName = QStrSampleWsName.left(nameCutIndex);
-  outputWsName += "_" + correctionType + "_Corrected";
+  outputWsName += geometryType + "_Corrected";
 
   // Using container
   if (m_uiForm.ckUseCan->isChecked()) {
@@ -523,31 +517,6 @@ void ApplyAbsorptionCorrections::loadSettings(const QSettings &settings) {
   m_uiForm.dsCorrections->readSettings(settings.group());
   m_uiForm.dsContainer->readSettings(settings.group());
   m_uiForm.dsSample->readSettings(settings.group());
-}
-
-/**
- * Handles when the type of geometry changes
- *
- * Updates the file extension to search for
- */
-void ApplyAbsorptionCorrections::handleGeometryChange(int index) {
-  QString ext("");
-  switch (index) {
-  case 0:
-    // Geometry is flat
-    ext = "_flt_abs";
-    break;
-  case 1:
-    // Geometry is cylinder
-    ext = "_cyl_abs";
-    break;
-  case 2:
-    // Geometry is annulus
-    ext = "_ann_abs";
-    break;
-  }
-  m_uiForm.dsCorrections->setWSSuffixes(QStringList(ext));
-  m_uiForm.dsCorrections->setFBSuffixes(QStringList(ext + ".nxs"));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -21,8 +21,6 @@ public:
   ~ApplyAbsorptionCorrections();
 
 private slots:
-  /// Handles the geometry being changed
-  void handleGeometryChange(int index);
   /// Handles a new sample being loaded
   void newSample(const QString &dataName);
   /// Handles a new container being loaded

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.ui
@@ -98,30 +98,66 @@
       <string>Options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="ckRebinContainer">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Rebin Container to sample</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ckUseCan">
+        <property name="text">
+         <string>Use Container:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="ckScaleCan">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Scale Container by factor:</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
       <item row="3" column="1">
-       <layout class="QHBoxLayout" name="loScaleFactor">
+       <layout class="QHBoxLayout" name="loShiftFactor">
         <item>
-         <widget class="QDoubleSpinBox" name="spCanScale">
+         <widget class="QDoubleSpinBox" name="spCanShift">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="decimals">
            <number>5</number>
           </property>
+          <property name="minimum">
+           <double>-999.990000000000009</double>
+          </property>
           <property name="maximum">
            <double>999.990000000000009</double>
           </property>
           <property name="singleStep">
-           <double>0.100000000000000</double>
+           <double>0.010000000000000</double>
           </property>
           <property name="value">
-           <double>1.000000000000000</double>
+           <double>0.000000000000000</double>
           </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="1">
        <widget class="MantidQt::MantidWidgets::DataSelector" name="dsContainer" native="true">
         <property name="enabled">
          <bool>false</bool>
@@ -155,85 +191,30 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
-       <layout class="QHBoxLayout" name="loShiftFactor">
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="loScaleFactor">
         <item>
-         <widget class="QDoubleSpinBox" name="spCanShift">
+         <widget class="QDoubleSpinBox" name="spCanScale">
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="decimals">
            <number>5</number>
           </property>
-          <property name="minimum">
-           <double>-999.990000000000009</double>
-          </property>
           <property name="maximum">
            <double>999.990000000000009</double>
           </property>
           <property name="singleStep">
-           <double>0.010000000000000</double>
+           <double>0.100000000000000</double>
           </property>
           <property name="value">
-           <double>0.000000000000000</double>
+           <double>1.000000000000000</double>
           </property>
          </widget>
         </item>
        </layout>
       </item>
       <item row="3" column="0">
-       <widget class="QCheckBox" name="ckScaleCan">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Scale Container by factor:</string>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="cbGeometry">
-        <item>
-         <property name="text">
-          <string>Flat Plate</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Cylinder</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Annulus</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="lbGeometry">
-        <property name="text">
-         <string>Geometry:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="ckRebinContainer">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Rebin Container to sample</string>
-        </property>
-        <property name="checked">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
        <widget class="QCheckBox" name="ckShiftCan">
         <property name="enabled">
          <bool>false</bool>
@@ -243,13 +224,6 @@
         </property>
         <property name="checked">
          <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="ckUseCan">
-        <property name="text">
-         <string>Use Container:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
**Description of work.**

See the title. The geometry is not needed for applying the corrections.

**To test:**

1. Take some reduced data and calculate monte carlo absorptions for FlatPlate.
2. Go to Indirect>Corrections>Apply Absorption Correction
Supply the input workspace and the correction workspace, run.
The corrected output workspace should contain `_flt_` in its name.
3. Repeat 1-2 for Annulus and Cylinder, labels should be `_cyl_` and `_anl_` respectively.
4. Think of any side effects this change might have? 

<!-- Instructions for testing. -->

Fixes #25185 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes, since it's a minor change with no functional effects.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
