### PR TITLE
Update Windows build instructions for cmake 3.14

### DIFF
--- a/dev-docs/source/BuildingWithCMake.rst
+++ b/dev-docs/source/BuildingWithCMake.rst
@@ -73,13 +73,13 @@ From the CMake gui
 * Start it and click the "Browse Source" button to point to ``/path/to/Mantid``.
 * Click "Browse Build" and point to the directory you want to build into - it's recommended that you create a new directory for this (see above), though it can be the same as the source directory.
 * Click "Configure" down near the bottom of the window.
-* A new window will appear asking which 'Generator' you want to use.
+* A new window will appear asking which 'Generator' you want to use:
 
   * Linux/Mac developers should choose ``Ninja``
-  * Windows developers should choose ``Visual Studio 15 2017 Win64`` (the Win64 is very important)
+  * Windows developers should choose ``Visual Studio 15 2017`` and in the _Optional platform for generator\_ box select ``x64``. If you see errors related to HDF5 then you have most likely selected the wrong platform. 
 
 * Wait a while....
-* You will be presented with a list of options in red that can in principle be changed. You probably don't want to change anything, except perhaps checking "MAKE_VATES" if you want to build that.
+* You will be presented with a list of options in red that can in principle be changed. You probably don't want to change anything, except perhaps checking ``MAKE_VATES`` if you want to build that.
 * Click "Configure" again and wait....
 * Finally, click "Generate". This will create the build files, e.g. for a Visual Studio build there will be a ``Mantid.sln`` in the directory you selected as your build directory.
 

--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -34,7 +34,7 @@ Install the following:
   * open up Git Bash and run ``git config --global lfs.storage C:/GitLFSStorage``
   * run ``git lfs install`` to initialize Git LFS. (Note that if you miss this step you may get errors due to the third party libraries not checking out properly. This can be fixed later by running ``git lfs fetch`` and ``git lfs checkout`` in the ``external\src\ThirdParty`` directory.)
 
-* `CMake <https://cmake.org/download/>`_ >= 3.7
+* `CMake <https://cmake.org/download/>`_ >= 3.14
 * `MiKTeX <https://miktex.org/download>`_. Installation instructions are  `available here <https://miktex.org/howto/install-miktex>`_. Once installed:
 
   * open the MikTeX console from the start menu
@@ -92,7 +92,7 @@ OSX
 The build environment on OS X is described here :ref:`BuildingOnOSX`.
 
 Getting the Mantid code
-############################
+#######################
 We use `Git`_ as our version control system (VCS). The master copies of our repositories are located at `GitHub <http://github.com/mantidproject>`_. We have a number of repositories, of which the main one (the one containing all the source code for Mantid itself) is called simply `mantid <http://github.com/mantidproject/mantid>`_.
 
 If you are not already set up with Git, you can follow these `instructions <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_.

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -4,6 +4,14 @@
 Tools Overview
 ==============
 
+.. toctree::
+   :hidden:
+
+   AlgorithmProfiler
+
+.. contents:: Contents
+   :local:
+
 Creating classes: class_maker.py
 --------------------------------
 
@@ -42,6 +50,11 @@ This python script is located in in /buildconfig/. It will delete a
 class from one subproject. CMakeList.txt is adjusted. For details, run:
 
 ``buildconfig/delete_class.py --help``
+
+Profiling an algorithm
+----------------------
+
+On Linux the build can be configured to generated algorithm profiling information. See :doc:`AlgorithmProfiler <AlgorithmProfiler>` for more details.
 
 Leak checking etc
 -----------------


### PR DESCRIPTION
**Description of work.**

Updates the instructions for building on Windows with CMake 3.14. The platform is no longer a part of the generator name and must be selected separately.

**To test:**

Review the text.

*There is no associated issue.*

*This does not require release notes* because **it is a developer docs change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
