### PR TITLE
Increase font size in SANS table

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -10,3 +10,11 @@ SANS Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 4.1.0 <v4.1.0>`
+
+ISIS SANS Interface
+-------------------
+
+Improvements
+############
+
+- Increased font size in run table.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -417,6 +417,11 @@ class SANSDataProcessorGui(QMainWindow,
              "Options"]
             , self.cell(""), self)
 
+        # Default QTreeView size is too small
+        font = self.data_processor_table.font()
+        font.setPointSize(13)
+        self.data_processor_table.setFont(font)
+
         self.data_processor_table.setRootIsDecorated(False)
 
         row_entry = [''] * 16


### PR DESCRIPTION
**Description of work.**
Recently the ISIS SANS gui has switched to using the JobTreeView widget for a runs table, which has a different default font size to the previous table. The SANS scientists have requested that we increase the font size to make text in the table more readable

**Report to:** Rob

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. In the main tab, type some text in the table. Is it large enough to be readable without being too large?

Fixes #24930 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
