### PR TITLE
Fix workbench startup script on macOS under Gatekeeper

### DIFF
--- a/Framework/Kernel/src/NetworkProxyOSX.cpp
+++ b/Framework/Kernel/src/NetworkProxyOSX.cpp
@@ -221,7 +221,9 @@ ProxyInfo findHttpProxy(const std::string &targetURLString,
   ProxyInfo httpProxy;
   CFDictionaryRef dict = SCDynamicStoreCopyProxies(nullptr);
   if (!dict) {
-    logger.debug("NetworkProxyOSX SCDynamicStoreCopyProxies returned NULL");
+    logger.debug("NetworkProxyOSX SCDynamicStoreCopyProxies returned NULL. No "
+                 "proxy information retrieved");
+    return httpProxy;
   }
 
   // Query the proxy pac first.

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -845,6 +845,7 @@ set_target_properties ( MantidPlot PROPERTIES FOLDER "Qt4" )
 # Custom Info.plist file for OS X
 ###########################################################################
 if( APPLE )
+  set ( MAC_BUNDLE_EXECUTABLE Mantid_osx_launcher )
   # Setting the CFBundleIdentifer attribute on OS X 10.6 (SL) and before
   # causes problems with trying to install the package on the same
   # machine as it was built. It tries to relocate the package to the build directory
@@ -860,7 +861,8 @@ if( APPLE )
   else()
     set ( MAC_BUNDLE_IDENTIFIER "" )
   endif()
-
+  set ( MAC_BUNDLE_ICON MantidPlot.icns )
+  set ( MAC_BUNDLE_NAME MantidPlot )
   configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/../installers/MacInstaller/Info.plist.in
                    ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
                    @ONLY )

--- a/buildconfig/CMake/Packaging/osx/MantidWorkbench_osx_launcher
+++ b/buildconfig/CMake/Packaging/osx/MantidWorkbench_osx_launcher
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
-
 INSTALLDIR=$(cd "$(dirname "$0")"; pwd)
 PLUGIN_DIR=$INSTALLDIR/../PlugIns
-cd $INSTALLDIR
-QT_PLUGIN_PATH=$PLUGIN_DIR ./workbench-script $* || /usr/bin/python ../../scripts/ErrorReporter/error_dialog_app.py --exitcode=$? --directory=$INSTALLDIR --qtdir=$PLUGIN_DIR --application=workbench
+
+# On first launch of quarantined apps launchd passes a command line parameter of the form -psn_0_XXXXXX
+# to the application. We discard this otherwise workbench's argparse will choke on it.
+# https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder
+if [[ "${1}" == -psn_* ]]; then
+  shift 1
+fi
+env PYTHONPATH=${INSTALLDIR}:${PYTHONPATH} env QT_PLUGIN_PATH=$PLUGIN_DIR ${INSTALLDIR}/workbench-script $* || /usr/bin/python $INSTALLDIR/../../scripts/ErrorReporter/error_dialog_app.py --exitcode=$? --directory=$INSTALLDIR --qtdir=$PLUGIN_DIR --application=workbench

--- a/installers/MacInstaller/Info.plist.in
+++ b/installers/MacInstaller/Info.plist.in
@@ -5,11 +5,11 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>Mantid_osx_launcher</string>
+	<string>@MAC_BUNDLE_EXECUTABLE@</string>
 	<key>CFBundleGetInfoString</key>
 	<string>@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@</string>
 	<key>CFBundleIconFile</key>
-	<string>MantidPlot.icns</string>
+	<string>@MAC_BUNDLE_ICON@</string>
 	<key>CFBundleIdentifier</key>
 	<string>@MAC_BUNDLE_IDENTIFIER@</string>
 	<key>CFBundleInfoDictionaryVersion</key>
@@ -17,7 +17,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>@VERSION_MAJOR@.@VERSION_MINOR@.@VERSION_PATCH@</string>
 	<key>CFBundleName</key>
-	<string>MantidPlot</string>
+	<string>@MAC_BUNDLE_NAME@</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -58,19 +58,31 @@ else()
 endif()
 
 # Install MantidWorkbench for OSX
-if ( APPLE )
+if( APPLE )
+  set ( MAC_BUNDLE_EXECUTABLE MantidWorkbench )
+  if (OSX_VERSION VERSION_GREATER 10.7 OR OSX_VERSION VERSION_EQUAL 10.7)
+    set ( MAC_BUNDLE_IDENTIFIER "org.mantidproject.MantidWorkbench" )
+  else()
+    set ( MAC_BUNDLE_IDENTIFIER "" )
+  endif()
+  set ( MAC_BUNDLE_ICON MantidWorkbench.icns )
+  set ( MAC_BUNDLE_NAME MantidWorkbench )
+  configure_file ( ${CMAKE_CURRENT_SOURCE_DIR}/../../../installers/MacInstaller/Info.plist.in
+                   ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+                   @ONLY )
 
-    configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/make_package.rb.in
-        ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb
-        @ONLY )
-    install ( FILES  ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb DESTINATION MantidWorkbench.app/ )
-    install ( CODE "
-        set ( bundle \${CMAKE_INSTALL_PREFIX}/MantidWorkbench.app )
-        execute_process(COMMAND chmod +x ./make_package.rb WORKING_DIRECTORY \${bundle})
-        execute_process(COMMAND ./make_package.rb WORKING_DIRECTORY \${bundle} RESULT_VARIABLE install_name_tool_result)
-        if(NOT install_name_tool_result EQUAL 0)
-          message(FATAL_ERROR \"Package script failed!!!\n\")
-        endif()
-    ")
+  configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/make_package.rb.in
+      ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb
+      @ONLY )
+  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb DESTINATION MantidWorkbench.app/ )
+  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist DESTINATION MantidWorkbench.app/Contents/ )
+  install ( CODE "
+      set ( bundle \${CMAKE_INSTALL_PREFIX}/MantidWorkbench.app )
+      execute_process(COMMAND chmod +x ./make_package.rb WORKING_DIRECTORY \${bundle})
+      execute_process(COMMAND ./make_package.rb WORKING_DIRECTORY \${bundle} RESULT_VARIABLE install_name_tool_result)
+      if(NOT install_name_tool_result EQUAL 0)
+        message(FATAL_ERROR \"Package script failed!!!\n\")
+      endif()
+  ")
 
 endif()


### PR DESCRIPTION
**Description of work.**

Fixes 2 issues with `MantidWorkbench.app` on macOS:
* fixes Info.plist to be populated with the correct information similar to `MantidPlot.app`
* fixes startup script to ignore arguments of the form `-psn_X_XXXXXX` that are passed by launchd on first launch of a quarantined app: https://stackoverflow.com/questions/10242115/os-x-strange-psn-command-line-parameter-when-launched-from-finder

**To test:**

Download the [built package](
http://builds.mantidproject.org/job/pull_requests-osx/28389/artifact/build/mantid-4.0.0-Yosemite.dmg) from Jenkins and check Workbench and MantidPlot start first time after package extraction.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **workbench is not yet released.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.