### PR TITLE
Indirect ConvFit - Loading sample error

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -21,10 +21,17 @@ Improvements
 - :ref:`BASISCrystalDiffraction <algm-BASISCrystalDiffraction>` resolves between run with old and new DAS.
 
 
-Data Reduction
---------------
+Data Analysis Interface
+-----------------------
 
 Bug Fixes
 #########
+- Fixed an error caused by loading a Sample into ConvFit which does not have a resolution parameter for the analyser.
 
+
+Data Reduction Interface
+------------------------
+
+Bug Fixes
+#########
 - Fixed a bug in the :ref:`Integration <algm-Integration>` algorithm causing the Moments tab to crash.

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -167,19 +167,22 @@ getAnalyser(MatrixWorkspace_sptr workspace) {
   } else {
     readAnalyserFromFile(analysers[0], workspace);
   }
-  return workspace->getInstrument()->getComponentByName(analysers[0]);
+  return instrument->getComponentByName(analysers[0]);
 }
 
 boost::optional<double> instrumentResolution(MatrixWorkspace_sptr workspace) {
   try {
-    auto analyser = getAnalyser(workspace);
-    if (analyser != nullptr)
+    auto const analyser = getAnalyser(workspace);
+    if (analyser && analyser->hasParameter("resolution"))
       return analyser->getNumberParameter("resolution")[0];
-    else
-      return workspace->getInstrument()->getNumberParameter("resolution")[0];
-  } catch (const Mantid::Kernel::Exception::NotFoundError &) {
+
+    auto const instrument = workspace->getInstrument();
+    if (instrument && instrument->hasParameter("resolution"))
+      return instrument->getNumberParameter("resolution")[0];
     return boost::none;
-  } catch (const std::invalid_argument &) {
+  } catch (Mantid::Kernel::Exception::NotFoundError const &) {
+    return boost::none;
+  } catch (std::invalid_argument const &) {
     return boost::none;
   }
 }

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -179,6 +179,9 @@ boost::optional<double> instrumentResolution(MatrixWorkspace_sptr workspace) {
     auto const instrument = workspace->getInstrument();
     if (instrument && instrument->hasParameter("resolution"))
       return instrument->getNumberParameter("resolution")[0];
+    else if (instrument && instrument->hasParameter("EFixed"))
+      return instrument->getNumberParameter("EFixed")[0] * 0.01;
+
     return boost::none;
   } catch (Mantid::Kernel::Exception::NotFoundError const &) {
     return boost::none;


### PR DESCRIPTION
**Description of work.**
This PR fixes an error which is caused by loading a sample workspace into convFit when the workspace does not have a "resolution" parameter stored for its analyser.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab
2. Load the data below as sample
No error should occur!

**Data Files**
[irs26174_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3002255/irs26174_graphite002_red.zip)

Fixes #25351

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
