### PR TITLE
Change pyqtSignal to Signal to fix DGSPlanner not opening in MantidPlot 

### DIFF
--- a/scripts/DGSPlanner/InstrumentSetupWidget.py
+++ b/scripts/DGSPlanner/InstrumentSetupWidget.py
@@ -148,7 +148,7 @@ class GonioTableModel(QtCore.QAbstractTableModel):
 
 class InstrumentSetupWidget(QtWidgets.QWidget):
     #signal when things change and valid
-    changed=QtCore.pyqtSignal(dict)
+    changed=QtCore.Signal(dict)
 
     def __init__(self,parent=None):
         # pylint: disable=unused-argument,super-on-old-class


### PR DESCRIPTION
Changes `pyqtSignal` to `Signal` to be compatible with qtpy's importing of PyQt4 and 5 signals.