### PR TITLE
Fix cppcheck 1.87 warnings in Parallel

### DIFF
--- a/Framework/Parallel/src/IO/MultiProcessEventLoader.cpp
+++ b/Framework/Parallel/src/IO/MultiProcessEventLoader.cpp
@@ -196,11 +196,9 @@ void MultiProcessEventLoader::assembleFromShared(
   std::vector<std::thread> workers;
 
   std::vector<std::atomic<uint32_t>> cnts(m_segmentNames.size());
+  std::fill(cnts.begin(), cnts.end(), 0);
   std::vector<std::atomic<uint32_t>> processCounter(m_segmentNames.size());
-  for (auto &cnt : cnts)
-    cnt = 0;
-  for (auto &cnt : processCounter)
-    cnt = 0;
+  std::fill(processCounter.begin(), processCounter.end(), 0);
 
   const unsigned portion{std::max<unsigned>(m_numPixels / m_numThreads / 3, 1)};
 


### PR DESCRIPTION
This PR fixes `cppcheck` 1.87 warnings in the Parallel module.

**To test:**

Code review.

Fixes partially #22912

*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
