### PR TITLE
Change unittest mock imports

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceObserverTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceObserverTest.py
@@ -9,17 +9,10 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import unittest
-import sys
 
 from mantid.api import AnalysisDataService as ADS, AnalysisDataServiceObserver
 from mantid.simpleapi import CreateSampleWorkspace, RenameWorkspace, GroupWorkspaces, UnGroupWorkspace, DeleteWorkspace
-
-if sys.version_info.major >= 3:
-    # Python 3 and above
-    from unittest import mock
-else:
-    # Python 2
-    import mock
+from mantid.py3compat import mock
 
 
 class FakeADSObserver(AnalysisDataServiceObserver):

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigObserverTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigObserverTest.py
@@ -5,13 +5,9 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
-from mantid.kernel import ConfigService, ConfigObserver
 
-if sys.version_info.major == 2:
-    import mock
-else:
-    from unittest import mock
+from mantid.kernel import ConfigService, ConfigObserver
+from mantid.py3compat import mock
 
 
 class ConfigObserverTest(unittest.TestCase):

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigPropertyObserverTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigPropertyObserverTest.py
@@ -5,13 +5,9 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
-from mantid.kernel import ConfigService, ConfigPropertyObserver
 
-if sys.version_info.major == 2:
-    import mock
-else:
-    from unittest import mock
+from mantid.kernel import ConfigService, ConfigPropertyObserver
+from mantid.py3compat import mock
 
 
 class ConfigObserverTest(unittest.TestCase):

--- a/Framework/PythonInterface/test/python/mantid/plots/helperfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/helperfunctionsTest.py
@@ -12,10 +12,10 @@ import unittest
 
 import matplotlib
 import numpy as np
-from mock import Mock
 
 import mantid.api
 import mantid.plots.helperfunctions as funcs
+from mantid.py3compat.mock import Mock
 from mantid.kernel import config
 from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import AddTimeSeriesLog, ConjoinWorkspaces, CreateMDHistoWorkspace, CreateSampleWorkspace, \

--- a/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
+++ b/Testing/SystemTests/tests/analysis/ErrorReporterServerTest.py
@@ -4,15 +4,9 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-
-import sys
+from mantid.py3compat import mock
 import systemtesting
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter # noqa
-
-if sys.version_info.major < 3:
-    import mock
-else:
-    from unittest import mock
 
 
 class ErrorReportServerTests(systemtesting.MantidSystemTest):

--- a/dev-docs/source/MVPTutorial/Mocking.rst
+++ b/dev-docs/source/MVPTutorial/Mocking.rst
@@ -22,10 +22,7 @@ First are the import statements
     import view
 
     import unittest
-    if sys.version_info.major == 3:
-        from unittest import mock
-    else:
-        import mock
+    from mantid.py3compat import mock
 
 A different import is used for ``mock``, depending on whether we're
 using Python 2 or 3.

--- a/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
+++ b/dev-docs/source/MVPTutorial/MockingExerciseSolution.rst
@@ -13,10 +13,7 @@ Mocking Exercise Solution
     import view
 
     import unittest
-    if sys.version_info.major == 3:
-        from unittest import mock
-    else:
-        import mock
+    from mantid.py3compat import mock
 
     class presenterTest(unittest.TestCase):
         def setUp(self):

--- a/qt/applications/workbench/workbench/plotting/test/test_globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_globalfiguremanager.py
@@ -1,26 +1,24 @@
 import unittest
-try:
-    from unittest import Mock, call, patch
-except ImportError:
-    from mock import Mock, call, patch
 
+from mantid.py3compat import mock
+from mock import call, patch
 from workbench.plotting.globalfiguremanager import FigureAction, GlobalFigureManager, GlobalFigureManagerObserver
 from workbench.plotting.observabledictionary import DictionaryAction
 
 
 class MockGlobalFigureManager:
     def __init__(self):
-        self.notify_observers = Mock()
+        self.notify_observers = mock.Mock()
         self.mock_figs = {}
-        self.figs = Mock()
-        self.figs.keys = Mock(return_value=self.mock_figs)
+        self.figs = mock.Mock()
+        self.figs.keys = mock.Mock(return_value=self.mock_figs)
 
 
 class MockCanvas:
     def __init__(self):
-        self.mpl_disconnect = Mock()
+        self.mpl_disconnect = mock.Mock()
         self.figure = None
-        self.draw_idle = Mock()
+        self.draw_idle = mock.Mock()
 
 
 class MockFigureManager:
@@ -28,7 +26,7 @@ class MockFigureManager:
         self.num = num
         self.canvas = MockCanvas()
         self._cidgcf = -1231231
-        self.destroy = Mock()
+        self.destroy = mock.Mock()
 
 
 class TestGlobalFigureManagerObserver(unittest.TestCase):
@@ -92,7 +90,7 @@ class TestGlobalFigureManager(unittest.TestCase):
 
     def add_manager(self, num=0):
         mock_manager = MockFigureManager(num)
-        mock_fig = Mock()
+        mock_fig = mock.Mock()
         mock_manager.canvas.figure = mock_fig
         GlobalFigureManager.set_active(mock_manager)
         return mock_manager, mock_fig
@@ -171,7 +169,7 @@ class TestGlobalFigureManager(unittest.TestCase):
         num = 0
         self.add_manager(num)
 
-        other_mock_fig = Mock()
+        other_mock_fig = mock.Mock()
         other_mock_manager = MockFigureManager(num + 1)
         other_mock_manager.canvas.figure = other_mock_fig
         GlobalFigureManager.set_active(other_mock_manager)
@@ -261,8 +259,8 @@ class TestGlobalFigureManager(unittest.TestCase):
         self.assertEqual({0: 4, 1: 3, 2: 2, 3: 1}, last_active_values)
 
     def test_add_observer(self):
-        good_observer = Mock()
-        good_observer.notify = Mock()
+        good_observer = mock.Mock()
+        good_observer.notify = mock.Mock()
         self.assertTrue(1, len(GlobalFigureManager.observers))
 
     def test_fail_adding_bad_observer(self):
@@ -277,8 +275,8 @@ class TestGlobalFigureManager(unittest.TestCase):
         num = 10
         mock_observers = []
         for i in range(num):
-            good_observer = Mock()
-            good_observer.notify = Mock()
+            good_observer = mock.Mock()
+            good_observer.notify = mock.Mock()
             GlobalFigureManager.add_observer(good_observer)
             mock_observers.append(good_observer)
 

--- a/qt/applications/workbench/workbench/plugins/test/test_editor.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_editor.py
@@ -7,16 +7,11 @@
 #    This file is part of the mantid workbench.
 #
 #
-
 import os
+from qtpy.QtWidgets import QMainWindow
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-from qtpy.QtWidgets import QMainWindow
-
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
 from workbench.plugins.editor import MultiFileEditor
 

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -9,15 +9,12 @@
 #
 
 import unittest
-try:
-    import mock
-except ImportError:
-    from unittest import mock
 
 from qtpy.QtWidgets import QMainWindow, QApplication
 
 from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateWorkspace,
                               GroupWorkspaces)
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 import matplotlib as mpl

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverymodel.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverymodel.py
@@ -11,20 +11,15 @@ from __future__ import (absolute_import, unicode_literals)
 
 import os
 import shutil
-import sys
 import time
 import unittest
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.kernel import ConfigService
 from mantid.simpleapi import CreateSampleWorkspace
+from mantid.py3compat import mock
 from workbench.projectrecovery.projectrecovery import ProjectRecovery, NO_OF_CHECKPOINTS_KEY
 from workbench.projectrecovery.recoverygui.projectrecoverymodel import ProjectRecoveryModel
-
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class ProjectRecoveryModelTest(unittest.TestCase):

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
@@ -9,15 +9,10 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
-import sys
 import unittest
 
+from mantid.py3compat import mock
 from workbench.projectrecovery.recoverygui.projectrecoverypresenter import ProjectRecoveryPresenter
-
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
 
 
 PATCH_PROJECT_RECOVERY_VIEW = 'workbench.projectrecovery.recoverygui.projectrecoverypresenter.ProjectRecoveryWidgetView'

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
@@ -9,15 +9,9 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
-import sys
-
-from workbench.projectrecovery.recoverygui.projectrecoverywidgetview import ProjectRecoveryWidgetView
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
-
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
+from workbench.projectrecovery.recoverygui.projectrecoverywidgetview import ProjectRecoveryWidgetView
 
 
 class ProjectRecoveryWidgetViewTest(GuiTest):

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py
@@ -9,16 +9,11 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
-import sys
 from qtpy.QtWidgets import QTableWidgetItem
 
-from workbench.projectrecovery.recoverygui.recoveryfailureview import RecoveryFailureView
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
-
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
+from workbench.projectrecovery.recoverygui.recoveryfailureview import RecoveryFailureView
 
 
 class RecoveryFailureViewTest(GuiTest):

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -19,14 +19,12 @@ import unittest
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.kernel import ConfigService
+from mantid.py3compat import mock
 from workbench.projectrecovery.projectrecovery import ProjectRecovery, SAVING_TIME_KEY, NO_OF_CHECKPOINTS_KEY, \
     RECOVERY_ENABLED_KEY
 
 if sys.version_info.major >= 3:
-    from unittest import mock
     unicode = str
-else:
-    import mock
 
 
 def is_macOS():

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecoveryloader.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecoveryloader.py
@@ -17,13 +17,11 @@ import unittest
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace
+from mantid.py3compat import mock
 from workbench.projectrecovery.projectrecovery import ProjectRecovery
 
 if sys.version_info.major >= 3:
-    from unittest import mock
     unicode = str
-else:
-    import mock
 
 
 class ProjectRecoveryLoaderTest(unittest.TestCase):

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecoverysaver.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecoverysaver.py
@@ -18,13 +18,11 @@ import unittest
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces
+from mantid.py3compat import mock
 from workbench.projectrecovery.projectrecovery import ProjectRecovery
 
 if sys.version_info.major >= 3:
-    from unittest import mock
     unicode = str
-else:
-    import mock
 
 
 class FakeEncoder(object):

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_model.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_model.py
@@ -9,16 +9,12 @@
 #
 from __future__ import absolute_import, division, print_function
 
-from workbench.plotting.globalfiguremanager import FigureAction
+import unittest
 
+from mantid.py3compat import mock
+from workbench.plotting.globalfiguremanager import FigureAction
 from workbench.widgets.plotselector.model import PlotSelectorModel
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
-
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class PlotSelectorModelTest(unittest.TestCase):

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_presenter.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_presenter.py
@@ -9,17 +9,13 @@
 #
 from __future__ import absolute_import, division, print_function
 
+import os
+import unittest
+
+from mantid.py3compat import mock
 from workbench.widgets.plotselector.model import PlotSelectorModel
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
 from workbench.widgets.plotselector.view import PlotSelectorView, Column
-
-import os
-
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class PlotSelectorPresenterTest(unittest.TestCase):

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
@@ -20,7 +20,6 @@ from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
 from workbench.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView, Column
 
 
-
 class PlotSelectorWidgetTest(GuiTest):
 
     def setUp(self):

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
@@ -9,19 +9,16 @@
 #
 from __future__ import absolute_import, division, print_function
 
-from mantidqt.utils.qt.testing import GuiTest
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtTest import QTest
+import unittest
 
+from mantid.py3compat import mock
+from mantidqt.utils.qt.testing import GuiTest
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
 from workbench.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView, Column
 
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class PlotSelectorWidgetTest(GuiTest):

--- a/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
+++ b/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
@@ -7,9 +7,9 @@
 #  This file is part of the mantid workbench
 from __future__ import absolute_import, unicode_literals
 
-from mock import MagicMock
 from qtpy.QtWidgets import QApplication, QWidget
 
+from mantid.py3compat.mock import MagicMock
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from workbench.widgets.settings.presenter import SettingsPresenter

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -10,13 +10,11 @@
 
 # std imports
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+
 
 # 3rdparty imports
 from mantid.api import WorkspaceFactory
+from mantid.py3compat import mock
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QDialog, QDialogButtonBox
 

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -11,13 +11,11 @@ from __future__  import absolute_import
 
 # std imports
 from unittest import TestCase, main
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+
 
 # third party imports
 from mantid.api import AnalysisDataService, WorkspaceFactory
+from mantid.py3compat import mock
 # register mantid projection
 import mantid.plots  # noqa
 import matplotlib

--- a/qt/python/mantidqt/project/test/test_plotsloader.py
+++ b/qt/python/mantidqt/project/test/test_plotsloader.py
@@ -20,7 +20,7 @@ from mantidqt.project.plotsloader import PlotsLoader  # noqa
 import mantid.plots.plotfunctions  # noqa
 from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.dataobjects import Workspace2D  # noqa
-from mantid.py3compat import mock
+from mantid.py3compat import mock  # noqa
 
 
 def pass_func():

--- a/qt/python/mantidqt/project/test/test_plotsloader.py
+++ b/qt/python/mantidqt/project/test/test_plotsloader.py
@@ -11,7 +11,6 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 import matplotlib
 matplotlib.use('AGG')
 
-import sys  # noqa
 import unittest  # noqa
 import matplotlib.pyplot as plt  # noqa
 import matplotlib.figure  # noqa
@@ -21,13 +20,7 @@ from mantidqt.project.plotsloader import PlotsLoader  # noqa
 import mantid.plots.plotfunctions  # noqa
 from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.dataobjects import Workspace2D  # noqa
-
-if sys.version_info.major >= 3:
-    # Python 3 and above
-    from unittest import mock
-else:
-    # Python 2
-    import mock
+from mantid.py3compat import mock
 
 
 def pass_func():

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -9,7 +9,6 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import os
-import sys
 import tempfile
 import unittest
 
@@ -17,14 +16,8 @@ from qtpy.QtWidgets import QMessageBox
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, RenameWorkspace, UnGroupWorkspace
+from mantid.py3compat import mock
 from mantidqt.project.project import Project
-
-if sys.version_info.major >= 3:
-    # Python 3 and above
-    from unittest import mock
-else:
-    # Python 2
-    import mock
 
 
 class FakeGlobalFigureManager(object):

--- a/qt/python/mantidqt/project/test/test_projectloader.py
+++ b/qt/python/mantidqt/project/test/test_projectloader.py
@@ -6,9 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
 #
-
 import matplotlib
-import sys
 import tempfile
 import unittest
 from os.path import isdir
@@ -22,13 +20,8 @@ import tempfile  # noqa
 
 from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.simpleapi import CreateSampleWorkspace  # noqa
+from mantid.py3compat import mock
 from mantidqt.project import projectloader, projectsaver  # noqa
-
-
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
 
 
 project_file_ext = ".mtdproj"

--- a/qt/python/mantidqt/project/test/test_projectloader.py
+++ b/qt/python/mantidqt/project/test/test_projectloader.py
@@ -20,7 +20,7 @@ import tempfile  # noqa
 
 from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.simpleapi import CreateSampleWorkspace  # noqa
-from mantid.py3compat import mock
+from mantid.py3compat import mock  # noqa
 from mantidqt.project import projectloader, projectsaver  # noqa
 
 

--- a/qt/python/mantidqt/project/test/test_projectsaver.py
+++ b/qt/python/mantidqt/project/test/test_projectsaver.py
@@ -10,19 +10,15 @@ import json
 import matplotlib.backend_bases
 import matplotlib.figure
 import os
-import sys
 import tempfile
 import unittest
 from shutil import rmtree
 
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import CreateSampleWorkspace
+from mantid.py3compat import mock
 from mantidqt.project import projectsaver
 
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
 
 project_file_ext = ".mtdproj"
 working_directory = tempfile.mkdtemp()

--- a/qt/python/mantidqt/utils/test/test_modal_tester.py
+++ b/qt/python/mantidqt/utils/test/test_modal_tester.py
@@ -10,11 +10,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from mock import patch
 import unittest
-
 from qtpy.QtWidgets import QInputDialog
 
+from mantid.py3compat.mock import patch
 from mantidqt.utils.qt.testing import GuiTest, ModalTester
 
 

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -9,18 +9,13 @@
 #
 from __future__ import (absolute_import)
 
+from qtpy.QtCore import QCoreApplication, QObject
+import sys
 import unittest
 
-import sys
-from qtpy.QtCore import QCoreApplication, QObject
-
+from mantid.py3compat.mock import patch
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.writetosignal import WriteToSignal
-
-if sys.version_info.major == 2:
-    from mock import patch
-else:
-    from unittest.mock import patch
 
 
 class Receiver(QObject):

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -11,15 +11,9 @@ from __future__ import (absolute_import, unicode_literals)
 
 import unittest
 
-import six
-
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 
 class PythonFileInterpreterTest(GuiTest):

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -11,11 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
+from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_scriptcompatibility.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_scriptcompatibility.py
@@ -9,11 +9,8 @@
 #
 
 import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
+from mantid.py3compat import mock
 from mantidqt.widgets.codeeditor.scriptcompatibility import (mantid_api_import_needed,
                                                              mantid_algorithm_used_without_import)
 

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
@@ -11,16 +11,12 @@ from __future__ import (absolute_import, division, print_function)
 
 import matplotlib
 matplotlib.use('Agg') # noqa: E402
+import unittest
 
+from mantid.py3compat import mock
 from mantidqt.widgets.samplelogs.model import SampleLogsModel
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
 from mantidqt.widgets.samplelogs.view import SampleLogsView
-
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class SampleLogsTest(unittest.TestCase):

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -6,21 +6,17 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import)
 
+from functools import (partial)
+
+from mantid.py3compat import mock
+from sans.gui_logic.presenter.run_tab_presenter import RunTabPresenter
+from sans.common.enums import (RangeStepType, OutputMode, SANSFacility, SANSInstrument)
+from sans.test_helper.test_director import TestDirector
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.settings_diagnostic_tab import SettingsDiagnosticTab
 from ui.sans_isis.diagnostics_page import DiagnosticsPage
 from ui.sans_isis.masking_table import MaskingTable
 from ui.sans_isis.beam_centre import BeamCentre
-from sans.gui_logic.presenter.run_tab_presenter import RunTabPresenter
-from sans.common.enums import (RangeStepType, OutputMode, SANSFacility, SANSInstrument)
-from sans.test_helper.test_director import TestDirector
-from functools import (partial)
-
-import sys
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 def create_mock_settings_diagnostic_tab():

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -1471,12 +1471,9 @@ class CrystalFieldFitTest(unittest.TestCase):
 
     def test_CrystalField_PointCharge_file(self):
         from CrystalField import PointCharge
-        import sys
         import mantid.simpleapi
-        if sys.version_info.major == 3:
-            from unittest import mock
-        else:
-            import mock
+        from mantid.py3compat import mock
+
         # Just check that LoadCIF is called... we'll rely on LoadCIF working properly!
         with mock.patch.object(mantid.simpleapi, 'LoadCIF') as loadcif:
             self.assertRaises(RuntimeError, PointCharge, 'somefile.cif')  # Error because no actual CIF loaded

--- a/scripts/test/MultiPlotting/AxisChangerTwoPresenter_test.py
+++ b/scripts/test/MultiPlotting/AxisChangerTwoPresenter_test.py
@@ -6,14 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.AxisChanger.axis_changer_presenter import AxisChangerPresenter
 from MultiPlotting.AxisChanger.axis_changer_view import AxisChangerView
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class AxisChangerTwoPresenterTest(unittest.TestCase):

--- a/scripts/test/MultiPlotting/AxisChangerTwoView_test.py
+++ b/scripts/test/MultiPlotting/AxisChangerTwoView_test.py
@@ -6,14 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.AxisChanger.axis_changer_view import AxisChangerView
-
 from Muon.GUI.Common import mock_widget
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class AxisChangerTwoViewTest(unittest.TestCase):

--- a/scripts/test/MultiPlotting/DefaultGridspec_test.py
+++ b/scripts/test/MultiPlotting/DefaultGridspec_test.py
@@ -9,48 +9,40 @@ import unittest
 from MultiPlotting.gridspec_engine import defaultGridspecGrid
 
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-
 class DefaultGridSpecTest(unittest.TestCase):
 
     def test_someSquares(self):
-        roots = [2,3,4,5,123]
+        roots = [2, 3, 4, 5, 123]
         for root in roots:
             result = defaultGridspecGrid(root*root)
-            self.assertEquals(result, [root,root])
+            self.assertEquals(result, [root, root])
  
     def test_notSquares(self):
-        roots = [3,4,5,123]
+        roots = [3, 4, 5, 123]
         for root in roots:
             result = defaultGridspecGrid(root*root-1)
-            self.assertEquals(result, [root,root])
+            self.assertEquals(result, [root, root])
 
     def test_specialCaseOne(self):
         number = 1
         result = defaultGridspecGrid(number)
-        self.assertEquals(result, [1,1])
+        self.assertEquals(result, [1, 1])
 
     def test_specialCaseTwo(self):
         number = 2
         result = defaultGridspecGrid(number)
-        self.assertEquals(result, [1,2])
-
+        self.assertEquals(result, [1, 2])
 
     def test_specialCaseThree(self):
         number = 3
         result = defaultGridspecGrid(number)
-        self.assertEquals(result, [3,1])
+        self.assertEquals(result, [3, 1])
 
     def test_smallerGrid(self):
         number = 5
         result = defaultGridspecGrid(number)
-        self.assertEquals(result, [2,3])
+        self.assertEquals(result, [2, 3])
 
 
- 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/MultiPlotting/Gridspec_test.py
+++ b/scripts/test/MultiPlotting/Gridspec_test.py
@@ -4,16 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import unittest
 from matplotlib.gridspec import GridSpec
+import unittest
 
 from MultiPlotting.gridspec_engine import gridspecEngine
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class GridSpecTest(unittest.TestCase):
@@ -34,13 +28,13 @@ class GridSpecTest(unittest.TestCase):
         self.engine = gridspecEngine(max_plot=10)
         result = self.engine.getGridSpec(100)
         self.assertEquals(result, None)
- 
 
     def test_returnType(self):
         gridspec = GridSpec(1,1)
         self.engine = gridspecEngine()
         result = self.engine.getGridSpec(1)
         self.assertEquals(type(result),type(gridspec))
- 
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/MultiPlotting/MultiPlotWidget_test.py
+++ b/scripts/test/MultiPlotting/MultiPlotWidget_test.py
@@ -6,18 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from Muon.GUI.Common import mock_widget
-
+from mantid.py3compat import mock
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
 from MultiPlotting.QuickEdit.quickEdit_widget import QuickEditWidget
 from MultiPlotting.subplot.subplot import subplot
 from MultiPlotting.multi_plotting_context import PlottingContext
+from Muon.GUI.Common import mock_widget
 
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 class bounds(object):
     def __init__(self,x,y):
@@ -37,6 +32,7 @@ class bounds(object):
     def errors(self):
         return self.error
 
+
 def data():
     values = {}
     values["one"] = bounds([5,20],[5,10])
@@ -44,6 +40,7 @@ def data():
     values["three"] = bounds([-1,11],[7,8])
     values["four"] = bounds([4,12],[4,50])
     return values
+
 
 class MultiPlotWidgetTest(unittest.TestCase):
 
@@ -88,7 +85,6 @@ class MultiPlotWidgetTest(unittest.TestCase):
 
         self.widget._update_quick_edit("no match")
         self.assertEquals(self.widget.quickEdit.rm_subplot.call_count, 1)
-        
 
     def test_updateQuickEdit1Match(self):
         self.widget._context.subplots = data()
@@ -136,7 +132,6 @@ class MultiPlotWidgetTest(unittest.TestCase):
         self.widget.quickEdit.set_plot_x_range.assert_called_with([6,10])
         self.widget.quickEdit.set_plot_y_range.assert_called_with([0,9])
 
-  
     def test_selectionChangedAll(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic

--- a/scripts/test/MultiPlotting/MultiPlottingContext_test.py
+++ b/scripts/test/MultiPlotting/MultiPlottingContext_test.py
@@ -6,14 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.multi_plotting_context import PlottingContext
 from MultiPlotting.subplot.subplot_context import subplotContext
 
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 class gen_ws(object):
     def __init__(self,mock):
@@ -26,6 +22,7 @@ class gen_ws(object):
     @property
     def OutputWorkspace(self):
         return self._OutputWorkspace
+
 
 class MultiPlottingContextTest(unittest.TestCase):
     def setUp(self):
@@ -55,7 +52,6 @@ class MultiPlottingContextTest(unittest.TestCase):
             self.context.addLine("one",ws,specNum)
             self.assertEquals(patch.call_count,1)
             patch.assert_called_with(mockWS,specNum)
-
 
     def test_updateLayout(self):
         # add mocks

--- a/scripts/test/MultiPlotting/QuickEditPresenter_test.py
+++ b/scripts/test/MultiPlotting/QuickEditPresenter_test.py
@@ -6,14 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.QuickEdit.quickEdit_presenter import QuickEditPresenter
 from MultiPlotting.QuickEdit.quickEdit_view import QuickEditView
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class QuickEditPresenterTest(unittest.TestCase):

--- a/scripts/test/MultiPlotting/QuickEditWidget_test.py
+++ b/scripts/test/MultiPlotting/QuickEditWidget_test.py
@@ -6,16 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.QuickEdit.quickEdit_presenter import QuickEditPresenter
 from MultiPlotting.QuickEdit.quickEdit_widget import QuickEditWidget
-
 from Muon.GUI.Common import mock_widget
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class QuickEditWidgetTest(unittest.TestCase):

--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -6,13 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.subplot.subplot_context import subplotContext
 from mantid import plots
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class line(object):

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -4,17 +4,13 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import unittest
 from matplotlib.gridspec import GridSpec
+import unittest
 
+from mantid.py3compat import mock
 from MultiPlotting.subplot.subplot import subplot
 from MultiPlotting.multi_plotting_context import PlottingContext
-
 from Muon.GUI.Common import mock_widget
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 def rm_logic(name):

--- a/scripts/test/Muon/FFTModel_test.py
+++ b/scripts/test/Muon/FFTModel_test.py
@@ -4,16 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
-
-from  Muon.GUI.FrequencyDomainAnalysis.FFT import fft_model
-
 import unittest
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+from mantid.py3compat import mock
+from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_model
 
 
 class FFTModelTest(unittest.TestCase):

--- a/scripts/test/Muon/FFTPresenter_test.py
+++ b/scripts/test/Muon/FFTPresenter_test.py
@@ -4,20 +4,14 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.utilities import load_utils
 from Muon.GUI.Common import thread_model
 from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_presenter
 from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_view
 from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_model
-
-import unittest
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class FFTPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/LoadWidgetPresenter_test.py
+++ b/scripts/test/Muon/LoadWidgetPresenter_test.py
@@ -6,16 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.load_widget.load_presenter import LoadPresenter
 from Muon.GUI.Common.load_widget.load_view import LoadView
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
-
-from Muon.GUI.Common import mock_widget
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class LoadPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/LoadWidgetView_test.py
+++ b/scripts/test/Muon/LoadWidgetView_test.py
@@ -5,15 +5,10 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from mantid.py3compat import mock
 
 from Muon.GUI.Common.load_widget.load_view import LoadView
-
 from Muon.GUI.Common import mock_widget
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class LoadViewTest(unittest.TestCase):

--- a/scripts/test/Muon/MaxEntModel_test.py
+++ b/scripts/test/Muon/MaxEntModel_test.py
@@ -4,16 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
-
-from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_model
-
 import unittest
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+from mantid.py3compat import mock
+from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_model
 
 
 class MaxEntModelTest(unittest.TestCase):

--- a/scripts/test/Muon/MaxEntPresenter_test.py
+++ b/scripts/test/Muon/MaxEntPresenter_test.py
@@ -6,21 +6,19 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 
-import sys
-
-from  Muon.GUI.Common.utilities import load_utils
-from  Muon.GUI.Common import thread_model
-from  Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_presenter
-from  Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_view
-from  Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_model
-
 import unittest
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+
+from mantid.py3compat import mock
+from Muon.GUI.Common.utilities import load_utils
+from Muon.GUI.Common import thread_model
+from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_presenter
+from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_view
+from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_model
+
+
 def test(inputs):
     inputs["OutputPhaseTable"] = "test"
+
 
 class MaxEntPresenterTest(unittest.TestCase):
     def setUp(self):

--- a/scripts/test/Muon/PeriodicTableModel_test.py
+++ b/scripts/test/Muon/PeriodicTableModel_test.py
@@ -8,12 +8,8 @@ from __future__ import absolute_import, print_function
 
 import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import PeriodicTableModel
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class PeriodicTableModelTest(unittest.TestCase):

--- a/scripts/test/Muon/PeriodicTablePresenter_test.py
+++ b/scripts/test/Muon/PeriodicTablePresenter_test.py
@@ -8,18 +8,12 @@ from __future__ import absolute_import, print_function
 
 import unittest
 
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter import PeriodicTablePresenter
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import PeriodicTableModel
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table import PeriodicTable as silxPT, PeriodicTableItem
-
-from Muon.GUI.Common import mock_widget
-
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class PeriodicTablePresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/PlottingView_test.py
+++ b/scripts/test/Muon/PlottingView_test.py
@@ -11,18 +11,12 @@ os.environ["QT_API"] = "pyqt"  # noqa E402
 
 from matplotlib.figure import Figure
 
-from mantid import WorkspaceFactory
-from mantid import plots
+from mantid import WorkspaceFactory, plots
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.ElementalAnalysis.Plotting.subPlot_object import subPlot
 from Muon.GUI.ElementalAnalysis.Plotting.plotting_view import PlotView
 from Muon.GUI.ElementalAnalysis.Plotting.AxisChanger.axis_changer_presenter import AxisChangerPresenter
-
-from Muon.GUI.Common import mock_widget
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 def get_subPlot(name):

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -1,8 +1,8 @@
-import unittest
-import sys
-import six
 from PyQt4 import QtGui
+import six
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_view import GroupingTableView
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_presenter import GroupingTablePresenter, MuonGroup
 
@@ -15,11 +15,6 @@ from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_view import Groupin
 
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
-
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 
 class GroupingTabPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -1,7 +1,8 @@
-import unittest
-import sys
-import six
 from PyQt4 import QtGui
+import six
+import unittest
+
+from mantid.py3compat import mock
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_view import GroupingTableView
 from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_presenter import GroupingTablePresenter
@@ -10,10 +11,6 @@ from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.observer_pattern import Observer
 
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 maximum_number_of_groups = 20
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
@@ -1,13 +1,7 @@
-import unittest
-import sys
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
 from PyQt4 import QtGui
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_model import PairingTableModel
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter

--- a/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
@@ -1,7 +1,7 @@
-import unittest
-import sys
 from PyQt4 import QtGui
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_model import PairingTableModel
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter
@@ -11,16 +11,13 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
 
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 def pair_name():
     name = []
     for i in range(21):
         name.append("pair_" + str(i+1))
     return name
+
 
 class GroupSelectorTest(unittest.TestCase):
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -1,14 +1,8 @@
-import unittest
-import sys
-import six
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
 from PyQt4 import QtGui
+import six
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_model import PairingTableModel
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter

--- a/scripts/test/Muon/help_widget_presenter_test.py
+++ b/scripts/test/Muon/help_widget_presenter_test.py
@@ -4,17 +4,12 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.help_widget.help_widget_view import HelpWidgetView
 from Muon.GUI.Common.help_widget.help_widget_presenter import HelpWidgetPresenter
-import unittest
 from Muon.GUI.Common import mock_widget
-
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 
 class HelpWidgetPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/home_grouping_widget_test.py
+++ b/scripts/test/Muon/home_grouping_widget_test.py
@@ -4,27 +4,21 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
+import unittest
 
+from mantid import ConfigService
+from mantid.api import FileFinder
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_model import HomeGroupingWidgetModel
 from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_presenter import HomeGroupingWidgetPresenter
 from Muon.GUI.Common.home_grouping_widget.home_grouping_widget_view import HomeGroupingWidgetView
+from Muon.GUI.Common.observer_pattern import Observer
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-from Muon.GUI.Common import mock_widget
-import unittest
-from PyQt4 import QtGui
-from Muon.GUI.Common.observer_pattern import Observer
-from mantid.api import FileFinder
-from mantid import ConfigService
-import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.muon_pair import MuonPair
-
-
-if sys.version_info.major < 2:
-    from unittest import mock
-else:
-    import mock
+import Muon.GUI.Common.utilities.load_utils as load_utils
 
 
 class HomeTabGroupingPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -4,22 +4,18 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
+import unittest
 
+from mantid.api import FileFinder
+from mantid.py3compat import mock
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import InstrumentWidgetView
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter import InstrumentWidgetPresenter
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_model import InstrumentWidgetModel
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
-import unittest
-from PyQt4 import QtGui
-from Muon.GUI.Common.observer_pattern import Observer
-from mantid.api import FileFinder
 
-if sys.version_info.major < 2:
-    from unittest import mock
-else:
-    import mock
+from Muon.GUI.Common.observer_pattern import Observer
 
 
 class HomeTabInstrumentPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/home_plot_widget_test.py
+++ b/scripts/test/Muon/home_plot_widget_test.py
@@ -4,20 +4,15 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.home_plot_widget.home_plot_widget_view import HomePlotWidgetView
 from Muon.GUI.Common.home_plot_widget.home_plot_widget_presenter import HomePlotWidgetPresenter
 from Muon.GUI.Common.home_plot_widget.home_plot_widget_model import HomePlotWidgetModel
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
-import unittest
-from PyQt4 import QtGui
-
-if sys.version_info.major < 2:
-    from unittest import mock
-else:
-    import mock
 
 
 class HomeTabPlotPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/home_runinfo_presenter_test.py
+++ b/scripts/test/Muon/home_runinfo_presenter_test.py
@@ -4,25 +4,19 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
+import unittest
 
+from mantid.api import FileFinder
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.home_runinfo_widget.home_runinfo_widget_view import HomeRunInfoWidgetView
 from Muon.GUI.Common.home_runinfo_widget.home_runinfo_widget_presenter import HomeRunInfoWidgetPresenter
 from Muon.GUI.Common.home_runinfo_widget.home_runinfo_widget_model import HomeRunInfoWidgetModel
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-
-from Muon.GUI.Common import mock_widget
-from mantid.api import FileFinder
-import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.muon_pair import MuonPair
-import unittest
-from PyQt4 import QtGui
-
-if sys.version_info.major < 2:
-    from unittest import mock
-else:
-    import mock
+import Muon.GUI.Common.utilities.load_utils as load_utils
 
 
 class HomeTabRunInfoPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -1,12 +1,7 @@
 import six
-import sys
 import unittest
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
+from mantid.py3compat import mock
 from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.load_file_widget.view import BrowseFileWidgetView
 from Muon.GUI.Common.load_file_widget.presenter import BrowseFileWidgetPresenter

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -4,14 +4,9 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
 import unittest
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_file_widget.view import BrowseFileWidgetView
 from Muon.GUI.Common.load_file_widget.presenter import BrowseFileWidgetPresenter
 from Muon.GUI.Common.load_file_widget.model import BrowseFileWidgetModel

--- a/scripts/test/Muon/load_run_widget/loadrun_model_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_model_test.py
@@ -4,18 +4,13 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
+from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.utilities.muon_test_helpers import IteratorWithException
-import unittest
-from Muon.GUI.Common.muon_data_context import MuonDataContext
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class LoadRunWidgetModelTest(unittest.TestCase):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -4,24 +4,17 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
+import unittest
+
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
 from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_data_context import MuonDataContext
-
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 import Muon.GUI.Common.utilities.muon_file_utils as fileUtils
-
-import unittest
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
-from PyQt4 import QtGui
 
 
 class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -4,24 +4,17 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
 import os
+import unittest
 
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
 from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-
-import unittest
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
-from PyQt4 import QtGui
 
 
 class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -4,24 +4,18 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
 import six
+import unittest
 
+
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
-
 from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-
-import unittest
-from PyQt4 import QtGui
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
@@ -4,25 +4,17 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+from PyQt4 import QtGui
 import os
+import unittest
 
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
-
-from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-
-import unittest
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
-from PyQt4 import QtGui
 
 
 class LoadRunWidgetPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
@@ -4,19 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from PyQt4 import QtGui
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from PyQt4 import QtGui
-
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
-
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
@@ -29,6 +20,10 @@ from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
+
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
 
 
 class LoadRunWidgetPresenterLoadFailTest(unittest.TestCase):

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
@@ -4,19 +4,12 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from PyQt4 import QtGui
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from PyQt4 import QtGui
-
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
-
+from mantid import ConfigService
+from mantid.api import FileFinder
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
@@ -27,8 +20,10 @@ from Muon.GUI.Common.load_file_widget.model import BrowseFileWidgetModel
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 from Muon.GUI.Common import mock_widget
-from mantid.api import FileFinder
-from mantid import ConfigService
+
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
 
 
 class LoadRunWidgetPresenterMultipleFileTest(unittest.TestCase):

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
@@ -4,19 +4,11 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from PyQt4 import QtGui
 import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
-from PyQt4 import QtGui
-
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
-from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
-
+from mantid.api import FileFinder
+from mantid.py3compat import mock
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.load_run_widget.load_run_presenter import LoadRunWidgetPresenter
@@ -29,7 +21,10 @@ from Muon.GUI.Common import mock_widget
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.muon_data_context import MuonDataContext
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
-from mantid.api import FileFinder
+
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_model import LoadWidgetModel
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
+from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPresenter
 
 
 class LoadRunWidgetPresenterTest(unittest.TestCase):

--- a/scripts/test/Muon/muon_data_context_test.py
+++ b/scripts/test/Muon/muon_data_context_test.py
@@ -4,22 +4,15 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
+import copy
+import unittest
+
+from mantid.api import AnalysisDataService, FileFinder
+from mantid.py3compat import mock
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 from Muon.GUI.Common.muon_data_context import MuonDataContext
-from mantid.api import AnalysisDataService
-import unittest
 from Muon.GUI.Common.observer_pattern import Observer
-from mantid.api import FileFinder
-
-
-import copy
-
-if sys.version_info.major < 2:
-    from unittest import mock
-else:
-    import mock
 
 
 class MuonDataContextTest(unittest.TestCase):

--- a/scripts/test/Muon/transformWidget_test.py
+++ b/scripts/test/Muon/transformWidget_test.py
@@ -4,23 +4,17 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import sys
-
-from  Muon.GUI.Common import mock_widget
-from  Muon.GUI.Common.utilities import load_utils
-from  Muon.GUI.FrequencyDomainAnalysis.FFT import fft_presenter
-from  Muon.GUI.FrequencyDomainAnalysis.Transform import transform_widget
-from  Muon.GUI.FrequencyDomainAnalysis.Transform import transform_view
-from  Muon.GUI.FrequencyDomainAnalysis.TransformSelection import transform_selection_view
-from  Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_presenter
-
-
-# need to update this
 import unittest
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+
+from mantid.py3compat import mock
+from Muon.GUI.Common import mock_widget
+from Muon.GUI.Common.utilities import load_utils
+from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_presenter
+from Muon.GUI.FrequencyDomainAnalysis.Transform import transform_widget
+from Muon.GUI.FrequencyDomainAnalysis.Transform import transform_view
+from Muon.GUI.FrequencyDomainAnalysis.TransformSelection import transform_selection_view
+from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_presenter
+
 
 class TransformTest(unittest.TestCase):
     def setUp(self):

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -5,17 +5,12 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import Muon.GUI.Common.utilities.load_utils as utils
-import sys
 import os
+import unittest
+
 from mantid import simpleapi, ConfigService
 from mantid.api import AnalysisDataService, ITableWorkspace
 
-import unittest
-
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 def create_simple_workspace(data_x, data_y, run_number=0):
     alg = simpleapi.AlgorithmManager.create("CreateWorkspace")

--- a/scripts/test/Muon/utilities/muon_file_utils_test.py
+++ b/scripts/test/Muon/utilities/muon_file_utils_test.py
@@ -4,16 +4,11 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-import Muon.GUI.Common.utilities.muon_file_utils as utils
-import sys
 import os
-
 import unittest
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
+from mantid.py3compat import mock
+from Muon.GUI.Common.utilities.muon_file_utils as utils
 
 
 class MuonFileUtilsTest(unittest.TestCase):

--- a/scripts/test/Muon/utilities/muon_file_utils_test.py
+++ b/scripts/test/Muon/utilities/muon_file_utils_test.py
@@ -8,7 +8,7 @@ import os
 import unittest
 
 from mantid.py3compat import mock
-from Muon.GUI.Common.utilities.muon_file_utils as utils
+import Muon.GUI.Common.utilities.muon_file_utils as utils
 
 
 class MuonFileUtilsTest(unittest.TestCase):

--- a/scripts/test/Muon/utilities/muon_load_data_test.py
+++ b/scripts/test/Muon/utilities/muon_load_data_test.py
@@ -7,12 +7,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from Muon.GUI.Common.muon_load_data import MuonLoadData
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
+
 
 class MuonLoadDataTest(unittest.TestCase):
 

--- a/scripts/test/Muon/utilities/thread_model_test.py
+++ b/scripts/test/Muon/utilities/thread_model_test.py
@@ -5,14 +5,10 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from Muon.GUI.Common.thread_model import ThreadModel
 from Muon.GUI.Common import mock_widget
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class testModelWithoutExecute:

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -5,14 +5,12 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
-import sys
-from sans.algorithm_detail.batch_execution import get_all_names_to_save, ReductionPackage
+
 from mantid.simpleapi import CreateSampleWorkspace
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
+from mantid.py3compat import mock
+from sans.algorithm_detail.batch_execution import get_all_names_to_save, ReductionPackage
 
 
 class GetAllNamesToSaveTest(unittest.TestCase):

--- a/scripts/test/SANS/algorithm_detail/centre_finder_new_test.py
+++ b/scripts/test/SANS/algorithm_detail/centre_finder_new_test.py
@@ -7,14 +7,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.algorithm_detail.centre_finder_new import centre_finder_new, centre_finder_mass
 from sans.common.enums import (SANSDataType, FindDirectionEnum, DetectorType)
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class CentreFinderNewTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -5,10 +5,9 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
 
 from mantid.kernel import ConfigService
-from sans.common.enums import SANSInstrument
+from mantid.py3compat import mock
 from sans.gui_logic.models.run_summation import RunSummation
 from sans.gui_logic.models.run_file import SummableRunFile
 from sans.gui_logic.models.run_selection import RunSelection
@@ -20,11 +19,6 @@ from ui.sans_isis.add_runs_page import AddRunsPage
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from fake_signal import FakeSignal
 from assert_called import assert_called
-
-if sys.version_info.major == 2:
-    import mock
-else:
-    from unittest import mock
 
 
 class MockedOutAddRunsFilenameManager(AddRunsFilenameManager):

--- a/scripts/test/SANS/gui_logic/batch_process_runner_test.py
+++ b/scripts/test/SANS/gui_logic/batch_process_runner_test.py
@@ -5,16 +5,13 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
-from sans.gui_logic.models.batch_process_runner import BatchProcessRunner
-import unittest
-import sys
-from sans.common.enums import (OutputMode)
-from qtpy.QtCore import QThreadPool
 
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
+from qtpy.QtCore import QThreadPool
+import unittest
+
+from mantid.py3compat import mock
+from sans.common.enums import (OutputMode)
+from sans.gui_logic.models.batch_process_runner import BatchProcessRunner
 
 
 class BatchProcessRunnerTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/beam_centre_model_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_model_test.py
@@ -7,18 +7,13 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.gui_logic.models.beam_centre_model import BeamCentreModel
 from sans.common.enums import FindDirectionEnum, SANSInstrument, DetectorType, SANSFacility
 from sans.test_helper.test_director import TestDirector
 from sans.state.data import get_data_builder
 from sans.test_helper.file_information_mock import SANSFileInformationMock
-
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class BeamCentreModelTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -5,16 +5,14 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.test_helper.mock_objects import create_mock_beam_centre_tab
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.presenter.beam_centre_presenter import BeamCentrePresenter
 from sans.test_helper.mock_objects import (create_run_tab_presenter_mock)
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class BeamCentrePresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/create_file_information_test.py
+++ b/scripts/test/SANS/gui_logic/create_file_information_test.py
@@ -4,18 +4,12 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from qtpy.QtCore import QCoreApplication
+import unittest
 
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.create_file_information import create_file_information
 from ui.sans_isis.work_handler import WorkHandler
-import sys
-import unittest
-from qtpy.QtCore import QCoreApplication
-
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
-
 
 class CreateFileInformationTest(unittest.TestCase):
     def setUp(self):

--- a/scripts/test/SANS/gui_logic/create_state_test.py
+++ b/scripts/test/SANS/gui_logic/create_state_test.py
@@ -7,8 +7,8 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
 
+from mantid.py3compat import mock
 from sans.gui_logic.models.create_state import (create_states, create_gui_state_from_userfile)
 from sans.common.enums import (SANSInstrument, ISISReductionMode, SANSFacility, SaveType)
 from sans.gui_logic.models.state_gui_model import StateGuiModel
@@ -16,10 +16,6 @@ from sans.gui_logic.models.table_model import TableModel, TableIndexModel
 from sans.state.state import State
 from qtpy.QtCore import QCoreApplication
 
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 class GuiCommonTest(unittest.TestCase):
     def setUp(self):

--- a/scripts/test/SANS/gui_logic/diagnostics_page_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/diagnostics_page_presenter_test.py
@@ -5,17 +5,14 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.test_helper.mock_objects import create_mock_diagnostics_tab
 from sans.common.enums import SANSInstrument, DetectorType, IntegralEnum, SANSFacility
 from sans.gui_logic.presenter.diagnostic_presenter import DiagnosticsPagePresenter
 from sans.test_helper.mock_objects import (create_run_tab_presenter_mock)
-
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
 
 
 class DiagnosticsPagePresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/masking_table_presenter_test.py
@@ -7,14 +7,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
 
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.masking_table_presenter import (MaskingTablePresenter, masking_information)
 from sans.test_helper.mock_objects import (FakeParentPresenter, FakeState, create_mock_masking_table, create_run_tab_presenter_mock)
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class MaskingTablePresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/run_selector_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_selector_presenter_test.py
@@ -5,7 +5,8 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.run_selector_presenter import RunSelectorPresenter
 from sans.gui_logic.models.run_selection import RunSelection
 from sans.gui_logic.models.run_finder import SummableRunFinder
@@ -14,10 +15,6 @@ from ui.sans_isis.run_selector_widget import RunSelectorWidget
 from fake_signal import FakeSignal
 
 from assert_called import assert_called
-if sys.version_info.major == 2:
-    import mock
-else:
-    from unittest import mock
 
 
 class RunSelectorPresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -8,10 +8,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
-import sys
 
 from mantid.kernel import config
 from mantid.kernel import PropertyManagerDataService
+from mantid.py3compat import mock
 
 from sans.gui_logic.presenter.run_tab_presenter import RunTabPresenter
 from sans.common.enums import (SANSFacility, ReductionDimensionality, SaveType, ISISReductionMode,
@@ -24,10 +24,6 @@ from sans.common.enums import BatchReductionEntry, SANSInstrument
 from sans.gui_logic.models.table_model import TableModel, TableIndexModel
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
-if sys.version_info.major >= 3:
-    from unittest import mock
-else:
-    import mock
 
 BATCH_FILE_TEST_CONTENT_1 = [{BatchReductionEntry.SampleScatter: 1, BatchReductionEntry.SampleTransmission: 2,
                               BatchReductionEntry.SampleDirect: 3, BatchReductionEntry.Output: 'test_file',

--- a/scripts/test/SANS/gui_logic/save_other_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/save_other_presenter_test.py
@@ -5,14 +5,12 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
 import unittest
-import sys
+
 from mantid import ConfigService
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.save_other_presenter import SaveOtherPresenter
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class SaveOtherPresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/settings_diagnostic_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/settings_diagnostic_presenter_test.py
@@ -8,18 +8,14 @@ from __future__ import (absolute_import, division, print_function)
 
 import tempfile
 import unittest
-import sys
 import os
 import json
 
 import mantid
 
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.settings_diagnostic_presenter import SettingsDiagnosticPresenter
 from sans.test_helper.mock_objects import (create_run_tab_presenter_mock, FakeState, create_mock_settings_diagnostic_tab)
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class SettingsDiagnosticPresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/summation_settings_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/summation_settings_presenter_test.py
@@ -5,7 +5,8 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
+
+from mantid.py3compat import mock
 from sans.gui_logic.presenter.summation_settings_presenter import SummationSettingsPresenter
 from sans.gui_logic.models.summation_settings import SummationSettings
 from sans.gui_logic.models.binning_type import BinningType
@@ -13,10 +14,6 @@ from ui.sans_isis.summation_settings_widget import SummationSettingsWidget
 from fake_signal import FakeSignal
 
 from assert_called import assert_called
-if sys.version_info.major == 3:
-    from unittest import mock
-else:
-    import mock
 
 
 class SummationSettingsPresenterTest(unittest.TestCase):

--- a/scripts/test/SANS/gui_logic/table_model_test.py
+++ b/scripts/test/SANS/gui_logic/table_model_test.py
@@ -8,14 +8,11 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 
+from mantid.py3compat import mock
 from sans.gui_logic.models.table_model import (TableModel, TableIndexModel, OptionsColumnModel, SampleShapeColumnModel, options_column_bool)
 from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
 from qtpy.QtCore import QCoreApplication
 from sans.common.enums import (RowState, SampleShape)
-try:
-    from unittest import mock
-except:
-    import mock
 
 
 class TableModelTest(unittest.TestCase):

--- a/scripts/test/TOFTOF/TOFTOFGUITest.py
+++ b/scripts/test/TOFTOF/TOFTOFGUITest.py
@@ -6,15 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 
+from qtpy.QtWidgets import QApplication
+import unittest
+
+from mantid.py3compat import mock
 from reduction_gui.reduction.toftof.toftof_reduction import TOFTOFScriptElement, OptionalFloat
 from reduction_gui.widgets.toftof.toftof_setup import TOFTOFSetupWidget
-from qtpy.QtWidgets import QApplication
 
-import unittest
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 try:
     unicode('test for unicode type')


### PR DESCRIPTION
**Description of work.**
This PR changes all the various `unittest.mock`/`mock` imports we use in testing to a `py3compat` import.

**To test:**
Unit and system tests pass

Fixes #25190 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
