### PR TITLE
Disable fit button on workbench plots with no associated workspaces 

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -242,9 +242,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         # Hack to ensure the canvas is up to date
         self.canvas.draw_idle()
         if figure_type(self.canvas.figure) != FigureType.Line:
-            action = self.toolbar._actions['toggle_fit']
-            action.setEnabled(False)
-            action.setVisible(False)
+            self._set_fit_enabled(False)
 
         self._update_workspace_labels()
 
@@ -335,9 +333,16 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         num_new_curves = len(curve_labels) - len(self.workspace_labels)
         self.workspace_labels += curve_labels[-num_new_curves:]
         self._update_fit_browser_workspace_labels()
+        can_fit = self.fit_browser.can_fit_spectra(self.workspace_labels)
+        self._set_fit_enabled(can_fit)
 
     def _update_fit_browser_workspace_labels(self):
         self.fit_browser.workspace_labels = self.workspace_labels
+
+    def _set_fit_enabled(self, on):
+        action = self.toolbar._actions['toggle_fit']
+        action.setEnabled(on)
+        action.setVisible(on)
 
 # -----------------------------------------------------------------------------
 # Figure control

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -36,6 +36,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
     """
 
     closing = Signal()
+    pattern_fittable_curve = re.compile('(.+?): spec (\d+)')
 
     def __init__(self, canvas, toolbar_state_checker, parent=None):
         super(FitPropertyBrowser, self).__init__(parent)
@@ -64,6 +65,15 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         self.plotGuess.connect(self.plot_guess_slot, Qt.QueuedConnection)
         self.functionChanged.connect(self.function_changed_slot, Qt.QueuedConnection)
 
+    @classmethod
+    def can_fit_spectra(cls, labels):
+        """
+        Determine if the spectra referred to by the plot labels can be used in this fit browser.
+        :param labels: A list of curve labels which can identify spectra in a workspace.
+        :return: True or False
+        """
+        return any(map(lambda s: re.match(cls.pattern_fittable_curve, s), labels))
+
     def closeEvent(self, event):
         """
         Emit self.closing signal used by figure manager to put the menu buttons in correct states
@@ -76,15 +86,16 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         Override the base class method. Initialise the peak editing tool.
         """
         allowed_spectra = {}
-        pattern = re.compile('(.+?): spec (\d+)')
         for label in self.workspace_labels:
-            a_match = re.match(pattern, label)
-            name, spec = a_match.group(1), int(a_match.group(2))
-            spec_list = allowed_spectra.get(name, [])
-            spec_list.append(spec)
-            allowed_spectra[name] = spec_list
-        for name, spec_list in allowed_spectra.items():
-            self.addAllowedSpectra(name, spec_list)
+            a_match = re.match(self.pattern_fittable_curve, label)
+            if a_match:
+                name, spec = a_match.group(1), int(a_match.group(2))
+                spec_list = allowed_spectra.get(name, [])
+                spec_list.append(spec)
+                allowed_spectra[name] = spec_list
+        if len(allowed_spectra) > 0:
+            for name, spec_list in allowed_spectra.items():
+                self.addAllowedSpectra(name, spec_list)
         self.tool = FitInteractiveTool(self.canvas, self.toolbar_state_checker,
                                        current_peak_type=self.defaultPeakType())
         self.tool.fit_start_x_moved.connect(self.setStartX)


### PR DESCRIPTION
**Description of work.**
Disable fit for lines that have no associated workspaces. 

**To test:**
See the issue

<!-- Instructions for testing. -->

Fixes #25207 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
