### PR TITLE
Indirect ConvFit : avoid nullptr if component does not exist

### DIFF
--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -149,18 +149,20 @@ void readAnalyserFromFile(const std::string &analyser,
 
 Mantid::Geometry::IComponent_const_sptr
 getAnalyser(MatrixWorkspace_sptr workspace) {
-  auto instrument = workspace->getInstrument();
-  auto analysers = instrument->getStringParameter("analyser");
+  auto const instrument = workspace->getInstrument();
+  auto const analysers = instrument->getStringParameter("analyser");
 
   if (analysers.empty())
     throw std::invalid_argument(
         "Could not load instrument resolution from parameter file");
 
-  auto component = instrument->getComponentByName(analysers[0]);
+  auto const component = instrument->getComponentByName(analysers[0]);
   if (component) {
-    auto resolutionParameters = component->getNumberParameter("resolution");
-    if (resolutionParameters.empty()) {
-      readAnalyserFromFile(analysers[0], workspace);
+    if (component->hasParameter("resolution")) {
+      auto const resolutionParameters =
+          component->getNumberParameter("resolution");
+      if (resolutionParameters.empty())
+        readAnalyserFromFile(analysers[0], workspace);
     }
   } else {
     readAnalyserFromFile(analysers[0], workspace);

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -157,9 +157,14 @@ getAnalyser(MatrixWorkspace_sptr workspace) {
         "Could not load instrument resolution from parameter file");
 
   auto component = instrument->getComponentByName(analysers[0]);
-  auto resolutionParameters = component->getNumberParameter("resolution");
-  if (nullptr == component || resolutionParameters.empty())
+  if (component) {
+    auto resolutionParameters = component->getNumberParameter("resolution");
+    if (resolutionParameters.empty()) {
+      readAnalyserFromFile(analysers[0], workspace);
+    }
+  } else {
     readAnalyserFromFile(analysers[0], workspace);
+  }
   return workspace->getInstrument()->getComponentByName(analysers[0]);
 }
 


### PR DESCRIPTION
**Description of work.**
Fixes a hard crash when the analyser is not defined as an instrument component.

**To test:**
Go to Interfaces > Indirect > Data Analysis > ConvFit tab.
Load the attached file in the sample input, wait until it loads.
Mantid should not crash, unlike in current `release-next`.

Chop off `.zip`; it's a nexus file.

[example_red.nxs.zip](https://github.com/mantidproject/mantid/files/2970413/example_red.nxs.zip)

<!-- Instructions for testing. -->

Fixes #25188 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes, since it's a minor change.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
