### PR TITLE
Fix cppcheck 1.87 warnings in Examples

### DIFF
--- a/Framework/Examples/LorentzianTest.cpp
+++ b/Framework/Examples/LorentzianTest.cpp
@@ -77,8 +77,8 @@ void LorentzianTest::functionDerivLocal(Jacobian *out, const double *xValues,
   const double w = fwhm() / 2.;
 
   for (size_t i = 0; i < nData; i++) {
-    double diff = xValues[i] - c;
-    double invDenominator = 1 / ((diff * diff + w * w));
+    const double diff = xValues[i] - c;
+    const double invDenominator = 1 / ((diff * diff + w * w));
     out->set(i, 0, w * w * invDenominator);
     out->set(i, 1, 2.0 * h * diff * w * w * invDenominator * invDenominator);
     out->set(i, 2,

--- a/Framework/Examples/LorentzianTest.cpp
+++ b/Framework/Examples/LorentzianTest.cpp
@@ -49,14 +49,14 @@ void LorentzianTest::init() {
 //               must be calculated
 void LorentzianTest::functionLocal(double *out, const double *xValues,
                                    const size_t nData) const {
-  const double &height = getParameter("Height");
-  const double &peakCentre = getParameter("PeakCentre");
-  const double &hwhm = getParameter("HWHM");
+  const double h = height();
+  const double c = centre();
+  const double w = fwhm() / 2.;
 
   // This for-loop calculates the function for nData data-points
   for (size_t i = 0; i < nData; i++) {
-    double diff = xValues[i] - peakCentre;
-    out[i] = height * (hwhm * hwhm / (diff * diff + hwhm * hwhm));
+    double diff = xValues[i] - c;
+    out[i] = h * (w * w / (diff * diff + w * w));
   }
 }
 
@@ -72,20 +72,17 @@ void LorentzianTest::functionLocal(double *out, const double *xValues,
 // I.e. substitute the code below with the four lines of code above
 void LorentzianTest::functionDerivLocal(Jacobian *out, const double *xValues,
                                         const size_t nData) {
-  const double &height = getParameter("Height");
-  const double &peakCentre = getParameter("PeakCentre");
-  const double &hwhm = getParameter("HWHM");
+  const double h = height();
+  const double c = centre();
+  const double w = fwhm() / 2.;
 
   for (size_t i = 0; i < nData; i++) {
-    double diff = xValues[i] - peakCentre;
-    double invDenominator = 1 / ((diff * diff + hwhm * hwhm));
-    out->set(i, 0, hwhm * hwhm * invDenominator);
-    out->set(i, 1,
-             2.0 * height * diff * hwhm * hwhm * invDenominator *
-                 invDenominator);
+    double diff = xValues[i] - c;
+    double invDenominator = 1 / ((diff * diff + w * w));
+    out->set(i, 0, w * w * invDenominator);
+    out->set(i, 1, 2.0 * h * diff * w * w * invDenominator * invDenominator);
     out->set(i, 2,
-             height * (-hwhm * hwhm * invDenominator + 1) * 2.0 * hwhm *
-                 invDenominator);
+             h * (-w * w * invDenominator + 1) * 2.0 * w * invDenominator);
   }
 }
 

--- a/Framework/Examples/ModifyData.cpp
+++ b/Framework/Examples/ModifyData.cpp
@@ -77,9 +77,6 @@ void ModifyData::exec() {
   // Assign it to the output workspace property
   setProperty("OutputWorkspace", outputW);
 
-  // Get the newly set workspace
-  MatrixWorkspace_const_sptr newW = getProperty("OutputWorkspace");
-
   // Check the new workspace
   g_log.information() << "New values:" << std::endl;
   int count = 0;


### PR DESCRIPTION
Fix `cppcheck` 1.87 warnings in Examples.

**To test:**

Code review.

Fixes partially #22912.

*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
