### PR TITLE
Fix cppcheck 1.87 warnings in LiveData

### DIFF
--- a/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaTopicSubscriber.cpp
@@ -43,20 +43,6 @@ std::unique_ptr<Conf> createGlobalConfiguration(const std::string &brokerAddr) {
   conf->set("api.version.request", "true", errorMsg);
   return conf;
 }
-
-/// Create and return a topic configuration object for a given global
-/// configuration
-std::unique_ptr<Conf> createTopicConfiguration(Conf *globalConf) {
-  auto conf = std::unique_ptr<Conf>(Conf::create(Conf::CONF_TOPIC));
-  std::string errorMsg;
-  // default to start consumption from the end of the topic
-  // NB, can be circumvented by calling assign rather than subscribe
-  conf->set("auto.offset.reset", "largest", errorMsg);
-
-  // tie the global config to this topic configuration
-  globalConf->set("default_topic_conf", conf.get(), errorMsg);
-  return conf;
-}
 } // namespace
 
 namespace Mantid {
@@ -292,7 +278,6 @@ void KafkaTopicSubscriber::seek(const std::string &topic, uint32_t partition,
 void KafkaTopicSubscriber::createConsumer() {
   // Create configurations
   auto globalConf = createGlobalConfiguration(m_brokerAddr);
-  auto topicConf = createTopicConfiguration(globalConf.get());
 
   std::string errorMsg;
   m_consumer = std::unique_ptr<KafkaConsumer>(

--- a/Framework/LiveData/src/Kafka/private/Schema/flatbuffers/base.h
+++ b/Framework/LiveData/src/Kafka/private/Schema/flatbuffers/base.h
@@ -48,14 +48,6 @@
 #include "stl_emulation.h"
 
 /// @cond FLATBUFFERS_INTERNAL
-#if __cplusplus <= 199711L && \
-    (!defined(_MSC_VER) || _MSC_VER < 1600) && \
-    (!defined(__GNUC__) || \
-      (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ < 40400))
-  #error A C++11 compatible compiler with support for the auto typing is \
-         required for FlatBuffers.
-  #error __cplusplus _MSC_VER __GNUC__  __GNUC_MINOR__  __GNUC_PATCHLEVEL__
-#endif
 
 #if !defined(__clang__) && \
     defined(__GNUC__) && \

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -143,8 +143,6 @@ bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
 // and it doesn't check the return value.  (It does, however, trap the Poco
 // exceptions.)
 {
-  bool rv = false; // assume failure
-
   // If we don't have an address, force a connection to the test server running
   // on
   // localhost on the default port
@@ -170,8 +168,8 @@ bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
       RECV_TIMEOUT, 0)); // POCO timespan is seconds, microseconds
   g_log.debug() << "Connected to " << m_socket.address().toString() << '\n';
 
-  rv = m_isConnected = true;
-  return rv;
+  m_isConnected = true;
+  return true;
 }
 
 /// Test to see if the object has connected to the SMS daemon
@@ -588,15 +586,10 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::GeometryPkt &pkt) {
         }
       }
     }
-  }
-
-  // Check to see if we can complete the initialzation steps
-  if (!m_workspaceInitialized) {
     if (readyForInitPart2()) {
       initWorkspacePart2();
     }
   }
-
   return false;
 }
 
@@ -616,15 +609,10 @@ bool SNSLiveEventDataListener::rxPacket(const ADARA::BeamlineInfoPkt &pkt) {
   if (!m_workspaceInitialized) {
     // We need the instrument name
     m_instrumentName = pkt.longName();
-  }
-
-  // Check to see if we can complete the initialzation steps
-  if (!m_workspaceInitialized) {
     if (readyForInitPart2()) {
       initWorkspacePart2();
     }
   }
-
   return false;
 }
 

--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -43,8 +43,7 @@ if ( CPPCHECK_EXECUTABLE )
 
   set ( CPPCHECK_EXCLUDES
         Framework/LiveData/src/ISIS/DAE/
-        Framework/LiveData/src/ISIS/private/flatbuffers/
-        Framework/LiveData/src/ISIS/private/schema/
+        Framework/LiveData/src/Kafka/private/Schema/
         Framework/DataHandling/src/LoadRaw/
         Framework/ICat/inc/MantidICat/ICat3/GSoapGenerated/
         Framework/ICat/src/ICat3/GSoapGenerated/
@@ -67,8 +66,17 @@ if ( CPPCHECK_EXECUTABLE )
 
   # Header files to be ignored require different handling
   set ( CPPCHECK_HEADER_EXCLUDES
+        Framework/LiveData/src/Kafka/private/Schema/ba57_run_info_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/df12_det_spec_map_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/ev42_events_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/fwdi_forwarder_internal_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/f142_logdata_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/is84_isis_events_generated.h
+        Framework/LiveData/src/Kafka/private/Schema/flatbuffers/base.h
+        Framework/LiveData/src/Kafka/private/Schema/flatbuffers/flatbuffers.h
+        Framework/LiveData/src/Kafka/private/Schema/flatbuffers/stl_emulation.h
         MantidPlot/src/origin/OPJFile.h
-		MantidPlot/src/origin/tree.hh
+        MantidPlot/src/origin/tree.hh
       )
 
   # setup the standard arguments


### PR DESCRIPTION
Fix `cppcheck` 1.87 warnings in the LiveData module.

`Framework/LiveData/src/Kafka/private/Schema/flatbuffers/base.h` had a check for C++11 compatiblity which caused `cppcheck` to skip some files in LiveData. The `#ifdef`s were removed since we now use C++14 for building Mantid. Also, `CppCheckSetup.cmake` was corrected for paths and header files which should be excluded by `cppcheck`

**To test:**

Code review.

Fixes #22912. 

*This does not require release notes* because this is an internal change.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
