### PR TITLE
Fix cppcheck 1.87 warnings in HistogramData

### DIFF
--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -141,7 +141,7 @@ void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
   const auto xold = input.points();
   const auto &yold = input.y();
   const auto nypts = yold.size();
-  size_t step(stepSize), index2(0);
+  size_t step(stepSize);
   double x1(0.), x2(0.), y1(0.), y2(0.), overgap(0.);
   // Copy over end value skipped by loop
   ynew.back() = yold.back();
@@ -150,7 +150,8 @@ void interpolateYLinearInplace(const Histogram &input, const size_t stepSize,
     const double xp = xold[i];
     if (step == stepSize) {
       x1 = xp;
-      index2 = ((i + stepSize) >= nypts ? nypts - 1 : (i + stepSize));
+      const auto index2 =
+          ((i + stepSize) >= nypts ? nypts - 1 : (i + stepSize));
       x2 = xold[index2];
       overgap = 1.0 / (x2 - x1);
       y1 = yold[i];


### PR DESCRIPTION
Fix cppcheck 1.87 warnings in the HistogramsData module.

**To test:**

Code review.

Fixes a part of #22912.

*This does not require release notes* because this is an internal change only.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
