### PR TITLE
LoadAndMerge: 

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
@@ -86,7 +86,7 @@ class LoadAndMerge(PythonAlgorithm):
         alg.setLogging(self.isLogging())
         alg.initialize()
         for key in self._loader_options.keys():
-            alg.setPropertyValue(key, self._loader_options.getPropertyValue(key))
+            alg.setProperty(key, self._loader_options.getProperty(key).value)
         return alg
 
     def PyExec(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
@@ -23,39 +23,39 @@ class LoadAndMergeTest(unittest.TestCase):
     def test_single_run_load(self):
         out1 = LoadAndMerge(Filename='170257')
         self.assertTrue(out1)
-        self.assertEquals(out1.getName(), 'out1')
+        self.assertEquals(out1.name(), 'out1')
         self.assertTrue(isinstance(out1, MatrixWorkspace))
         mtd.clear()
 
     def test_many_runs_summed(self):
         out2 = LoadAndMerge(Filename='170257+170258',LoaderName='LoadILLIndirect')
         self.assertTrue(out2)
-        self.assertEquals(out2.getName(), 'out2')
+        self.assertEquals(out2.name(), 'out2')
         self.assertTrue(isinstance(out2, MatrixWorkspace))
         mtd.clear()
 
     def test_many_runs_listed(self):
         out3 = LoadAndMerge(Filename='170257,170258',LoaderName='LoadILLIndirect')
         self.assertTrue(out3)
-        self.assertEquals(out3.getName(), 'out3')
+        self.assertEquals(out3.name(), 'out3')
         self.assertTrue(isinstance(out3, WorkspaceGroup))
         self.assertEquals(out3.getNumberOfEntries(), 2)
         self.assertTrue(isinstance(out3.getItem(0), MatrixWorkspace))
         self.assertTrue(isinstance(out3.getItem(1), MatrixWorkspace))
-        self.assertEquals(out3.getItem(0).getName(),'170257')
-        self.assertEquals(out3.getItem(1).getName(),'170258')
+        self.assertEquals(out3.getItem(0).name(),'170257')
+        self.assertEquals(out3.getItem(1).name(),'170258')
         mtd.clear()
 
     def test_many_runs_mixed(self):
         out4 = LoadAndMerge(Filename='170257+170258,170300+170302',LoaderName='LoadILLIndirect')
         self.assertTrue(out4)
-        self.assertEquals(out4.getName(), 'out4')
+        self.assertEquals(out4.name(), 'out4')
         self.assertTrue(isinstance(out4, WorkspaceGroup))
         self.assertEquals(out4.getNumberOfEntries(), 2)
         self.assertTrue(isinstance(out4.getItem(0), MatrixWorkspace))
         self.assertTrue(isinstance(out4.getItem(1), MatrixWorkspace))
-        self.assertEquals(out4.getItem(0).getName(),'170257_170258')
-        self.assertEquals(out4.getItem(1).getName(),'170300_170302')
+        self.assertEquals(out4.getItem(0).name(),'170257_170258')
+        self.assertEquals(out4.getItem(1).name(),'170300_170302')
         mtd.clear()
 
     def test_merge_options(self):
@@ -66,7 +66,7 @@ class LoadAndMergeTest(unittest.TestCase):
     def test_specific_loader(self):
         out5 = LoadAndMerge(Filename='170257',LoaderName='LoadILLIndirect',)
         self.assertTrue(out5)
-        self.assertEquals(out5.getName(), 'out5')
+        self.assertEquals(out5.name(), 'out5')
         self.assertTrue(isinstance(out5, MatrixWorkspace))
         mtd.clear()
 
@@ -74,7 +74,7 @@ class LoadAndMergeTest(unittest.TestCase):
         out6 = LoadAndMerge(Filename='967101',LoaderName='LoadILLDiffraction',
                              LoaderVersion=1,LoaderOptions=dict({'DataType':'Raw'}))
         self.assertTrue(out6)
-        self.assertEquals(out6.getName(), 'out6')
+        self.assertEquals(out6.name(), 'out6')
         self.assertTrue(isinstance(out6, MatrixWorkspace))
         mtd.clear()
 
@@ -86,7 +86,7 @@ class LoadAndMergeTest(unittest.TestCase):
                             LoaderVersion=1,
                             LoaderOptions={'BeamCentre': 100.235})
         self.assertTrue(outLocale)
-        self.assertEquals(outLocale.getName(), 'outLocale')
+        self.assertEquals(outLocale.name(), 'outLocale')
         self.assertTrue(isinstance(outLocale, MatrixWorkspace))
         mtd.clear()
         locale.setlocale(locale.LC_ALL, loc)
@@ -99,8 +99,8 @@ class LoadAndMergeTest(unittest.TestCase):
         self.assertEquals(mtd['__out'].getNumberOfEntries(), 2)
         self.assertTrue(isinstance(mtd['__out'].getItem(0), MatrixWorkspace))
         self.assertTrue(isinstance(mtd['__out'].getItem(1), MatrixWorkspace))
-        self.assertEquals(mtd['__out'].getItem(0).getName(),'__170257_170258')
-        self.assertEquals(mtd['__out'].getItem(1).getName(),'__170300_170302')
+        self.assertEquals(mtd['__out'].getItem(0).name(),'__170257_170258')
+        self.assertEquals(mtd['__out'].getItem(1).name(),'__170300_170302')
         mtd.clear()
 
     def test_non_ill_load(self):
@@ -110,8 +110,8 @@ class LoadAndMergeTest(unittest.TestCase):
         self.assertEquals(out7.getNumberOfEntries(), 2)
         self.assertTrue(isinstance(out7.getItem(0), MatrixWorkspace))
         self.assertTrue(isinstance(out7.getItem(1), MatrixWorkspace))
-        self.assertEquals(out7.getItem(0).getName(),'IRS26173')
-        self.assertEquals(out7.getItem(1).getName(),'IRS26174')
+        self.assertEquals(out7.getItem(0).name(),'IRS26173')
+        self.assertEquals(out7.getItem(1).name(),'IRS26174')
         mtd.clear()
 
     def test_multi_period_loader_list(self):
@@ -119,10 +119,10 @@ class LoadAndMergeTest(unittest.TestCase):
         self.assertTrue(out8)
         self.assertTrue(isinstance(out8, WorkspaceGroup))
         self.assertEquals(out8.getNumberOfEntries(), 4)
-        self.assertEquals(out8.getItem(0).getName(),'MUSR00015196_1')
-        self.assertEquals(out8.getItem(1).getName(),'MUSR00015196_2')
-        self.assertEquals(out8.getItem(2).getName(),'MUSR00015197_1')
-        self.assertEquals(out8.getItem(3).getName(),'MUSR00015197_2')
+        self.assertEquals(out8.getItem(0).name(),'MUSR00015196_1')
+        self.assertEquals(out8.getItem(1).name(),'MUSR00015196_2')
+        self.assertEquals(out8.getItem(2).name(),'MUSR00015197_1')
+        self.assertEquals(out8.getItem(3).name(),'MUSR00015197_2')
         mtd.clear()
 
     def test_multi_period_loader_sum(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from mantid.simpleapi import LoadAndMerge, config, mtd
-
+import locale
 
 class LoadAndMergeTest(unittest.TestCase):
 
@@ -18,6 +18,7 @@ class LoadAndMergeTest(unittest.TestCase):
         config['default.instrument'] = 'IN16B'
         config.appendDataSearchSubDir('ILL/IN16B/')
         config.appendDataSearchSubDir('ILL/D20/')
+        config.appendDataSearchSubDir('ILL/D17/')
 
     def test_single_run_load(self):
         out1 = LoadAndMerge(Filename='170257')
@@ -76,6 +77,19 @@ class LoadAndMergeTest(unittest.TestCase):
         self.assertEquals(out6.getName(), 'out6')
         self.assertTrue(isinstance(out6, MatrixWorkspace))
         mtd.clear()
+
+    def test_loader_option_locale(self):
+        loc = locale.getlocale()
+        locale.setlocale(locale.LC_ALL, 'fr_FR.utf8')
+        outLocale = LoadAndMerge(Filename='317370',
+                            LoaderName='LoadILLReflectometry',
+                            LoaderVersion=1,
+                            LoaderOptions={'BeamCentre': 100.235})
+        self.assertTrue(outLocale)
+        self.assertEquals(outLocale.getName(), 'outLocale')
+        self.assertTrue(isinstance(outLocale, MatrixWorkspace))
+        mtd.clear()
+        locale.setlocale(locale.LC_ALL, loc)
 
     def test_output_hidden(self):
         LoadAndMerge(Filename='170257+170258,170300+170302',LoaderName='LoadILLIndirect',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from mantid.simpleapi import LoadAndMerge, config, mtd
-import locale
+
 
 class LoadAndMergeTest(unittest.TestCase):
 
@@ -18,7 +18,6 @@ class LoadAndMergeTest(unittest.TestCase):
         config['default.instrument'] = 'IN16B'
         config.appendDataSearchSubDir('ILL/IN16B/')
         config.appendDataSearchSubDir('ILL/D20/')
-        config.appendDataSearchSubDir('ILL/D17/')
 
     def test_single_run_load(self):
         out1 = LoadAndMerge(Filename='170257')
@@ -77,19 +76,6 @@ class LoadAndMergeTest(unittest.TestCase):
         self.assertEquals(out6.name(), 'out6')
         self.assertTrue(isinstance(out6, MatrixWorkspace))
         mtd.clear()
-
-    def test_loader_option_locale(self):
-        loc = locale.getlocale()
-        locale.setlocale(locale.LC_ALL, 'fr_FR.utf8')
-        outLocale = LoadAndMerge(Filename='317370',
-                            LoaderName='LoadILLReflectometry',
-                            LoaderVersion=1,
-                            LoaderOptions={'BeamCentre': 100.235})
-        self.assertTrue(outLocale)
-        self.assertEquals(outLocale.name(), 'outLocale')
-        self.assertTrue(isinstance(outLocale, MatrixWorkspace))
-        mtd.clear()
-        locale.setlocale(locale.LC_ALL, loc)
 
     def test_output_hidden(self):
         LoadAndMerge(Filename='170257+170258,170300+170302',LoaderName='LoadILLIndirect',

--- a/docs/source/release/v4.0.0/framework.rst
+++ b/docs/source/release/v4.0.0/framework.rst
@@ -139,6 +139,7 @@ Bugfixes
 - Fixed a bug in :ref:`IkedaCarpenterPV <func-IkedaCarpenterPV>` where a sign in zv was different from `FullProf NPROF=13 <http://www.ccp14.ac.uk/ccp/web-mirrors/plotr/Tutorials&Documents/TOF_FullProf.pdf>`_.
 - :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>` now save and load spectrum numbers even when histograms have no detectors.
 - :ref:`SavePlot1D <algm-SavePlot1D>` has been updated to follow changes to the plotly api.
+- :ref:`LoadAndMerge <algm-LoadAndMerge>` allows now international execution.
 
 Python
 ------


### PR DESCRIPTION
The loader options converted a number to string to set a propertyValue. Now, we get a number and set this number.

**To test:**

Code review sufficient.

```
file = 'ILL/D17/317370.nxs'
loadOption = {
    'XUnit': 'TimeOfFlight',
    'BeamCentre': 127.5,
    'BraggAngle': 0.0
}
ws = LoadAndMerge(
    Filename=file,
    LoaderName='LoadILLReflectometry',
    LoaderVersion=-1,
    LoaderOptions=loadOption,
)
```

Fixes #25305.



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
