### PR TITLE
MantidPlot: Stop crashing when plotting color fill for workspace with text axis

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -414,8 +414,12 @@ public:
   virtual Axis *getAxis(const std::size_t &axisIndex) const;
   void replaceAxis(const std::size_t &axisIndex, Axis *const newAxis);
 
-  /// Returns true if the workspace contains data in histogram form (as opposed
-  /// to point-like)
+  /// Will return the number of Axis currently stored in the workspace it is not
+  /// always safe to assume it is just 2
+  size_t numberOfAxis() const;
+
+  /// Returns true if the workspace contains data in histogram form (as
+  /// opposed to point-like)
   virtual bool isHistogramData() const;
 
   /// Returns true if the workspace contains common X bins

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -878,12 +878,10 @@ void MatrixWorkspace::replaceAxis(const std::size_t &axisIndex,
 }
 
 /**
- * Return the number of Axis stored by this workspace 
+ * Return the number of Axis stored by this workspace
  * @return int
  */
-size_t MatrixWorkspace::numberOfAxis() const {
-  return m_axes.size();
-}
+size_t MatrixWorkspace::numberOfAxis() const { return m_axes.size(); }
 
 /// Returns the units of the data in the workspace
 std::string MatrixWorkspace::YUnit() const { return m_YUnit; }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -877,6 +877,14 @@ void MatrixWorkspace::replaceAxis(const std::size_t &axisIndex,
   m_axes[axisIndex] = newAxis;
 }
 
+/**
+ * Return the number of Axis stored by this workspace 
+ * @return int
+ */
+size_t MatrixWorkspace::numberOfAxis() const {
+  return m_axes.size();
+}
+
 /// Returns the units of the data in the workspace
 std::string MatrixWorkspace::YUnit() const { return m_YUnit; }
 

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -3381,8 +3381,7 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
  * @param wsName :: The name of the workspace which provides data for the plot
  * @param curveType :: The type of curve
  * @param window :: An optional pointer to a plot window. If not NULL the window
- * is cleared
- *                      and reused
+ * is cleared and reused
  * @param hidden
  * @returns A pointer to the created plot
  */
@@ -3394,6 +3393,16 @@ MultiLayer *MantidUI::drawSingleColorFillPlot(const QString &wsName,
           getWorkspace(wsName));
   if (!workspace)
     return nullptr;
+
+  // Check if an axis is a String, if so then throw log without this, it will
+  // cause MantidPlot to get into an error loop forcing users to terminate.
+  for (auto i = 0u; i < workspace->numberOfAxis(); ++i) {
+    if (workspace->getAxis(i)->isText()) {
+      g_log.error("Colorfill Plot - Cannot plot a workspace which has an axis "
+                  "of type text.");
+      return nullptr;
+    }
+  }
 
   ScopedOverrideCursor waitCursor;
 
@@ -4029,9 +4038,9 @@ void MantidUI::memoryImage2() {
 }
 
 #endif
-  //=======================================================================
-  // End of Windows specific stuff
-  //=======================================================================
+//=======================================================================
+// End of Windows specific stuff
+//=======================================================================
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/CompAssembly.h"

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -4038,9 +4038,9 @@ void MantidUI::memoryImage2() {
 }
 
 #endif
-//=======================================================================
-// End of Windows specific stuff
-//=======================================================================
+  //=======================================================================
+  // End of Windows specific stuff
+  //=======================================================================
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/CompAssembly.h"

--- a/docs/source/release/v4.0.0/ui.rst
+++ b/docs/source/release/v4.0.0/ui.rst
@@ -88,6 +88,7 @@ BugFixes
 - Fixed an issue where MantidPlot would crash when renaming workspaces.
 - Fixed issue with filenames containing spaces that are passed to Mantid when launched from the command line.
 - The catalog search error tooltips now display properly on windows.
+- Stop MantidPlot from attempting to contour plot/colorfill plot when a workspace has a TextAxis.
 
 MantidWorkbench
 ---------------


### PR DESCRIPTION
**Description of work.**
When you attempt colorfill plot, on a workspace in the workspace widget, you should no longer crash an error should appear in the logger.

**To test:**
- Open mantidplot
- Load this workspace:
[map_text_axis.zip](https://github.com/mantidproject/mantid/files/2970798/map_text_axis.zip)
- Right click on the workspace and do Color Fill Plot
- It should say in the logger that you can not do it because one of the Axis is text.
<!-- Instructions for testing. -->

Partial fix for issue #24997  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
