### PR TITLE
Clang-tidy readability-named-parameter to Framework

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -1623,7 +1623,7 @@ Poco::ActiveResult<bool> Algorithm::executeAsync() {
  * @param i :: Unused argument
  * @return true if executed successfully.
  */
-bool Algorithm::executeAsyncImpl(const Poco::Void &) {
+bool Algorithm::executeAsyncImpl(const Poco::Void & /*unused*/) {
   AsyncFlagHolder running(m_runningAsync);
   return this->execute();
 }

--- a/Framework/API/src/Column.cpp
+++ b/Framework/API/src/Column.cpp
@@ -39,15 +39,17 @@ void Column::setPlotType(int t) {
 /**
  * No implementation by default.
  */
-void Column::sortIndex(bool, size_t, size_t, std::vector<size_t> &,
-                       std::vector<std::pair<size_t, size_t>> &) const {
+void Column::sortIndex(
+    bool /*unused*/, size_t /*unused*/, size_t /*unused*/,
+    std::vector<size_t> & /*unused*/,
+    std::vector<std::pair<size_t, size_t>> & /*unused*/) const {
   throw std::runtime_error("Cannot sort column of type " + m_type);
 }
 
 /**
  * No implementation by default.
  */
-void Column::sortValues(const std::vector<size_t> &) {
+void Column::sortValues(const std::vector<size_t> & /*unused*/) {
   throw std::runtime_error("Cannot sort column of type " + m_type);
 }
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -78,25 +78,30 @@ public:
 };
 // SAX content handler for grapping stuff quickly from IDF
 class myContentHandler : public Poco::XML::ContentHandler {
-  void startElement(const XMLString &, const XMLString &localName,
-                    const XMLString &, const Attributes &attrList) override {
+  void startElement(const XMLString & /*uri*/, const XMLString &localName,
+                    const XMLString & /*qname*/,
+                    const Attributes &attrList) override {
     if (localName == "instrument" || localName == "parameter-file") {
       throw DummyException(
           static_cast<std::string>(attrList.getValue("", "valid-from")),
           static_cast<std::string>(attrList.getValue("", "valid-to")));
     }
   }
-  void endElement(const XMLString &, const XMLString &,
-                  const XMLString &) override {}
+  void endElement(const XMLString & /*uri*/, const XMLString & /*localName*/,
+                  const XMLString & /*qname*/) override {}
   void startDocument() override {}
   void endDocument() override {}
-  void characters(const XMLChar[], int, int) override {}
-  void endPrefixMapping(const XMLString &) override {}
-  void ignorableWhitespace(const XMLChar[], int, int) override {}
-  void processingInstruction(const XMLString &, const XMLString &) override {}
-  void setDocumentLocator(const Locator *) override {}
-  void skippedEntity(const XMLString &) override {}
-  void startPrefixMapping(const XMLString &, const XMLString &) override {}
+  void characters(const XMLChar /*ch*/[], int /*start*/,
+                  int /*length*/) override {}
+  void endPrefixMapping(const XMLString & /*prefix*/) override {}
+  void ignorableWhitespace(const XMLChar /*ch*/[], int /*start*/,
+                           int /*length*/) override {}
+  void processingInstruction(const XMLString & /*target*/,
+                             const XMLString & /*data*/) override {}
+  void setDocumentLocator(const Locator * /*loc*/) override {}
+  void skippedEntity(const XMLString & /*name*/) override {}
+  void startPrefixMapping(const XMLString & /*prefix*/,
+                          const XMLString & /*uri*/) override {}
 };
 
 } // namespace
@@ -557,7 +562,8 @@ void ExperimentInfo::setDetectorGrouping(
  * implementation throws, since no grouping information for update is available
  * when grouping comes from a call to `cacheDetectorGroupings`. This method is
  * overridden in MatrixWorkspace. */
-void ExperimentInfo::updateCachedDetectorGrouping(const size_t) const {
+void ExperimentInfo::updateCachedDetectorGrouping(
+    const size_t /*unused*/) const {
   throw std::runtime_error("ExperimentInfo::updateCachedDetectorGrouping: "
                            "Cannot update -- grouping information not "
                            "available");

--- a/Framework/API/src/FileLoaderRegistry.cpp
+++ b/Framework/API/src/FileLoaderRegistry.cpp
@@ -17,7 +17,7 @@ namespace {
 //----------------------------------------------------------------------------------------------
 /// @cond
 template <typename T> struct DescriptorCallback {
-  void apply(T &) {} // general one does nothing
+  void apply(T & /*unused*/) {} // general one does nothing
 };
 template <> struct DescriptorCallback<Kernel::FileDescriptor> {
   void apply(Kernel::FileDescriptor &descriptor) {

--- a/Framework/API/src/FunctionGenerator.cpp
+++ b/Framework/API/src/FunctionGenerator.cpp
@@ -203,8 +203,9 @@ void FunctionGenerator::setUpForFit() {
 }
 
 /// Declare a new parameter
-void FunctionGenerator::declareParameter(const std::string &, double,
-                                         const std::string &) {
+void FunctionGenerator::declareParameter(const std::string & /*name*/,
+                                         double /*initValue*/,
+                                         const std::string & /*description*/) {
   throw Kernel::Exception::NotImplementedError(
       "FunctionGenerator cannot not have its own parameters.");
 }

--- a/Framework/API/src/FunctionProperty.cpp
+++ b/Framework/API/src/FunctionProperty.cpp
@@ -48,7 +48,8 @@ operator=(const boost::shared_ptr<IFunction> &value) {
 
 //--------------------------------------------------------------------------------------
 /// Add the value of another property
-FunctionProperty &FunctionProperty::operator+=(Kernel::Property const *) {
+FunctionProperty &FunctionProperty::
+operator+=(Kernel::Property const * /*right*/) {
   throw Kernel::Exception::NotImplementedError(
       "+= operator is not implemented for FunctionProperty.");
   return *this;

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -586,17 +586,17 @@ namespace {
 class AttType : public IFunction::ConstAttributeVisitor<std::string> {
 protected:
   /// Apply if string
-  std::string apply(const std::string &) const override {
+  std::string apply(const std::string & /*str*/) const override {
     return "std::string";
   }
   /// Apply if int
-  std::string apply(const int &) const override { return "int"; }
+  std::string apply(const int & /*i*/) const override { return "int"; }
   /// Apply if double
-  std::string apply(const double &) const override { return "double"; }
+  std::string apply(const double & /*d*/) const override { return "double"; }
   /// Apply if bool
-  std::string apply(const bool &) const override { return "bool"; }
+  std::string apply(const bool & /*i*/) const override { return "bool"; }
   /// Apply if vector
-  std::string apply(const std::vector<double> &) const override {
+  std::string apply(const std::vector<double> & /*unused*/) const override {
     return "std::vector<double>";
   }
 };

--- a/Framework/API/src/ISpectrum.cpp
+++ b/Framework/API/src/ISpectrum.cpp
@@ -206,16 +206,16 @@ void ISpectrum::invalidateSpectrumDefinition() const {
 }
 
 /// Override in child classes for polymorphic copying of data.
-void ISpectrum::copyDataInto(DataObjects::EventList &) const {
+void ISpectrum::copyDataInto(DataObjects::EventList & /*unused*/) const {
   throw std::runtime_error("Incompatible types in ISpectrum::copyDataFrom");
 }
 /// Override in child classes for polymorphic copying of data.
-void ISpectrum::copyDataInto(DataObjects::Histogram1D &) const {
+void ISpectrum::copyDataInto(DataObjects::Histogram1D & /*unused*/) const {
   throw std::runtime_error("Incompatible types in ISpectrum::copyDataFrom");
 }
 
 /// Override in child classes for polymorphic copying of data.
-void ISpectrum::copyDataInto(SpectrumTester &) const {
+void ISpectrum::copyDataInto(SpectrumTester & /*unused*/) const {
   throw std::runtime_error("Incompatible types in ISpectrum::copyDataFrom");
 }
 

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1695,7 +1695,8 @@ signal_t MatrixWorkspace::getSignalWithMaskAtCoord(
 MDMasking for a Matrix Workspace has not been implemented.
 @param :
 */
-void MatrixWorkspace::setMDMasking(Mantid::Geometry::MDImplicitFunction *) {
+void MatrixWorkspace::setMDMasking(
+    Mantid::Geometry::MDImplicitFunction * /*maskingRegion*/) {
   throw std::runtime_error(
       "MatrixWorkspace::setMDMasking has no implementation");
 }
@@ -2023,14 +2024,15 @@ void MatrixWorkspace::invalidateCachedSpectrumNumbers() {
 /// Cache a lookup of grouped detIDs to member IDs. Always throws
 /// std::runtime_error since MatrixWorkspace supports detector grouping via
 /// spectra instead of the caching mechanism.
-void MatrixWorkspace::cacheDetectorGroupings(const det2group_map &) {
+void MatrixWorkspace::cacheDetectorGroupings(
+    const det2group_map & /*mapping*/) {
   throw std::runtime_error("Cannot cache detector groupings in a "
                            "MatrixWorkspace -- grouping must be defined via "
                            "spectra");
 }
 
 /// Throws an exception. This method is only for MDWorkspaces.
-size_t MatrixWorkspace::groupOfDetectorID(const detid_t) const {
+size_t MatrixWorkspace::groupOfDetectorID(const detid_t /*detID*/) const {
   throw std::runtime_error("ExperimentInfo::groupOfDetectorID can not be used "
                            "for MatrixWorkspace, only for MDWorkspaces");
 }

--- a/Framework/API/src/MatrixWorkspaceMDIterator.cpp
+++ b/Framework/API/src/MatrixWorkspaceMDIterator.cpp
@@ -303,7 +303,7 @@ size_t MatrixWorkspaceMDIterator::getLinearIndex() const {
       "MatrixWorkspaceMDIterator does not implement getLinearIndex");
 }
 
-bool MatrixWorkspaceMDIterator::isWithinBounds(const size_t) const {
+bool MatrixWorkspaceMDIterator::isWithinBounds(const size_t /*index*/) const {
   throw std::runtime_error(
       "MatrixWorkspaceMDIterator does not implement isWithinBounds");
 }

--- a/Framework/Algorithms/src/ApodizationFunctions.cpp
+++ b/Framework/Algorithms/src/ApodizationFunctions.cpp
@@ -47,7 +47,7 @@ double gaussian(const double time, const double decayConstant) {
  * @param :: [input] the decay constant (tau)
  * @returns :: Function evaluation
  */
-double none(const double, const double) { return 1.; }
+double none(const double /*unused*/, const double /*unused*/) { return 1.; }
 } // namespace ApodizationFunctions
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/src/LineProfile.cpp
+++ b/Framework/Algorithms/src/LineProfile.cpp
@@ -260,7 +260,8 @@ void profile(std::vector<double> &Xs, std::vector<double> &Ys,
  * @param n Number of summed points.
  * @return The average.
  */
-double averageMode(const double sum, const size_t n, const size_t) noexcept {
+double averageMode(const double sum, const size_t n,
+                   const size_t /*unused*/) noexcept {
   return sum / static_cast<double>(n);
 }
 

--- a/Framework/Algorithms/src/PerformIndexOperations.cpp
+++ b/Framework/Algorithms/src/PerformIndexOperations.cpp
@@ -57,7 +57,7 @@ using VecCommands = std::vector<boost::shared_ptr<Command>>;
  */
 class NullCommand : public Command {
   bool isValid() const override { return false; }
-  MatrixWorkspace_sptr execute(MatrixWorkspace_sptr) const override {
+  MatrixWorkspace_sptr execute(MatrixWorkspace_sptr /*input*/) const override {
     throw std::runtime_error(
         "Should not be attempting ::execute on a NullCommand");
   }

--- a/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
+++ b/Framework/Algorithms/src/TimeAtSampleStrategyDirect.cpp
@@ -48,7 +48,7 @@ TimeAtSampleStrategyDirect::TimeAtSampleStrategyDirect(
  * @return Correction struct
  */
 Correction Mantid::Algorithms::TimeAtSampleStrategyDirect::calculate(
-    const size_t &) const {
+    const size_t & /*workspace_index*/) const {
 
   // Correction is L1 and Ei dependent only. Detector positions are not
   // required.

--- a/Framework/Algorithms/src/WeightingStrategy.cpp
+++ b/Framework/Algorithms/src/WeightingStrategy.cpp
@@ -34,8 +34,8 @@ WeightingStrategy::WeightingStrategy() : m_cutOff(0) {}
 Calculate the weight at distance from epicenter. Always returns 1 for this
 implementation
 */
-double FlatWeighting::weightAt(const double &, const double &, const double &,
-                               const double &) {
+double FlatWeighting::weightAt(const double & /*adjX*/, const double & /*ix*/,
+                               const double & /*adjY*/, const double & /*iy*/) {
   return 1;
 }
 
@@ -43,7 +43,9 @@ double FlatWeighting::weightAt(const double &, const double &, const double &,
 Calculate the weight at distance from epicenter. Always returns 1
 @return 1
 */
-double FlatWeighting::weightAt(const Mantid::Kernel::V3D &) { return 1; }
+double FlatWeighting::weightAt(const Mantid::Kernel::V3D & /*distance*/) {
+  return 1;
+}
 
 //----------------------------------------------------------------------------
 // Linear Weighting Implementations
@@ -121,7 +123,7 @@ double ParabolicWeighting::weightAt(const double &adjX, const double &ix,
 Calculate the weight at distance from epicenter. Always throws.
 @throw runtime_error if used
 */
-double NullWeighting::weightAt(const Mantid::Kernel::V3D &) {
+double NullWeighting::weightAt(const Mantid::Kernel::V3D & /*distance*/) {
   throw std::runtime_error(
       "NullWeighting strategy cannot be used to evaluate weights.");
 }
@@ -130,8 +132,8 @@ double NullWeighting::weightAt(const Mantid::Kernel::V3D &) {
 Calculate the weight at distance from epicenter. Always throws.
 @throws runtime_error if called
 */
-double NullWeighting::weightAt(const double &, const double &, const double &,
-                               const double &) {
+double NullWeighting::weightAt(const double & /*adjX*/, const double & /*ix*/,
+                               const double & /*adjY*/, const double & /*iy*/) {
   throw std::runtime_error(
       "NullWeighting strategy cannot be used to evaluate weights.");
 }

--- a/Framework/Crystal/src/CompositeCluster.cpp
+++ b/Framework/Crystal/src/CompositeCluster.cpp
@@ -90,7 +90,7 @@ size_t CompositeCluster::size() const {
 }
 
 /// Add an index. This method does not apply to composite clusters.
-void CompositeCluster::addIndex(const size_t &) {
+void CompositeCluster::addIndex(const size_t & /*index*/) {
   throw std::runtime_error("addIndex not implemented on CompositeCluster");
 }
 

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -252,7 +252,7 @@ AbsoluteBackgroundStrategy::AbsoluteBackgroundStrategy(const double background)
     : m_background(background) {}
 
 bool AbsoluteBackgroundStrategy::isBelowBackground(
-    const double intensity, const HistogramData::HistogramY &) const {
+    const double intensity, const HistogramData::HistogramY & /*y*/) const {
   return intensity < m_background;
 }
 
@@ -545,9 +545,9 @@ SimpleReduceStrategy::SimpleReduceStrategy(
     const CompareStrategy *compareStrategy)
     : ReducePeakListStrategy(compareStrategy) {}
 
-std::vector<SXPeak>
-SimpleReduceStrategy::reduce(const std::vector<SXPeak> &peaks,
-                             Mantid::Kernel::ProgressBase &) const {
+std::vector<SXPeak> SimpleReduceStrategy::reduce(
+    const std::vector<SXPeak> &peaks,
+    Mantid::Kernel::ProgressBase & /*progress*/) const {
   // If the peaks are empty then do nothing
   if (peaks.empty()) {
     return peaks;

--- a/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
+++ b/Framework/Crystal/src/IntegratePeakTimeSlices.cpp
@@ -2335,7 +2335,7 @@ bool IntegratePeakTimeSlices::isGoodFit(std::vector<double> const &params,
  * @return  true if there is enough data, otherwise false
  */
 bool DataModeHandler::IsEnoughData(const double *ParameterValues,
-                                   Kernel::Logger &) {
+                                   Kernel::Logger & /*unused*/) {
   // Check if flat
   double Varx, Vary, Cov;
 

--- a/Framework/Crystal/src/PeakBackground.cpp
+++ b/Framework/Crystal/src/PeakBackground.cpp
@@ -62,7 +62,8 @@ bool PeakBackground::isBackground(Mantid::API::IMDIterator *iterator) const {
   return true;
 }
 
-void PeakBackground::configureIterator(Mantid::API::IMDIterator *const) const {}
+void PeakBackground::configureIterator(
+    Mantid::API::IMDIterator *const /*iterator*/) const {}
 
 } // namespace Crystal
 } // namespace Mantid

--- a/Framework/Crystal/src/PeaksInRegion.cpp
+++ b/Framework/Crystal/src/PeaksInRegion.cpp
@@ -85,8 +85,8 @@ bool PeaksInRegion::pointOutsideAnyExtents(const V3D &testPoint) const {
          testPoint[2] < m_extents[4] || testPoint[2] > m_extents[5];
 }
 
-bool PeaksInRegion::pointInsideAllExtents(const V3D &testPoint,
-                                          const Mantid::Kernel::V3D &) const {
+bool PeaksInRegion::pointInsideAllExtents(
+    const V3D &testPoint, const Mantid::Kernel::V3D & /*peakCenter*/) const {
   return testPoint[0] >= m_extents[0] && testPoint[0] <= m_extents[1] &&
          testPoint[1] >= m_extents[2] && testPoint[1] <= m_extents[3] &&
          testPoint[2] >= m_extents[4] && testPoint[2] <= m_extents[5];

--- a/Framework/Crystal/src/PeaksOnSurface.cpp
+++ b/Framework/Crystal/src/PeaksOnSurface.cpp
@@ -92,7 +92,9 @@ void PeaksOnSurface::validateExtentsInput() const {
   }
 }
 
-bool PeaksOnSurface::pointOutsideAnyExtents(const V3D &) const { return true; }
+bool PeaksOnSurface::pointOutsideAnyExtents(const V3D & /*testPoint*/) const {
+  return true;
+}
 
 bool lineIntersectsSphere(const V3D &line, const V3D &lineStart,
                           const V3D &peakCenter, const double peakRadius) {

--- a/Framework/Crystal/src/SetSpecialCoordinates.cpp
+++ b/Framework/Crystal/src/SetSpecialCoordinates.cpp
@@ -92,7 +92,7 @@ void SetSpecialCoordinates::init() {
 }
 
 bool SetSpecialCoordinates::writeCoordinatesToMDEventWorkspace(
-    Workspace_sptr inWS, SpecialCoordinateSystem) {
+    Workspace_sptr inWS, SpecialCoordinateSystem /*unused*/) {
   bool written = false;
   if (auto mdEventWS = boost::dynamic_pointer_cast<IMDEventWorkspace>(inWS)) {
     g_log.warning("SetSpecialCoordinates: This algorithm cannot set the "
@@ -104,7 +104,7 @@ bool SetSpecialCoordinates::writeCoordinatesToMDEventWorkspace(
 }
 
 bool SetSpecialCoordinates::writeCoordinatesToMDHistoWorkspace(
-    Workspace_sptr inWS, SpecialCoordinateSystem) {
+    Workspace_sptr inWS, SpecialCoordinateSystem /*unused*/) {
   bool written = false;
   if (auto mdHistoWS = boost::dynamic_pointer_cast<IMDHistoWorkspace>(inWS)) {
     g_log.warning("SetSpecialCoordinates: This algorithm cannot set the "

--- a/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
@@ -164,7 +164,8 @@ double IqtFit<QENSFitSimultaneous>::getStartX(std::size_t index) const {
   return QENSFitSimultaneous::getProperty("StartX" + getPropertySuffix(index));
 }
 
-template <typename Base> double IqtFit<Base>::getStartX(std::size_t) const {
+template <typename Base>
+double IqtFit<Base>::getStartX(std::size_t /*unused*/) const {
   return Base::getProperty("StartX");
 }
 
@@ -173,7 +174,8 @@ double IqtFit<QENSFitSimultaneous>::getEndX(std::size_t index) const {
   return QENSFitSimultaneous::getProperty("EndX" + getPropertySuffix(index));
 }
 
-template <typename Base> double IqtFit<Base>::getEndX(std::size_t) const {
+template <typename Base>
+double IqtFit<Base>::getEndX(std::size_t /*unused*/) const {
   return Base::getProperty("EndX");
 }
 

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -608,7 +608,7 @@ std::string QENSFitSequential::getOutputBaseName() const {
 
 bool QENSFitSequential::throwIfElasticQConversionFails() const { return false; }
 
-bool QENSFitSequential::isFitParameter(const std::string &) const {
+bool QENSFitSequential::isFitParameter(const std::string & /*unused*/) const {
   return true;
 }
 

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSimultaneous.cpp
@@ -622,7 +622,7 @@ bool QENSFitSimultaneous::throwIfElasticQConversionFails() const {
   return false;
 }
 
-bool QENSFitSimultaneous::isFitParameter(const std::string &) const {
+bool QENSFitSimultaneous::isFitParameter(const std::string & /*unused*/) const {
   return true;
 }
 

--- a/Framework/CurveFitting/src/AugmentedLagrangianOptimizer.cpp
+++ b/Framework/CurveFitting/src/AugmentedLagrangianOptimizer.cpp
@@ -61,7 +61,7 @@ struct FunctionData {
  * @return A value for the constraint
  */
 double evaluateConstraint(const DblMatrix &cmatrix, const size_t index,
-                          const size_t, const double *x) {
+                          const size_t /*unused*/, const double *x) {
   assert(index < cmatrix.numRows());
   const double *row = cmatrix[index];
 

--- a/Framework/CurveFitting/src/FuncMinimizers/DampedGaussNewtonMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/DampedGaussNewtonMinimizer.cpp
@@ -41,7 +41,7 @@ DampedGaussNewtonMinimizer::DampedGaussNewtonMinimizer(double relTol)
 
 /// Initialize minimizer, i.e. pass a function to minimize.
 void DampedGaussNewtonMinimizer::initialize(API::ICostFunction_sptr function,
-                                            size_t) {
+                                            size_t /*maxIterations*/) {
   m_leastSquares =
       boost::dynamic_pointer_cast<CostFunctions::CostFuncLeastSquares>(
           function);
@@ -53,7 +53,7 @@ void DampedGaussNewtonMinimizer::initialize(API::ICostFunction_sptr function,
 }
 
 /// Do one iteration.
-bool DampedGaussNewtonMinimizer::iterate(size_t) {
+bool DampedGaussNewtonMinimizer::iterate(size_t /*iteration*/) {
   const bool verbose = getProperty("Verbose");
   const double damping = getProperty("Damping");
 

--- a/Framework/CurveFitting/src/FuncMinimizers/DerivMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/DerivMinimizer.cpp
@@ -152,7 +152,7 @@ void DerivMinimizer::initialize(API::ICostFunction_sptr function,
  * Perform one iteration.
  * @return :: true to continue, false to stop.
  */
-bool DerivMinimizer::iterate(size_t) {
+bool DerivMinimizer::iterate(size_t /*iteration*/) {
   if (m_gslSolver == nullptr) {
     throw std::runtime_error("Minimizer " + this->name() +
                              " was not initialized.");

--- a/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/FABADAMinimizer.cpp
@@ -195,7 +195,7 @@ void FABADAMinimizer::initialize(API::ICostFunction_sptr function,
  *
  * @return :: true if iterations must be continued, false otherwise
  */
-bool FABADAMinimizer::iterate(size_t) {
+bool FABADAMinimizer::iterate(size_t /*iteration*/) {
 
   if (!m_leastSquares) {
     throw std::runtime_error("Cost function isn't set up.");

--- a/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMDMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMDMinimizer.cpp
@@ -46,7 +46,7 @@ LevenbergMarquardtMDMinimizer::LevenbergMarquardtMDMinimizer()
 
 /// Initialize minimizer, i.e. pass a function to minimize.
 void LevenbergMarquardtMDMinimizer::initialize(API::ICostFunction_sptr function,
-                                               size_t) {
+                                               size_t /*maxIterations*/) {
   m_leastSquares =
       boost::dynamic_pointer_cast<CostFunctions::CostFuncLeastSquares>(
           function);
@@ -60,7 +60,7 @@ void LevenbergMarquardtMDMinimizer::initialize(API::ICostFunction_sptr function,
 }
 
 /// Do one iteration.
-bool LevenbergMarquardtMDMinimizer::iterate(size_t) {
+bool LevenbergMarquardtMDMinimizer::iterate(size_t /*iteration*/) {
   const bool verbose = getProperty("Verbose");
   const double muMax = getProperty("MuMax");
   const double absError = getProperty("AbsError");

--- a/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/LevenbergMarquardtMinimizer.cpp
@@ -54,7 +54,7 @@ LevenbergMarquardtMinimizer::LevenbergMarquardtMinimizer()
 }
 
 void LevenbergMarquardtMinimizer::initialize(
-    API::ICostFunction_sptr costFunction, size_t) {
+    API::ICostFunction_sptr costFunction, size_t /*maxIterations*/) {
   // set-up GSL container to be used with GSL simplex algorithm
   auto leastSquares =
       boost::dynamic_pointer_cast<CostFunctions::CostFuncLeastSquares>(
@@ -98,7 +98,7 @@ LevenbergMarquardtMinimizer::~LevenbergMarquardtMinimizer() {
   }
 }
 
-bool LevenbergMarquardtMinimizer::iterate(size_t) {
+bool LevenbergMarquardtMinimizer::iterate(size_t /*iteration*/) {
   m_absError = getProperty("AbsError");
   m_relError = getProperty("RelError");
 

--- a/Framework/CurveFitting/src/FuncMinimizers/SimplexMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/SimplexMinimizer.cpp
@@ -55,7 +55,8 @@ SimplexMinimizer::SimplexMinimizer(const double epsabs)
   gslContainer.params = nullptr;
 }
 
-void SimplexMinimizer::initialize(API::ICostFunction_sptr function, size_t) {
+void SimplexMinimizer::initialize(API::ICostFunction_sptr function,
+                                  size_t /*maxIterations*/) {
   m_costFunction = function;
 
   const gsl_multimin_fminimizer_type *T = gsl_multimin_fminimizer_nmsimplex;
@@ -86,7 +87,7 @@ void SimplexMinimizer::initialize(API::ICostFunction_sptr function, size_t) {
  * Do one iteration.
  * @return :: true if iterations to be continued, false if they can stop
  */
-bool SimplexMinimizer::iterate(size_t) {
+bool SimplexMinimizer::iterate(size_t /*iteration*/) {
   int status = gsl_multimin_fminimizer_iterate(m_gslSolver);
   if (status) {
     m_errorString = gsl_strerror(status);

--- a/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
@@ -138,7 +138,7 @@ void TrustRegionMinimizer::evalHF(const DoubleFortranVector &x,
 
 /** Perform a single iteration.
  */
-bool TrustRegionMinimizer::iterate(size_t) {
+bool TrustRegionMinimizer::iterate(size_t /*iteration*/) {
   int max_tr_decrease = 100;
   auto &w = m_workspace;
   auto &options = m_options;

--- a/Framework/CurveFitting/src/Functions/Bk2BkExpConvPV.cpp
+++ b/Framework/CurveFitting/src/Functions/Bk2BkExpConvPV.cpp
@@ -125,8 +125,9 @@ void Bk2BkExpConvPV::functionLocal(double *out, const double *xValues,
 
 /** Local derivative
  */
-void Bk2BkExpConvPV::functionDerivLocal(API::Jacobian *, const double *,
-                                        const size_t) {
+void Bk2BkExpConvPV::functionDerivLocal(API::Jacobian * /*jacobian*/,
+                                        const double * /*xValues*/,
+                                        const size_t /*nData*/) {
   throw Mantid::Kernel::Exception::NotImplementedError(
       "functionDerivLocal is not implemented for IkedaCarpenterPV.");
 }

--- a/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp
@@ -165,10 +165,10 @@ double jm6(double nj, double j) {
 double f20(double nj, double j) { return 3 * pow(nj, 2) - j * (j + 1); }
 
 //------------------------------
-double f21(double nj, double) { return nj; }
+double f21(double nj, double /*unused*/) { return nj; }
 
 //------------------------------
-double f22(double, double) { return 1.0; }
+double f22(double /*unused*/, double /*unused*/) { return 1.0; }
 
 //------------------------------
 double f40(double nj, double j) {
@@ -185,10 +185,10 @@ double f41(double nj, double j) {
 double f42(double nj, double j) { return 7 * pow(nj, 2) - j * (j + 1) - 5; }
 
 //------------------------------
-double f43(double nj, double) { return nj; }
+double f43(double nj, double /*unused*/) { return nj; }
 
 //------------------------------
-double f44(double, double) { return 1.0; }
+double f44(double /*unused*/, double /*unused*/) { return 1.0; }
 
 //------------------------------
 double f60(double nj, double j) {
@@ -220,10 +220,10 @@ double f63(double nj, double j) {
 double f64(double nj, double j) { return 11 * pow(nj, 2) - j * (j + 1) - 38; }
 
 //------------------------------
-double f65(double nj, double) { return nj; }
+double f65(double nj, double /*unused*/) { return nj; }
 
 //------------------------------
-double f66(double, double) { return 1.0; }
+double f66(double /*unused*/, double /*unused*/) { return 1.0; }
 
 //-------------------------------
 // ff(k,q,nj,j) := fkq(nj,j)

--- a/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
@@ -355,8 +355,9 @@ std::string CrystalFieldSpectrumControl::name() const {
   return "CrystalFieldSpectrumControl";
 }
 
-void CrystalFieldSpectrumControl::function(const API::FunctionDomain &,
-                                           API::FunctionValues &) const {
+void CrystalFieldSpectrumControl::function(
+    const API::FunctionDomain & /*domain*/,
+    API::FunctionValues & /*values*/) const {
   throw Kernel::Exception::NotImplementedError(
       "This method is intentionally not implemented.");
 }
@@ -370,8 +371,9 @@ std::string CrystalFieldPhysPropControl::name() const {
   return "CrystalFieldPhysPropControl";
 }
 
-void CrystalFieldPhysPropControl::function(const API::FunctionDomain &,
-                                           API::FunctionValues &) const {
+void CrystalFieldPhysPropControl::function(
+    const API::FunctionDomain & /*domain*/,
+    API::FunctionValues & /*values*/) const {
   throw Kernel::Exception::NotImplementedError(
       "This method is intentionally not implemented.");
 }

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -76,8 +76,8 @@ public:
     throw Exception::NotImplementedError(
         "This method is intentionally not implemented.");
   }
-  void functionGeneral(const API::FunctionDomainGeneral &,
-                       API::FunctionValues &) const override {
+  void functionGeneral(const API::FunctionDomainGeneral & /*domain*/,
+                       API::FunctionValues & /*values*/) const override {
     throw Exception::NotImplementedError(
         "This method is intentionally not implemented.");
   }
@@ -385,8 +385,9 @@ void CrystalFieldFunction::setUpForFit() {
 }
 
 /// Declare a new parameter
-void CrystalFieldFunction::declareParameter(const std::string &, double,
-                                            const std::string &) {
+void CrystalFieldFunction::declareParameter(
+    const std::string & /*name*/, double /*initValue*/,
+    const std::string & /*description*/) {
   throw Kernel::Exception::NotImplementedError(
       "CrystalFieldFunction cannot have its own parameters.");
 }

--- a/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldMultiSpectrum.cpp
@@ -54,8 +54,8 @@ public:
     throw Exception::NotImplementedError(
         "This method is intentionally not implemented.");
   }
-  void functionGeneral(const API::FunctionDomainGeneral &,
-                       API::FunctionValues &) const override {
+  void functionGeneral(const API::FunctionDomainGeneral & /*domain*/,
+                       API::FunctionValues & /*values*/) const override {
     throw Exception::NotImplementedError(
         "This method is intentionally not implemented.");
   }

--- a/Framework/CurveFitting/src/Functions/CrystalFieldPeaks.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldPeaks.cpp
@@ -36,8 +36,9 @@ size_t CrystalFieldPeaks::getDefaultDomainSize() const {
   return m_defaultDomainSize;
 }
 
-void CrystalFieldPeaks::functionGeneral(const API::FunctionDomainGeneral &,
-                                        API::FunctionValues &values) const {
+void CrystalFieldPeaks::functionGeneral(
+    const API::FunctionDomainGeneral & /*domain*/,
+    API::FunctionValues &values) const {
 
   DoubleFortranVector en;
   ComplexFortranMatrix wf;

--- a/Framework/CurveFitting/src/Functions/CrystalFieldPeaksBase.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldPeaksBase.cpp
@@ -455,8 +455,9 @@ std::string CrystalFieldPeaksBaseImpl::name() const {
   return "CrystalFieldPeaksBaseImpl";
 }
 
-void CrystalFieldPeaksBaseImpl::function(const API::FunctionDomain &,
-                                         API::FunctionValues &) const {
+void CrystalFieldPeaksBaseImpl::function(
+    const API::FunctionDomain & /*domain*/,
+    API::FunctionValues & /*values*/) const {
   throw Kernel::Exception::NotImplementedError(
       "Method is intentionally not implemented.");
 }

--- a/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
+++ b/Framework/CurveFitting/src/Functions/DynamicKuboToyabe.cpp
@@ -302,8 +302,9 @@ void DynamicKuboToyabe::functionDeriv(const API::FunctionDomain &domain,
 //----------------------------------------------------------------------------------------------
 /** Function to calculate derivative analytically
  */
-void DynamicKuboToyabe::functionDeriv1D(API::Jacobian *, const double *,
-                                        const size_t) {
+void DynamicKuboToyabe::functionDeriv1D(API::Jacobian * /*jacobian*/,
+                                        const double * /*xValues*/,
+                                        const size_t /*nData*/) {
   throw Mantid::Kernel::Exception::NotImplementedError(
       "functionDeriv1D is not implemented for DynamicKuboToyabe.");
 }

--- a/Framework/CurveFitting/src/Functions/IkedaCarpenterPV.cpp
+++ b/Framework/CurveFitting/src/Functions/IkedaCarpenterPV.cpp
@@ -389,8 +389,9 @@ void IkedaCarpenterPV::functionLocal(double *out, const double *xValues,
   }
 }
 
-void IkedaCarpenterPV::functionDerivLocal(API::Jacobian *, const double *,
-                                          const size_t) {
+void IkedaCarpenterPV::functionDerivLocal(API::Jacobian * /*jacobian*/,
+                                          const double * /*xValues*/,
+                                          const size_t /*nData*/) {
   throw Mantid::Kernel::Exception::NotImplementedError(
       "functionDerivLocal is not implemented for IkedaCarpenterPV.");
 }

--- a/Framework/CurveFitting/src/Functions/Resolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Resolution.cpp
@@ -29,7 +29,9 @@ void Resolution::function1D(double *out, const double *xValues,
   m_fun.function1D(out, xValues, nData);
 }
 
-void Resolution::functionDeriv1D(Jacobian *, const double *, const size_t) {
+void Resolution::functionDeriv1D(Jacobian * /*jacobian*/,
+                                 const double * /*xValues*/,
+                                 const size_t /*nData*/) {
   // do nothing: no fitting parameters
 }
 

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
@@ -456,9 +456,9 @@ void ThermalNeutronBk2BkExpConvPVoigt::function(
 //----------------------------------------------------------------------------------------------
 /** Disabled derivative
  */
-void ThermalNeutronBk2BkExpConvPVoigt::functionDerivLocal(API::Jacobian *,
-                                                          const double *,
-                                                          const size_t) {
+void ThermalNeutronBk2BkExpConvPVoigt::functionDerivLocal(
+    API::Jacobian * /*unused*/, const double * /*unused*/,
+    const size_t /*unused*/) {
   throw Mantid::Kernel::Exception::NotImplementedError(
       "functionDerivLocal is not implemented for IkedaCarpenterPV.");
 }

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronDtoTOFFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronDtoTOFFunction.cpp
@@ -126,9 +126,9 @@ void ThermalNeutronDtoTOFFunction::functionDeriv1D(Jacobian *out,
 
 /** Some forbidden function
  */
-void ThermalNeutronDtoTOFFunction::functionDerivLocal(API::Jacobian *,
-                                                      const double *,
-                                                      const size_t) {
+void ThermalNeutronDtoTOFFunction::functionDerivLocal(
+    API::Jacobian * /*unused*/, const double * /*unused*/,
+    const size_t /*unused*/) {
   throw Mantid::Kernel::Exception::NotImplementedError(
       "functionDerivLocal is not implemented for "
       "ThermalNeutronDtoTOFFunction.");

--- a/Framework/DataHandling/src/DataBlockComposite.cpp
+++ b/Framework/DataHandling/src/DataBlockComposite.cpp
@@ -219,7 +219,7 @@ int64_t DataBlockComposite::getMinSpectrumID() const {
   return min;
 }
 
-void DataBlockComposite::setMinSpectrumID(int64_t) {
+void DataBlockComposite::setMinSpectrumID(int64_t /*minSpecID*/) {
   // DO NOTHING
 }
 
@@ -234,7 +234,7 @@ int64_t DataBlockComposite::getMaxSpectrumID() const {
   return max;
 }
 
-void DataBlockComposite::setMaxSpectrumID(int64_t) {
+void DataBlockComposite::setMaxSpectrumID(int64_t /*minSpecID*/) {
   // DO NOTHING
 }
 

--- a/Framework/DataHandling/src/LoadEMU.cpp
+++ b/Framework/DataHandling/src/LoadEMU.cpp
@@ -111,9 +111,9 @@ double GetNeXusValue<double>(NeXus::NXEntry &entry, const std::string &path,
   }
 }
 template <>
-std::string GetNeXusValue<std::string>(NeXus::NXEntry &entry,
-                                       const std::string &path,
-                                       const std::string &defval, int32_t) {
+std::string
+GetNeXusValue<std::string>(NeXus::NXEntry &entry, const std::string &path,
+                           const std::string &defval, int32_t /*unused*/) {
 
   try {
     NeXus::NXChar dataSet = entry.openNXChar(path);
@@ -137,12 +137,10 @@ void MapNeXusToProperty(NeXus::NXEntry &entry, const std::string &path,
 
 // sting is a special case
 template <>
-void MapNeXusToProperty<std::string>(NeXus::NXEntry &entry,
-                                     const std::string &path,
-                                     const std::string &defval,
-                                     API::LogManager &logManager,
-                                     const std::string &name,
-                                     const std::string &, int32_t index) {
+void MapNeXusToProperty<std::string>(
+    NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
+    API::LogManager &logManager, const std::string &name,
+    const std::string & /*unused*/, int32_t index) {
 
   std::string value = GetNeXusValue<std::string>(entry, path, defval, index);
   logManager.addProperty<std::string>(name, value);
@@ -444,7 +442,8 @@ protected:
   // fields
   std::vector<size_t> &m_eventCounts;
 
-  void addEventImpl(size_t id, size_t, size_t, double) override {
+  void addEventImpl(size_t id, size_t /*x*/, size_t /*y*/,
+                    double /*tof*/) override {
     m_eventCounts[id]++;
   }
 
@@ -473,7 +472,7 @@ protected:
   int64_t m_startTime;
   bool m_saveAsTOF;
 
-  void addEventImpl(size_t id, size_t x, size_t, double tobs) override {
+  void addEventImpl(size_t id, size_t x, size_t /*y*/, double tobs) override {
 
     // get the absolute time for the start of the frame
     auto offset = m_startTime + frameStart();

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -101,9 +101,9 @@ double GetNeXusValue<double>(NeXus::NXEntry &entry, const std::string &path,
 }
 
 template <>
-std::string GetNeXusValue<std::string>(NeXus::NXEntry &entry,
-                                       const std::string &path,
-                                       const std::string &defval, int32_t) {
+std::string
+GetNeXusValue<std::string>(NeXus::NXEntry &entry, const std::string &path,
+                           const std::string &defval, int32_t /*unused*/) {
 
   try {
     NeXus::NXChar dataSet = entry.openNXChar(path);
@@ -127,12 +127,10 @@ void MapNeXusToProperty(NeXus::NXEntry &entry, const std::string &path,
 
 // sting is a special case
 template <>
-void MapNeXusToProperty<std::string>(NeXus::NXEntry &entry,
-                                     const std::string &path,
-                                     const std::string &defval,
-                                     API::LogManager &logManager,
-                                     const std::string &name,
-                                     const std::string &, int32_t index) {
+void MapNeXusToProperty<std::string>(
+    NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
+    API::LogManager &logManager, const std::string &name,
+    const std::string & /*unused*/, int32_t index) {
 
   std::string value = GetNeXusValue<std::string>(entry, path, defval, index);
   logManager.addProperty<std::string>(name, value);
@@ -350,7 +348,8 @@ protected:
   const std::vector<double> &m_L2;
   SimpleHist m_histogram;
 
-  void addEventImpl(size_t id, size_t, size_t, double tobs) override {
+  void addEventImpl(size_t id, size_t /*x*/, size_t /*y*/,
+                    double tobs) override {
     m_eventCounts[id]++;
     // the maximum occurs at the elastic peak
     double deltaT = 1.0e6 * (m_L1 + m_L2[id]) / m_V0 - tobs;
@@ -405,7 +404,8 @@ protected:
   double m_tofCorrection;
   double m_sampleTime;
 
-  void addEventImpl(size_t id, size_t, size_t, double tobs) override {
+  void addEventImpl(size_t id, size_t /*x*/, size_t /*y*/,
+                    double tobs) override {
 
     // get the absolute time for the start of the frame
     auto const offset = m_startTime + frameStart();

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -499,8 +499,8 @@ public:
     setSpectrumAxisValues();
   }
 
-  Mantid::MantidVec::value_type *operator()(Mantid::API::MatrixWorkspace_sptr,
-                                            int index) {
+  Mantid::MantidVec::value_type *
+  operator()(Mantid::API::MatrixWorkspace_sptr /*unused*/, int index) {
     auto isPointData =
         m_workspace->getNumberHistograms() == m_spectrumAxisValues.size();
     double value = 0;

--- a/Framework/DataObjects/src/AffineMatrixParameterParser.cpp
+++ b/Framework/DataObjects/src/AffineMatrixParameterParser.cpp
@@ -76,7 +76,7 @@ AffineMatrixParameter *AffineMatrixParameterParser::createParameter(
 //----------------------------------------------------------------------------------------------
 
 void AffineMatrixParameterParser::setSuccessorParser(
-    Mantid::API::ImplicitFunctionParameterParser *) {
+    Mantid::API::ImplicitFunctionParameterParser * /*paramParser*/) {
   throw std::runtime_error(
       "Cannot set a successor parser on a AffineMatrixParameterParser");
 }

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -488,7 +488,7 @@ MantidVec &EventWorkspace::dataDx(const std::size_t index) {
 /// Deprecated, use mutableY() instead. Return the data Y vector at a given
 /// workspace index
 /// Note: these non-const access methods will throw NotImplementedError
-MantidVec &EventWorkspace::dataY(const std::size_t) {
+MantidVec &EventWorkspace::dataY(const std::size_t /*index*/) {
   throw NotImplementedError("EventWorkspace::dataY cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");
@@ -497,7 +497,7 @@ MantidVec &EventWorkspace::dataY(const std::size_t) {
 /// Deprecated, use mutableE() instead. Return the data E vector at a given
 /// workspace index
 /// Note: these non-const access methods will throw NotImplementedError
-MantidVec &EventWorkspace::dataE(const std::size_t) {
+MantidVec &EventWorkspace::dataE(const std::size_t /*index*/) {
   throw NotImplementedError("EventWorkspace::dataE cannot return a non-const "
                             "array: you can't modify the histogrammed data in "
                             "an EventWorkspace!");

--- a/Framework/DataObjects/src/Events.cpp
+++ b/Framework/DataObjects/src/Events.cpp
@@ -166,9 +166,9 @@ WeightedEventNoTime::WeightedEventNoTime(double tof, float weight,
  * @param weight: weight of this neutron event.
  * @param errorSquared: the square of the error on the event
  */
-WeightedEventNoTime::WeightedEventNoTime(double tof,
-                                         const Mantid::Types::Core::DateAndTime,
-                                         double weight, double errorSquared)
+WeightedEventNoTime::WeightedEventNoTime(
+    double tof, const Mantid::Types::Core::DateAndTime /*unused*/,
+    double weight, double errorSquared)
     : m_tof(tof), m_weight(static_cast<float>(weight)),
       m_errorSquared(static_cast<float>(errorSquared)) {}
 
@@ -178,9 +178,9 @@ WeightedEventNoTime::WeightedEventNoTime(double tof,
  * @param weight: weight of this neutron event.
  * @param errorSquared: the square of the error on the event
  */
-WeightedEventNoTime::WeightedEventNoTime(double tof,
-                                         const Mantid::Types::Core::DateAndTime,
-                                         float weight, float errorSquared)
+WeightedEventNoTime::WeightedEventNoTime(
+    double tof, const Mantid::Types::Core::DateAndTime /*unused*/, float weight,
+    float errorSquared)
     : m_tof(tof), m_weight(weight), m_errorSquared(errorSquared) {}
 
 /** Constructor, copy from a TofEvent object but add weights

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -29,7 +29,7 @@ struct AreaInfo {
  * implementation uses the shoelace formula but requires the last element to
  * be the same as the first element. Also note that it returns 2x the area!
  */
-template <class T> double polyArea(const T &) { return 0.; }
+template <class T> double polyArea(const T & /*unused*/) { return 0.; }
 template <class T, class... Ts>
 double polyArea(const T &v1, const T &v2, Ts &&... vertices) {
   return v2.X() * v1.Y() - v2.Y() * v1.X() +

--- a/Framework/DataObjects/src/MDEventFactory.cpp
+++ b/Framework/DataObjects/src/MDEventFactory.cpp
@@ -317,9 +317,11 @@ API::IMDEventWorkspace *MDEventFactory::createMDWorkspaceND<0>(
 /** Method to create any MDBox type with 0 number of dimensions. As it is wrong,
  * just throws */
 API::IMDNode *MDEventFactory::createMDBoxWrong(
-    API::BoxController *,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &,
-    const uint32_t, const size_t, const size_t) {
+    API::BoxController * /*unused*/,
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        & /*unused*/,
+    const uint32_t /*unused*/, const size_t /*unused*/,
+    const size_t /*unused*/) {
   throw std::invalid_argument("MDBox/MDGridBox can not have 0 dimensions");
 }
 /**Method to create MDBox for lean events (Constructor wrapper) with given

--- a/Framework/DataObjects/src/PeakNoShapeFactory.cpp
+++ b/Framework/DataObjects/src/PeakNoShapeFactory.cpp
@@ -11,14 +11,14 @@ namespace Mantid {
 namespace DataObjects {
 
 void PeakNoShapeFactory::setSuccessor(
-    boost::shared_ptr<const PeakShapeFactory>) {}
+    boost::shared_ptr<const PeakShapeFactory> /*successorFactory*/) {}
 
 /**
  * @brief Creational method
  * @return new NoShape object
  */
 Mantid::Geometry::PeakShape *
-PeakNoShapeFactory::create(const std::string &) const {
+PeakNoShapeFactory::create(const std::string & /*source*/) const {
   return new NoShape;
 }
 

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -969,7 +969,7 @@ PeaksWorkspace::getSpecialCoordinateSystem() const {
 
 // prevent shared pointer from deleting this
 struct NullDeleter {
-  template <typename T> void operator()(T *) {}
+  template <typename T> void operator()(T * /*unused*/) {}
 };
 /**Get access to shared pointer containing workspace porperties */
 API::LogManager_sptr PeaksWorkspace::logs() {
@@ -983,8 +983,8 @@ API::LogManager_const_sptr PeaksWorkspace::getLogs() const {
   return API::LogManager_const_sptr(new API::LogManager(this->run()));
 }
 
-ITableWorkspace *
-PeaksWorkspace::doCloneColumns(const std::vector<std::string> &) const {
+ITableWorkspace *PeaksWorkspace::doCloneColumns(
+    const std::vector<std::string> & /*colNames*/) const {
   throw Kernel::Exception::NotImplementedError(
       "PeaksWorkspace cannot clone columns.");
 }

--- a/Framework/Geometry/src/ComponentParser.cpp
+++ b/Framework/Geometry/src/ComponentParser.cpp
@@ -26,9 +26,9 @@ void ComponentParser::characters(const Poco::XML::XMLChar ch[], int start,
 
 //----------------------------------------------------------------------------------------------
 /// Signals start of element
-void ComponentParser::startElement(const Poco::XML::XMLString &,
+void ComponentParser::startElement(const Poco::XML::XMLString & /*uri*/,
                                    const Poco::XML::XMLString &localName,
-                                   const Poco::XML::XMLString &,
+                                   const Poco::XML::XMLString & /*qname*/,
                                    const Poco::XML::Attributes &attr) {
   // Find the parent of this new component.
   Component *current = nullptr;
@@ -59,9 +59,9 @@ void ComponentParser::startElement(const Poco::XML::XMLString &,
 
 //----------------------------------------------------------------------------------------------
 /// Signals end of element
-void ComponentParser::endElement(const Poco::XML::XMLString &,
+void ComponentParser::endElement(const Poco::XML::XMLString & /*uri*/,
                                  const Poco::XML::XMLString &localName,
-                                 const Poco::XML::XMLString &) {
+                                 const Poco::XML::XMLString & /*qname*/) {
   Component *current = nullptr;
   if (!m_current.empty())
     current = m_current.back();

--- a/Framework/Geometry/src/IObjComponent.cpp
+++ b/Framework/Geometry/src/IObjComponent.cpp
@@ -42,7 +42,7 @@ void IObjComponent::setGeometryHandler(GeometryHandler *h) {
 /**
  * Copy constructor
  */
-IObjComponent::IObjComponent(const IObjComponent &) {
+IObjComponent::IObjComponent(const IObjComponent & /*unused*/) {
   // Copy constructor just creates new handle. Copies nothing.
   handle = std::make_unique<GeometryHandler>(this);
 }

--- a/Framework/Geometry/src/Instrument/DetectorGroup.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorGroup.cpp
@@ -338,38 +338,42 @@ std::string DetectorGroup::getParameterType(const std::string & /*name*/,
 }
 
 /// Default implementation
-std::vector<double> DetectorGroup::getNumberParameter(const std::string &,
-                                                      bool) const {
+std::vector<double>
+DetectorGroup::getNumberParameter(const std::string & /*pname*/,
+                                  bool /*recursive*/) const {
   return std::vector<double>(0);
 }
 
 /// Default implementation
-std::vector<V3D> DetectorGroup::getPositionParameter(const std::string &,
-                                                     bool) const {
+std::vector<V3D>
+DetectorGroup::getPositionParameter(const std::string & /*pname*/,
+                                    bool /*recursive*/) const {
   return std::vector<V3D>(0);
 }
 
 /// Default implementation
-std::vector<Quat> DetectorGroup::getRotationParameter(const std::string &,
-                                                      bool) const {
+std::vector<Quat>
+DetectorGroup::getRotationParameter(const std::string & /*pname*/,
+                                    bool /*recursive*/) const {
   return std::vector<Quat>(0);
 }
 
 /// Default implementation
-std::vector<std::string> DetectorGroup::getStringParameter(const std::string &,
-                                                           bool) const {
+std::vector<std::string>
+DetectorGroup::getStringParameter(const std::string & /*pname*/,
+                                  bool /*recursive*/) const {
   return std::vector<std::string>(0);
 }
 
 /// Default implementation
-std::vector<int> DetectorGroup::getIntParameter(const std::string &,
-                                                bool) const {
+std::vector<int> DetectorGroup::getIntParameter(const std::string & /*pname*/,
+                                                bool /*recursive*/) const {
   return std::vector<int>(0);
 }
 
 /// Default implementation
-std::vector<bool> DetectorGroup::getBoolParameter(const std::string &,
-                                                  bool) const {
+std::vector<bool> DetectorGroup::getBoolParameter(const std::string & /*pname*/,
+                                                  bool /*recursive*/) const {
   return std::vector<bool>(0);
 }
 
@@ -460,7 +464,8 @@ size_t DetectorGroup::index() const {
   throw std::runtime_error("A DetectorGroup cannot have an index");
 }
 
-size_t DetectorGroup::registerContents(class ComponentVisitor &) const {
+size_t
+DetectorGroup::registerContents(class ComponentVisitor & /*component*/) const {
   throw std::runtime_error("DetectorGroup::registerContents. This should not "
                            "be called. DetectorGroups are not part of the "
                            "instrument. On-the-fly only.");

--- a/Framework/Geometry/src/Instrument/GridDetector.cpp
+++ b/Framework/Geometry/src/Instrument/GridDetector.cpp
@@ -756,21 +756,21 @@ void GridDetector::testIntersectionWithChildren(
 
 //-------------------------------------------------------------------------------------------------
 /// Does the point given lie within this object component?
-bool GridDetector::isValid(const V3D &) const {
+bool GridDetector::isValid(const V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "GridDetector::isValid() is not implemented.");
 }
 
 //-------------------------------------------------------------------------------------------------
 /// Does the point given lie on the surface of this object component?
-bool GridDetector::isOnSide(const V3D &) const {
+bool GridDetector::isOnSide(const V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "GridDetector::isOnSide() is not implemented.");
 }
 
 //-------------------------------------------------------------------------------------------------
 /// Checks whether the track given will pass through this Component.
-int GridDetector::interceptSurface(Track &) const {
+int GridDetector::interceptSurface(Track & /*track*/) const {
   throw Kernel::Exception::NotImplementedError(
       "GridDetector::interceptSurface() is not implemented.");
 }
@@ -778,14 +778,14 @@ int GridDetector::interceptSurface(Track &) const {
 //-------------------------------------------------------------------------------------------------
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double GridDetector::solidAngle(const V3D &) const {
+double GridDetector::solidAngle(const V3D & /*observer*/) const {
   throw Kernel::Exception::NotImplementedError(
       "GridDetector::solidAngle() is not implemented.");
 }
 
 //-------------------------------------------------------------------------------------------------
 /// Try to find a point that lies within (or on) the object
-int GridDetector::getPointInObject(V3D &) const {
+int GridDetector::getPointInObject(V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "GridDetector::getPointInObject() is not implemented.");
 }

--- a/Framework/Geometry/src/Instrument/StructuredDetector.cpp
+++ b/Framework/Geometry/src/Instrument/StructuredDetector.cpp
@@ -480,32 +480,32 @@ StructuredDetector::getComponentByName(const std::string &cname,
 
 //-------------------------------------------------------------------------------------------------
 /// Does the point given lie within this object component?
-bool StructuredDetector::isValid(const V3D &) const {
+bool StructuredDetector::isValid(const V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "StructuredDetector::isValid() is not implemented.");
 }
 
 /// Does the point given lie on the surface of this object component?
-bool StructuredDetector::isOnSide(const V3D &) const {
+bool StructuredDetector::isOnSide(const V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "StructuredDetector::isOnSide() is not implemented.");
 }
 
 /// Checks whether the track given will pass through this Component.
-int StructuredDetector::interceptSurface(Track &) const {
+int StructuredDetector::interceptSurface(Track & /*track*/) const {
   throw Kernel::Exception::NotImplementedError(
       "StructuredDetector::interceptSurface() is not implemented.");
 }
 
 /// Finds the approximate solid angle covered by the component when viewed from
 /// the point given
-double StructuredDetector::solidAngle(const V3D &) const {
+double StructuredDetector::solidAngle(const V3D & /*observer*/) const {
   throw Kernel::Exception::NotImplementedError(
       "StructuredDetector::solidAngle() is not implemented.");
 }
 
 /// Try to find a point that lies within (or on) the object
-int StructuredDetector::getPointInObject(V3D &) const {
+int StructuredDetector::getPointInObject(V3D & /*point*/) const {
   throw Kernel::Exception::NotImplementedError(
       "StructuredDetector::getPointInObject() is not implemented.");
 }

--- a/Framework/Geometry/src/MDGeometry/MDFrameFactory.cpp
+++ b/Framework/Geometry/src/MDGeometry/MDFrameFactory.cpp
@@ -34,7 +34,7 @@ bool GeneralFrameFactory::canInterpret(const MDFrameArgument &argument) const {
   return canInterpret;
 }
 
-QLab *QLabFrameFactory::createRaw(const MDFrameArgument &) const {
+QLab *QLabFrameFactory::createRaw(const MDFrameArgument & /*argument*/) const {
   return new QLab;
 }
 
@@ -43,7 +43,8 @@ bool QLabFrameFactory::canInterpret(const MDFrameArgument &argument) const {
   return argument.frameString == QLab::QLabName;
 }
 
-QSample *QSampleFrameFactory::createRaw(const MDFrameArgument &) const {
+QSample *
+QSampleFrameFactory::createRaw(const MDFrameArgument & /*argument*/) const {
   return new QSample;
 }
 
@@ -88,7 +89,8 @@ UnknownFrameFactory::createRaw(const MDFrameArgument &argument) const {
 }
 
 /// Indicate an ability to intepret the string
-bool UnknownFrameFactory::canInterpret(const MDFrameArgument &) const {
+bool UnknownFrameFactory::canInterpret(
+    const MDFrameArgument & /*unitString*/) const {
   return true; // This can interpret everything
 }
 

--- a/Framework/Geometry/src/MDGeometry/QLab.cpp
+++ b/Framework/Geometry/src/MDGeometry/QLab.cpp
@@ -24,7 +24,9 @@ Kernel::UnitLabel QLab::getUnitLabel() const {
 
 const Kernel::MDUnit &QLab::getMDUnit() const { return *m_unit; }
 
-bool QLab::setMDUnit(const Mantid::Kernel::MDUnit &) { return false; }
+bool QLab::setMDUnit(const Mantid::Kernel::MDUnit & /*newUnit*/) {
+  return false;
+}
 
 bool QLab::canConvertTo(const Mantid::Kernel::MDUnit &otherUnit) const {
   /*

--- a/Framework/Geometry/src/MDGeometry/QSample.cpp
+++ b/Framework/Geometry/src/MDGeometry/QSample.cpp
@@ -23,7 +23,9 @@ Kernel::UnitLabel QSample::getUnitLabel() const {
 
 const Kernel::MDUnit &QSample::getMDUnit() const { return *m_unit; }
 
-bool QSample::setMDUnit(const Mantid::Kernel::MDUnit &) { return false; }
+bool QSample::setMDUnit(const Mantid::Kernel::MDUnit & /*newUnit*/) {
+  return false;
+}
 
 bool QSample::canConvertTo(const Kernel::MDUnit &otherUnit) const {
   return this->getMDUnit() == otherUnit;

--- a/Framework/Geometry/src/MDGeometry/UnknownFrame.cpp
+++ b/Framework/Geometry/src/MDGeometry/UnknownFrame.cpp
@@ -17,11 +17,14 @@ UnknownFrame::UnknownFrame(const Kernel::UnitLabel &unit)
 
 const std::string UnknownFrame::UnknownFrameName = "Unknown frame";
 
-bool UnknownFrame::canConvertTo(const Mantid::Kernel::MDUnit &) const {
+bool UnknownFrame::canConvertTo(
+    const Mantid::Kernel::MDUnit & /*otherUnit*/) const {
   return false; // Cannot convert since it is unknown
 }
 
-bool UnknownFrame::setMDUnit(const Mantid::Kernel::MDUnit &) { return false; }
+bool UnknownFrame::setMDUnit(const Mantid::Kernel::MDUnit & /*newUnit*/) {
+  return false;
+}
 
 std::string UnknownFrame::name() const { return UnknownFrameName; }
 

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -356,18 +356,18 @@ int MeshObject2D::getPointInObject(Kernel::V3D &point) const {
   return this->isValid(point) ? 1 : 0;
 }
 
-Kernel::V3D
-MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator &,
-                                    const size_t) const {
+Kernel::V3D MeshObject2D::generatePointInObject(
+    Kernel::PseudoRandomNumberGenerator & /*rng*/,
+    const size_t /*unused*/) const {
   // How this would work for a finite plane is not clear. Points within the
   // plane can of course be generated, but most implementations of this method
   // use the bounding box
   throw std::runtime_error("Not implemented.");
 }
 
-Kernel::V3D
-MeshObject2D::generatePointInObject(Kernel::PseudoRandomNumberGenerator &,
-                                    const BoundingBox &, const size_t) const {
+Kernel::V3D MeshObject2D::generatePointInObject(
+    Kernel::PseudoRandomNumberGenerator & /*rng*/,
+    const BoundingBox & /*activeRegion*/, const size_t /*unused*/) const {
 
   // How this would work for a finite plane is not clear. Points within the
   // plane can of course be generated, but most implementations of this method
@@ -400,9 +400,10 @@ detail::ShapeInfo::GeometryShape MeshObject2D::shape() const {
   return detail::ShapeInfo::GeometryShape::NOSHAPE;
 }
 
-void MeshObject2D::GetObjectGeom(detail::ShapeInfo::GeometryShape &,
-                                 std::vector<Kernel::V3D> &, double &,
-                                 double &) const {
+void MeshObject2D::GetObjectGeom(detail::ShapeInfo::GeometryShape & /*type*/,
+                                 std::vector<Kernel::V3D> & /*vectors*/,
+                                 double & /*myradius*/,
+                                 double & /*myheight*/) const {
 
   throw std::runtime_error("Not implemented");
 }

--- a/Framework/Geometry/src/Objects/RuleItems.cpp
+++ b/Framework/Geometry/src/Objects/RuleItems.cpp
@@ -694,7 +694,7 @@ std::unique_ptr<SurfPoint> SurfPoint::clone() const
   return std::unique_ptr<SurfPoint>(doClone());
 }
 
-void SurfPoint::setLeaf(std::unique_ptr<Rule> nR, const int)
+void SurfPoint::setLeaf(std::unique_ptr<Rule> nR, const int /*unused*/)
 /**
   Replaces a leaf with a rule.
   This REQUIRES that nR is of type SurfPoint
@@ -709,7 +709,8 @@ void SurfPoint::setLeaf(std::unique_ptr<Rule> nR, const int)
     *this = *newX;
 }
 
-void SurfPoint::setLeaves(std::unique_ptr<Rule> aR, std::unique_ptr<Rule>)
+void SurfPoint::setLeaves(std::unique_ptr<Rule> aR,
+                          std::unique_ptr<Rule> /*unused*/)
 /**
   Replaces a leaf with a rule.
   This REQUIRES that nR is of type SurfPoint
@@ -994,7 +995,7 @@ void CompObj::setObj(CSGObject *val)
   key = val;
 }
 
-void CompObj::setLeaf(std::unique_ptr<Rule> aR, const int)
+void CompObj::setLeaf(std::unique_ptr<Rule> aR, const int /*unused*/)
 /**
   Replaces a leaf with a rule.
   This REQUIRES that aR is of type SurfPoint
@@ -1258,7 +1259,7 @@ std::unique_ptr<BoolValue> BoolValue::clone() const
   return std::unique_ptr<BoolValue>(doClone());
 }
 
-void BoolValue::setLeaf(std::unique_ptr<Rule> aR, const int)
+void BoolValue::setLeaf(std::unique_ptr<Rule> aR, const int /*unused*/)
 /**
   Replaces a leaf with a rule.
   This REQUIRES that aR is of type SurfPoint

--- a/Framework/Geometry/src/Objects/Rules.cpp
+++ b/Framework/Geometry/src/Objects/Rules.cpp
@@ -445,7 +445,7 @@ Rule::Rule()
 */
 {}
 
-Rule::Rule(const Rule &)
+Rule::Rule(const Rule & /*unused*/)
     : Parent(nullptr)
 /**
   Constructor copies.
@@ -462,7 +462,7 @@ Rule::Rule(Rule *A)
 */
 {}
 
-Rule &Rule::operator=(const Rule &)
+Rule &Rule::operator=(const Rule & /*unused*/)
 /**
   Assignment operator=
   does not set parent as Rules

--- a/Framework/Geometry/src/Surfaces/Surface.cpp
+++ b/Framework/Geometry/src/Surfaces/Surface.cpp
@@ -53,7 +53,7 @@ Surface::Surface()
 */
 {}
 
-int Surface::side(const Kernel::V3D &) const
+int Surface::side(const Kernel::V3D & /*unused*/) const
 /// Surface side : throw AbsObjMethod
 {
   throw Kernel::Exception::AbsObjMethod("Surface::side");

--- a/Framework/Kernel/src/EnabledWhenProperty.cpp
+++ b/Framework/Kernel/src/EnabledWhenProperty.cpp
@@ -207,7 +207,7 @@ bool EnabledWhenProperty::isVisible(const IPropertyManager *algo) const {
 }
 
 /// Does nothing in this case and put here to satisfy the interface.
-void EnabledWhenProperty::modify_allowed_values(Property *const) {}
+void EnabledWhenProperty::modify_allowed_values(Property *const /*unused*/) {}
 
 /**
  * Clones the current EnabledWhenProperty object and returns

--- a/Framework/Kernel/src/Exception.cpp
+++ b/Framework/Kernel/src/Exception.cpp
@@ -256,7 +256,8 @@ MisMatch<T>::MisMatch(const MisMatch<T> &A)
 */
 {}
 
-template <typename T> MisMatch<T> &MisMatch<T>::operator=(const MisMatch<T> &) {
+template <typename T>
+MisMatch<T> &MisMatch<T>::operator=(const MisMatch<T> & /*unused*/) {
   /**
     Copy assignment
     @param rhs :: MisMatch to copy

--- a/Framework/Kernel/src/InternetHelper.cpp
+++ b/Framework/Kernel/src/InternetHelper.cpp
@@ -323,7 +323,8 @@ void InternetHelper::setProxy(const Kernel::ProxyInfo &proxy) {
 /** Process any headers from the response stream
 Basic implementation does nothing.
 */
-void InternetHelper::processResponseHeaders(const Poco::Net::HTTPResponse &) {}
+void InternetHelper::processResponseHeaders(
+    const Poco::Net::HTTPResponse & /*unused*/) {}
 
 /** Process any HTTP errors states.
 

--- a/Framework/Kernel/src/InvisibleProperty.cpp
+++ b/Framework/Kernel/src/InvisibleProperty.cpp
@@ -10,7 +10,7 @@ namespace Mantid {
 namespace Kernel {
 
 /// Is the property to be shown in the GUI? Always false.
-bool InvisibleProperty::isVisible(const IPropertyManager *) const {
+bool InvisibleProperty::isVisible(const IPropertyManager * /*algo*/) const {
   return false;
 }
 

--- a/Framework/Kernel/src/MDUnitFactory.cpp
+++ b/Framework/Kernel/src/MDUnitFactory.cpp
@@ -16,12 +16,12 @@ LabelUnit *LabelUnitFactory::createRaw(const std::string &unitString) const {
   return new LabelUnit(UnitLabel(unitString));
 }
 
-bool LabelUnitFactory::canInterpret(const std::string &) const {
+bool LabelUnitFactory::canInterpret(const std::string & /*unitString*/) const {
   return true; // Can always treat a unit as a label unit.
 }
 
-InverseAngstromsUnit *
-InverseAngstromsUnitFactory::createRaw(const std::string &) const {
+InverseAngstromsUnit *InverseAngstromsUnitFactory::createRaw(
+    const std::string & /*unitString*/) const {
   return new InverseAngstromsUnit;
 }
 

--- a/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
+++ b/Framework/Kernel/src/Math/Optimization/SLSQPMinimizer.cpp
@@ -229,10 +229,12 @@ double d_sign(double *a, double *b) {
 }
 
 // --------------------- Forward declarations of helpers ---------------------
-int slsqpb_(int *, int *, int *, int *, double *, double *, double *, double *,
-            double *, double *, double *, double *, int *, int *, double *,
-            double *, double *, double *, double *, double *, double *,
-            double *, int *);
+int slsqpb_(int * /*m*/, int * /*meq*/, int * /*la*/, int * /*n*/,
+            double * /*x*/, double * /*xl*/, double * /*xu*/, double * /*f*/,
+            double * /*c__*/, double * /*g*/, double * /*a*/, double * /*acc*/,
+            int * /*iter*/, int * /*mode*/, double * /*r__*/, double * /*l*/,
+            double * /*x0*/, double * /*mu*/, double * /*s*/, double * /*u*/,
+            double * /*v*/, double * /*w*/, int * /*iw*/);
 int dcopy___(int *n, double *dx, int *incx, double *dy, int *incy);
 int daxpy_sl__(int *n, double *da, double *dx, int *incx, double *dy,
                int *incy);

--- a/Framework/Kernel/src/NetworkProxyLinux.cpp
+++ b/Framework/Kernel/src/NetworkProxyLinux.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
  */
 NetworkProxy::NetworkProxy() : m_logger("network_proxy_logger_generic") {}
 
-ProxyInfo NetworkProxy::getHttpProxy(const std::string &) {
+ProxyInfo NetworkProxy::getHttpProxy(const std::string & /*unused*/) {
   ProxyInfo proxyInfo; // NoProxy.
   char *proxy_var = getenv("http_proxy");
   if (proxy_var == nullptr)

--- a/Framework/Kernel/src/NullValidator.cpp
+++ b/Framework/Kernel/src/NullValidator.cpp
@@ -16,6 +16,8 @@ IValidator_sptr NullValidator::clone() const {
 /** Always returns valid, that is ""
  *  @returns an empty string
  */
-std::string NullValidator::check(const boost::any &) const { return ""; }
+std::string NullValidator::check(const boost::any & /*unused*/) const {
+  return "";
+}
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/src/OptionalBool.cpp
+++ b/Framework/Kernel/src/OptionalBool.cpp
@@ -63,7 +63,7 @@ std::map<OptionalBool::Value, std::string> OptionalBool::enumToStrMap() {
  * serialize this type.
  * @return A new Json::Value
  */
-Json::Value encodeAsJson(const OptionalBool &) {
+Json::Value encodeAsJson(const OptionalBool & /*unused*/) {
   throw Exception::NotImplementedError(
       "encodeAsJson not implemented for OptionalBool type");
 }

--- a/Framework/Kernel/src/PropertyWithValueJSON.cpp
+++ b/Framework/Kernel/src/PropertyWithValueJSON.cpp
@@ -32,7 +32,7 @@ template <typename T> using ValueAsTypeMemFn = T (Json::Value::*)() const;
 // createProperty is called.
 struct FromJson {
   template <typename T>
-  explicit FromJson(ValueAsTypeMemFn<T>)
+  explicit FromJson(ValueAsTypeMemFn<T> /*unused*/)
       : m_self{std::make_unique<ModelT<T>>()} {}
 
   std::unique_ptr<Property> createProperty(const std::string &name,

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -844,7 +844,8 @@ void TimeSeriesProperty<TYPE>::makeFilterByValue(
  */
 template <>
 void TimeSeriesProperty<std::string>::makeFilterByValue(
-    std::vector<SplittingInterval> &, double, double, double, bool) const {
+    std::vector<SplittingInterval> & /*split*/, double /*min*/, double /*max*/,
+    double /*TimeTolerance*/, bool /*centre*/) const {
   throw Exception::NotImplementedError("TimeSeriesProperty::makeFilterByValue "
                                        "is not implemented for string "
                                        "properties");
@@ -908,8 +909,8 @@ void TimeSeriesProperty<TYPE>::expandFilterToRange(
  */
 template <>
 void TimeSeriesProperty<std::string>::expandFilterToRange(
-    std::vector<SplittingInterval> &, double, double,
-    const TimeInterval &) const {
+    std::vector<SplittingInterval> & /*split*/, double /*min*/, double /*max*/,
+    const TimeInterval & /*range*/) const {
   throw Exception::NotImplementedError("TimeSeriesProperty::makeFilterByValue "
                                        "is not implemented for string "
                                        "properties");
@@ -988,7 +989,7 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(
  */
 template <>
 double TimeSeriesProperty<std::string>::averageValueInFilter(
-    const TimeSplitterType &) const {
+    const TimeSplitterType & /*filter*/) const {
   throw Exception::NotImplementedError("TimeSeriesProperty::"
                                        "averageValueInFilter is not "
                                        "implemented for string properties");
@@ -1060,7 +1061,7 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(
 template <>
 std::pair<double, double>
 TimeSeriesProperty<std::string>::averageAndStdDevInFilter(
-    const TimeSplitterType &) const {
+    const TimeSplitterType & /*filter*/) const {
   throw Exception::NotImplementedError("TimeSeriesProperty::"
                                        "averageAndStdDevInFilter is not "
                                        "implemented for string properties");
@@ -1438,7 +1439,7 @@ std::map<DateAndTime, TYPE> TimeSeriesProperty<TYPE>::valueAsMap() const {
  * @return Nothing in this case
  */
 template <typename TYPE>
-std::string TimeSeriesProperty<TYPE>::setValue(const std::string &) {
+std::string TimeSeriesProperty<TYPE>::setValue(const std::string & /*unused*/) {
   throw Exception::NotImplementedError("TimeSeriesProperty<TYPE>::setValue - "
                                        "Cannot extract TimeSeries from a "
                                        "std::string");
@@ -1450,7 +1451,8 @@ std::string TimeSeriesProperty<TYPE>::setValue(const std::string &) {
  * @return Nothing in this case
  */
 template <typename TYPE>
-std::string TimeSeriesProperty<TYPE>::setValueFromJson(const Json::Value &) {
+std::string
+TimeSeriesProperty<TYPE>::setValueFromJson(const Json::Value & /*unused*/) {
   throw Exception::NotImplementedError("TimeSeriesProperty<TYPE>::setValue - "
                                        "Cannot extract TimeSeries from a "
                                        "Json::Value");
@@ -1461,8 +1463,8 @@ std::string TimeSeriesProperty<TYPE>::setValueFromJson(const Json::Value &) {
  * @return Nothing in this case
  */
 template <typename TYPE>
-std::string
-TimeSeriesProperty<TYPE>::setDataItem(const boost::shared_ptr<DataItem>) {
+std::string TimeSeriesProperty<TYPE>::setDataItem(
+    const boost::shared_ptr<DataItem> /*unused*/) {
   throw Exception::NotImplementedError("TimeSeriesProperty<TYPE>::setValue - "
                                        "Cannot extract TimeSeries from "
                                        "DataItem");

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -185,7 +185,7 @@ void UsageServiceImpl::sendFeatureUsageReport(const bool synchronous = false) {
   }
 }
 
-void UsageServiceImpl::timerCallback(Poco::Timer &) {
+void UsageServiceImpl::timerCallback(Poco::Timer & /*unused*/) {
   m_timerTicks++;
   if (m_timerTicks > m_timerTicksTarget) {
     // send startup report

--- a/Framework/LiveData/src/ADARA/ADARAParser.cpp
+++ b/Framework/LiveData/src/ADARA/ADARAParser.cpp
@@ -280,8 +280,8 @@ bool Parser::rxUnknownPkt(const Packet &pkt) {
   return false;
 }
 
-bool Parser::rxOversizePkt(const PacketHeader *hdr, const uint8_t *,
-                           unsigned int, unsigned int) {
+bool Parser::rxOversizePkt(const PacketHeader *hdr, const uint8_t * /*unused*/,
+                           unsigned int /*unused*/, unsigned int /*unused*/) {
   // NOTE: ADARA::PacketHeader *hdr can be NULL...! ;-o
   /* Default is to discard the data */
   if (hdr != nullptr)

--- a/Framework/LiveData/src/FakeEventDataListener.cpp
+++ b/Framework/LiveData/src/FakeEventDataListener.cpp
@@ -48,7 +48,8 @@ FakeEventDataListener::~FakeEventDataListener() {
   delete m_rand;
 }
 
-bool FakeEventDataListener::connect(const Poco::Net::SocketAddress &) {
+bool FakeEventDataListener::connect(
+    const Poco::Net::SocketAddress & /*address*/) {
   // Do nothing for now. Later, put in stuff to help test failure modes.
   return true;
 }
@@ -144,7 +145,7 @@ boost::shared_ptr<Workspace> FakeEventDataListener::extractData() {
 /** Callback method called at specified interval by timer.
  *  Used to fill buffer workspace with events between calls to extractData.
  */
-void FakeEventDataListener::generateEvents(Poco::Timer &) {
+void FakeEventDataListener::generateEvents(Poco::Timer & /*unused*/) {
   std::lock_guard<std::mutex> _lock(m_mutex);
   for (long i = 0; i < m_callbackloop; ++i) {
     m_buffer->getSpectrum(0).addEventQuickly(

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -90,7 +90,8 @@ FileEventDataListener::~FileEventDataListener() {
   delete m_chunkload;
 }
 
-bool FileEventDataListener::connect(const Poco::Net::SocketAddress &) {
+bool FileEventDataListener::connect(
+    const Poco::Net::SocketAddress & /*address*/) {
   // Do nothing for now. Later, put in stuff to help test failure modes.
   return true;
 }

--- a/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
@@ -265,7 +265,8 @@ void KafkaHistoStreamDecoder::initLocalCaches(
   m_workspace = histoBuffer;
 }
 
-void KafkaHistoStreamDecoder::sampleDataFromMessage(const std::string &) {
+void KafkaHistoStreamDecoder::sampleDataFromMessage(
+    const std::string & /*buffer*/) {
   throw Kernel::Exception::NotImplementedError("This method will require "
                                                "implementation when processing "
                                                "sample environment messages.");

--- a/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertMDHistoToMatrixWorkspace.cpp
@@ -30,7 +30,7 @@ namespace {
  * A shared pointer deleter that doesn't delete.
  */
 struct NullDeleter {
-  void operator()(void const *) const { // Do nothing
+  void operator()(void const * /*unused*/) const { // Do nothing
   }
 };
 

--- a/Framework/MDAlgorithms/src/FindPeaksMD.cpp
+++ b/Framework/MDAlgorithms/src/FindPeaksMD.cpp
@@ -43,7 +43,7 @@ template <size_t nd> struct IsFullEvent<MDEvent<nd>, nd> : boost::true_type {};
  * to return true
  */
 template <typename MDE, size_t nd>
-bool isFullMDEvent(const boost::true_type &) {
+bool isFullMDEvent(const boost::true_type & /*unused*/) {
   return true;
 }
 
@@ -52,7 +52,7 @@ bool isFullMDEvent(const boost::true_type &) {
  * to return false
  */
 template <typename MDE, size_t nd>
-bool isFullMDEvent(const boost::false_type &) {
+bool isFullMDEvent(const boost::false_type & /*unused*/) {
   return false;
 }
 
@@ -70,7 +70,7 @@ template <typename MDE, size_t nd> bool isFullMDEvent() {
  */
 template <typename MDE, size_t nd>
 void addDetectors(DataObjects::Peak &peak, MDBoxBase<MDE, nd> &box,
-                  const boost::true_type &) {
+                  const boost::true_type & /*unused*/) {
   if (box.getNumChildren() > 0) {
     std::cerr << "Box has children\n";
     addDetectors(peak, box, boost::true_type());
@@ -90,8 +90,9 @@ void addDetectors(DataObjects::Peak &peak, MDBoxBase<MDE, nd> &box,
 /// Add detectors based on lean events. Always throws as they do not know their
 /// IDs
 template <typename MDE, size_t nd>
-void addDetectors(DataObjects::Peak &, MDBoxBase<MDE, nd> &,
-                  const boost::false_type &) {
+void addDetectors(DataObjects::Peak & /*unused*/,
+                  MDBoxBase<MDE, nd> & /*unused*/,
+                  const boost::false_type & /*unused*/) {
   throw std::runtime_error("FindPeaksMD - Workspace contains lean events, "
                            "cannot include detector information");
 }

--- a/Framework/MDAlgorithms/src/IntegrateFlux.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateFlux.cpp
@@ -32,7 +32,7 @@ namespace {
 class NoEventWorkspaceDeleting {
 public:
   /// deleting operator. Does nothing
-  void operator()(const API::MatrixWorkspace *) {}
+  void operator()(const API::MatrixWorkspace * /*unused*/) {}
 };
 } // namespace
 

--- a/Framework/MDAlgorithms/src/MDEventWSWrapper.cpp
+++ b/Framework/MDAlgorithms/src/MDEventWSWrapper.cpp
@@ -61,7 +61,8 @@ void MDEventWSWrapper::createEmptyEventWS(const MDWSDescription &description) {
 }
 /// terminator for attempting initiate 0 dimensions workspace, will throw.
 template <>
-void MDEventWSWrapper::createEmptyEventWS<0>(const MDWSDescription &) {
+void MDEventWSWrapper::createEmptyEventWS<0>(
+    const MDWSDescription & /*unused*/) {
   throw(std::invalid_argument("MDEventWSWrapper:createEmptyEventWS can not be "
                               "initiated with 0 dimensions"));
 }
@@ -120,8 +121,10 @@ void MDEventWSWrapper::addMDDataND(float *sigErr, uint16_t *runIndex,
 /// the function used in template metaloop termination on 0 dimensions and to
 /// throw the error in attempt to add data to 0-dimension workspace
 template <>
-void MDEventWSWrapper::addMDDataND<0>(float *, uint16_t *, uint32_t *,
-                                      coord_t *, size_t) const {
+void MDEventWSWrapper::addMDDataND<0>(float * /*unused*/, uint16_t * /*unused*/,
+                                      uint32_t * /*unused*/,
+                                      coord_t * /*unused*/,
+                                      size_t /*unused*/) const {
   throw(std::invalid_argument(" class has not been initiated, can not add data "
                               "to 0-dimensional workspace"));
 }

--- a/Framework/MDAlgorithms/src/WeightedMeanMD.cpp
+++ b/Framework/MDAlgorithms/src/WeightedMeanMD.cpp
@@ -74,8 +74,8 @@ void WeightedMeanMD::execHistoHisto(
 //----------------------------------------------------------------------------------------------
 /// Run the algorithm with a MDHisotWorkspace as output, scalar and operand
 void WeightedMeanMD::execHistoScalar(
-    Mantid::DataObjects::MDHistoWorkspace_sptr,
-    Mantid::DataObjects::WorkspaceSingleValue_const_sptr) {
+    Mantid::DataObjects::MDHistoWorkspace_sptr /*out*/,
+    Mantid::DataObjects::WorkspaceSingleValue_const_sptr /*scalar*/) {
   throw std::runtime_error(
       this->name() + " can only be run with two MDHistoWorkspaces as inputs");
 }

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -557,7 +557,7 @@ template <typename VecType> size_t getSizeOf(const VecType &vec) {
 }
 
 // Special case of V3D
-size_t getSizeOf(const Kernel::V3D &) { return 3; }
+size_t getSizeOf(const Kernel::V3D & /*unused*/) { return 3; }
 } // namespace
 
 /**

--- a/Framework/Parallel/src/IO/EventsListsShmemManager.cpp
+++ b/Framework/Parallel/src/IO/EventsListsShmemManager.cpp
@@ -28,7 +28,8 @@ EventsListsShmemManager::EventsListsShmemManager(const std::string &segmentName,
 }
 
 EventsListsShmemManager::EventsListsShmemManager(const std::string &segmentName,
-                                                 const std::string &elName, int)
+                                                 const std::string &elName,
+                                                 int /*unused*/)
     : m_segmentName(segmentName), m_chunksName(elName), m_chunks(nullptr) {}
 
 /// Appends ToF event to given pixel in given chunk of shared storage

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/MappingTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/MappingTypeHandler.cpp
@@ -49,7 +49,7 @@ void MappingTypeHandler::set(Kernel::IPropertyManager *alg,
  */
 std::unique_ptr<Kernel::Property>
 MappingTypeHandler::create(const std::string &name, const object &defaultValue,
-                           const boost::python::api::object &,
+                           const boost::python::api::object & /*validator*/,
                            const unsigned int direction) const {
   // Wrap the property manager in a PropertyManagerProperty instance.
   std::unique_ptr<Kernel::Property> valueProp =

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/SequenceTypeHandler.cpp
@@ -31,7 +31,7 @@ template <typename HeldType> struct StdVectorExtractor {
   }
 };
 template <> struct StdVectorExtractor<bool> {
-  static std::vector<bool> extract(const boost::python::object &) {
+  static std::vector<bool> extract(const boost::python::object & /*unused*/) {
     throw std::runtime_error(
         "Unable to supported extracting std::vector<bool> from python object");
   }

--- a/Framework/SINQ/src/LoadFlexiNexus.cpp
+++ b/Framework/SINQ/src/LoadFlexiNexus.cpp
@@ -252,7 +252,7 @@ int LoadFlexiNexus::calculateCAddress(int *pos, int *dim, int rank) {
   }
   return result;
 }
-int LoadFlexiNexus::calculateF77Address(int *, int) {
+int LoadFlexiNexus::calculateF77Address(int * /*unused*/, int /*unused*/) {
   // --- Unused code ---
   // int result = 0;
 


### PR DESCRIPTION
**Description of work.**
applies clang-tidy readability-named-parameter to Framework.
/*unused*/ is default. But variable names taken from header files where available

**To test:**
Code review

Fixes partially #15452 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
