### PR TITLE
Crash when opening AlgorithmHistoryWindow with a workspace with no history

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -166,8 +166,7 @@ class WorkspaceWidget(PluginWidget):
                 except Exception as exception:
                     logger.warning("Could not open history of '{}'. "
                                    "".format(name))
-                    logger.debug("{}: {}".format(type(exception).__name__,
-                                                 exception))
+                    logger.warning("{}: {}".format(type(exception).__name__, exception))
 
     def _action_double_click_workspace(self, name):
         self._do_show_data([name])

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -298,7 +298,7 @@ class AlgorithmHistoryWindow : public QDialog {
 #include "MantidQtWidgets/Common/AlgorithmHistoryWindow.h"
 %End
 public:
-	AlgorithmHistoryWindow(QWidget *parent /TransferThis/, const QString &workspaceName);
+	AlgorithmHistoryWindow(QWidget *parent /TransferThis/, const QString &workspaceName) throw(std::invalid_argument);
 };
 
 // ---------------------------------

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -201,6 +201,16 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
       m_histPropWindow(nullptr), m_execSumGrpBox(nullptr),
       m_envHistGrpBox(nullptr), m_wsName(wsptr->getName().c_str()),
       m_view(wsptr->getHistory().createView()) {
+
+  // create a tree widget to display history properties
+  if (!m_histPropWindow)
+    m_histPropWindow = createAlgHistoryPropWindow();
+
+  if (!m_histPropWindow) {
+    throw std::runtime_error(
+        "No history could be found on the given workspace");
+  }
+
   setWindowTitle(tr("Algorithm History"));
   setMinimumHeight(500);
   setMinimumWidth(750);
@@ -234,10 +244,6 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
     // Populate the History Tree widget
     m_Historytree->populateAlgHistoryTreeWidget(m_algHist);
   }
-
-  // create a tree widget to display history properties
-  if (!m_histPropWindow)
-    m_histPropWindow = createAlgHistoryPropWindow();
 
   // connect history tree with window
   connect(m_Historytree,
@@ -366,10 +372,16 @@ AlgorithmHistoryWindow::createEnvHistGrpBox(const EnvironmentHistory &envHist) {
 }
 AlgHistoryProperties *AlgorithmHistoryWindow::createAlgHistoryPropWindow() {
   std::vector<PropertyHistory_sptr> histProp;
-  const Mantid::API::AlgorithmHistories &entries =
+  const Mantid::API::AlgorithmHistories entries =
       m_algHist.getAlgorithmHistories();
-  auto rIter = entries.rbegin();
-  histProp = (*rIter)->getProperties();
+
+  if (entries.size() != 0) {
+    auto rIter = entries.rbegin();
+    histProp = (*rIter)->getProperties();
+  } else {
+    window_log.warning("No history found for the workspace");
+    return nullptr;
+  }
 
   // AlgHistoryProperties * phistPropWindow=new
   // AlgHistoryProperties(this,m_algHist);

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -202,13 +202,8 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
       m_envHistGrpBox(nullptr), m_wsName(wsptr->getName().c_str()),
       m_view(wsptr->getHistory().createView()) {
 
-  // create a tree widget to display history properties
-  if (!m_histPropWindow)
-    m_histPropWindow = createAlgHistoryPropWindow();
-
-  if (!m_histPropWindow) {
-    throw std::runtime_error(
-        "No history could be found on the given workspace");
+  if (m_algHist.empty()) {
+    throw std::invalid_argument("No history found on the given workspace");
   }
 
   setWindowTitle(tr("Algorithm History"));
@@ -244,6 +239,10 @@ AlgorithmHistoryWindow::AlgorithmHistoryWindow(
     // Populate the History Tree widget
     m_Historytree->populateAlgHistoryTreeWidget(m_algHist);
   }
+
+  // create a tree widget to display history properties
+  if (!m_histPropWindow)
+    m_histPropWindow = createAlgHistoryPropWindow();
 
   // connect history tree with window
   connect(m_Historytree,
@@ -372,16 +371,10 @@ AlgorithmHistoryWindow::createEnvHistGrpBox(const EnvironmentHistory &envHist) {
 }
 AlgHistoryProperties *AlgorithmHistoryWindow::createAlgHistoryPropWindow() {
   std::vector<PropertyHistory_sptr> histProp;
-  const Mantid::API::AlgorithmHistories entries =
+  const Mantid::API::AlgorithmHistories &entries =
       m_algHist.getAlgorithmHistories();
-
-  if (entries.size() != 0) {
-    auto rIter = entries.rbegin();
-    histProp = (*rIter)->getProperties();
-  } else {
-    window_log.warning("No history found for the workspace");
-    return nullptr;
-  }
+  auto rIter = entries.rbegin();
+  histProp = (*rIter)->getProperties();
 
   // AlgHistoryProperties * phistPropWindow=new
   // AlgHistoryProperties(this,m_algHist);


### PR DESCRIPTION
**Description of work.**
It Crashed. Now it does not. The workbench would Segfault when this happened, to solve this I added an exception to be thrown. This stops the constructor and works fine in Workbench and MantidPlot.

**To test:**
- Open Workbench
- Run this script
```python
LoadEmptyInstrument(InstrumentName='PG3', OutputWorkspace='PG3')
wksp = WorkspaceFactory.create(mtd['PG3'], NVectors=mtd['PG3'].getNumberHistograms(),
                               XLength=11, YLength=10)
AnalysisDataService.addOrReplace('wksp', wksp)
```
- Right click on wksp
- Click show history
- The logger should show some warnings but not crash workbench.

<!-- Instructions for testing. -->

Fixes #25230. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
