### PR TITLE
SortXAxis allow a skip of the histogram validity check

### DIFF
--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -53,7 +53,10 @@ void SortXAxis::init() {
                   "Ascending or descending sorting", Direction::Input);
   declareProperty("IgnoreHistogramValidation", false,
                   "This will stop SortXAxis from throwing if the workspace is "
-                  "not a valid histogram for this algorithm to work on.");
+                  "not a valid histogram for this algorithm to work on. THIS "
+                  "IS TEMPORARY, this item will be removed for 4.1 and thus "
+                  "should only be used internally for the TOSCA legacy data "
+                  "in indirect .");
 }
 
 void SortXAxis::exec() {

--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -67,12 +67,10 @@ void SortXAxis::exec() {
       getProperty("IgnoreHistogramValidation");
 
   // Check if it is a valid histogram here
-  bool isAProperHistogram;
-  if (!ignoreHistogramValidation) {
-    isAProperHistogram = determineIfHistogramIsValid(*inputWorkspace);
-  } else {
-    isAProperHistogram = false;
-  }
+  const bool isAProperHistogram =
+      (!ignoreHistogramValidation)
+          ? determineIfHistogramIsValid(*inputWorkspace)
+          : false;
 
   // Define everything you can outside of the for loop
   // Assume that all spec are the same size

--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -51,15 +51,24 @@ void SortXAxis::init() {
       boost::make_shared<StringListValidator>(orderingValues);
   declareProperty("Ordering", orderingValues[0], orderingValidator,
                   "Ascending or descending sorting", Direction::Input);
+  declareProperty("IgnoreHistogramValidation", false,
+                  "This will stop SortXAxis from throwing if the workspace is "
+                  "not a valid histogram for this algorithm to work on.");
 }
 
 void SortXAxis::exec() {
 
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   MatrixWorkspace_sptr outputWorkspace = inputWorkspace->clone();
+  bool ignoreHistogramValidation = getProperty("IgnoreHistogramValidation");
 
   // Check if it is a valid histogram here
-  bool isAProperHistogram = determineIfHistogramIsValid(*inputWorkspace);
+  bool isAProperHistogram;
+  if (!ignoreHistogramValidation) {
+    isAProperHistogram = determineIfHistogramIsValid(*inputWorkspace);
+  } else {
+    isAProperHistogram = false;
+  }
 
   // Define everything you can outside of the for loop
   // Assume that all spec are the same size

--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -60,7 +60,7 @@ void SortXAxis::exec() {
 
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   MatrixWorkspace_sptr outputWorkspace = inputWorkspace->clone();
-  bool ignoreHistogramValidation = getProperty("IgnoreHistogramValidation");
+  const bool ignoreHistogramValidation = getProperty("IgnoreHistogramValidation");
 
   // Check if it is a valid histogram here
   bool isAProperHistogram;

--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -60,7 +60,8 @@ void SortXAxis::exec() {
 
   MatrixWorkspace_const_sptr inputWorkspace = getProperty("InputWorkspace");
   MatrixWorkspace_sptr outputWorkspace = inputWorkspace->clone();
-  const bool ignoreHistogramValidation = getProperty("IgnoreHistogramValidation");
+  const bool ignoreHistogramValidation =
+      getProperty("IgnoreHistogramValidation");
 
   // Check if it is a valid histogram here
   bool isAProperHistogram;

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -1019,7 +1019,8 @@ def rebin_reduction(workspace_name, rebin_string, multi_frame_rebin_string, num_
         else:
             # Regular data
             SortXAxis(InputWorkspace=workspace_name,
-                      OutputWorkspace=workspace_name)
+                      OutputWorkspace=workspace_name,
+                      IgnoreHistogramValidation=True)
             Rebin(InputWorkspace=workspace_name,
                   OutputWorkspace=workspace_name,
                   Params=rebin_string)


### PR DESCRIPTION
**Description of work.**
At the ISIS facility there is some legacy data that has spectra missing a detector. This means when convert units runs it doesn't reverse the XAxis order like all of the other spectra. This means SortXAxis would not "Sort" it. Therefore in an Indirect workflow it breaks on some older TOSCA data. This is a semi-temporary fix for that data/workflow.

**Report to:** Sanghamitra. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**
- Open MantidPlot
- Open Interfaces->Indirect->Data Reduction
- Switch to the TOSCA instrument
- Enter the run number 4790
- Then click run
- It should run successfully.
<!-- Instructions for testing. -->

Fixes #25242. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
