### PR TITLE
Fix cppcheck 1.87 warnings in DataObjects

### DIFF
--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -319,7 +319,6 @@ void calcTrapezoidYIntersections(const std::vector<double> &xAxis,
   double area(0.);
   ConvexPolygon poly;
   areaInfos.reserve(nx * ny);
-  size_t vertBits = 0;
   size_t yj0, yj1;
   for (size_t xi = x_start; xi < x_end; ++xi) {
     const size_t xj = xi - x_start;
@@ -347,7 +346,7 @@ void calcTrapezoidYIntersections(const std::vector<double> &xAxis,
         // Checks if this bin is not completely outside new quadrilateral
       } else if (yAxis[yi + 1] >= std::min(nll.Y(), nlr.Y()) &&
                  yAxis[yi] <= std::max(nul.Y(), nur.Y())) {
-        vertBits = 0;
+        size_t vertBits = 0;
         if (nll.Y() >= yAxis[yi] && nll.Y() <= yAxis[yi + 1])
           vertBits |= LL_IN;
         if (nul.Y() >= yAxis[yi] && nul.Y() <= yAxis[yi + 1])

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -76,13 +76,13 @@ void GroupingWorkspace::makeDetectorIDToGroupVector(
   ngroups = 0;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number
-    int group = static_cast<int>(this->readY(wi)[0]);
+    int group = static_cast<int>(this->y(wi).front());
     if (group == 0)
       group = -1;
     auto detIDs = this->getDetectorIDs(wi);
     for (auto detID : detIDs) {
-      if (detID <
-          0) // if you need negative detector ids, use the other function
+      // if you need negative detector ids, use the other function
+      if (detID < 0)
         continue;
       if (detIDToGroup.size() < static_cast<size_t>(detID + 1))
         detIDToGroup.resize(detID + 1);

--- a/Framework/DataObjects/src/MDHistoWorkspace.cpp
+++ b/Framework/DataObjects/src/MDHistoWorkspace.cpp
@@ -138,8 +138,10 @@ void MDHistoWorkspace::init(
     std::vector<Mantid::Geometry::MDHistoDimension_sptr> &dimensions) {
   std::vector<IMDDimension_sptr> dim2;
   dim2.reserve(dimensions.size());
-  for (auto &dimension : dimensions)
-    dim2.push_back(boost::dynamic_pointer_cast<IMDDimension>(dimension));
+  std::transform(dimensions.cbegin(), dimensions.cend(),
+                 std::back_inserter(dim2), [](const auto dimension) {
+                   return boost::dynamic_pointer_cast<IMDDimension>(dimension);
+                 });
   this->init(dim2);
   m_nEventsContributed = 0;
 }
@@ -592,10 +594,9 @@ IMDWorkspace::LinePlot MDHistoWorkspace::getLinePoints(
     }
 
     ++it;
-    coord_t linePos = 0;
     for (; it != boundaries.cend(); ++it) {
       // This is our current position along the line
-      linePos = *it;
+      const coord_t linePos = *it;
 
       // This is the full position at this boundary
       VMD pos = start + (dir * linePos);

--- a/Framework/DataObjects/src/MaskWorkspace.cpp
+++ b/Framework/DataObjects/src/MaskWorkspace.cpp
@@ -85,9 +85,6 @@ void MaskWorkspace::clearMask() {
  * @return The total number of masked spectra.
  */
 size_t MaskWorkspace::getNumberMasked() const {
-  // Determine whether has instrument or not
-  Geometry::Instrument_const_sptr inst = getInstrument();
-
   size_t numMasked(0);
   const size_t numWksp(this->getNumberHistograms());
   for (size_t i = 0; i < numWksp; i++) {
@@ -114,9 +111,6 @@ size_t MaskWorkspace::getNumberMasked() const {
  */
 set<detid_t> MaskWorkspace::getMaskedDetectors() const {
   set<detid_t> detIDs;
-
-  Geometry::Instrument_const_sptr inst = this->getInstrument();
-
   /*
    * Note
    * This test originally just checked if there was an instument and ignored

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -63,7 +63,6 @@ const std::vector<Kernel::V3D> &PeakShapeEllipsoid::directions() const {
 
 std::vector<Kernel::V3D> PeakShapeEllipsoid::getDirectionInSpecificFrame(
     Kernel::Matrix<double> &invertedGoniometerMatrix) const {
-  std::vector<Kernel::V3D> directionsInFrame;
 
   if ((invertedGoniometerMatrix.numCols() != m_directions.size()) ||
       (invertedGoniometerMatrix.numRows() != m_directions.size())) {
@@ -71,10 +70,13 @@ std::vector<Kernel::V3D> PeakShapeEllipsoid::getDirectionInSpecificFrame(
                                 "compatible with the direction vector");
   }
 
-  for (const auto &direction : m_directions) {
-    directionsInFrame.push_back(invertedGoniometerMatrix * direction);
-  }
-
+  std::vector<Kernel::V3D> directionsInFrame;
+  directionsInFrame.reserve(m_directions.size());
+  std::transform(m_directions.cbegin(), m_directions.cend(),
+                 std::back_inserter(directionsInFrame),
+                 [&invertedGoniometerMatrix](const auto &direction) {
+                   return invertedGoniometerMatrix * direction;
+                 });
   return directionsInFrame;
 }
 

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -173,11 +173,8 @@ void PeaksWorkspace::removePeaks(std::vector<int> badPeaks) {
       std::remove_if(peaks.begin(), peaks.end(), [&ip, badPeaks](Peak &pk) {
         (void)pk;
         ip++;
-        for (int badPeak : badPeaks) {
-          if (badPeak == ip)
-            return true;
-        }
-        return false;
+        return std::any_of(badPeaks.cbegin(), badPeaks.cend(),
+                           [ip](int badPeak) { return badPeak == ip; });
       });
   peaks.erase(it, peaks.end());
 }

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -402,9 +402,8 @@ IMDHistoWorkspace_sptr ReflectometryTransform::executeMDNormPoly(
 
   for (size_t nHistoIndex = 0; nHistoIndex < inputWs->getNumberHistograms();
        ++nHistoIndex) {
-    const MantidVec X = inputWs->readX(nHistoIndex);
-    const MantidVec Y = inputWs->readY(nHistoIndex);
-    const MantidVec E = inputWs->readE(nHistoIndex);
+    const auto &Y = inputWs->y(nHistoIndex);
+    const auto &E = inputWs->e(nHistoIndex);
 
     const size_t numBins = Y.size();
     for (size_t nBinIndex = 0; nBinIndex < numBins; ++nBinIndex) {

--- a/Framework/DataObjects/src/SplittersWorkspace.cpp
+++ b/Framework/DataObjects/src/SplittersWorkspace.cpp
@@ -39,7 +39,6 @@ void SplittersWorkspace::addSplitter(
 }
 
 Kernel::SplittingInterval SplittersWorkspace::getSplitter(size_t index) {
-  API::Column_const_sptr column = this->getColumn("start");
   API::TableRow row = this->getRow(index);
   int64_t start, stop;
   int wsgroup;


### PR DESCRIPTION
This PR fixes most `cppcheck` 1.87 issues in the DataObjects module. Some `useStlAlgorithm` warnings were deemed not worth fixing. In these cases, the warnings could be suppressed once we update `cppcheck` on the build servers.

**To test:**

Code review.

Fixes part of #22912.


*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
