### PR TITLE
Mock out threading in unit tests

### DIFF
--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -45,6 +45,7 @@ class GroupingTabPresenterTest(unittest.TestCase):
                                               self.grouping_table_widget,
                                               self.pairing_table_widget)
 
+        self.presenter.create_update_thread = mock.MagicMock(return_value=mock.MagicMock())
         self.view.display_warning_box = mock.MagicMock()
         self.grouping_table_view.warning_popup = mock.MagicMock()
         self.pairing_table_view.warning_popup = mock.MagicMock()
@@ -156,7 +157,6 @@ class GroupingTabPresenterTest(unittest.TestCase):
             self.assertEqual(mock_save.call_args[0][-1], "grouping.xml")
 
     def test_update_all_calculates_groups_and_pairs(self):
-        self.presenter.create_update_thread = mock.MagicMock(return_value=mock.MagicMock())
         self.presenter.handle_update_all_clicked()
 
         self.presenter.update_thread.threadWrapperSetUp.assert_called_once_with(self.presenter.disable_editing,


### PR DESCRIPTION
**Description of work.**

grouping_tab_presenter_test is sporadically failing on the build servers. The issue seems to be with the tests triggering multiple threads at once. This PR mocks out the threading to provide a quick fix for this issue.

**To test:**

If you are able to to replicate it test that the intermittent build failure goes away

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because fixes an internal testing issue


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
