### PR TITLE
TableWorkspaceDisplay - automatically mark columns as X/Y/YErr. Add Scatter with Errors

### DIFF
--- a/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
+++ b/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
@@ -8,6 +8,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mantid.py3compat.mock import Mock
+from mantidqt.utils.testing.strict_mock import StrictMock
 
 AXIS_INDEX_FOR_HORIZONTAL = 0
 AXIS_INDEX_FOR_VERTICAL = 1
@@ -72,41 +73,43 @@ class MockWorkspace:
         # This is assigned to a function, as the original implementation is a function that returns
         # the spectrumInfo object
         self.spectrumInfo = self._return_MockSpectrumInfo
-        self.getNumberHistograms = Mock(return_value=1)
-        self.isHistogramData = Mock(return_value=isHistogramData)
-        self.blocksize = Mock(return_value=len(read_return))
-        self.readX = Mock(return_value=read_return)
-        self.readY = Mock(return_value=read_return)
-        self.readE = Mock(return_value=read_return)
-        self.axes = Mock(return_value=axes)
+        self.getNumberHistograms = StrictMock(return_value=1)
+        self.isHistogramData = StrictMock(return_value=isHistogramData)
+        self.blocksize = StrictMock(return_value=len(read_return))
+        self.readX = StrictMock(return_value=read_return)
+        self.readY = StrictMock(return_value=read_return)
+        self.readE = StrictMock(return_value=read_return)
+        self.axes = StrictMock(return_value=axes)
         self.hasMaskedBins = None
         self.maskedBinsIndices = None
-        self.isCommonBins = Mock(return_value=True)
+        self.isCommonBins = StrictMock(return_value=True)
 
         self.column_types = ["int", "float", "string", "v3d", "bool"]
-        self.columnTypes = Mock(return_value=self.column_types)
+        self.columnTypes = StrictMock(return_value=self.column_types)
 
         self.mock_spectrum = MockSpectrum()
-        self.getSpectrum = Mock(return_value=self.mock_spectrum)
+        self.getSpectrum = StrictMock(return_value=self.mock_spectrum)
 
         self.mock_axis = MockMantidAxis()
-        self.getAxis = Mock(return_value=self.mock_axis)
+        self.getAxis = StrictMock(return_value=self.mock_axis)
 
-        self.setCell = Mock()
+        self.setCell = StrictMock()
 
-        self.name = Mock(return_value=self.TEST_NAME)
+        self.name = StrictMock(return_value=self.TEST_NAME)
 
         self._column_names = []
         for i in range(self.COLS):
             self._column_names.append("col{0}".format(i))
 
-        self.getColumnNames = Mock(return_value=self._column_names)
+        self.getColumnNames = StrictMock(return_value=self._column_names)
         self.column_count = self.COLS
-        self.columnCount = Mock(return_value=self.column_count)
+        self.columnCount = StrictMock(return_value=self.column_count)
 
         self.row_count = self.ROWS
-        self.rowCount = Mock(return_value=self.row_count)
+        self.rowCount = StrictMock(return_value=self.row_count)
 
-        self.column = Mock(return_value=[1] * self.row_count)
+        self.column = StrictMock(return_value=[1] * self.row_count)
 
-        self.emit_repaint = Mock()
+        self.emit_repaint = StrictMock()
+
+        self.getPlotType = StrictMock()

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/__init__.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/__init__.py
@@ -4,13 +4,12 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
-
-from mantidqt.widgets.workspacedisplay.status_bar_view import StatusBarView
-from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
-from mantidqt.widgets.workspacedisplay.table.io import TableWorkspaceDisplayDecoder, TableWorkspaceDisplayEncoder
+#  This file is part of the mantidqt package.
 from mantidqt.project.decoderfactory import DecoderFactory
 from mantidqt.project.encoderfactory import EncoderFactory
+from mantidqt.widgets.workspacedisplay.status_bar_view import StatusBarView
+from mantidqt.widgets.workspacedisplay.table.io import TableWorkspaceDisplayDecoder, TableWorkspaceDisplayEncoder
+from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 
 
 def compatible_check_for_encoder(obj, _):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/__main__.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/__main__.py
@@ -4,16 +4,13 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
-#
-#
+#  This file is part of the mantidqt package.
 
 # To Run - target this package with PyCharm, and __main__ will be executed
 
 import matplotlib
 
 matplotlib.use('Qt5Agg')
-
 
 from qtpy.QtWidgets import QApplication  # noqa: F402
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
@@ -4,11 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#    This file is part of the mantid workbench.
-#
-#
-
-
+#    This file is part of the mantidqt package.
 class ErrorColumn:
     CANNOT_SET_Y_TO_BE_OWN_YERR_MESSAGE = "Cannot set Y column to be its own YErr"
     UNHANDLED_COMPARISON_LOGIC_MESSAGE = "Unhandled comparison logic with type {}"

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
@@ -5,6 +5,9 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #    This file is part of the mantidqt package.
+from __future__ import absolute_import
+
+
 class ErrorColumn:
     CANNOT_SET_Y_TO_BE_OWN_YERR_MESSAGE = "Cannot set Y column to be its own YErr"
     UNHANDLED_COMPARISON_LOGIC_MESSAGE = "Unhandled comparison logic with type {}"

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/io.py
@@ -4,12 +4,10 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
-#
-
-from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
-from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
+#  This file is part of the mantidqt package.
 from mantid.api import AnalysisDataService as ADS  # noqa
+from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
+from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 
 
 class TableWorkspaceDisplayAttributes(object):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
@@ -5,6 +5,9 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #    This file is part of the mantidqt package.
+from __future__ import absolute_import
+
+
 class MarkedColumns:
     X_LABEL = "[X{}]"
     Y_LABEL = "[Y{}]"

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
@@ -4,11 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#    This file is part of the mantid workbench.
-#
-#
-
-
+#    This file is part of the mantidqt package.
 class MarkedColumns:
     X_LABEL = "[X{}]"
     Y_LABEL = "[Y{}]"
@@ -96,6 +92,8 @@ class MarkedColumns:
         Retrieve the corresponding YErr column for each Y column, so that it can be plotted
         :param selected_columns: Selected Y columns for which their YErr columns will be retrieved
         :return: Dict[Selected Column] = Column with YErr
+        :returns: Dictionary, where the keys are selected columns,
+                  and the values the error associated with the selected columns
         """
         yerr_for_col = {}
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
@@ -71,12 +71,13 @@ class TableWorkspaceDisplayModel:
             elif plot_type == TableWorkspaceColumnTypeMapping.YERR:
                 # only mark YErrs only if there are any columns that have been marked as Y
                 # if there are none then do not mark anything as YErr
-                if len(self.marked_columns.as_y) > 0:
-                    # assume all the YErrs are associated with the first Y column. There isn't a way to know
-                    # the correct Y column, as that information is not stored in the table workspace - the
-                    # original table workspace does not associate Y errors columns with specific Y columns
+                if len(self.marked_columns.as_y) > len(self.marked_columns.as_y_err):
+                    # Assume all the YErrs are associated with the first available (no other YErr has it) Y column.
+                    # There isn't a way to know the correct Y column, as that information is not stored
+                    # in the table workspace - the original table workspace does not associate Y errors
+                    # columns with specific Y columns
                     err_for_column = self.marked_columns.as_y[len(self.marked_columns.as_y_err)]
-                    label = str(len(self.marked_columns.as_y) - 1)
+                    label = str(len(self.marked_columns.as_y_err))
                     self.marked_columns.add_y_err(ErrorColumn(col, err_for_column, label))
 
     def _get_v3d_from_str(self, string):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
@@ -5,15 +5,30 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
-#
-#
+#  This file is part of the mantidqt package.
 from __future__ import (absolute_import, division, print_function)
 
 from mantid.dataobjects import PeaksWorkspace, TableWorkspace
 from mantid.kernel import V3D
 from mantid.simpleapi import DeleteTableRows, SortPeaksWorkspace, SortTableWorkspace, StatisticsOfTableWorkspace
+from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.marked_columns import MarkedColumns
+
+
+class TableWorkspaceColumnTypeMapping(object):
+    """
+    Enum can't be used here because the original C++ code maps the types to integers.
+    Comparing the integer to a Python enum does not work, as it does not simply compare
+    the integer values. So the types are just stored as integers here
+    """
+    NotSet = -1000
+    NoType = 0
+    X = 1
+    Y = 2
+    Z = 3
+    XERR = 4
+    YERR = 5
+    LABEL = 6
 
 
 class TableWorkspaceDisplayModel:
@@ -45,6 +60,24 @@ class TableWorkspaceDisplayModel:
         self.ws_num_cols = self.ws.columnCount()
         self.marked_columns = MarkedColumns()
         self._original_column_headers = self.get_column_headers()
+
+        # loads the types of the columns
+        for col in range(self.ws_num_cols):
+            plot_type = self.ws.getPlotType(col)
+            if plot_type == TableWorkspaceColumnTypeMapping.X:
+                self.marked_columns.add_x(col)
+            elif plot_type == TableWorkspaceColumnTypeMapping.Y:
+                self.marked_columns.add_y(col)
+            elif plot_type == TableWorkspaceColumnTypeMapping.YERR:
+                # only mark YErrs only if there are any columns that have been marked as Y
+                # if there are none then do not mark anything as YErr
+                if len(self.marked_columns.as_y) > 0:
+                    # assume all the YErrs are associated with the first Y column. There isn't a way to know
+                    # the correct Y column, as that information is not stored in the table workspace - the
+                    # original table workspace does not associate Y errors columns with specific Y columns
+                    err_for_column = self.marked_columns.as_y[len(self.marked_columns.as_y_err)]
+                    label = str(len(self.marked_columns.as_y) - 1)
+                    self.marked_columns.add_y_err(ErrorColumn(col, err_for_column, label))
 
     def _get_v3d_from_str(self, string):
         if '[' in string and ']' in string:

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
@@ -69,7 +69,7 @@ class TableWorkspaceDisplayModel:
             elif plot_type == TableWorkspaceColumnTypeMapping.Y:
                 self.marked_columns.add_y(col)
             elif plot_type == TableWorkspaceColumnTypeMapping.YERR:
-                # only mark YErrs only if there are any columns that have been marked as Y
+                # mark YErrs only if there are any columns that have been marked as Y
                 # if there are none then do not mark anything as YErr
                 if len(self.marked_columns.as_y) > len(self.marked_columns.as_y_err):
                     # Assume all the YErrs are associated with the first available (no other YErr has it) Y column.

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/plot_type.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/plot_type.py
@@ -6,3 +6,4 @@ class PlotType(Enum):
     SCATTER = 2
     LINE_AND_SYMBOL = 3
     LINEAR_WITH_ERR = 4
+    SCATTER_WITH_ERR = 5

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -35,7 +35,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
     TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE = "Too many selected to set as Y Error"
     CANNOT_PLOT_AGAINST_SELF_MESSAGE = "Cannot plot column against itself."
     NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = "Column '{}' does not have an associated Y error column." \
-                                            " Please set it by doing: Right click on column ->" \
+                                            "\n\nPlease set it by doing: Right click on column ->" \
                                             " Set error for Y -> The label shown on the Y column"
     PLOT_FUNCTION_ERROR_MESSAGE = "One or more of the columns being plotted contain invalid data for Matplotlib.\n\nError message:\n{}"
     INVALID_DATA_WINDOW_TITLE = "Invalid data - Mantid Workbench"

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -34,7 +34,9 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
     ITEM_CHANGED_UNKNOWN_ERROR_MESSAGE = "Unknown error occurred: {}"
     TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE = "Too many selected to set as Y Error"
     CANNOT_PLOT_AGAINST_SELF_MESSAGE = "Cannot plot column against itself."
-    NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = "There is no associated YErr for each selected Y column."
+    NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE = "Column '{}' does not have an associated Y error column." \
+                                            " Please set it by doing: Right click on column ->" \
+                                            " Set error for Y -> The label shown on the Y column"
     PLOT_FUNCTION_ERROR_MESSAGE = "One or more of the columns being plotted contain invalid data for Matplotlib.\n\nError message:\n{}"
     INVALID_DATA_WINDOW_TITLE = "Invalid data - Mantid Workbench"
     COLUMN_DISPLAY_LABEL = 'Column {}'
@@ -322,7 +324,9 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
                     # the column is not contained within the selected one
                     pass
             if len(yerr) != len(selected_columns):
-                self.view.show_warning(self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE)
+                column_headers = self.model.original_column_headers()
+                self.view.show_warning(self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(
+                    ",".join([column_headers[col] for col in selected_columns])))
                 return
         x = self.model.get_column(selected_x)
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -4,9 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
-#
-#
+#  This file is part of mantidqt package.
 from __future__ import absolute_import, division, print_function
 
 from functools import partial
@@ -309,22 +307,34 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
 
         self._do_plot(selected_columns, selected_x, plot_type)
 
+    def _is_error_plot(self, plot_type):
+        return plot_type == PlotType.LINEAR_WITH_ERR or plot_type == PlotType.SCATTER_WITH_ERR
+
     def _do_plot(self, selected_columns, selected_x, plot_type):
-        if plot_type == PlotType.LINEAR_WITH_ERR:
+        if self._is_error_plot(plot_type):
             yerr = self.model.marked_columns.find_yerr(selected_columns)
+            # remove the Y error columns if they are in the selection for plotting
+            # this prevents them from being treated as Y columns
+            for err_col in yerr.values():
+                try:
+                    selected_columns.remove(err_col)
+                except ValueError:
+                    # the column is not contained within the selected one
+                    pass
             if len(yerr) != len(selected_columns):
                 self.view.show_warning(self.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE)
                 return
         x = self.model.get_column(selected_x)
 
-        fig, ax = self.plot.subplots(subplot_kw={'projection': 'mantid'})
+        fig, ax = self.plot.subplots()
         fig.canvas.set_window_title(self.model.get_name())
         ax.set_xlabel(self.model.get_column_header(selected_x))
 
         plot_func = self._get_plot_function_from_type(ax, plot_type)
         kwargs = {}
         for column in selected_columns:
-            if plot_type == PlotType.LINEAR_WITH_ERR:
+            # if the errors are being plotted, retrieve the data for the column
+            if self._is_error_plot(plot_type):
                 yerr_column = yerr[column]
                 yerr_column_data = self.model.get_column(yerr_column)
                 kwargs["yerr"] = yerr_column_data
@@ -352,6 +362,8 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
             plot_func = partial(ax.plot, marker='o')
         elif type == PlotType.LINEAR_WITH_ERR:
             plot_func = ax.errorbar
+        elif type == PlotType.SCATTER_WITH_ERR:
+            plot_func = partial(ax.errorbar, fmt='o')
         else:
             raise ValueError("Plot Type: {} not currently supported!".format(type))
         return plot_func

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -588,7 +588,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.LINEAR_WITH_ERR)
 
     @with_mock_presenter(add_selection_model=True, add_plot=True)
-    def test_do_action_plot_multiple_y_linear_error_plot(self, ws, view, twd):
+    def test_do_action_plot_multiple_y_scatter_error_plot(self, ws, view, twd):
         """
         Test for _Scatter_ plotting (with errors) multiple Y columns in selection,
         each of which has an associated Y error column
@@ -607,7 +607,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
                                                        append_yerr_to_selection=True)
 
     @with_mock_presenter(add_selection_model=True, add_plot=True)
-    def test_do_action_plot_multiple_y_linear_error_plot_append_yerrs(self, ws, view, twd):
+    def test_do_action_plot_multiple_y_scatter_error_plot_append_yerrs(self, ws, view, twd):
         self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.SCATTER_WITH_ERR, {'fmt': 'o'},
                                                        append_yerr_to_selection=True)
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -621,6 +621,8 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         :param extra_errorbar_assert_kwargs: Extra arguments expanded in the assertion for the errorbar call
         :return:
         """
+        if extra_errorbar_assert_kwargs is None:
+            extra_errorbar_assert_kwargs = dict()
         col_as_x = 0
         col_as_y1 = 1
         col_as_y1_err = 2

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -416,11 +416,13 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, 1)]
         twd.action_set_as_x()
 
-        view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, 2)]
+        y_column_index = 2
+        view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, y_column_index)]
         twd.action_set_as_y()
 
         twd.action_plot(PlotType.LINEAR_WITH_ERR)
-        view.show_warning.assert_called_once_with(TableWorkspaceDisplay.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE)
+        view.show_warning.assert_called_once_with(
+            TableWorkspaceDisplay.NO_ASSOCIATED_YERR_FOR_EACH_Y_MESSAGE.format(ws._column_names[y_column_index]))
 
     @patch('mantidqt.widgets.workspacedisplay.table.presenter.logger.error')
     @with_mock_presenter(add_selection_model=True, add_plot=True)
@@ -459,7 +461,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y)]
         twd.action_plot(PlotType.LINEAR)
 
-        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
+        twd.plot.subplots.assert_called_once_with()
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
         col_y_name = twd.model.get_column_header(col_as_y)
@@ -486,7 +488,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
                                                                   MockQModelIndex(1, col_as_y2)]
         twd.action_plot(PlotType.LINEAR)
 
-        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
+        twd.plot.subplots.assert_called_once_with()
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
 
@@ -503,7 +505,50 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         twd.plot.mock_ax.legend.assert_called_once_with()
 
     @with_mock_presenter(add_selection_model=True, add_plot=True)
-    def test_do_action_plot_success_error_plot(self, ws, view, twd):
+    def test_do_action_plot_linear_error_plot(self, ws, view, twd):
+        """
+        Test for _Linear_ plotting (with errors) a single Y column in selection, which has an associated Y error column
+        """
+        self.do_test_plot_single_y_with_error(view, twd, PlotType.LINEAR_WITH_ERR)
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_scatter_error_plot(self, ws, view, twd):
+        """
+        Test for _Scatter_ plotting (with errors) a single Y column in selection, which has an associated Y error column
+        """
+        self.do_test_plot_single_y_with_error(view, twd, PlotType.SCATTER_WITH_ERR, {'fmt': 'o'})
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_linear_error_plot_append_yerr(self, ws, view, twd):
+        """
+        Test for _Linear_ plotting (with errors) a single Y column in selection, which has an associated Y error column.
+
+        This tests the case where the Y Error column is part of the user's selection
+        """
+        self.do_test_plot_single_y_with_error(view, twd, PlotType.LINEAR_WITH_ERR, append_yerr_to_selection=True)
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_scatter_error_plot_append_yerr(self, ws, view, twd):
+        """
+        Test for _Scatter_ plotting (with errors) a single Y column in selection, which has an associated Y error column.
+
+        This tests the case where the Y Error column is part of the user's selection
+        """
+        self.do_test_plot_single_y_with_error(view, twd, PlotType.SCATTER_WITH_ERR, {'fmt': 'o'},
+                                              append_yerr_to_selection=True)
+
+    def do_test_plot_single_y_with_error(self, view, twd, plot_type, extra_errorbar_assert_kwargs=None,
+                                         append_yerr_to_selection=False):
+        """
+        Does the test for plotting with a single Y column that has an associated error
+        :param twd: The presenter
+        :param view: The mock view
+        :param plot_type: The type of the plot
+        :param extra_errorbar_assert_kwargs: Extra arguments expanded in the assertion for the errorbar call
+        :return:
+        """
+        if extra_errorbar_assert_kwargs is None:
+            extra_errorbar_assert_kwargs = {}
         col_as_x = 1
         col_as_y = 2
         col_as_y_err = 3
@@ -513,26 +558,69 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_x)]
         twd.action_set_as_x()
-
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y_err)]
         twd.action_set_as_y_err(col_as_y, '0')
-
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y)]
-        twd.action_plot(PlotType.LINEAR_WITH_ERR)
+        if append_yerr_to_selection:
+            view.mock_selection_model.selectedColumns.return_value.append(MockQModelIndex(1, col_as_y_err))
 
-        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
+        twd.action_plot(plot_type)
+
+        twd.plot.subplots.assert_called_once_with()
+
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
         col_y_name = twd.model.get_column_header(col_as_y)
         twd.plot.mock_ax.set_ylabel.assert_called_once_with(col_y_name)
         twd.plot.mock_ax.errorbar.assert_called_once_with(expected_x_data, expected_y_data,
                                                           label=TableWorkspaceDisplay.COLUMN_DISPLAY_LABEL.format(
-                                                              col_y_name), yerr=expected_y_err_data)
+                                                              col_y_name), yerr=expected_y_err_data,
+                                                          **extra_errorbar_assert_kwargs)
         twd.plot.mock_fig.show.assert_called_once_with()
         twd.plot.mock_ax.legend.assert_called_once_with()
 
     @with_mock_presenter(add_selection_model=True, add_plot=True)
-    def test_do_action_plot_multiple_y_success_error_plot(self, ws, view, twd):
+    def test_do_action_plot_multiple_y_linear_error_plot(self, ws, view, twd):
+        """
+        Test for _Linear_ plotting (with errors) multiple Y columns in selection,
+        each of which has an associated Y error column
+        """
+        self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.LINEAR_WITH_ERR)
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_multiple_y_linear_error_plot(self, ws, view, twd):
+        """
+        Test for _Scatter_ plotting (with errors) multiple Y columns in selection,
+        each of which has an associated Y error column
+        """
+        self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.SCATTER_WITH_ERR, {'fmt': 'o'})
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_multiple_y_linear_error_plot_append_yerrs(self, ws, view, twd):
+        """
+        Test for _Scatter_ plotting (with errors) multiple Y columns in selection,
+        each of which has an associated Y error column
+
+        This tests the case where the Y Error columns are part of the user's selection
+        """
+        self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.LINEAR_WITH_ERR,
+                                                       append_yerr_to_selection=True)
+
+    @with_mock_presenter(add_selection_model=True, add_plot=True)
+    def test_do_action_plot_multiple_y_linear_error_plot_append_yerrs(self, ws, view, twd):
+        self.do_test_action_plot_multiple_y_error_plot(view, twd, PlotType.SCATTER_WITH_ERR, {'fmt': 'o'},
+                                                       append_yerr_to_selection=True)
+
+    def do_test_action_plot_multiple_y_error_plot(self, view, twd, plot_type, extra_errorbar_assert_kwargs=None,
+                                                  append_yerr_to_selection=False):
+        """
+        Does the test for plotting with multiple Y columns. Each of them has an associated error
+        :param twd: The presenter
+        :param view: The mock view
+        :param plot_type: The type of the plot
+        :param extra_errorbar_assert_kwargs: Extra arguments expanded in the assertion for the errorbar call
+        :return:
+        """
         col_as_x = 0
         col_as_y1 = 1
         col_as_y1_err = 2
@@ -555,9 +643,12 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y1),
                                                                   MockQModelIndex(1, col_as_y2)]
-        twd.action_plot(PlotType.LINEAR_WITH_ERR)
+        if append_yerr_to_selection:
+            view.mock_selection_model.selectedColumns.return_value.extend(
+                [MockQModelIndex(1, col_as_y1_err), MockQModelIndex(1, col_as_y2_err)])
+        twd.action_plot(plot_type)
 
-        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
+        twd.plot.subplots.assert_called_once_with()
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
 
@@ -567,9 +658,11 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
         twd.plot.mock_ax.errorbar.assert_has_calls([
             call(expected_x_data, expected_y1_data,
-                 label=TableWorkspaceDisplay.COLUMN_DISPLAY_LABEL.format(col_y1_name), yerr=expected_y1_err_data),
+                 label=TableWorkspaceDisplay.COLUMN_DISPLAY_LABEL.format(col_y1_name), yerr=expected_y1_err_data,
+                 **extra_errorbar_assert_kwargs),
             call(expected_x_data, expected_y2_data,
-                 label=TableWorkspaceDisplay.COLUMN_DISPLAY_LABEL.format(col_y2_name), yerr=expected_y2_err_data)])
+                 label=TableWorkspaceDisplay.COLUMN_DISPLAY_LABEL.format(col_y2_name), yerr=expected_y2_err_data,
+                 **extra_errorbar_assert_kwargs)])
         twd.plot.mock_fig.show.assert_called_once_with()
         twd.plot.mock_ax.legend.assert_called_once_with()
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
@@ -62,6 +62,10 @@ class TableWorkspaceDisplayView(QTableWidget):
     def resizeEvent(self, event):
         QTableWidget.resizeEvent(self, event)
         header = self.horizontalHeader()
+        # resizes the column headers to fit the contents,
+        # currently this overwrites any manual changes to the widths of the columns
+        header.resizeSections(QHeaderView.ResizeToContents)
+        # then allows the users to resize the headers manually
         header.setSectionResizeMode(QHeaderView.Interactive)
 
     def emit_repaint(self):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
@@ -4,7 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#  This file is part of the mantid workbench.
+#  This file is part of the mantidqt package.
 from __future__ import (absolute_import, division, print_function)
 
 import sys
@@ -128,12 +128,16 @@ class TableWorkspaceDisplayView(QTableWidget):
         plot_scatter = QAction("Scatter", plot)
         plot_scatter.triggered.connect(partial(self.presenter.action_plot, PlotType.SCATTER))
 
+        plot_scatter_with_yerr = QAction("Scatter with Y Errors", plot)
+        plot_scatter_with_yerr.triggered.connect(partial(self.presenter.action_plot, PlotType.SCATTER_WITH_ERR))
+
         plot_line_and_points = QAction("Line + Symbol", plot)
         plot_line_and_points.triggered.connect(partial(self.presenter.action_plot, PlotType.LINE_AND_SYMBOL))
 
         plot.addAction(plot_line)
         plot.addAction(plot_line_with_yerr)
         plot.addAction(plot_scatter)
+        plot.addAction(plot_scatter_with_yerr)
         plot.addAction(plot_line_and_points)
         menu_main.addMenu(plot)
 


### PR DESCRIPTION
**Description of work.**
Automatically marks columns that have a plot type. Currently supports columns as X, Y and YErr.

Adds Scatter plot with Y errors.

**Report to:** James Lord ISIS

**To test:**
Run the following script for a test table workspace:
```python
# The following line helps with future compatibility with Python 3
# print must now be used as a function, e.g print('Hello','World')
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

import matplotlib.pyplot as plt

import numpy as np

import math

import random

tab = WorkspaceFactory.createTable()

tab.addColumn("int", "spectrum", 1)

tab.addColumn("double", "voltage", 2)

tab.addColumn("double", "error", 5)

tab.addColumn("int", "spectrum1", 1)
tab.addColumn("double", "voltage1", 2)
tab.addColumn("double", "voltage2", 2)
tab.addColumn("double", "voltage3", 2)
tab.addColumn("double", "error1", 5)
tab.addColumn("double", "error2", 5)
tab.addColumn("double", "error3", 5)

for i in range(64):
    r = [i, 10.0+math.sin(i*0.2)+random.uniform(-0.1, 0.1), random.uniform(0.05, 0.15),1,2,3,2,3,4,5]
    tab.addRow(r)

AnalysisDataService.addOrReplace("tab", tab)
```

- Right Click the `voltage[Y0]` column. Select Plot -> Linear with Error
- Do the same for Scatter with Error
- Select columns: `spectrum[X0]`, `voltage[Y0]`, and `error[Y0_YErr]` at the same time. Right click on any of the columns and select some plot with error
- Right click `error[Y0_YErr]` column, and do `Set as None`.
- Repeat step 1: Right Click the `voltage[Y0]` column. Select Plot -> Linear with Error
- An error message should show up, saying which column doesn't have an associated YErr column. See if the error message makes sense
Fixes #25178


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
