### PR TITLE
Indirect - Fix ApplyCorrections when only sample attenuation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import mantid.simpleapi as s_api
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceGroupProperty, \
-    PropertyMode, MatrixWorkspace, Progress
+    PropertyMode, MatrixWorkspace, Progress, WorkspaceGroup
 from mantid.kernel import Direction, logger
 
 
@@ -171,6 +171,9 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
             issues['CorrectionsWorkspace'] = error_msg
             issues['CanWorkspace'] = error_msg
 
+        if not isinstance(self._corrections_workspace, WorkspaceGroup):
+            issues['CorrectionsWorkspace'] = "The corrections workspace should be a workspace group."
+
         if self._use_corrections:
             if self._corrections_workspace.size() == 0:
                 issues['CorrectionsWorkspace'] = "No corrections found in the supplied corrections workspace group."
@@ -227,7 +230,11 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
 
         if self._use_corrections:
             if self._corrections_workspace.size() == 1:
-                self._factors = ['acc']
+                correction_name = self._corrections_workspace[0].getName()
+                if 'acc' in correction_name:
+                    self._factors = ['acc']
+                elif 'ass' in correction_name:
+                    self._factors = ['ass']
             if self._corrections_workspace.size() == 2:
                 self._factors = ['acc', 'ass']
                 self._corrections_approximation = self._two_factor_corrections_approximation

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrection.py
@@ -171,10 +171,10 @@ class ApplyPaalmanPingsCorrection(PythonAlgorithm):
             issues['CorrectionsWorkspace'] = error_msg
             issues['CanWorkspace'] = error_msg
 
-        if not isinstance(self._corrections_workspace, WorkspaceGroup):
-            issues['CorrectionsWorkspace'] = "The corrections workspace should be a workspace group."
-
         if self._use_corrections:
+            if not isinstance(self._corrections_workspace, WorkspaceGroup):
+                issues['CorrectionsWorkspace'] = "The corrections workspace should be a workspace group."
+
             if self._corrections_workspace.size() == 0:
                 issues['CorrectionsWorkspace'] = "No corrections found in the supplied corrections workspace group."
             else:

--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -110,6 +110,11 @@ Improvements
 - The option to choose which spectrum to Plot Spectrum for is now available in the ContainerSubtraction Tab and
   ApplyAbsorptionCorrections Tab.
 
+Bugfixes
+########
+- Fixed a bug where ApplyAbsorptionCorrections would not apply corrections if the *_Corrections* group workspace
+  did not contain sample attenuation (*_ass*).
+
 
 Data Reduction Interface
 ------------------------


### PR DESCRIPTION
**Description of work.**
This PR fixes the Apply Absorption Corrections tab which won't work if there is only sample attenuation (_ass).

**To test:**
1.`Interfaces`->`Indirect`->`Corrections`->`CalculateMonteCarloAbsorption`
2. Enter the data below
Sample: `26176`
Container: `26174`
Shape: `FlatPlate`
Sample and Container Height & width: `1.0`
Sample and Container Thickness: `0.1`
Sample mass density: `1`
Sample Formula: `H2-O`
Container mass density: `6`
Container Formula: `V`
3. Click Run and wait.
4. In the output group, delete the `_asc` workspace (so the group only contains `_ass`)
5. Go to `ApplyAbsorptionCorrections`
6. Sample is `26176` and corrections workspace is the one generated above
7. Click Run. No error!

Fixes #25212

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2977934/irs26176_graphite002_red.zip)
[irs26174_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2977935/irs26174_graphite002_red.zip)

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
