### PR TITLE
Enable TSVSerializer for Qt5 shape saving.

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -56,6 +56,7 @@ set ( QT5_SRC_FILES
   src/SelectFunctionDialog.cpp
   src/SelectWorkspacesDialog.cpp
   src/TextPropertyWidget.cpp
+  src/TSVSerialiser.cpp
   src/UserFunctionDialog.cpp
   src/UserSubWindow.cpp
   src/VatesViewerInterface.cpp

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/TSVSerialiser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/TSVSerialiser.h
@@ -15,14 +15,10 @@
 #include <string>
 #include <vector>
 
-#include "qstring.h"
 #include <QColor>
 #include <QPoint>
 #include <QRect>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#error "TSVSerialiser os only available in Qt 4 builds"
-#endif
+#include <QString>
 
 /** Parses the formatting used in MantidPlot project files
 

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -5,9 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/Shape2D.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 
 #include <QMouseEvent>
 #include <QPainter>
@@ -167,7 +165,6 @@ bool Shape2D::isMasked(const QPointF &p) const {
  * @return a new shape2D with old state applied
  */
 Shape2D *Shape2D::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv(lines);
 
   if (!tsv.selectLine("Type"))
@@ -203,10 +200,6 @@ Shape2D *Shape2D::loadFromProject(const std::string &lines) {
   }
 
   return shape;
-#else
-  Q_UNUSED(lines);
-  return nullptr;
-#endif
 }
 
 /**
@@ -237,7 +230,6 @@ Shape2D *Shape2D::loadShape2DFromType(const std::string &type,
  * @return a string representing the state of the shape 2D
  */
 std::string Shape2D::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv;
   bool props[]{m_scalable, m_editing, m_selected, m_visible};
 
@@ -253,10 +245,6 @@ std::string Shape2D::saveToProject() const {
   tsv.writeLine("FillColor") << fillColor;
 
   return tsv.outputLines();
-#else
-  throw std::runtime_error(
-      "InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 // --- Shape2DEllipse --- //
@@ -370,24 +358,17 @@ void Shape2DEllipse::setPoint(const QString &prop, const QPointF &value) {
  * @return a new shape2D in the shape of a ellipse
  */
 Shape2D *Shape2DEllipse::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv(lines);
   tsv.selectLine("Parameters");
   double radius1, radius2, x, y;
   tsv >> radius1 >> radius2 >> x >> y;
   return new Shape2DEllipse(QPointF(x, y), radius1, radius2);
-#else
-  Q_UNUSED(lines);
-  throw std::runtime_error(
-      "Shape2DEllipse::loadFromProject not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the shape 2D ellipe to a Mantid project file
  * @return a string representing the state of the shape 2D
  */
 std::string Shape2DEllipse::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv;
   double radius1 = getDouble("radius1");
   double radius2 = getDouble("radius2");
@@ -397,10 +378,6 @@ std::string Shape2DEllipse::saveToProject() const {
   tsv.writeLine("Parameters") << radius1 << radius2 << centre.x(), centre.y();
   tsv.writeRaw(Shape2D::saveToProject());
   return tsv.outputLines();
-#else
-  throw std::runtime_error(
-      "Shape2DEllipse::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 // --- Shape2DRectangle --- //
 
@@ -445,7 +422,6 @@ void Shape2DRectangle::addToPath(QPainterPath &path) const {
  * @return a new shape2D in the shape of a rectangle
  */
 Shape2D *Shape2DRectangle::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv(lines);
   tsv.selectLine("Parameters");
   double x0, y0, x1, y1;
@@ -453,18 +429,12 @@ Shape2D *Shape2DRectangle::loadFromProject(const std::string &lines) {
   QPointF point1(x0, y0);
   QPointF point2(x1, y1);
   return new Shape2DRectangle(point1, point2);
-#else
-  Q_UNUSED(lines);
-  throw std::runtime_error(
-      "Shape2DRectangle::loadFromProject not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the shape 2D rectangle to a Mantid project file
  * @return a string representing the state of the shape 2D
  */
 std::string Shape2DRectangle::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv;
   auto x0 = m_boundingRect.x0();
   auto x1 = m_boundingRect.x1();
@@ -475,10 +445,6 @@ std::string Shape2DRectangle::saveToProject() const {
   tsv.writeLine("Parameters") << x0 << y0 << x1 << y1;
   tsv.writeRaw(Shape2D::saveToProject());
   return tsv.outputLines();
-#else
-  throw std::runtime_error(
-      "Shape2DRectangle::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 // --- Shape2DRing --- //
@@ -625,7 +591,6 @@ void Shape2DRing::setColor(const QColor &color) {
  * @return a new shape2D in the shape of a ring
  */
 Shape2D *Shape2DRing::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv(lines);
   tsv.selectLine("Parameters");
   double xWidth, yWidth;
@@ -637,18 +602,12 @@ Shape2D *Shape2DRing::loadFromProject(const std::string &lines) {
 
   auto baseShape = Shape2D::loadFromProject(baseShapeLines);
   return new Shape2DRing(baseShape, xWidth, yWidth);
-#else
-  Q_UNUSED(lines);
-  throw std::runtime_error(
-      "Shape2DRing::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the shape 2D ring to a Mantid project file
  * @return a string representing the state of the shape 2D
  */
 std::string Shape2DRing::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv;
   auto xWidth = getDouble("xwidth");
   auto yWidth = getDouble("ywidth");
@@ -659,10 +618,6 @@ std::string Shape2DRing::saveToProject() const {
   tsv.writeSection("shape", baseShape->saveToProject());
   tsv.writeRaw(Shape2D::saveToProject());
   return tsv.outputLines();
-#else
-  throw std::runtime_error(
-      "Shape2DRing::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 //------------------------------------------------------------------------------
@@ -804,7 +759,6 @@ void Shape2DFree::subtractPolygon(const QPolygonF &polygon) {
  * @return a new freefrom shape2D
  */
 Shape2D *Shape2DFree::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv(lines);
   QPolygonF polygon;
 
@@ -818,18 +772,12 @@ Shape2D *Shape2DFree::loadFromProject(const std::string &lines) {
   }
 
   return new Shape2DFree(polygon);
-#else
-  Q_UNUSED(lines);
-  throw std::runtime_error(
-      "InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the shape 2D to a Mantid project file
  * @return a string representing the state of the shape 2D
  */
 std::string Shape2DFree::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   API::TSVSerialiser tsv;
 
   tsv.writeLine("Type") << "free";
@@ -839,10 +787,6 @@ std::string Shape2DFree::saveToProject() const {
   }
   tsv.writeRaw(Shape2D::saveToProject());
   return tsv.outputLines();
-#else
-  throw std::runtime_error(
-      "InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 Shape2DFree::Shape2DFree(const QPolygonF &polygon) : m_polygon(polygon) {


### PR DESCRIPTION
**Description of work.**

Quick fix to enable shapes to be saved in the Qt5 build. Issue will be created to implement this function correctly for workbench and remove TSVSerializer again.
Refs #24470


**Report to:** [user name]/[nobody]. <!--If the original issue was raised by a user they should be named here. Do not leak email addresses-->

**To test:**

Follow instructions in the issue and check the shape details look okay in the saved table.

Fixes #24470 

*This does not require release notes* because **it only affects the workbench and that is not yet released.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
