### PR TITLE
Indirect Fit Output - Save each result workspace individually

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -189,7 +189,7 @@ Plot
   Plots the selected parameter stored in the result workspace.
 
 Save Result
-  Saves the result workspace in the default save directory.
+  Saves the workspaces from the *_Results* group workspace in the default save directory.
 
 .. seealso:: Common options are detailed in the :ref:`qens-fitting-features` section.
 
@@ -344,7 +344,7 @@ Edit Result
   algorithm. See below for more detail.
 
 Save Result
-  Saves the result workspace in the default save directory.
+  Saves the workspaces from the *_Results* group workspace in the default save directory.
 
 .. seealso:: Common options are detailed in the :ref:`qens-fitting-features` section.
 
@@ -447,7 +447,7 @@ Edit Result
   algorithm. See below for more detail.
 
 Save Result
-  Saves the result workspace in the default save directory.
+  Saves the workspaces from the *_Results* group workspace in the default save directory.
 
 Theory
 ~~~~~~
@@ -527,7 +527,7 @@ Plot
   Plots the selected parameter stored in the result workspace.
 
 Save Result
-  Saves the result workspace in the default save directory.
+  Saves the workspaces from the *_Results* group workspace in the default save directory.
   
 .. seealso:: Common options are detailed in the :ref:`qens-fitting-features` section.
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -86,11 +86,16 @@ IAlgorithm_sptr saveNexusProcessedAlgorithm(Workspace_sptr workspace,
   return saveAlg;
 }
 
-void saveWorkspace(WorkspaceGroup_sptr resultWorkspace) {
+void saveWorkspace(Workspace_sptr resultWorkspace) {
   auto const filename = Mantid::Kernel::ConfigService::Instance().getString(
                             "defaultsave.directory") +
                         resultWorkspace->getName() + ".nxs";
   saveNexusProcessedAlgorithm(resultWorkspace, filename)->execute();
+}
+
+void saveWorkspace(WorkspaceGroup_sptr resultGroup) {
+  for (auto const workspace : *resultGroup)
+    saveWorkspace(workspace);
 }
 
 bool workspaceIsPlottable(MatrixWorkspace_const_sptr workspace) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -93,7 +93,7 @@ void saveWorkspace(Workspace_sptr resultWorkspace) {
   saveNexusProcessedAlgorithm(resultWorkspace, filename)->execute();
 }
 
-void saveWorkspace(WorkspaceGroup_sptr resultGroup) {
+void saveWorkspace(WorkspaceGroup_const_sptr resultGroup) {
   for (auto const workspace : *resultGroup)
     saveWorkspace(workspace);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -86,15 +86,15 @@ IAlgorithm_sptr saveNexusProcessedAlgorithm(Workspace_sptr workspace,
   return saveAlg;
 }
 
-void saveWorkspace(Workspace_sptr resultWorkspace) {
+void saveWorkspace(Workspace_sptr workspace) {
   auto const filename = Mantid::Kernel::ConfigService::Instance().getString(
                             "defaultsave.directory") +
-                        resultWorkspace->getName() + ".nxs";
-  saveNexusProcessedAlgorithm(resultWorkspace, filename)->execute();
+                        workspace->getName() + ".nxs";
+  saveNexusProcessedAlgorithm(workspace, filename)->execute();
 }
 
-void saveWorkspace(WorkspaceGroup_const_sptr resultGroup) {
-  for (auto const workspace : *resultGroup)
+void saveWorkspacesInGroup(WorkspaceGroup_const_sptr group) {
+  for (auto const workspace : *group)
     saveWorkspace(workspace);
 }
 
@@ -308,7 +308,7 @@ void IndirectFitOutputOptionsModel::plotPDF(
 
 void IndirectFitOutputOptionsModel::saveResult() const {
   if (m_resultGroup)
-    saveWorkspace(m_resultGroup);
+    saveWorkspacesInGroup(m_resultGroup);
   else
     throw std::runtime_error(noWorkspaceErrorMessage("saving"));
 }


### PR DESCRIPTION
**Description of work.**
This PR changes the Save Result process so that the individual workspaces within the `_Results` group workspace from a fit are saved independantly of each other. This prevents confusion from the user when trying to load in a workspace into the `FQFit` tab using `Browse`.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit`
2. Go to `MultipleInput` tab and click `Add Workspace`
3. Load the two datasets below and select All Spectra. Then click `Add`
4. Select One Lorentzian as Fit type
5. Click `Run` and wait
6. Set your default save directory and then click `Save Result`
7. Check that your directory contains the two workspaces contained within the output group workspace ending in suffix `_Results`. These two workspaces should end in `_Result`.
8. Go to FQFit and click `Browse`. These two workspaces should be allowed to be entered because the suffix `_Result` is correct.

Reduced files:
[irs26176_withhistory_red.zip](https://github.com/mantidproject/mantid/files/2983639/irs26176_withhistory_red.zip)
[irs26173_graphite002_red.zip](https://github.com/mantidproject/mantid/files/2983640/irs26173_graphite002_red.zip)

Resolution in both cases:
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/2983638/irs26173_graphite002_res.zip)

Fixes #25248

No release notes are required I believe.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
