### PR TITLE
Indirect Reduction - Fix error when loading Reduction from invalid facility

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -39,3 +39,4 @@ Data Reduction Interface
 Bug Fixes
 #########
 - Fixed a bug in the :ref:`Integration <algm-Integration>` algorithm causing the Moments tab to crash.
+- Fixed an unexpected error when opening the Data Reduction interface with an unrelated facility selected.

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -217,12 +217,8 @@ QString ISISCalibration::backgroundRangeString() const {
 }
 
 QString ISISCalibration::instrumentDetectorRangeString() {
-  try {
-    return getInstrumentDetail("spectra-min") + "," +
-           getInstrumentDetail("spectra-max");
-  } catch (std::exception const &ex) {
-    showMessageBox(ex.what());
-  }
+  return getInstrumentDetail("spectra-min") + "," +
+         getInstrumentDetail("spectra-max");
 }
 
 QString ISISCalibration::outputWorkspaceName() const {
@@ -302,7 +298,13 @@ void ISISCalibration::run() {
   const auto outputWorkspaceNameStem = outputWorkspaceName().toLower();
 
   m_outputCalibrationName = outputWorkspaceNameStem + "_calib";
-  m_batchAlgoRunner->addAlgorithm(calibrationAlgorithm(filenames));
+
+  try {
+    m_batchAlgoRunner->addAlgorithm(calibrationAlgorithm(filenames));
+  } catch (std::exception const &ex) {
+    g_log.warning(ex.what());
+    return;
+  }
 
   // Initially take the calibration workspace as the result
   m_pythonExportWsName = m_outputCalibrationName.toStdString();

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -371,6 +371,7 @@ void ISISCalibration::setDefaultInstDetails() {
   try {
     setDefaultInstDetails(getInstrumentDetails());
   } catch (std::exception const &ex) {
+    g_log.warning(ex.what());
     showMessageBox(ex.what());
   }
 }

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -216,7 +216,7 @@ QString ISISCalibration::backgroundRangeString() const {
          m_properties["CalBackMax"]->valueText();
 }
 
-QString ISISCalibration::instrumentDetectorRangeString() const {
+QString ISISCalibration::instrumentDetectorRangeString() {
   return getInstrumentDetail("spectra-min") + "," +
          getInstrumentDetail("spectra-max");
 }
@@ -708,7 +708,7 @@ void ISISCalibration::addRuntimeSmoothing(const QString &workspaceName) {
 }
 
 IAlgorithm_sptr
-ISISCalibration::calibrationAlgorithm(const QString &inputFiles) const {
+ISISCalibration::calibrationAlgorithm(const QString &inputFiles) {
   auto calibrationAlg =
       AlgorithmManager::Instance().create("IndirectCalibration");
   calibrationAlg->initialize();

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -37,7 +37,7 @@ public:
 
   QString peakRangeString() const;
   QString backgroundRangeString() const;
-  QString instrumentDetectorRangeString() const;
+  QString instrumentDetectorRangeString();
   QString outputWorkspaceName() const;
   QString resolutionDetectorRangeString() const;
   QString rebinString() const;
@@ -89,8 +89,7 @@ private:
                       const double &minimum, const double &maximum,
                       const QString &minPropertyName,
                       const QString &maxPropertyName);
-  Mantid::API::IAlgorithm_sptr
-  calibrationAlgorithm(const QString &inputFiles) const;
+  Mantid::API::IAlgorithm_sptr calibrationAlgorithm(const QString &inputFiles);
   Mantid::API::IAlgorithm_sptr
   resolutionAlgorithm(const QString &inputFiles) const;
   Mantid::API::IAlgorithm_sptr

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -271,28 +271,28 @@ void ISISDiagnostics::setDefaultInstDetails() {
   try {
     setDefaultInstDetails(getInstrumentDetails());
   } catch (std::exception const &ex) {
-    g_log.warning(ex.what());
+    showMessageBox(ex.what());
   }
 }
 
 void ISISDiagnostics::setDefaultInstDetails(
     QMap<QString, QString> const &instrumentDetails) {
-  // Set the search instrument for runs
-  m_uiForm.dsInputFiles->setInstrumentOverride(
-      getInstrumentDetail(instrumentDetails, "instrument"));
-
-  auto const specMin =
+  auto const instrument = getInstrumentDetail(instrumentDetails, "instrument");
+  auto const spectraMin =
       getInstrumentDetail(instrumentDetails, "spectra-min").toDouble();
-  auto const specMax =
+  auto const spectraMax =
       getInstrumentDetail(instrumentDetails, "spectra-max").toDouble();
 
-  // Set spectra range
-  m_dblManager->setMaximum(m_properties["SpecMin"], specMax);
-  m_dblManager->setMinimum(m_properties["SpecMax"], specMin);
+  // Set the search instrument for runs
+  m_uiForm.dsInputFiles->setInstrumentOverride(instrument);
 
-  m_dblManager->setValue(m_properties["SpecMin"], specMin);
-  m_dblManager->setValue(m_properties["SpecMax"], specMax);
-  m_dblManager->setValue(m_properties["PreviewSpec"], specMin);
+  // Set spectra range
+  m_dblManager->setMaximum(m_properties["SpecMin"], spectraMax);
+  m_dblManager->setMinimum(m_properties["SpecMax"], spectraMin);
+
+  m_dblManager->setValue(m_properties["SpecMin"], spectraMin);
+  m_dblManager->setValue(m_properties["SpecMax"], spectraMax);
+  m_dblManager->setValue(m_properties["PreviewSpec"], spectraMin);
 
   // Set peak and background ranges
   if (instrumentDetails.size() >= 8) {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -66,6 +66,9 @@ private slots:
 
 private:
   void setInstrumentDefault(QMap<QString, QString> const &instDetails);
+  void setInstrumentCheckBoxProperty(QCheckBox *checkbox,
+                                     QMap<QString, QString> const &instDetails,
+                                     QString const &instrumentProperty);
 
   Ui::ISISEnergyTransfer m_uiForm;
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -65,6 +65,8 @@ private slots:
                        QString const tooltip = "");
 
 private:
+  void setInstrumentDefault(QMap<QString, QString> const &instDetails);
+
   Ui::ISISEnergyTransfer m_uiForm;
 
   std::pair<std::string, std::string> createMapFile(

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -102,33 +102,37 @@ QMap<QString, QString> IndirectDataReductionTab::getInstrumentDetails() const {
   return m_idrUI->getInstrumentDetails();
 }
 
-QString IndirectDataReductionTab::getInstrumentDetail(
-    QString const &key, bool const &validateDetail) const {
-  return getInstrumentDetail(getInstrumentDetails(), key, validateDetail);
+QString
+IndirectDataReductionTab::getInstrumentDetail(QString const &key) const {
+  return getInstrumentDetail(getInstrumentDetails(), key);
 }
 
 QString IndirectDataReductionTab::getInstrumentDetail(
-    QMap<QString, QString> const &instrumentDetails, QString const &key,
-    bool const &validateDetail) const {
-  auto const instrumentDetail = instrumentDetails[key];
-  if (validateDetail)
-    validateInstrumentDetail(key, instrumentDetail);
-  return instrumentDetail;
+    QMap<QString, QString> const &instrumentDetails, QString const &key) const {
+  validateInstrumentDetail(key);
+  return instrumentDetails[key];
 }
 
 void IndirectDataReductionTab::validateInstrumentDetail(
-    QString const &key, QString const &value) const {
+    QString const &key) const {
   auto const instrumentName = getInstrumentName().toStdString();
 
   if (instrumentName.empty())
-    throw std::invalid_argument(
-        "No instrument had been found. Please check that a valid "
-        "facility and instrument has been set.");
-  else if (value.isEmpty())
-    throw std::invalid_argument(
-        "No " + key.toStdString() + " found for the " + instrumentName +
-        " instrument. Please check that a valid facility and "
-        "instrument has been set.");
+    throw std::runtime_error(
+        "Please select a valid facility and/or instrument.");
+  else if (!hasInstrumentDetail(key))
+    throw std::runtime_error("Could not find " + key.toStdString() +
+                             " for the " + instrumentName +
+                             " instrument. Please select a valid instrument.");
+}
+
+bool IndirectDataReductionTab::hasInstrumentDetail(QString const &key) const {
+  return hasInstrumentDetail(getInstrumentDetails(), key);
+}
+
+bool IndirectDataReductionTab::hasInstrumentDetail(
+    QMap<QString, QString> const &instrumentDetails, QString const &key) const {
+  return instrumentDetails.contains(key) && !instrumentDetails[key].isEmpty();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -102,18 +102,33 @@ QMap<QString, QString> IndirectDataReductionTab::getInstrumentDetails() const {
   return m_idrUI->getInstrumentDetails();
 }
 
-QString
-IndirectDataReductionTab::getInstrumentDetail(QString const &key) const {
-  return getInstrumentDetail(getInstrumentDetails(), key);
+QString IndirectDataReductionTab::getInstrumentDetail(
+    QString const &key, bool const &validateDetail) const {
+  return getInstrumentDetail(getInstrumentDetails(), key, validateDetail);
 }
 
 QString IndirectDataReductionTab::getInstrumentDetail(
-    QMap<QString, QString> const &instrumentDetails, QString const &key) const {
-  auto const value = instrumentDetails[key];
-  if (!value.isEmpty())
-    return value;
-  throw std::runtime_error("No " + key.toStdString() + " found for the " +
-                           getInstrumentName().toStdString() + " instrument.");
+    QMap<QString, QString> const &instrumentDetails, QString const &key,
+    bool const &validateDetail) const {
+  auto const instrumentDetail = instrumentDetails[key];
+  if (validateDetail)
+    validateInstrumentDetail(key, instrumentDetail);
+  return instrumentDetail;
+}
+
+void IndirectDataReductionTab::validateInstrumentDetail(
+    QString const &key, QString const &value) const {
+  auto const instrumentName = getInstrumentName().toStdString();
+
+  if (instrumentName.empty())
+    throw std::invalid_argument(
+        "No instrument had been found. Please check that a valid "
+        "facility and instrument has been set.");
+  else if (value.isEmpty())
+    throw std::invalid_argument(
+        "No " + key.toStdString() + " found for the " + instrumentName +
+        " instrument. Please check that a valid facility and "
+        "instrument has been set.");
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -82,12 +82,13 @@ protected:
                            std::string reflection = "");
 
   QMap<QString, QString> getInstrumentDetails() const;
-  QString getInstrumentDetail(QString const &key,
-                              bool const &validateDetail = true) const;
+  QString getInstrumentDetail(QString const &key) const;
   QString getInstrumentDetail(QMap<QString, QString> const &instrumentDetails,
-                              QString const &key,
-                              bool const &validateDetail = true) const;
-  void validateInstrumentDetail(QString const &key, QString const &value) const;
+                              QString const &key) const;
+  void validateInstrumentDetail(QString const &key) const;
+  bool hasInstrumentDetail(QString const &key) const;
+  bool hasInstrumentDetail(QMap<QString, QString> const &instrumentDetails,
+                           QString const &key) const;
   MantidWidgets::IndirectInstrumentConfig *getInstrumentConfiguration() const;
   QString getInstrumentName() const;
   QString getAnalyserName() const;

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -82,9 +82,12 @@ protected:
                            std::string reflection = "");
 
   QMap<QString, QString> getInstrumentDetails() const;
-  QString getInstrumentDetail(QString const &key) const;
+  QString getInstrumentDetail(QString const &key,
+                              bool const &validateDetail = true) const;
   QString getInstrumentDetail(QMap<QString, QString> const &instrumentDetails,
-                              QString const &key) const;
+                              QString const &key,
+                              bool const &validateDetail = true) const;
+  void validateInstrumentDetail(QString const &key, QString const &value) const;
   MantidWidgets::IndirectInstrumentConfig *getInstrumentConfiguration() const;
   QString getInstrumentName() const;
   QString getAnalyserName() const;

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -23,7 +23,7 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
   m_uiForm.setupUi(parent);
 
   connect(this, SIGNAL(newInstrumentConfiguration()), this,
-          SLOT(instrumentSet()));
+          SLOT(setInstrument()));
 
   // Update the preview plot when the algorithm is complete
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
@@ -106,12 +106,17 @@ void IndirectTransmission::transAlgDone(bool error) {
   m_uiForm.pbSave->setEnabled(true);
 }
 
-void IndirectTransmission::instrumentSet() {
-  auto const instrument = getInstrumentDetail("instrument");
-  if (!instrument.isEmpty()) {
-    m_uiForm.dsSampleInput->setInstrumentOverride(instrument);
-    m_uiForm.dsCanInput->setInstrumentOverride(instrument);
+void IndirectTransmission::setInstrument() {
+  try {
+    setInstrument(getInstrumentDetail("instrument"));
+  } catch (std::exception const &ex) {
+    showMessageBox(ex.what());
   }
+}
+
+void IndirectTransmission::setInstrument(QString const &instrumentName) {
+  m_uiForm.dsSampleInput->setInstrumentOverride(instrumentName);
+  m_uiForm.dsCanInput->setInstrumentOverride(instrumentName);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -108,10 +108,10 @@ void IndirectTransmission::transAlgDone(bool error) {
 
 void IndirectTransmission::instrumentSet() {
   auto const instrument = getInstrumentDetail("instrument");
-
-  // Set the search instrument for runs
-  m_uiForm.dsSampleInput->setInstrumentOverride(instrument);
-  m_uiForm.dsCanInput->setInstrumentOverride(instrument);
+  if (!instrument.isEmpty()) {
+    m_uiForm.dsSampleInput->setInstrumentOverride(instrument);
+    m_uiForm.dsCanInput->setInstrumentOverride(instrument);
+  }
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.h
@@ -36,7 +36,7 @@ public:
 
 private slots:
   void transAlgDone(bool error);
-  void instrumentSet();
+  void setInstrument();
 
   void runClicked();
   void plotClicked();
@@ -53,6 +53,8 @@ private slots:
   void setPlotIsPlotting(bool plotting);
 
 private:
+  void setInstrument(QString const &instrumentName);
+
   Ui::IndirectTransmission m_uiForm;
 };
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug causing an error when trying to load the Reduction interface when a non-compatible facility is selected.

**To test:**
1. Set  `HFIR` as default facility
2. Open `Interfaces`->`Indirect`->`Data Reduction`
There should be no error, but a message box telling you to change the facility/instrument.
3. Select the `ISIS` facility and the `TOSCA` instrument
4. Go to `S(Q,w)` tab
5. Load the data below
6. Q-Low, Q_width, Q-High should be 0.5, 0.05 and 1.8
6. E-Low, E_width, E-High should be -0.5, 0.005 and 0.5
7. Click `Run` and a message should appear telling you to choose a valid instrument which has an EFixed.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3002359/irs26176_graphite002_red.zip)

Fixes #25290

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
