### PR TITLE
Indirect Paalman Pings re-enable Run button after an error

### DIFF
--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -400,6 +400,7 @@ void ApplyAbsorptionCorrections::addInterpolationStep(
 void ApplyAbsorptionCorrections::absCorComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(absCorComplete(bool)));
+  setRunIsRunning(false);
 
   if (!error) {
     if (m_uiForm.ckUseCan->isChecked()) {
@@ -421,7 +422,6 @@ void ApplyAbsorptionCorrections::absCorComplete(bool error) {
             SLOT(postProcessComplete(bool)));
     m_batchAlgoRunner->executeBatchAsync();
   } else {
-    setRunIsRunning(false);
     setPlotSpectrumEnabled(false);
     setPlotContourEnabled(false);
     setSaveResultEnabled(false);

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -305,6 +305,7 @@ bool CalculatePaalmanPings::doValidation(bool silent) {
 void CalculatePaalmanPings::absCorComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(absCorComplete(bool)));
+  setRunIsRunning(false);
 
   if (!error) {
     // Convert the spectrum axis of correction factors to Q
@@ -345,9 +346,12 @@ void CalculatePaalmanPings::absCorComplete(bool error) {
     connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
             SLOT(postProcessComplete(bool)));
     m_batchAlgoRunner->executeBatchAsync();
-  } else
+  } else {
+    setPlotResultEnabled(false);
+    setSaveResultEnabled(false);
     emit showMessageBox("Absorption correction calculation failed.\nSee "
                         "Results Log for more details.");
+  }
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR ensures the run button on CalculatePaalmanPings in Indirect Data Corrections is re-enabled after an error has occured.

**To test:**
See the test in the issue #25235 and load the data files below.

Clicking Run should result in the same error message but the run button should be enabled again.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2979084/irs26176_graphite002_red.zip)
[irs26174_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2979085/irs26174_graphite002_red.zip)

Fixes #25235

No Release notes required as the run button was never disabled before this release.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
