### PR TITLE
Muon - Add algorithms to SeeAlso

### DIFF
--- a/Framework/Muon/inc/MantidMuon/MuonGroupingAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/MuonGroupingAsymmetry.h
@@ -29,7 +29,13 @@ public:
            "grouping in Muon data.";
   }
   const std::vector<std::string> seeAlso() const override {
-    return {"MuonProcess", "EstimateMuonAsymmetryFromCounts", "Minus", "Plus"};
+    return {"MuonProcess",
+            "EstimateMuonAsymmetryFromCounts",
+            "Minus",
+            "Plus",
+            "MuonGroupingCounts",
+            "MuonPairingAsymmetry",
+            "MuonPreProcess"};
   }
 
 private:

--- a/Framework/Muon/inc/MantidMuon/MuonGroupingCounts.h
+++ b/Framework/Muon/inc/MantidMuon/MuonGroupingCounts.h
@@ -27,7 +27,12 @@ public:
            "in Muon data.";
   }
   const std::vector<std::string> seeAlso() const override {
-    return {"MuonProcess", "Minus", "Plus"};
+    return {"MuonProcess",
+            "Minus",
+            "Plus",
+            "MuonGroupingAsymmetry",
+            "MuonPairingAsymmetry",
+            "MuonPreProcess"};
   }
 
   /// Perform validation of inputs to the algorithm

--- a/Framework/Muon/inc/MantidMuon/MuonPairingAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPairingAsymmetry.h
@@ -29,8 +29,9 @@ public:
            "from Muon data.";
   }
   const std::vector<std::string> seeAlso() const override {
-    return {"MuonProcess",   "MuonPreProcess", "AsymmetryCalc",
-            "AppendSpectra", "Plus",           "Minus"};
+    return {"MuonProcess",        "MuonPreProcess", "AsymmetryCalc",
+            "AppendSpectra",      "Plus",           "Minus",
+            "MuonGroupingCounts", "MuonPreProcess"};
   }
 
 private:

--- a/Framework/Muon/inc/MantidMuon/MuonPairingAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPairingAsymmetry.h
@@ -29,9 +29,14 @@ public:
            "from Muon data.";
   }
   const std::vector<std::string> seeAlso() const override {
-    return {"MuonProcess",        "MuonPreProcess", "AsymmetryCalc",
-            "AppendSpectra",      "Plus",           "Minus",
-            "MuonGroupingCounts", "MuonPreProcess"};
+    return {"MuonProcess",
+            "MuonPreProcess",
+            "AsymmetryCalc",
+            "AppendSpectra",
+            "Plus",
+            "Minus",
+            "MuonGroupingAsymmetry",
+            "MuonGroupingCounts"};
   }
 
 private:

--- a/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
+++ b/Framework/Muon/inc/MantidMuon/MuonPreProcess.h
@@ -30,8 +30,14 @@ public:
            "data. Sample logs are modified to record the input parameters.";
   }
   const std::vector<std::string> seeAlso() const override {
-    return {"MuonProcess", "ApplyDeadTimeCorr", "ChangeBinOffset",
-            "CropWorkspace", "Rebin"};
+    return {"MuonProcess",
+            "ApplyDeadTimeCorr",
+            "ChangeBinOffset",
+            "CropWorkspace",
+            "Rebin",
+            "MuonGroupingAsymmetry",
+            "MuonGroupingCounts",
+            "MuonPairingAsymmetry"};
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
This PR adds algorithms to the SeeAlso section of 4 muon algorithms.

**To test:**
The algorithms should now have the three other algorithms in their seeAlso section (see the issue for more information).

Fixes #24010

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
