### PR TITLE
Clang-tidy readability-named-parameter to MantidPlot

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -6264,7 +6264,7 @@ void ApplicationWindow::renameWindow() {
   rwd->exec();
 }
 
-void ApplicationWindow::renameWindow(QTreeWidgetItem *item, int,
+void ApplicationWindow::renameWindow(QTreeWidgetItem *item, int /*unused*/,
                                      const QString &text) {
   if (!item)
     return;
@@ -9756,7 +9756,7 @@ void ApplicationWindow::modifiedProject() {
   saved = false;
 }
 
-void ApplicationWindow::modifiedProject(MdiSubWindow *) { modifiedProject(); }
+void ApplicationWindow::modifiedProject(MdiSubWindow * /*unused*/) { modifiedProject(); }
 
 void ApplicationWindow::timerEvent(QTimerEvent *e) {
   if (e->timerId() == savingTimerId)
@@ -14519,7 +14519,7 @@ void ApplicationWindow::folderItemDoubleClicked(QTreeWidgetItem *it) {
 }
 
 void ApplicationWindow::folderItemChanged(QTreeWidgetItem *it,
-                                          QTreeWidgetItem *) {
+                                          QTreeWidgetItem * /*unused*/) {
   if (!it)
     return;
 
@@ -14755,8 +14755,8 @@ void ApplicationWindow::addFolderListViewItem(Folder *f) {
 }
 
 void ApplicationWindow::find(const QString &s, bool windowNames, bool labels,
-                             bool, bool caseSensitive, bool partialMatch,
-                             bool) {
+                             bool /*unused*/, bool caseSensitive, bool partialMatch,
+                             bool /*unused*/) {
   if (windowNames || labels) {
     MdiSubWindow *w = currentFolder()->findWindow(s, windowNames, labels,
                                                   caseSensitive, partialMatch);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -9756,7 +9756,9 @@ void ApplicationWindow::modifiedProject() {
   saved = false;
 }
 
-void ApplicationWindow::modifiedProject(MdiSubWindow * /*unused*/) { modifiedProject(); }
+void ApplicationWindow::modifiedProject(MdiSubWindow * /*unused*/) {
+  modifiedProject();
+}
 
 void ApplicationWindow::timerEvent(QTimerEvent *e) {
   if (e->timerId() == savingTimerId)
@@ -14755,8 +14757,8 @@ void ApplicationWindow::addFolderListViewItem(Folder *f) {
 }
 
 void ApplicationWindow::find(const QString &s, bool windowNames, bool labels,
-                             bool /*unused*/, bool caseSensitive, bool partialMatch,
-                             bool /*unused*/) {
+                             bool /*unused*/, bool caseSensitive,
+                             bool partialMatch, bool /*unused*/) {
   if (windowNames || labels) {
     MdiSubWindow *w = currentFolder()->findWindow(s, windowNames, labels,
                                                   caseSensitive, partialMatch);

--- a/MantidPlot/src/ArrowMarker.cpp
+++ b/MantidPlot/src/ArrowMarker.cpp
@@ -45,7 +45,8 @@ ArrowMarker::ArrowMarker()
       d_op(None) {}
 
 void ArrowMarker::draw(QPainter *p, const QwtScaleMap &xMap,
-                       const QwtScaleMap &yMap, const QRect & /*unused*/) const {
+                       const QwtScaleMap &yMap,
+                       const QRect & /*unused*/) const {
   const int x0 = xMap.transform(d_rect.left());
   const int y0 = yMap.transform(d_rect.top());
   const int x1 = xMap.transform(d_rect.right());

--- a/MantidPlot/src/ArrowMarker.cpp
+++ b/MantidPlot/src/ArrowMarker.cpp
@@ -45,7 +45,7 @@ ArrowMarker::ArrowMarker()
       d_op(None) {}
 
 void ArrowMarker::draw(QPainter *p, const QwtScaleMap &xMap,
-                       const QwtScaleMap &yMap, const QRect &) const {
+                       const QwtScaleMap &yMap, const QRect & /*unused*/) const {
   const int x0 = xMap.transform(d_rect.left());
   const int y0 = yMap.transform(d_rect.top());
   const int x1 = xMap.transform(d_rect.right());
@@ -362,7 +362,7 @@ void ArrowMarker::setEditable(bool yes) {
   plot()->replot();
 }
 
-bool ArrowMarker::eventFilter(QObject *, QEvent *e) {
+bool ArrowMarker::eventFilter(QObject * /*unused*/, QEvent *e) {
   switch (e->type()) {
   case QEvent::MouseButtonPress: {
     const QMouseEvent *me = (const QMouseEvent *)e;

--- a/MantidPlot/src/ConfigDialog.cpp
+++ b/MantidPlot/src/ConfigDialog.cpp
@@ -3153,7 +3153,7 @@ void ConfigDialog::insertLanguagesList() {
   boxLanguage->setCurrentIndex(lang);
 }
 
-void ConfigDialog::showPointsBox(bool) {
+void ConfigDialog::showPointsBox(bool /*unused*/) {
   if (generatePointsBtn->isChecked()) {
     lblPoints->show();
     generatePointsBox->show();

--- a/MantidPlot/src/Convolution.cpp
+++ b/MantidPlot/src/Convolution.cpp
@@ -45,7 +45,8 @@ Convolution::Convolution(ApplicationWindow *parent, Table *t,
 }
 
 bool Convolution::setDataFromTable(Table *t, const QString &signalColName,
-                                   const QString &responseColName, int /*unused*/, int /*unused*/) {
+                                   const QString &responseColName,
+                                   int /*unused*/, int /*unused*/) {
   if (t && d_table != t)
     d_table = t;
 

--- a/MantidPlot/src/Convolution.cpp
+++ b/MantidPlot/src/Convolution.cpp
@@ -45,7 +45,7 @@ Convolution::Convolution(ApplicationWindow *parent, Table *t,
 }
 
 bool Convolution::setDataFromTable(Table *t, const QString &signalColName,
-                                   const QString &responseColName, int, int) {
+                                   const QString &responseColName, int /*unused*/, int /*unused*/) {
   if (t && d_table != t)
     d_table = t;
 

--- a/MantidPlot/src/CurvesDialog.cpp
+++ b/MantidPlot/src/CurvesDialog.cpp
@@ -194,7 +194,7 @@ CurvesDialog::~CurvesDialog() {
   }
 }
 
-void CurvesDialog::showCurveBtn(int) {
+void CurvesDialog::showCurveBtn(int /*unused*/) {
   QwtPlotItem *it = d_graph->plotItem(contents->currentRow());
   if (!it)
     return;

--- a/MantidPlot/src/DockedWindow.cpp
+++ b/MantidPlot/src/DockedWindow.cpp
@@ -82,7 +82,7 @@ void DockedWindow::dragMousePress(QPoint pos) {
   }
 }
 
-void DockedWindow::dragMouseRelease(QPoint) {
+void DockedWindow::dragMouseRelease(QPoint /*unused*/) {
   if (m_dragMouseDown) {
     m_dragMouseDown = false;
   }

--- a/MantidPlot/src/FitDialog.cpp
+++ b/MantidPlot/src/FitDialog.cpp
@@ -549,7 +549,7 @@ void FitDialog::showCovarianceMatrix() {
   d_current_fit->covarianceMatrix(matrixName);
 }
 
-void FitDialog::showPointsBox(bool) {
+void FitDialog::showPointsBox(bool /*unused*/) {
   if (generatePointsBtn->isChecked()) {
     lblPoints->show();
     generatePointsBox->show();
@@ -1265,7 +1265,7 @@ void FitDialog::closeEvent(QCloseEvent *e) {
   e->accept();
 }
 
-void FitDialog::enableApplyChanges(int) { btnApply->setEnabled(true); }
+void FitDialog::enableApplyChanges(int /*unused*/) { btnApply->setEnabled(true); }
 
 void FitDialog::deleteFitCurves() {
   d_graph->deleteFitCurves();

--- a/MantidPlot/src/FitDialog.cpp
+++ b/MantidPlot/src/FitDialog.cpp
@@ -1265,7 +1265,9 @@ void FitDialog::closeEvent(QCloseEvent *e) {
   e->accept();
 }
 
-void FitDialog::enableApplyChanges(int /*unused*/) { btnApply->setEnabled(true); }
+void FitDialog::enableApplyChanges(int /*unused*/) {
+  btnApply->setEnabled(true);
+}
 
 void FitDialog::deleteFitCurves() {
   d_graph->deleteFitCurves();

--- a/MantidPlot/src/FloatingWindow.cpp
+++ b/MantidPlot/src/FloatingWindow.cpp
@@ -221,7 +221,7 @@ void FloatingWindow::dragMousePress(QPoint pos) {
   }
 }
 
-void FloatingWindow::dragMouseRelease(QPoint) {
+void FloatingWindow::dragMouseRelease(QPoint /*unused*/) {
   if (m_dragMouseDown) {
     m_dragMouseDown = false;
   }

--- a/MantidPlot/src/Graph.cpp
+++ b/MantidPlot/src/Graph.cpp
@@ -1491,7 +1491,7 @@ void Graph::exportImage(const QString &fileName, int quality,
   pic.save(fileName, nullptr, quality);
 }
 
-void Graph::exportVector(const QString &fileName, int, bool color,
+void Graph::exportVector(const QString &fileName, int /*unused*/, bool color,
                          bool keepAspect, QPrinter::PageSize pageSize) {
   if (fileName.isEmpty()) {
     QMessageBox::critical(this, tr("MantidPlot - Error"),
@@ -3356,7 +3356,7 @@ bool Graph::zoomOn() {
   return (d_zoomer[0]->isEnabled() || d_zoomer[1]->isEnabled());
 }
 
-void Graph::zoomed(const QwtDoubleRect &) {
+void Graph::zoomed(const QwtDoubleRect & /*unused*/) {
   updateSecondaryAxis(QwtPlot::xTop);
   updateSecondaryAxis(QwtPlot::yRight);
   d_plot->replot();
@@ -4876,7 +4876,7 @@ void Graph::setAntialiasing(bool on, bool update) {
   }
 }
 
-bool Graph::focusNextPrevChild(bool) {
+bool Graph::focusNextPrevChild(bool /*next*/) {
   QList<int> mrkKeys = d_plot->markerKeys();
   int n = mrkKeys.size();
   if (n < 2)

--- a/MantidPlot/src/Graph3D.cpp
+++ b/MantidPlot/src/Graph3D.cpp
@@ -898,13 +898,13 @@ void Graph3D::setAxisTickLength(int axis, double majorLength,
   sp->updateGL();
 }
 
-void Graph3D::rotationChanged(double, double, double) { emit modified(); }
+void Graph3D::rotationChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
 
-void Graph3D::scaleChanged(double, double, double) { emit modified(); }
+void Graph3D::scaleChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
 
-void Graph3D::shiftChanged(double, double, double) { emit modified(); }
+void Graph3D::shiftChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
 
-void Graph3D::zoomChanged(double) { emit modified(); }
+void Graph3D::zoomChanged(double /*unused*/) { emit modified(); }
 
 void Graph3D::resetAxesLabels() {
   sp->coordinates()->axes[X1].setLabelString(labels[0]);

--- a/MantidPlot/src/Graph3D.cpp
+++ b/MantidPlot/src/Graph3D.cpp
@@ -898,11 +898,20 @@ void Graph3D::setAxisTickLength(int axis, double majorLength,
   sp->updateGL();
 }
 
-void Graph3D::rotationChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
+void Graph3D::rotationChanged(double /*unused*/, double /*unused*/,
+                              double /*unused*/) {
+  emit modified();
+}
 
-void Graph3D::scaleChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
+void Graph3D::scaleChanged(double /*unused*/, double /*unused*/,
+                           double /*unused*/) {
+  emit modified();
+}
 
-void Graph3D::shiftChanged(double /*unused*/, double /*unused*/, double /*unused*/) { emit modified(); }
+void Graph3D::shiftChanged(double /*unused*/, double /*unused*/,
+                           double /*unused*/) {
+  emit modified();
+}
 
 void Graph3D::zoomChanged(double /*unused*/) { emit modified(); }
 

--- a/MantidPlot/src/ImageMarker.cpp
+++ b/MantidPlot/src/ImageMarker.cpp
@@ -46,7 +46,7 @@ ImageMarker::ImageMarker(const QString &fn)
 }
 
 void ImageMarker::draw(QPainter *p, const QwtScaleMap &xMap,
-                       const QwtScaleMap &yMap, const QRect &) const {
+                       const QwtScaleMap &yMap, const QRect & /*unused*/) const {
   const int x0 = xMap.transform(xValue());
   const int y0 = yMap.transform(yValue());
   const int x1 = xMap.transform(d_x_right);

--- a/MantidPlot/src/ImageMarker.cpp
+++ b/MantidPlot/src/ImageMarker.cpp
@@ -46,7 +46,8 @@ ImageMarker::ImageMarker(const QString &fn)
 }
 
 void ImageMarker::draw(QPainter *p, const QwtScaleMap &xMap,
-                       const QwtScaleMap &yMap, const QRect & /*unused*/) const {
+                       const QwtScaleMap &yMap,
+                       const QRect & /*unused*/) const {
   const int x0 = xMap.transform(xValue());
   const int y0 = yMap.transform(yValue());
   const int x1 = xMap.transform(d_x_right);

--- a/MantidPlot/src/LineProfileTool.cpp
+++ b/MantidPlot/src/LineProfileTool.cpp
@@ -187,7 +187,7 @@ void LineProfileTool::addLineMarker(const QPoint &start, const QPoint &end) {
   d_graph->replot();
 }
 
-void LineProfileTool::paintEvent(QPaintEvent *) {
+void LineProfileTool::paintEvent(QPaintEvent * /*unused*/) {
   QPainter p(this);
   p.setPen(QPen(Qt::red, 1, Qt::SolidLine));
   p.drawLine(d_op_start, d_op_start + d_op_dp);

--- a/MantidPlot/src/Mantid/MantidCurve.cpp
+++ b/MantidPlot/src/Mantid/MantidCurve.cpp
@@ -142,7 +142,7 @@ QString MantidCurve::createCopyName(const QString &curveName) {
 }
 
 void MantidCurve::doDraw(QPainter *p, const QwtScaleMap &xMap,
-                         const QwtScaleMap &yMap, const QRect &,
+                         const QwtScaleMap &yMap, const QRect & /*unused*/,
                          MantidQwtWorkspaceData const *const d) const {
   int sh = 0;
   if (symbol().style() != QwtSymbol::NoSymbol) {

--- a/MantidPlot/src/Mantid/MantidMDCurve.cpp
+++ b/MantidPlot/src/Mantid/MantidMDCurve.cpp
@@ -122,7 +122,7 @@ MantidMDCurve::~MantidMDCurve() {
 /**
  * Clone the curve for the use by a particular Graph
  */
-MantidMDCurve *MantidMDCurve::clone(const Graph *) const {
+MantidMDCurve *MantidMDCurve::clone(const Graph * /*g*/) const {
   MantidMDCurve *mc = new MantidMDCurve(*this); /*
    if (g)
    {

--- a/MantidPlot/src/Mantid/MantidMatrixFunction.cpp
+++ b/MantidPlot/src/Mantid/MantidMatrixFunction.cpp
@@ -301,7 +301,7 @@ void MantidMatrixFunctionWorkspaceObserver::afterReplaceHandle(
 
 void MantidMatrixFunctionWorkspaceObserver::preDeleteHandle(
     const std::string &wsName,
-    const boost::shared_ptr<Mantid::API::Workspace>) {
+    const boost::shared_ptr<Mantid::API::Workspace> /*ws*/) {
   if (m_function->m_workspace && wsName == m_function->m_workspace->getName()) {
     emit requestClose();
   }

--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1055,7 +1055,7 @@ void MantidUI::showAlgorithmHistory() {
 @param transpose :: Transpose the table
 @return A pointer to the new Table.
 */
-Table *MantidUI::importTableWorkspace(const QString &wsName, bool,
+Table *MantidUI::importTableWorkspace(const QString &wsName, bool /*unused*/,
                                       bool makeVisible, bool transpose) {
   ITableWorkspace_sptr ws;
   if (AnalysisDataService::Instance().doesExist(wsName.toStdString())) {
@@ -2319,7 +2319,7 @@ MultiLayer *MantidUI::plotInstrumentSpectrumList(const QString &wsName,
  * Sets the flag that tells the scripting environment that
  * a script is currently running
  */
-void MantidUI::setIsRunning(bool) {
+void MantidUI::setIsRunning(bool /*unused*/) {
   // deprecated
 }
 

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -322,7 +322,7 @@ bool PeakPickerTool::eventFilter(QObject *obj, QEvent *event) {
   return QwtPlotPicker::eventFilter(obj, event);
 }
 
-void PeakPickerTool::windowStateChanged(Qt::WindowStates,
+void PeakPickerTool::windowStateChanged(Qt::WindowStates /*unused*/,
                                         Qt::WindowStates newState) {
   (void)newState;
 }
@@ -330,7 +330,7 @@ void PeakPickerTool::windowStateChanged(Qt::WindowStates,
 void PeakPickerTool::functionCleared() { d_graph->plotWidget()->replot(); }
 
 void PeakPickerTool::draw(QPainter *p, const QwtScaleMap &xMap,
-                          const QwtScaleMap &yMap, const QRect &) const {
+                          const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
   try {
     MantidQt::MantidWidgets::PropertyHandler *h =
         m_fitPropertyBrowser->getHandler();

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -330,7 +330,8 @@ void PeakPickerTool::windowStateChanged(Qt::WindowStates /*unused*/,
 void PeakPickerTool::functionCleared() { d_graph->plotWidget()->replot(); }
 
 void PeakPickerTool::draw(QPainter *p, const QwtScaleMap &xMap,
-                          const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
+                          const QwtScaleMap &yMap,
+                          const QRect & /*canvasRect*/) const {
   try {
     MantidQt::MantidWidgets::PropertyHandler *h =
         m_fitPropertyBrowser->getHandler();

--- a/MantidPlot/src/MultiLayer.cpp
+++ b/MantidPlot/src/MultiLayer.cpp
@@ -108,7 +108,7 @@ void LayerButton::mousePressEvent(QMouseEvent *event) {
     emit clicked(this);
 }
 
-void LayerButton::mouseDoubleClickEvent(QMouseEvent *) {
+void LayerButton::mouseDoubleClickEvent(QMouseEvent * /*unused*/) {
   emit showCurvesDialog();
 }
 

--- a/MantidPlot/src/MultiPeakFit.cpp
+++ b/MantidPlot/src/MultiPeakFit.cpp
@@ -46,8 +46,8 @@ MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Graph *g,
   init(peaks);
 }
 
-MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Table *t, const QString &,
-                           const QString &, int, int, PeakProfile profile,
+MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Table *t, const QString & /*unused*/,
+                           const QString & /*unused*/, int /*unused*/, int /*unused*/, PeakProfile profile,
                            int peaks)
     : Fit(parent, t), d_profile(profile) {
   init(peaks);

--- a/MantidPlot/src/MultiPeakFit.cpp
+++ b/MantidPlot/src/MultiPeakFit.cpp
@@ -46,9 +46,10 @@ MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Graph *g,
   init(peaks);
 }
 
-MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Table *t, const QString & /*unused*/,
-                           const QString & /*unused*/, int /*unused*/, int /*unused*/, PeakProfile profile,
-                           int peaks)
+MultiPeakFit::MultiPeakFit(ApplicationWindow *parent, Table *t,
+                           const QString & /*unused*/,
+                           const QString & /*unused*/, int /*unused*/,
+                           int /*unused*/, PeakProfile profile, int peaks)
     : Fit(parent, t), d_profile(profile) {
   init(peaks);
 }

--- a/MantidPlot/src/Plot.cpp
+++ b/MantidPlot/src/Plot.cpp
@@ -54,7 +54,7 @@ Detacher::Detacher(QwtPlotItem *plotItem) : m_plotItem(plotItem) {}
 
 Detacher::~Detacher() { delete m_plotItem; }
 
-Plot::Plot(int width, int height, QWidget *parent, const char *)
+Plot::Plot(int width, int height, QWidget *parent, const char * /*unused*/)
     : QwtPlot(parent) {
   setAutoReplot(false);
 
@@ -150,7 +150,7 @@ void Plot::printFrame(QPainter *painter, const QRect &rect) const {
   painter->restore();
 }
 
-void Plot::printCanvas(QPainter *painter, const QRect &,
+void Plot::printCanvas(QPainter *painter, const QRect & /*boundingRect*/,
                        const QRect &canvasRect, const QwtScaleMap map[axisCnt],
                        const QwtPlotPrintFilter &pfilter) const {
   painter->save();

--- a/MantidPlot/src/Plot3DDialog.cpp
+++ b/MantidPlot/src/Plot3DDialog.cpp
@@ -677,7 +677,7 @@ void Plot3DDialog::accept() {
     close();
 }
 
-void Plot3DDialog::changeZoom(int) {
+void Plot3DDialog::changeZoom(int /*unused*/) {
   if (generalDialog->currentWidget() != static_cast<QWidget *>(general))
     return;
 

--- a/MantidPlot/src/PlotCurve.cpp
+++ b/MantidPlot/src/PlotCurve.cpp
@@ -1033,7 +1033,7 @@ void DataCurve::moveLabels(const QPoint &pos) {
   d_click_pos_y = d_plot->invTransform(yAxis(), pos.y());
 }
 
-PlotCurve *DataCurve::clone(const Graph *) const {
+PlotCurve *DataCurve::clone(const Graph * /*unused*/) const {
   return new DataCurve(*this);
 }
 
@@ -1042,7 +1042,7 @@ PlotMarker::PlotMarker(int index, double angle)
       d_label_y_offset(0.0) {}
 
 void PlotMarker::draw(QPainter *p, const QwtScaleMap &xMap,
-                      const QwtScaleMap &yMap, const QRect &) const {
+                      const QwtScaleMap &yMap, const QRect & /*unused*/) const {
   p->save();
   int x = xMap.transform(xValue());
   int y = yMap.transform(yValue());

--- a/MantidPlot/src/PlotDialog.cpp
+++ b/MantidPlot/src/PlotDialog.cpp
@@ -309,7 +309,7 @@ void PlotDialog::showCustomPenColumn(bool on) {
     defaultPenBox->hide();
 }
 
-void PlotDialog::showPlotAssociations(QTreeWidgetItem *item, int) {
+void PlotDialog::showPlotAssociations(QTreeWidgetItem *item, int /*unused*/) {
   if (!item)
     return;
 
@@ -1131,7 +1131,7 @@ void PlotDialog::initPercentilePage() {
  * Hides the "Custom color map" button when the user has not selected that
  * specific button.
  */
-void PlotDialog::showColorMapEditor(bool) {
+void PlotDialog::showColorMapEditor(bool /*unused*/) {
   if (grayScaleBox->isChecked() || defaultScaleBox->isChecked()) {
     mSelectColormap->hide();
     boxSetCMapAsDefault->hide();
@@ -2852,7 +2852,7 @@ void PlotDialog::changeColormap(const QString &filename) {
   setColorMapName();
 }
 
-void PlotDialog::showDefaultContourLinesBox(bool) {
+void PlotDialog::showDefaultContourLinesBox(bool /*unused*/) {
   if (autoContourBox->isChecked())
     defaultPenBox->hide();
   else

--- a/MantidPlot/src/SmoothFilter.cpp
+++ b/MantidPlot/src/SmoothFilter.cpp
@@ -114,7 +114,7 @@ void SmoothFilter::smoothFFT(double *x, double *y) {
   gsl_fft_real_workspace_free(work);
 }
 
-void SmoothFilter::smoothAverage(double *, double *y) {
+void SmoothFilter::smoothAverage(double * /*unused*/, double *y) {
   int p2 = d_smooth_points / 2;
   double m = double(2 * p2 + 1);
   double aux = 0.0;
@@ -150,7 +150,7 @@ void SmoothFilter::smoothAverage(double *, double *y) {
   delete[] s;
 }
 
-void SmoothFilter::smoothSavGol(double *, double *y) {
+void SmoothFilter::smoothSavGol(double * /*unused*/, double *y) {
   double *s = new double[d_n];
   int nl = d_smooth_points;
   int nr = d_sav_gol_points;

--- a/MantidPlot/src/Table.cpp
+++ b/MantidPlot/src/Table.cpp
@@ -146,7 +146,7 @@ void Table::setAutoUpdateValues(bool on) {
   }
 }
 
-void Table::colWidthModified(int, int, int) {
+void Table::colWidthModified(int /*unused*/, int /*unused*/, int /*unused*/) {
   emit modifiedWindow(this);
   setHeaderColType();
 }
@@ -2915,7 +2915,7 @@ void Table::setReadOnlyAllColumns(bool on) {
   }
 }
 
-void Table::moveColumn(int, int fromIndex, int toIndex) {
+void Table::moveColumn(int /*unused*/, int fromIndex, int toIndex) {
   int to = toIndex;
   if (fromIndex < toIndex)
     to = toIndex - 1;
@@ -3327,7 +3327,7 @@ void MyTable::setText(int row, int col, const QString &txt) {
 
 void MyTable::blockResizing(bool yes) { m_blockResizing = yes; }
 
-void MyTable::resizeData(int) {
+void MyTable::resizeData(int /*unused*/) {
   if (m_blockResizing) {
     emit unwantedResize();
   }

--- a/MantidPlot/src/TiledWindow.cpp
+++ b/MantidPlot/src/TiledWindow.cpp
@@ -687,7 +687,9 @@ void TiledWindow::mousePressEvent(QMouseEvent *ev) {
 /**
  * Mouse release event handler.
  */
-void TiledWindow::mouseReleaseEvent(QMouseEvent * /*unused*/) { m_buttonPressed = false; }
+void TiledWindow::mouseReleaseEvent(QMouseEvent * /*unused*/) {
+  m_buttonPressed = false;
+}
 
 /**
  * Mouse move event handler.

--- a/MantidPlot/src/TiledWindow.cpp
+++ b/MantidPlot/src/TiledWindow.cpp
@@ -180,7 +180,7 @@ public:
 
 protected:
   /// Paint event handler
-  void paintEvent(QPaintEvent *) override {
+  void paintEvent(QPaintEvent * /*unused*/) override {
     QPainter painter(this);
     painter.fillRect(this->rect().adjusted(0, 0, -1, -1), QColor("white"));
     if (m_draw) {
@@ -274,7 +274,7 @@ void TiledWindow::init(int nrows, int ncols) {
  * Save the window info to a string.
  * TODO: not implemented.
  */
-QString TiledWindow::saveToString(const QString &info, bool) {
+QString TiledWindow::saveToString(const QString &info, bool /*unused*/) {
   UNUSED_ARG(info);
   QString s = "<tiled_widget>\n";
   s += "</tiled_widget>\n";
@@ -687,7 +687,7 @@ void TiledWindow::mousePressEvent(QMouseEvent *ev) {
 /**
  * Mouse release event handler.
  */
-void TiledWindow::mouseReleaseEvent(QMouseEvent *) { m_buttonPressed = false; }
+void TiledWindow::mouseReleaseEvent(QMouseEvent * /*unused*/) { m_buttonPressed = false; }
 
 /**
  * Mouse move event handler.
@@ -1123,7 +1123,7 @@ void TiledWindow::dragEnterEvent(QDragEnterEvent *ev) {
 /**
  * The drag leave event handler.
  */
-void TiledWindow::dragLeaveEvent(QDragLeaveEvent *) { clearDrops(); }
+void TiledWindow::dragLeaveEvent(QDragLeaveEvent * /*unused*/) { clearDrops(); }
 
 /**
  * The drag move event handler.

--- a/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
+++ b/MantidPlot/src/lib/3rdparty/qtcolorpicker/src/qtcolorpicker.cpp
@@ -175,7 +175,7 @@ public:
   QColor color() const;
   QString text() const;
 
-  void setSelected(bool);
+  void setSelected(bool /*selected*/);
   bool isSelected() const;
 signals:
   void clicked();
@@ -217,7 +217,7 @@ public:
   QColor color(int index) const;
 
 signals:
-  void selected(const QColor &);
+  void selected(const QColor & /*_t1*/);
   void hid();
 
 public slots:
@@ -795,7 +795,7 @@ QColor ColorPickerPopup::lastSelected() const { return lastSel; }
     Sets focus on the popup to enable keyboard navigation. Draws
     focusRect and selection rect.
 */
-void ColorPickerPopup::showEvent(QShowEvent *) {
+void ColorPickerPopup::showEvent(QShowEvent * /*unused*/) {
   bool foundSelected = false;
   for (int i = 0; i < grid->columnCount(); ++i) {
     for (int j = 0; j < grid->rowCount(); ++j) {
@@ -930,7 +930,7 @@ void ColorPickerItem::setColor(const QColor &color, const QString &text) {
 /*!
 
 */
-void ColorPickerItem::mouseMoveEvent(QMouseEvent *) {
+void ColorPickerItem::mouseMoveEvent(QMouseEvent * /*unused*/) {
   setFocus();
   update();
 }
@@ -938,7 +938,7 @@ void ColorPickerItem::mouseMoveEvent(QMouseEvent *) {
 /*!
 
 */
-void ColorPickerItem::mouseReleaseEvent(QMouseEvent *) {
+void ColorPickerItem::mouseReleaseEvent(QMouseEvent * /*unused*/) {
   sel = true;
   emit selected();
 }
@@ -946,7 +946,7 @@ void ColorPickerItem::mouseReleaseEvent(QMouseEvent *) {
 /*!
 
 */
-void ColorPickerItem::mousePressEvent(QMouseEvent *) {
+void ColorPickerItem::mousePressEvent(QMouseEvent * /*unused*/) {
   setFocus();
   update();
 }
@@ -954,7 +954,7 @@ void ColorPickerItem::mousePressEvent(QMouseEvent *) {
 /*!
 
 */
-void ColorPickerItem::paintEvent(QPaintEvent *) {
+void ColorPickerItem::paintEvent(QPaintEvent * /*unused*/) {
   QPainter p(this);
   int w = width();  // width of cell in pixels
   int h = height(); // height of cell in pixels
@@ -982,7 +982,7 @@ ColorPickerButton::ColorPickerButton(QWidget *parent) : QFrame(parent) {
 /*!
 
 */
-void ColorPickerButton::mousePressEvent(QMouseEvent *) {
+void ColorPickerButton::mousePressEvent(QMouseEvent * /*unused*/) {
   setFrameShadow(Sunken);
   update();
 }
@@ -990,7 +990,7 @@ void ColorPickerButton::mousePressEvent(QMouseEvent *) {
 /*!
 
 */
-void ColorPickerButton::mouseMoveEvent(QMouseEvent *) {
+void ColorPickerButton::mouseMoveEvent(QMouseEvent * /*unused*/) {
   setFocus();
   update();
 }
@@ -998,7 +998,7 @@ void ColorPickerButton::mouseMoveEvent(QMouseEvent *) {
 /*!
 
 */
-void ColorPickerButton::mouseReleaseEvent(QMouseEvent *) {
+void ColorPickerButton::mouseReleaseEvent(QMouseEvent * /*unused*/) {
   setFrameShadow(Raised);
   repaint();
   emit clicked();

--- a/MantidPlot/src/muParserScript.cpp
+++ b/MantidPlot/src/muParserScript.cpp
@@ -349,7 +349,9 @@ bool muParserScript::setInt(int val, const char *name) {
   return setDouble((double)val, name);
 }
 
-bool muParserScript::setQObject(QObject * /*unused*/, const char * /*unused*/) { return false; }
+bool muParserScript::setQObject(QObject * /*unused*/, const char * /*unused*/) {
+  return false;
+}
 
 QString muParserScript::compileColArg(const QString &in) {
   QString out = "\"";

--- a/MantidPlot/src/muParserScript.cpp
+++ b/MantidPlot/src/muParserScript.cpp
@@ -349,7 +349,7 @@ bool muParserScript::setInt(int val, const char *name) {
   return setDouble((double)val, name);
 }
 
-bool muParserScript::setQObject(QObject *, const char *) { return false; }
+bool muParserScript::setQObject(QObject * /*unused*/, const char * /*unused*/) { return false; }
 
 QString muParserScript::compileColArg(const QString &in) {
   QString out = "\"";

--- a/MantidPlot/src/muParserScripting.cpp
+++ b/MantidPlot/src/muParserScripting.cpp
@@ -156,7 +156,7 @@ const muParserScripting::mathFunction muParserScripting::math_functions[] = {
      "function computes the one where W<-1 for x<0. (also see w0(x))."},
     {nullptr, 0, nullptr, nullptr, nullptr, nullptr}};
 
-void muParserScripting::setSysArgs(const QStringList &) {
+void muParserScripting::setSysArgs(const QStringList & /*args*/) {
   throw std::runtime_error(
       "muParserScripting does not support command line arguments");
 }

--- a/MantidPlot/src/nrutil.cpp
+++ b/MantidPlot/src/nrutil.cpp
@@ -75,7 +75,7 @@ vector(long nl,
 }
 
 void free_vector(double *v, long nl,
-                 long) { // free a double vector allocated with vector()
+                 long /*unused*/) { // free a double vector allocated with vector()
   free((FREE_ARG)(v + nl - NR_END));
 }
 
@@ -87,7 +87,7 @@ size_t *ivector(long nl, long nh) {
   return v - nl + NR_END;
 }
 
-void free_ivector(size_t *v, long nl, long) {
+void free_ivector(size_t *v, long nl, long /*unused*/) {
   free((FREE_ARG)(v + nl - NR_END));
 }
 
@@ -99,7 +99,7 @@ int *intvector(long nl, long nh) {
   return v - nl + NR_END;
 }
 
-void free_intvector(int *v, long nl, long) {
+void free_intvector(int *v, long nl, long /*unused*/) {
   free((FREE_ARG)(v + nl - NR_END));
 }
 

--- a/MantidPlot/src/nrutil.cpp
+++ b/MantidPlot/src/nrutil.cpp
@@ -74,8 +74,9 @@ vector(long nl,
   return v - nl + NR_END;
 }
 
-void free_vector(double *v, long nl,
-                 long /*unused*/) { // free a double vector allocated with vector()
+void free_vector(
+    double *v, long nl,
+    long /*unused*/) { // free a double vector allocated with vector()
   free((FREE_ARG)(v + nl - NR_END));
 }
 


### PR DESCRIPTION
**Description of work.**
applies clang-tidy readability-named-parameter to Mantidplot.
/unused/ is default. But variable names taken from header files where available

**To test:**
Code review

Fixes partially #15452 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
