### PR TITLE
Indirect data reduction transmission crash fix

### DIFF
--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -135,6 +135,7 @@ Bugfixes
 - A bug where specifying a custom detector grouping for OSIRIS was not working has been fixed.
 - A bug caused by incorrect masked detectors during a reduction of an individual runs has been fixed. This could sometimes cause 
   unexpected peaks in the output plots.
+- A crash caused by data being loaded multiple times on the transmission tab has been fixed.
 
 .. figure:: ../../images/TOSCA_Individual_Runs_Bug.png
   :class: screenshot

--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -135,7 +135,8 @@ Bugfixes
 - A bug where specifying a custom detector grouping for OSIRIS was not working has been fixed.
 - A bug caused by incorrect masked detectors during a reduction of an individual runs has been fixed. This could sometimes cause 
   unexpected peaks in the output plots.
-- A crash caused by data being loaded multiple times on the transmission tab has been fixed.
+- A crash caused by data being loaded multiple times on the transmission tab has been fixed, as part of this fix the preview now shows a
+  preview of the plot on run being clicked and not before as this was the cause of the issue.
 
 .. figure:: ../../images/TOSCA_Individual_Runs_Bug.png
   :class: screenshot

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -28,10 +28,6 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
   // Update the preview plot when the algorithm is complete
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(transAlgDone(bool)));
-  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(QString)), this,
-          SLOT(dataLoaded()));
-  connect(m_uiForm.dsCanInput, SIGNAL(dataReady(QString)), this,
-          SLOT(dataLoaded()));
 
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
@@ -84,30 +80,6 @@ bool IndirectTransmission::validate() {
     return false;
 
   return true;
-}
-
-void IndirectTransmission::dataLoaded() {
-  if (validate())
-    previewPlot();
-}
-
-void IndirectTransmission::previewPlot() {
-  QString sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-  QString canWsName = m_uiForm.dsCanInput->getCurrentDataName();
-  QString outWsName = sampleWsName + "_transmission";
-
-  IAlgorithm_sptr transAlg =
-      AlgorithmManager::Instance().create("IndirectTransmissionMonitor", -1);
-  transAlg->initialize();
-
-  transAlg->setProperty("SampleWorkspace", sampleWsName.toStdString());
-  transAlg->setProperty("CanWorkspace", canWsName.toStdString());
-  transAlg->setProperty("OutputWorkspace", outWsName.toStdString());
-
-  // Set the workspace name for Python script export
-  m_pythonExportWsName = sampleWsName.toStdString() + "_Trans";
-
-  runAlgorithm(transAlg);
 }
 
 void IndirectTransmission::transAlgDone(bool error) {

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.h
@@ -35,8 +35,6 @@ public:
   bool validate() override;
 
 private slots:
-  void dataLoaded();
-  void previewPlot();
   void transAlgDone(bool error);
   void instrumentSet();
 


### PR DESCRIPTION
**Description of work.**
changed preview window to not run the entire algorithm on loading data which led to attempting to load the same data multiple times while the previous load was still running, the preview window now displays a preview of the plot when run is clicked and not before, preventing both this issue, and preventing the algorithm from being ran twice by the gui.

**Testing**

Follow instructions for reproducing issue, no crash should occur, also attempt inputting the background then hitting enter twice, this should also not cause the preview to attempt to run twice, which could also cause a crash.

Fixes #25191 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
