### PR TITLE
TOFTOF LoadMLZ: add instrument parameter Efixed

### DIFF
--- a/Framework/DataHandling/src/LoadMLZ.cpp
+++ b/Framework/DataHandling/src/LoadMLZ.cpp
@@ -88,7 +88,7 @@ void LoadMLZ::exec() {
   initInstrumentSpecific();
 
   loadDataIntoTheWorkSpace(dataFirstEntry);
-  loadRunDetails(dataFirstEntry);    // must run after runLoadInstrument
+  loadRunDetails(dataFirstEntry); // must run after runLoadInstrument
   loadExperimentDetails(dataFirstEntry);
   maskDetectors(dataFirstEntry);
 
@@ -336,12 +336,12 @@ void LoadMLZ::loadRunDetails(NXEntry &entry) {
 
   // set instrument parameter Efixed, catch error, but don't stop
   try {
-        IAlgorithm_sptr setPar = createChildAlgorithm("SetInstrumentParameter");
-        setPar->setProperty<MatrixWorkspace_sptr>("Workspace", m_localWorkspace);
-        setPar->setProperty("ParameterName", "Efixed");
-        setPar->setProperty("ParameterType", "Number");
-        setPar->setProperty("Value", std::to_string(ei));
-        setPar->execute();
+    IAlgorithm_sptr setPar = createChildAlgorithm("SetInstrumentParameter");
+    setPar->setProperty<MatrixWorkspace_sptr>("Workspace", m_localWorkspace);
+    setPar->setProperty("ParameterName", "Efixed");
+    setPar->setProperty("ParameterType", "Number");
+    setPar->setProperty("Value", std::to_string(ei));
+    setPar->execute();
   } catch (...) {
     g_log.warning("Cannot set the instrument parameter Efixed.");
   }

--- a/Framework/DataHandling/test/LoadMLZTest.h
+++ b/Framework/DataHandling/test/LoadMLZTest.h
@@ -9,8 +9,8 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidGeometry/Instrument.h"
 #include "MantidDataHandling/LoadMLZ.h"
+#include "MantidGeometry/Instrument.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;

--- a/Framework/DataHandling/test/LoadMLZTest.h
+++ b/Framework/DataHandling/test/LoadMLZTest.h
@@ -9,6 +9,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidDataHandling/LoadMLZ.h"
 #include <cxxtest/TestSuite.h>
 
@@ -41,9 +42,9 @@ public:
   }
 
   /*
-   * This test only loads the Sample Data
+   * This test loading of the Sample Data
    */
-  void testExecJustSample() {
+  void testLoad() {
     LoadMLZ loader;
     loader.initialize();
     loader.setPropertyValue("Filename", m_dataFile);
@@ -55,10 +56,14 @@ public:
     MatrixWorkspace_sptr output =
         AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
             outputSpace);
-    MatrixWorkspace_sptr output2D =
-        boost::dynamic_pointer_cast<MatrixWorkspace>(output);
 
-    TS_ASSERT_EQUALS(output2D->getNumberHistograms(), 1006); // to check
+    TS_ASSERT_EQUALS(output->getNumberHistograms(), 1006);
+
+    // test whether instrument parameter Efixed has been set
+    auto instrument = output->getInstrument();
+    TS_ASSERT(instrument->hasParameter("Efixed"));
+    auto efixed = instrument->getNumberParameter("Efixed")[0];
+    TS_ASSERT_DELTA(efixed, 2.272, 0.001);
 
     AnalysisDataService::Instance().clear();
   }


### PR DESCRIPTION
**Description of work.**

This is a minor change to the TOFTOF data loader to add an instrument parameter `Efixed` to the output workspace.

**Report to:** Spencer Howells

**To test:**

```python
ws = LoadMLZ('TOFTOFTestdata.nxs')
instrument = ws.getInstrument()
print("Workspace has instrument parameter Efixed: {}".format(instrument.hasParameter("Efixed")))
print("Efixed = {:.2f} meV".format(instrument.getNumberParameter("Efixed")[0]))
```
Expected output:
```
Workspace has instrument parameter Efixed: True
Efixed = 2.27 meV
```


Fixes #25284. 

*This does not require release notes* because **it is a minor internal change**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
