### PR TITLE
Fix cppcheck 1.87 warnings in API

### DIFF
--- a/Framework/API/inc/MantidAPI/DeprecatedAlgorithm.h
+++ b/Framework/API/inc/MantidAPI/DeprecatedAlgorithm.h
@@ -25,7 +25,7 @@ class MANTID_API_DLL DeprecatedAlgorithm {
 public:
   DeprecatedAlgorithm();
   virtual ~DeprecatedAlgorithm();
-  const std::string deprecationMsg(const IAlgorithm *);
+  std::string deprecationMsg(const IAlgorithm *);
 
 public:
   void useAlgorithm(const std::string &, const int version = -1);

--- a/Framework/API/src/AlgorithmHistory.cpp
+++ b/Framework/API/src/AlgorithmHistory.cpp
@@ -203,13 +203,14 @@ AlgorithmHistory_sptr AlgorithmHistory::operator[](const size_t index) const {
  */
 const std::string &
 AlgorithmHistory::getPropertyValue(const std::string &name) const {
-  for (const auto &hist : m_properties) {
-    if (hist->name() == name) {
-      return hist->value();
-    }
+  const auto found = std::find_if(
+      m_properties.cbegin(), m_properties.cend(),
+      [&name](const auto &history) { return history->name() == name; });
+  if (found == m_properties.cend()) {
+    throw Kernel::Exception::NotFoundError(
+        "Could not find the specified property", name);
   }
-  throw Kernel::Exception::NotFoundError(
-      "Could not find the specified property", name);
+  return (*found)->value();
 }
 
 /**

--- a/Framework/API/src/CatalogManager.cpp
+++ b/Framework/API/src/CatalogManager.cpp
@@ -105,9 +105,9 @@ void CatalogManagerImpl::destroyCatalog(const std::string &sessionID) {
 std::vector<CatalogSession_sptr> CatalogManagerImpl::getActiveSessions() {
   std::vector<CatalogSession_sptr> sessions;
   sessions.reserve(m_activeCatalogs.size());
-  std::transform(m_activeCatalogs.cbegin(), m_activeCatalogs.cend(),
-                 std::back_inserter(sessions),
-                 [](const auto &catalog) { return catalog.first; });
+  for (const auto &activeCatalog : m_activeCatalogs) {
+    sessions.emplace_back(activeCatalog.first);
+  }
   return sessions;
 }
 

--- a/Framework/API/src/CatalogManager.cpp
+++ b/Framework/API/src/CatalogManager.cpp
@@ -63,13 +63,15 @@ ICatalog_sptr CatalogManagerImpl::getCatalog(const std::string &sessionID) {
     return composite;
   }
 
-  for (auto &activeCatalog : m_activeCatalogs) {
-    if (sessionID == activeCatalog.first->getSessionId())
-      return activeCatalog.second;
+  const auto found =
+      std::find_if(m_activeCatalogs.cbegin(), m_activeCatalogs.cend(),
+                   [&sessionID](const auto &catalog) {
+                     return catalog.first->getSessionId() == sessionID;
+                   });
+  if (found == m_activeCatalogs.cend()) {
+    throw std::runtime_error("The session ID you have provided is invalid.");
   }
-
-  // If we reached this point then the session is corrupt/invalid.
-  throw std::runtime_error("The session ID you have provided is invalid.");
+  return found->second;
 }
 
 /**
@@ -103,10 +105,9 @@ void CatalogManagerImpl::destroyCatalog(const std::string &sessionID) {
 std::vector<CatalogSession_sptr> CatalogManagerImpl::getActiveSessions() {
   std::vector<CatalogSession_sptr> sessions;
   sessions.reserve(m_activeCatalogs.size());
-  for (auto &activeCatalog : m_activeCatalogs) {
-    sessions.push_back(activeCatalog.first);
-  }
-
+  std::transform(m_activeCatalogs.cbegin(), m_activeCatalogs.cend(),
+                 std::back_inserter(sessions),
+                 [](const auto &catalog) { return catalog.first; });
   return sessions;
 }
 

--- a/Framework/API/src/DataProcessorAlgorithm.cpp
+++ b/Framework/API/src/DataProcessorAlgorithm.cpp
@@ -293,13 +293,11 @@ GenericDataProcessorAlgorithm<Base>::assemble(const std::string &partialWSName,
 template <class Base>
 void GenericDataProcessorAlgorithm<Base>::saveNexus(
     const std::string &outputWSName, const std::string &outputFile) {
-  bool saveOutput = true;
 #ifdef MPI_BUILD
-  if (boost::mpi::communicator().rank() > 0)
-    saveOutput = false;
+  if (boost::mpi::communicator().rank() <= 0 && !outputFile.empty()) {
+#else
+  if (!outputFile.empty()) {
 #endif
-
-  if (saveOutput && !outputFile.empty()) {
     IAlgorithm_sptr saveAlg = createChildAlgorithm("SaveNexus");
     saveAlg->setPropertyValue("Filename", outputFile);
     saveAlg->setPropertyValue("InputWorkspace", outputWSName);

--- a/Framework/API/src/DeprecatedAlgorithm.cpp
+++ b/Framework/API/src/DeprecatedAlgorithm.cpp
@@ -56,7 +56,7 @@ void DeprecatedAlgorithm::deprecatedDate(const std::string &date) {
 }
 
 /// This merely prints the deprecation error for people to see.
-const std::string DeprecatedAlgorithm::deprecationMsg(const IAlgorithm *algo) {
+std::string DeprecatedAlgorithm::deprecationMsg(const IAlgorithm *algo) {
   std::stringstream msg;
   if (algo != nullptr)
     msg << algo->name() << " is ";
@@ -72,13 +72,14 @@ const std::string DeprecatedAlgorithm::deprecationMsg(const IAlgorithm *algo) {
     // sanity check
     if (!AlgorithmFactory::Instance().exists(this->m_replacementAlgorithm,
                                              this->m_replacementVersion)) {
-      std::ostringstream msg;
-      msg << "Invalid replacement algorithm '" + this->m_replacementAlgorithm +
-                 "'";
+      std::ostringstream invalidReplacementMsg;
+      invalidReplacementMsg << "Invalid replacement algorithm '" +
+                                   this->m_replacementAlgorithm + "'";
       if (this->m_replacementVersion > 0)
-        msg << " version " << this->m_replacementVersion << "\n";
-      msg << "Replacement algorithm not registered.";
-      g_log.warning(msg.str());
+        invalidReplacementMsg << " version " << this->m_replacementVersion
+                              << "\n";
+      invalidReplacementMsg << "Replacement algorithm not registered.";
+      g_log.warning(invalidReplacementMsg.str());
     }
 
     msg << ". Use " << this->m_replacementAlgorithm;

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1038,9 +1038,8 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
   std::vector<std::string> pathNames;
   if (!matchingFiles.empty()) {
     pathNames.reserve(matchingFiles.size());
-    std::transform(matchingFiles.begin(), matchingFiles.end(),
-                   std::back_inserter(pathNames),
-                   [](const auto &element) { return element.second; });
+    for (auto &elem : matchingFiles)
+      pathNames.emplace_back(std::move(elem.second));
   } else {
     pathNames.emplace_back(std::move(mostRecentFile));
   }

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1038,8 +1038,9 @@ std::vector<std::string> ExperimentInfo::getResourceFilenames(
   std::vector<std::string> pathNames;
   if (!matchingFiles.empty()) {
     pathNames.reserve(matchingFiles.size());
-    for (auto elem : matchingFiles)
-      pathNames.emplace_back(std::move(elem.second));
+    std::transform(matchingFiles.begin(), matchingFiles.end(),
+                   std::back_inserter(pathNames),
+                   [](const auto &element) { return element.second; });
   } else {
     pathNames.emplace_back(std::move(mostRecentFile));
   }

--- a/Framework/API/src/Expression.cpp
+++ b/Framework/API/src/Expression.cpp
@@ -219,14 +219,13 @@ void Expression::tokenize() {
 
   size_t min_prec = 1000;
   size_t is = 0;
-  size_t is1 = 0;
   unsigned int lvl = 0;
-  size_t last = m_expr.size() - 1;
+  const size_t last = m_expr.size() - 1;
   bool inString = false;
   int skip = 0;
   bool canBeBinary = false;
-  bool isNumber =
-      false; // if parser is inside a number (important case is 123.45e+67)
+  // if parser is inside a number (important case is 123.45e+67)
+  bool isNumber = false;
   bool canDotBeAdded = false;
   bool canEBeAdded = false;
   bool canPlusBeAdded = false;
@@ -278,12 +277,7 @@ void Expression::tokenize() {
                                m_expr, i);
           }
         }
-
-        if (is_op_symbol(m_expr[i + 1])) {
-          is1 = i + 2;
-        } else {
-          is1 = i + 1;
-        }
+        auto is1 = i + (is_op_symbol(m_expr[i + 1]) ? 2 : 1);
 
         if (is1 > last) {
           throw ParsingError("Syntax error", m_expr, last);

--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -705,10 +705,10 @@ FileFinderImpl::getPath(const std::vector<IArchiveSearch_sptr> &archs,
     for (const auto &filename : filenames) {
       for (const auto &searchPath : searchPaths) {
         try {
-          Poco::Path path(searchPath, filename + extension);
-          Poco::File file(path);
+          const Poco::Path filePath(searchPath, filename + extension);
+          const Poco::File file(filePath);
           if (file.exists())
-            return path.toString();
+            return filePath.toString();
 
         } catch (Poco::Exception &) { /* File does not exist, just carry on. */
         }
@@ -736,13 +736,14 @@ FileFinderImpl::getPath(const std::vector<IArchiveSearch_sptr> &archs,
   // Search the archive
   if (!archs.empty()) {
     g_log.debug() << "Search the archives\n";
-    std::string path = getArchivePath(archs, filenames, exts);
+    const std::string archivePath = getArchivePath(archs, filenames, exts);
     try {
-      if (!path.empty() && Poco::File(path).exists()) {
-        return path;
+      if (!archivePath.empty() && Poco::File(archivePath).exists()) {
+        return archivePath;
       }
     } catch (std::exception &e) {
-      g_log.error() << "Cannot open file " << path << ": " << e.what() << '\n';
+      g_log.error() << "Cannot open file " << archivePath << ": " << e.what()
+                    << '\n';
       return "";
     }
 

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -212,23 +212,23 @@ CompositeFunction_sptr FunctionFactoryImpl::createComposite(
     inputError(expr.str());
 
   for (; it != terms.end(); ++it) {
-    const Expression &term = it->bracketsRemoved();
+    const Expression &currentTerm = it->bracketsRemoved();
     IFunction_sptr fun;
     std::map<std::string, std::string> pAttributes;
-    if (term.name() == ";") {
-      fun = createComposite(term, pAttributes);
+    if (currentTerm.name() == ";") {
+      fun = createComposite(currentTerm, pAttributes);
       if (!fun)
         continue;
     } else {
-      std::string parName = term[0].name();
+      std::string parName = currentTerm[0].name();
       if (parName.size() >= 10 && parName.substr(0, 10) == "constraint") {
-        addConstraints(cfun, term[1].bracketsRemoved());
+        addConstraints(cfun, currentTerm[1].bracketsRemoved());
         continue;
       } else if (parName == "ties") {
-        addTies(cfun, term[1].bracketsRemoved());
+        addTies(cfun, currentTerm[1].bracketsRemoved());
         continue;
       } else {
-        fun = createSimple(term, pAttributes);
+        fun = createSimple(currentTerm, pAttributes);
       }
     }
     cfun->addFunction(fun);

--- a/Framework/API/src/HistoryView.cpp
+++ b/Framework/API/src/HistoryView.cpp
@@ -45,11 +45,6 @@ void HistoryView::unroll(size_t index) {
   unroll(it);
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
-#define GCC_VERSION                                                            \
-  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-#endif
-
 /**
  * Unroll an algorithm history to export its child algorithms.
  *
@@ -70,24 +65,11 @@ void HistoryView::unroll(std::vector<HistoryItem>::iterator &it) {
     it->unrolled(true);
 
     // insert each of the records, in order, at this position
-    std::vector<HistoryItem> tmpHistory;
-    tmpHistory.reserve(childHistories.size());
-    for (const auto &item : childHistories) {
-      tmpHistory.emplace_back(item);
-    }
-// since we are using a std::vector, do all insertions at the same time.
-#if !defined(GCC_VERSION) || GCC_VERSION >= 40900
+    std::vector<HistoryItem> tmpHistory(childHistories.cbegin(),
+                                        childHistories.cend());
+    // since we are using a std::vector, do all insertions at the same time.
     ++it; // move iterator forward to insertion position
     it = m_historyItems.insert(it, tmpHistory.begin(), tmpHistory.end());
-#else
-    // workaround for GCC < 4.9
-    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55817
-    ++it;
-    for (auto itItem = tmpHistory.rbegin(); itItem != tmpHistory.rend();
-         ++itItem) {
-      it = m_historyItems.insert(it, *itItem);
-    }
-#endif
   } else
     ++it;
 }

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1352,8 +1352,9 @@ void IFunction::setAttributeValue(const std::string &attName,
 std::vector<std::string> IFunction::getAttributeNames() const {
   std::vector<std::string> names;
   names.reserve(m_attrs.size());
-  std::transform(m_attrs.cbegin(), m_attrs.cend(), std::back_inserter(names),
-                 [](const auto &element) { return element.first; });
+  for (const auto &attr : m_attrs) {
+    names.emplace_back(attr.first);
+  }
   return names;
 }
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1352,9 +1352,8 @@ void IFunction::setAttributeValue(const std::string &attName,
 std::vector<std::string> IFunction::getAttributeNames() const {
   std::vector<std::string> names;
   names.reserve(m_attrs.size());
-  for (const auto &attr : m_attrs) {
-    names.push_back(attr.first);
-  }
+  std::transform(m_attrs.cbegin(), m_attrs.cend(), std::back_inserter(names),
+                 [](const auto &element) { return element.first; });
   return names;
 }
 

--- a/Framework/API/src/ImmutableCompositeFunction.cpp
+++ b/Framework/API/src/ImmutableCompositeFunction.cpp
@@ -97,11 +97,14 @@ ImmutableCompositeFunction::parameterIndex(const std::string &name) const {
  * Returns the alias or name of parameter i
  */
 std::string ImmutableCompositeFunction::parameterName(size_t i) const {
-  for (const auto &alias : m_aliases) {
-    if (alias.second == i)
-      return alias.first;
+  const auto found =
+      std::find_if(m_aliases.cbegin(), m_aliases.cend(),
+                   [i](const auto &element) { return element.second == i; });
+  if (found == m_aliases.cend()) {
+    return CompositeFunction::parameterName(i);
+  } else {
+    return found->first;
   }
-  return CompositeFunction::parameterName(i);
 }
 
 //-----------------------------------------------------------------------------------------------

--- a/Framework/API/src/IndexProperty.cpp
+++ b/Framework/API/src/IndexProperty.cpp
@@ -79,10 +79,8 @@ Indexing::SpectrumIndexSet IndexProperty::getIndices() const {
             std::vector<Indexing::GlobalSpectrumIndex>(m_value.begin(),
                                                        m_value.end()));
       case IndexType::SpectrumNum: {
-        std::vector<Indexing::SpectrumNumber> spectrumNumbers;
-        for (const auto index : m_value)
-          spectrumNumbers.push_back(static_cast<Indexing::SpectrumNumber>(
-              static_cast<int32_t>(index)));
+        std::vector<Indexing::SpectrumNumber> spectrumNumbers(m_value.cbegin(),
+                                                              m_value.cend());
         return indexInfo.makeIndexSet(spectrumNumbers);
       }
       }
@@ -109,10 +107,8 @@ Indexing::IndexInfo IndexProperty::getFilteredIndexInfo() const {
                                                        m_value.end()),
             indexInfo};
   case IndexType::SpectrumNum: {
-    std::vector<Indexing::SpectrumNumber> spectrumNumbers;
-    for (const auto index : m_value)
-      spectrumNumbers.push_back(
-          static_cast<Indexing::SpectrumNumber>(static_cast<int32_t>(index)));
+    std::vector<Indexing::SpectrumNumber> spectrumNumbers(m_value.cbegin(),
+                                                          m_value.cend());
     return {spectrumNumbers, indexInfo};
   }
   default:

--- a/Framework/API/src/MDGeometry.cpp
+++ b/Framework/API/src/MDGeometry.cpp
@@ -194,11 +194,10 @@ Mantid::Geometry::VecIMDDimension_const_sptr
 MDGeometry::getNonIntegratedDimensions() const {
   using namespace Mantid::Geometry;
   VecIMDDimension_const_sptr vecCollapsedDimensions;
-  for (const auto &current : this->m_dimensions) {
-    if (!current->getIsIntegrated()) {
-      vecCollapsedDimensions.push_back(current);
-    }
-  }
+  std::copy_if(
+      m_dimensions.cbegin(), m_dimensions.cend(),
+      std::back_inserter(vecCollapsedDimensions),
+      [](const auto &dimension) { return !dimension->getIsIntegrated(); });
   return vecCollapsedDimensions;
 }
 

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1128,9 +1128,9 @@ MatrixWorkspace::maskedBinsIndices(const size_t &workspaceIndex) const {
   auto maskedBins = it->second;
   std::vector<size_t> maskedIds;
   maskedIds.reserve(maskedBins.size());
-  std::transform(maskedBins.cbegin(), maskedBins.cend(),
-                 std::back_inserter(maskedIds),
-                 [](const auto &element) { return element.first; });
+  for (const auto &mb : maskedBins) {
+    maskedIds.emplace_back(mb.first);
+  }
   return maskedIds;
 }
 

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -604,9 +604,8 @@ std::vector<size_t> MatrixWorkspace::getIndicesFromDetectorIDs(
   for (const auto detId : detIdList) {
     auto wsIndices = detectorIDtoWSIndices.find(detId);
     if (wsIndices != detectorIDtoWSIndices.end()) {
-      for (auto index : wsIndices->second) {
-        indexList.push_back(index);
-      }
+      std::copy(wsIndices->second.cbegin(), wsIndices->second.cend(),
+                std::back_inserter(indexList));
     }
   }
   return indexList;
@@ -997,7 +996,6 @@ bool MatrixWorkspace::isCommonBins() const {
 
   // Check that the values of each histogram are identical.
   if (m_isCommonBinsFlag) {
-    const size_t numBins = x(0).size();
     const size_t lastSpec = numHist - 1;
     for (size_t i = 0; i < lastSpec; ++i) {
       const auto &xi = x(i);
@@ -1130,9 +1128,9 @@ MatrixWorkspace::maskedBinsIndices(const size_t &workspaceIndex) const {
   auto maskedBins = it->second;
   std::vector<size_t> maskedIds;
   maskedIds.reserve(maskedBins.size());
-  for (auto &mb : maskedBins) {
-    maskedIds.push_back(mb.first);
-  }
+  std::transform(maskedBins.cbegin(), maskedBins.cend(),
+                 std::back_inserter(maskedIds),
+                 [](const auto &element) { return element.first; });
   return maskedIds;
 }
 
@@ -1445,12 +1443,10 @@ private:
 class MWXDimension : public Mantid::Geometry::IMDDimension {
 public:
   MWXDimension(const MatrixWorkspace *ws, const std::string &dimensionId)
-      : m_ws(ws), m_dimensionId(dimensionId),
+      : m_ws(ws), m_X(ws->readX(0)), m_dimensionId(dimensionId),
         m_frame(Kernel::make_unique<Geometry::GeneralFrame>(
             m_ws->getAxis(0)->unit()->label(),
-            m_ws->getAxis(0)->unit()->label())) {
-    m_X = ws->readX(0);
-  }
+            m_ws->getAxis(0)->unit()->label())) {}
 
   /// the name of the dimennlsion as can be displayed along the axis
   std::string getName() const override {

--- a/Framework/API/src/MultiDomainFunction.cpp
+++ b/Framework/API/src/MultiDomainFunction.cpp
@@ -321,10 +321,10 @@ void MultiDomainFunction::setLocalAttribute(size_t i,
   } else {
     // value must be either an int or a list of ints: "a,b,c,..."
     list.toList();
-    std::transform(list.begin(), list.end(), std::back_inserter(indx),
-                   [](const auto &element) {
-                     return boost::lexical_cast<size_t>(element.name());
-                   });
+    indx.reserve(list.size());
+    for (const auto &k : list) {
+      indx.emplace_back(boost::lexical_cast<size_t>(k.name()));
+    }
   }
   setDomainIndices(i, indx);
 }

--- a/Framework/API/src/MultiDomainFunction.cpp
+++ b/Framework/API/src/MultiDomainFunction.cpp
@@ -321,9 +321,10 @@ void MultiDomainFunction::setLocalAttribute(size_t i,
   } else {
     // value must be either an int or a list of ints: "a,b,c,..."
     list.toList();
-    for (const auto &k : list) {
-      indx.push_back(boost::lexical_cast<size_t>(k.name()));
-    }
+    std::transform(list.begin(), list.end(), std::back_inserter(indx),
+                   [](const auto &element) {
+                     return boost::lexical_cast<size_t>(element.name());
+                   });
   }
   setDomainIndices(i, indx);
 }

--- a/Framework/API/src/ParameterReference.cpp
+++ b/Framework/API/src/ParameterReference.cpp
@@ -99,12 +99,11 @@ bool ParameterReference::isParameterOf(const IFunction *fun) const {
   if (fun == m_function) {
     return true;
   }
-  auto fLocal = m_function;
   size_t iLocal = m_index;
   auto cf = dynamic_cast<const CompositeFunction *>(m_function);
   while (cf) {
     size_t iFun = cf->functionIndex(iLocal);
-    fLocal = cf->getFunction(iFun).get();
+    const auto fLocal = cf->getFunction(iFun).get();
     if (fLocal == fun) {
       return true;
     }

--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -203,8 +203,9 @@ bool ParameterTie::isConstant() const { return m_varMap.empty(); }
 std::vector<ParameterReference> ParameterTie::getRHSParameters() const {
   std::vector<ParameterReference> out;
   out.reserve(m_varMap.size());
-  std::transform(m_varMap.cbegin(), m_varMap.cend(), std::back_inserter(out),
-                 [](const auto &element) { return element.second; });
+  for (auto &&varPair : m_varMap) {
+    out.emplace_back(varPair.second);
+  }
   return out;
 }
 

--- a/Framework/API/src/ParameterTie.cpp
+++ b/Framework/API/src/ParameterTie.cpp
@@ -188,12 +188,9 @@ bool ParameterTie::findParametersOf(const IFunction *fun) const {
   if (getLocalFunction() == fun) {
     return true;
   }
-  for (const auto &varPair : m_varMap) {
-    if (varPair.second.isParameterOf(fun)) {
-      return true;
-    }
-  }
-  return false;
+  return std::any_of(
+      m_varMap.cbegin(), m_varMap.cend(),
+      [fun](const auto &element) { return element.second.isParameterOf(fun); });
 }
 
 /**
@@ -206,9 +203,8 @@ bool ParameterTie::isConstant() const { return m_varMap.empty(); }
 std::vector<ParameterReference> ParameterTie::getRHSParameters() const {
   std::vector<ParameterReference> out;
   out.reserve(m_varMap.size());
-  for (auto &&varPair : m_varMap) {
-    out.emplace_back(varPair.second);
-  }
+  std::transform(m_varMap.cbegin(), m_varMap.cend(), std::back_inserter(out),
+                 [](const auto &element) { return element.second; });
   return out;
 }
 

--- a/Framework/API/src/SerialAlgorithm.cpp
+++ b/Framework/API/src/SerialAlgorithm.cpp
@@ -12,10 +12,14 @@ namespace API {
 Parallel::ExecutionMode SerialAlgorithm::getParallelExecutionMode(
     const std::map<std::string, Parallel::StorageMode> &storageModes) const {
   using namespace Parallel;
-  for (const auto &item : storageModes)
-    if (item.second != StorageMode::MasterOnly)
-      throw std::runtime_error(item.first + " must have " +
-                               Parallel::toString(StorageMode::MasterOnly));
+  const auto nonMasterOnly = std::find_if(
+      storageModes.cbegin(), storageModes.cend(), [](const auto &element) {
+        return element.second != StorageMode::MasterOnly;
+      });
+  if (nonMasterOnly != storageModes.cend()) {
+    throw std::runtime_error(nonMasterOnly->first + " must have " +
+                             Parallel::toString(StorageMode::MasterOnly));
+  }
   return getCorrespondingExecutionMode(StorageMode::MasterOnly);
 }
 

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -165,9 +165,9 @@ std::vector<std::string> WorkspaceGroup::getNames() const {
   std::vector<std::string> out;
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   out.reserve(m_workspaces.size());
-  std::transform(m_workspaces.cbegin(), m_workspaces.cend(),
-                 std::back_inserter(out),
-                 [](const auto &workspace) { return workspace->getName(); });
+  for (const auto &workspace : m_workspaces) {
+    out.emplace_back(workspace->getName());
+  }
   return out;
 }
 

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -39,11 +39,13 @@ WorkspaceGroup::~WorkspaceGroup() { observeADSNotifications(false); }
  * group
  */
 const std::string WorkspaceGroup::toString() const {
-  std::string descr = this->id() + "\n";
+  const std::string firstLine = this->id() + "\n";
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-  for (const auto &workspace : m_workspaces) {
-    descr += " -- " + workspace->getName() + '\n';
-  }
+  const auto descr =
+      std::accumulate(m_workspaces.cbegin(), m_workspaces.cend(), firstLine,
+                      [](const auto &string, const auto &workspace) {
+                        return string + " -- " + workspace->getName() + '\n';
+                      });
   return descr;
 }
 
@@ -128,11 +130,10 @@ void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
  */
 bool WorkspaceGroup::contains(const std::string &wsName) const {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-  for (const auto &workspace : m_workspaces) {
-    if (workspace->getName() == wsName)
-      return true;
-  }
-  return false;
+  return std::any_of(m_workspaces.cbegin(), m_workspaces.cend(),
+                     [&wsName](const auto &workspace) {
+                       return workspace->getName() == wsName;
+                     });
 }
 
 /**
@@ -161,12 +162,12 @@ void WorkspaceGroup::reportMembers(std::set<Workspace_sptr> &memberList) const {
  * vector is being iterated over.
  */
 std::vector<std::string> WorkspaceGroup::getNames() const {
-  std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   std::vector<std::string> out;
+  std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   out.reserve(m_workspaces.size());
-  for (const auto &workspace : m_workspaces) {
-    out.push_back(workspace->getName());
-  }
+  std::transform(m_workspaces.cbegin(), m_workspaces.cend(),
+                 std::back_inserter(out),
+                 [](const auto &workspace) { return workspace->getName(); });
   return out;
 }
 
@@ -194,13 +195,16 @@ Workspace_sptr WorkspaceGroup::getItem(const size_t index) const {
  */
 Workspace_sptr WorkspaceGroup::getItem(const std::string &wsName) const {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-  for (const auto &workspace : m_workspaces) {
-    if (workspace->getName() == wsName) {
-      return workspace;
-    }
+  const auto found = std::find_if(m_workspaces.cbegin(), m_workspaces.cend(),
+                                  [&wsName](const auto &workspace) {
+                                    return workspace->getName() == wsName;
+                                  });
+  if (found == m_workspaces.cend()) {
+    throw std::out_of_range("Workspace " + wsName +
+                            " not contained in the group");
+  } else {
+    return *found;
   }
-  throw std::out_of_range("Workspace " + wsName +
-                          " not contained in the group");
 }
 
 /** Return all workspaces in the group as one call for thread safety


### PR DESCRIPTION
This fixes cppcheck 1.87 issues in the API module. Most of the changes deal with using STL algorithms instead of raw loops.

**To test:**

Very careful code review.

This fixes some parts of #22912.

*This does not require release notes* because this is internal cleanup.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
