### PR TITLE
Add clang-tidy instructions to dev-docs

### DIFF
--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -221,20 +221,34 @@ Use
 Clang-tidy
 ----------
 
-Mantid has built clang-tidy support into cmake. This allows a user to detect and fix code which does not follow best practices,
-such as unused parameters or not using range-based for loops.
+Clang-tidy is a set of tools which allows a developer to detect and fix code which does not follow current best practices,
+such as unused parameters or not using range-based for loops. Primarily this is used for modernising C++ code.
+
+The full list of clang-tidy checks can be seen `here <https://clang.llvm.org/extra/clang-tidy/checks/list.html>`_.
 
 Installing
 ~~~~~~~~~~
 
-Mantid does not come packaged with clang-tidy, each developer must download it themselves:
+Mantid does not come packaged with clang-tidy; each developer must download it themselves. Windows users can utilise clang-tidy support for Visual Studio.
+For other operating systems, Mantid provides clang-tidy functionality through cmake.
 
 - **Ubuntu**: Run ``sudo apt-get install clang-tidy`` in the command line.
 - **Windows**: Download the `Visual Studio extension <https://marketplace.visualstudio.com/items?itemName=caphyon.ClangPowerTools>`_. Windows can operate clang-tidy from Visual Studio alone and so do not need to touch cmake.
 
-For other operating systems, check out the clang-tidy `downloads <http://releases.llvm.org/download.html>`_.
+For non-Ubuntu systems, download the latest clang-tidy `pre-compile binaries <http://releases.llvm.org/download.html>`_. Windows users should add to path when prompted.
 
-Setup
+Visual Studio
+~~~~~~~~~~~~~
+
+Once you have installed the clang-tidy extension, Visual Studio will have additional options under ``Tools -> Options -> Clang Power Tools``.
+Here you can set clang-tidy after to run after building and select which checks to run. The default settings *should* not require alteration for clang-tidy to work.
+
+To run clang-tidy, right click on a target and highlight ``Clang Power Tools``. You will have a number of options. ``Tidy`` will highlight code which fails one of the checks, whereas
+``Tidy fix`` will automatically change your code.
+
+*Note: clang-tidy does not work on* **ALL BUILD** *so it is necessary to select a subtarget.*
+
+Cmake
 ~~~~~
 
 In the cmake gui, find the ``CLANG_TIDY_EXE`` parameter. If you are a non-Linux developer, you may have to manually point to your clang-tidy install.
@@ -243,8 +257,7 @@ Configure, and check the cmake log for the message `clang-tidy found`. If the `c
 Once you have clang-tidy, there are several relevant parameters you will want to change:
 
 - ``ENABLE_CLANG_TIDY`` will turn on clang-tidy support.
-- ``CLANG_TIDY_CHECKS`` is a semi-colon separated list of checks for clang-tidy to carry out. The full list can be seen `here <https://clang.llvm.org/extra/clang-tidy/checks/list.html>`_.
-  This defaults to all ``modernize-`` checks.
+- ``CLANG_TIDY_CHECKS`` is a semi-colon separated list of checks for clang-tidy to carry out. This defaults to all ``modernize-`` checks.
 - ``APPLY_CLANG_TIDY_FIX`` will automatically change the code whenever a check has returned a result. The behaviour of ``ENABLE_CLANG_TIDY`` without this checked is to highlight issues only.
 
 Configure the build to check that your selected options are reflected in ``CMAKE_CXX_CLANG_TIDY``, and then generate.

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -241,7 +241,7 @@ Visual Studio
 ~~~~~~~~~~~~~
 
 Once you have installed the clang-tidy extension, Visual Studio will have additional options under ``Tools -> Options -> Clang Power Tools``.
-Here you can which checks to run via a checkbox or by supplying a custom check string. For example::
+Here you can select which checks to run via a checkbox or by supplying a custom check string. For example::
 
     -*,modernize-*
 

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -227,9 +227,12 @@ such as unused parameters or not using range-based for loops.
 Installing
 ~~~~~~~~~~
 
-Mantid does not come packaged with clang-tidy. You can install clang-tidy `here <http://releases.llvm.org/download.html>`_.
+Mantid does not come packaged with clang-tidy, each developer must download it themselves:
 
-Alternatively, for **Ubuntu** users, run ``sudo apt-get install clang-tidy`` in the command line.
+- **Ubuntu**: Run ``sudo apt-get install clang-tidy`` in the command line.
+- **Windows**: Download the `Visual Studio extension <https://marketplace.visualstudio.com/items?itemName=caphyon.ClangPowerTools>`_. Windows can operate clang-tidy from Visual Studio alone and so do not need to touch cmake.
+
+For other operating systems, check out the clang-tidy `downloads <http://releases.llvm.org/download.html>`_.
 
 Setup
 ~~~~~

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -235,13 +235,18 @@ For other operating systems, Mantid provides clang-tidy functionality through cm
 - **Ubuntu**: Run ``sudo apt-get install clang-tidy`` in the command line.
 - **Windows**: Download the `Visual Studio extension <https://marketplace.visualstudio.com/items?itemName=caphyon.ClangPowerTools>`_. Windows can operate clang-tidy from Visual Studio alone and so do not need to touch cmake.
 
-For non-Ubuntu systems, download the latest clang-tidy `pre-compile binaries <http://releases.llvm.org/download.html>`_. Windows users should add to path when prompted.
+For non-Ubuntu systems, download the latest clang-tidy `pre-compiled binary <http://releases.llvm.org/download.html>`_. Windows users should add to path when prompted.
 
 Visual Studio
 ~~~~~~~~~~~~~
 
 Once you have installed the clang-tidy extension, Visual Studio will have additional options under ``Tools -> Options -> Clang Power Tools``.
-Here you can set clang-tidy after to run after building and select which checks to run. The default settings *should* not require alteration for clang-tidy to work.
+Here you can which checks to run via a checkbox or by supplying a custom check string. For example::
+
+    -*,modernize-*
+
+will disable basic default checks (``-*``) and run all conversions to modern C++ (``modernize-*``), such as converting to range-based for loops or using the auto keyword.
+Other settings *should* not require alteration for clang-tidy to work.
 
 To run clang-tidy, right click on a target and highlight ``Clang Power Tools``. You will have a number of options. ``Tidy`` will highlight code which fails one of the checks, whereas
 ``Tidy fix`` will automatically change your code.

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -224,10 +224,20 @@ Clang-tidy
 Mantid has built clang-tidy support into cmake. This allows a user to detect and fix code which does not follow best practices,
 such as unused parameters or not using range-based for loops.
 
-cmake-gui
-~~~~~~~~~
+Installing
+~~~~~~~~~~
 
-Open up the gui and search for *clang-tidy* parameters. There are several relevant options:
+Mantid does not come packaged with clang-tidy. You can install clang-tidy `here <http://releases.llvm.org/download.html>`_.
+
+Alternatively, for **Ubuntu** users, run ``sudo apt-get install clang-tidy`` in the command line.
+
+Setup
+~~~~~
+
+In the cmake gui, find the ``CLANG_TIDY_EXE`` parameter. If you are a non-Linux developer, you may have to manually point to your clang-tidy install.
+Configure, and check the cmake log for the message `clang-tidy found`. If the `clang-tidy not found` warning was posted instead then it has not worked.
+
+Once you have clang-tidy, there are several relevant parameters you will want to change:
 
 - ``ENABLE_CLANG_TIDY`` will turn on clang-tidy support.
 - ``CLANG_TIDY_CHECKS`` is a semi-colon separated list of checks for clang-tidy to carry out. The full list can be seen `here <https://clang.llvm.org/extra/clang-tidy/checks/list.html>`_.

--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -218,3 +218,39 @@ Use
 	- ``--page_handle`` the page handle to use [default page name]
 	- ``--add_heading`` add a heading to the page (uses the page name)
 
+Clang-tidy
+----------
+
+Mantid has built clang-tidy support into cmake. This allows a user to detect and fix code which does not follow best practices,
+such as unused parameters or not using range-based for loops.
+
+cmake-gui
+~~~~~~~~~
+
+Open up the gui and search for *clang-tidy* parameters. There are several relevant options:
+
+- ``ENABLE_CLANG_TIDY`` will turn on clang-tidy support.
+- ``CLANG_TIDY_CHECKS`` is a semi-colon separated list of checks for clang-tidy to carry out. The full list can be seen `here <https://clang.llvm.org/extra/clang-tidy/checks/list.html>`_.
+  This defaults to all ``modernize-`` checks.
+- ``APPLY_CLANG_TIDY_FIX`` will automatically change the code whenever a check has returned a result. The behaviour of ``ENABLE_CLANG_TIDY`` without this checked is to highlight issues only.
+
+Configure the build to check that your selected options are reflected in ``CMAKE_CXX_CLANG_TIDY``, and then generate.
+When you next build, clang-tidy will perform the selected checks on the code included in the target.
+
+*Note: There is a known issue that clang-tidy is only being applied to certain directories within* ``Framework`` *and* ``Mantidplot``.
+
+Options
+~~~~~~~
+
+Some clang-tidy checks have optional arguments. For example, ``modernize-loop-convert``, which changes loops to range-based,
+assigns a riskiness to each loop and can accept a ``MinConfidence`` argument to determine which risk levels to address.
+
+Adding the optional arguments is clunky and will rarely be required, so it has not been directly added to Mantid's cmake setup.
+To add optional arguments, add the following onto the end of ``CLANG_TIDY_CHECKS``::
+
+    ;-config={CheckOptions: [ {key: check-to-choose-option.option-name, value: option-value} ]}
+
+For example, to convert all loops classified as *risky* or above, we would append::
+
+    ;-config={CheckOptions: [ {key: modernize-loop-convert.MinConfidence, value: risky} ]}
+


### PR DESCRIPTION
**Description of work.**
This PR adds information on how to run clang-tidy via cmake for Mantid in dev-docs -> ToolsOverview.rst

**To test:**
1. Build `dev-docs-html`
2. In your build directory, open `dev-docs -> html -> ToolsOverview.html`
3. Go to the `clang-tidy` section (it should be at the bottom of the page and in the contents)
4. Check that it makes sense, and check for spelling errors

*There is no associated issue.*

*This does not require release notes* because **change to developer documentation**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
