### PR TITLE
Clang-tidy modernize-loop-convert Framework

### DIFF
--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -400,9 +400,9 @@ void IFunction::removeConstraint(const std::string &parName) {
 void IFunction::setConstraintPenaltyFactor(const std::string &parName,
                                            const double &c) {
   size_t iPar = parameterIndex(parName);
-  for (auto &m_constraint : m_constraints) {
-    if (iPar == (*m_constraint).getLocalIndex()) {
-      (*m_constraint).setPenaltyFactor(c);
+  for (auto &constraint : m_constraints) {
+    if (iPar == constraint->getLocalIndex()) {
+      constraint->setPenaltyFactor(c);
       return;
     }
   }

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -400,9 +400,9 @@ void IFunction::removeConstraint(const std::string &parName) {
 void IFunction::setConstraintPenaltyFactor(const std::string &parName,
                                            const double &c) {
   size_t iPar = parameterIndex(parName);
-  for (auto it = m_constraints.begin(); it != m_constraints.end(); ++it) {
-    if (iPar == (**it).getLocalIndex()) {
-      (**it).setPenaltyFactor(c);
+  for (auto & m_constraint : m_constraints) {
+    if (iPar == (*m_constraint).getLocalIndex()) {
+      (*m_constraint).setPenaltyFactor(c);
       return;
     }
   }

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -400,7 +400,7 @@ void IFunction::removeConstraint(const std::string &parName) {
 void IFunction::setConstraintPenaltyFactor(const std::string &parName,
                                            const double &c) {
   size_t iPar = parameterIndex(parName);
-  for (auto & m_constraint : m_constraints) {
+  for (auto &m_constraint : m_constraints) {
     if (iPar == (*m_constraint).getLocalIndex()) {
       (*m_constraint).setPenaltyFactor(c);
       return;

--- a/Framework/Algorithms/src/CalculateDynamicRange.cpp
+++ b/Framework/Algorithms/src/CalculateDynamicRange.cpp
@@ -83,10 +83,8 @@ void CalculateDynamicRange::calculateQMinMax(MatrixWorkspace_sptr workspace,
   // PARALLEL_FOR_NO_WSP_CHECK does not work with range-based for so NOLINT this
   // block
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int64_t index = 0;
-       index <
-       static_cast<int64_t>(indices.size()); // NOLINT (modernize-for-loop)
-       ++index) {
+  for (int64_t index = 0; index < static_cast<int64_t>(indices.size());
+       ++index) { // NOLINT (modernize-for-loop)
     if (!spectrumInfo.isMonitor(indices[index]) &&
         !spectrumInfo.isMasked(indices[index])) {
       const auto &spectrum = workspace->histogram(indices[index]);

--- a/Framework/Algorithms/src/CalculateDynamicRange.cpp
+++ b/Framework/Algorithms/src/CalculateDynamicRange.cpp
@@ -80,8 +80,9 @@ void CalculateDynamicRange::calculateQMinMax(MatrixWorkspace_sptr workspace,
   const auto &spectrumInfo = workspace->spectrumInfo();
   double min = std::numeric_limits<double>::max(),
          max = std::numeric_limits<double>::min();
+  // PARALLEL_FOR_NO_WSP_CHECK does not work with range-based for so NOLINT this block
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int64_t index = 0; index < static_cast<int64_t>(indices.size());
+  for (int64_t index = 0; index < static_cast<int64_t>(indices.size()); //NOLINT (modernize-for-loop)
        ++index) {
     if (!spectrumInfo.isMonitor(indices[index]) &&
         !spectrumInfo.isMasked(indices[index])) {

--- a/Framework/Algorithms/src/CalculateDynamicRange.cpp
+++ b/Framework/Algorithms/src/CalculateDynamicRange.cpp
@@ -80,9 +80,12 @@ void CalculateDynamicRange::calculateQMinMax(MatrixWorkspace_sptr workspace,
   const auto &spectrumInfo = workspace->spectrumInfo();
   double min = std::numeric_limits<double>::max(),
          max = std::numeric_limits<double>::min();
-  // PARALLEL_FOR_NO_WSP_CHECK does not work with range-based for so NOLINT this block
+  // PARALLEL_FOR_NO_WSP_CHECK does not work with range-based for so NOLINT this
+  // block
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (int64_t index = 0; index < static_cast<int64_t>(indices.size()); //NOLINT (modernize-for-loop)
+  for (int64_t index = 0;
+       index <
+       static_cast<int64_t>(indices.size()); // NOLINT (modernize-for-loop)
        ++index) {
     if (!spectrumInfo.isMonitor(indices[index]) &&
         !spectrumInfo.isMasked(indices[index])) {

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1930,8 +1930,8 @@ void FitPeaks::setupParameterTableWorkspace(
   // add columns
   table_ws->addColumn("int", "wsindex");
   table_ws->addColumn("int", "peakindex");
-  for (size_t iparam = 0; iparam < param_names.size(); ++iparam)
-    table_ws->addColumn("double", param_names[iparam]);
+  for (const auto & param_name : param_names)
+    table_ws->addColumn("double", param_name);
   if (with_chi2)
     table_ws->addColumn("double", "chi2");
 
@@ -1966,8 +1966,8 @@ void FitPeaks::generateFittedParametersValueWorkspaces() {
   std::vector<std::string> param_vec;
   if (m_rawPeaksTable) {
     std::vector<std::string> peak_params = m_peakFunction->getParameterNames();
-    for (size_t i = 0; i < peak_params.size(); ++i)
-      param_vec.push_back(peak_params[i]);
+    for (const auto & peak_param : peak_params)
+      param_vec.push_back(peak_param);
   } else {
     param_vec.emplace_back("centre");
     param_vec.emplace_back("width");

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -1930,7 +1930,7 @@ void FitPeaks::setupParameterTableWorkspace(
   // add columns
   table_ws->addColumn("int", "wsindex");
   table_ws->addColumn("int", "peakindex");
-  for (const auto & param_name : param_names)
+  for (const auto &param_name : param_names)
     table_ws->addColumn("double", param_name);
   if (with_chi2)
     table_ws->addColumn("double", "chi2");
@@ -1966,7 +1966,7 @@ void FitPeaks::generateFittedParametersValueWorkspaces() {
   std::vector<std::string> param_vec;
   if (m_rawPeaksTable) {
     std::vector<std::string> peak_params = m_peakFunction->getParameterNames();
-    for (const auto & peak_param : peak_params)
+    for (const auto &peak_param : peak_params)
       param_vec.push_back(peak_param);
   } else {
     param_vec.emplace_back("centre");

--- a/Framework/Algorithms/src/GetEiMonDet2.cpp
+++ b/Framework/Algorithms/src/GetEiMonDet2.cpp
@@ -224,7 +224,7 @@ void GetEiMonDet2::averageDetectorDistanceAndTOF(
   // cppcheck-suppress syntaxError
   PRAGMA_OMP(parallel for if ( m_detectorEPPTable->threadSafe())
              reduction(+: n, distanceSum, eppSum))
-  for (int i = 0; i < static_cast<int>(detectorIndices.size()); ++i) {
+  for (int i = 0; i < static_cast<int>(detectorIndices.size()); ++i) { // NOLINT (modernize-for-loop)
     PARALLEL_START_INTERUPT_REGION
     const size_t index = detectorIndices[i];
     interruption_point();

--- a/Framework/Algorithms/src/GetEiMonDet2.cpp
+++ b/Framework/Algorithms/src/GetEiMonDet2.cpp
@@ -224,7 +224,8 @@ void GetEiMonDet2::averageDetectorDistanceAndTOF(
   // cppcheck-suppress syntaxError
   PRAGMA_OMP(parallel for if ( m_detectorEPPTable->threadSafe())
              reduction(+: n, distanceSum, eppSum))
-  for (int i = 0; i < static_cast<int>(detectorIndices.size()); ++i) { // NOLINT (modernize-for-loop)
+  for (int i = 0; i < static_cast<int>(detectorIndices.size());
+       ++i) { // NOLINT (modernize-for-loop)
     PARALLEL_START_INTERUPT_REGION
     const size_t index = detectorIndices[i];
     interruption_point();

--- a/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
+++ b/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
@@ -40,8 +40,8 @@ MaxentTransformMultiFourier::imageToData(const std::vector<double> &image) {
   std::vector<double> data;
   data.reserve(m_numSpec * dataOneSpec.size());
   for (size_t s = 0; s < m_numSpec; s++) {
-    for (double &i : dataOneSpec) {
-      data.emplace_back(i);
+    for (const double &data_item : dataOneSpec) {
+      data.emplace_back(data_item);
     }
   }
 

--- a/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
+++ b/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
@@ -40,8 +40,8 @@ MaxentTransformMultiFourier::imageToData(const std::vector<double> &image) {
   std::vector<double> data;
   data.reserve(m_numSpec * dataOneSpec.size());
   for (size_t s = 0; s < m_numSpec; s++) {
-    for (size_t i = 0; i < dataOneSpec.size(); i++) {
-      data.emplace_back(dataOneSpec[i]);
+    for (double & i : dataOneSpec) {
+      data.emplace_back(i);
     }
   }
 

--- a/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
+++ b/Framework/Algorithms/src/MaxEnt/MaxentTransformMultiFourier.cpp
@@ -40,7 +40,7 @@ MaxentTransformMultiFourier::imageToData(const std::vector<double> &image) {
   std::vector<double> data;
   data.reserve(m_numSpec * dataOneSpec.size());
   for (size_t s = 0; s < m_numSpec; s++) {
-    for (double & i : dataOneSpec) {
+    for (double &i : dataOneSpec) {
       data.emplace_back(i);
     }
   }

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -726,7 +726,7 @@ ReflectometryWorkflowBase2::convertProcessingInstructionsToWorkspaceIndices(
   std::string converted = "";
   std::string currentNumber = "";
   std::string ignoreThese = "-,:+";
-  for (char instruction : instructions) {
+  for (const char instruction : instructions) {
     if (std::find(ignoreThese.begin(), ignoreThese.end(), instruction) !=
         ignoreThese.end()) {
       // Found a spacer so add currentNumber to converted followed by separator
@@ -757,7 +757,7 @@ ReflectometryWorkflowBase2::convertProcessingInstructionsToSpectrumNumbers(
   std::string converted = "";
   std::string currentNumber = "";
   std::string ignoreThese = "-,:+";
-  for (char instruction : instructions) {
+  for (const char instruction : instructions) {
     if (std::find(ignoreThese.begin(), ignoreThese.end(), instruction) !=
         ignoreThese.end()) {
       // Found a spacer so add currentNumber to converted after seperator

--- a/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Algorithms/src/ReflectometryWorkflowBase2.cpp
@@ -726,15 +726,15 @@ ReflectometryWorkflowBase2::convertProcessingInstructionsToWorkspaceIndices(
   std::string converted = "";
   std::string currentNumber = "";
   std::string ignoreThese = "-,:+";
-  for (auto i = 0u; i < instructions.size(); ++i) {
-    if (std::find(ignoreThese.begin(), ignoreThese.end(), instructions[i]) !=
+  for (char instruction : instructions) {
+    if (std::find(ignoreThese.begin(), ignoreThese.end(), instruction) !=
         ignoreThese.end()) {
       // Found a spacer so add currentNumber to converted followed by separator
       converted.append(convertToWorkspaceIndex(currentNumber, ws));
-      converted.push_back(instructions[i]);
+      converted.push_back(instruction);
       currentNumber = "";
     } else {
-      currentNumber.push_back(instructions[i]);
+      currentNumber.push_back(instruction);
     }
   }
   // Add currentNumber onto converted
@@ -757,15 +757,15 @@ ReflectometryWorkflowBase2::convertProcessingInstructionsToSpectrumNumbers(
   std::string converted = "";
   std::string currentNumber = "";
   std::string ignoreThese = "-,:+";
-  for (auto i = 0u; i < instructions.size(); ++i) {
-    if (std::find(ignoreThese.begin(), ignoreThese.end(), instructions[i]) !=
+  for (char instruction : instructions) {
+    if (std::find(ignoreThese.begin(), ignoreThese.end(), instruction) !=
         ignoreThese.end()) {
       // Found a spacer so add currentNumber to converted after seperator
       converted.append(convertToSpectrumNumber(currentNumber, ws));
-      converted.push_back(instructions[i]);
+      converted.push_back(instruction);
       currentNumber = "";
     } else {
-      currentNumber.push_back(instructions[i]);
+      currentNumber.push_back(instruction);
     }
   }
   // Add currentNumber onto converted

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -130,7 +130,7 @@ std::pair<double, double> cylinderTwoThetaRange(
                                       1.75 * M_PI}};
   double minTwoTheta{std::numeric_limits<double>::max()};
   double maxTwoTheta{std::numeric_limits<double>::lowest()};
-  for (double angle : angles) {
+  for (const double &angle : angles) {
     const auto basePoint =
         geometry.centreOfBottomBase +
         (basis1 * std::cos(angle) + basis2 * std::sin(angle)) * geometry.radius;

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -130,10 +130,10 @@ std::pair<double, double> cylinderTwoThetaRange(
                                       1.75 * M_PI}};
   double minTwoTheta{std::numeric_limits<double>::max()};
   double maxTwoTheta{std::numeric_limits<double>::lowest()};
-  for (size_t i = 0; i < angles.size(); ++i) {
+  for (double angle : angles) {
     const auto basePoint =
         geometry.centreOfBottomBase +
-        (basis1 * std::cos(angles[i]) + basis2 * std::sin(angles[i])) *
+        (basis1 * std::cos(angle) + basis2 * std::sin(angle)) *
             geometry.radius;
     for (int i = 0; i < 3; ++i) {
       const auto point = basePoint + geometry.axis * (0.5 * geometry.height *

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -133,8 +133,7 @@ std::pair<double, double> cylinderTwoThetaRange(
   for (double angle : angles) {
     const auto basePoint =
         geometry.centreOfBottomBase +
-        (basis1 * std::cos(angle) + basis2 * std::sin(angle)) *
-            geometry.radius;
+        (basis1 * std::cos(angle) + basis2 * std::sin(angle)) * geometry.radius;
     for (int i = 0; i < 3; ++i) {
       const auto point = basePoint + geometry.axis * (0.5 * geometry.height *
                                                       static_cast<double>(i));

--- a/Framework/Catalog/src/ONCatEntity.cpp
+++ b/Framework/Catalog/src/ONCatEntity.cpp
@@ -126,12 +126,11 @@ Content ONCatEntity::getNestedContent(const Content &content,
   auto currentNode = content;
 
   // Use the path tokens to drill down through the JSON nodes.
-  for (auto pathToken = pathTokens.cbegin(); pathToken != pathTokens.cend();
-       ++pathToken) {
-    if (!currentNode.isMember(*pathToken)) {
+  for (const auto & pathToken : pathTokens) {
+    if (!currentNode.isMember(pathToken)) {
       throw ContentError("");
     }
-    currentNode = currentNode[*pathToken];
+    currentNode = currentNode[pathToken];
   }
 
   return currentNode;

--- a/Framework/Catalog/src/ONCatEntity.cpp
+++ b/Framework/Catalog/src/ONCatEntity.cpp
@@ -126,7 +126,7 @@ Content ONCatEntity::getNestedContent(const Content &content,
   auto currentNode = content;
 
   // Use the path tokens to drill down through the JSON nodes.
-  for (const auto & pathToken : pathTokens) {
+  for (const auto &pathToken : pathTokens) {
     if (!currentNode.isMember(pathToken)) {
       throw ContentError("");
     }

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -324,10 +324,10 @@ void LoadPSIMuonBin::generateUnknownAxis() {
   }
 
   // Create Errors
-  for (auto &m_histogram : m_histograms) {
+  for (auto &histogram : m_histograms) {
     std::vector<double> newEAxis;
     for (auto eIndex = 0u; eIndex < m_histograms[0].size(); ++eIndex) {
-      newEAxis.push_back(sqrt(m_histogram[eIndex]));
+      newEAxis.push_back(sqrt(histogram[eIndex]));
     }
     m_eAxis.push_back(newEAxis);
   }
@@ -527,7 +527,7 @@ void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
   logAlg->executeAsChildAlg();
 
   if (m_header.realT0[0] != 0) {
-    for (float i : m_header.realT0) {
+    for (const float &i : m_header.realT0) {
       if (i == 0)
         break;
       logAlg->setProperty("LogType", "String");

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -324,7 +324,7 @@ void LoadPSIMuonBin::generateUnknownAxis() {
   }
 
   // Create Errors
-  for (auto &histogram : m_histograms) {
+  for (const auto &histogram : m_histograms) {
     std::vector<double> newEAxis;
     for (auto eIndex = 0u; eIndex < m_histograms[0].size(); ++eIndex) {
       newEAxis.push_back(sqrt(histogram[eIndex]));

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -324,11 +324,10 @@ void LoadPSIMuonBin::generateUnknownAxis() {
   }
 
   // Create Errors
-  for (auto histogramIndex = 0u; histogramIndex < m_histograms.size();
-       ++histogramIndex) {
+  for (auto & m_histogram : m_histograms) {
     std::vector<double> newEAxis;
     for (auto eIndex = 0u; eIndex < m_histograms[0].size(); ++eIndex) {
-      newEAxis.push_back(sqrt(m_histograms[histogramIndex][eIndex]));
+      newEAxis.push_back(sqrt(m_histogram[eIndex]));
     }
     m_eAxis.push_back(newEAxis);
   }
@@ -528,12 +527,12 @@ void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
   logAlg->executeAsChildAlg();
 
   if (m_header.realT0[0] != 0) {
-    for (auto i = 0u; i < 16; ++i) {
-      if (m_header.realT0[i] == 0)
+    for (float i : m_header.realT0) {
+      if (i == 0)
         break;
       logAlg->setProperty("LogType", "String");
       logAlg->setProperty("LogName", "realT0 + i");
-      logAlg->setProperty("LogText", std::to_string(m_header.realT0[i]));
+      logAlg->setProperty("LogText", std::to_string(i));
       logAlg->executeAsChildAlg();
     }
   }

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -324,7 +324,7 @@ void LoadPSIMuonBin::generateUnknownAxis() {
   }
 
   // Create Errors
-  for (auto & m_histogram : m_histograms) {
+  for (auto &m_histogram : m_histograms) {
     std::vector<double> newEAxis;
     for (auto eIndex = 0u; eIndex < m_histograms[0].size(); ++eIndex) {
       newEAxis.push_back(sqrt(m_histogram[eIndex]));

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -52,10 +52,10 @@ Workspace2D::~Workspace2D() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
 #else
-  for (auto &i : data) {
+  for (size_t i = 0; i < data.size(); ++i) { // NOLINT (modernize-loop-convert)
 #endif
     // Clear out the memory
-    delete i;
+    delete data[i];
   }
 }
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -52,10 +52,10 @@ Workspace2D::~Workspace2D() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
 #else
-  for (size_t i = 0; i < data.size(); ++i) {
+  for (auto & i : data) {
 #endif
     // Clear out the memory
-    delete data[i];
+    delete i;
   }
 }
 

--- a/Framework/DataObjects/src/Workspace2D.cpp
+++ b/Framework/DataObjects/src/Workspace2D.cpp
@@ -52,7 +52,7 @@ Workspace2D::~Workspace2D() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*this))
   for (int64_t i = 0; i < static_cast<int64_t>(data.size()); i++) {
 #else
-  for (auto & i : data) {
+  for (auto &i : data) {
 #endif
     // Clear out the memory
     delete i;

--- a/Framework/Kernel/src/PropertyWithValueJSON.cpp
+++ b/Framework/Kernel/src/PropertyWithValueJSON.cpp
@@ -58,14 +58,14 @@ private:
   template <typename T> struct ModelT : ConceptT {
     std::unique_ptr<Property>
     singleValueProperty(const std::string &name,
-                        const Json::Value &value) const final {
+                        const Json::Value &value) const override final {
       using ToCppT = pwvjdetail::ToCpp<T>;
       return std::make_unique<PropertyWithValue<T>>(name, ToCppT()(value));
     }
 
     std::unique_ptr<Property>
     arrayValueProperty(const std::string &name,
-                       const Json::Value &value) const final {
+                       const Json::Value &value) const override final {
       using ToCppVectorT = pwvjdetail::ToCpp<std::vector<T>>;
       return std::make_unique<ArrayProperty<T>>(name, ToCppVectorT()(value));
     }

--- a/Framework/Kernel/src/PropertyWithValueJSON.cpp
+++ b/Framework/Kernel/src/PropertyWithValueJSON.cpp
@@ -58,14 +58,14 @@ private:
   template <typename T> struct ModelT : ConceptT {
     std::unique_ptr<Property>
     singleValueProperty(const std::string &name,
-                        const Json::Value &value) const override final {
+                        const Json::Value &value) const final {
       using ToCppT = pwvjdetail::ToCpp<T>;
       return std::make_unique<PropertyWithValue<T>>(name, ToCppT()(value));
     }
 
     std::unique_ptr<Property>
     arrayValueProperty(const std::string &name,
-                       const Json::Value &value) const override final {
+                       const Json::Value &value) const final {
       using ToCppVectorT = pwvjdetail::ToCpp<std::vector<T>>;
       return std::make_unique<ArrayProperty<T>>(name, ToCppVectorT()(value));
     }

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -211,9 +211,9 @@ void groupWorkspaces(const std::string &groupName,
 
   if (group) {
     // Exists and is a group -> add missing workspaces to it
-    for (auto it = inputWorkspaces.begin(); it != inputWorkspaces.end(); ++it) {
-      if (!group->contains(*it)) {
-        group->add(*it);
+    for (const auto & inputWorkspace : inputWorkspaces) {
+      if (!group->contains(inputWorkspace)) {
+        group->add(inputWorkspace);
       }
     }
   } else {
@@ -320,8 +320,8 @@ getAllDetectorIDsFromGroupWorkspace(Mantid::API::WorkspaceGroup_sptr ws) {
   MatrixWorkspace_sptr matrixWS;
 
   std::vector<Workspace_sptr> workspaces = ws->getAllItems();
-  for (size_t i = 0; i < workspaces.size(); i++) {
-    matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(workspaces[i]);
+  for (const auto & workspace : workspaces) {
+    matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
     detectorIDsSingleWorkspace = getAllDetectorIDsFromMatrixWorkspace(matrixWS);
     detectorIDs.insert(detectorIDsSingleWorkspace.begin(),
                        detectorIDsSingleWorkspace.end());

--- a/Framework/Muon/src/MuonAlgorithmHelper.cpp
+++ b/Framework/Muon/src/MuonAlgorithmHelper.cpp
@@ -211,7 +211,7 @@ void groupWorkspaces(const std::string &groupName,
 
   if (group) {
     // Exists and is a group -> add missing workspaces to it
-    for (const auto & inputWorkspace : inputWorkspaces) {
+    for (const auto &inputWorkspace : inputWorkspaces) {
       if (!group->contains(inputWorkspace)) {
         group->add(inputWorkspace);
       }
@@ -320,7 +320,7 @@ getAllDetectorIDsFromGroupWorkspace(Mantid::API::WorkspaceGroup_sptr ws) {
   MatrixWorkspace_sptr matrixWS;
 
   std::vector<Workspace_sptr> workspaces = ws->getAllItems();
-  for (const auto & workspace : workspaces) {
+  for (const auto &workspace : workspaces) {
     matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
     detectorIDsSingleWorkspace = getAllDetectorIDsFromMatrixWorkspace(matrixWS);
     detectorIDs.insert(detectorIDsSingleWorkspace.begin(),


### PR DESCRIPTION
**Description of Work:**
This PR runs clang-tidy on Framework to use range-based for loops where possible

**To test:**
1. Code inspection
2. Tests pass

Note that if you search framework code for `for \(.*\.begin\(\);.*\.end\(\);.*\)` (regex for an old for loop) you will find some instances which remain. There are some instances where clang-tidy has decided they should not be / it doesn't know how to change the loops to range-based. These stragglers should be manually assessed at a later date

Fixes partially #22183

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
