### PR TITLE
Project Recovery: MantidPlot handles repair with successful sanity check.

### DIFF
--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -807,8 +807,9 @@ void ProjectRecovery::repairCheckpointDirectory() {
 
   for (auto c : vectorToDelete) {
     // Remove c recursively
-    const Poco::Path sanityCheckPath(getRecoveryFolderCheck());
-    if (sanityCheckPath.toString() == Poco::Path(c).popDirectory().toString()) {
+    const std::string sanityCheckPath = getRecoveryFolderCheck();
+    const auto searchResult = c.find(sanityCheckPath);
+    if (searchResult != std::string::npos) {
       Poco::File(c).remove(true);
     }
   }

--- a/MantidPlot/src/ProjectRecovery.cpp
+++ b/MantidPlot/src/ProjectRecovery.cpp
@@ -808,7 +808,7 @@ void ProjectRecovery::repairCheckpointDirectory() {
   for (auto c : vectorToDelete) {
     // Remove c recursively
     const std::string sanityCheckPath = getRecoveryFolderCheck();
-    const auto searchResult = c.find(sanityCheckPath);
+    const auto searchResult = c.find(Poco::Path(sanityCheckPath).toString());
     if (searchResult != std::string::npos) {
       Poco::File(c).remove(true);
     }


### PR DESCRIPTION
**Description of work.**
Project Recovery is supposed to remove Locked, old and legacy checkpoints. It is currently in `release-next` not doing that for all checkpoints due to a dodgy sanity check logic. The logic has been updated to reflect all possibilities whilst still providing the security needed.

**To test:**
- In your Operating systems `mantidproject`/`.mantid` folder, navigate to recovery, then navigate to your environment name.
- Make a directory called `718292` or any arbitrary number
- Inside of there make a directory called `2019-01-11T11-51-10` to add a realistic date.
- Inside of there create an empty file called `projectrecovery.lock`
- All of this will simulate a recovery lock file being present.
- Open MantidPlot
- It should say in the logger that a repair has occurred and the created directories should no longer be present.

<!-- Instructions for testing. -->

Fixes #25285 .

No release notes required, this is a fix for something added since last release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
