### PR TITLE
Handle the exception when a connection cannot be made to the error reporting remote

### DIFF
--- a/scripts/ErrorReporter/error_report_presenter.py
+++ b/scripts/ErrorReporter/error_report_presenter.py
@@ -9,11 +9,14 @@ from __future__ import (absolute_import, print_function)
 import os
 
 import requests
+
 from ErrorReporter.retrieve_recovery_files import zip_recovery_directory
 from mantid.kernel import ConfigService, ErrorReporter, Logger, UsageService
 
 
 class ErrorReporterPresenter(object):
+    SENDING_ERROR_MESSAGE = 'There was an error when sending the report.\nPlease contact mantid-help@mantidproject.org directly'
+
     def __init__(self, view, exit_code):
         self.error_log = Logger("error")
         self._view = view
@@ -103,8 +106,7 @@ class ErrorReporterPresenter(object):
         status = errorReporter.sendErrorReport()
 
         if status != 201:
-            self._view.display_message_box('Error contacting server', 'There was an error when sending the report.\n'
-                                                                      'Please contact mantid-help@mantidproject.org directly',
+            self._view.display_message_box('Error contacting server', self.SENDING_ERROR_MESSAGE,
                                            'http request returned with status {}'.format(status))
             self.error_log.error("Failed to send error report http request returned status {}".format(status))
 

--- a/scripts/ErrorReporter/error_report_presenter.py
+++ b/scripts/ErrorReporter/error_report_presenter.py
@@ -9,7 +9,6 @@ from __future__ import (absolute_import, print_function)
 import os
 
 import requests
-
 from ErrorReporter.retrieve_recovery_files import zip_recovery_directory
 from mantid.kernel import ConfigService, ErrorReporter, Logger, UsageService
 
@@ -104,7 +103,7 @@ class ErrorReporterPresenter(object):
         status = errorReporter.sendErrorReport()
 
         if status != 201:
-            self._view.display_message_box('Error contacting server', 'There was an error when sending the report.'
+            self._view.display_message_box('Error contacting server', 'There was an error when sending the report.\n'
                                                                       'Please contact mantid-help@mantidproject.org directly',
                                            'http request returned with status {}'.format(status))
             self.error_log.error("Failed to send error report http request returned status {}".format(status))

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, print_function)
 
 import qtpy  # noqa
+
 if qtpy.PYQT5:
     from ErrorReporter import resources_qt5  # noqa
 elif qtpy.PYQT4:
@@ -14,12 +15,10 @@ elif qtpy.PYQT4:
 else:
     raise RuntimeError("Unknown QT version: {}".format(qtpy.QT_VERSION))
 
-from qtpy import QtCore, QtGui, QtWidgets
-from qtpy.QtCore import Signal
-from qtpy.QtWidgets import QMessageBox
-
-
-from mantidqt.utils.qt import load_ui
+from qtpy import QtCore, QtGui, QtWidgets # noqa: E402
+from qtpy.QtCore import Signal # noqa: E402
+from qtpy.QtWidgets import QMessageBox # noqa: E402
+from mantidqt.utils.qt import load_ui # noqa: E402
 
 ErrorReportUIBase, ErrorReportUI = load_ui(__file__, 'errorreport.ui')
 

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -6,13 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, print_function)
 
+import qtpy  # noqa
+if qtpy.PYQT5:
+    from ErrorReporter import resources_qt5  # noqa
+elif qtpy.PYQT4:
+    from ErrorReporter import resources_qt4  # noqa
+else:
+    raise RuntimeError("Unknown QT version: {}".format(qtpy.QT_VERSION))
+
 from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtCore import Signal
+from qtpy.QtWidgets import QMessageBox
 
-try:
-    from ErrorReporter import resources_qt5  # noqa
-except (ImportError, RuntimeError):
-    from ErrorReporter import resources_qt4  # noqa
 
 from mantidqt.utils.qt import load_ui
 
@@ -90,18 +95,14 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
             self.nonIDShareButton.setEnabled(False)
 
     def display_message_box(self, title, message, details):
-        msg = QtGui.QMessageBox(self)
-        msg.setIcon(QtGui.QMessageBox.Warning)
-
-        message_length = len(message)
-
-        # This is to ensure that the QMessage box is wide enough to display nicely.
-        msg.setText(10 * ' ' + message + ' ' * (30 - message_length))
+        msg = QMessageBox(self)
+        msg.setIcon(QMessageBox.Warning)
+        msg.setText(message)
         msg.setWindowTitle(title)
         msg.setDetailedText(details)
-        msg.setStandardButtons(QtGui.QMessageBox.Ok)
-        msg.setDefaultButton(QtGui.QMessageBox.Ok)
-        msg.setEscapeButton(QtGui.QMessageBox.Ok)
+        msg.setStandardButtons(QMessageBox.Ok)
+        msg.setDefaultButton(QMessageBox.Ok)
+        msg.setEscapeButton(QMessageBox.Ok)
         msg.exec_()
 
     def set_report_callback(self, callback):

--- a/scripts/test/ErrorReportPresenterTest.py
+++ b/scripts/test/ErrorReportPresenterTest.py
@@ -1,10 +1,13 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-import sys
+
 from ErrorReporter.error_report_presenter import ErrorReporterPresenter
-if sys.version_info.major > 2:
-    from unittest import mock
-else:
-    import mock
+from mantid.py3compat import mock
 
 
 class ErrorReportPresenterTest(unittest.TestCase):
@@ -80,8 +83,7 @@ class ErrorReportPresenterTest(unittest.TestCase):
                                                       email, text_box, file_hash)
         self.errorreport_mock_instance.sendErrorReport.assert_called_once_with()
         self.view.display_message_box.assert_called_once_with('Error contacting server',
-                                                              'There was an error when sending the report.'
-                                                              'Please contact mantid-help@mantidproject.org directly',
+                                                              ErrorReporterPresenter.SENDING_ERROR_MESSAGE,
                                                               'http request returned with status 500')
 
     def test_error_handler_share_all_sunny_day_case(self):
@@ -96,7 +98,8 @@ class ErrorReportPresenterTest(unittest.TestCase):
 
         self.error_report_presenter.error_handler(continue_working, share, name, email, text_box)
 
-        self.error_report_presenter._send_report_to_server.called_once_with(share_identifiable=True, name=name, email=email,
+        self.error_report_presenter._send_report_to_server.called_once_with(share_identifiable=True, name=name,
+                                                                            email=email,
                                                                             file_hash=mock.ANY, uptime=mock.ANY,
                                                                             text_box=text_box)
         self.assertEqual(self.error_report_presenter._upload_recovery_file.call_count, 1)


### PR DESCRIPTION
**Description of work.**
Surrounds the `request.post` that submits recovery data in a `try.. except`. This captures any connection errors that throw exceptions. 

The `except Exception as e` is broad, as I am not sure of all the types of exceptions that can be thrown, but in any case they are logged with the stack trace to the error log.

Added a special case for logging a HTTP 413 (payload too large) response.

Fixed the QMessageBox bad import from `qtpy.QtGui` to `qtpy.QtWidgets`. Removed padding for error message text.

**To test:**
- Open MantidPlot & segfault it. Click yes to submit info, it should submit.
- For testing the bad connection, I am not sure - maybe change the domain in the script so that the connection fails? Or breakpoint before it and disconnect from the internet.
- Disconnect from the internet and crash Mantid, then submit a report. It should show a warning message that it can't be sent, and an email to contact.
<!-- Instructions for testing. -->

Fixes #25255 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
