### PR TITLE
Stop Multiple Manage Directories Opening in SANS

### DIFF
--- a/scripts/Interface/ui/sans_isis/run_selector_widget.py
+++ b/scripts/Interface/ui/sans_isis/run_selector_widget.py
@@ -58,7 +58,7 @@ class RunSelectorWidget(QtWidgets.QWidget, Ui_RunSelectorWidget):
         return "Files ( *" + " *".join(extensions) + ")"
 
     def show_directories_manager(self):
-        manageuserdirectories.ManageUserDirectories.openUserDirsDialog(self)
+        manageuserdirectories.ManageUserDirectories(self).exec_()
 
     def run_not_found(self):
         QtWidgets.QMessageBox.warning(self, "Run Not Found!",

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -837,7 +837,7 @@ class SANSDataProcessorGui(QMainWindow,
         return str(self.mask_file_input_line_edit.text())
 
     def show_directory_manager(self):
-        manageuserdirectories.ManageUserDirectories.openUserDirsDialog(self)
+        manageuserdirectories.ManageUserDirectories(self).exec_()
 
     def _on_load_mask_file(self):
         load_file(self.mask_file_input_line_edit, "*.*", self.__generic_settings,


### PR DESCRIPTION
**Description of work.**
This PR makes the manage directories widget accessible from SANS modal, so only one can be opened at a time.

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. In the top right hand corner, click the manage directories button.
3. Check that, not matter how many times you click it, only one window will open
4. In the add runs tab (left hand side), check this manage directories button

Fixes #24730 

*This does not require release notes* because **Small change to way we handle widget. Not raised by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
