### PR TITLE
Indirect - Prevent loading of workspace with one data point on FQFit

### DIFF
--- a/docs/source/release/v4.0.0/indirect_inelastic.rst
+++ b/docs/source/release/v4.0.0/indirect_inelastic.rst
@@ -135,6 +135,7 @@ Bugfixes
   fixed.
 - A bug causing the preview plot in Elwin not to update when changing the selected workspace has been
   fixed.
+- Fixed an issue on FQFit where a workspace with only one data point could be loaded.
 
 
 Data Corrections Interface

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -61,8 +61,8 @@ void JumpFit::setupFitTab() {
   m_uiForm->svSpectrumView->hideSpectrumSelector();
   m_uiForm->svSpectrumView->hideMaskSpectrumSelector();
 
-  setSampleWSSuffices({"_Result"});
-  setSampleFBSuffices({"_Result.nxs"});
+  setSampleWSSuffices({"_Result", "_Results"});
+  setSampleFBSuffices({"_Result.nxs", "_Results.nxs"});
 
   addFunctions(getWidthFunctions());
   addFunctions(getEISFFunctions());

--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -61,8 +61,8 @@ void JumpFit::setupFitTab() {
   m_uiForm->svSpectrumView->hideSpectrumSelector();
   m_uiForm->svSpectrumView->hideMaskSpectrumSelector();
 
-  setSampleWSSuffices({"_Result", "_Results"});
-  setSampleFBSuffices({"_Result.nxs", "_Results.nxs"});
+  setSampleWSSuffices({"_Result"});
+  setSampleFBSuffices({"_Result.nxs"});
 
   addFunctions(getWidthFunctions());
   addFunctions(getEISFFunctions());

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -220,6 +220,9 @@ void JumpFitModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
   if (!spectrum)
     throw std::invalid_argument("Workspace contains no Width or EISF spectra.");
 
+  if (workspace->y(0).size() == 1)
+    throw std::invalid_argument("Workspace contains only one data point.");
+
   const auto hwhmWorkspace =
       createHWHMWorkspace(workspace, name, parameters.widthSpectra);
   IndirectFittingModel::addNewWorkspace(hwhmWorkspace,


### PR DESCRIPTION
**Description of work.**
This PR prevents the user from loading a workspace with one data point. This prevents an error when clicking Run.

**To test:**
Repeat the steps seen in #25224 .

Fixes #25224

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
