### PR TITLE
Show log value in viewer

### DIFF
--- a/qt/python/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/model.py
@@ -29,14 +29,24 @@ def get_type(log):
 
 
 def get_value(log):
-    """Returns the first value if length==1 otherwise returns number of
-    entries
+    """Returns the either the value or the number of entries
     """
+    MAX_LOG_SIZE = 20  # the maximum log length to try to show in the value column
+
     if isinstance(log, TimeSeriesProperties):
-        if log.size() > 1:
-            return "({} entries)".format(log.size())
+        if log.size() == 1:
+            return '{} (1 entry)'.format(log.firstValue())
         else:
-            return log.firstValue()
+            entry_descr = '({} entries)'.format(log.size())
+
+            # show the value if they are all the same
+            if log.size() < MAX_LOG_SIZE:
+                value = set(log.value)
+                if len(value) == 1:
+                    return "{} {}".format(value.pop(), entry_descr)
+
+            # otherwise just show the number of values
+            return entry_descr
     else:
         return log.value
 

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
@@ -55,7 +55,7 @@ class SampleLogsModelTest(unittest.TestCase):
         self.assertEqual(itemModel.rowCount(), 48)
         self.assertEqual(itemModel.item(0,0).text(), "ChopperStatus1")
         self.assertEqual(itemModel.item(0,1).text(), "float series")
-        self.assertEqual(itemModel.item(0,2).text(), "(2 entries)")
+        self.assertEqual(itemModel.item(0,2).text(), "4.0 (2 entries)")
         self.assertEqual(itemModel.item(0,3).text(), "")
 
     def test_model_MD(self):


### PR DESCRIPTION
Since the SNS DAS puts a time-series for even then unchanging string
logs, see if they are all the same and just put it in the value column.
This was not made specific for strings because it was discovered that we
have other logs that have multiple "entries", but are all just one
value.

**To test:**

Load a file into the workbench and show the logs. See that the "value" column has a lot more information.

*There is no associated issue.*

*This does not require release notes* because it is part of the workbench.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
