### PR TITLE
Make a copy of an output workspace group

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -546,7 +546,12 @@ void QENSFitSequential::exec() {
 
   setProperty("OutputWorkspace", resultWs);
   setProperty("OutputParameterWorkspace", parameterWs);
-  setProperty("OutputWorkspaceGroup", groupWs);
+  // Copy the group to prevent the ADS having two entries for one workspace
+  auto outGroupWs = WorkspaceGroup_sptr(new WorkspaceGroup);
+  for (auto item : groupWs->getAllItems()) {
+    outGroupWs->addWorkspace(item);
+  }
+  setProperty("OutputWorkspaceGroup", outGroupWs);
 }
 
 std::map<std::string, std::string>


### PR DESCRIPTION
**Description of work.**
QENSFitSequential algorithm makes two entries in the ADS pointing to the same workspace group. This PR changes the algorithm so it makes a copy of the workspace group to store.

**To test:**
Run the script, delete all workspaces.
```
from __future__ import (absolute_import, division, print_function, unicode_literals)

from mantid.simpleapi import *

run = Load('irs26173_graphite002_red.nxs')

Simple = '''name=DeltaFunction, Height=0.5, Centre=0.0, constraints=(0<Height);
            name=Lorentzian, Amplitude= 0.1, PeakCentre = 0.0, FWHM= 0.3, ties = f0.Centre'''


startX = -0.5
endX = 0.5
specMin = 0
specMax = run.getNumberHistograms() - 1
convolve = False  # Convolve the fitted model components with the resolution
minimizer = "Levenberg-Marquardt"
maxIt = 500

result, params, fit_group = QENSFitSequential(InputWorkspace=run,
                              Function=Simple,
                              OutputWorkspace='qout%s' % run,
                              StartX=startX, EndX=endX,
                              SpecMin=specMin, SpecMax=specMax,
                              ConvolveMembers=convolve,
                              Minimizer=minimizer,
                              MaxIterations=maxIt)
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
