### PR TITLE
Turn off X errorbars in workbench plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -167,7 +167,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     dimension
     """
     x, y, dy, dx, kwargs = _get_data_for_plot(axes, workspace, kwargs,
-                                              with_dy=True, with_dx=True)
+                                              with_dy=True, with_dx=False)
     _setLabels1D(axes, workspace)
     return axes.errorbar(x, y, dy, dx, *args, **kwargs)
 


### PR DESCRIPTION
**Description of work.**
This PR brings workbench error plots in-line with Mantidplot by not including x errors in the plot
It would be useful to allow users to toggle x error bars in plots, rather than always disabling, but this functionality will be introduced in 4.1. Issue #25203 tracks this.

**Report to:** Jos

**To test:**
In workbench load the attached data.
Plot with errors and see that there are no x error bars (the x errors for this ws are huge, so the plot will be obviously incorrect if x error bars are present)

[plotting_data_in_workbench.zip](https://github.com/mantidproject/mantid/files/2971123/plotting_data_in_workbench.zip)

Fixes #25201 

*This does not require release notes* because **workbench not yet released**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
