### PR TITLE
Corrected range validation

### DIFF
--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -120,10 +120,10 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
  */
 size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX) {
-  if (startX > *xData.rawData().end()){
-    throw std::invalid_argument( "Start of range is after data end." );
+  if (startX > *xData.rawData().end()) {
+    throw std::invalid_argument("Start of range is after data end.");
   }
-  
+
   auto upper =
       std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
   return std::distance(xData.rawData().begin(), upper);
@@ -137,10 +137,10 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
  */
 size_t endIndexFromTime(const HistogramData::BinEdges &xData,
                         const double endX) {
-  if (endX < *xData.rawData().begin()){
-    throw std::invalid_argument( "End of range is before data start." );
+  if (endX < *xData.rawData().begin()) {
+    throw std::invalid_argument("End of range is before data start.");
   }
-  
+
   auto lower =
       std::upper_bound(xData.rawData().begin(), xData.rawData().end(), endX);
   return std::distance(xData.rawData().begin(), lower - 1);

--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -120,12 +120,16 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
  */
 size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX) {
+  if (startX > *xData.rawData().end()){
+    throw std::invalid_argument( "Start of range is after data end." );
+  }
+  
   auto upper =
       std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
   return std::distance(xData.rawData().begin(), upper);
 }
 /**
- * find the first index in bin edges that is after
+ * find the last index in bin edges that is before
  * the end time.
  * @param xData :: [input] HistogramData as bin edges
  * @param endX :: [input] the end time
@@ -133,6 +137,10 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
  */
 size_t endIndexFromTime(const HistogramData::BinEdges &xData,
                         const double endX) {
+  if (endX < *xData.rawData().begin()){
+    throw std::invalid_argument( "End of range is before data start." );
+  }
+  
   auto lower =
       std::upper_bound(xData.rawData().begin(), xData.rawData().end(), endX);
   return std::distance(xData.rawData().begin(), lower - 1);

--- a/Framework/Muon/src/MuonAsymmetryHelper.cpp
+++ b/Framework/Muon/src/MuonAsymmetryHelper.cpp
@@ -120,12 +120,12 @@ double estimateNormalisationConst(const HistogramData::Histogram &histogram,
  */
 size_t startIndexFromTime(const HistogramData::BinEdges &xData,
                           const double startX) {
-  if (startX > *xData.rawData().end()) {
-    throw std::invalid_argument("Start of range is after data end.");
-  }
-
   auto upper =
       std::lower_bound(xData.rawData().begin(), xData.rawData().end(), startX);
+
+  if (upper == xData.rawData().end()) {
+    throw std::invalid_argument("Start of range is after data end.");
+  }
   return std::distance(xData.rawData().begin(), upper);
 }
 /**
@@ -137,12 +137,12 @@ size_t startIndexFromTime(const HistogramData::BinEdges &xData,
  */
 size_t endIndexFromTime(const HistogramData::BinEdges &xData,
                         const double endX) {
-  if (endX < *xData.rawData().begin()) {
-    throw std::invalid_argument("End of range is before data start.");
-  }
 
   auto lower =
       std::upper_bound(xData.rawData().begin(), xData.rawData().end(), endX);
+  if (lower == xData.rawData().begin()) {
+    throw std::invalid_argument("End of range is before data start.");
+  }
   return std::distance(xData.rawData().begin(), lower - 1);
 }
 

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
 
-
 def calculate_group_data(context, group_name, run, rebin):
     processed_data = _run_pre_processing(context, run, rebin)
 
@@ -129,6 +128,8 @@ def _get_MuonGroupingAsymmetry_parameters(context, group_name, run):
 
     if 'GroupRangeMax' in context.gui_variables:
         params['AsymmetryTimeMax'] = context.gui_variables['GroupRangeMax']
+    else:
+        params['AsymmetryTimeMax'] = max(context.loaded_data(run)['OutputWorkspace'][0].workspace.dataX(0))
 
     if context.is_multi_period() and 'SummedPeriods' in context.gui_variables:
         summed_periods = context.gui_variables["SummedPeriods"]

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import Muon.GUI.Common.utilities.algorithm_utils as algorithm_utils
 
+
 def calculate_group_data(context, group_name, run, rebin):
     processed_data = _run_pre_processing(context, run, rebin)
 

--- a/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -186,7 +186,10 @@ class GroupingTablePresenter(object):
 
     def handle_group_range_min_updated(self):
         range_min_new = float(self._view.group_range_min.text())
-        if range_min_new < self._model._data.gui_variables['GroupRangeMax']:
+        range_max_current = self._model._data.gui_variables['GroupRangeMax'] if 'GroupRangeMax' in\
+                                                                                self._model._data.gui_variables \
+            else self._model.get_last_data_from_file()
+        if range_min_new < range_max_current:
             self._model._data.add_or_replace_gui_variables(GroupRangeMin=range_min_new)
         else:
             self._view.group_range_min.setText(str(self._model._data.gui_variables['GroupRangeMin']))
@@ -194,8 +197,11 @@ class GroupingTablePresenter(object):
 
     def handle_group_range_max_updated(self):
         range_max_new = float(self._view.group_range_max.text())
-        if range_max_new > self._model._data.gui_variables['GroupRangeMin']:
-            self._model._data.add_or_replace_gui_variables(GroupRangeMax=float(self._view.group_range_max.text()))
+        range_min_current = self._model._data.gui_variables['GroupRangeMin'] if 'GroupRangeMin' in\
+                                                                                self._model._data.gui_variables \
+            else self._model.get_first_good_data_from_file()
+        if range_max_new > range_min_current:
+            self._model._data.add_or_replace_gui_variables(GroupRangeMax=range_max_new)
         else:
             self._view.group_range_max.setText(str(self._model._data.gui_variables['GroupRangeMax']))
             self._view.warning_popup('Maximum of group asymmetry range must be greater than minimum')

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -66,6 +66,7 @@ def run_MuonGroupingAsymmetry(parameter_dict):
     alg = mantid.AlgorithmManager.create("MuonGroupingAsymmetry")
     alg.initialize()
     alg.setAlwaysStoreInADS(False)
+    alg.setRethrows(True)
     alg.setProperty("OutputWorkspace", "__notUsed")
     alg.setProperties(parameter_dict)
     alg.execute()

--- a/scripts/test/Muon/home_grouping_widget_test.py
+++ b/scripts/test/Muon/home_grouping_widget_test.py
@@ -51,8 +51,6 @@ class HomeTabGroupingPresenterTest(unittest.TestCase):
         self.context.update_current_data()
         test_pair = MuonPair('test_pair', 'top', 'bottom', alpha=0.75)
         self.context.add_pair(pair=test_pair)
-        self.context.show_all_groups()
-        self.context.show_all_pairs()
         self.presenter.update_group_pair_list()
 
     def tearDown(self):


### PR DESCRIPTION
**Description of work.**
This updates the validation on the group asymmetry ranges so that they do not fail if one of the two is still set to come from file.

**To test:**
* Open up the Frequency Domain Analysis GUI and load any run. In this case the run does not matter. EMU19489 can be found in the unit test data.
* Go to the grouping tab select to manually change the minima of the range beneath the first table try to change it to invalid and valid values and check the GUI behaves appropriately. 
* Switch to manually updating the maxima if the range and taking the minima from file and check the same things
<!-- Instructions for testing. -->

Fixes #25227  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it fixes a bug introduced in this release cycle.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
