### PR TITLE
Indirect Reduction TOSCA - Include Summed File Masked Detectors

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -28,9 +28,7 @@ def _elems_or_none(l):
 
 
 def add_missing_elements(from_list, to_list):
-    for element in from_list:
-        if element not in to_list:
-            to_list.append(element)
+    to_list.extend([element for element in from_list if element not in to_list])
     return sorted(to_list)
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -176,9 +176,6 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
             rebin_string_2, num_bins = get_multi_frame_rebin(c_ws_name,
                                                              self._rebin_string)
 
-            if self._sum_files:
-                logger.warning('current {0}'.format(str(masked_detectors)))
-
             if not self._sum_files:
                 masked_detectors = get_detectors_to_mask(workspaces)
             else:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -27,6 +27,13 @@ def _elems_or_none(l):
     return l if len(l) != 0 else None
 
 
+def add_missing_elements(from_list, to_list):
+    for element in from_list:
+        if element not in to_list:
+            to_list.append(element)
+    return sorted(to_list)
+
+
 class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
     _chopped_data = None
@@ -169,8 +176,14 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
             rebin_string_2, num_bins = get_multi_frame_rebin(c_ws_name,
                                                              self._rebin_string)
 
+            if self._sum_files:
+                logger.warning('current {0}'.format(str(masked_detectors)))
+
             if not self._sum_files:
                 masked_detectors = get_detectors_to_mask(workspaces)
+            else:
+                summed_file_masked_detectors = get_detectors_to_mask(workspaces)
+                masked_detectors = add_missing_elements(summed_file_masked_detectors, masked_detectors)
 
             # Process workspaces
             for ws_name in workspaces:


### PR DESCRIPTION
**Description of work.**
This PR extends on a previous improvement to data reduction for the TOSCA instrument. 

It would probably be better to include any bad detectors calculated using the SummedFile in the masked detectors. 
At the moment it only gets all the masked detectors for the individual runs and puts them together. The further step is to add in the missing masked detectors found using IdentifyNoisyDetectors on the SummedFile.

Note that this will probably not have a large impact on the result (barely noticeable), however it is probably preferred (after talking to Svemir).

~No release notes required as this has already been mentioned in the release notes for #25070 ~

**To test:**
See the issue testing instructions.

The plot should look like:
x axis 0 -4000 y axis 0-1
![image](https://user-images.githubusercontent.com/40830825/54018023-92241100-417f-11e9-9407-44eb87cbfca7.png)

Fixes #25243

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
