### PR TITLE
Clang-tidy modernize-loop-convert Risky

### DIFF
--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -287,7 +287,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
     for (; plusToken != end; ++plusToken)
       plusTokenStrings.push_back(plusToken->str());
 
-    for (auto & plusTokenString : plusTokenStrings) {
+    for (auto &plusTokenString : plusTokenStrings) {
       try {
         m_parser.parse(plusTokenString);
       } catch (const std::range_error &re) {
@@ -320,7 +320,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
         if (temp.empty())
           temp.push_back(f[0]);
         else {
-          for (auto & parsedFile : f[0])
+          for (auto &parsedFile : f[0])
             temp[0].push_back(parsedFile);
         }
       } else {

--- a/Framework/API/src/MultipleFileProperty.cpp
+++ b/Framework/API/src/MultipleFileProperty.cpp
@@ -287,10 +287,9 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
     for (; plusToken != end; ++plusToken)
       plusTokenStrings.push_back(plusToken->str());
 
-    for (auto plusTokenString = plusTokenStrings.begin();
-         plusTokenString != plusTokenStrings.end(); ++plusTokenString) {
+    for (auto & plusTokenString : plusTokenStrings) {
       try {
-        m_parser.parse(*plusTokenString);
+        m_parser.parse(plusTokenString);
       } catch (const std::range_error &re) {
         g_log.error(re.what());
         throw;
@@ -307,7 +306,7 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
       // existing) file within a token, but which has unexpected zero padding,
       // or some other anomaly.
       if (VectorHelper::flattenVector(f).empty())
-        f.push_back(std::vector<std::string>(1, *plusTokenString));
+        f.push_back(std::vector<std::string>(1, plusTokenString));
 
       if (plusTokenStrings.size() > 1) {
         // See [3] in header documentation.  Basically, for reasons of
@@ -321,9 +320,8 @@ MultipleFileProperty::setValueAsMultipleFiles(const std::string &propValue) {
         if (temp.empty())
           temp.push_back(f[0]);
         else {
-          for (auto parsedFile = f[0].begin(); parsedFile != f[0].end();
-               ++parsedFile)
-            temp[0].push_back(*parsedFile);
+          for (auto & parsedFile : f[0])
+            temp[0].push_back(parsedFile);
         }
       } else {
         temp.insert(temp.end(), f.begin(), f.end());

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -112,7 +112,7 @@ void IndexPeaks::exec() {
     std::vector<V3D> q_vectors;
 
     q_vectors.reserve(n_peaks);
-    for (auto &peak : peaks) {
+    for (const auto &peak : peaks) {
       q_vectors.push_back(peak.getQSampleFrame());
     }
 
@@ -132,7 +132,7 @@ void IndexPeaks::exec() {
 
     // get list of run numbers in this peaks workspace
     std::vector<int> run_numbers;
-    for (auto &peak : peaks) {
+    for (const auto &peak : peaks) {
       int run = peak.getRunNumber();
       bool found = false;
       size_t k = 0;
@@ -149,12 +149,11 @@ void IndexPeaks::exec() {
     // index the peaks for each run separately, using a UB matrix optimized for
     // that run
 
-    for (size_t run_index = 0; run_index < run_numbers.size(); run_index++) {
+    for (const int run : run_numbers) {
       std::vector<V3D> miller_indices;
       std::vector<V3D> q_vectors;
 
-      int run = run_numbers[run_index];
-      for (auto &peak : peaks) {
+      for (const auto &peak : peaks) {
         if (peak.getRunNumber() == run)
           q_vectors.push_back(peak.getQSampleFrame());
       }

--- a/Framework/DataHandling/src/LoadFullprofResolution.cpp
+++ b/Framework/DataHandling/src/LoadFullprofResolution.cpp
@@ -179,8 +179,7 @@ void LoadFullprofResolution::exec() {
 
   // Parse .irf and export profile parameters
   map<int, map<string, double>> bankparammap;
-  for (size_t i = 0; i < vec_bankids.size(); ++i) {
-    int bankid = vec_bankids[i];
+  for (int bankid : vec_bankids) {
     g_log.debug() << "Parse bank " << bankid << " of total "
                   << vec_bankids.size() << ".\n";
     map<string, double> parammap;

--- a/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Framework/Geometry/src/Math/Acomp.cpp
@@ -1450,10 +1450,10 @@ given a inner bracket expand that etc.
   // First:: Union take presidence over Intersection
   //      :: check brackets
   int blevel = 0; // bracket level
-  for (unsigned int i = 0; i < Ln.size(); i++) {
-    if (Ln[i] == '(')
+  for (char i : Ln) {
+    if (i == '(')
       blevel++;
-    if (Ln[i] == ')') {
+    if (i == ')') {
       if (!blevel) // error condition
       {
         deleteComp();
@@ -1461,7 +1461,7 @@ given a inner bracket expand that etc.
       }
       blevel--;
     }
-    if (Ln[i] == '+' && !blevel) // must be union
+    if (i == '+' && !blevel) // must be union
       Intersect = 0;
   }
   if (blevel != 0)

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -152,8 +152,8 @@ int OPJFile::compareFunctionnames(const char *sname) const {
 
 vector<string> OPJFile::findDataByIndex(int index) const {
   vector<string> str;
-  for (const auto & spread : SPREADSHEET)
-    for (const auto & i : spread.column)
+  for (const auto &spread : SPREADSHEET)
+    for (const auto &i : spread.column)
       if (i.index == index) {
         str.push_back(i.name);
         str.emplace_back("T_" + spread.name);
@@ -165,8 +165,8 @@ vector<string> OPJFile::findDataByIndex(int index) const {
       str.emplace_back("M_" + i.name);
       return str;
     }
-  for (const auto & i : EXCEL)
-    for (const auto & j : i.sheet)
+  for (const auto &i : EXCEL)
+    for (const auto &j : i.sheet)
       for (const auto &k : j.column)
         if (k.index == index) {
           str.push_back(k.name);
@@ -212,7 +212,7 @@ void OPJFile::convertSpreadToExcel(int spread) {
                         SPREADSHEET[spread].maxRows,
                         SPREADSHEET[spread].bHidden,
                         SPREADSHEET[spread].bLoose));
-  for (auto & i : SPREADSHEET[spread].column) {
+  for (auto &i : SPREADSHEET[spread].column) {
     string name = i.name;
     int pos = static_cast<int>(name.find_last_of("@"));
     string col = name;

--- a/MantidPlot/src/origin/OPJFile.cpp
+++ b/MantidPlot/src/origin/OPJFile.cpp
@@ -152,31 +152,31 @@ int OPJFile::compareFunctionnames(const char *sname) const {
 
 vector<string> OPJFile::findDataByIndex(int index) const {
   vector<string> str;
-  for (unsigned int spread = 0; spread < SPREADSHEET.size(); spread++)
-    for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); i++)
-      if (SPREADSHEET[spread].column[i].index == index) {
-        str.push_back(SPREADSHEET[spread].column[i].name);
-        str.emplace_back("T_" + SPREADSHEET[spread].name);
+  for (const auto & spread : SPREADSHEET)
+    for (const auto & i : spread.column)
+      if (i.index == index) {
+        str.push_back(i.name);
+        str.emplace_back("T_" + spread.name);
         return str;
       }
-  for (unsigned int i = 0; i < MATRIX.size(); i++)
-    if (MATRIX[i].index == index) {
-      str.push_back(MATRIX[i].name);
-      str.emplace_back("M_" + MATRIX[i].name);
+  for (const auto &i : MATRIX)
+    if (i.index == index) {
+      str.push_back(i.name);
+      str.emplace_back("M_" + i.name);
       return str;
     }
-  for (unsigned int i = 0; i < EXCEL.size(); i++)
-    for (unsigned int j = 0; j < EXCEL[i].sheet.size(); j++)
-      for (unsigned int k = 0; k < EXCEL[i].sheet[j].column.size(); k++)
-        if (EXCEL[i].sheet[j].column[k].index == index) {
-          str.push_back(EXCEL[i].sheet[j].column[k].name);
-          str.emplace_back("E_" + EXCEL[i].name);
+  for (const auto & i : EXCEL)
+    for (const auto & j : i.sheet)
+      for (const auto &k : j.column)
+        if (k.index == index) {
+          str.push_back(k.name);
+          str.emplace_back("E_" + i.name);
           return str;
         }
-  for (unsigned int i = 0; i < FUNCTION.size(); i++)
-    if (FUNCTION[i].index == index) {
-      str.push_back(FUNCTION[i].name);
-      str.emplace_back("F_" + FUNCTION[i].name);
+  for (const auto &i : FUNCTION)
+    if (i.index == index) {
+      str.push_back(i.name);
+      str.emplace_back("F_" + i.name);
       return str;
     }
   return str;
@@ -212,8 +212,8 @@ void OPJFile::convertSpreadToExcel(int spread) {
                         SPREADSHEET[spread].maxRows,
                         SPREADSHEET[spread].bHidden,
                         SPREADSHEET[spread].bLoose));
-  for (unsigned int i = 0; i < SPREADSHEET[spread].column.size(); ++i) {
-    string name = SPREADSHEET[spread].column[i].name;
+  for (auto & i : SPREADSHEET[spread].column) {
+    string name = i.name;
     int pos = static_cast<int>(name.find_last_of("@"));
     string col = name;
     unsigned int index = 0;
@@ -224,8 +224,8 @@ void OPJFile::convertSpreadToExcel(int spread) {
 
     if (EXCEL.back().sheet.size() <= index)
       EXCEL.back().sheet.resize(index + 1);
-    SPREADSHEET[spread].column[i].name = col;
-    EXCEL.back().sheet[index].column.push_back(SPREADSHEET[spread].column[i]);
+    i.name = col;
+    EXCEL.back().sheet[index].column.push_back(i);
   }
   SPREADSHEET.erase(SPREADSHEET.begin() + spread);
 }


### PR DESCRIPTION
**Description of work.**
This PR runs modernize-loop-convert in "risky" mode. This means that it automatically changes loops deemed complex to range-based for loops, and therefore require a bit more human intervention.

**To test:**
Code review - I'm not sure what to call the variables in `OPJFile.cpp`. Suggestions highly welcome

Fixes partially #22183 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
