### PR TITLE
Clang-tidy modernize-loop-convert MantidPlot

### DIFF
--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -1955,9 +1955,9 @@ void AxesDialog::updateGrid() {
   bool antiAlias = m_chkAntialiseGrid->isChecked();
   switch (m_cmbApplyGridFormat->currentIndex()) {
   case 0: {
-    for (auto &gridItr : m_Grid_list) {
-      if (gridItr->modified()) {
-        gridItr->apply(m_graph->plotWidget()->grid(), antiAlias);
+    for (auto &grid : m_Grid_list) {
+      if (grid->modified()) {
+        grid->apply(m_graph->plotWidget()->grid(), antiAlias);
         m_graph->replot();
         m_graph->notifyChanges();
       }
@@ -1969,13 +1969,13 @@ void AxesDialog::updateGrid() {
     if (!plot) {
       return;
     }
-    for (auto &gridItr : m_Grid_list) {
+    for (auto &grid : m_Grid_list) {
       QList<Graph *> layers = plot->layersList();
       foreach (Graph *g, layers) {
         if (g->isPiePlot()) {
           continue;
         }
-        gridItr->apply(g->plotWidget()->grid(), antiAlias);
+        grid->apply(g->plotWidget()->grid(), antiAlias);
         g->replot();
       }
     }
@@ -1994,8 +1994,8 @@ void AxesDialog::updateGrid() {
           if (g->isPiePlot()) {
             continue;
           }
-          for (auto &gridItr : m_Grid_list) {
-            gridItr->apply(g->plotWidget()->grid(), antiAlias, true);
+          for (auto &grid : m_Grid_list) {
+            grid->apply(g->plotWidget()->grid(), antiAlias, true);
             g->replot();
           }
         }
@@ -2012,15 +2012,15 @@ void AxesDialog::updateGrid() {
  */
 bool AxesDialog::pressToGraph() {
   // Check if all tabs and axes are valid first
-  for (auto &axisItr : m_Axis_list) {
-    if (!(axisItr->valid())) {
+  for (auto &axis : m_Axis_list) {
+    if (!(axis->valid())) {
       g_log.warning("Axis options are invalid!");
       return false;
     }
   }
 
-  for (auto &scaleItr : m_Scale_list) {
-    if (!(scaleItr->valid())) {
+  for (auto &scale : m_Scale_list) {
+    if (!(scale->valid())) {
       g_log.warning("Scale options are invalid!");
       return false;
     }
@@ -2028,12 +2028,12 @@ bool AxesDialog::pressToGraph() {
 
   updateGrid();
 
-  for (auto &axisItr : m_Axis_list) {
-    axisItr->apply();
+  for (auto &axis : m_Axis_list) {
+    axis->apply();
   }
 
-  for (auto &scaleItr : m_Scale_list) {
-    scaleItr->apply();
+  for (auto &scale : m_Scale_list) {
+    scale->apply();
   }
 
   if (m_generalModified) {

--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -1955,10 +1955,9 @@ void AxesDialog::updateGrid() {
   bool antiAlias = m_chkAntialiseGrid->isChecked();
   switch (m_cmbApplyGridFormat->currentIndex()) {
   case 0: {
-    for (auto gridItr = m_Grid_list.begin(); gridItr != m_Grid_list.end();
-         gridItr++) {
-      if ((*gridItr)->modified()) {
-        (*gridItr)->apply(m_graph->plotWidget()->grid(), antiAlias);
+    for (auto & gridItr : m_Grid_list) {
+      if (gridItr->modified()) {
+        gridItr->apply(m_graph->plotWidget()->grid(), antiAlias);
         m_graph->replot();
         m_graph->notifyChanges();
       }
@@ -1970,14 +1969,13 @@ void AxesDialog::updateGrid() {
     if (!plot) {
       return;
     }
-    for (auto gridItr = m_Grid_list.begin(); gridItr != m_Grid_list.end();
-         gridItr++) {
+    for (auto & gridItr : m_Grid_list) {
       QList<Graph *> layers = plot->layersList();
       foreach (Graph *g, layers) {
         if (g->isPiePlot()) {
           continue;
         }
-        (*gridItr)->apply(g->plotWidget()->grid(), antiAlias);
+        gridItr->apply(g->plotWidget()->grid(), antiAlias);
         g->replot();
       }
     }
@@ -1996,9 +1994,8 @@ void AxesDialog::updateGrid() {
           if (g->isPiePlot()) {
             continue;
           }
-          for (auto gridItr = m_Grid_list.begin(); gridItr != m_Grid_list.end();
-               gridItr++) {
-            (*gridItr)->apply(g->plotWidget()->grid(), antiAlias, true);
+          for (auto & gridItr : m_Grid_list) {
+            gridItr->apply(g->plotWidget()->grid(), antiAlias, true);
             g->replot();
           }
         }
@@ -2015,17 +2012,15 @@ void AxesDialog::updateGrid() {
  */
 bool AxesDialog::pressToGraph() {
   // Check if all tabs and axes are valid first
-  for (auto axisItr = m_Axis_list.begin(); axisItr != m_Axis_list.end();
-       axisItr++) {
-    if (!((*axisItr)->valid())) {
+  for (auto & axisItr : m_Axis_list) {
+    if (!(axisItr->valid())) {
       g_log.warning("Axis options are invalid!");
       return false;
     }
   }
 
-  for (auto scaleItr = m_Scale_list.begin(); scaleItr != m_Scale_list.end();
-       scaleItr++) {
-    if (!((*scaleItr)->valid())) {
+  for (auto & scaleItr : m_Scale_list) {
+    if (!(scaleItr->valid())) {
       g_log.warning("Scale options are invalid!");
       return false;
     }
@@ -2033,14 +2028,12 @@ bool AxesDialog::pressToGraph() {
 
   updateGrid();
 
-  for (auto axisItr = m_Axis_list.begin(); axisItr != m_Axis_list.end();
-       axisItr++) {
-    (*axisItr)->apply();
+  for (auto & axisItr : m_Axis_list) {
+    axisItr->apply();
   }
 
-  for (auto scaleItr = m_Scale_list.begin(); scaleItr != m_Scale_list.end();
-       scaleItr++) {
-    (*scaleItr)->apply();
+  for (auto & scaleItr : m_Scale_list) {
+    scaleItr->apply();
   }
 
   if (m_generalModified) {

--- a/MantidPlot/src/AxesDialog.cpp
+++ b/MantidPlot/src/AxesDialog.cpp
@@ -1955,7 +1955,7 @@ void AxesDialog::updateGrid() {
   bool antiAlias = m_chkAntialiseGrid->isChecked();
   switch (m_cmbApplyGridFormat->currentIndex()) {
   case 0: {
-    for (auto & gridItr : m_Grid_list) {
+    for (auto &gridItr : m_Grid_list) {
       if (gridItr->modified()) {
         gridItr->apply(m_graph->plotWidget()->grid(), antiAlias);
         m_graph->replot();
@@ -1969,7 +1969,7 @@ void AxesDialog::updateGrid() {
     if (!plot) {
       return;
     }
-    for (auto & gridItr : m_Grid_list) {
+    for (auto &gridItr : m_Grid_list) {
       QList<Graph *> layers = plot->layersList();
       foreach (Graph *g, layers) {
         if (g->isPiePlot()) {
@@ -1994,7 +1994,7 @@ void AxesDialog::updateGrid() {
           if (g->isPiePlot()) {
             continue;
           }
-          for (auto & gridItr : m_Grid_list) {
+          for (auto &gridItr : m_Grid_list) {
             gridItr->apply(g->plotWidget()->grid(), antiAlias, true);
             g->replot();
           }
@@ -2012,14 +2012,14 @@ void AxesDialog::updateGrid() {
  */
 bool AxesDialog::pressToGraph() {
   // Check if all tabs and axes are valid first
-  for (auto & axisItr : m_Axis_list) {
+  for (auto &axisItr : m_Axis_list) {
     if (!(axisItr->valid())) {
       g_log.warning("Axis options are invalid!");
       return false;
     }
   }
 
-  for (auto & scaleItr : m_Scale_list) {
+  for (auto &scaleItr : m_Scale_list) {
     if (!(scaleItr->valid())) {
       g_log.warning("Scale options are invalid!");
       return false;
@@ -2028,11 +2028,11 @@ bool AxesDialog::pressToGraph() {
 
   updateGrid();
 
-  for (auto & axisItr : m_Axis_list) {
+  for (auto &axisItr : m_Axis_list) {
     axisItr->apply();
   }
 
-  for (auto & scaleItr : m_Scale_list) {
+  for (auto &scaleItr : m_Scale_list) {
     scaleItr->apply();
   }
 

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1210,8 +1210,8 @@ void ConfigDialog::deleteDialog() {
     if (status == QMessageBox::Yes) {
       // For each program selected, remove all details from the user.properties
       // file;
-      for (int i = 0; i < selectedItems.size(); ++i) {
-        m_sendToSettings.erase(selectedItems[i]->text(0).toStdString());
+      for (auto & selectedItem : selectedItems) {
+        m_sendToSettings.erase(selectedItem->text(0).toStdString());
       }
       // clear the tree and repopulate it without the programs that have just
       // been deleted
@@ -1226,7 +1226,7 @@ void ConfigDialog::populateProgramTree() {
       Mantid::Kernel::ConfigService::Instance().getKeys(
           "workspace.sendto.name");
 
-  for (size_t i = 0; i < programNames.size(); i++) {
+  for (auto & programName : programNames) {
     // Create a map for the keys and details to go into
     std::map<std::string, std::string> programKeysAndDetails;
 
@@ -1234,16 +1234,16 @@ void ConfigDialog::populateProgramTree() {
     // (optional - arguments, save parameters, workspace type)
     std::vector<std::string> programKeys =
         (Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
-                                                           programNames[i]));
+                                                           programName));
 
-    for (size_t j = 0; j < programKeys.size(); j++) {
+    for (const auto & programKey : programKeys) {
       // Assign a key to its value using the map
-      programKeysAndDetails[programKeys[j]] =
+      programKeysAndDetails[programKey] =
           (Mantid::Kernel::ConfigService::Instance().getString(
-              ("workspace.sendto." + programNames[i] + "." + programKeys[j])));
+              ("workspace.sendto." + programName + "." + programKey)));
     }
 
-    m_sendToSettings.emplace(programNames[i], programKeysAndDetails);
+    m_sendToSettings.emplace(programName, programKeysAndDetails);
   }
   updateProgramTree();
 }
@@ -1296,11 +1296,11 @@ void ConfigDialog::updateSendToTab() {
       cfgSvc.getKeys("workspace.sendto.name");
 
   for (const auto &itr : m_sendToSettings) {
-    for (size_t i = 0; i < programNames.size(); ++i) {
-      if (programNames[i] == itr.first) {
+    for (auto & programName : programNames) {
+      if (programName == itr.first) {
         // The selected program hasn't been deleted so set to blank string (all
         // those left without blank strings are to be deleted
-        programNames[i] = "";
+        programName = "";
       }
     }
 
@@ -1317,14 +1317,14 @@ void ConfigDialog::updateSendToTab() {
 
   // Delete the keys that are in the config but not in the temporary
   // m_sendToSettings map
-  for (size_t i = 0; i < programNames.size(); ++i) {
-    if (programNames[i] != "") {
-      cfgSvc.remove("workspace.sendto.name." + programNames[i]);
+  for (const auto & programName : programNames) {
+    if (programName != "") {
+      cfgSvc.remove("workspace.sendto.name." + programName);
       std::vector<std::string> programKeys =
-          cfgSvc.getKeys("workspace.sendto." + programNames[i]);
-      for (size_t j = 0; j < programKeys.size(); ++j) {
-        cfgSvc.remove("workspace.sendto." + programNames[i] + "." +
-                      programKeys[j]);
+          cfgSvc.getKeys("workspace.sendto." + programName);
+      for (const auto & programKey : programKeys) {
+        cfgSvc.remove("workspace.sendto." + programName + "." +
+                      programKey);
       }
     }
   }

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -1210,7 +1210,7 @@ void ConfigDialog::deleteDialog() {
     if (status == QMessageBox::Yes) {
       // For each program selected, remove all details from the user.properties
       // file;
-      for (auto & selectedItem : selectedItems) {
+      for (auto &selectedItem : selectedItems) {
         m_sendToSettings.erase(selectedItem->text(0).toStdString());
       }
       // clear the tree and repopulate it without the programs that have just
@@ -1226,7 +1226,7 @@ void ConfigDialog::populateProgramTree() {
       Mantid::Kernel::ConfigService::Instance().getKeys(
           "workspace.sendto.name");
 
-  for (auto & programName : programNames) {
+  for (auto &programName : programNames) {
     // Create a map for the keys and details to go into
     std::map<std::string, std::string> programKeysAndDetails;
 
@@ -1236,7 +1236,7 @@ void ConfigDialog::populateProgramTree() {
         (Mantid::Kernel::ConfigService::Instance().getKeys("workspace.sendto." +
                                                            programName));
 
-    for (const auto & programKey : programKeys) {
+    for (const auto &programKey : programKeys) {
       // Assign a key to its value using the map
       programKeysAndDetails[programKey] =
           (Mantid::Kernel::ConfigService::Instance().getString(
@@ -1296,7 +1296,7 @@ void ConfigDialog::updateSendToTab() {
       cfgSvc.getKeys("workspace.sendto.name");
 
   for (const auto &itr : m_sendToSettings) {
-    for (auto & programName : programNames) {
+    for (auto &programName : programNames) {
       if (programName == itr.first) {
         // The selected program hasn't been deleted so set to blank string (all
         // those left without blank strings are to be deleted
@@ -1317,14 +1317,13 @@ void ConfigDialog::updateSendToTab() {
 
   // Delete the keys that are in the config but not in the temporary
   // m_sendToSettings map
-  for (const auto & programName : programNames) {
+  for (const auto &programName : programNames) {
     if (programName != "") {
       cfgSvc.remove("workspace.sendto.name." + programName);
       std::vector<std::string> programKeys =
           cfgSvc.getKeys("workspace.sendto." + programName);
-      for (const auto & programKey : programKeys) {
-        cfgSvc.remove("workspace.sendto." + programName + "." +
-                      programKey);
+      for (const auto &programKey : programKeys) {
+        cfgSvc.remove("workspace.sendto." + programName + "." + programKey);
       }
     }
   }

--- a/MantidPlot/src/ContourLinesEditor.cpp
+++ b/MantidPlot/src/ContourLinesEditor.cpp
@@ -329,26 +329,20 @@ void ContourLinesEditor::updatePen() {
   d_pen_list[d_pen_index] = pen;
 
   if (applyAllColorBox->isChecked()) {
-    for (auto &i : d_pen_list) {
-      QPen p = i;
-      p.setColor(penColorBox->color());
-      i = p;
+    for (auto &pen : d_pen_list) {
+      pen.setColor(penColorBox->color());
     }
   }
 
   if (applyAllStyleBox->isChecked()) {
-    for (auto &i : d_pen_list) {
-      QPen p = i;
-      p.setStyle(penStyleBox->style());
-      i = p;
+    for (auto &pen : d_pen_list) {
+      pen.setStyle(penStyleBox->style());
     }
   }
 
   if (applyAllWidthBox->isChecked()) {
-    for (auto &i : d_pen_list) {
-      QPen p = i;
-      p.setWidthF(penWidthBox->value());
-      i = p;
+    for (auto &pen : d_pen_list) {
+      pen.setWidthF(penWidthBox->value());
     }
   }
 

--- a/MantidPlot/src/ContourLinesEditor.cpp
+++ b/MantidPlot/src/ContourLinesEditor.cpp
@@ -329,26 +329,26 @@ void ContourLinesEditor::updatePen() {
   d_pen_list[d_pen_index] = pen;
 
   if (applyAllColorBox->isChecked()) {
-    for (int i = 0; i < d_pen_list.size(); i++) {
-      QPen p = d_pen_list[i];
+    for (auto & i : d_pen_list) {
+      QPen p = i;
       p.setColor(penColorBox->color());
-      d_pen_list[i] = p;
+      i = p;
     }
   }
 
   if (applyAllStyleBox->isChecked()) {
-    for (int i = 0; i < d_pen_list.size(); i++) {
-      QPen p = d_pen_list[i];
+    for (auto & i : d_pen_list) {
+      QPen p = i;
       p.setStyle(penStyleBox->style());
-      d_pen_list[i] = p;
+      i = p;
     }
   }
 
   if (applyAllWidthBox->isChecked()) {
-    for (int i = 0; i < d_pen_list.size(); i++) {
-      QPen p = d_pen_list[i];
+    for (auto & i : d_pen_list) {
+      QPen p = i;
       p.setWidthF(penWidthBox->value());
-      d_pen_list[i] = p;
+      i = p;
     }
   }
 

--- a/MantidPlot/src/ContourLinesEditor.cpp
+++ b/MantidPlot/src/ContourLinesEditor.cpp
@@ -329,7 +329,7 @@ void ContourLinesEditor::updatePen() {
   d_pen_list[d_pen_index] = pen;
 
   if (applyAllColorBox->isChecked()) {
-    for (auto & i : d_pen_list) {
+    for (auto &i : d_pen_list) {
       QPen p = i;
       p.setColor(penColorBox->color());
       i = p;
@@ -337,7 +337,7 @@ void ContourLinesEditor::updatePen() {
   }
 
   if (applyAllStyleBox->isChecked()) {
-    for (auto & i : d_pen_list) {
+    for (auto &i : d_pen_list) {
       QPen p = i;
       p.setStyle(penStyleBox->style());
       i = p;
@@ -345,7 +345,7 @@ void ContourLinesEditor::updatePen() {
   }
 
   if (applyAllWidthBox->isChecked()) {
-    for (auto & i : d_pen_list) {
+    for (auto &i : d_pen_list) {
       QPen p = i;
       p.setWidthF(penWidthBox->value());
       i = p;

--- a/MantidPlot/src/CurvesDialog.cpp
+++ b/MantidPlot/src/CurvesDialog.cpp
@@ -352,8 +352,8 @@ void CurvesDialog::setGraph(Graph *graph) {
 void CurvesDialog::addCurves() {
   QStringList emptyColumns;
   QList<QListWidgetItem *> lst = available->selectedItems();
-  for (auto i : lst) {
-    QString text = i->text();
+  for (auto &item : lst) {
+    QString text = item->text();
     if (contents->findItems(text, Qt::MatchExactly).isEmpty()) {
       if (!addCurve(text))
         emptyColumns << text;

--- a/MantidPlot/src/CurvesDialog.cpp
+++ b/MantidPlot/src/CurvesDialog.cpp
@@ -352,8 +352,8 @@ void CurvesDialog::setGraph(Graph *graph) {
 void CurvesDialog::addCurves() {
   QStringList emptyColumns;
   QList<QListWidgetItem *> lst = available->selectedItems();
-  for (int i = 0; i < lst.size(); ++i) {
-    QString text = lst.at(i)->text();
+  for (auto i : lst) {
+    QString text = i->text();
     if (contents->findItems(text, Qt::MatchExactly).isEmpty()) {
       if (!addCurve(text))
         emptyColumns << text;
@@ -454,8 +454,7 @@ void CurvesDialog::removeCurves() {
     return;
   }
 
-  for (int i = 0; i < lst.size(); ++i) {
-    QListWidgetItem *it = lst.at(i);
+  for (auto it : lst) {
     QString s = it->text();
     if (boxShowRange->isChecked()) {
       QStringList lst = s.split("[");

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -998,8 +998,7 @@ void Graph::initScaleLimits() { // We call this function the first time we add
   QwtDoubleInterval intv[QwtPlot::axisCnt];
   const QwtPlotItemList &itmList = d_plot->itemList();
   double maxSymbolSize = 0;
-  for (const auto &it : itmList) {
-    const QwtPlotItem *item = it;
+  for (const auto &item : itmList) {
     if (item->rtti() != QwtPlotItem::Rtti_PlotCurve)
       continue;
 
@@ -4394,8 +4393,8 @@ void Graph::copy(Graph *g) {
       insertText(t);
   }
 
-  QVector<int> l = g->lineMarkerKeys();
-  for (int i : l) {
+  QVector<int> lineKeys = g->lineMarkerKeys();
+  for (int i : lineKeys) {
     ArrowMarker *lmrk = dynamic_cast<ArrowMarker *>(g->arrow(i));
     if (lmrk)
       addArrow(lmrk);
@@ -5860,7 +5859,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> imageSections = tsv.sections("image");
-  for (auto &imageSection : imageSections) {
+  for (const auto &imageSection : imageSections) {
     QStringList sl = QString::fromUtf8(imageSection.c_str()).split("\t");
     insertImageMarker(sl, fileVersion);
   }
@@ -5881,11 +5880,11 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> legendSections = tsv.sections("legend");
-  for (auto &legendSection : legendSections)
+  for (const auto &legendSection : legendSections)
     insertText("legend", legendSection);
 
   std::vector<std::string> lineSections = tsv.sections("line");
-  for (auto &lineSection : lineSections) {
+  for (const auto &lineSection : lineSections) {
     QStringList sl = QString::fromUtf8(lineSection.c_str()).split("\t");
     addArrow(sl, fileVersion);
   }
@@ -5953,7 +5952,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> pieLabelSections = tsv.sections("PieLabel");
-  for (auto &pieLabelSection : pieLabelSections)
+  for (const auto &pieLabelSection : pieLabelSections)
     insertText("PieLabel", pieLabelSection);
 
   if (tsv.selectLine("PlotTitle")) {
@@ -5987,7 +5986,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> textSections = tsv.sections("text");
-  for (auto &textSection : textSections)
+  for (const auto &textSection : textSections)
     insertText("text", textSection);
 
   if (tsv.selectLine("TitleFont")) {
@@ -6126,7 +6125,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> functionSections = tsv.sections("Function");
-    for (auto &functionSection : functionSections) {
+    for (const auto &functionSection : functionSections) {
       curveID++;
       QStringList sl = QString::fromUtf8(functionSection.c_str()).split("\n");
       restoreFunction(sl);
@@ -6212,7 +6211,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> specSections = tsv.sections("spectrogram");
-    for (auto &specSection : specSections) {
+    for (const auto &specSection : specSections) {
       MantidQt::API::TSVSerialiser specTSV(specSection);
       Spectrogram *s = nullptr;
 

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -998,7 +998,7 @@ void Graph::initScaleLimits() { // We call this function the first time we add
   QwtDoubleInterval intv[QwtPlot::axisCnt];
   const QwtPlotItemList &itmList = d_plot->itemList();
   double maxSymbolSize = 0;
-  for (const auto & it : itmList) {
+  for (const auto &it : itmList) {
     const QwtPlotItem *item = it;
     if (item->rtti() != QwtPlotItem::Rtti_PlotCurve)
       continue;
@@ -5860,7 +5860,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> imageSections = tsv.sections("image");
-  for (auto & imageSection : imageSections) {
+  for (auto &imageSection : imageSections) {
     QStringList sl = QString::fromUtf8(imageSection.c_str()).split("\t");
     insertImageMarker(sl, fileVersion);
   }
@@ -5881,11 +5881,11 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> legendSections = tsv.sections("legend");
-  for (auto & legendSection : legendSections)
+  for (auto &legendSection : legendSections)
     insertText("legend", legendSection);
 
   std::vector<std::string> lineSections = tsv.sections("line");
-  for (auto & lineSection : lineSections) {
+  for (auto &lineSection : lineSections) {
     QStringList sl = QString::fromUtf8(lineSection.c_str()).split("\t");
     addArrow(sl, fileVersion);
   }
@@ -5953,7 +5953,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> pieLabelSections = tsv.sections("PieLabel");
-  for (auto & pieLabelSection : pieLabelSections)
+  for (auto &pieLabelSection : pieLabelSections)
     insertText("PieLabel", pieLabelSection);
 
   if (tsv.selectLine("PlotTitle")) {
@@ -5987,7 +5987,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> textSections = tsv.sections("text");
-  for (auto & textSection : textSections)
+  for (auto &textSection : textSections)
     insertText("text", textSection);
 
   if (tsv.selectLine("TitleFont")) {
@@ -6126,7 +6126,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> functionSections = tsv.sections("Function");
-    for (auto & functionSection : functionSections) {
+    for (auto &functionSection : functionSections) {
       curveID++;
       QStringList sl = QString::fromUtf8(functionSection.c_str()).split("\n");
       restoreFunction(sl);
@@ -6212,7 +6212,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> specSections = tsv.sections("spectrogram");
-    for (auto & specSection : specSections) {
+    for (auto &specSection : specSections) {
       MantidQt::API::TSVSerialiser specTSV(specSection);
       Spectrogram *s = nullptr;
 

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -4378,8 +4378,8 @@ void Graph::copy(Graph *g) {
   setAxisLabelRotation(QwtPlot::xTop, g->labelsRotation(QwtPlot::xTop));
 
   QVector<int> imag = g->imageMarkerKeys();
-  for (int i = 0; i < (int)imag.size(); i++)
-    addImage(dynamic_cast<ImageMarker *>(g->imageMarker(imag[i])));
+  for (int i : imag)
+    addImage(dynamic_cast<ImageMarker *>(g->imageMarker(i)));
 
   QList<LegendWidget *> texts = g->textsList();
   foreach (LegendWidget *t, texts) {
@@ -4396,8 +4396,8 @@ void Graph::copy(Graph *g) {
   }
 
   QVector<int> l = g->lineMarkerKeys();
-  for (int i = 0; i < (int)l.size(); i++) {
-    ArrowMarker *lmrk = dynamic_cast<ArrowMarker *>(g->arrow(l[i]));
+  for (int i : l) {
+    ArrowMarker *lmrk = dynamic_cast<ArrowMarker *>(g->arrow(i));
     if (lmrk)
       addArrow(lmrk);
   }
@@ -5861,8 +5861,8 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> imageSections = tsv.sections("image");
-  for (auto it = imageSections.begin(); it != imageSections.end(); ++it) {
-    QStringList sl = QString::fromUtf8((*it).c_str()).split("\t");
+  for (auto & imageSection : imageSections) {
+    QStringList sl = QString::fromUtf8(imageSection.c_str()).split("\t");
     insertImageMarker(sl, fileVersion);
   }
 
@@ -5882,12 +5882,12 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> legendSections = tsv.sections("legend");
-  for (auto it = legendSections.begin(); it != legendSections.end(); ++it)
-    insertText("legend", *it);
+  for (auto & legendSection : legendSections)
+    insertText("legend", legendSection);
 
   std::vector<std::string> lineSections = tsv.sections("line");
-  for (auto it = lineSections.begin(); it != lineSections.end(); ++it) {
-    QStringList sl = QString::fromUtf8((*it).c_str()).split("\t");
+  for (auto & lineSection : lineSections) {
+    QStringList sl = QString::fromUtf8(lineSection.c_str()).split("\t");
     addArrow(sl, fileVersion);
   }
 
@@ -5954,8 +5954,8 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> pieLabelSections = tsv.sections("PieLabel");
-  for (auto it = pieLabelSections.begin(); it != pieLabelSections.end(); ++it)
-    insertText("PieLabel", *it);
+  for (auto & pieLabelSection : pieLabelSections)
+    insertText("PieLabel", pieLabelSection);
 
   if (tsv.selectLine("PlotTitle")) {
     QString title, color;
@@ -5988,8 +5988,8 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
   }
 
   std::vector<std::string> textSections = tsv.sections("text");
-  for (auto it = textSections.begin(); it != textSections.end(); ++it)
-    insertText("text", *it);
+  for (auto & textSection : textSections)
+    insertText("text", textSection);
 
   if (tsv.selectLine("TitleFont")) {
     QString font;
@@ -6127,10 +6127,9 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> functionSections = tsv.sections("Function");
-    for (auto it = functionSections.begin(); it != functionSections.end();
-         ++it) {
+    for (auto & functionSection : functionSections) {
       curveID++;
-      QStringList sl = QString::fromUtf8((*it).c_str()).split("\n");
+      QStringList sl = QString::fromUtf8(functionSection.c_str()).split("\n");
       restoreFunction(sl);
     }
 
@@ -6214,8 +6213,8 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
     }
 
     std::vector<std::string> specSections = tsv.sections("spectrogram");
-    for (auto it = specSections.begin(); it != specSections.end(); ++it) {
-      MantidQt::API::TSVSerialiser specTSV(*it);
+    for (auto & specSection : specSections) {
+      MantidQt::API::TSVSerialiser specTSV(specSection);
       Spectrogram *s = nullptr;
 
       if (specTSV.selectLine("workspace")) {
@@ -6252,7 +6251,7 @@ void Graph::loadFromProject(const std::string &lines, ApplicationWindow *app,
         continue;
 
       plotSpectrogram(s, GraphOptions::ColorMap);
-      s->loadFromProject(*it);
+      s->loadFromProject(specSection);
       curveID++;
     }
 
@@ -6716,8 +6715,8 @@ std::string Graph::saveScale() {
 
 std::string Graph::saveMarkers() {
   MantidQt::API::TSVSerialiser tsv;
-  for (int i = 0; i < d_images.size(); ++i) {
-    auto mrkI = dynamic_cast<ImageMarker *>(d_plot->marker(d_images[i]));
+  for (int d_image : d_images) {
+    auto mrkI = dynamic_cast<ImageMarker *>(d_plot->marker(d_image));
     if (!mrkI)
       continue;
 
@@ -6731,8 +6730,8 @@ std::string Graph::saveMarkers() {
     tsv.writeRaw(s.toStdString());
   }
 
-  for (int i = 0; i < d_lines.size(); ++i) {
-    auto mrkL = dynamic_cast<ArrowMarker *>(d_plot->marker(d_lines[i]));
+  for (int d_line : d_lines) {
+    auto mrkL = dynamic_cast<ArrowMarker *>(d_plot->marker(d_line));
     if (!mrkL)
       continue;
 

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -997,10 +997,9 @@ void Graph::initScaleLimits() { // We call this function the first time we add
 
   QwtDoubleInterval intv[QwtPlot::axisCnt];
   const QwtPlotItemList &itmList = d_plot->itemList();
-  QwtPlotItemIterator it;
   double maxSymbolSize = 0;
-  for (it = itmList.begin(); it != itmList.end(); ++it) {
-    const QwtPlotItem *item = *it;
+  for (const auto & it : itmList) {
+    const QwtPlotItem *item = it;
     if (item->rtti() != QwtPlotItem::Rtti_PlotCurve)
       continue;
 

--- a/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
@@ -206,13 +206,9 @@ void MonitorDlg::update() {
     return;
 
   m_algMonitor->lock();
-  QVector<Mantid::API::AlgorithmID>::const_iterator iend =
-      m_algMonitor->algorithms().end();
-  for (QVector<Mantid::API::AlgorithmID>::const_iterator itr =
-           m_algMonitor->algorithms().begin();
-       itr != iend; ++itr) {
+  for (const auto &item : m_algMonitor->algorithms()) {
     IAlgorithm_sptr alg =
-        Mantid::API::AlgorithmManager::Instance().getAlgorithm(*itr);
+        Mantid::API::AlgorithmManager::Instance().getAlgorithm(item);
     if (!alg) {
       continue;
     }
@@ -226,9 +222,7 @@ void MonitorDlg::update() {
     AlgButton *cancelButton = new AlgButton("Cancel", alg);
     m_tree->setItemWidget(algItem, 1, algProgress);
     m_tree->setItemWidget(algItem, 2, cancelButton);
-    const std::vector<Mantid::Kernel::Property *> &prop_list =
-        alg->getProperties();
-    for (auto prop : prop_list) {
+    for (auto &prop : alg->getProperties()) {
       QStringList lstr;
       Mantid::Kernel::MaskedProperty<std::string> *maskedProp =
           dynamic_cast<Mantid::Kernel::MaskedProperty<std::string> *>(prop);
@@ -236,10 +230,10 @@ void MonitorDlg::update() {
         lstr << QString::fromStdString(maskedProp->name()) + ": "
              << QString::fromStdString(maskedProp->getMaskedValue());
       } else {
-        lstr << QString::fromStdString((*prop).name()) + ": "
-             << QString::fromStdString((*prop).value());
+        lstr << QString::fromStdString(prop->name()) + ": "
+             << QString::fromStdString(prop->value());
       }
-      if ((*prop).isDefault())
+      if (prop->isDefault())
         lstr << " Default";
       algItem->addChild(new QTreeWidgetItem(lstr));
     }

--- a/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmMonitor.cpp
@@ -228,20 +228,18 @@ void MonitorDlg::update() {
     m_tree->setItemWidget(algItem, 2, cancelButton);
     const std::vector<Mantid::Kernel::Property *> &prop_list =
         alg->getProperties();
-    for (std::vector<Mantid::Kernel::Property *>::const_iterator prop =
-             prop_list.begin();
-         prop != prop_list.end(); ++prop) {
+    for (auto prop : prop_list) {
       QStringList lstr;
       Mantid::Kernel::MaskedProperty<std::string> *maskedProp =
-          dynamic_cast<Mantid::Kernel::MaskedProperty<std::string> *>(*prop);
+          dynamic_cast<Mantid::Kernel::MaskedProperty<std::string> *>(prop);
       if (maskedProp) {
         lstr << QString::fromStdString(maskedProp->name()) + ": "
              << QString::fromStdString(maskedProp->getMaskedValue());
       } else {
-        lstr << QString::fromStdString((**prop).name()) + ": "
-             << QString::fromStdString((**prop).value());
+        lstr << QString::fromStdString((*prop).name()) + ": "
+             << QString::fromStdString((*prop).value());
       }
-      if ((**prop).isDefault())
+      if ((*prop).isDefault())
         lstr << " Default";
       algItem->addChild(new QTreeWidgetItem(lstr));
     }

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -63,7 +63,7 @@ void FirstTimeSetup::initLayout() {
   // Populate list of facilities
   m_uiForm.cbFacility->clear();
   auto faclist = Mantid::Kernel::ConfigService::Instance().getFacilityNames();
-  for (auto &it : faclist) {
+  for (const auto &it : faclist) {
     m_uiForm.cbFacility->addItem(QString::fromStdString(it));
   }
 

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -63,8 +63,8 @@ void FirstTimeSetup::initLayout() {
   // Populate list of facilities
   m_uiForm.cbFacility->clear();
   auto faclist = Mantid::Kernel::ConfigService::Instance().getFacilityNames();
-  for (const auto &it : faclist) {
-    m_uiForm.cbFacility->addItem(QString::fromStdString(it));
+  for (const auto &facilityName : faclist) {
+    m_uiForm.cbFacility->addItem(QString::fromStdString(facilityName));
   }
 
   Mantid::Kernel::ConfigServiceImpl &config =

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -63,8 +63,8 @@ void FirstTimeSetup::initLayout() {
   // Populate list of facilities
   m_uiForm.cbFacility->clear();
   auto faclist = Mantid::Kernel::ConfigService::Instance().getFacilityNames();
-  for (auto it = faclist.begin(); it != faclist.end(); ++it) {
-    m_uiForm.cbFacility->addItem(QString::fromStdString(*it));
+  for (auto & it : faclist) {
+    m_uiForm.cbFacility->addItem(QString::fromStdString(it));
   }
 
   Mantid::Kernel::ConfigServiceImpl &config =

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -63,7 +63,7 @@ void FirstTimeSetup::initLayout() {
   // Populate list of facilities
   m_uiForm.cbFacility->clear();
   auto faclist = Mantid::Kernel::ConfigService::Instance().getFacilityNames();
-  for (auto & it : faclist) {
+  for (auto &it : faclist) {
     m_uiForm.cbFacility->addItem(QString::fromStdString(it));
   }
 

--- a/MantidPlot/src/Mantid/FitParameterTie.cpp
+++ b/MantidPlot/src/Mantid/FitParameterTie.cpp
@@ -120,9 +120,9 @@ QString FitParameterTie::exprRHS() const {
  *   from i (inclusive) must be incremented.
  */
 void FitParameterTie::functionInserted(int i) {
-  for (int &m_iFunction : m_iFunctions) {
-    if (m_iFunction >= i) {
-      m_iFunction++;
+  for (int &iFunction : m_iFunctions) {
+    if (iFunction >= i) {
+      iFunction++;
     }
   }
 }
@@ -136,12 +136,12 @@ void FitParameterTie::functionInserted(int i) {
  * @return true if the tie remains valid and false otherwise.
  */
 bool FitParameterTie::functionDeleted(int i) {
-  for (int &m_iFunction : m_iFunctions) {
-    if (m_iFunction == i) {
+  for (int &iFunction : m_iFunctions) {
+    if (iFunction == i) {
       return false;
     }
-    if (m_iFunction > i) {
-      m_iFunction--;
+    if (iFunction > i) {
+      iFunction--;
     }
   }
   return true;

--- a/MantidPlot/src/Mantid/FitParameterTie.cpp
+++ b/MantidPlot/src/Mantid/FitParameterTie.cpp
@@ -120,9 +120,9 @@ QString FitParameterTie::exprRHS() const {
  *   from i (inclusive) must be incremented.
  */
 void FitParameterTie::functionInserted(int i) {
-  for (int j = 0; j < m_iFunctions.size(); j++) {
-    if (m_iFunctions[j] >= i) {
-      m_iFunctions[j]++;
+  for (int & m_iFunction : m_iFunctions) {
+    if (m_iFunction >= i) {
+      m_iFunction++;
     }
   }
 }
@@ -136,12 +136,12 @@ void FitParameterTie::functionInserted(int i) {
  * @return true if the tie remains valid and false otherwise.
  */
 bool FitParameterTie::functionDeleted(int i) {
-  for (int j = 0; j < m_iFunctions.size(); j++) {
-    if (m_iFunctions[j] == i) {
+  for (int & m_iFunction : m_iFunctions) {
+    if (m_iFunction == i) {
       return false;
     }
-    if (m_iFunctions[j] > i) {
-      m_iFunctions[j]--;
+    if (m_iFunction > i) {
+      m_iFunction--;
     }
   }
   return true;

--- a/MantidPlot/src/Mantid/FitParameterTie.cpp
+++ b/MantidPlot/src/Mantid/FitParameterTie.cpp
@@ -120,7 +120,7 @@ QString FitParameterTie::exprRHS() const {
  *   from i (inclusive) must be incremented.
  */
 void FitParameterTie::functionInserted(int i) {
-  for (int & m_iFunction : m_iFunctions) {
+  for (int &m_iFunction : m_iFunctions) {
     if (m_iFunction >= i) {
       m_iFunction++;
     }
@@ -136,7 +136,7 @@ void FitParameterTie::functionInserted(int i) {
  * @return true if the tie remains valid and false otherwise.
  */
 bool FitParameterTie::functionDeleted(int i) {
-  for (int & m_iFunction : m_iFunctions) {
+  for (int &m_iFunction : m_iFunctions) {
     if (m_iFunction == i) {
       return false;
     }

--- a/MantidPlot/src/Mantid/InputHistory.cpp
+++ b/MantidPlot/src/Mantid/InputHistory.cpp
@@ -66,7 +66,7 @@ void InputHistoryImpl::save() {
 void InputHistoryImpl::updateAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
   const std::vector<Property *> &props = alg->getProperties();
   QList<PropertyData> prop_hist_list;
-  for (auto prop : props)
+  for (auto &prop : props)
     if (!prop->isDefault()) {
       PropertyData prop_hist(QString::fromStdString(prop->name()),
                              QString::fromStdString(prop->value()));

--- a/MantidPlot/src/Mantid/InputHistory.cpp
+++ b/MantidPlot/src/Mantid/InputHistory.cpp
@@ -53,9 +53,8 @@ void InputHistoryImpl::save() {
     alg.next();
     const QList<PropertyData> &prop_hist = alg.value();
     settings.beginGroup(alg.key());
-    for (QList<PropertyData>::const_iterator prop = prop_hist.begin();
-         prop != prop_hist.end(); ++prop)
-      settings.setValue(prop->name, prop->value);
+    for (const auto & prop : prop_hist)
+      settings.setValue(prop.name, prop.value);
     settings.endGroup();
   }
   settings.endGroup();
@@ -67,14 +66,13 @@ void InputHistoryImpl::save() {
 void InputHistoryImpl::updateAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
   const std::vector<Property *> &props = alg->getProperties();
   QList<PropertyData> prop_hist_list;
-  for (std::vector<Property *>::const_iterator prop = props.begin();
-       prop != props.end(); ++prop)
-    if (!(*prop)->isDefault()) {
-      PropertyData prop_hist(QString::fromStdString((*prop)->name()),
-                             QString::fromStdString((*prop)->value()));
+  for (auto prop : props)
+    if (!prop->isDefault()) {
+      PropertyData prop_hist(QString::fromStdString(prop->name()),
+                             QString::fromStdString(prop->value()));
       prop_hist_list.push_back(prop_hist);
     } else {
-      PropertyData prop_hist(QString::fromStdString((*prop)->name()), "");
+      PropertyData prop_hist(QString::fromStdString(prop->name()), "");
       prop_hist_list.push_back(prop_hist);
     }
   m_history[QString::fromStdString(alg->name())] = prop_hist_list;
@@ -86,9 +84,8 @@ void InputHistoryImpl::printAll() {
     alg.next();
     std::cerr << alg.key().toStdString() << '\n';
     const QList<PropertyData> &prop_list = alg.value();
-    for (QList<PropertyData>::const_iterator prop = prop_list.begin();
-         prop != prop_list.end(); ++prop)
-      std::cerr << prop->name.toStdString() << ": " << prop->value.toStdString()
+    for (const auto & prop : prop_list)
+      std::cerr << prop.name.toStdString() << ": " << prop.value.toStdString()
                 << '\n';
   }
 }
@@ -103,9 +100,8 @@ InputHistoryImpl::algorithmProperties(const QString &algName) {
   if (a != m_history.end()) {
     QMap<QString, QString> m;
     const QList<PropertyData> &prop_list = a.value();
-    for (QList<PropertyData>::const_iterator prop = prop_list.begin();
-         prop != prop_list.end(); ++prop)
-      m[prop->name] = prop->value;
+    for (const auto & prop : prop_list)
+      m[prop.name] = prop.value;
     return m;
   }
   return QMap<QString, QString>();

--- a/MantidPlot/src/Mantid/InputHistory.cpp
+++ b/MantidPlot/src/Mantid/InputHistory.cpp
@@ -53,7 +53,7 @@ void InputHistoryImpl::save() {
     alg.next();
     const QList<PropertyData> &prop_hist = alg.value();
     settings.beginGroup(alg.key());
-    for (const auto & prop : prop_hist)
+    for (const auto &prop : prop_hist)
       settings.setValue(prop.name, prop.value);
     settings.endGroup();
   }
@@ -84,7 +84,7 @@ void InputHistoryImpl::printAll() {
     alg.next();
     std::cerr << alg.key().toStdString() << '\n';
     const QList<PropertyData> &prop_list = alg.value();
-    for (const auto & prop : prop_list)
+    for (const auto &prop : prop_list)
       std::cerr << prop.name.toStdString() << ": " << prop.value.toStdString()
                 << '\n';
   }
@@ -100,7 +100,7 @@ InputHistoryImpl::algorithmProperties(const QString &algName) {
   if (a != m_history.end()) {
     QMap<QString, QString> m;
     const QList<PropertyData> &prop_list = a.value();
-    for (const auto & prop : prop_list)
+    for (const auto &prop : prop_list)
       m[prop.name] = prop.value;
     return m;
   }

--- a/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
@@ -73,8 +73,8 @@ void MantidMatrixExtensionRequest::setNumberFormat(
 void MantidMatrixExtensionRequest::setNumberFormatForAll(
     MantidMatrixTabExtensionMap &extensions, const QChar &format,
     int precision) {
-  for (auto it = extensions.begin(); it != extensions.end(); ++it) {
-    auto &extension = it->second;
+  for (auto & it : extensions) {
+    auto &extension = it.second;
     m_extensionHandler->setNumberFormat(extension, format, precision);
   }
 }
@@ -146,8 +146,8 @@ int MantidMatrixExtensionRequest::getPrecision(
  */
 void MantidMatrixExtensionRequest::setColumnWidthForAll(
     MantidMatrixTabExtensionMap &extensions, int width, int numberOfColumns) {
-  for (auto it = extensions.begin(); it != extensions.end(); ++it) {
-    auto &extension = it->second;
+  for (auto & it : extensions) {
+    auto &extension = it.second;
     m_extensionHandler->setColumnWidth(extension, width, numberOfColumns);
   }
 }
@@ -219,8 +219,8 @@ int MantidMatrixExtensionRequest::getColumnWidth(
  */
 bool MantidMatrixExtensionRequest::tableViewMatchesObject(
     MantidMatrixTabExtensionMap &extensions, QObject *object) {
-  for (auto it = extensions.begin(); it != extensions.end(); ++it) {
-    auto &extension = it->second;
+  for (auto & it : extensions) {
+    auto &extension = it.second;
     if (extension.tableView.get() == object) {
       return true;
     }

--- a/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixExtensionRequest.cpp
@@ -73,7 +73,7 @@ void MantidMatrixExtensionRequest::setNumberFormat(
 void MantidMatrixExtensionRequest::setNumberFormatForAll(
     MantidMatrixTabExtensionMap &extensions, const QChar &format,
     int precision) {
-  for (auto & it : extensions) {
+  for (auto &it : extensions) {
     auto &extension = it.second;
     m_extensionHandler->setNumberFormat(extension, format, precision);
   }
@@ -146,7 +146,7 @@ int MantidMatrixExtensionRequest::getPrecision(
  */
 void MantidMatrixExtensionRequest::setColumnWidthForAll(
     MantidMatrixTabExtensionMap &extensions, int width, int numberOfColumns) {
-  for (auto & it : extensions) {
+  for (auto &it : extensions) {
     auto &extension = it.second;
     m_extensionHandler->setColumnWidth(extension, width, numberOfColumns);
   }
@@ -219,7 +219,7 @@ int MantidMatrixExtensionRequest::getColumnWidth(
  */
 bool MantidMatrixExtensionRequest::tableViewMatchesObject(
     MantidMatrixTabExtensionMap &extensions, QObject *object) {
-  for (auto & it : extensions) {
+  for (auto &it : extensions) {
     auto &extension = it.second;
     if (extension.tableView.get() == object) {
       return true;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -468,7 +468,7 @@ QStringList MantidUI::getAlgorithmNames() {
   QStringList sl;
   std::vector<std::string> algorithmKeys =
       Mantid::API::AlgorithmFactory::Instance().getKeys();
-  sl.reserve(static_cast<size_t>(algorithmKeys.size()));
+  sl.reserve(static_cast<int>(algorithmKeys.size()));
   for (const auto &algorithmKey : algorithmKeys)
     sl << QString::fromStdString(algorithmKey);
   return sl;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -466,10 +466,11 @@ QStringList MantidUI::getWorkspaceNames() {
 
 QStringList MantidUI::getAlgorithmNames() {
   QStringList sl;
-  std::vector<std::string> sv;
-  sv = Mantid::API::AlgorithmFactory::Instance().getKeys();
-  for (const auto &i : sv)
-    sl << QString::fromStdString(i);
+  std::vector<std::string> algorithmKeys =
+      Mantid::API::AlgorithmFactory::Instance().getKeys();
+  sl.reserve(algorithmKeys.size());
+  for (const auto &algorithmKey : algorithmKeys)
+    sl << QString::fromStdString(algorithmKey);
   return sl;
 }
 
@@ -3178,15 +3179,15 @@ MultiLayer *MantidUI::plot1D(const QMultiMap<QString, int> &toPlot,
       (spectrumPlot) ? MantidMatrixCurve::Spectrum : MantidMatrixCurve::Bin;
   MantidMatrixCurve *firstCurve(nullptr);
   QString logValue("");
-  for (auto &i : curveSpecList) {
+  for (const auto &curveSpec : curveSpecList) {
 
     if (!log.isEmpty()) { // Get log value from workspace
-      logValue = logValue.number(i.logVal, 'g', 6);
+      logValue = logValue.number(curveSpec.logVal, 'g', 6);
     }
 
-    auto *wsCurve =
-        new MantidMatrixCurve(logValue, i.wsName, g, i.index, indexType, errs,
-                              plotAsDistribution, style, multipleSpectra);
+    auto *wsCurve = new MantidMatrixCurve(
+        logValue, curveSpec.wsName, g, curveSpec.index, indexType, errs,
+        plotAsDistribution, style, multipleSpectra);
     if (!firstCurve) {
       firstCurve = wsCurve;
       g->setNormalizable(firstCurve->isNormalizable());

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -468,7 +468,7 @@ QStringList MantidUI::getAlgorithmNames() {
   QStringList sl;
   std::vector<std::string> algorithmKeys =
       Mantid::API::AlgorithmFactory::Instance().getKeys();
-  sl.reserve(algorithmKeys.size());
+  sl.reserve(static_cast<size_t>(algorithmKeys.size()));
   for (const auto &algorithmKey : algorithmKeys)
     sl << QString::fromStdString(algorithmKey);
   return sl;

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -468,7 +468,7 @@ QStringList MantidUI::getAlgorithmNames() {
   QStringList sl;
   std::vector<std::string> sv;
   sv = Mantid::API::AlgorithmFactory::Instance().getKeys();
-  for (const auto & i : sv)
+  for (const auto &i : sv)
     sl << QString::fromStdString(i);
   return sl;
 }
@@ -3178,15 +3178,15 @@ MultiLayer *MantidUI::plot1D(const QMultiMap<QString, int> &toPlot,
       (spectrumPlot) ? MantidMatrixCurve::Spectrum : MantidMatrixCurve::Bin;
   MantidMatrixCurve *firstCurve(nullptr);
   QString logValue("");
-  for (auto & i : curveSpecList) {
+  for (auto &i : curveSpecList) {
 
     if (!log.isEmpty()) { // Get log value from workspace
       logValue = logValue.number(i.logVal, 'g', 6);
     }
 
-    auto *wsCurve = new MantidMatrixCurve(
-        logValue, i.wsName, g, i.index, indexType,
-        errs, plotAsDistribution, style, multipleSpectra);
+    auto *wsCurve =
+        new MantidMatrixCurve(logValue, i.wsName, g, i.index, indexType, errs,
+                              plotAsDistribution, style, multipleSpectra);
     if (!firstCurve) {
       firstCurve = wsCurve;
       g->setNormalizable(firstCurve->isNormalizable());
@@ -3328,7 +3328,7 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
   int nPlots = wsNames.size();
   if (nPlots > 1) {
     QList<MultiLayer *> plots;
-    for (const auto & wsName : wsNames) {
+    for (const auto &wsName : wsNames) {
       const bool hidden = true;
       MultiLayer *plot =
           this->drawSingleColorFillPlot(wsName, curveType, nullptr, hidden);
@@ -3359,7 +3359,7 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
 
       int row = 0;
       int col = 0;
-      for (auto & plot : plots) {
+      for (auto &plot : plots) {
         tiledWindow->addWidget(plot, row, col);
         ++col;
         if (col == nCols) {

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -468,8 +468,8 @@ QStringList MantidUI::getAlgorithmNames() {
   QStringList sl;
   std::vector<std::string> sv;
   sv = Mantid::API::AlgorithmFactory::Instance().getKeys();
-  for (size_t i = 0; i < sv.size(); i++)
-    sl << QString::fromStdString(sv[i]);
+  for (const auto & i : sv)
+    sl << QString::fromStdString(i);
   return sl;
 }
 
@@ -3178,14 +3178,14 @@ MultiLayer *MantidUI::plot1D(const QMultiMap<QString, int> &toPlot,
       (spectrumPlot) ? MantidMatrixCurve::Spectrum : MantidMatrixCurve::Bin;
   MantidMatrixCurve *firstCurve(nullptr);
   QString logValue("");
-  for (size_t i = 0; i < curveSpecList.size(); i++) {
+  for (auto & i : curveSpecList) {
 
     if (!log.isEmpty()) { // Get log value from workspace
-      logValue = logValue.number(curveSpecList[i].logVal, 'g', 6);
+      logValue = logValue.number(i.logVal, 'g', 6);
     }
 
     auto *wsCurve = new MantidMatrixCurve(
-        logValue, curveSpecList[i].wsName, g, curveSpecList[i].index, indexType,
+        logValue, i.wsName, g, i.index, indexType,
         errs, plotAsDistribution, style, multipleSpectra);
     if (!firstCurve) {
       firstCurve = wsCurve;
@@ -3328,11 +3328,10 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
   int nPlots = wsNames.size();
   if (nPlots > 1) {
     QList<MultiLayer *> plots;
-    for (QStringList::const_iterator cit = wsNames.begin();
-         cit != wsNames.end(); ++cit) {
+    for (const auto & wsName : wsNames) {
       const bool hidden = true;
       MultiLayer *plot =
-          this->drawSingleColorFillPlot(*cit, curveType, nullptr, hidden);
+          this->drawSingleColorFillPlot(wsName, curveType, nullptr, hidden);
       if (plot)
         plots.append(plot);
     }
@@ -3360,8 +3359,8 @@ void MantidUI::drawColorFillPlots(const QStringList &wsNames,
 
       int row = 0;
       int col = 0;
-      for (auto it = plots.begin(); it != plots.end(); ++it) {
-        tiledWindow->addWidget(*it, row, col);
+      for (auto & plot : plots) {
+        tiledWindow->addWidget(plot, row, col);
         ++col;
         if (col == nCols) {
           col = 0;

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
@@ -57,8 +57,8 @@ SampleLogDialogBase::SampleLogDialogBase(const QString &wsname,
       m_experimentInfoIndex(experimentInfoIndex), buttonPlot(nullptr),
       buttonClose(nullptr), m_spinNumber(nullptr) {
 
-  for (size_t i = 0; i < NUM_STATS; ++i) {
-    statValues[i] = nullptr;
+  for (auto & statValue : statValues) {
+    statValue = nullptr;
   }
 
   // No further initialisation provided, must be done in derived classes
@@ -115,8 +115,8 @@ void SampleLogDialogBase::showLogStatistics() {
 void SampleLogDialogBase::showLogStatisticsOfItem(
     QTreeWidgetItem *item, const LogFilterGenerator::FilterType filter) {
   // Assume that you can't show the stats
-  for (size_t i = 0; i < NUM_STATS; i++) {
-    statValues[i]->setText(QString(""));
+  for (auto & statValue : statValues) {
+    statValue->setText(QString(""));
   }
 
   // used in numeric time series below, the default filter value

--- a/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
+++ b/MantidPlot/src/Mantid/SampleLogDialogBase.cpp
@@ -57,7 +57,7 @@ SampleLogDialogBase::SampleLogDialogBase(const QString &wsname,
       m_experimentInfoIndex(experimentInfoIndex), buttonPlot(nullptr),
       buttonClose(nullptr), m_spinNumber(nullptr) {
 
-  for (auto & statValue : statValues) {
+  for (auto &statValue : statValues) {
     statValue = nullptr;
   }
 
@@ -115,7 +115,7 @@ void SampleLogDialogBase::showLogStatistics() {
 void SampleLogDialogBase::showLogStatisticsOfItem(
     QTreeWidgetItem *item, const LogFilterGenerator::FilterType filter) {
   // Assume that you can't show the stats
-  for (auto & statValue : statValues) {
+  for (auto &statValue : statValues) {
     statValue->setText(QString(""));
   }
 

--- a/MantidPlot/src/Matrix.cpp
+++ b/MantidPlot/src/Matrix.cpp
@@ -1614,8 +1614,8 @@ Matrix::loadFromProject(const std::string &lines, ApplicationWindow *app,
     if (!dataLines.empty())
       boost::split(dataVec, dataLines, boost::is_any_of("\n"));
 
-    for (auto lineIt = dataVec.begin(); lineIt != dataVec.end(); ++lineIt) {
-      boost::split(valVec, *lineIt, boost::is_any_of("\t"));
+    for (auto & lineIt : dataVec) {
+      boost::split(valVec, lineIt, boost::is_any_of("\t"));
 
       // Take the row number from the front
       int row = 0;

--- a/MantidPlot/src/Matrix.cpp
+++ b/MantidPlot/src/Matrix.cpp
@@ -1614,7 +1614,7 @@ Matrix::loadFromProject(const std::string &lines, ApplicationWindow *app,
     if (!dataLines.empty())
       boost::split(dataVec, dataLines, boost::is_any_of("\n"));
 
-    for (auto & lineIt : dataVec) {
+    for (auto &lineIt : dataVec) {
       boost::split(valVec, lineIt, boost::is_any_of("\t"));
 
       // Take the row number from the front

--- a/MantidPlot/src/MdPlottingCmapsProvider.cpp
+++ b/MantidPlot/src/MdPlottingCmapsProvider.cpp
@@ -96,9 +96,9 @@ void MdPlottingCmapsProvider::appendAllFileNamesForFileType(
 
   QFileInfoList info = directory.entryInfoList(filter, QDir::Files);
 
-  for (auto &it : info) {
-    colorMapNames.append(it.baseName());
-    colorMapFiles.append(it.absoluteFilePath());
+  for (const auto &fileInfo : info) {
+    colorMapNames.append(fileInfo.baseName());
+    colorMapFiles.append(fileInfo.absoluteFilePath());
   }
 }
 
@@ -109,8 +109,8 @@ MdPlottingCmapsProvider::getSliceViewerIndicesForCommonColorMaps(
 
   std::vector<int> indexVector;
 
-  for (auto &it : colorMapNamesSliceViewer) {
-    if (colorMapNamesVsi.indexOf(it) != -1) {
+  for (const auto &colorMapName : colorMapNamesSliceViewer) {
+    if (colorMapNamesVsi.indexOf(colorMapName) != -1) {
       indexVector.push_back(index);
     }
 

--- a/MantidPlot/src/MdPlottingCmapsProvider.cpp
+++ b/MantidPlot/src/MdPlottingCmapsProvider.cpp
@@ -52,7 +52,7 @@ void MdPlottingCmapsProvider::getColorMapsForMdPlotting(
   std::vector<int> indexList = getSliceViewerIndicesForCommonColorMaps(
       colorMapNamesSliceViewer, colorMapNamesVsi);
 
-  for (int & it : indexList) {
+  for (int &it : indexList) {
     colorMapNames.append(colorMapNamesSliceViewer[it]);
     colorMapFiles.append(colorMapFilesSliceViewer[it]);
   }
@@ -96,7 +96,7 @@ void MdPlottingCmapsProvider::appendAllFileNamesForFileType(
 
   QFileInfoList info = directory.entryInfoList(filter, QDir::Files);
 
-  for (auto & it : info) {
+  for (auto &it : info) {
     colorMapNames.append(it.baseName());
     colorMapFiles.append(it.absoluteFilePath());
   }
@@ -109,7 +109,7 @@ MdPlottingCmapsProvider::getSliceViewerIndicesForCommonColorMaps(
 
   std::vector<int> indexVector;
 
-  for (auto & it : colorMapNamesSliceViewer) {
+  for (auto &it : colorMapNamesSliceViewer) {
     if (colorMapNamesVsi.indexOf(it) != -1) {
       indexVector.push_back(index);
     }

--- a/MantidPlot/src/MdPlottingCmapsProvider.cpp
+++ b/MantidPlot/src/MdPlottingCmapsProvider.cpp
@@ -52,10 +52,9 @@ void MdPlottingCmapsProvider::getColorMapsForMdPlotting(
   std::vector<int> indexList = getSliceViewerIndicesForCommonColorMaps(
       colorMapNamesSliceViewer, colorMapNamesVsi);
 
-  for (std::vector<int>::iterator it = indexList.begin(); it != indexList.end();
-       ++it) {
-    colorMapNames.append(colorMapNamesSliceViewer[*it]);
-    colorMapFiles.append(colorMapFilesSliceViewer[*it]);
+  for (int & it : indexList) {
+    colorMapNames.append(colorMapNamesSliceViewer[it]);
+    colorMapFiles.append(colorMapFilesSliceViewer[it]);
   }
 }
 
@@ -97,9 +96,9 @@ void MdPlottingCmapsProvider::appendAllFileNamesForFileType(
 
   QFileInfoList info = directory.entryInfoList(filter, QDir::Files);
 
-  for (QFileInfoList::iterator it = info.begin(); it != info.end(); ++it) {
-    colorMapNames.append(it->baseName());
-    colorMapFiles.append(it->absoluteFilePath());
+  for (auto & it : info) {
+    colorMapNames.append(it.baseName());
+    colorMapFiles.append(it.absoluteFilePath());
   }
 }
 
@@ -110,9 +109,8 @@ MdPlottingCmapsProvider::getSliceViewerIndicesForCommonColorMaps(
 
   std::vector<int> indexVector;
 
-  for (QStringList::iterator it = colorMapNamesSliceViewer.begin();
-       it != colorMapNamesSliceViewer.end(); ++it) {
-    if (colorMapNamesVsi.indexOf(*it) != -1) {
+  for (auto & it : colorMapNamesSliceViewer) {
+    if (colorMapNamesVsi.indexOf(it) != -1) {
       indexVector.push_back(index);
     }
 

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -1324,10 +1324,10 @@ void MultiLayer::dropOntoMDCurve(Graph *g, MantidMDCurve *originalCurve,
 
   // Loop through all selected workspaces create curves and put them onto the
   // graph
-  for (int i = 0; i < allWsNames.size(); i++) {
+  for (auto & allWsName : allWsNames) {
     // Capability query the candidate workspaces
     Workspace_sptr ws =
-        AnalysisDataService::Instance().retrieve(allWsNames[i].toStdString());
+        AnalysisDataService::Instance().retrieve(allWsName.toStdString());
     IMDWorkspace_sptr imdWS = boost::dynamic_pointer_cast<IMDWorkspace>(ws);
     // Only process IMDWorkspaces
     if (imdWS) {

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -1324,7 +1324,7 @@ void MultiLayer::dropOntoMDCurve(Graph *g, MantidMDCurve *originalCurve,
 
   // Loop through all selected workspaces create curves and put them onto the
   // graph
-  for (auto & allWsName : allWsNames) {
+  for (auto &allWsName : allWsNames) {
     // Capability query the candidate workspaces
     Workspace_sptr ws =
         AnalysisDataService::Instance().retrieve(allWsName.toStdString());

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -421,10 +421,10 @@ void ProjectRecovery::deleteExistingUnusedCheckpoints(
   std::vector<int> possiblePids = orderProcessIDs(possiblePidsPaths);
   // check if pid exists
   std::vector<std::string> folderPaths;
-  for (auto i = 0u; i < possiblePids.size(); ++i) {
-    if (!isPIDused(possiblePids[i])) {
+  for (int possiblePid : possiblePids) {
+    if (!isPIDused(possiblePid)) {
       std::string folder = recoverFolder;
-      folder.append(std::to_string(possiblePids[i]) + "/");
+      folder.append(std::to_string(possiblePid) + "/");
       folderPaths.emplace_back(folder);
     }
   }
@@ -728,9 +728,9 @@ ProjectRecovery::findOlderCheckpoints(const std::string &recoverFolder,
   // Currently set to a month in microseconds
   const Poco::Timestamp::TimeDiff timeToDeleteAfter(2592000000000);
   std::vector<std::string> folderPaths;
-  for (auto i = 0u; i < possiblePids.size(); ++i) {
+  for (int possiblePid : possiblePids) {
     std::string folder = recoverFolder;
-    folder.append(std::to_string(possiblePids[i]) + "/");
+    folder.append(std::to_string(possiblePid) + "/");
     // check if the checkpoint is too old
     if (olderThanAGivenTime(Poco::Path(folder), timeToDeleteAfter)) {
       folderPaths.emplace_back(folder);
@@ -743,9 +743,9 @@ std::vector<std::string>
 ProjectRecovery::findLockedCheckpoints(const std::string &recoverFolder,
                                        const std::vector<int> &possiblePids) {
   std::vector<std::string> files;
-  for (auto i = 0u; i < possiblePids.size(); ++i) {
+  for (int possiblePid : possiblePids) {
     std::string folder = recoverFolder;
-    folder.append(std::to_string(possiblePids[i]) + "/");
+    folder.append(std::to_string(possiblePid) + "/");
     auto checkpointsInsidePIDs = getListOfFoldersInDirectory(folder);
     for (auto c : checkpointsInsidePIDs) {
       if (Poco::File(c.setFileName(LOCK_FILE_NAME)).exists()) {

--- a/MantidPlot/src/ProjectRecoveryGUIs/ProjectRecoveryPresenter.cpp
+++ b/MantidPlot/src/ProjectRecoveryGUIs/ProjectRecoveryPresenter.cpp
@@ -65,8 +65,8 @@ bool ProjectRecoveryPresenter::startRecoveryFailure() {
 QStringList ProjectRecoveryPresenter::getRow(int i) {
   const auto &vec = m_model->getRow(i);
   QStringList returnVal;
-  for (auto i = 0u; i < vec.size(); ++i) {
-    QString newString = QString::fromStdString(vec[i]);
+  for (const auto & i : vec) {
+    QString newString = QString::fromStdString(i);
     returnVal << newString;
   }
   return returnVal;

--- a/MantidPlot/src/ProjectRecoveryGUIs/ProjectRecoveryPresenter.cpp
+++ b/MantidPlot/src/ProjectRecoveryGUIs/ProjectRecoveryPresenter.cpp
@@ -65,7 +65,7 @@ bool ProjectRecoveryPresenter::startRecoveryFailure() {
 QStringList ProjectRecoveryPresenter::getRow(int i) {
   const auto &vec = m_model->getRow(i);
   QStringList returnVal;
-  for (const auto & i : vec) {
+  for (const auto &i : vec) {
     QString newString = QString::fromStdString(i);
     returnVal << newString;
   }

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -659,21 +659,21 @@ QString ProjectSerialiser::saveWorkspaces() {
       wsNames += "\t";
       wsNames += wsName;
       std::vector<std::string> secondLevelItems = group->getNames();
-      for (size_t j = 0; j < secondLevelItems.size(); j++) {
+      for (const auto & secondLevelItem : secondLevelItems) {
 
         // check whether the user wants to save this workspace
-        if (!m_saveAll && !contains(m_workspaceNames, secondLevelItems[j]))
+        if (!m_saveAll && !contains(m_workspaceNames, secondLevelItem))
           continue;
 
         wsNames += ",";
-        wsNames += QString::fromStdString(secondLevelItems[j]);
+        wsNames += QString::fromStdString(secondLevelItem);
 
         // Do not save out grouped workspaces in project recovery mode
         if (!m_projectRecovery) {
-          const std::string fileName(workingDir + "//" + secondLevelItems[j] +
+          const std::string fileName(workingDir + "//" + secondLevelItem +
                                      ".nxs");
           window->mantidUI->savedatainNexusFormat(fileName,
-                                                  secondLevelItems[j]);
+                                                  secondLevelItem);
         }
       }
     } else {

--- a/MantidPlot/src/ProjectSerialiser.cpp
+++ b/MantidPlot/src/ProjectSerialiser.cpp
@@ -659,7 +659,7 @@ QString ProjectSerialiser::saveWorkspaces() {
       wsNames += "\t";
       wsNames += wsName;
       std::vector<std::string> secondLevelItems = group->getNames();
-      for (const auto & secondLevelItem : secondLevelItems) {
+      for (const auto &secondLevelItem : secondLevelItems) {
 
         // check whether the user wants to save this workspace
         if (!m_saveAll && !contains(m_workspaceNames, secondLevelItem))
@@ -672,8 +672,7 @@ QString ProjectSerialiser::saveWorkspaces() {
         if (!m_projectRecovery) {
           const std::string fileName(workingDir + "//" + secondLevelItem +
                                      ".nxs");
-          window->mantidUI->savedatainNexusFormat(fileName,
-                                                  secondLevelItem);
+          window->mantidUI->savedatainNexusFormat(fileName, secondLevelItem);
         }
       }
     } else {

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -487,7 +487,7 @@ void ScriptingWindow::loadFromProject(const std::string &lines,
  * @param files :: List of file names to oepn
  */
 void ScriptingWindow::loadFromFileList(const QStringList &files) {
-  for (const auto & file : files) {
+  for (const auto &file : files) {
     if (file.isEmpty())
       continue;
     openUnique(file);

--- a/MantidPlot/src/ScriptingWindow.cpp
+++ b/MantidPlot/src/ScriptingWindow.cpp
@@ -487,10 +487,10 @@ void ScriptingWindow::loadFromProject(const std::string &lines,
  * @param files :: List of file names to oepn
  */
 void ScriptingWindow::loadFromFileList(const QStringList &files) {
-  for (auto file = files.begin(); file != files.end(); ++file) {
-    if (file->isEmpty())
+  for (const auto & file : files) {
+    if (file.isEmpty())
       continue;
-    openUnique(*file);
+    openUnique(file);
   }
 }
 

--- a/MantidPlot/src/Spectrogram.cpp
+++ b/MantidPlot/src/Spectrogram.cpp
@@ -720,9 +720,9 @@ void Spectrogram::setContourLinePen(int index, const QPen &pen) {
 
   if (d_pen_list.isEmpty()) {
     QPen p = defaultContourPen();
-    for (int i = 0; i < levels.size(); i++) {
+    for (double level : levels) {
       if (p.style() == Qt::NoPen)
-        d_pen_list << contourPen(levels[i]);
+        d_pen_list << contourPen(level);
       else
         d_pen_list << p;
     }

--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -3069,7 +3069,7 @@ Table::loadFromProject(const std::string &lines, ApplicationWindow *app,
 
   if (tsv.hasSection("com")) {
     std::vector<std::string> sections = tsv.sections("com");
-    for (auto lines : sections) {
+    for (const auto &lines : sections) {
       /* This is another special case because of legacy.
        * Format: `<col nr="X">\nYYY\n</col>`
        * where X is the row index (0..n), and YYY is the formula.
@@ -3150,7 +3150,7 @@ Table::loadFromProject(const std::string &lines, ApplicationWindow *app,
     tsv >> dataStr;
     QStringList dataLines = dataStr.split("\n");
 
-    for (auto &dataLine : dataLines) {
+    for (const auto &dataLine : dataLines) {
       QStringList fields = dataLine.split("\t");
       int row = fields[0].toInt();
       for (int col = 0; col < table->numCols(); ++col) {

--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -3150,7 +3150,7 @@ Table::loadFromProject(const std::string &lines, ApplicationWindow *app,
     tsv >> dataStr;
     QStringList dataLines = dataStr.split("\n");
 
-    for (auto & dataLine : dataLines) {
+    for (auto &dataLine : dataLines) {
       QStringList fields = dataLine.split("\t");
       int row = fields[0].toInt();
       for (int col = 0; col < table->numCols(); ++col) {

--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -3069,14 +3069,13 @@ Table::loadFromProject(const std::string &lines, ApplicationWindow *app,
 
   if (tsv.hasSection("com")) {
     std::vector<std::string> sections = tsv.sections("com");
-    for (auto it = sections.begin(); it != sections.end(); ++it) {
+    for (auto lines : sections) {
       /* This is another special case because of legacy.
        * Format: `<col nr="X">\nYYY\n</col>`
        * where X is the row index (0..n), and YYY is the formula.
        * YYY may span multiple lines.
        * There may be multiple <col>s in each com section.
        */
-      const std::string lines = *it;
       std::vector<std::string> valVec;
       boost::split(valVec, lines, boost::is_any_of("\n"));
 
@@ -3151,8 +3150,8 @@ Table::loadFromProject(const std::string &lines, ApplicationWindow *app,
     tsv >> dataStr;
     QStringList dataLines = dataStr.split("\n");
 
-    for (auto it = dataLines.begin(); it != dataLines.end(); ++it) {
-      QStringList fields = it->split("\t");
+    for (auto & dataLine : dataLines) {
+      QStringList fields = dataLine.split("\t");
       int row = fields[0].toInt();
       for (int col = 0; col < table->numCols(); ++col) {
         if (fields.count() >= col + 2) {

--- a/MantidPlot/src/TableStatistics.cpp
+++ b/MantidPlot/src/TableStatistics.cpp
@@ -361,7 +361,7 @@ MantidQt::API::IProjectSerialisable *TableStatistics::loadFromProject(
 
   if (tsv.hasSection("com")) {
     std::vector<std::string> sections = tsv.sections("com");
-    for (auto lines : sections) {
+    for (const auto &lines : sections) {
       /* This is another special case because of legacy.
        * Format: `<col nr="X">\nYYY\n</col>`
        * where X is the row index (0..n), and YYY is the formula.

--- a/MantidPlot/src/TableStatistics.cpp
+++ b/MantidPlot/src/TableStatistics.cpp
@@ -361,14 +361,13 @@ MantidQt::API::IProjectSerialisable *TableStatistics::loadFromProject(
 
   if (tsv.hasSection("com")) {
     std::vector<std::string> sections = tsv.sections("com");
-    for (auto it = sections.begin(); it != sections.end(); ++it) {
+    for (auto lines : sections) {
       /* This is another special case because of legacy.
        * Format: `<col nr="X">\nYYY\n</col>`
        * where X is the row index (0..n), and YYY is the formula.
        * YYY may span multiple lines.
        * There may be multiple <col>s in each com section.
        */
-      const std::string lines = *it;
       std::vector<std::string> valVec;
       boost::split(valVec, lines, boost::is_any_of("\n"));
 
@@ -414,8 +413,8 @@ std::string TableStatistics::saveToProject(ApplicationWindow *app) {
   tsv << birthDate();
 
   tsv.writeLine("Targets");
-  for (auto it = d_targets.begin(); it != d_targets.end(); ++it)
-    tsv << *it;
+  for (int & d_target : d_targets)
+    tsv << d_target;
 
   tsv.writeRaw(app->windowGeometryInfo(this));
 

--- a/MantidPlot/src/TableStatistics.cpp
+++ b/MantidPlot/src/TableStatistics.cpp
@@ -413,7 +413,7 @@ std::string TableStatistics::saveToProject(ApplicationWindow *app) {
   tsv << birthDate();
 
   tsv.writeLine("Targets");
-  for (int & d_target : d_targets)
+  for (int &d_target : d_targets)
     tsv << d_target;
 
   tsv.writeRaw(app->windowGeometryInfo(this));

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -1175,9 +1175,9 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       // add texts
       vector<text> texts = opj.layerTexts(g, l);
       if (style != GraphOptions::Pie) {
-        for (const auto & text : texts) {
-          addText(text, graph, nullptr, layerRect, fFontScaleFactor,
-                  fXScale, fYScale);
+        for (const auto &text : texts) {
+          addText(text, graph, nullptr, layerRect, fFontScaleFactor, fXScale,
+                  fYScale);
         }
       }
 
@@ -1186,7 +1186,7 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
                 fFontScaleFactor, fXScale, fYScale);
 
       vector<line> lines = opj.layerLines(g, l);
-      for (auto & line : lines) {
+      for (auto &line : lines) {
         ArrowMarker mrk;
         mrk.setStartPoint(line.begin.x, line.begin.y);
         mrk.setEndPoint(line.end.x, line.end.y);
@@ -1226,7 +1226,7 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       }
 
       vector<bitmap> bitmaps = opj.layerBitmaps(g, l);
-      for (auto & bitmap : bitmaps) {
+      for (auto &bitmap : bitmaps) {
         QPixmap bmp;
         bmp.loadFromData(bitmap.data, uint(bitmap.size), "BMP");
         QTemporaryFile file;
@@ -1430,7 +1430,7 @@ QString ImportOPJ::parseOriginTags(const QString &str) {
       }
     }
     flag = false;
-    for (const auto & rxtag : rxtags) {
+    for (const auto &rxtag : rxtags) {
       if (rxtag.indexIn(line) > -1) {
         flag = true;
         break;

--- a/MantidPlot/src/importOPJ.cpp
+++ b/MantidPlot/src/importOPJ.cpp
@@ -1175,8 +1175,8 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       // add texts
       vector<text> texts = opj.layerTexts(g, l);
       if (style != GraphOptions::Pie) {
-        for (size_t i = 0; i < texts.size(); ++i) {
-          addText(texts[i], graph, nullptr, layerRect, fFontScaleFactor,
+        for (const auto & text : texts) {
+          addText(text, graph, nullptr, layerRect, fFontScaleFactor,
                   fXScale, fYScale);
         }
       }
@@ -1186,20 +1186,20 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
                 fFontScaleFactor, fXScale, fYScale);
 
       vector<line> lines = opj.layerLines(g, l);
-      for (size_t i = 0; i < lines.size(); ++i) {
+      for (auto & line : lines) {
         ArrowMarker mrk;
-        mrk.setStartPoint(lines[i].begin.x, lines[i].begin.y);
-        mrk.setEndPoint(lines[i].end.x, lines[i].end.y);
-        mrk.drawStartArrow(lines[i].begin.shape_type > 0);
-        mrk.drawEndArrow(lines[i].end.shape_type > 0);
-        mrk.setHeadLength(int(lines[i].end.shape_length));
+        mrk.setStartPoint(line.begin.x, line.begin.y);
+        mrk.setEndPoint(line.end.x, line.end.y);
+        mrk.drawStartArrow(line.begin.shape_type > 0);
+        mrk.drawEndArrow(line.end.shape_type > 0);
+        mrk.setHeadLength(int(line.end.shape_length));
         mrk.setHeadAngle(
-            arrowAngle(lines[i].end.shape_length, lines[i].end.shape_width));
-        mrk.setColor(ColorBox::color(lines[i].color));
-        mrk.setWidth((int)lines[i].width);
+            arrowAngle(line.end.shape_length, line.end.shape_width));
+        mrk.setColor(ColorBox::color(line.color));
+        mrk.setWidth((int)line.width);
         Qt::PenStyle s;
 
-        switch (lines[i].line_style) {
+        switch (line.line_style) {
         case OPJFile::Solid:
           s = Qt::SolidLine;
           break;
@@ -1226,9 +1226,9 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
       }
 
       vector<bitmap> bitmaps = opj.layerBitmaps(g, l);
-      for (size_t i = 0; i < bitmaps.size(); ++i) {
+      for (auto & bitmap : bitmaps) {
         QPixmap bmp;
-        bmp.loadFromData(bitmaps[i].data, uint(bitmaps[i].size), "BMP");
+        bmp.loadFromData(bitmap.data, uint(bitmap.size), "BMP");
         QTemporaryFile file;
         file.setFileTemplate(QDir::tempPath() + "/XXXXXX.bmp");
         if (file.open()) {
@@ -1236,44 +1236,44 @@ bool ImportOPJ::importGraphs(const OPJFile &opj) {
           ImageMarker *mrk = graph->addImage(file.fileName());
           double left, top, right, bottom;
           left = top = right = bottom = 0.0;
-          switch (bitmaps[i].attach) {
+          switch (bitmap.attach) {
           case OPJFile::Scale:
-            left = bitmaps[i].left;
-            top = bitmaps[i].top;
-            right = left + bitmaps[i].width;
-            bottom = top - bitmaps[i].height;
+            left = bitmap.left;
+            top = bitmap.top;
+            right = left + bitmap.width;
+            bottom = top - bitmap.height;
             break;
           case OPJFile::Frame:
-            if (bitmaps[i].width > 0) {
-              left = (rangeX.max - rangeX.min) * bitmaps[i].left + rangeX.min;
-              right = left + bitmaps[i].width;
+            if (bitmap.width > 0) {
+              left = (rangeX.max - rangeX.min) * bitmap.left + rangeX.min;
+              right = left + bitmap.width;
             } else {
-              right = (rangeX.max - rangeX.min) * bitmaps[i].left + rangeX.min;
-              left = right + bitmaps[i].width;
+              right = (rangeX.max - rangeX.min) * bitmap.left + rangeX.min;
+              left = right + bitmap.width;
             }
 
-            if (bitmaps[i].height > 0) {
-              top = rangeY.max - (rangeY.max - rangeY.min) * bitmaps[i].top;
-              bottom = top - bitmaps[i].height;
+            if (bitmap.height > 0) {
+              top = rangeY.max - (rangeY.max - rangeY.min) * bitmap.top;
+              bottom = top - bitmap.height;
             } else {
-              bottom = rangeY.max - (rangeY.max - rangeY.min) * bitmaps[i].top;
-              top = bottom - bitmaps[i].height;
+              bottom = rangeY.max - (rangeY.max - rangeY.min) * bitmap.top;
+              top = bottom - bitmap.height;
             }
             break;
           case OPJFile::Page:
             // rect graphRect = opj.graphRect(g);
             left = (rangeX.max - rangeX.min) *
-                       (bitmaps[i].left -
+                       (bitmap.left -
                         (double)layerRect.left / (double)graphRect.width()) /
                        ((double)layerRect.width() / (double)graphRect.width()) +
                    rangeX.min;
             top = rangeY.max -
                   (rangeY.max - rangeY.min) *
-                      (bitmaps[i].top -
+                      (bitmap.top -
                        (double)layerRect.top / (double)graphRect.height()) /
                       ((double)layerRect.height() / (double)graphRect.height());
-            right = left + bitmaps[i].width;
-            bottom = top - bitmaps[i].height;
+            right = left + bitmap.width;
+            bottom = top - bitmap.height;
             break;
           }
 
@@ -1430,8 +1430,8 @@ QString ImportOPJ::parseOriginTags(const QString &str) {
       }
     }
     flag = false;
-    for (int i = 0; i < 7; ++i) {
-      if (rxtags[i].indexIn(line) > -1) {
+    for (const auto & rxtag : rxtags) {
+      if (rxtag.indexIn(line) > -1) {
         flag = true;
         break;
       }

--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -551,7 +551,7 @@ ColorPickerPopup::~ColorPickerPopup() {
     pointer to this item; otherwise returns 0.
 */
 ColorPickerItem *ColorPickerPopup::find(const QColor &col) const {
-  for (auto item : items) {
+  for (auto *item : items) {
     if (item && item->color() == col)
       return item;
   }
@@ -838,7 +838,7 @@ void ColorPickerPopup::regenerateGrid() {
   grid->setSpacing(0);
 
   int ccol = 0, crow = 0;
-  for (auto item : items) {
+  for (auto *item : items) {
     if (item) {
       widgetAt[crow][ccol] = item;
       grid->addWidget(item, crow, ccol++);

--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -551,9 +551,9 @@ ColorPickerPopup::~ColorPickerPopup() {
     pointer to this item; otherwise returns 0.
 */
 ColorPickerItem *ColorPickerPopup::find(const QColor &col) const {
-  for (int i = 0; i < items.size(); ++i) {
-    if (items.at(i) && items.at(i)->color() == col)
-      return items.at(i);
+  for (auto item : items) {
+    if (item && item->color() == col)
+      return item;
   }
 
   return nullptr;
@@ -838,10 +838,10 @@ void ColorPickerPopup::regenerateGrid() {
   grid->setSpacing(0);
 
   int ccol = 0, crow = 0;
-  for (int i = 0; i < items.size(); ++i) {
-    if (items.at(i)) {
-      widgetAt[crow][ccol] = items.at(i);
-      grid->addWidget(items.at(i), crow, ccol++);
+  for (auto item : items) {
+    if (item) {
+      widgetAt[crow][ccol] = item;
+      grid->addWidget(item, crow, ccol++);
       if (ccol == columns) {
         ++crow;
         ccol = 0;

--- a/MantidPlot/src/lib/src/ColorBox.cpp
+++ b/MantidPlot/src/lib/src/ColorBox.cpp
@@ -129,8 +129,8 @@ QList<QColor> ColorBox::colorList() {
   //    for (int i = 0; i < lst.size(); i++)
   //      indexedColors << QColor(lst[i]);
   //  } else {
-  for (int i = 0; i < colors_count; i++)
-    indexedColors << colors[i];
+  for (const auto & color : colors)
+    indexedColors << color;
   //  }
   //  settings.endGroup();
 
@@ -181,8 +181,8 @@ QStringList ColorBox::defaultColorNames() {
 
 QList<QColor> ColorBox::defaultColors() {
   QList<QColor> lst;
-  for (int i = 0; i < colors_count; i++)
-    lst << colors[i];
+  for (const auto & color : colors)
+    lst << color;
 
   return lst;
 }

--- a/MantidPlot/src/lib/src/ColorBox.cpp
+++ b/MantidPlot/src/lib/src/ColorBox.cpp
@@ -129,7 +129,7 @@ QList<QColor> ColorBox::colorList() {
   //    for (int i = 0; i < lst.size(); i++)
   //      indexedColors << QColor(lst[i]);
   //  } else {
-  for (const auto & color : colors)
+  for (const auto &color : colors)
     indexedColors << color;
   //  }
   //  settings.endGroup();
@@ -181,7 +181,7 @@ QStringList ColorBox::defaultColorNames() {
 
 QList<QColor> ColorBox::defaultColors() {
   QList<QColor> lst;
-  for (const auto & color : colors)
+  for (const auto &color : colors)
     lst << color;
 
   return lst;

--- a/MantidPlot/src/muParserScript.cpp
+++ b/MantidPlot/src/muParserScript.cpp
@@ -488,8 +488,8 @@ QVariant muParserScript::evaluateImpl() {
   double val = 0.0;
   try {
     current = this;
-    for (QStringList::iterator i = muCode.begin(); i != muCode.end(); ++i) {
-      parser.SetExpr(i->toAscii().constData());
+    for (auto & i : muCode) {
+      parser.SetExpr(i.toAscii().constData());
       val = parser.Eval();
     }
   } catch (EmptySourceError &) {
@@ -506,8 +506,8 @@ bool muParserScript::executeImpl() {
     return false;
   try {
     current = this;
-    for (QStringList::iterator i = muCode.begin(); i != muCode.end(); ++i) {
-      parser.SetExpr(i->toAscii().constData());
+    for (auto & i : muCode) {
+      parser.SetExpr(i.toAscii().constData());
       parser.Eval();
     }
   } catch (EmptySourceError &) {

--- a/MantidPlot/src/muParserScript.cpp
+++ b/MantidPlot/src/muParserScript.cpp
@@ -488,7 +488,7 @@ QVariant muParserScript::evaluateImpl() {
   double val = 0.0;
   try {
     current = this;
-    for (auto & i : muCode) {
+    for (auto &i : muCode) {
       parser.SetExpr(i.toAscii().constData());
       val = parser.Eval();
     }
@@ -506,7 +506,7 @@ bool muParserScript::executeImpl() {
     return false;
   try {
     current = this;
-    for (auto & i : muCode) {
+    for (auto &i : muCode) {
       parser.SetExpr(i.toAscii().constData());
       parser.Eval();
     }

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -159,48 +159,48 @@ vector<string> OPJFile::findDataByIndex(int index) const {
         str.emplace_back("T_" + spread.name);
         return str;
       }
-  for (const auto &i : MATRIX)
-    if (i.index == index) {
-      str.push_back(i.name);
-      str.emplace_back("M_" + i.name);
+  for (const auto &mat : MATRIX)
+    if (mat.index == index) {
+      str.push_back(mat.name);
+      str.emplace_back("M_" + mat.name);
       return str;
     }
-  for (const auto &i : EXCEL)
-    for (unsigned int j = 0; j < i.sheet.size(); j++)
-      for (unsigned int k = 0; k < i.sheet[j].column.size(); k++)
-        if (i.sheet[j].column[k].index == index) {
-          str.push_back(i.sheet[j].column[k].name);
-          str.emplace_back("E_" + i.name);
+  for (const auto &document : EXCEL)
+    for (unsigned int j = 0; j < document.sheet.size(); j++)
+      for (unsigned int k = 0; k < document.sheet[j].column.size(); k++)
+        if (document.sheet[j].column[k].index == index) {
+          str.push_back(document.sheet[j].column[k].name);
+          str.emplace_back("E_" + document.name);
           return str;
         }
-  for (const auto &i : FUNCTION)
-    if (i.index == index) {
-      str.push_back(i.name);
-      str.emplace_back("F_" + i.name);
+  for (const auto &func : FUNCTION)
+    if (func.index == index) {
+      str.push_back(func.name);
+      str.emplace_back("F_" + func.name);
       return str;
     }
   return str;
 }
 
 string OPJFile::findObjectByIndex(int index) {
-  for (auto &i : SPREADSHEET)
-    if (i.objectID == index) {
-      return i.name;
+  for (auto &spread : SPREADSHEET)
+    if (spread.objectID == index) {
+      return spread.name;
     }
 
-  for (auto &i : MATRIX)
-    if (i.objectID == index) {
-      return i.name;
+  for (auto &mat : MATRIX)
+    if (mat.objectID == index) {
+      return mat.name;
     }
 
-  for (auto &i : EXCEL)
-    if (i.objectID == index) {
-      return i.name;
+  for (auto &document : EXCEL)
+    if (document.objectID == index) {
+      return document.name;
     }
 
-  for (auto &i : GRAPH)
-    if (i.objectID == index) {
-      return i.name;
+  for (auto &g : GRAPH)
+    if (g.objectID == index) {
+      return g.name;
     }
 
   return "";

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -152,55 +152,55 @@ int OPJFile::compareFunctionnames(const char *sname) const {
 
 vector<string> OPJFile::findDataByIndex(int index) const {
   vector<string> str;
-  for (unsigned int spread = 0; spread < SPREADSHEET.size(); spread++)
-    for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); i++)
-      if (SPREADSHEET[spread].column[i].index == index) {
-        str.push_back(SPREADSHEET[spread].column[i].name);
-        str.emplace_back("T_" + SPREADSHEET[spread].name);
+  for (const auto & spread : SPREADSHEET)
+    for (unsigned int i = 0; i < spread.column.size(); i++)
+      if (spread.column[i].index == index) {
+        str.push_back(spread.column[i].name);
+        str.emplace_back("T_" + spread.name);
         return str;
       }
-  for (unsigned int i = 0; i < MATRIX.size(); i++)
-    if (MATRIX[i].index == index) {
-      str.push_back(MATRIX[i].name);
-      str.emplace_back("M_" + MATRIX[i].name);
+  for (const auto & i : MATRIX)
+    if (i.index == index) {
+      str.push_back(i.name);
+      str.emplace_back("M_" + i.name);
       return str;
     }
-  for (unsigned int i = 0; i < EXCEL.size(); i++)
-    for (unsigned int j = 0; j < EXCEL[i].sheet.size(); j++)
-      for (unsigned int k = 0; k < EXCEL[i].sheet[j].column.size(); k++)
-        if (EXCEL[i].sheet[j].column[k].index == index) {
-          str.push_back(EXCEL[i].sheet[j].column[k].name);
-          str.emplace_back("E_" + EXCEL[i].name);
+  for (const auto & i : EXCEL)
+    for (unsigned int j = 0; j < i.sheet.size(); j++)
+      for (unsigned int k = 0; k < i.sheet[j].column.size(); k++)
+        if (i.sheet[j].column[k].index == index) {
+          str.push_back(i.sheet[j].column[k].name);
+          str.emplace_back("E_" + i.name);
           return str;
         }
-  for (unsigned int i = 0; i < FUNCTION.size(); i++)
-    if (FUNCTION[i].index == index) {
-      str.push_back(FUNCTION[i].name);
-      str.emplace_back("F_" + FUNCTION[i].name);
+  for (const auto & i : FUNCTION)
+    if (i.index == index) {
+      str.push_back(i.name);
+      str.emplace_back("F_" + i.name);
       return str;
     }
   return str;
 }
 
 string OPJFile::findObjectByIndex(int index) {
-  for (unsigned int i = 0; i < SPREADSHEET.size(); i++)
-    if (SPREADSHEET[i].objectID == index) {
-      return SPREADSHEET[i].name;
+  for (auto & i : SPREADSHEET)
+    if (i.objectID == index) {
+      return i.name;
     }
 
-  for (unsigned int i = 0; i < MATRIX.size(); i++)
-    if (MATRIX[i].objectID == index) {
-      return MATRIX[i].name;
+  for (auto & i : MATRIX)
+    if (i.objectID == index) {
+      return i.name;
     }
 
-  for (unsigned int i = 0; i < EXCEL.size(); i++)
-    if (EXCEL[i].objectID == index) {
-      return EXCEL[i].name;
+  for (auto & i : EXCEL)
+    if (i.objectID == index) {
+      return i.name;
     }
 
-  for (unsigned int i = 0; i < GRAPH.size(); i++)
-    if (GRAPH[i].objectID == index) {
-      return GRAPH[i].name;
+  for (auto & i : GRAPH)
+    if (i.objectID == index) {
+      return i.name;
     }
 
   return "";

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -152,20 +152,20 @@ int OPJFile::compareFunctionnames(const char *sname) const {
 
 vector<string> OPJFile::findDataByIndex(int index) const {
   vector<string> str;
-  for (const auto & spread : SPREADSHEET)
+  for (const auto &spread : SPREADSHEET)
     for (unsigned int i = 0; i < spread.column.size(); i++)
       if (spread.column[i].index == index) {
         str.push_back(spread.column[i].name);
         str.emplace_back("T_" + spread.name);
         return str;
       }
-  for (const auto & i : MATRIX)
+  for (const auto &i : MATRIX)
     if (i.index == index) {
       str.push_back(i.name);
       str.emplace_back("M_" + i.name);
       return str;
     }
-  for (const auto & i : EXCEL)
+  for (const auto &i : EXCEL)
     for (unsigned int j = 0; j < i.sheet.size(); j++)
       for (unsigned int k = 0; k < i.sheet[j].column.size(); k++)
         if (i.sheet[j].column[k].index == index) {
@@ -173,7 +173,7 @@ vector<string> OPJFile::findDataByIndex(int index) const {
           str.emplace_back("E_" + i.name);
           return str;
         }
-  for (const auto & i : FUNCTION)
+  for (const auto &i : FUNCTION)
     if (i.index == index) {
       str.push_back(i.name);
       str.emplace_back("F_" + i.name);
@@ -183,22 +183,22 @@ vector<string> OPJFile::findDataByIndex(int index) const {
 }
 
 string OPJFile::findObjectByIndex(int index) {
-  for (auto & i : SPREADSHEET)
+  for (auto &i : SPREADSHEET)
     if (i.objectID == index) {
       return i.name;
     }
 
-  for (auto & i : MATRIX)
+  for (auto &i : MATRIX)
     if (i.objectID == index) {
       return i.name;
     }
 
-  for (auto & i : EXCEL)
+  for (auto &i : EXCEL)
     if (i.objectID == index) {
       return i.name;
     }
 
-  for (auto & i : GRAPH)
+  for (auto &i : GRAPH)
     if (i.objectID == index) {
       return i.name;
     }

--- a/MantidPlot/src/origin/OPJFile.h
+++ b/MantidPlot/src/origin/OPJFile.h
@@ -439,11 +439,11 @@ class OPJFile {
 public:
   OPJFile(const char *filename);
   ~OPJFile() {
-    for (unsigned int g = 0; g < GRAPH.size(); ++g)
-      for (unsigned int l = 0; l < GRAPH[g].layer.size(); ++l)
-        for (unsigned int b = 0; b < GRAPH[g].layer[l].bitmaps.size(); ++b)
-          if (GRAPH[g].layer[l].bitmaps[b].size > 0)
-            delete GRAPH[g].layer[l].bitmaps[b].data;
+    for (auto & g : GRAPH)
+      for (unsigned int l = 0; l < g.layer.size(); ++l)
+        for (unsigned int b = 0; b < g.layer[l].bitmaps.size(); ++b)
+          if (g.layer[l].bitmaps[b].size > 0)
+            delete g.layer[l].bitmaps[b].data;
   }
   int Parse();
   double Version() const {

--- a/MantidPlot/src/origin/OPJFile.h
+++ b/MantidPlot/src/origin/OPJFile.h
@@ -439,7 +439,7 @@ class OPJFile {
 public:
   OPJFile(const char *filename);
   ~OPJFile() {
-    for (auto & g : GRAPH)
+    for (auto &g : GRAPH)
       for (unsigned int l = 0; l < g.layer.size(); ++l)
         for (unsigned int b = 0; b < g.layer[l].bitmaps.size(); ++b)
           if (g.layer[l].bitmaps[b].size > 0)

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -108,8 +108,7 @@ Below is an example refactoring.
   auto instrument = ws->getInstrument();
   std::vector<IComponent_const_sptr> children;
   instrument->getChildren(children, true /*Get all sub-children too*/);
-  std::vector<IComponent_const_sptr>::const_iterator it;
-  for (it = children.begin(); it != children.end(); ++it) {
+  for (auto & it : children) {
     if (const ObjComponent* obj = dynamic_cast<const ObjComponent*>(it->get())) {
       // Do something with the obj component
       obj.solidAngle(observer);

--- a/docs/source/interfaces/DataProcessorWidget.rst
+++ b/docs/source/interfaces/DataProcessorWidget.rst
@@ -273,7 +273,7 @@ input properties with their values, as illustrated in the figure above. The widg
 .. code-block:: c
 
     auto optionsMap = parseKeyValueString(options);
-    for (auto kvp = optionsMap.begin(); kvp != optionsMap.end(); ++kvp) {
+    for (auto & kvp : optionsMap) {
       try {
         alg->setProperty(kvp->first, kvp->second);
       } catch (Mantid::Kernel::Exception::NotFoundError &) {

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -491,8 +491,8 @@ void AlgorithmHistoryWindow::copytoClipboard() {
 }
 
 void AlgorithmHistoryWindow::doUnroll(const std::vector<int> &unrollIndicies) {
-  for (int unrollIndicie : unrollIndicies) {
-    m_view->unroll(unrollIndicie);
+  for (int index : unrollIndicies) {
+    m_view->unroll(index);
   }
 }
 
@@ -744,14 +744,14 @@ void AlgHistoryTreeWidget::populateNestedHistory(
     parentWidget->setCheckState(1, Qt::Unchecked);
   }
 
-  for (const auto &entrie : entries) {
-    int nAlgVersion = entrie->version();
-    algName = concatVersionwithName(entrie->name(), nAlgVersion);
+  for (const auto &entry : entries) {
+    int nAlgVersion = entry->version();
+    algName = concatVersionwithName(entry->name(), nAlgVersion);
 
     AlgHistoryItem *item =
-        new AlgHistoryItem(QStringList(algName), entrie, parentWidget);
+        new AlgHistoryItem(QStringList(algName), entry, parentWidget);
     parentWidget->addChild(item);
-    populateNestedHistory(item, entrie);
+    populateNestedHistory(item, entry);
   }
 }
 

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -744,7 +744,7 @@ void AlgHistoryTreeWidget::populateNestedHistory(
     parentWidget->setCheckState(1, Qt::Unchecked);
   }
 
-  for (const auto & entrie : entries) {
+  for (const auto &entrie : entries) {
     int nAlgVersion = entrie->version();
     algName = concatVersionwithName(entrie->name(), nAlgVersion);
 

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -491,8 +491,8 @@ void AlgorithmHistoryWindow::copytoClipboard() {
 }
 
 void AlgorithmHistoryWindow::doUnroll(const std::vector<int> &unrollIndicies) {
-  for (auto it = unrollIndicies.begin(); it != unrollIndicies.end(); ++it) {
-    m_view->unroll(*it);
+  for (int unrollIndicie : unrollIndicies) {
+    m_view->unroll(unrollIndicie);
   }
 }
 
@@ -744,15 +744,14 @@ void AlgHistoryTreeWidget::populateNestedHistory(
     parentWidget->setCheckState(1, Qt::Unchecked);
   }
 
-  for (auto algHistIter = entries.begin(); algHistIter != entries.end();
-       ++algHistIter) {
-    int nAlgVersion = (*algHistIter)->version();
-    algName = concatVersionwithName((*algHistIter)->name(), nAlgVersion);
+  for (const auto & entrie : entries) {
+    int nAlgVersion = entrie->version();
+    algName = concatVersionwithName(entrie->name(), nAlgVersion);
 
     AlgHistoryItem *item =
-        new AlgHistoryItem(QStringList(algName), *algHistIter, parentWidget);
+        new AlgHistoryItem(QStringList(algName), entrie, parentWidget);
     parentWidget->addChild(item);
-    populateNestedHistory(item, *algHistIter);
+    populateNestedHistory(item, entrie);
   }
 }
 


### PR DESCRIPTION
**Description of work.**
This PR runs clang-tidy on MantidPlot and docs (+ one qt file has snuck in here) to use range-based for loops where possible

**To test:**
1. Code inspection
2. Tests pass

Note that if you search mantidplot code for `for \(.*\.begin\(\);.*\.end\(\);.*\)` (regex for an old for loop) you will find some instances which remain. There are some instances where clang-tidy has decided they should not be / it doesn't know how to change the loops to range-based. These stragglers should be manually assessed at a later date

Fixes partially #22183 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
