### PR TITLE
Change Mask Energies Label Indirect

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -178,8 +178,8 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Energies
-  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask Energies of Spectrum’ label 
+Mask X Range
+  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 
 Run
@@ -329,8 +329,8 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Energies
-  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask Energies of Spectrum’ label 
+Mask X Range
+  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 
 Run
@@ -432,8 +432,8 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Energies
-  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask Energies of Spectrum’ label 
+Mask Q Range
+  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 
 Run
@@ -516,8 +516,8 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Energies
-  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask Energies of Spectrum’ label 
+Mask Q Range
+  Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 
 Run

--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -432,7 +432,7 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Q Range
+Mask X Range
   Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 
@@ -516,7 +516,7 @@ Plot Guess
 Fit Spectra
   Choose a range or discontinuous list of spectra to be fitted.
 
-Mask Q Range
+Mask X Range
   Energy ranges may be excluded from a fit by selecting a spectrum next to the ‘Mask X Range of Spectrum’ label
   and then providing a comma-separated list of pairs, where each pair designates a range to exclude from the fit.
 

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
@@ -17,7 +17,7 @@ QStringList convFitHeaders() {
           << "WS Index"
           << "StartX"
           << "EndX"
-          << "Mask Q Range";
+          << "Mask X Range";
   return headers;
 }
 } // namespace

--- a/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitDataTablePresenter.cpp
@@ -17,7 +17,7 @@ QStringList convFitHeaders() {
           << "WS Index"
           << "StartX"
           << "EndX"
-          << "Mask Energies";
+          << "Mask Q Range";
   return headers;
 }
 } // namespace

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
@@ -64,7 +64,7 @@ QStringList defaultHeaders() {
           << "WS Index"
           << "StartX"
           << "EndX"
-          << "Mask Energies";
+          << "Mask X Range";
   return headers;
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelector.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelector.ui
@@ -99,7 +99,7 @@
    <item>
     <widget class="QLabel" name="lbMaskSpectrum">
      <property name="text">
-      <string>Mask Energies of Spectrum</string>
+      <string>Mask X Range of Spectrum</string>
      </property>
     </widget>
    </item>

--- a/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.cpp
@@ -17,7 +17,7 @@ QStringList jumpFitHeaders() {
           << "WS Index"
           << "StartX"
           << "EndX"
-          << "Mask Energies";
+          << "Mask Q Range";
   return headers;
 }
 } // namespace

--- a/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitDataTablePresenter.cpp
@@ -17,7 +17,7 @@ QStringList jumpFitHeaders() {
           << "WS Index"
           << "StartX"
           << "EndX"
-          << "Mask Q Range";
+          << "Mask X Range";
   return headers;
 }
 } // namespace


### PR DESCRIPTION
**Description of work.**
This PR changes the name of a column in some indirect tabs to more accurately describe the nature of the x data (previously it was "Mask Energies", but the x data is not necessarily energy)

**To test:**
1. Interfaces -> Indirect -> Data Analysis
2. The Multiple input table in the MSDFit and IqtFit tabs should have a column "Mask X Range"
3. The multiple input table in the ConvFit and FQFit tabs should have a column "Mask Q Range"

Fixes #25214 

*This does not require release notes* because **fill in an explanation of why**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
