### PR TITLE
SNSPowderReduction fixes

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -62,6 +62,28 @@ def determineChunking(filename, chunkSize):
     return strategy
 
 
+def uniqueDescription(name, wksp):
+    wksp = str(wksp)
+    if name == 'AbsorptionWorkspace':
+        sample = mtd[wksp].sample()
+        materialname = sample.getMaterial().name()
+        shapeXML = sample.getShape().getShapeXML()
+        density = str(sample.getMaterial().numberDensity)
+        wavelength = mtd[wksp].readX(0)
+        wavelength = '{} to {} with {} bins'.format(wavelength[0], wavelength[-1], mtd[wksp].readY(0).size)
+        value = ';'.join((materialname, density, shapeXML, wavelength))
+    elif name == CAL_WKSP:
+        value = str(np.sum(mtd[wksp].column('difc')))  # less false collisions than the workspace name
+    elif name == GRP_WKSP:
+        value = ','.join(mtd[wksp].extractY().astype(int).astype(str).ravel())
+    elif name == MASK_WKSP:
+        value = ','.join([str(item) for item in mtd[wksp].getMaskedDetectors()])
+    else:
+        raise RuntimeError('Do not know how to create unique description for Property "{}"'.format(name))
+
+    return '{}={}'.format(name, value)
+
+
 class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
     def category(self):
         return "Diffraction\\Reduction"
@@ -186,17 +208,22 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
         return False
 
+    def __needToLoadCal(self):
+        if (not self.getProperty(CAL_FILE).isDefault) or (not self.getProperty(GROUP_FILE).isDefault):
+            return bool(self.__calWksp and self.__grpWksp and self.__mskWksp)
+        return False
+
     def __determineCharacterizations(self, filename, wkspname):
-        useCharac = self.__isCharacterizationsNeeded()
-        useCal = (not self.getProperty(CAL_FILE).isDefault) or (not self.getProperty(GROUP_FILE).isDefault)
+        useCharTable = self.__isCharacterizationsNeeded()
+        needToLoadCal = self.__needToLoadCal()
+
         # something needs to use the workspace and it needs to not already be in memory
-        loadFile = (useCharac or useCal) and (not mtd.doesExist(wkspname))
-        self.log().notice('useChara={} useCal={} loadFile={}'.format(useCharac, useCal, loadFile))
+        loadFile = (useCharTable or needToLoadCal) and (not mtd.doesExist(wkspname))
 
         # input workspace is only needed to find a row in the characterizations table
         tempname = None
         if loadFile:
-            if useCharac or useCal:
+            if useCharTable or needToLoadCal:
                 tempname = '__%s_temp' % wkspname
                 # set the loader for this file
                 try:
@@ -224,13 +251,13 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 args[name] = prop.value
         if tempname is not None:
             args['InputWorkspace'] = tempname
-        if useCharac:
+        if useCharTable:
             args['Characterizations'] = self.charac
 
-        if useCharac:
+        if useCharTable:
             PDDetermineCharacterizations(**args)
 
-        if loadFile and (useCharac or useCal):
+        if loadFile and (useCharTable or needToLoadCal):
             DeleteWorkspace(Workspace=tempname)
 
     def __getCacheName(self, wkspname, additional_props=None):
@@ -245,6 +272,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
         propman_properties = ['bank', 'd_min', 'd_max', 'tof_min', 'tof_max', 'wavelength_min', 'wavelength_max']
         alignandfocusargs = []
+
         # calculate general properties
         for name in PROPS_FOR_ALIGN + PROPS_IN_PD_CHARACTER:
             # skip these because this has been reworked to only worry about information in workspaces
@@ -253,19 +281,17 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             prop = self.getProperty(name)
             if name == 'PreserveEvents' or not prop.isDefault:
                 value = prop.valueAsStr  # default representation for everything
-                if name == 'AbsorptionWorkspace':  # TODO need better unique identifier for absorption workspace
-                    value = str(mtd[self.__grpWksp].extractY().sum())
                 alignandfocusargs.append('%s=%s' % (name, value))
-        # special calculations for group and mask - calibration hasn't been customized yet
+
+        # special calculations for workspaces
+        if self.absorption:
+            alignandfocusargs.append(uniqueDescription('AbsorptionWorkspace', self.absorption))
         if self.__calWksp:
-            value = str(np.sum(mtd[self.__calWksp].column('difc')))  # less false collisions than the workspace name
-            alignandfocusargs.append('%s=%s' % (CAL_WKSP, value))
+            alignandfocusargs.append(uniqueDescription(CAL_WKSP, self.__calWksp))
         if self.__grpWksp:
-            value = ','.join(mtd[self.__grpWksp].extractY().astype(int).astype(str).ravel())
-            alignandfocusargs.append('%s=%s' % (GRP_WKSP, value))
+            alignandfocusargs.append(uniqueDescription(GRP_WKSP, self.__grpWksp))
         if self.__mskWksp:
-            value = ','.join([str(item) for item in mtd[self.__mskWksp].getMaskedDetectors()])
-            alignandfocusargs.append('%s=%s' % (MASK_WKSP, value))
+            alignandfocusargs.append(uniqueDescription(MASK_WKSP, self.__mskWksp))
 
         alignandfocusargs += additional_props or []
         reductionPropertiesName = self.getProperty('ReductionProperties').valueAsStr
@@ -285,13 +311,6 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         return self.__getCacheName('summed_'+wsname, additional_props=[newprop])
 
     def __processFile(self, filename, file_prog_start, determineCharacterizations, createUnfocused):  # noqa: C902
-        chunks = determineChunking(filename, self.chunkSize)
-        numSteps = 6  # for better progress reporting - 6 steps per chunk
-        if createUnfocused:
-            numSteps = 7  # one more for accumulating the unfocused workspace
-        self.log().information('Processing \'{}\' in {:d} chunks'.format(filename, len(chunks)))
-        prog_per_chunk_step = self.prog_per_file * 1./(numSteps*float(len(chunks)))
-
         # create a unique name for the workspace
         wkspname = '__' + self.__wkspNameFromFile(filename)
         wkspname += '_f%d' % self._filenames.index(filename)  # add file number to be unique
@@ -301,6 +320,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
         # check for a cachefilename
         cachefile = self.__getCacheName(self.__wkspNameFromFile(filename))
+        self.log().information('looking for cachefile "{}"'.format(cachefile))
         if (not createUnfocused) and self.useCaching and os.path.exists(cachefile):
             try:
                 if self.__loadCacheFile(cachefile, wkspname):
@@ -308,6 +328,15 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             except RuntimeError as e:
                 # log as a warning and carry on as though the cache file didn't exist
                 self.log().warning('Failed to load cache file "{}": {}'.format(cachefile, e))
+        else:
+            self.log().information('not using cache')
+
+        chunks = determineChunking(filename, self.chunkSize)
+        numSteps = 6  # for better progress reporting - 6 steps per chunk
+        if createUnfocused:
+            numSteps = 7  # one more for accumulating the unfocused workspace
+        self.log().information('Processing \'{}\' in {:d} chunks'.format(filename, len(chunks)))
+        prog_per_chunk_step = self.prog_per_file * 1./(numSteps*float(len(chunks)))
 
         unfocusname_chunk = ''
         canSkipLoadingLogs = False
@@ -398,6 +427,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         # write out the cachefile for the main reduced data independent of whether
         # the unfocussed workspace was requested
         if self.useCaching and not os.path.exists(cachefile):
+            self.log().information('Saving data to cachefile "{}"'.format(cachefile))
             SaveNexusProcessed(InputWorkspace=wkspname, Filename=cachefile)
 
         return wkspname, unfocusname
@@ -583,7 +613,11 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if not prop.isDefault:
                 editinstrargs[name] = prop.value
         if editinstrargs:
-            EditInstrumentGeometry(Workspace=wkspname, **editinstrargs)
+            try:
+                EditInstrumentGeometry(Workspace=wkspname, **editinstrargs)
+            except RuntimeError as e:
+                # treat this as a non-fatal error
+                self.log().warning('Failed to update instrument geometry in cache file: {}'.format(e))
 
         return True
 

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -210,7 +210,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
 
     def __needToLoadCal(self):
         if (not self.getProperty(CAL_FILE).isDefault) or (not self.getProperty(GROUP_FILE).isDefault):
-            return bool(self.__calWksp and self.__grpWksp and self.__mskWksp)
+            return not bool(self.__calWksp and self.__grpWksp and self.__mskWksp)
         return False
 
     def __determineCharacterizations(self, filename, wkspname):

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -307,6 +307,8 @@ void AlignAndFocusPowder::exec() {
   tmax = getProperty("TMax");
   m_preserveEvents = getProperty("PreserveEvents");
   m_resampleX = getProperty("ResampleX");
+  const double compressEventsTolerance = getProperty("CompressTolerance");
+  const double wallClockTolerance = getProperty("CompressWallClockTolerance");
   // determine some bits about d-space and binning
   if (m_resampleX != 0) {
     m_params.clear(); // ignore the normal rebin parameters
@@ -412,10 +414,9 @@ void AlignAndFocusPowder::exec() {
   m_progress = make_unique<Progress>(this, 0., 1., 21);
 
   if (m_inputEW) {
-    double tolerance = getProperty("CompressTolerance");
-    if (tolerance > 0.) {
-      double wallClockTolerance = getProperty("CompressWallClockTolerance");
-      g_log.information() << "running CompressEvents(Tolerance=" << tolerance;
+    if (compressEventsTolerance > 0.) {
+      g_log.information() << "running CompressEvents(Tolerance="
+                          << compressEventsTolerance;
       if (!isEmpty(wallClockTolerance))
         g_log.information() << " and WallClockTolerance=" << wallClockTolerance;
       g_log.information() << ") started at "
@@ -424,7 +425,7 @@ void AlignAndFocusPowder::exec() {
       compressAlg->setProperty("InputWorkspace", m_outputEW);
       compressAlg->setProperty("OutputWorkspace", m_outputEW);
       compressAlg->setProperty("OutputWorkspace", m_outputEW);
-      compressAlg->setProperty("Tolerance", tolerance);
+      compressAlg->setProperty("Tolerance", compressEventsTolerance);
       if (!isEmpty(wallClockTolerance)) {
         compressAlg->setProperty("WallClockTolerance", wallClockTolerance);
         compressAlg->setPropertyValue("StartTime",
@@ -717,11 +718,10 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   // compress again if appropriate
-  double tolerance = getProperty("CompressTolerance");
   m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
-  if ((m_outputEW) && (tolerance > 0.)) {
-    double wallClockTolerance = getProperty("CompressWallClockTolerance");
-    g_log.information() << "running CompressEvents(Tolerance=" << tolerance;
+  if ((m_outputEW) && (compressEventsTolerance > 0.)) {
+    g_log.information() << "running CompressEvents(Tolerance="
+                        << compressEventsTolerance;
     if (!isEmpty(wallClockTolerance))
       g_log.information() << " and WallClockTolerance=" << wallClockTolerance;
     g_log.information() << ") started at "
@@ -729,7 +729,7 @@ void AlignAndFocusPowder::exec() {
     API::IAlgorithm_sptr compressAlg = createChildAlgorithm("CompressEvents");
     compressAlg->setProperty("InputWorkspace", m_outputEW);
     compressAlg->setProperty("OutputWorkspace", m_outputEW);
-    compressAlg->setProperty("Tolerance", tolerance);
+    compressAlg->setProperty("Tolerance", compressEventsTolerance);
     if (!isEmpty(wallClockTolerance)) {
       compressAlg->setProperty("WallClockTolerance", wallClockTolerance);
       compressAlg->setPropertyValue("StartTime",


### PR DESCRIPTION
Various issues were discovered during unscripted testing. This resolves the last of them.
1. The vanadium radius wasn't being given to the Carpenter correction
2. Not correctly identifying cache files/cache descriptions were not unique
3. Loading the file (`MetaDataOnly=True`) when not necessary
4. Printing information about chunking when cache file was being used

Plus some other bits of code cleanup (e.g.. improving variable names, moving code into functions).

**To test:**

Try out various reductions.

Fixes #24961.

*This does not require release notes* because it is already covered in all the other things in `SNSPowderReduction` and `AlignAndFocusPowder`.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
