### PR TITLE
Fix cppcheck 1.87 warnings in ICat

### DIFF
--- a/Framework/ICat/src/ICat3/ICat3Helper.cpp
+++ b/Framework/ICat/src/ICat3/ICat3Helper.cpp
@@ -312,9 +312,9 @@ void CICatHelper::listInstruments(std::vector<std::string> &instruments) {
   int result = icat.listInstruments(&request, &response);
 
   if (result == 0) {
-    for (const auto &instrument : response.return_) {
-      instruments.push_back(instrument);
-    }
+    instruments.reserve(instruments.size() + response.return_.size());
+    std::move(response.return_.begin(), response.return_.end(),
+              std::back_inserter(instruments));
   } else {
     CErrorHandling::throwErrorMessages(icat);
   }
@@ -338,9 +338,9 @@ void CICatHelper::listInvestigationTypes(
   int result = icat.listInvestigationTypes(&request, &response);
 
   if (result == 0) {
-    for (const auto &type : response.return_) {
-      investTypes.push_back(type);
-    }
+    investTypes.reserve(investTypes.size() + response.return_.size());
+    std::move(response.return_.begin(), response.return_.end(),
+              std::back_inserter(investTypes));
   } else {
     CErrorHandling::throwErrorMessages(icat);
   }


### PR DESCRIPTION
This PR fixes `cppcheck` 1.87 warnings in the ICat module.

**To test:**

Code review.

Fixes some parts of #22912.

*This does not require release notes* because this is internal code cleanup.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
