### PR TITLE
Fix cppcheck 1.87 warnings in PythonInterface

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/DeprecatedAlgorithmChecker.cpp
@@ -34,9 +34,8 @@ public:
    * @param algName The name of the algorithm
    * @param version The algorithm version
    */
-  DeprecatedAlgorithmChecker(const std::string &algName, int version) {
-    m_alg = AlgorithmManager::Instance().createUnmanaged(algName, version);
-  }
+  DeprecatedAlgorithmChecker(const std::string &algName, int version)
+      : m_alg(AlgorithmManager::Instance().createUnmanaged(algName, version)) {}
 
   /// Check if the algorithm is deprecated
   /// @returns A string containing a deprecation message if the algorithm is

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -285,8 +285,8 @@ PyObject *row(ITableWorkspace &self, int row) {
 
   PyObject *result = PyDict_New();
 
-  for (int colIndex = 0; colIndex < numCols; colIndex++) {
-    Mantid::API::Column_const_sptr col = self.getColumn(colIndex);
+  for (int columnIndex = 0; columnIndex < numCols; columnIndex++) {
+    Mantid::API::Column_const_sptr col = self.getColumn(columnIndex);
     const std::type_info &typeID = col->get_type_info();
 
     if (PyDict_SetItemString(result, col->name().c_str(),

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -106,8 +106,7 @@ PyObject *getValue(Mantid::API::Column_const_sptr column,
   }
 
   // -- Use the boost preprocessor to generate a list of else if clause to cut
-  // out copy
-  // and pasted code.
+  // out copy and pasted code.
   // cppcheck-suppress unreadVariable
   PyObject *result(nullptr);
   if (false) {
@@ -184,12 +183,12 @@ void setValue(const Column_sptr column, const int row, const object &value) {
  */
 bool addColumnPlotType(ITableWorkspace &self, const std::string &type,
                        const std::string &name, int plottype) {
-  auto column = self.addColumn(type, name);
+  auto newColumn = self.addColumn(type, name);
 
-  if (column)
-    column->setPlotType(plottype);
+  if (newColumn)
+    newColumn->setPlotType(plottype);
 
-  return column != nullptr;
+  return newColumn != nullptr;
 }
 
 /**
@@ -286,12 +285,12 @@ PyObject *row(ITableWorkspace &self, int row) {
 
   PyObject *result = PyDict_New();
 
-  for (int col = 0; col < numCols; col++) {
-    Mantid::API::Column_const_sptr column = self.getColumn(col);
-    const std::type_info &typeID = column->get_type_info();
+  for (int colIndex = 0; colIndex < numCols; colIndex++) {
+    Mantid::API::Column_const_sptr col = self.getColumn(colIndex);
+    const std::type_info &typeID = col->get_type_info();
 
-    if (PyDict_SetItemString(result, column->name().c_str(),
-                             getValue(column, typeID, row)))
+    if (PyDict_SetItemString(result, col->name().c_str(),
+                             getValue(col, typeID, row)))
       throw std::runtime_error("Error while building dict");
   }
 
@@ -308,9 +307,9 @@ boost::python::list columnTypes(ITableWorkspace &self) {
 
   boost::python::list types;
 
-  for (int col = 0; col < numCols; col++) {
-    const auto column = self.getColumn(col);
-    const auto &type = column->type();
+  for (int colIndex = 0; colIndex < numCols; colIndex++) {
+    const auto col = self.getColumn(colIndex);
+    const auto &type = col->type();
     types.append(type);
   }
 
@@ -340,23 +339,23 @@ void addRowFromDict(ITableWorkspace &self, const dict &rowItems) {
   self.appendRow();
 
   // Declared in this scope so we can access them in catch block
-  Column_sptr column; // Column in table
-  object value;       // Value from dictionary
+  Column_sptr col; // Column in table
+  object value;    // Value from dictionary
 
   try {
     // Retrieve and set the value for each column
     auto columns = self.getColumnNames();
     for (auto &iter : columns) {
-      column = self.getColumn(iter);
+      col = self.getColumn(iter);
       value = rowItems[iter];
-      setValue(column, rowIndex, value);
+      setValue(col, rowIndex, value);
     }
   } catch (error_already_set &) {
     // One of the columns wasn't found in the dictionary
     if (PyErr_ExceptionMatches(PyExc_KeyError)) {
       std::ostringstream msg;
       msg << "Missing key-value entry for column ";
-      msg << "<" << column->name() << ">";
+      msg << "<" << col->name() << ">";
       PyErr_SetString(PyExc_KeyError, msg.str().c_str());
     }
 
@@ -366,8 +365,8 @@ void addRowFromDict(ITableWorkspace &self, const dict &rowItems) {
       msg << "Wrong datatype <";
       msg << std::string(
           extract<std::string>(value.attr("__class__").attr("__name__")));
-      msg << "> for column <" << column->name() << "> ";
-      msg << "(expected <" << column->type() << ">)";
+      msg << "> for column <" << col->name() << "> ";
+      msg << "(expected <" << col->type() << ">)";
       PyErr_SetString(PyExc_TypeError, msg.str().c_str());
     }
 
@@ -401,11 +400,11 @@ void addRowFromSequence(ITableWorkspace &self, const object &rowItems) {
 
   // Loop over sequence and set each column value in same order
   for (decltype(nitems) i = 0; i < nitems; ++i) {
-    auto column = self.getColumn(i);
+    auto col = self.getColumn(i);
     auto value = rowItems[i];
 
     try {
-      setValue(column, rowIndex, value);
+      setValue(col, rowIndex, value);
     } catch (error_already_set &) {
       // Wrong type of data for one of the columns
       if (PyErr_ExceptionMatches(PyExc_TypeError)) {
@@ -413,8 +412,8 @@ void addRowFromSequence(ITableWorkspace &self, const object &rowItems) {
         msg << "Wrong datatype <";
         msg << std::string(
             extract<std::string>(value.attr("__class__").attr("__name__")));
-        msg << "> for column <" << column->name() << "> ";
-        msg << "(expected <" << column->type() << ">)";
+        msg << "> for column <" << col->name() << "> ";
+        msg << "(expected <" << col->type() << ">)";
         PyErr_SetString(PyExc_TypeError, msg.str().c_str());
       }
 
@@ -455,11 +454,11 @@ void getCellLoc(ITableWorkspace &self, const object &col_or_row,
  */
 PyObject *cell(ITableWorkspace &self, const object &value, int row_or_col) {
   // Find the column and row
-  Mantid::API::Column_sptr column;
-  int row(-1);
-  getCellLoc(self, value, row_or_col, column, row);
-  const std::type_info &typeID = column->get_type_info();
-  return getValue(column, typeID, row);
+  Mantid::API::Column_sptr col;
+  int rowIndex;
+  getCellLoc(self, value, row_or_col, col, rowIndex);
+  const std::type_info &typeID = col->get_type_info();
+  return getValue(col, typeID, rowIndex);
 }
 
 /**
@@ -473,10 +472,10 @@ PyObject *cell(ITableWorkspace &self, const object &value, int row_or_col) {
 void setCell(ITableWorkspace &self, const object &col_or_row,
              const int row_or_col, const object &value,
              const bool &notify_replace) {
-  Mantid::API::Column_sptr column;
-  int row(-1);
-  getCellLoc(self, col_or_row, row_or_col, column, row);
-  setValue(column, row, value);
+  Mantid::API::Column_sptr col;
+  int rowIndex;
+  getCellLoc(self, col_or_row, row_or_col, col, rowIndex);
+  setValue(col, rowIndex, value);
 
   if (notify_replace) {
     self.modified();

--- a/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Projection.cpp
@@ -47,7 +47,7 @@ object createWorkspace() {
   object main = import("__main__");
   object global(main.attr("__dict__"));
   // Add a function to the namespace
-  object result = exec(
+  exec(
       "def createWorkspace(proj, OutputWorkspace=None):\n"
       "  '''Create a TableWorkspace using this projection'''\n"
       "  import inspect\n"

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -197,13 +197,14 @@ AlgorithmAdapter<BaseAlgorithm>::validateInputs() {
     boost::python::list keys = resultDict.keys();
     size_t numItems = boost::python::len(keys);
     for (size_t i = 0; i < numItems; ++i) {
-      boost::python::object value = resultDict[keys[i]];
+      boost::python::object key = keys[i];
+      boost::python::object value = resultDict[key];
       if (value) {
         try {
-          std::string key = boost::python::extract<std::string>(keys[i]);
-          std::string value =
-              boost::python::extract<std::string>(resultDict[keys[i]]);
-          resultMap[key] = value;
+          std::string keyAsString = boost::python::extract<std::string>(key);
+          std::string valueAsString =
+              boost::python::extract<std::string>(value);
+          resultMap[std::move(keyAsString)] = std::move(valueAsString);
         } catch (boost::python::error_already_set &) {
           this->getLogger().error()
               << "In validateInputs(self): Invalid type for key/value pair "

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -28,8 +28,9 @@ std::vector<std::string> getSymmetryOperationStrings(Group &self) {
   const std::vector<SymmetryOperation> &symOps = self.getSymmetryOperations();
 
   std::vector<std::string> pythonSymOps;
+  pythonSymOps.reserve(symOps.size());
   for (const auto &symOp : symOps) {
-    pythonSymOps.push_back(symOp.identifier());
+    pythonSymOps.emplace_back(symOp.identifier());
   }
 
   return pythonSymOps;

--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -64,15 +64,10 @@ template <typename DestElementType> struct CopyToImpl {
                   PyArrayObject *arr) {
     // Use the iterator API to iterate through the array
     // and assign each value to the corresponding vector
-    typedef union {
-      DestElementType *output;
-      void *input;
-    } npy_union;
-    npy_union data;
     object iter(handle<>(Converters::Impl::func_PyArray_IterNew(arr)));
     do {
-      data.input = PyArray_ITER_DATA(iter.ptr());
-      *first++ = *data.output;
+      void *data = PyArray_ITER_DATA(iter.ptr());
+      *first++ = *static_cast<DestElementType *>(data);
       PyArray_ITER_NEXT(iter.ptr());
     } while (PyArray_ITER_NOTDONE(iter.ptr()));
   }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -14,6 +14,7 @@
 #include <boost/python/make_function.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/tuple.hpp>
+#include <numeric>
 
 using Mantid::Kernel::Material;
 using Mantid::PhysicalConstants::NeutronAtom;
@@ -57,11 +58,12 @@ bool toBool(Material &self) {
  * @return the relative molecular mass
  */
 double relativeMolecularMass(Material &self) {
-  double retval = 0.;
-  for (const auto &formulaUnit : self.chemicalFormula()) {
-    retval += formulaUnit.atom->mass * formulaUnit.multiplicity;
-  }
-  return retval;
+  const auto &formula = self.chemicalFormula();
+  return std::accumulate(formula.cbegin(), formula.cend(), 0.,
+                         [](double sum, const auto &formulaUnit) {
+                           return sum + formulaUnit.atom->mass *
+                                            formulaUnit.multiplicity;
+                         });
 }
 } // namespace
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Statistics.cpp
@@ -299,8 +299,6 @@ void export_Statistics() {
                    [ReturnNumpyArray()])
           .staticmethod("getMomentsAboutMean");
 
-  //------------------------------ Statistics
-  // values--------------------------------
   // Want this in the same scope as above so must be here
   class_<Statistics>("Statistics")
       .add_property("minimum", &Statistics::minimum,


### PR DESCRIPTION
Fix some `cppcheck` 1.87 warnings in the PythonInterface module. Some `unmatchedExpression` and `unreadVariable` warnings in the Python bindings will need to be dealt with later when `cppcheck` gets updated on the build servers.

**To test:**

Code review. Check that no `scope` declarations were accidentally removed from the Python bindings.

Progress towards #22912. 

*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
