### PR TITLE
Crop the IvsQ output of RROA if Q limits specified

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -10,6 +10,8 @@
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 #include "ReflectometryWorkflowBase2.h"
 
+#include <boost/optional.hpp>
+
 namespace Mantid {
 namespace Algorithms {
 
@@ -42,6 +44,31 @@ private:
     std::string iVsLam;
   };
 
+  class RebinParams {
+  public:
+    RebinParams(const double qMin, const bool qMinIsDefault, const double qMax,
+                const bool qMaxIsDefault, const boost::optional<double> qStep)
+        : m_qMin(qMin), m_qMinIsDefault(qMinIsDefault), m_qMax(qMax),
+          m_qMaxIsDefault(qMaxIsDefault), m_qStep(qStep){};
+
+    double qMin() const { return m_qMin; };
+    bool qMinIsDefault() const { return m_qMinIsDefault; }
+    double qMax() const { return m_qMax; };
+    bool qMaxIsDefault() const { return m_qMaxIsDefault; }
+    double qStep() const { return *m_qStep; };
+    bool hasQStep() const { return m_qStep.is_initialized(); }
+    std::vector<double> asVector() const {
+      return std::vector<double>{qMin(), qStep(), qMax()};
+    };
+
+  private:
+    double m_qMin;
+    bool m_qMinIsDefault;
+    double m_qMax;
+    bool m_qMaxIsDefault;
+    boost::optional<double> m_qStep;
+  };
+
   void init() override;
   void exec() override;
   std::string
@@ -57,10 +84,17 @@ private:
                            const double twoTheta);
   /// Calculate theta
   double calculateTheta(Mantid::API::MatrixWorkspace_sptr inputWS);
+  /// Find cropping and binning parameters
+  RebinParams getRebinParams(MatrixWorkspace_sptr inputWS, const double theta);
+  boost::optional<double> getQStep(MatrixWorkspace_sptr inputWS,
+                                   const double theta);
   /// Rebin and scale a workspace in Q
   Mantid::API::MatrixWorkspace_sptr
-  rebinAndScale(Mantid::API::MatrixWorkspace_sptr inputWS, double theta,
-                std::vector<double> &params);
+  rebinAndScale(Mantid::API::MatrixWorkspace_sptr inputWS,
+                RebinParams const &params);
+  /// Crop a workspace in Q
+  MatrixWorkspace_sptr cropQ(MatrixWorkspace_sptr inputWS,
+                             RebinParams const &params);
   /// Populate algorithmic correction properties
   void populateAlgorithmicCorrectionProperties(
       Mantid::API::IAlgorithm_sptr alg,
@@ -74,7 +108,7 @@ private:
                             const std::string &propertyName);
   void applyFloodCorrections();
   double getPropertyOrDefault(const std::string &propertyName,
-                              const double defaultValue);
+                              const double defaultValue, bool &isDefault);
   void setOutputWorkspaces(WorkspaceNames const &outputGroupNames,
                            std::vector<std::string> &IvsLamGroup,
                            std::vector<std::string> &IvsQBinnedGroup,

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -453,14 +453,25 @@ void ReflectometryReductionOneAuto2::exec() {
   alg->setProperty("InputWorkspace", inputWS);
   alg->execute();
 
+  // Set the unbinned output workspace in Q, cropped to the min/max q
   MatrixWorkspace_sptr IvsQ = alg->getProperty("OutputWorkspace");
-  setProperty("OutputWorkspace", IvsQ);
+  auto const params = getRebinParams(IvsQ, theta);
+  auto IvsQC = IvsQ;
+  if (!(params.qMinIsDefault() && params.qMaxIsDefault()))
+    IvsQC = cropQ(IvsQ, params);
+  setProperty("OutputWorkspace", IvsQC);
 
-  std::vector<double> params;
-  MatrixWorkspace_sptr IvsQB = rebinAndScale(IvsQ, theta, params);
+  // Set the binned output workspace in Q
+  if (params.hasQStep()) {
+    MatrixWorkspace_sptr IvsQB = rebinAndScale(IvsQ, params);
+    setProperty("OutputWorkspaceBinned", IvsQB);
+  } else {
+    g_log.error("NRCalculateSlitResolution failed. Workspace in Q will not be "
+                "rebinned. Please provide dQ/Q.");
+    setProperty("OutputWorkspaceBinned", IvsQC);
+  }
 
-  setProperty("OutputWorkspaceBinned", IvsQB);
-
+  // Set the output workspace in wavelength, if debug outputs are enabled
   bool const isDebug = getProperty("Debug");
   if (isDebug || isChild()) {
     MatrixWorkspace_sptr IvsLam = alg->getProperty("OutputWorkspaceWavelength");
@@ -469,11 +480,10 @@ void ReflectometryReductionOneAuto2::exec() {
 
   // Set other properties so they can be updated in the Reflectometry interface
   setProperty("ThetaIn", theta);
-  if (!params.empty()) {
-    setProperty("MomentumTransferMin", params[0]);
-    setProperty("MomentumTransferStep", -params[1]);
-    setProperty("MomentumTransferMax", params[2]);
-  }
+  setProperty("MomentumTransferMin", params.qMin());
+  setProperty("MomentumTransferMax", params.qMax());
+  if (params.hasQStep())
+    setProperty("MomentumTransferStep", -params.qStep());
   if (getPointerToProperty("ScaleFactor")->isDefault())
     setProperty("ScaleFactor", 1.0);
 }
@@ -654,18 +664,26 @@ void ReflectometryReductionOneAuto2::populateAlgorithmicCorrectionProperties(
   }
 }
 
-/** Rebin and scale a workspace in Q.
+auto ReflectometryReductionOneAuto2::getRebinParams(
+    MatrixWorkspace_sptr inputWS, const double theta) -> RebinParams {
+  bool qMinIsDefault = true, qMaxIsDefault = true;
+  auto const qMin = getPropertyOrDefault("MomentumTransferMin",
+                                         inputWS->x(0).front(), qMinIsDefault);
+  auto const qMax = getPropertyOrDefault("MomentumTransferMax",
+                                         inputWS->x(0).back(), qMaxIsDefault);
+  return RebinParams(qMin, qMinIsDefault, qMax, qMaxIsDefault,
+                     getQStep(inputWS, theta));
+}
+
+/** Get the binning step the final output workspace in Q
  *
  * @param inputWS :: the workspace in Q
  * @param theta :: the angle of this run
- * @param params :: [output] rebin parameters
- * @return :: the output workspace
+ * @return :: the rebin step in Q, or none if it could not be found
  */
-MatrixWorkspace_sptr
-ReflectometryReductionOneAuto2::rebinAndScale(MatrixWorkspace_sptr inputWS,
-                                              const double theta,
-                                              std::vector<double> &params) {
-
+boost::optional<double>
+ReflectometryReductionOneAuto2::getQStep(MatrixWorkspace_sptr inputWS,
+                                         const double theta) {
   Property *qStepProp = getProperty("MomentumTransferStep");
   double qstep;
   if (!qStepProp->isDefault()) {
@@ -686,29 +704,30 @@ ReflectometryReductionOneAuto2::rebinAndScale(MatrixWorkspace_sptr inputWS,
     calcRes->execute();
 
     if (!calcRes->isExecuted()) {
-      g_log.error(
-          "NRCalculateSlitResolution failed. Workspace in Q will not be "
-          "rebinned. Please provide dQ/Q.");
-      return inputWS;
+      return boost::none;
     }
     qstep = calcRes->getProperty("Resolution");
     qstep = -qstep;
   }
+  return qstep;
+}
 
-  auto qmin =
-      getPropertyOrDefault("MomentumTransferMin", inputWS->x(0).front());
-  auto qmax = getPropertyOrDefault("MomentumTransferMax", inputWS->x(0).back());
-
-  params.push_back(qmin);
-  params.push_back(qstep);
-  params.push_back(qmax);
-
+/** Rebin and scale a workspace in Q.
+ *
+ * @param inputWS :: the workspace in Q
+ * @param params :: A vector containing the three rebin parameters (min, step
+ * and max)
+ * @return :: the output workspace
+ */
+MatrixWorkspace_sptr
+ReflectometryReductionOneAuto2::rebinAndScale(MatrixWorkspace_sptr inputWS,
+                                              RebinParams const &params) {
   // Rebin
   IAlgorithm_sptr algRebin = createChildAlgorithm("Rebin");
   algRebin->initialize();
   algRebin->setProperty("InputWorkspace", inputWS);
   algRebin->setProperty("OutputWorkspace", inputWS);
-  algRebin->setProperty("Params", params);
+  algRebin->setProperty("Params", params.asVector());
   algRebin->execute();
   MatrixWorkspace_sptr IvsQ = algRebin->getProperty("OutputWorkspace");
 
@@ -728,16 +747,35 @@ ReflectometryReductionOneAuto2::rebinAndScale(MatrixWorkspace_sptr inputWS,
   return IvsQ;
 }
 
+MatrixWorkspace_sptr
+ReflectometryReductionOneAuto2::cropQ(MatrixWorkspace_sptr inputWS,
+                                      RebinParams const &params) {
+  IAlgorithm_sptr algCrop = createChildAlgorithm("CropWorkspace");
+  algCrop->initialize();
+  algCrop->setProperty("InputWorkspace", inputWS);
+  algCrop->setProperty("OutputWorkspace", inputWS);
+  if (!params.qMinIsDefault())
+    algCrop->setProperty("XMin", params.qMin());
+  if (!params.qMaxIsDefault())
+    algCrop->setProperty("XMax", params.qMax());
+  algCrop->execute();
+  MatrixWorkspace_sptr IvsQ = algCrop->getProperty("OutputWorkspace");
+  return IvsQ;
+}
+
 /**
  * @brief Get the Property Or return a default given value
  *
- * @param propertyName
- * @param defaultValue
+ * @param propertyName : the name of the property to get
+ * @param defaultValue : the default value to use if the property is not set
+ * @param isDefault [out] : true if the default value was used
  */
 double ReflectometryReductionOneAuto2::getPropertyOrDefault(
-    const std::string &propertyName, const double defaultValue) {
+    const std::string &propertyName, const double defaultValue,
+    bool &isDefault) {
   Property *property = getProperty(propertyName);
-  if (property->isDefault())
+  isDefault = property->isDefault();
+  if (isDefault)
     return defaultValue;
   else
     return getProperty(propertyName);

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto2Test.h
@@ -537,7 +537,7 @@ public:
     TS_ASSERT(outQbinned->x(0)[7] - outQbinned->x(0)[6] > 0.05);
   }
 
-  void test_IvsQ_q_range() {
+  void test_IvsLam_range() {
 
     ReflectometryReductionOneAuto2 alg;
     alg.setChild(true);
@@ -555,13 +555,73 @@ public:
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
 
     TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(outQ->blocksize(), 14);
+    TS_ASSERT_EQUALS(outQ->binEdges(0).size(), 15);
     // X range in outLam
-    TS_ASSERT_DELTA(outLam->x(0)[0], 1.7924, 0.0001);
-    TS_ASSERT_DELTA(outLam->x(0)[7], 8.0658, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[0], 1.7924, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[1], 2.6886, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[7], 8.0658, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[13], 13.4431, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[14], 14.3393, 0.0001);
+  }
+
+  void test_IvsQ_range() {
+
+    ReflectometryReductionOneAuto2 alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", m_TOF);
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "3");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outQ->binEdges(0).size(), 15);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLam->binEdges(0)[0], 1.7924, 0.0001);
+    TS_ASSERT_DELTA(outLam->binEdges(0)[7], 8.0658, 0.0001);
     // X range in outQ
-    TS_ASSERT_DELTA(outQ->x(0)[0], 0.3353, 0.0001);
-    TS_ASSERT_DELTA(outQ->x(0)[7], 0.5962, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[0], 0.3353, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[1], 0.3577, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[6], 0.5366, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[7], 0.5962, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[12], 1.3415, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[13], 1.7886, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[14], 2.6830, 0.0001);
+  }
+
+  void test_IvsQ_range_cropped() {
+
+    ReflectometryReductionOneAuto2 alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspace", m_TOF);
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("MomentumTransferMin", 0.5);
+    alg.setProperty("MomentumTransferMax", 1.5);
+    alg.setProperty("ProcessingInstructions", "3");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    // X range in outQ is cropped to momentum transfer limits
+    TS_ASSERT_EQUALS(outQ->binEdges(0).size(), 7);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[0], 0.5366, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[1], 0.5962, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[5], 1.0732, 0.0001);
+    TS_ASSERT_DELTA(outQ->binEdges(0)[6], 1.3414, 0.0001);
   }
 
   void test_optional_outputs() {

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v2.rst
@@ -64,11 +64,20 @@ can be specified manually by setting the :literal:`CorrectionAlgorithm` to eithe
 Note that when using a correction algorithm, monitors will not be integrated, even if
 :literal:`NormalizeByIntegratedMonitors` was set to true.
 
-Finally, properties :literal:`MomentumTransferMin`, :literal:`MomentumTransferStep` and :literal:`MomentumTransferMax` are
-used to rebin the output workspace in Q, and :literal:`ScaleFactor` is used to scale the rebinned workspace. When they
-are not provided the algorithm will attempt to determine the bin width using :ref:`algm-NRCalculateSlitResolution` (note that, for
-the latter to run successfully, a :literal:`slit` component with a :literal:`vertical gap` must be defined in the
-instrument definition file).
+:literal:`OutputWorkspace` is cropped to `MomentumTransferMin` and/or
+:literal:`MomentumTransferMax`, if they are given.
+
+:literal:`OutputWorkspaceBinned` is rebinned to the resolution specified by
+:literal:`MomentumTransferStep`, if it is given; otherwise the algorithm
+attempts to determine the bin width using :ref:`algm-NRCalculateSlitResolution`
+(note that to calculate the resolution this way, a :literal:`slit` component
+with a `vertical gap` must be defined in the instrument definition file - if it
+cannot be found, rebinning will not be done and a warning will be
+logged). `MomentumTransferMin` and `MomentumTransferMax` are used for the rebin
+if provided; otherwise the original min/max in Q is retained.
+
+Finally, `ScaleFactor` is used to scale the rebinned workspace
+:literal:`OutputWorkspaceBinned`.
 
 See :ref:`algm-ReflectometryReductionOne` for more information
 on how the input properties are used by the wrapped algorithm.

--- a/docs/source/release/v4.0.0/reflectometry.rst
+++ b/docs/source/release/v4.0.0/reflectometry.rst
@@ -27,6 +27,7 @@ Improvements
 - Added flood corrections to :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto-v2>`. The correction data can be provided either via a flood workspace passed as a property or taken from the parameter file.
 - The four Ascii save algorithms :ref:`algm-SaveANSTOAscii`, :ref:`algm-SaveILLCosmosAscii`, :ref:`algm-SaveReflCustomAscii`, and :ref:`algm-SaveReflThreeColumnAscii` now correctly save x-error and can treat correctly point data and histograms. They are, however, deprecated in favour of :ref:`algm-SaveReflectometryAscii`. Please see :ref:`algm-SaveReflectometryAscii` for more documentation.
 - :ref:`algm-ReflectometryReductionOneAuto` now supports the Wildes method for polarization corrections as well as Fredrikze when configured in the parameters file.
+- :ref:`algm-ReflectometryReductionOneAuto` now crops the unbinned output workspace in Q to ``MomentumTransferMin`` and ``MomentumTransferMax``, if specified
 - :ref:`algm-ReflectometryReductionOne`, :ref:`algm-ReflectometryReductionOneAuto`, :ref:`algm-CreateTransmissionWorkspace`, and :ref:`algm-CreateTransmissionWorkspaceAuto` now use spectrum numbers for their processing instructions instead of workspace indices.
 - :ref:`algm-ReflectometryReductionOne` and :ref:`algm-ReflectometryReductionOneAuto` now take a parameter to pass processing instructions to the transmission workspace algorithms and no longer accept strict spectrum checking.
 - Common naming of slit component name and size properties across algorithms.

--- a/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
+++ b/qt/widgets/common/test/DataProcessorUI/GenericDataProcessorPresenterTest.h
@@ -267,7 +267,7 @@ private:
         << "12346"
         << "1.5"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -287,7 +287,7 @@ private:
         << "24682"
         << "1.5"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -315,7 +315,7 @@ private:
         << "12346"
         << "1.5"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -335,7 +335,7 @@ private:
         << "24682"
         << "1.5"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -355,7 +355,7 @@ private:
         << "30001"
         << "1.5"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -383,7 +383,7 @@ private:
         << "12346"
         << "1.5"
         << "11116"
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -405,7 +405,7 @@ private:
         << "24682"
         << "1.5"
         << "22222"
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -1658,7 +1658,7 @@ public:
         << "dataB"
         << "2.3"
         << ""
-        << "1.4"
+        << "0.13"
         << "2.9"
         << "0.04"
         << "1"
@@ -2421,7 +2421,7 @@ public:
     rowlist[0].insert(1);
 
     const auto expected = QString(
-        "0\t12346\t1.5\t\t1.4\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
+        "0\t12346\t1.5\t\t0.13\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
 
     // The user hits "copy selected" with the second and third rows selected
     EXPECT_CALL(mockDataProcessorView, setClipboard(expected));
@@ -2471,9 +2471,9 @@ public:
 
     const auto expected = QString(
         "0\t12345\t0.5\t\t0.1\t1.6\t0.04\t1\tProcessingInstructions='1'\t\n"
-        "0\t12346\t1.5\t\t1.4\t2.9\t0.04\t1\tProcessingInstructions='1'\t\n"
+        "0\t12346\t1.5\t\t0.13\t2.9\t0.04\t1\tProcessingInstructions='1'\t\n"
         "1\t24681\t0.5\t\t0.1\t1.6\t0.04\t1\tProcessingInstructions='1'\t\n"
-        "1\t24682\t1.5\t\t1.4\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
+        "1\t24682\t1.5\t\t0.13\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
 
     // The user hits "copy selected" with the second and third rows selected
     EXPECT_CALL(mockDataProcessorView, setClipboard(expected));
@@ -2501,7 +2501,7 @@ public:
     rowlist[0].insert(1);
 
     const auto expected = QString(
-        "0\t12346\t1.5\t\t1.4\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
+        "0\t12346\t1.5\t\t0.13\t2.9\t0.04\t1\tProcessingInstructions='1'\t");
 
     // The user hits "copy selected" with the second and third rows selected
     EXPECT_CALL(mockDataProcessorView, setClipboard(expected));
@@ -2543,7 +2543,7 @@ public:
 
     const auto expected = QString(
         "0\t12345\t0.5\t\t0.1\t1.6\t0.04\t1\tProcessingInstructions='1'\t\n"
-        "0\t12346\t1.5\t\t1.4\t2.9\t0.04\t1\tProcessingInstructions='1'\t\n"
+        "0\t12346\t1.5\t\t0.13\t2.9\t0.04\t1\tProcessingInstructions='1'\t\n"
         "1\t24681\t0.5\t\t0.1\t1.6\t0.04\t1\tProcessingInstructions='1'\t");
 
     // The user hits "copy selected" with the second and third rows selected
@@ -3304,16 +3304,16 @@ public:
             "IvsQ_TOF_12345_TOF_12346");
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[0], 0.01108, 1e-5);
+        out->x(0)[0], 0.13860, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[1], 0.01153, 1e-5);
+        out->x(0)[1], 0.14415, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[2], 0.01199, 1e-5);
+        out->x(0)[2], 0.14991, 1e-5);
     TSM_ASSERT_DELTA(
         "Logarithmic rebinning should have been applied, with param 0.04",
-        out->x(0)[3], 0.01247, 1e-5);
+        out->x(0)[3], 0.15591, 1e-5);
 
     // Check output and tidy up
     checkWorkspacesExistInADS(m_defaultWorkspacesNoPrefix);


### PR DESCRIPTION
If the momentum transfer min and/or max are specified, crop the IvsQ output workspace to these limits. This is an interim output workspace which is used further down the reduction for stitching, and it is important to crop unwanted regions before the stitch. The main output (IvsQ_binned) is already cropped as a result of the rebin step.

Fixes #23817

**Report to:** Max, Jos and Christy at ISIS

**To test:**
This script runs various combinations of setting the min/max and also checks that it works with/without specifying the rebin step.
```
LoadISISNexus(Filename='INTER13460', OutputWorkspace='TOF_13460')

def printResults(title):
    print
    print title
    ws=mtd['IvsQ_13460']
    x=ws.readX(0)
    print 'IvsQ       :', x.min(), x.max()
    ws=mtd['IvsQ_binned_13460']
    x=ws.readX(0)
    print 'IvsQ_binned:',x.min(), x.max()

# uncropped (with/without step set)
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460')
printResults('No crop or rebin')
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferStep=0.1)
printResults('Rebin only')

# crop to min, max, or both
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMin=0.014)
printResults('Crop min')
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMax=0.06)
printResults('Crop max')
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMin=0.014,MomentumTransferMax=0.06)
printResults('Crop min and max')

# crop to min, max, or both (with step set)
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMin=0.014,MomentumTransferStep=0.1)
printResults('Crop min and rebin')
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMax=0.06,MomentumTransferStep=0.1)
printResults('Crop max and rebin')
ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',MomentumTransferMin=0.014,MomentumTransferMax=0.06,MomentumTransferStep=0.1)
printResults('Crop min and max and rebin')
```

This is the expected output. When a crop is done, the binned and unbinned ranges are very similar (but not exactly the same, because the Crop uses the containing bin edge):
```
No crop or rebin
IvsQ       : 0.00903136516241 0.101671597976
IvsQ_binned: 0.00903136516241 0.101671597976

Rebin only
IvsQ       : 0.00903136516241 0.101671597976
IvsQ_binned: 0.00903136516241 0.101671597976

Crop min
IvsQ       : 0.0140029369968 0.101671597976
IvsQ_binned: 0.014 0.101671597976

Crop max
IvsQ       : 0.00903136516241 0.0597163305856
IvsQ_binned: 0.00903136516241 0.06

Crop min and max
IvsQ       : 0.0140029369968 0.0597163305856
IvsQ_binned: 0.014 0.06

Crop min and rebin
IvsQ       : 0.0140029369968 0.101671597976
IvsQ_binned: 0.014 0.101671597976

Crop max and rebin
IvsQ       : 0.00903136516241 0.0597163305856
IvsQ_binned: 0.00903136516241 0.06

Crop min and max and rebin
IvsQ       : 0.0140029369968 0.0597163305856
IvsQ_binned: 0.014 0.06
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
