### PR TITLE
Fix cppcheck 1.87 warnings in Indexing

### DIFF
--- a/Framework/Indexing/src/Group.cpp
+++ b/Framework/Indexing/src/Group.cpp
@@ -28,9 +28,9 @@ IndexInfo group(const IndexInfo &source, std::vector<SpectrumNumber> &&specNums,
   const auto &sourceDefs = source.spectrumDefinitions();
   for (const auto &groupIndices : grouping) {
     specDefs.emplace_back(SpectrumDefinition{});
-    for (const auto &i : groupIndices) {
+    for (const auto groupIndex : groupIndices) {
       auto &newSpecDef = specDefs.back();
-      for (const auto &specDef : (*sourceDefs)[i]) {
+      for (const auto &specDef : (*sourceDefs)[groupIndex]) {
         newSpecDef.add(specDef.first, specDef.second);
       }
     }

--- a/Framework/Indexing/src/Group.cpp
+++ b/Framework/Indexing/src/Group.cpp
@@ -26,9 +26,9 @@ IndexInfo group(const IndexInfo &source, std::vector<SpectrumNumber> &&specNums,
                              "number and grouping vectors");
   std::vector<SpectrumDefinition> specDefs;
   const auto &sourceDefs = source.spectrumDefinitions();
-  for (const auto &group : grouping) {
+  for (const auto &groupIndices : grouping) {
     specDefs.emplace_back(SpectrumDefinition{});
-    for (const auto &i : group) {
+    for (const auto &i : groupIndices) {
       auto &newSpecDef = specDefs.back();
       for (const auto &specDef : (*sourceDefs)[i]) {
         newSpecDef.add(specDef.first, specDef.second);

--- a/Framework/Indexing/src/IndexInfo.cpp
+++ b/Framework/Indexing/src/IndexInfo.cpp
@@ -74,9 +74,14 @@ IndexInfo::IndexInfo(std::vector<IndexType> indices, const IndexInfo &parent)
           Kernel::make_unique<Parallel::Communicator>(*parent.m_communicator)) {
   if (const auto parentSpectrumDefinitions = parent.spectrumDefinitions()) {
     m_spectrumDefinitions = Kernel::make_cow<std::vector<SpectrumDefinition>>();
+    const auto &indexSet = parent.makeIndexSet(indices);
     auto &specDefs = m_spectrumDefinitions.access();
-    for (const auto i : parent.makeIndexSet(indices))
-      specDefs.push_back(parentSpectrumDefinitions->operator[](i));
+    specDefs.reserve(specDefs.size() + indexSet.size());
+    std::transform(indexSet.begin(), indexSet.end(),
+                   std::back_inserter(specDefs),
+                   [&parentSpectrumDefinitions](const auto index) {
+                     return (*parentSpectrumDefinitions)[index];
+                   });
   }
   m_spectrumNumberTranslator = Kernel::make_cow<SpectrumNumberTranslator>(
       std::move(indices), *parent.m_spectrumNumberTranslator);

--- a/Framework/Indexing/src/SpectrumNumberTranslator.cpp
+++ b/Framework/Indexing/src/SpectrumNumberTranslator.cpp
@@ -196,9 +196,11 @@ void SpectrumNumberTranslator::setupSpectrumNumberToIndexMap() const {
 std::vector<SpectrumNumber> SpectrumNumberTranslator::spectrumNumbers(
     const std::vector<GlobalSpectrumIndex> &globalIndices) const {
   std::vector<SpectrumNumber> spectrumNumbers;
-  for (const auto index : globalIndices)
-    spectrumNumbers.push_back(
-        m_globalSpectrumNumbers[static_cast<size_t>(index)]);
+  spectrumNumbers.reserve(globalIndices.size());
+  std::transform(globalIndices.cbegin(), globalIndices.cend(),
+                 std::back_inserter(spectrumNumbers), [this](const auto index) {
+                   return m_globalSpectrumNumbers[static_cast<size_t>(index)];
+                 });
   return spectrumNumbers;
 }
 


### PR DESCRIPTION
This PR fixes `cppcheck` 1.87 warnings in the Indexing module.

**To test:**

Code review.

Fixes partially #22912.

*This does not require release notes* because this is an internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
