### PR TITLE
Enable Frequency Domain Analysis GUI on failure

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -151,8 +151,12 @@ class GroupingTabPresenter(object):
         self.update_thread = self.create_update_thread()
         self.update_thread.threadWrapperSetUp(self.disable_editing,
                                               self.handle_update_finished,
-                                              self._view.display_warning_box)
+                                              self.error_callback)
         self.update_thread.start()
+
+    def error_callback(self, error_message):
+        self.enable_editing_notifier.notify_subscribers()
+        self._view.display_warning_box(error_message)
 
     def handle_update_finished(self):
         self.enable_editing()

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -251,8 +251,9 @@ class LoadRunWidgetPresenter(object):
             self._view.notify_loading_finished()
         except IndexError as error:
             self._view.warning_popup(error)
-        self.enable_loading()
-        self.enable_notifier.notify_subscribers()
+        finally:
+            self.enable_loading()
+            self.enable_notifier.notify_subscribers()
 
     class DisableEditingNotifier(Observable):
 

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -104,7 +104,6 @@ class LoadRunWidgetPresenter(object):
     # ------------------------------------------------------------------------------------------------------------------
 
     def handle_run_changed_by_user(self):
-        self.disable_notifier.notify_subscribers()
         run_string = self._view.get_run_edit_text()
         if not run_string:
             return
@@ -219,35 +218,40 @@ class LoadRunWidgetPresenter(object):
         self._load_thread = self.create_load_thread()
         self._load_thread.threadWrapperSetUp(self.disable_loading,
                                              finished_callback,
-                                             self._view.warning_popup)
+                                             self.error_callback)
         self._load_thread.loadData(filenames)
         self._load_thread.start()
 
-    def handle_load_thread_finished(self):
+    def error_callback(self, error_message):
+        self.enable_notifier.notify_subscribers()
+        self._view.warning_popup(error_message)
 
+    def handle_load_thread_finished(self):
         self._load_thread.deleteLater()
         self._load_thread = None
 
         self.on_loading_finished()
 
     def on_loading_finished(self):
-        if self.run_list and self.run_list[0] == 'Current':
-            self.run_list = [self._model._loaded_data_store.get_latest_data()['run']][0]
-            self._model.current_run = self.run_list
+        try:
+            if self.run_list and self.run_list[0] == 'Current':
+                self.run_list = [self._model._loaded_data_store.get_latest_data()['run']][0]
+                self._model.current_run = self.run_list
 
-        run_list = [[run] for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]
-        self._model._context.current_runs = run_list
-
-        if self._load_multiple_runs and self._multiple_file_mode == "Co-Add":
-            run_list_to_add = [run for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]
-            run_list = [[run for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]]
-            load_utils.combine_loaded_runs(self._model, run_list_to_add)
+            run_list = [[run] for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]
             self._model._context.current_runs = run_list
 
-        self.update_view_from_model(run_list)
-        self._view.notify_loading_finished()
-        self.enable_loading()
-        self.enable_notifier.notify_subscribers()
+            if self._load_multiple_runs and self._multiple_file_mode == "Co-Add":
+                run_list_to_add = [run for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]
+                run_list = [[run for run in self.run_list if self._model._loaded_data_store.get_data(run=[run])]]
+                load_utils.combine_loaded_runs(self._model, run_list_to_add)
+                self._model._context.current_runs = run_list
+
+            self.update_view_from_model(run_list)
+            self._view.notify_loading_finished()
+        finally:
+            self.enable_loading()
+            self.enable_notifier.notify_subscribers()
 
     class DisableEditingNotifier(Observable):
 

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -249,9 +249,12 @@ class LoadRunWidgetPresenter(object):
 
             self.update_view_from_model(run_list)
             self._view.notify_loading_finished()
-        finally:
-            self.enable_loading()
-            self.enable_notifier.notify_subscribers()
+        except IndexError as error:
+            self._view.warning_popup(error)
+        self.enable_loading()
+        self.enable_notifier.notify_subscribers()
+
+
 
     class DisableEditingNotifier(Observable):
 

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -254,8 +254,6 @@ class LoadRunWidgetPresenter(object):
         self.enable_loading()
         self.enable_notifier.notify_subscribers()
 
-
-
     class DisableEditingNotifier(Observable):
 
         def __init__(self, outer):

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -161,7 +161,7 @@ class GroupingTabPresenterTest(unittest.TestCase):
 
         self.presenter.update_thread.threadWrapperSetUp.assert_called_once_with(self.presenter.disable_editing,
                                                                                 self.presenter.handle_update_finished,
-                                                                                self.view.display_warning_box)
+                                                                                self.presenter.error_callback)
         self.presenter.update_thread.start.assert_called_once_with()
 
     def test_removing_group_removes_linked_pairs(self):


### PR DESCRIPTION
**Description of work.**
This PR re-enables the GUI if an error has occurred during loading or processing. 

**To test:**
Open the frequency domain analysis GUI.
Try to load more than 100 runs at a time.
This should return an error and then re-enable the GUI.

<!-- Instructions for testing. -->

Fixes #25175. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
