### PR TITLE
Formatting CMake files: qt from applications to python

### DIFF
--- a/qt/applications/CMakeLists.txt
+++ b/qt/applications/CMakeLists.txt
@@ -1,3 +1,3 @@
-if ( ENABLE_WORKBENCH )
-  add_subdirectory ( workbench )
-endif ()
+if(ENABLE_WORKBENCH)
+  add_subdirectory(workbench)
+endif()

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -1,60 +1,54 @@
 # Create egg link to binary output directory
-add_python_package ( workbench EXECUTABLE )
+add_python_package(workbench EXECUTABLE)
 
-# Configure resources data in place for ease of development. The output
-# file is added to the toplevel gitignore
-set ( _qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc )
-set ( _output_res_py ${CMAKE_CURRENT_LIST_DIR}/workbench/app/resources.py )
-add_custom_command ( OUTPUT ${_output_res_py}
-  COMMAND ${PYRCC5_CMD} -o ${_output_res_py} ${_qrc_file}
-  COMMENT "Generating workbench resources module"
-  DEPENDS ${_qrc_file}
-)
-add_custom_target ( workbench_resources ALL DEPENDS ${_output_res_py} )
+# Configure resources data in place for ease of development. The output file is
+# added to the toplevel gitignore
+set(_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
+set(_output_res_py ${CMAKE_CURRENT_LIST_DIR}/workbench/app/resources.py)
+add_custom_command(OUTPUT ${_output_res_py}
+                   COMMAND ${PYRCC5_CMD} -o ${_output_res_py} ${_qrc_file}
+                   COMMENT "Generating workbench resources module"
+                   DEPENDS ${_qrc_file})
+add_custom_target(workbench_resources ALL DEPENDS ${_output_res_py})
 
 # Dependency chain
-add_dependencies ( workbench workbench_resources mantidqt )
+add_dependencies(workbench workbench_resources mantidqt)
 
 # ctest targets
-set ( TEST_FILES
-  workbench/config/test/test_user.py
-  workbench/test/test_import.py
+set(TEST_FILES
+    workbench/config/test/test_user.py
+    workbench/test/test_import.py
+    workbench/plotting/test/test_figuremanager.py
+    workbench/plotting/test/test_globalfiguremanager.py
+    workbench/plugins/test/test_editor.py
+    workbench/plugins/test/test_exception_handler.py
+    workbench/plugins/test/test_jupyterconsole.py
+    workbench/plugins/test/test_workspacewidget.py
+    workbench/widgets/plotselector/test/test_plotselector_model.py
+    workbench/widgets/plotselector/test/test_plotselector_presenter.py
+    workbench/widgets/plotselector/test/test_plotselector_view.py
+    workbench/widgets/settings/test/test_settings_presenter.py
+    workbench/widgets/settings/test/test_settings_view.py
+    workbench/widgets/settings/general/test/test_general_settings.py
+    workbench/projectrecovery/test/test_projectrecovery.py
+    workbench/projectrecovery/test/test_projectrecoveryloader.py
+    workbench/projectrecovery/test/test_projectrecoverysaver.py
+    workbench/projectrecovery/recoverygui/test/test_projectrecoverymodel.py
+    workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
+    workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
+    workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py)
 
-  workbench/plotting/test/test_figuremanager.py
-  workbench/plotting/test/test_globalfiguremanager.py
-
-  workbench/plugins/test/test_editor.py
-  workbench/plugins/test/test_exception_handler.py
-  workbench/plugins/test/test_jupyterconsole.py
-  workbench/plugins/test/test_workspacewidget.py
-
-  workbench/widgets/plotselector/test/test_plotselector_model.py
-  workbench/widgets/plotselector/test/test_plotselector_presenter.py
-  workbench/widgets/plotselector/test/test_plotselector_view.py
-
-  workbench/widgets/settings/test/test_settings_presenter.py
-  workbench/widgets/settings/test/test_settings_view.py
-  workbench/widgets/settings/general/test/test_general_settings.py
-
-  workbench/projectrecovery/test/test_projectrecovery.py
-  workbench/projectrecovery/test/test_projectrecoveryloader.py
-  workbench/projectrecovery/test/test_projectrecoverysaver.py
-  workbench/projectrecovery/recoverygui/test/test_projectrecoverymodel.py
-  workbench/projectrecovery/recoverygui/test/test_projectrecoverypresenter.py
-  workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
-  workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py
-)
-
-set ( PYUNITTEST_RUN_SERIAL ON )
-set ( PYUNITTEST_QT_API pyqt5)
-pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR}
+set(PYUNITTEST_RUN_SERIAL ON)
+set(PYUNITTEST_QT_API pyqt5)
+pyunittest_add_test (${CMAKE_CURRENT_SOURCE_DIR}
   workbench ${TEST_FILES}
 )
 
-if ( CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode" )
-  set ( PYUNITTEST_RUNNER ${CMAKE_BINARY_DIR}/bin/$<CONFIG>/workbench-script.pyw -x)
+if(CMAKE_GENERATOR MATCHES "Visual Studio" OR CMAKE_GENERATOR MATCHES "Xcode")
+  set(PYUNITTEST_RUNNER ${CMAKE_BINARY_DIR}/bin/$<CONFIG>/workbench-script.pyw
+      -x)
 else()
-  set ( PYUNITTEST_RUNNER ${CMAKE_BINARY_DIR}/bin/workbench -x)
+  set(PYUNITTEST_RUNNER ${CMAKE_BINARY_DIR}/bin/workbench -x)
 endif()
 
 # Install MantidWorkbench for OSX
@@ -71,13 +65,13 @@ if( APPLE )
                    ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
                    @ONLY )
 
-  configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/make_package.rb.in
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/make_package.rb.in
       ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb
       @ONLY )
-  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb DESTINATION MantidWorkbench.app/ )
-  install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist DESTINATION MantidWorkbench.app/Contents/ )
-  install ( CODE "
-      set ( bundle \${CMAKE_INSTALL_PREFIX}/MantidWorkbench.app )
+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/make_package.rb DESTINATION MantidWorkbench.app/ )
+  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist DESTINATION MantidWorkbench.app/Contents/ )
+  install (CODE "
+      set (bundle \${CMAKE_INSTALL_PREFIX}/MantidWorkbench.app)
       execute_process(COMMAND chmod +x ./make_package.rb WORKING_DIRECTORY \${bundle})
       execute_process(COMMAND ./make_package.rb WORKING_DIRECTORY \${bundle} RESULT_VARIABLE install_name_tool_result)
       if(NOT install_name_tool_result EQUAL 0)

--- a/qt/paraview_ext/CMakeLists.txt
+++ b/qt/paraview_ext/CMakeLists.txt
@@ -1,41 +1,41 @@
 # Define the project name
-project( Vates )
+project(Vates)
 
-include( CommonVatesSetup )
+include(CommonVatesSetup)
 
 # Select either building Paraview plugins
-set( USE_PARAVIEW ON CACHE BOOL "Create paraview plugins. " )
+set(USE_PARAVIEW ON CACHE BOOL "Create paraview plugins. ")
 
 # Paraview dependencies built if Paraview is found
-if( ParaView_FOUND AND USE_PARAVIEW )
-  message( STATUS "Using ParaView ${PARAVIEW_VERSION_FULL}" )
-  include( ${PARAVIEW_USE_FILE} )
+if(ParaView_FOUND AND USE_PARAVIEW)
+  message(STATUS "Using ParaView ${PARAVIEW_VERSION_FULL}")
+  include(${PARAVIEW_USE_FILE})
 
-  function (set_pvplugin_properties target QT_VERSION vers)
-    # Workaround Qt compiler detection
+  function(set_pvplugin_properties target QT_VERSION vers)
+    # Workaround Qt compiler detection 
     # https://forum.qt.io/topic/43778/error-when-initializing-qstringlist-using-initializer-list/3
-    # https://bugreports.qt.io/browse/QTBUG-39142
-    # This is only required for Qt4
-    if ( vers EQUAL 4 )
-      set_target_properties ( ${_target} PROPERTIES COMPILE_DEFINITIONS Q_COMPILER_INITIALIZER_LISTS )
+    # https://bugreports.qt.io/browse/QTBUG-39142 
+	# This is only required for Qt4
+    if(vers EQUAL 4)
+      set_target_properties(${_target}
+                            PROPERTIES COMPILE_DEFINITIONS
+                                       Q_COMPILER_INITIALIZER_LISTS)
     endif()
-    set_target_properties ( ${target} PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}
-      RUNTIME_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}
-      FOLDER "MantidVatesParaViewPlugins"
-    )
+    set_target_properties(${target} PROPERTIES
+                 LIBRARY_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}
+                 RUNTIME_OUTPUT_DIRECTORY ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY}/qt${vers}
+                 FOLDER "MantidVatesParaViewPlugins")
   endfunction()
 
-  function (install_pvplugin target QT_VERSION vers)
-    install( TARGETS ${target} ${SYSTEM_PACKAGE_TARGET}
-      DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt${vers}
-    )
+  function(install_pvplugin target QT_VERSION vers)
+    install(TARGETS ${target} ${SYSTEM_PACKAGE_TARGET}
+            DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt${vers})
   endfunction()
 
-  add_subdirectory( VatesAPI )
-  add_subdirectory( VatesAlgorithms )
-  add_subdirectory( PVPlugins )
-  add_subdirectory( VatesSimpleGui )
-else( ParaView_FOUND AND USE_PARAVIEW )
-  message( STATUS "Vates-Paraview plugins and widgets will not be built." )
-endif( ParaView_FOUND AND USE_PARAVIEW )
+  add_subdirectory(VatesAPI)
+  add_subdirectory(VatesAlgorithms)
+  add_subdirectory(PVPlugins)
+  add_subdirectory(VatesSimpleGui)
+else(ParaView_FOUND AND USE_PARAVIEW)
+  message(STATUS "Vates-Paraview plugins and widgets will not be built.")
+endif(ParaView_FOUND AND USE_PARAVIEW)

--- a/qt/paraview_ext/PVPlugins/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/CMakeLists.txt
@@ -1,53 +1,63 @@
 # bring in Mantid/VATES API dependencies
-set_mantid_subprojects( qt/paraview_ext/VatesAPI )
-
+set_mantid_subprojects(qt/paraview_ext/VatesAPI)
 
 # vtktypemacro doesn't play nicely with -Wpedantic
-get_property ( _compile_options DIRECTORY PROPERTY COMPILE_OPTIONS )
-list ( REMOVE_ITEM _compile_options -Wpedantic )
-set_property ( DIRECTORY PROPERTY COMPILE_OPTIONS ${_compile_options} )
+get_property(_compile_options DIRECTORY PROPERTY COMPILE_OPTIONS)
+list(REMOVE_ITEM _compile_options -Wpedantic)
+set_property(DIRECTORY PROPERTY COMPILE_OPTIONS ${_compile_options})
 
-add_subdirectory( Filters )
-add_subdirectory( Readers )
-add_subdirectory( Representations )
-add_subdirectory( Sources )
+add_subdirectory(Filters)
+add_subdirectory(Readers)
+add_subdirectory(Representations)
+add_subdirectory(Sources)
 
-# NonOrthogonalSourcePlugin is necessary for viewing materials with nonorthogonal basis vectors.
-# Added as a dependency to MantidParaViewMDEWSourceSMPlugin (chosen arbitrarily)
-set ( _plugin_filename ${CMAKE_SHARED_LIBRARY_PREFIX}NonOrthogonalSource${CMAKE_SHARED_LIBRARY_SUFFIX} )
-if (CMAKE_GENERATOR MATCHES "Visual Studio")
-  set ( _pv_library_output_dir ${ParaView_DIR}/bin )
-  # add_custom_command doesn't support generator expressions for the OUTPUT argument
-  string ( REPLACE "$<CONFIG>" "${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
-elseif (CMAKE_GENERATOR MATCHES "Xcode")
-  set ( _pv_library_output_dir ${ParaView_DIR}/lib )
-  # add_custom_command doesn't support generator expressions for the OUTPUT argument
-  string ( REPLACE "$<CONFIG>" "${CMAKE_CFG_INTDIR}" _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
-else ()
-  set ( _pv_library_output_dir ${ParaView_DIR}/lib )
-  set ( _plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY} )
+# NonOrthogonalSourcePlugin is necessary for viewing materials with
+# nonorthogonal basis vectors. Added as a dependency to
+# MantidParaViewMDEWSourceSMPlugin (chosen arbitrarily)
+set(
+  _plugin_filename
+  ${CMAKE_SHARED_LIBRARY_PREFIX}NonOrthogonalSource${CMAKE_SHARED_LIBRARY_SUFFIX}
+  )
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  set(_pv_library_output_dir ${ParaView_DIR}/bin)
+  # add_custom_command doesn't support generator expressions for the OUTPUT
+  # argument
+  string(REPLACE "$<CONFIG>"
+                 "${CMAKE_CFG_INTDIR}"
+                 _plugin_library_output
+                 ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY})
+elseif(CMAKE_GENERATOR MATCHES "Xcode")
+  set(_pv_library_output_dir ${ParaView_DIR}/lib)
+  # add_custom_command doesn't support generator expressions for the OUTPUT
+  # argument
+  string(REPLACE "$<CONFIG>"
+                 "${CMAKE_CFG_INTDIR}"
+                 _plugin_library_output
+                 ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY})
+else()
+  set(_pv_library_output_dir ${ParaView_DIR}/lib)
+  set(_plugin_library_output ${PVPLUGINS_LIBRARY_OUTPUT_DIRECTORY})
 endif()
 
-if (CMAKE_GENERATOR MATCHES "Xcode")
+if(CMAKE_GENERATOR MATCHES "Xcode")
   # assume ParaView was built with Makefile or Ninja generator.
-  add_custom_command ( OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
+  add_custom_command(OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
+                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                             ${_pv_library_output_dir}/${_plugin_filename}
+                             ${_plugin_library_output}/qt4/${_plugin_filename})
+else()
+  add_custom_command(
+    OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    ${_pv_library_output_dir}/${_plugin_filename}
-    ${_plugin_library_output}/qt4/${_plugin_filename}
-  )
-else ()
-  add_custom_command ( OUTPUT ${_plugin_library_output}/qt4/${_plugin_filename}
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    ${_pv_library_output_dir}/${CMAKE_CFG_INTDIR}/${_plugin_filename}
-    ${_plugin_library_output}/qt4/${_plugin_filename}
-  )
+            ${_pv_library_output_dir}/${CMAKE_CFG_INTDIR}/${_plugin_filename}
+            ${_plugin_library_output}/qt4/${_plugin_filename})
 endif()
-add_custom_target ( copy_nonorthogonal_plugin DEPENDS ${_plugin_library_output}/qt4/${_plugin_filename} )
-add_dependencies ( MantidParaViewMDEWSourceSMPlugin copy_nonorthogonal_plugin )
+add_custom_target(copy_nonorthogonal_plugin
+                  DEPENDS ${_plugin_library_output}/qt4/${_plugin_filename})
+add_dependencies(MantidParaViewMDEWSourceSMPlugin copy_nonorthogonal_plugin)
 
-if ( (NOT APPLE) AND NonOrthogonalSourcePlugin_LOCATION)
+if((NOT APPLE) AND NonOrthogonalSourcePlugin_LOCATION)
   # make_package.rb handles this for OSX
-  install( FILES ${NonOrthogonalSourcePlugin_LOCATION} ${SYSTEM_PACKAGE_TARGET}
-    DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt4
-  )
+  install(FILES ${NonOrthogonalSourcePlugin_LOCATION} ${SYSTEM_PACKAGE_TARGET}
+          DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt4)
 endif()

--- a/qt/paraview_ext/PVPlugins/Filters/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Filters/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_subdirectory( SplatterPlot )
-add_subdirectory( ScaleWorkspace )
-add_subdirectory( PeaksFilter )
+add_subdirectory(SplatterPlot)
+add_subdirectory(ScaleWorkspace)
+add_subdirectory(PeaksFilter)

--- a/qt/paraview_ext/PVPlugins/Filters/PeaksFilter/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Filters/PeaksFilter/CMakeLists.txt
@@ -1,25 +1,34 @@
-PROJECT(PeaksFilter)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewPeaksFilterSMPlugin "1.0"
-SERVER_MANAGER_XML PeaksFilter.xml
-SERVER_MANAGER_SOURCES vtkPeaksFilter.cxx vtkPeaksFilter.h)
-set_pvplugin_properties (MantidParaViewPeaksFilterSMPlugin QT_VERSION 4)
+project(PeaksFilter)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewPeaksFilterSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    PeaksFilter.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkPeaksFilter.cxx
+                    vtkPeaksFilter.h)
+set_pvplugin_properties(MantidParaViewPeaksFilterSMPlugin QT_VERSION 4)
 
-target_link_libraries( MantidParaViewPeaksFilterSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${vtkjsoncpp_LIBRARIES}
-)
+target_link_libraries(MantidParaViewPeaksFilterSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${vtkjsoncpp_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewPeaksFilterSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewPeaksFilterSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewPeaksFilterSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewPeaksFilterSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewPeaksFilterSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewPeaksFilterSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Filters/ScaleWorkspace/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Filters/ScaleWorkspace/CMakeLists.txt
@@ -1,23 +1,31 @@
-PROJECT(ScaleWorkspace)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewScaleWorkspaceSMPlugin "1.0"
-SERVER_MANAGER_XML ScaleWorkspace.xml
-SERVER_MANAGER_SOURCES vtkScaleWorkspace.cxx)
-set_pvplugin_properties (MantidParaViewScaleWorkspaceSMPlugin QT_VERSION 4)
+project(ScaleWorkspace)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewScaleWorkspaceSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    ScaleWorkspace.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkScaleWorkspace.cxx)
+set_pvplugin_properties(MantidParaViewScaleWorkspaceSMPlugin QT_VERSION 4)
 
-target_link_libraries( MantidParaViewScaleWorkspaceSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${vtkjsoncpp_LIBRARIES}
-)
+target_link_libraries(MantidParaViewScaleWorkspaceSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${vtkjsoncpp_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewScaleWorkspaceSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewScaleWorkspaceSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewScaleWorkspaceSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewScaleWorkspaceSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewScaleWorkspaceSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewScaleWorkspaceSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Filters/SplatterPlot/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Filters/SplatterPlot/CMakeLists.txt
@@ -1,30 +1,38 @@
-PROJECT(SplatterPlot)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewSplatterPlotSMPlugin "1.0"
-	SERVER_MANAGER_XML SplatterPlot.xml
-	SERVER_MANAGER_SOURCES vtkSplatterPlot.cxx
-	GUI_RESOURCES SplatterPlot.qrc)
-set_pvplugin_properties (MantidParaViewSplatterPlotSMPlugin QT_VERSION 4)
+project(SplatterPlot)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewSplatterPlotSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    SplatterPlot.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkSplatterPlot.cxx
+                    GUI_RESOURCES
+                    SplatterPlot.qrc)
+set_pvplugin_properties(MantidParaViewSplatterPlotSMPlugin QT_VERSION 4)
 
+include_directories(SYSTEM ${QWT5_INCLUDE_DIR})
 
-include_directories ( SYSTEM ${QWT5_INCLUDE_DIR} )
+target_link_libraries(MantidParaViewSplatterPlotSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${QWT5_LIBRARIES}
+                      ${vtkjsoncpp_LIBRARIES})
 
-target_link_libraries( MantidParaViewSplatterPlotSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${QWT5_LIBRARIES}
-${vtkjsoncpp_LIBRARIES}
-)
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewSplatterPlotSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewSplatterPlotSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewSplatterPlotSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewSplatterPlotSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
-
-install_pvplugin (MantidParaViewSplatterPlotSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewSplatterPlotSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Readers/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Readers/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory( MDEWNexusReader )
-add_subdirectory( PeaksReader )
-add_subdirectory( NexusPeaksReader )
-add_subdirectory( MDHWNexusReader )
+add_subdirectory(MDEWNexusReader)
+add_subdirectory(PeaksReader)
+add_subdirectory(NexusPeaksReader)
+add_subdirectory(MDHWNexusReader)

--- a/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Readers/MDEWNexusReader/CMakeLists.txt
@@ -1,30 +1,37 @@
-project( MantidParaViewMDEWNexusReader )
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-add_paraview_plugin( MantidParaViewMDEWNexusReaderSMPlugin "1.0"
-	SERVER_MANAGER_XML MDEWNexusReader.xml
-	SERVER_MANAGER_SOURCES vtkMDEWNexusReader.cxx
-)
-set_pvplugin_properties (MantidParaViewMDEWNexusReaderSMPlugin QT_VERSION 4)
+project(MantidParaViewMDEWNexusReader)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewMDEWNexusReaderSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    MDEWNexusReader.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkMDEWNexusReader.cxx)
+set_pvplugin_properties(MantidParaViewMDEWNexusReaderSMPlugin QT_VERSION 4)
 
-include_directories ( SYSTEM ${QWT5_INCLUDE_DIR} )
+include_directories(SYSTEM ${QWT5_INCLUDE_DIR})
 
-target_link_libraries( MantidParaViewMDEWNexusReaderSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${vtkjsoncpp_LIBRARIES}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${QWT5_LIBRARIES}
-Qt4::QtCore
-)
+target_link_libraries(MantidParaViewMDEWNexusReaderSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${vtkjsoncpp_LIBRARIES}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${QWT5_LIBRARIES}
+                      Qt4::QtCore)
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewMDEWNexusReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewMDEWNexusReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewMDEWNexusReaderSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewMDEWNexusReaderSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewMDEWNexusReaderSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewMDEWNexusReaderSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Readers/MDHWNexusReader/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Readers/MDHWNexusReader/CMakeLists.txt
@@ -1,29 +1,37 @@
-project( MantidParaViewMDHWNexusReader )
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-add_paraview_plugin( MantidParaViewMDHWNexusReaderSMPlugin "1.0"
-	SERVER_MANAGER_XML MDHWNexusReader.xml
-	SERVER_MANAGER_SOURCES vtkMDHWNexusReader.cxx
-)
-set_pvplugin_properties (MantidParaViewMDHWNexusReaderSMPlugin QT_VERSION 4)
+project(MantidParaViewMDHWNexusReader)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewMDHWNexusReaderSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    MDHWNexusReader.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkMDHWNexusReader.cxx)
+set_pvplugin_properties(MantidParaViewMDHWNexusReaderSMPlugin QT_VERSION 4)
 
-include_directories ( SYSTEM ${QWT5_INCLUDE_DIR} )
+include_directories(SYSTEM ${QWT5_INCLUDE_DIR})
 
-target_link_libraries( MantidParaViewMDHWNexusReaderSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${vtkjsoncpp_LIBRARIES}
-${QWT5_LIBRARIES}
-Qt4::QtCore
-)
+target_link_libraries(MantidParaViewMDHWNexusReaderSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${vtkjsoncpp_LIBRARIES}
+                      ${QWT5_LIBRARIES}
+                      Qt4::QtCore)
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewMDHWNexusReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewMDHWNexusReaderSMPlugin PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewMDHWNexusReaderSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewMDHWNexusReaderSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewMDHWNexusReaderSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewMDHWNexusReaderSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Readers/NexusPeaksReader/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Readers/NexusPeaksReader/CMakeLists.txt
@@ -1,26 +1,34 @@
-project( MantidParaViewNexusPeaksReader )
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-add_paraview_plugin( MantidParaViewNexusPeaksReaderSMPlugin "1.0"
-	SERVER_MANAGER_XML NexusPeaksReader.xml
-	SERVER_MANAGER_SOURCES vtkNexusPeaksReader.cxx
-)
-set_pvplugin_properties (MantidParaViewNexusPeaksReaderSMPlugin QT_VERSION 4)
+project(MantidParaViewNexusPeaksReader)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewNexusPeaksReaderSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    NexusPeaksReader.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkNexusPeaksReader.cxx)
+set_pvplugin_properties(MantidParaViewNexusPeaksReaderSMPlugin QT_VERSION 4)
 
-target_link_libraries( MantidParaViewNexusPeaksReaderSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${NEXUS_LIBRARIES}
-${NEXUS_C_LIBRARIES})
+target_link_libraries(MantidParaViewNexusPeaksReaderSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${NEXUS_LIBRARIES}
+                      ${NEXUS_C_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewNexusPeaksReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewNexusPeaksReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewNexusPeaksReaderSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewNexusPeaksReaderSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewNexusPeaksReaderSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewNexusPeaksReaderSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Readers/PeaksReader/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Readers/PeaksReader/CMakeLists.txt
@@ -1,28 +1,36 @@
-project( MantidParaViewPeaksReader )
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-add_paraview_plugin( MantidParaViewPeaksReaderSMPlugin "1.0"
-	SERVER_MANAGER_XML PeaksReader.xml
-	SERVER_MANAGER_SOURCES vtkPeaksReader.cxx
-)
-set_pvplugin_properties (MantidParaViewPeaksReaderSMPlugin QT_VERSION 4)
+project(MantidParaViewPeaksReader)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewPeaksReaderSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    PeaksReader.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkPeaksReader.cxx)
+set_pvplugin_properties(MantidParaViewPeaksReaderSMPlugin QT_VERSION 4)
 
 # Add to the 'VatesParaViewPlugins' group in VS
-set_property( TARGET MantidParaViewPeaksReaderSMPlugin PROPERTY FOLDER "MantidVatesParaViewPlugins" )
+set_property(TARGET MantidParaViewPeaksReaderSMPlugin
+             PROPERTY FOLDER "MantidVatesParaViewPlugins")
 
-target_link_libraries( MantidParaViewPeaksReaderSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-)
+target_link_libraries(MantidParaViewPeaksReaderSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewPeaksReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewPeaksReaderSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewPeaksReaderSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewPeaksReaderSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewPeaksReaderSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewPeaksReaderSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Representations/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Representations/CMakeLists.txt
@@ -1,11 +1,13 @@
-project( MantidParaViewRepresentation )
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewRepresentationSMPlugin "1.0"
-  SERVER_MANAGER_XML Representation.xml
-  SERVER_MANAGER_SOURCES
-    vtkAlignedGeometrySliceRepresentation.cxx
-    AlignedThreeSliceFilter.cxx
-    AlignedCutter.cxx)
-set_pvplugin_properties (MantidParaViewRepresentationSMPlugin QT_VERSION 4)
+project(MantidParaViewRepresentation)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewRepresentationSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    Representation.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkAlignedGeometrySliceRepresentation.cxx
+                    AlignedThreeSliceFilter.cxx
+                    AlignedCutter.cxx)
+set_pvplugin_properties(MantidParaViewRepresentationSMPlugin QT_VERSION 4)
 
-install_pvplugin (MantidParaViewRepresentationSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewRepresentationSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Sources/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Sources/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_subdirectory( MDEWSource )
-add_subdirectory( MDHWSource )
-add_subdirectory( PeaksSource )
-add_subdirectory( SinglePeakMarkerSource )
+add_subdirectory(MDEWSource)
+add_subdirectory(MDHWSource)
+add_subdirectory(PeaksSource)
+add_subdirectory(SinglePeakMarkerSource)

--- a/qt/paraview_ext/PVPlugins/Sources/MDEWSource/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Sources/MDEWSource/CMakeLists.txt
@@ -1,27 +1,36 @@
-PROJECT(MantidParaViewMDEWSource)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewMDEWSourceSMPlugin "1.0"
-	SERVER_MANAGER_XML MDEWSource.xml
-	SERVER_MANAGER_SOURCES vtkMDEWSource.cxx)
-set_pvplugin_properties (MantidParaViewMDEWSourceSMPlugin QT_VERSION 4)
+project(MantidParaViewMDEWSource)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewMDEWSourceSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    MDEWSource.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkMDEWSource.cxx)
+set_pvplugin_properties(MantidParaViewMDEWSourceSMPlugin QT_VERSION 4)
 
-include_directories ( SYSTEM ${QWT5_INCLUDE_DIR} )
-target_link_libraries( MantidParaViewMDEWSourceSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${vtkjsoncpp_LIBRARIES}
-${QWT5_LIBRARIES}
-Qt4::QtCore
-)
+include_directories(SYSTEM ${QWT5_INCLUDE_DIR})
+target_link_libraries(MantidParaViewMDEWSourceSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${vtkjsoncpp_LIBRARIES}
+                      ${QWT5_LIBRARIES}
+                      Qt4::QtCore)
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewMDEWSourceSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewMDEWSourceSMPlugin PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewMDEWSourceSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewMDEWSourceSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewMDEWSourceSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewMDEWSourceSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Sources/MDHWSource/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Sources/MDHWSource/CMakeLists.txt
@@ -1,29 +1,37 @@
-PROJECT(MantidParaViewMDHWSource)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewMDHWSourceSMPlugin "1.0"
-	SERVER_MANAGER_XML MDHWSource.xml
-	SERVER_MANAGER_SOURCES vtkMDHWSource.cxx)
-set_pvplugin_properties (MantidParaViewMDHWSourceSMPlugin QT_VERSION 4)
+project(MantidParaViewMDHWSource)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewMDHWSourceSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    MDHWSource.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkMDHWSource.cxx)
+set_pvplugin_properties(MantidParaViewMDHWSourceSMPlugin QT_VERSION 4)
 
-include_directories ( SYSTEM ${QWT5_INCLUDE_DIR} )
+include_directories(SYSTEM ${QWT5_INCLUDE_DIR})
 
-target_link_libraries( MantidParaViewMDHWSourceSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-${vtkjsoncpp_LIBRARIES}
-${QWT5_LIBRARIES}
-Qt4::QtCore
-)
+target_link_libraries(MantidParaViewMDHWSourceSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${vtkjsoncpp_LIBRARIES}
+                      ${QWT5_LIBRARIES}
+                      Qt4::QtCore)
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewMDHWSourceSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewMDHWSourceSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewMDHWSourceSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewMDHWSourceSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewMDHWSourceSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewMDHWSourceSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Sources/PeaksSource/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Sources/PeaksSource/CMakeLists.txt
@@ -1,24 +1,32 @@
-PROJECT(MantidParaViewPeaksSource)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewPeaksSourceSMPlugin "1.0"
-	SERVER_MANAGER_XML PeaksSource.xml
-	SERVER_MANAGER_SOURCES vtkPeaksSource.cxx)
-set_pvplugin_properties (MantidParaViewPeaksSourceSMPlugin QT_VERSION 4)
+project(MantidParaViewPeaksSource)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewPeaksSourceSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    PeaksSource.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkPeaksSource.cxx)
+set_pvplugin_properties(MantidParaViewPeaksSourceSMPlugin QT_VERSION 4)
 
-target_link_libraries( MantidParaViewPeaksSourceSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${CORE_MANTIDLIBS}
-DataObjects
-VatesAPI
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-)
+target_link_libraries(MantidParaViewPeaksSourceSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      DataObjects
+                      VatesAPI
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewPeaksSourceSMPlugin
-                        PROPERTIES INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewPeaksSourceSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set_target_properties(MantidParaViewPeaksSourceSMPlugin
                         PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+endif()
 
-install_pvplugin (MantidParaViewPeaksSourceSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewPeaksSourceSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/PVPlugins/Sources/SinglePeakMarkerSource/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/Sources/SinglePeakMarkerSource/CMakeLists.txt
@@ -1,18 +1,30 @@
-PROJECT(MantidParaViewSinglePeakMarkerSource)
-include_directories( SYSTEM ${PARAVIEW_INCLUDE_DIRS} )
-ADD_PARAVIEW_PLUGIN(MantidParaViewSinglePeakMarkerSourceSMPlugin "1.0"
-	SERVER_MANAGER_XML SinglePeakMarkerSource.xml
-	SERVER_MANAGER_SOURCES vtkSinglePeakMarkerSource.cxx)
-set_pvplugin_properties (MantidParaViewSinglePeakMarkerSourceSMPlugin QT_VERSION 4)
+project(MantidParaViewSinglePeakMarkerSource)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+add_paraview_plugin(MantidParaViewSinglePeakMarkerSourceSMPlugin
+                    "1.0"
+                    SERVER_MANAGER_XML
+                    SinglePeakMarkerSource.xml
+                    SERVER_MANAGER_SOURCES
+                    vtkSinglePeakMarkerSource.cxx)
+set_pvplugin_properties(MantidParaViewSinglePeakMarkerSourceSMPlugin QT_VERSION
+                        4)
 
-target_link_libraries( MantidParaViewSinglePeakMarkerSourceSMPlugin LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME} ${CORE_MANTIDLIBS} VatesAPI )
+target_link_libraries(MantidParaViewSinglePeakMarkerSourceSMPlugin
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${CORE_MANTIDLIBS}
+                      VatesAPI)
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(MantidParaViewSinglePeakMarkerSourceSMPlugin PROPERTIES
-                        INSTALL_RPATH "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(MantidParaViewSinglePeakMarkerSourceSMPlugin PROPERTIES
-                        INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    MantidParaViewSinglePeakMarkerSourceSMPlugin
+    PROPERTIES
+      INSTALL_RPATH
+      "@loader_path/../../../Contents/Libraries;@loader_path/../../../Contents/MacOS"
+    )
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(MantidParaViewSinglePeakMarkerSourceSMPlugin
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../../../${LIB_DIR}")
+endif()
 
-install_pvplugin (MantidParaViewSinglePeakMarkerSourceSMPlugin QT_VERSION 4)
+install_pvplugin(MantidParaViewSinglePeakMarkerSourceSMPlugin QT_VERSION 4)

--- a/qt/paraview_ext/VatesAPI/CMakeLists.txt
+++ b/qt/paraview_ext/VatesAPI/CMakeLists.txt
@@ -1,261 +1,272 @@
-#This is mainly here so you don't get a complaint when running cmake
-cmake_minimum_required( VERSION 3.5 )
+# This is mainly here so you don't get a complaint when running cmake
+cmake_minimum_required(VERSION 3.5)
 
-project( VatesAPI )
+project(VatesAPI)
 
-set( SRC_FILES
-src/ADSWorkspaceProvider.cpp
-src/BoxInfo.cpp
-src/Common.cpp
-src/CompositePeaksPresenterVsi.cpp
-src/ConcretePeaksPresenterVsi.cpp
-src/EventNexusLoadingPresenter.cpp
-src/FieldDataToMetadata.cpp
-src/IMDDimensionComparitor.cpp
-src/MDEWEventNexusLoadingPresenter.cpp
-src/MDEWLoadingPresenter.cpp
-src/MDEWInMemoryLoadingPresenter.cpp
-src/MDHWInMemoryLoadingPresenter.cpp
-src/MDHWLoadingPresenter.cpp
-src/MDHWNexusLoadingPresenter.cpp
-src/MDLoadingViewSimple.cpp
-src/MetadataToFieldData.cpp
-src/MetadataToFieldData.cpp
-src/MetaDataExtractorUtils.cpp
-src/MetadataJsonManager.cpp
-src/MDLoadingPresenter.cpp
-src/Normalization.cpp
-src/ProgressAction.cpp
-src/PresenterFactories.cpp
-src/PresenterUtilities.cpp
-src/SingleWorkspaceProvider.cpp
-src/TimeStepToTimeStep.cpp
-src/TimeToTimeStep.cpp
-src/VatesXMLDefinitions.cpp
-src/VatesConfigurations.cpp
-src/ViewFrustum.cpp
-src/VatesKnowledgeSerializer.cpp
-src/vtkDataSetFactory.cpp
-src/vtkDataSetToGeometry.cpp
-src/vtkDataSetToImplicitFunction.cpp
-src/vtkDataSetToNonOrthogonalDataSet.cpp
-src/vtkDataSetToPeaksFilteredDataSet.cpp
-src/vtkDataSetToScaledDataSet.cpp
-src/vtkDataSetToWsName.cpp
-src/vtkDataSetToWsLocation.cpp
-src/vtkMDLineFactory.cpp
-src/vtkMDQuadFactory.cpp
-src/vtkMD0DFactory.cpp
-src/vtkNullStructuredGrid.cpp
-src/vtkNullUnstructuredGrid.cpp
-src/vtkSplatterPlotFactory.cpp
-src/vtkMDHexFactory.cpp
-src/vtkPeakMarkerFactory.cpp
-src/vtkMDHistoHexFactory.cpp
-src/vtkMDHistoLineFactory.cpp
-src/vtkMDHistoQuadFactory.cpp
-src/vtkMDHistoHex4DFactory.cpp
-src/vtkSinglePeakMarker.cpp
-src/SQWLoadingPresenter.cpp
-)
+set(SRC_FILES
+    src/ADSWorkspaceProvider.cpp
+    src/BoxInfo.cpp
+    src/Common.cpp
+    src/CompositePeaksPresenterVsi.cpp
+    src/ConcretePeaksPresenterVsi.cpp
+    src/EventNexusLoadingPresenter.cpp
+    src/FieldDataToMetadata.cpp
+    src/IMDDimensionComparitor.cpp
+    src/MDEWEventNexusLoadingPresenter.cpp
+    src/MDEWLoadingPresenter.cpp
+    src/MDEWInMemoryLoadingPresenter.cpp
+    src/MDHWInMemoryLoadingPresenter.cpp
+    src/MDHWLoadingPresenter.cpp
+    src/MDHWNexusLoadingPresenter.cpp
+    src/MDLoadingViewSimple.cpp
+    src/MetadataToFieldData.cpp
+    src/MetadataToFieldData.cpp
+    src/MetaDataExtractorUtils.cpp
+    src/MetadataJsonManager.cpp
+    src/MDLoadingPresenter.cpp
+    src/Normalization.cpp
+    src/ProgressAction.cpp
+    src/PresenterFactories.cpp
+    src/PresenterUtilities.cpp
+    src/SingleWorkspaceProvider.cpp
+    src/TimeStepToTimeStep.cpp
+    src/TimeToTimeStep.cpp
+    src/VatesXMLDefinitions.cpp
+    src/VatesConfigurations.cpp
+    src/ViewFrustum.cpp
+    src/VatesKnowledgeSerializer.cpp
+    src/vtkDataSetFactory.cpp
+    src/vtkDataSetToGeometry.cpp
+    src/vtkDataSetToImplicitFunction.cpp
+    src/vtkDataSetToNonOrthogonalDataSet.cpp
+    src/vtkDataSetToPeaksFilteredDataSet.cpp
+    src/vtkDataSetToScaledDataSet.cpp
+    src/vtkDataSetToWsName.cpp
+    src/vtkDataSetToWsLocation.cpp
+    src/vtkMDLineFactory.cpp
+    src/vtkMDQuadFactory.cpp
+    src/vtkMD0DFactory.cpp
+    src/vtkNullStructuredGrid.cpp
+    src/vtkNullUnstructuredGrid.cpp
+    src/vtkSplatterPlotFactory.cpp
+    src/vtkMDHexFactory.cpp
+    src/vtkPeakMarkerFactory.cpp
+    src/vtkMDHistoHexFactory.cpp
+    src/vtkMDHistoLineFactory.cpp
+    src/vtkMDHistoQuadFactory.cpp
+    src/vtkMDHistoHex4DFactory.cpp
+    src/vtkSinglePeakMarker.cpp
+    src/SQWLoadingPresenter.cpp)
 
-set( INC_FILES
-inc/MantidVatesAPI/ADSWorkspaceProvider.h
-inc/MantidVatesAPI/BoxInfo.h
-inc/MantidVatesAPI/Common.h
-inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
-inc/MantidVatesAPI/ConcretePeaksPresenterVsi.h
-inc/MantidVatesAPI/ColorScaleGuard.h
-inc/MantidVatesAPI/DimensionViewFactory.h
-inc/MantidVatesAPI/EventNexusLoadingPresenter.h
-inc/MantidVatesAPI/FactoryChains.h
-inc/MantidVatesAPI/FieldDataToMetadata.h
-inc/MantidVatesAPI/FilteringUpdateProgressAction.h
-inc/MantidVatesAPI/GeometryView.h
-inc/MantidVatesAPI/MDEWEventNexusLoadingPresenter.h
-inc/MantidVatesAPI/MDEWLoadingPresenter.h
-inc/MantidVatesAPI/MDEWInMemoryLoadingPresenter.h
-inc/MantidVatesAPI/MDHWInMemoryLoadingPresenter.h
-inc/MantidVatesAPI/MDHWLoadingPresenter.h
-inc/MantidVatesAPI/MDHWNexusLoadingPresenter.h
-inc/MantidVatesAPI/MDLoadingPresenter.h
-inc/MantidVatesAPI/MDLoadingView.h
-inc/MantidVatesAPI/MDLoadingViewSimple.h
-inc/MantidVatesAPI/MDLoadingViewAdapter.h
-inc/MantidVatesAPI/MetaDataExtractorUtils.h
-inc/MantidVatesAPI/MetadataJsonManager.h
-inc/MantidVatesAPI/Normalization.h
-inc/MantidVatesAPI/IMDDimensionComparitor.h
-inc/MantidVatesAPI/MetadataToFieldData.h
-inc/MantidVatesAPI/NullPeaksPresenterVsi.h
-inc/MantidVatesAPI/PeaksPresenterVsi.h
-inc/MantidVatesAPI/PresenterFactories.h
-inc/MantidVatesAPI/ProgressAction.h
-inc/MantidVatesAPI/SingleWorkspaceProvider.h
-inc/MantidVatesAPI/SQWLoadingPresenter.h
-inc/MantidVatesAPI/TimeStepToTimeStep.h
-inc/MantidVatesAPI/TimeToTimeStep.h
-inc/MantidVatesAPI/VatesXMLDefinitions.h
-inc/MantidVatesAPI/VatesConfigurations.h
-inc/MantidVatesAPI/VatesKnowledgeSerializer.h
-inc/MantidVatesAPI/ViewFrustum.h
-inc/MantidVatesAPI/vtkDataSetFactory.h
-inc/MantidVatesAPI/vtkDataSetToGeometry.h
-inc/MantidVatesAPI/vtkDataSetToImplicitFunction.h
-inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
-inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
-inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
-inc/MantidVatesAPI/vtkDataSetToWsName.h
-inc/MantidVatesAPI/vtkDataSetToWsLocation.h
-inc/MantidVatesAPI/vtkMDLineFactory.h
-inc/MantidVatesAPI/vtkMDQuadFactory.h
-inc/MantidVatesAPI/vtkMDHexFactory.h
-inc/MantidVatesAPI/vtkMD0DFactory.h
-inc/MantidVatesAPI/vtkNullStructuredGrid.h
-inc/MantidVatesAPI/vtkNullUnstructuredGrid.h
-inc/MantidVatesAPI/vtkSplatterPlotFactory.h
-inc/MantidVatesAPI/vtkPeakMarkerFactory.h
-inc/MantidVatesAPI/vtkMDHistoHexFactory.h
-inc/MantidVatesAPI/vtkMDHistoLineFactory.h
-inc/MantidVatesAPI/vtkMDHistoQuadFactory.h
-inc/MantidVatesAPI/vtkMDHistoHex4DFactory.h
-inc/MantidVatesAPI/vtkSinglePeakMarker.h
-inc/MantidVatesAPI/WorkspaceProvider.h
-)
+set(INC_FILES
+    inc/MantidVatesAPI/ADSWorkspaceProvider.h
+    inc/MantidVatesAPI/BoxInfo.h
+    inc/MantidVatesAPI/Common.h
+    inc/MantidVatesAPI/CompositePeaksPresenterVsi.h
+    inc/MantidVatesAPI/ConcretePeaksPresenterVsi.h
+    inc/MantidVatesAPI/ColorScaleGuard.h
+    inc/MantidVatesAPI/DimensionViewFactory.h
+    inc/MantidVatesAPI/EventNexusLoadingPresenter.h
+    inc/MantidVatesAPI/FactoryChains.h
+    inc/MantidVatesAPI/FieldDataToMetadata.h
+    inc/MantidVatesAPI/FilteringUpdateProgressAction.h
+    inc/MantidVatesAPI/GeometryView.h
+    inc/MantidVatesAPI/MDEWEventNexusLoadingPresenter.h
+    inc/MantidVatesAPI/MDEWLoadingPresenter.h
+    inc/MantidVatesAPI/MDEWInMemoryLoadingPresenter.h
+    inc/MantidVatesAPI/MDHWInMemoryLoadingPresenter.h
+    inc/MantidVatesAPI/MDHWLoadingPresenter.h
+    inc/MantidVatesAPI/MDHWNexusLoadingPresenter.h
+    inc/MantidVatesAPI/MDLoadingPresenter.h
+    inc/MantidVatesAPI/MDLoadingView.h
+    inc/MantidVatesAPI/MDLoadingViewSimple.h
+    inc/MantidVatesAPI/MDLoadingViewAdapter.h
+    inc/MantidVatesAPI/MetaDataExtractorUtils.h
+    inc/MantidVatesAPI/MetadataJsonManager.h
+    inc/MantidVatesAPI/Normalization.h
+    inc/MantidVatesAPI/IMDDimensionComparitor.h
+    inc/MantidVatesAPI/MetadataToFieldData.h
+    inc/MantidVatesAPI/NullPeaksPresenterVsi.h
+    inc/MantidVatesAPI/PeaksPresenterVsi.h
+    inc/MantidVatesAPI/PresenterFactories.h
+    inc/MantidVatesAPI/ProgressAction.h
+    inc/MantidVatesAPI/SingleWorkspaceProvider.h
+    inc/MantidVatesAPI/SQWLoadingPresenter.h
+    inc/MantidVatesAPI/TimeStepToTimeStep.h
+    inc/MantidVatesAPI/TimeToTimeStep.h
+    inc/MantidVatesAPI/VatesXMLDefinitions.h
+    inc/MantidVatesAPI/VatesConfigurations.h
+    inc/MantidVatesAPI/VatesKnowledgeSerializer.h
+    inc/MantidVatesAPI/ViewFrustum.h
+    inc/MantidVatesAPI/vtkDataSetFactory.h
+    inc/MantidVatesAPI/vtkDataSetToGeometry.h
+    inc/MantidVatesAPI/vtkDataSetToImplicitFunction.h
+    inc/MantidVatesAPI/vtkDataSetToNonOrthogonalDataSet.h
+    inc/MantidVatesAPI/vtkDataSetToPeaksFilteredDataSet.h
+    inc/MantidVatesAPI/vtkDataSetToScaledDataSet.h
+    inc/MantidVatesAPI/vtkDataSetToWsName.h
+    inc/MantidVatesAPI/vtkDataSetToWsLocation.h
+    inc/MantidVatesAPI/vtkMDLineFactory.h
+    inc/MantidVatesAPI/vtkMDQuadFactory.h
+    inc/MantidVatesAPI/vtkMDHexFactory.h
+    inc/MantidVatesAPI/vtkMD0DFactory.h
+    inc/MantidVatesAPI/vtkNullStructuredGrid.h
+    inc/MantidVatesAPI/vtkNullUnstructuredGrid.h
+    inc/MantidVatesAPI/vtkSplatterPlotFactory.h
+    inc/MantidVatesAPI/vtkPeakMarkerFactory.h
+    inc/MantidVatesAPI/vtkMDHistoHexFactory.h
+    inc/MantidVatesAPI/vtkMDHistoLineFactory.h
+    inc/MantidVatesAPI/vtkMDHistoQuadFactory.h
+    inc/MantidVatesAPI/vtkMDHistoHex4DFactory.h
+    inc/MantidVatesAPI/vtkSinglePeakMarker.h
+    inc/MantidVatesAPI/WorkspaceProvider.h)
 
-set( TEST_FILES
-test/vtkDataSetToImplicitFunctionTest.h
-test/vtkDataSetToWsNameTest.h
-test/vtkDataSetToWsLocationTest.h
-test/ADSWorkspaceProviderTest.h
-test/BoxInfoTest.h
-test/EventNexusLoadingPresenterTest.h
-test/vtkDataSetFactoryTest.h
-test/vtkDataSetToGeometryTest.h
-test/vtkMDLineFactoryTest.h
-test/vtkMDQuadFactoryTest.h
-test/vtkMDHexFactoryTest.h
-test/vtkSplatterPlotFactoryTest.h
-test/vtkPeakMarkerFactoryTest.h
-test/vtkMDHistoHex4DFactoryTest.h
-test/vtkMDHistoHexFactoryTest.h
-test/vtkMDHistoLineFactoryTest.h
-test/vtkMDHistoQuadFactoryTest.h
-test/vtkMD0DFactoryTest.h
-test/FieldDataToMetadataTest.h
-test/FilteringUpdateProgressActionTest.h
-test/MDLoadingViewAdapterTest.h
-test/MDEWEventNexusLoadingPresenterTest.h
-test/MDEWInMemoryLoadingPresenterTest.h
-test/MDEWLoadingPresenterTest.h
-test/MDHWInMemoryLoadingPresenterTest.h
-test/MDHWLoadingPresenterTest.h
-test/MDHWNexusLoadingPresenterTest.h
-test/MDLoadingPresenterTest.h
-test/MDLoadingViewSimpleTest.h
-test/MetaDataExtractorUtilsTest.h
-test/MetadataJsonManagerTest.h
-test/MetadataToFieldDataTest.h
-test/NormalizationTest.h
-test/PresenterUtilitiesTest.h
-test/SingleWorkspaceProviderTest.h
-test/SQWLoadingPresenterTest.h
-test/TimeStepToTimeStepTest.h
-test/TimeToTimeStepTest.h
-test/VatesKnowledgeSerializerTest.h
-test/ViewFrustumTest.h
-test/vtkDataSetToScaledDataSetTest.h
-test/vtkDataSetToPeaksFilteredDataSetTest.h
-test/vtkDataSetToNonOrthogonalDataSetTest.h
-test/vtkNullUnstructuredGridTest.h
-test/vtkNullStructuredGridTest.h
-test/vtkMDHWSignalArrayTest.h
-test/NullPeaksPresenterVsiTest.h
-test/ConcretePeaksPresenterVsiTest.h
-test/CompositePeaksPresenterVsiTest.h
-)
+set(TEST_FILES
+    test/vtkDataSetToImplicitFunctionTest.h
+    test/vtkDataSetToWsNameTest.h
+    test/vtkDataSetToWsLocationTest.h
+    test/ADSWorkspaceProviderTest.h
+    test/BoxInfoTest.h
+    test/EventNexusLoadingPresenterTest.h
+    test/vtkDataSetFactoryTest.h
+    test/vtkDataSetToGeometryTest.h
+    test/vtkMDLineFactoryTest.h
+    test/vtkMDQuadFactoryTest.h
+    test/vtkMDHexFactoryTest.h
+    test/vtkSplatterPlotFactoryTest.h
+    test/vtkPeakMarkerFactoryTest.h
+    test/vtkMDHistoHex4DFactoryTest.h
+    test/vtkMDHistoHexFactoryTest.h
+    test/vtkMDHistoLineFactoryTest.h
+    test/vtkMDHistoQuadFactoryTest.h
+    test/vtkMD0DFactoryTest.h
+    test/FieldDataToMetadataTest.h
+    test/FilteringUpdateProgressActionTest.h
+    test/MDLoadingViewAdapterTest.h
+    test/MDEWEventNexusLoadingPresenterTest.h
+    test/MDEWInMemoryLoadingPresenterTest.h
+    test/MDEWLoadingPresenterTest.h
+    test/MDHWInMemoryLoadingPresenterTest.h
+    test/MDHWLoadingPresenterTest.h
+    test/MDHWNexusLoadingPresenterTest.h
+    test/MDLoadingPresenterTest.h
+    test/MDLoadingViewSimpleTest.h
+    test/MetaDataExtractorUtilsTest.h
+    test/MetadataJsonManagerTest.h
+    test/MetadataToFieldDataTest.h
+    test/NormalizationTest.h
+    test/PresenterUtilitiesTest.h
+    test/SingleWorkspaceProviderTest.h
+    test/SQWLoadingPresenterTest.h
+    test/TimeStepToTimeStepTest.h
+    test/TimeToTimeStepTest.h
+    test/VatesKnowledgeSerializerTest.h
+    test/ViewFrustumTest.h
+    test/vtkDataSetToScaledDataSetTest.h
+    test/vtkDataSetToPeaksFilteredDataSetTest.h
+    test/vtkDataSetToNonOrthogonalDataSetTest.h
+    test/vtkNullUnstructuredGridTest.h
+    test/vtkNullStructuredGridTest.h
+    test/vtkMDHWSignalArrayTest.h
+    test/NullPeaksPresenterVsiTest.h
+    test/ConcretePeaksPresenterVsiTest.h
+    test/CompositePeaksPresenterVsiTest.h)
 
-include_directories( inc )
-include_directories ( SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+include_directories(inc)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
 
 # For Windows:
-add_definitions( -DIN_MANTID_VATESAPI )
+add_definitions(-DIN_MANTID_VATESAPI)
 # Use a precompiled header where they are supported
-enable_precompiled_headers ( inc/MantidVatesAPI/PrecompiledHeader.h SRC_FILES )
+enable_precompiled_headers(inc/MantidVatesAPI/PrecompiledHeader.h SRC_FILES)
 # Add the target for this directory
-add_library( VatesAPI ${SRC_FILES} ${INC_FILES} )
+add_library(VatesAPI ${SRC_FILES} ${INC_FILES})
 # Set the name of the generated library
-set_target_properties( VatesAPI PROPERTIES OUTPUT_NAME MantidVatesAPI )
+set_target_properties(VatesAPI PROPERTIES OUTPUT_NAME MantidVatesAPI)
 # Add to the 'Framework' group in VS
-set_property( TARGET VatesAPI PROPERTY FOLDER "MantidVates" )
+set_property(TARGET VatesAPI PROPERTY FOLDER "MantidVates")
 
+target_link_libraries(VatesAPI
+                      PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
+                              ${MANTID_SUBPROJECT_LIBS}
+                              vtkCommonCore
+                              vtkCommonDataModel
+                              vtkIOLegacy
+                              vtkFiltersExtraction
+                              vtkFiltersSources
+                              ${vtkjsoncpp_LIBRARIES}
+                              vtkPVVTKExtensionsDefault
+                              ${POCO_LIBRARIES}
+                              ${Boost_LIBRARIES})
 
-target_link_libraries( VatesAPI PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${MANTID_SUBPROJECT_LIBS}
-vtkCommonCore
-vtkCommonDataModel
-vtkIOLegacy
-vtkFiltersExtraction
-vtkFiltersSources
-${vtkjsoncpp_LIBRARIES}
-vtkPVVTKExtensionsDefault
-${POCO_LIBRARIES}
-${Boost_LIBRARIES}
-)
-
-if ( MSVC )
+if(MSVC)
   # To simplify developer builds from the IDE we copy the ParaView DLLs to the
   # appropriate buildbinary folder. This avoids have to set the PATH to point to
   # a different ParaView build directory for each configuration
-  set ( _src_dir ${ParaView_DIR}/bin/${CMAKE_CFG_INTDIR} )
-  set ( _dest_dir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR} )
-  add_custom_command (
+  set(_src_dir ${ParaView_DIR}/bin/${CMAKE_CFG_INTDIR})
+  set(_dest_dir ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR})
+  add_custom_command(
     TARGET VatesAPI POST_BUILD
-    COMMAND xcopy ARGS \"${_src_dir}/*.dll\" \"${_dest_dir}\" /D /Y /F
-    COMMENT "Updating ParaView DLLs in bin/${CMAKE_CFG_INTDIR}"
-  )
-  unset ( _dest_dir )
-  unset ( _src_dir )
+    COMMAND xcopy
+            ARGS \"${_src_dir}/*.dll\"
+                 \"${_dest_dir}\"
+                 /D
+                 /Y
+                 /F
+    COMMENT "Updating ParaView DLLs in bin/${CMAKE_CFG_INTDIR}")
+  unset(_dest_dir)
+  unset(_src_dir)
 endif()
 
-
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(VatesAPI PROPERTIES INSTALL_RPATH "@loader_path/../MacOS;@loader_path/../Libraries")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(VatesAPI PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    VatesAPI
+    PROPERTIES INSTALL_RPATH "@loader_path/../MacOS;@loader_path/../Libraries")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(VatesAPI
+                        PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
+endif()
 
 # Create test file projects
-include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR} )
+include_directories(SYSTEM
+                    ${CXXTEST_INCLUDE_DIR}
+                    ${GMOCK_INCLUDE_DIR}
+                    ${GTEST_INCLUDE_DIR})
 
-include_directories( inc ../../../Framework/TestHelpers/inc ../../../Framework/DataHandling/inc ../../../Framework/DataObjects/inc ../../../Framework/MDAlgorithms/inc)
-set ( TESTHELPER_SRCS ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/MDEventsTestHelper.cpp
-                      ../../../Framework/TestHelpers/src/StartFrameworkManager.cpp )
-cxxtest_add_test( VatesAPITest ${TEST_FILES} )
-target_link_libraries( VatesAPITest LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-  ${MANTID_SUBPROJECT_LIBS}
-  VatesAPI
-  DataHandling
-  Kernel
-  DataObjects
-  Indexing
-  vtkCommonCore
-  vtkCommonDataModel
-  vtkIOLegacy
-  vtkFiltersExtraction
-  vtkFiltersSources
-  vtkPVVTKExtensionsDefault
-  ${vtkjsoncpp_LIBRARIES}
-  ${POCO_LIBRARIES}
-  ${Boost_LIBRARIES}
-  ${GMOCK_LIBRARIES}
-  ${GTEST_LIBRARIES}
-  )
-add_dependencies( AllTests VatesAPITest )
+include_directories(inc
+                    ../../../Framework/TestHelpers/inc
+                    ../../../Framework/DataHandling/inc
+                    ../../../Framework/DataObjects/inc
+                    ../../../Framework/MDAlgorithms/inc)
+set(TESTHELPER_SRCS
+    ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/MDEventsTestHelper.cpp
+    ../../../Framework/TestHelpers/src/StartFrameworkManager.cpp)
+cxxtest_add_test(VatesAPITest ${TEST_FILES})
+target_link_libraries(VatesAPITest
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${MANTID_SUBPROJECT_LIBS}
+                      VatesAPI
+                      DataHandling
+                      Kernel
+                      DataObjects
+                      Indexing
+                      vtkCommonCore
+                      vtkCommonDataModel
+                      vtkIOLegacy
+                      vtkFiltersExtraction
+                      vtkFiltersSources
+                      vtkPVVTKExtensionsDefault
+                      ${vtkjsoncpp_LIBRARIES}
+                      ${POCO_LIBRARIES}
+                      ${Boost_LIBRARIES}
+                      ${GMOCK_LIBRARIES}
+                      ${GTEST_LIBRARIES})
+add_dependencies(AllTests VatesAPITest)
 # Add to the 'UnitTests' group in VS
-set_property ( TARGET VatesAPITest PROPERTY FOLDER "UnitTests" )
+set_property(TARGET VatesAPITest PROPERTY FOLDER "UnitTests")
 
-install( TARGETS VatesAPI ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR} )
+install(TARGETS VatesAPI ${SYSTEM_PACKAGE_TARGET} DESTINATION ${LIB_DIR})

--- a/qt/paraview_ext/VatesAlgorithms/CMakeLists.txt
+++ b/qt/paraview_ext/VatesAlgorithms/CMakeLists.txt
@@ -1,79 +1,97 @@
-#This is mainly here so you don't get a complaint when running cmake
-cmake_minimum_required( VERSION 3.5 )
+# This is mainly here so you don't get a complaint when running cmake
+cmake_minimum_required(VERSION 3.5)
 
-project( VatesAlgorithms )
+project(VatesAlgorithms)
 
-set( SRC_FILES
-src/LoadVTK.cpp
-src/SaveMDWorkspaceToVTK.cpp
-src/SaveMDWorkspaceToVTKImpl.cpp
-)
+set(SRC_FILES
+    src/LoadVTK.cpp
+    src/SaveMDWorkspaceToVTK.cpp
+    src/SaveMDWorkspaceToVTKImpl.cpp)
 
-set( INC_FILES
-inc/MantidVatesAlgorithms/LoadVTK.h
-inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTK.h
-inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTKImpl.h
-)
+set(INC_FILES
+    inc/MantidVatesAlgorithms/LoadVTK.h
+    inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTK.h
+    inc/MantidVatesAlgorithms/SaveMDWorkspaceToVTKImpl.h)
 
-set( TEST_FILES
-test/LoadVTKTest.h
-test/SaveMDWorkspaceToVTKTest.h
-test/SaveMDWorkspaceToVTKImplTest.h
-)
+set(TEST_FILES
+    test/LoadVTKTest.h
+    test/SaveMDWorkspaceToVTKTest.h
+    test/SaveMDWorkspaceToVTKImplTest.h)
 
-include_directories( inc ../VatesAPI/inc )
-include_directories ( SYSTEM ${PARAVIEW_INCLUDE_DIRS})
+include_directories(inc ../VatesAPI/inc)
+include_directories(SYSTEM ${PARAVIEW_INCLUDE_DIRS})
 
 # For Windows:
-add_definitions( -DIN_MANTID_VATESAPI )
+add_definitions(-DIN_MANTID_VATESAPI)
 # Add the target for this directory
-add_library( VatesAlgorithms ${SRC_FILES} ${INC_FILES} )
+add_library(VatesAlgorithms ${SRC_FILES} ${INC_FILES})
 # target properties
-set_target_properties ( VatesAlgorithms PROPERTIES OUTPUT_NAME MantidVatesAlgorithms
-  FOLDER "MantidVates"
-)
+set_target_properties(VatesAlgorithms
+                      PROPERTIES OUTPUT_NAME
+                                 MantidVatesAlgorithms
+                                 FOLDER
+                                 "MantidVates")
 
-target_link_libraries( VatesAlgorithms LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-${MANTID_SUBPROJECT_LIBS}
-VatesAPI
-vtkCommonCore
-vtkCommonDataModel
-${vtkjsoncpp_LIBRARIES}
-vtkIOLegacy
-vtkIOXML
-vtkInteractionStyle
-vtkRenderingFreeType
-vtkRenderingOpenGL2
-${POCO_LIBRARIES}
-)
+target_link_libraries(VatesAlgorithms
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${MANTID_SUBPROJECT_LIBS}
+                      VatesAPI
+                      vtkCommonCore
+                      vtkCommonDataModel
+                      ${vtkjsoncpp_LIBRARIES}
+                      vtkIOLegacy
+                      vtkIOXML
+                      vtkInteractionStyle
+                      vtkRenderingFreeType
+                      vtkRenderingOpenGL2
+                      ${POCO_LIBRARIES})
 
-if (OSX_VERSION VERSION_GREATER 10.8)
-  set_target_properties(VatesAlgorithms PROPERTIES INSTALL_RPATH "@loader_path/../Contents/MacOS;@loader_path/../Libraries")
-elseif ( ${CMAKE_SYSTEM_NAME} STREQUAL "Linux" )
-  set_target_properties(VatesAlgorithms PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR};\$ORIGIN/../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}")
-endif ()
+if(OSX_VERSION VERSION_GREATER 10.8)
+  set_target_properties(
+    VatesAlgorithms
+    PROPERTIES INSTALL_RPATH
+               "@loader_path/../Contents/MacOS;@loader_path/../Libraries")
+elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  set_target_properties(
+    VatesAlgorithms
+    PROPERTIES
+      INSTALL_RPATH
+      "\$ORIGIN/../${LIB_DIR};\$ORIGIN/../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
+    )
+endif()
 
 # Create test file projects
-include_directories ( SYSTEM ${CXXTEST_INCLUDE_DIR} ${GMOCK_INCLUDE_DIR} ${GTEST_INCLUDE_DIR} )
+include_directories(SYSTEM
+                    ${CXXTEST_INCLUDE_DIR}
+                    ${GMOCK_INCLUDE_DIR}
+                    ${GTEST_INCLUDE_DIR})
 
-include_directories( inc ../../../Framework/TestHelpers/inc ../../../Framework/DataHandling/inc ../../../Framework/DataObjects/inc ../../../Framework/MDAlgorithms/inc)
-set ( TESTHELPER_SRCS ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
-                      ../../../Framework/TestHelpers/src/MDEventsTestHelper.cpp
-                      ../../../Framework/TestHelpers/src/StartFrameworkManager.cpp )
-cxxtest_add_test( VatesAlgorithmsTest ${TEST_FILES} )
-target_link_libraries( VatesAlgorithmsTest LINK_PRIVATE ${TCMALLOC_LIBRARIES_LINKTIME}
-  ${MANTID_SUBPROJECT_LIBS}
-  Indexing
-  VatesAPI
-  VatesAlgorithms
-  ${POCO_LIBRARIES}
-  ${GMOCK_LIBRARIES}
-  ${GTEST_LIBRARIES}
-  )
-add_dependencies( AllTests VatesAlgorithmsTest )
+include_directories(inc
+                    ../../../Framework/TestHelpers/inc
+                    ../../../Framework/DataHandling/inc
+                    ../../../Framework/DataObjects/inc
+                    ../../../Framework/MDAlgorithms/inc)
+set(TESTHELPER_SRCS
+    ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+    ../../../Framework/TestHelpers/src/MDEventsTestHelper.cpp
+    ../../../Framework/TestHelpers/src/StartFrameworkManager.cpp)
+cxxtest_add_test(VatesAlgorithmsTest ${TEST_FILES})
+target_link_libraries(VatesAlgorithmsTest
+                      LINK_PRIVATE
+                      ${TCMALLOC_LIBRARIES_LINKTIME}
+                      ${MANTID_SUBPROJECT_LIBS}
+                      Indexing
+                      VatesAPI
+                      VatesAlgorithms
+                      ${POCO_LIBRARIES}
+                      ${GMOCK_LIBRARIES}
+                      ${GTEST_LIBRARIES})
+add_dependencies(AllTests VatesAlgorithmsTest)
 # Add to the 'UnitTests' group in VS
-set_property ( TARGET VatesAlgorithmsTest PROPERTY FOLDER "UnitTests" )
+set_property(TARGET VatesAlgorithmsTest PROPERTY FOLDER "UnitTests")
 
-install( TARGETS VatesAlgorithms ${SYSTEM_PACKAGE_TARGET} DESTINATION ${PLUGINS_DIR} )
+install(TARGETS VatesAlgorithms ${SYSTEM_PACKAGE_TARGET}
+        DESTINATION ${PLUGINS_DIR})

--- a/qt/paraview_ext/VatesSimpleGui/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/CMakeLists.txt
@@ -1,8 +1,8 @@
-set( VSI_GLOBAL_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/test/global/scripts )
+set(VSI_GLOBAL_SCRIPTS ${CMAKE_CURRENT_SOURCE_DIR}/test/global/scripts)
 
-add_subdirectory( QtWidgets )
-include_directories( QtWidgets/inc )
+add_subdirectory(QtWidgets)
+include_directories(QtWidgets/inc)
 
-set_mantid_subprojects( qt/paraview_ext/VatesAPI )
-add_subdirectory( ViewWidgets )
-include_directories( ViewWidgets/inc )
+set_mantid_subprojects(qt/paraview_ext/VatesAPI)
+add_subdirectory(ViewWidgets)
+include_directories(ViewWidgets/inc)

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
@@ -1,61 +1,66 @@
-project( MantidVatesSimpleGuiQtWidgets )
+project(MantidVatesSimpleGuiQtWidgets)
 
 # These are the C++ files to be compiled.
-set( INCLUDE_FILES
-  inc/MantidVatesSimpleGuiQtWidgets/AxisInformation.h
-  inc/MantidVatesSimpleGuiQtWidgets/GeometryParser.h
-  inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
-  inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
-  inc/MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h
-)
+set(INCLUDE_FILES
+    inc/MantidVatesSimpleGuiQtWidgets/AxisInformation.h
+    inc/MantidVatesSimpleGuiQtWidgets/GeometryParser.h
+    inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
+    inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
+    inc/MantidVatesSimpleGuiQtWidgets/WidgetDllOption.h)
 
-set( SOURCE_FILES
-  src/AxisInformation.cpp
-  src/GeometryParser.cpp
-  src/ModeControlWidget.cpp
-  src/RotationPointDialog.cpp
-)
+set(SOURCE_FILES
+    src/AxisInformation.cpp
+    src/GeometryParser.cpp
+    src/ModeControlWidget.cpp
+    src/RotationPointDialog.cpp)
 
-set( MOC_FILES
-  inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
-  inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h
-)
+set(MOC_FILES inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
+    inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h)
 
-set( RES_FILES icons/QtWidgetsIcons.qrc )
+set(RES_FILES icons/QtWidgetsIcons.qrc)
 
-set( UI_FILES
-  inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.ui
-  inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.ui
-)
+set(UI_FILES inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.ui
+    inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.ui)
 
-mtd_add_qt_library (TARGET_NAME VatesSimpleGuiQtWidgets
-  QT_VERSION 4
-  SRC ${SOURCE_FILES}
-  MOC ${MOC_FILES}
-  NOMOC ${INCLUDE_FILES}
-  UI ${UI_FILES}
-  RES ${RES_FILES}
-  DEFS IN_MANTID_VATES_SIMPLEGUI_QTWIDGETS
+mtd_add_qt_library(
+  TARGET_NAME
+  VatesSimpleGuiQtWidgets
+  QT_VERSION
+  4
+  SRC
+  ${SOURCE_FILES}
+  MOC
+  ${MOC_FILES}
+  NOMOC
+  ${INCLUDE_FILES}
+  UI
+  ${UI_FILES}
+  RES
+  ${RES_FILES}
+  DEFS
+  IN_MANTID_VATES_SIMPLEGUI_QTWIDGETS
   INCLUDE_DIRS
-    inc
+  inc
   LINK_LIBS
-    ${TCMALLOC_LIBRARIES_LINKTIME}
-    ${POCO_LIBRARIES}
-    ${MANTID_SUBPROJECT_LIBS}
+  ${TCMALLOC_LIBRARIES_LINKTIME}
+  ${POCO_LIBRARIES}
+  ${MANTID_SUBPROJECT_LIBS}
   QT4_LINK_LIBS
-    Qwt5
+  Qwt5
   MTD_QT_LINK_LIBS
-    MantidQtWidgetsCommon
+  MantidQtWidgetsCommon
   INSTALL_DIR_BASE
-      ${PLUGINS_DIR}
+  ${PLUGINS_DIR}
   OSX_INSTALL_RPATH
-    @loader_path/../../Contents/Libraries
-    @loader_path/../../Contents/MacOS
+  @loader_path/../../Contents/Libraries
+  @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
-)
+  "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
+  )
 
 # Set the name of the generated library
-set_target_properties( VatesSimpleGuiQtWidgetsQt4 PROPERTIES OUTPUT_NAME MantidVatesSimpleGuiQtWidgetsQt4 )
+set_target_properties(VatesSimpleGuiQtWidgetsQt4
+                      PROPERTIES OUTPUT_NAME MantidVatesSimpleGuiQtWidgetsQt4)
 # Add to the 'VatesSimpleGui' group in VS
-set_property( TARGET VatesSimpleGuiQtWidgetsQt4 PROPERTY FOLDER MantidVatesSimpleGui )
+set_property(TARGET VatesSimpleGuiQtWidgetsQt4
+             PROPERTY FOLDER MantidVatesSimpleGui)

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
@@ -25,37 +25,30 @@ set(UI_FILES inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.ui
 mtd_add_qt_library(
   TARGET_NAME
   VatesSimpleGuiQtWidgets
-  QT_VERSION
-  4
-  SRC
-  ${SOURCE_FILES}
-  MOC
-  ${MOC_FILES}
-  NOMOC
-  ${INCLUDE_FILES}
-  UI
-  ${UI_FILES}
-  RES
-  ${RES_FILES}
-  DEFS
-  IN_MANTID_VATES_SIMPLEGUI_QTWIDGETS
+  QT_VERSION 4
+  SRC ${SOURCE_FILES}
+  MOC ${MOC_FILES}
+  NOMOC ${INCLUDE_FILES}
+  UI ${UI_FILES}
+  RES ${RES_FILES}
+  DEFS IN_MANTID_VATES_SIMPLEGUI_QTWIDGETS
   INCLUDE_DIRS
-  inc
+    inc
   LINK_LIBS
-  ${TCMALLOC_LIBRARIES_LINKTIME}
-  ${POCO_LIBRARIES}
-  ${MANTID_SUBPROJECT_LIBS}
+    ${TCMALLOC_LIBRARIES_LINKTIME}
+    ${POCO_LIBRARIES}
+    ${MANTID_SUBPROJECT_LIBS}
   QT4_LINK_LIBS
-  Qwt5
+    Qwt5
   MTD_QT_LINK_LIBS
-  MantidQtWidgetsCommon
+    MantidQtWidgetsCommon
   INSTALL_DIR_BASE
-  ${PLUGINS_DIR}
+    ${PLUGINS_DIR}
   OSX_INSTALL_RPATH
-  @loader_path/../../Contents/Libraries
-  @loader_path/../../Contents/MacOS
+    @loader_path/../../Contents/Libraries
+    @loader_path/../../Contents/MacOS
   LINUX_INSTALL_RPATH
-  "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
+    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR}"
   )
 
 # Set the name of the generated library

--- a/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/QtWidgets/CMakeLists.txt
@@ -14,7 +14,8 @@ set(SOURCE_FILES
     src/ModeControlWidget.cpp
     src/RotationPointDialog.cpp)
 
-set(MOC_FILES inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
+set(MOC_FILES 
+    inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.h
     inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.h)
 
 set(RES_FILES icons/QtWidgetsIcons.qrc)
@@ -23,8 +24,7 @@ set(UI_FILES inc/MantidVatesSimpleGuiQtWidgets/ModeControlWidget.ui
     inc/MantidVatesSimpleGuiQtWidgets/RotationPointDialog.ui)
 
 mtd_add_qt_library(
-  TARGET_NAME
-  VatesSimpleGuiQtWidgets
+  TARGET_NAME VatesSimpleGuiQtWidgets
   QT_VERSION 4
   SRC ${SOURCE_FILES}
   MOC ${MOC_FILES}

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -1,101 +1,96 @@
-project( MantidVatesSimpleGuiViewWidgets )
+project(MantidVatesSimpleGuiViewWidgets)
 
 # These are the C++ files to be compiled.
-set( INCLUDE_FILES
-  inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
-  inc/MantidVatesSimpleGuiViewWidgets/CameraManager.h
-  inc/MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h
-  inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
-  inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/ColorUpdater.h
-  inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
-  inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
-  inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
-  inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
-  inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
-  inc/MantidVatesSimpleGuiViewWidgets/VisibleAxesColor.h
-  inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
-  inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
-  inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
-  inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
-  inc/MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h
-  inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
-)
+set(INCLUDE_FILES
+    inc/MantidVatesSimpleGuiViewWidgets/AutoScaleRangeGenerator.h
+    inc/MantidVatesSimpleGuiViewWidgets/CameraManager.h
+    inc/MantidVatesSimpleGuiViewWidgets/BackgroundRgbProvider.h
+    inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
+    inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/ColorUpdater.h
+    inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
+    inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
+    inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
+    inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
+    inc/MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
+    inc/MantidVatesSimpleGuiViewWidgets/VisibleAxesColor.h
+    inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+    inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
+    inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
+    inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+    inc/MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h
+    inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h)
 
-set( SOURCE_FILES
-  src/AutoScaleRangeGenerator.cpp
-  src/CameraManager.cpp
-  src/BackgroundRgbProvider.cpp
-  src/ColorMapEditorPanel.cpp
-  src/ColorSelectionWidget.cpp
-  src/ColorUpdater.cpp
-  src/MdViewerWidget.cpp
-  src/MultisliceView.cpp
-  src/RebinAlgorithmDialogProvider.cpp
-  src/PeaksTableControllerVsi.cpp
-  src/PeaksTabWidget.cpp
-  src/PeaksWidget.cpp
-  src/pqCameraToolbarNonOrthogonalAxes.cpp
-  src/pqCameraReactionNonOrthogonalAxes.cpp
-  src/RebinnedSourcesManager.cpp
-  src/VisibleAxesColor.cpp
-  src/StandardView.cpp
-  src/SplatterPlotView.cpp
-  src/ThreesliceView.cpp
-  src/TimeControlWidget.cpp
-  src/VatesParaViewApplication.cpp
-  src/ViewBase.cpp
-  src/VsiApplyBehaviour.cpp
-)
+set(SOURCE_FILES
+    src/AutoScaleRangeGenerator.cpp
+    src/CameraManager.cpp
+    src/BackgroundRgbProvider.cpp
+    src/ColorMapEditorPanel.cpp
+    src/ColorSelectionWidget.cpp
+    src/ColorUpdater.cpp
+    src/MdViewerWidget.cpp
+    src/MultisliceView.cpp
+    src/RebinAlgorithmDialogProvider.cpp
+    src/PeaksTableControllerVsi.cpp
+    src/PeaksTabWidget.cpp
+    src/PeaksWidget.cpp
+    src/pqCameraToolbarNonOrthogonalAxes.cpp
+    src/pqCameraReactionNonOrthogonalAxes.cpp
+    src/RebinnedSourcesManager.cpp
+    src/VisibleAxesColor.cpp
+    src/StandardView.cpp
+    src/SplatterPlotView.cpp
+    src/ThreesliceView.cpp
+    src/TimeControlWidget.cpp
+    src/VatesParaViewApplication.cpp
+    src/ViewBase.cpp
+    src/VsiApplyBehaviour.cpp)
 
-# These are the headers to be preprocessed using
-# Qt's moc preprocessor.
-set( MOC_FILES
-  inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
-  inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
-  inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
-  inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
-  inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
-  inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
-  inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
-  inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
-  inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
-  inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
-  inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h
-)
+# These are the headers to be preprocessed using Qt's moc preprocessor.
+set(MOC_FILES
+    inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.h
+    inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksTableControllerVsi.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.h
+    inc/MantidVatesSimpleGuiViewWidgets/pqCameraReactionNonOrthogonalAxes.h
+    inc/MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h
+    inc/MantidVatesSimpleGuiViewWidgets/StandardView.h
+    inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.h
+    inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.h
+    inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
+    inc/MantidVatesSimpleGuiViewWidgets/VatesParaViewApplication.h
+    inc/MantidVatesSimpleGuiViewWidgets/ViewBase.h
+    inc/MantidVatesSimpleGuiViewWidgets/VsiApplyBehaviour.h)
 
-# These are the ui files to be processed using
-# Qt's ui file processor.
-set( UI_FILES
-  inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.ui
-  inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.ui
-  inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.ui
-  inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.ui
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.ui
-  inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.ui
-  inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.ui
-  inc/MantidVatesSimpleGuiViewWidgets/StandardView.ui
-  inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.ui
-  inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.ui
-  inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.ui
-)
+# These are the ui files to be processed using Qt's ui file processor.
+set(UI_FILES
+    inc/MantidVatesSimpleGuiViewWidgets/ColorSelectionWidget.ui
+    inc/MantidVatesSimpleGuiViewWidgets/ColorMapEditorPanel.ui
+    inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.ui
+    inc/MantidVatesSimpleGuiViewWidgets/MultisliceView.ui
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksWidget.ui
+    inc/MantidVatesSimpleGuiViewWidgets/PeaksTabWidget.ui
+    inc/MantidVatesSimpleGuiViewWidgets/pqCameraToolbarNonOrthogonalAxes.ui
+    inc/MantidVatesSimpleGuiViewWidgets/StandardView.ui
+    inc/MantidVatesSimpleGuiViewWidgets/SplatterPlotView.ui
+    inc/MantidVatesSimpleGuiViewWidgets/ThreesliceView.ui
+    inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.ui)
 
 # Add the QtWidgets icons
-set ( RES_FILES ../../../resources/icons/ViewWidgetsIcons.qrc )
+set(RES_FILES ../../../resources/icons/ViewWidgetsIcons.qrc)
 
-mtd_add_qt_library (TARGET_NAME VatesSimpleGuiViewWidgets
+mtd_add_qt_library(
+  TARGET_NAME VatesSimpleGuiViewWidgets
   QT_VERSION 4
   SRC ${SOURCE_FILES}
   MOC ${MOC_FILES}
@@ -103,62 +98,65 @@ mtd_add_qt_library (TARGET_NAME VatesSimpleGuiViewWidgets
   UI ${UI_FILES}
   RES ${RES_FILES}
   DEFS
-    IN_MANTID_VATES_SIMPLEGUI_VIEWWIDGETS
+	IN_MANTID_VATES_SIMPLEGUI_VIEWWIDGETS
   INCLUDE_DIRS
-    inc
+	inc
   SYSTEM_INCLUDE_DIRS
-    ${PARAVIEW_INCLUDE_DIRS}
+	${PARAVIEW_INCLUDE_DIRS}
   LINK_LIBS
-    ${TCMALLOC_LIBRARIES_LINKTIME}
-    pqApplicationComponents
-    pqComponents
-    ${vtkjsoncpp_LIBRARIES}
-    vtkPVServerManagerRendering
-    vtkRenderingFreeType
-    vtksys
-    VatesAPI
-    ${PYTHON_LIBRARIES}
-    ${POCO_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${CORE_MANTIDLIBS}
-    DataObjects
+	${TCMALLOC_LIBRARIES_LINKTIME}
+	pqApplicationComponents
+	pqComponents
+	${vtkjsoncpp_LIBRARIES}
+	vtkPVServerManagerRendering
+	vtkRenderingFreeType
+	vtksys
+	VatesAPI
+	${PYTHON_LIBRARIES}
+	${POCO_LIBRARIES}
+	${Boost_LIBRARIES}
+	${CORE_MANTIDLIBS}
+	DataObjects
   QT4_LINK_LIBS
-    Qwt5
+	Qwt5
   MTD_QT_LINK_LIBS
-    MantidQtWidgetsCommon
-    MantidQtWidgetsLegacyQwt
-    VatesSimpleGuiQtWidgets
-    MantidQtWidgetsFactory
-    MantidQtWidgetsSliceViewer
+	MantidQtWidgetsCommon
+	MantidQtWidgetsLegacyQwt
+	VatesSimpleGuiQtWidgets
+	MantidQtWidgetsFactory
+	MantidQtWidgetsSliceViewer
   INSTALL_DIR_BASE
-    ${PLUGINS_DIR}
+	${PLUGINS_DIR}
   OSX_INSTALL_RPATH
-    @loader_path/../../Contents/MacOS
-    @loader_path/../../Contents/Libraries
+	@loader_path/../../Contents/MacOS
+	@loader_path/../../Contents/Libraries
   LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR};\$ORIGIN"
-)
+	"\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../${LIB_DIR}/paraview-${ParaView_VERSION_MAJOR}.${ParaView_VERSION_MINOR};\$ORIGIN"
+  )
 
 # Set the name of the generated library
-set_target_properties( VatesSimpleGuiViewWidgetsQt4 PROPERTIES OUTPUT_NAME MantidVatesSimpleGuiViewWidgetsQt4 )
+set_target_properties(VatesSimpleGuiViewWidgetsQt4
+                      PROPERTIES OUTPUT_NAME MantidVatesSimpleGuiViewWidgetsQt4)
 # Add to the 'VatesSimpleGui' group in VS
-set_property( TARGET VatesSimpleGuiViewWidgetsQt4 PROPERTY FOLDER MantidVatesSimpleGui )
+set_property(TARGET VatesSimpleGuiViewWidgetsQt4
+             PROPERTY FOLDER MantidVatesSimpleGui)
 
-if( SQUISH_FOUND )
+if(SQUISH_FOUND)
   # Need to set the AUT first
-  set( SQUISH_AUT MantidPlot )
-  set( SQUISH_AUT_PATH $<TARGET_FILE_DIR:${SQUISH_AUT}> )
+  set(SQUISH_AUT MantidPlot)
+  set(SQUISH_AUT_PATH $<TARGET_FILE_DIR:${SQUISH_AUT}>)
 
   # Need to set environmental variables next
-  set( SQUISH_ENV_VARS
+  set(
+    SQUISH_ENV_VARS
     PV_PLUGIN_PATH=$<TARGET_FILE_DIR:${SQUISH_AUT}>/${PVPLUGINS_DIR}/${PVPLUGINS_DIR}
     SCRIPTS_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test/mp_scripts
     SQUISH_SCRIPT_DIR=${VSI_GLOBAL_SCRIPTS}:${CMAKE_CURRENT_SOURCE_DIR}/test/common/scripts
-  )
-  set( TEST_SUITES
-    test/suite_MDEventWorkspace
-    test/suite_MDHistoWorkspace
-  )
-  squish_add_test_suite( ${TEST_SUITES} )
+    )
+  set(TEST_SUITES
+      test/suite_MDEventWorkspace
+	  test/suite_MDHistoWorkspace)
+
+  squish_add_test_suite(${TEST_SUITES})
 
 endif()

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/CMakeLists.txt
@@ -155,7 +155,7 @@ if(SQUISH_FOUND)
     )
   set(TEST_SUITES
       test/suite_MDEventWorkspace
-	  test/suite_MDHistoWorkspace)
+      test/suite_MDHistoWorkspace)
 
   squish_add_test_suite(${TEST_SUITES})
 

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This file manages building/installation of the mantidqt and mantidqtpython
 # Python wrappers.
-#
+
 include(PythonPackageTargetFunctions)
 
 # Legacy wrappers for MantidPlot
@@ -8,10 +8,7 @@ if(ENABLE_MANTIDPLOT)
   add_subdirectory(mantidqtpython)
 endif()
 
-#
 # mantidqt
-#
-
 if(ENABLE_WORKBENCH)
   # The default value is just an empty string - this prevents a Python syntax
   # error when not on Windows Configure utils.qt.plugins file for build. It is
@@ -60,9 +57,8 @@ if(ENABLE_WORKBENCH)
       COMMENT "Copying debug PyQt5 to bin/Debug")
   endif()
 
-  #
+ 
   # Testing
-  #
 
   # ctest targets
   set(

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -1,82 +1,78 @@
 # This file manages building/installation of the mantidqt and mantidqtpython
 # Python wrappers.
 #
-include ( PythonPackageTargetFunctions )
+include(PythonPackageTargetFunctions)
 
 # Legacy wrappers for MantidPlot
-if ( ENABLE_MANTIDPLOT )
-  add_subdirectory ( mantidqtpython )
+if(ENABLE_MANTIDPLOT)
+  add_subdirectory(mantidqtpython)
 endif()
 
-###########################################################################
+#
 # mantidqt
-###########################################################################
+#
 
-if ( ENABLE_WORKBENCH )
-  # The default value is just an empty string - this prevents a Python syntax error when not on Windows
-  # Configure utils.qt.plugins file for build. It is placed in the source
-  # directory and added to the .gitignore for simplicity.
-  if ( WIN32 )
+if(ENABLE_WORKBENCH)
+  # The default value is just an empty string - this prevents a Python syntax
+  # error when not on Windows Configure utils.qt.plugins file for build. It is
+  # placed in the source directory and added to the .gitignore for simplicity.
+  if(WIN32)
     # Note: single quotes are added here to make this a Python string
-    set ( QT_PLUGINS_PATH "${THIRD_PARTY_DIR}/lib/qt%V/plugins" )
-  endif ()
-  # Configure the file necessary for DEVELOPMENT builds to run and detect Qt's plugins
-  configure_file ( mantidqt/utils/qt/plugins.py.in ${CMAKE_CURRENT_SOURCE_DIR}/mantidqt/utils/qt/plugins.py )
-  add_python_package ( mantidqt )
+    set(QT_PLUGINS_PATH "${THIRD_PARTY_DIR}/lib/qt%V/plugins")
+  endif()
+  # Configure the file necessary for DEVELOPMENT builds to run and detect Qt's
+  # plugins
+  configure_file(mantidqt/utils/qt/plugins.py.in
+                 ${CMAKE_CURRENT_SOURCE_DIR}/mantidqt/utils/qt/plugins.py)
+  add_python_package(mantidqt)
 
-  # Configure resources data in place for ease of development. The output
-  # file is added to the toplevel gitignore
-  set ( _qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc )
-  set ( _output_res_py ${CMAKE_CURRENT_LIST_DIR}/mantidqt/resources.py )
-  configure_file ( create_resources.cmake.in create_resources.cmake @ONLY)
-  add_custom_command ( OUTPUT ${_output_res_py}
-    COMMAND ${CMAKE_COMMAND} -P create_resources.cmake
-    COMMENT "Generating mantidqt resources module"
-    DEPENDS ${_qrc_file}
-  )
-  add_custom_target ( mantidqt_resources ALL DEPENDS ${_output_res_py} )
+  # Configure resources data in place for ease of development. The output file
+  # is added to the toplevel gitignore
+  set(_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
+  set(_output_res_py ${CMAKE_CURRENT_LIST_DIR}/mantidqt/resources.py)
+  configure_file(create_resources.cmake.in create_resources.cmake @ONLY)
+  add_custom_command(OUTPUT ${_output_res_py}
+                     COMMAND ${CMAKE_COMMAND} -P create_resources.cmake
+                     COMMENT "Generating mantidqt resources module"
+                     DEPENDS ${_qrc_file})
+  add_custom_target(mantidqt_resources ALL DEPENDS ${_output_res_py})
 
   # Now add any compiled sip targets
-  add_subdirectory ( mantidqt )
+  add_subdirectory(mantidqt)
 
   # Setup dependency chain
-  add_dependencies ( mantidqt
-    mantidqt_resources
-    mantidqt_commonqt5
-    mantidqt_instrumentviewqt5
-  )
+  add_dependencies(mantidqt
+                   mantidqt_resources
+                   mantidqt_commonqt5
+                   mantidqt_instrumentviewqt5)
 
-  if ( ENABLE_MANTIDPLOT )
-    add_dependencies ( mantidqt mantidqt_commonqt4 )
+  if(ENABLE_MANTIDPLOT)
+    add_dependencies(mantidqt mantidqt_commonqt4)
   endif()
 
-  if ( MSVC )
+  if(MSVC)
     # Debug builds need libraries that are linked with MSVC debug runtime
-    add_custom_command (
-      TARGET mantidqt
-      POST_BUILD
-      COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND}
-        -E copy_directory ${PYTHON_DIR}/msvc-site-packages/debug/PyQt5 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt5
-      COMMENT "Copying debug PyQt5 to bin/Debug"
-    )
-endif ()
+    add_custom_command(
+      TARGET mantidqt POST_BUILD
+      COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
+              ${PYTHON_DIR}/msvc-site-packages/debug/PyQt5
+              ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt5
+      COMMENT "Copying debug PyQt5 to bin/Debug")
+  endif()
 
-
-  ##########################################################################
+  #
   # Testing
-  ##########################################################################
+  #
 
   # ctest targets
-  set ( PYTHON_TEST_FILES
+  set(
+    PYTHON_TEST_FILES
     mantidqt/test/test_algorithm_observer.py
     mantidqt/test/test_import.py
-
     mantidqt/dialogs/test/test_algorithm_dialog.py
     mantidqt/dialogs/test/test_spectraselectiondialog.py
-
     mantidqt/plotting/test/test_figuretype.py
     mantidqt/plotting/test/test_functions.py
-
     mantidqt/project/test/test_plotssaver.py
     mantidqt/project/test/test_plotsloader.py
     mantidqt/project/test/test_project.py
@@ -84,79 +80,64 @@ endif ()
     mantidqt/project/test/test_projectsaver.py
     mantidqt/project/test/test_workspaceloader.py
     mantidqt/project/test/test_workspacesaver.py
-
     mantidqt/utils/test/test_async.py
     mantidqt/utils/test/test_modal_tester.py
     mantidqt/utils/test/test_qt_utils.py
     mantidqt/utils/test/test_writetosignal.py
-
     mantidqt/widgets/codeeditor/test/test_codeeditor.py
     mantidqt/widgets/codeeditor/test/test_errorformatter.py
     mantidqt/widgets/codeeditor/test/test_execution.py
     mantidqt/widgets/codeeditor/test/test_interpreter.py
-
     mantidqt/widgets/test/test_messagedisplay.py
     mantidqt/widgets/test/test_fitpropertybrowser.py
-
     mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
-
     mantidqt/widgets/observers/test/test_ads_observer.py
     mantidqt/widgets/observers/test/test_observing_presenter.py
     mantidqt/widgets/observers/test/test_observing_view.py
-
     mantidqt/widgets/embedded_find_replace_dialog/test/test_embedded_find_replace_dialog_presenter.py
-
     mantidqt/widgets/workspacedisplay/test/test_data_copier.py
     mantidqt/widgets/workspacedisplay/test/test_user_notifier.py
-
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_model.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
-
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_workbench_table_widget_item.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
-  )
+    )
 
-  # ctest target for widgets that only get tested in qt5, because they are only used in the workbench
-  set ( PYTHON_WIDGET_QT5_ONLY_TESTS
+  # ctest target for widgets that only get tested in qt5, because they are only
+  # used in the workbench
+  set(
+    PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/algorithmselector/test/observer_test.py
     mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
-
     mantidqt/widgets/codeeditor/test/test_interpreter_view.py
     mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
     mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
-
     mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_presenter.py
     mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
-
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
-
     mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
-
     mantidqt/widgets/test/test_jupyterconsole.py
-
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
-
-    mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
- )
+    mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py)
 
   # Tests
-  set ( PYUNITTEST_RUN_SERIAL ON )
-  set ( PYUNITTEST_QT_API pyqt5 )
-  pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR}
-    mantidqt_qt5 ${PYTHON_TEST_FILES} ${PYTHON_WIDGET_QT5_ONLY_TESTS}
-  )
-  set ( PYUNITTEST_QT_API pyqt )
-  pyunittest_add_test ( ${CMAKE_CURRENT_SOURCE_DIR}
-    mantidqt_qt4 ${PYTHON_TEST_FILES}
-  )
-  unset ( PYUNITTEST_QT_API )
-endif ()
+  set(PYUNITTEST_RUN_SERIAL ON)
+  set(PYUNITTEST_QT_API pyqt5)
+  pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR}
+                      mantidqt_qt5
+                      ${PYTHON_TEST_FILES}
+                      ${PYTHON_WIDGET_QT5_ONLY_TESTS})
+  set(PYUNITTEST_QT_API pyqt)
+  pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} mantidqt_qt4
+                      ${PYTHON_TEST_FILES})
+  unset(PYUNITTEST_QT_API)
+endif()

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -1,97 +1,92 @@
-include ( SipQtTargetFunctions )
+include(SipQtTargetFunctions)
 
-set ( COMMON_INC_DIR ../../widgets/common/inc )
-set ( COMMON_SIP_DIR ../common_sip )
-set ( _header_depends
+set(COMMON_INC_DIR ../../widgets/common/inc)
+set(COMMON_SIP_DIR ../common_sip)
+set(
+  _header_depends
   ${COMMON_SIP_DIR}/SIPVector.h
   ${COMMON_SIP_DIR}/string.sip
   ${COMMON_SIP_DIR}/vector.sip
-
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/AlgorithmDialog.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/Message.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/MessageDisplay.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/HintStrategy.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/Hint.h
-
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/Batch/Row.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/Batch/RowLocation.h
   ${COMMON_INC_DIR}/MantidQtWidgets/Common/Batch/JobTreeView.h
-  ${COMMON_INC_DIR}/MantidQtWidgets/Common/Batch/JobTreeViewSignalAdapter.h
-)
+  ${COMMON_INC_DIR}/MantidQtWidgets/Common/Batch/JobTreeViewSignalAdapter.h)
 
-find_package ( BoostPython REQUIRED )
+find_package(BoostPython REQUIRED)
 
-list ( APPEND common_link_libs
-  ${TCMALLOC_LIBRARIES_LINKTIME}
-  ${CORE_MANTIDLIBS}
-  ${POCO_LIBRARIES}
-  ${PYTHON_LIBRARIES}
-)
+list(APPEND common_link_libs
+            ${TCMALLOC_LIBRARIES_LINKTIME}
+            ${CORE_MANTIDLIBS}
+            ${POCO_LIBRARIES}
+            ${PYTHON_LIBRARIES})
 
 # Wrapper module linked against Qt4
-if ( ENABLE_MANTIDPLOT )
-  mtd_add_sip_module (
-    MODULE_NAME _commonqt4
-    TARGET_NAME mantidqt_commonqt4
-    SIP_SRCS _common.sip
-    HEADER_DEPS ${_header_depends}
-    PYQT_VERSION 4
-    INCLUDE_DIRS
-      ${CMAKE_CURRENT_LIST_DIR}
-      ${COMMON_SIP_DIR}
-      ${PYTHON_INCLUDE_PATH}
-      ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc
-    LINK_LIBS
-      ${common_link_libs}
-      MantidQtWidgetsCommonQt4
-      Qt4::QtCore
-      Qt4::QtGui
-      Qt4::Qscintilla
-      ${Boost_LIBRARIES}
-      API
-    INSTALL_DIR
-      ${LIB_DIR}/mantidqt
-    LINUX_INSTALL_RPATH
-      "\$ORIGIN/.."
-    OSX_INSTALL_RPATH
-      "@loader_path/.."
-    FOLDER Qt4
-  )
+if(ENABLE_MANTIDPLOT)
+  mtd_add_sip_module(MODULE_NAME _commonqt4
+                     TARGET_NAME mantidqt_commonqt4
+                     SIP_SRCS _common.sip
+                     HEADER_DEPS
+                       ${_header_depends}
+                     PYQT_VERSION 4
+                     INCLUDE_DIRS
+                       ${CMAKE_CURRENT_LIST_DIR}
+                       ${COMMON_SIP_DIR}
+                       ${PYTHON_INCLUDE_PATH}
+                       ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc
+                     LINK_LIBS
+                       ${common_link_libs}
+                       MantidQtWidgetsCommonQt4
+                       Qt4::QtCore
+                       Qt4::QtGui
+                       Qt4::Qscintilla
+                       ${Boost_LIBRARIES}
+                       API
+                     INSTALL_DIR
+                       ${LIB_DIR}/mantidqt
+                     LINUX_INSTALL_RPATH
+                       "\$ORIGIN/.."
+                     OSX_INSTALL_RPATH
+                       "@loader_path/.."
+                     FOLDER Qt4)
 endif()
 
 # Wrapper module linked against Qt5
-if ( ENABLE_WORKBENCH )
-  find_package ( QScintillaQt5 REQUIRED )
+if(ENABLE_WORKBENCH)
+  find_package(QScintillaQt5 REQUIRED)
 
-  mtd_add_sip_module (
-    MODULE_NAME _commonqt5
-    TARGET_NAME mantidqt_commonqt5
-    SIP_SRCS _common.sip
-    HEADER_DEPS ${_header_depends}
-    PYQT_VERSION 5
-    INCLUDE_DIRS
-      ${CMAKE_CURRENT_LIST_DIR}
-      ${COMMON_SIP_DIR}
-      ${PYTHON_INCLUDE_PATH}
-      ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc
-    LINK_LIBS
-      ${common_link_libs}
-      MantidQtWidgetsCommonQt5
-      Qt5::Core
-      Qt5::Gui
-      Qt5::Widgets
-      Qt5::Qscintilla
-      ${Boost_LIBRARIES}
-      API
-    INSTALL_DIR
-      ${WORKBENCH_LIB_DIR}/mantidqt
-    LINUX_INSTALL_RPATH
-      "\$ORIGIN/.."
-    OSX_INSTALL_RPATH
-      "@loader_path/.." 
-    FOLDER Qt5
-  )
+  mtd_add_sip_module(MODULE_NAME _commonqt5
+                     TARGET_NAME mantidqt_commonqt5
+                     SIP_SRCS _common.sip
+                     HEADER_DEPS
+                       ${_header_depends}
+                     PYQT_VERSION 5
+                     INCLUDE_DIRS
+                       ${CMAKE_CURRENT_LIST_DIR}
+                       ${COMMON_SIP_DIR}
+                       ${PYTHON_INCLUDE_PATH}
+                       ${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc
+                     LINK_LIBS
+                       ${common_link_libs}
+                       MantidQtWidgetsCommonQt5
+                       Qt5::Core
+                       Qt5::Gui
+                       Qt5::Widgets
+                       Qt5::Qscintilla
+                     ${Boost_LIBRARIES}
+                       API
+                     INSTALL_DIR
+                       ${WORKBENCH_LIB_DIR}/mantidqt
+                     LINUX_INSTALL_RPATH
+                       "\$ORIGIN/.."
+                     OSX_INSTALL_RPATH
+                       "@loader_path/.."
+                     FOLDER Qt5)
 endif()
 
-add_subdirectory ( widgets/instrumentview )
+add_subdirectory(widgets/instrumentview)

--- a/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
@@ -11,7 +11,7 @@ mtd_add_sip_module(MODULE_NAME _instrumentviewqt5
                    SIP_SRCS _instrumentview.sip
                    PYQT_VERSION 5
                    INCLUDE_DIRS
-				     ${PYTHON_INCLUDE_PATH}
+                     ${PYTHON_INCLUDE_PATH}
                    LINK_LIBS
                      ${common_link_libs}
                      MantidQtWidgetsInstrumentViewQt5

--- a/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/python/mantidqt/widgets/instrumentview/CMakeLists.txt
@@ -1,34 +1,30 @@
-# Defines a Python wrapper module for instrument view access
-# This wraps the low-level classes.
+# Defines a Python wrapper module for instrument view access This wraps the low-
+# level classes.
 
-set ( INSTRUMENTVIEW_INC_DIR ../../widgets/instrumentview/inc )
-set ( _header_depends
-  ${INSTRUMENTVIEW_INC_DIR}/InstrumentWidget.h
-)
+set(INSTRUMENTVIEW_INC_DIR ../../widgets/instrumentview/inc)
+set(_header_depends
+    ${INSTRUMENTVIEW_INC_DIR}/InstrumentWidget.h)
 
-# The wrapper is only defined for Qt5 and does not support
-# legacy Qt4 mode
-mtd_add_sip_module (
-  MODULE_NAME _instrumentviewqt5
-  TARGET_NAME mantidqt_instrumentviewqt5
-  SIP_SRCS _instrumentview.sip
-  PYQT_VERSION 5
-  INCLUDE_DIRS
-    ${PYTHON_INCLUDE_PATH}
-  LINK_LIBS
-    ${common_link_libs}
-    MantidQtWidgetsInstrumentViewQt5
-    MantidQtWidgetsCommonQt5
-    MantidQtWidgetsMplCppQt5
-    Qt5::Core
-    Qt5::Gui
-    Qt5::OpenGL
-    Qt5::Widgets
-  INSTALL_DIR
-    ${WORKBENCH_LIB_DIR}/mantidqt/widgets/instrumentview
-  LINUX_INSTALL_RPATH
-    "\$ORIGIN/../../.."
-  OSX_INSTALL_RPATH
-    "@loader_path/../../.." 
-  FOLDER Qt5
-)
+# The wrapper is only defined for Qt5 and does not support legacy Qt4 mode
+mtd_add_sip_module(MODULE_NAME _instrumentviewqt5
+                   TARGET_NAME mantidqt_instrumentviewqt5
+                   SIP_SRCS _instrumentview.sip
+                   PYQT_VERSION 5
+                   INCLUDE_DIRS
+				     ${PYTHON_INCLUDE_PATH}
+                   LINK_LIBS
+                     ${common_link_libs}
+                     MantidQtWidgetsInstrumentViewQt5
+                     MantidQtWidgetsCommonQt5
+                     MantidQtWidgetsMplCppQt5
+                     Qt5::Core
+                     Qt5::Gui
+                     Qt5::OpenGL
+                     Qt5::Widgets
+                   INSTALL_DIR
+                      ${WORKBENCH_LIB_DIR}/mantidqt/widgets/instrumentview
+                   LINUX_INSTALL_RPATH
+                     "\$ORIGIN/../../.."
+                   OSX_INSTALL_RPATH
+                     "@loader_path/../../.."
+                   FOLDER Qt5)

--- a/qt/python/mantidqtpython/CMakeLists.txt
+++ b/qt/python/mantidqtpython/CMakeLists.txt
@@ -1,4 +1,3 @@
-#
 # Python bindings for legacy mantidqtpython library This is a Qt4-only module
 # and serves to support MantidPlot alone.
 include(SipQtTargetFunctions)
@@ -128,8 +127,5 @@ if(MSVC)
     COMMENT "Copying debug PyQt4 to bin")
 endif()
 
-#
 # Installation settings
-#
-
 install(TARGETS mantidqtpython DESTINATION ${BIN_DIR})

--- a/qt/python/mantidqtpython/CMakeLists.txt
+++ b/qt/python/mantidqtpython/CMakeLists.txt
@@ -1,24 +1,24 @@
 #
-# Python bindings for legacy mantidqtpython library
-# This is a Qt4-only module and serves to support MantidPlot alone.
-include ( SipQtTargetFunctions )
+# Python bindings for legacy mantidqtpython library This is a Qt4-only module
+# and serves to support MantidPlot alone.
+include(SipQtTargetFunctions)
 
-set ( WIDGETS_DIR ../../widgets )
-set ( FACTORY_INC ${WIDGETS_DIR}/factory/inc )
-set ( WIDGETS_COMMON_INC ${WIDGETS_DIR}/common/inc )
-set ( DATAPROCESSOR_INC ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/DataProcessorUI )
-set ( INSTRUMENT_VIEW_INC ${WIDGETS_DIR}/instrumentview/inc )
-set ( SLICEVIEWER_INC ${WIDGETS_DIR}/sliceviewer/inc )
-set ( REFVIEWER_INC ${WIDGETS_DIR}/refdetectorview/inc )
-set ( COMMON_SIP_DIR ../common_sip )
-set ( HEADER_DEPENDS
+set(WIDGETS_DIR ../../widgets)
+set(FACTORY_INC ${WIDGETS_DIR}/factory/inc)
+set(WIDGETS_COMMON_INC ${WIDGETS_DIR}/common/inc)
+set(DATAPROCESSOR_INC
+    ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/DataProcessorUI)
+set(INSTRUMENT_VIEW_INC ${WIDGETS_DIR}/instrumentview/inc)
+set(SLICEVIEWER_INC ${WIDGETS_DIR}/sliceviewer/inc)
+set(REFVIEWER_INC ${WIDGETS_DIR}/refdetectorview/inc)
+set(COMMON_SIP_DIR ../common_sip)
+set(
+  HEADER_DEPENDS
   ${COMMON_SIP_DIR}/SIPVector.h
   ${COMMON_SIP_DIR}/string.sip
   ${COMMON_SIP_DIR}/vector.sip
   ../../../Framework/PythonInterface/core/inc/MantidPythonInterface/core/VersionCompat.h
-
   ${FACTORY_INC}/MantidQtWidgets/Factory/WidgetFactory.h
-
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/WorkspaceObserver.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/GraphOptions.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/AlgorithmDialog.h
@@ -33,22 +33,18 @@ set ( HEADER_DEPENDS
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/ManageUserDirectories.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/HintStrategy.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/Hint.h
-
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/Batch/Row.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/Batch/RowLocation.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/Batch/JobTreeView.h
   ${WIDGETS_COMMON_INC}/MantidQtWidgets/Common/Batch/JobTreeViewSignalAdapter.h
-
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/SliceViewerWindow.h
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/LineViewer.h
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/PeaksPresenter.h
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/ProxyCompositePeaksPresenter.h
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/PeaksPresenter.h
   ${SLICEVIEWER_INC}/MantidQtWidgets/SliceViewer/SliceViewer.h
-
   ${REFVIEWER_INC}/MantidQtWidgets/RefDetectorView/RefIVConnections.h
   ${REFVIEWER_INC}/MantidQtWidgets/RefDetectorView/RefMatrixWSImageView.h
-
   ${DATAPROCESSOR_INC}/WhiteList.h
   ${DATAPROCESSOR_INC}/PreprocessMap.h
   ${DATAPROCESSOR_INC}/ProcessingAlgorithm.h
@@ -77,64 +73,63 @@ set ( HEADER_DEPENDS
   ${DATAPROCESSOR_INC}/SaveTableAsCommand.h
   ${DATAPROCESSOR_INC}/SeparatorCommand.h
   ${DATAPROCESSOR_INC}/WorkspaceCommand.h
-
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidget.h
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
   ${INSTRUMENT_VIEW_INC}/MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h
-)
-
-mtd_add_sip_module (
-  MODULE_NAME mantidqtpython
-  TARGET_NAME mantidqtpython
-  SIP_SRCS mantidqtpython_def.sip
-  HEADER_DEPS ${HEADER_DEPENDS}
-  INCLUDE_DIRS
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${COMMON_SIP_DIR}
-    ${PYTHON_INCLUDE_PATH}
-    ../../../Framework/PythonInterface/core/inc
-  PYQT_VERSION 4
-  LINK_LIBS ${TCMALLOC_LIBRARIES_LINKTIME}
-    MantidQtWidgetsCommonQt4
-    MantidQtWidgetsLegacyQwtQt4
-    MantidQtWidgetsSliceViewerQt4
-    MantidQtWidgetsFactoryQt4
-    MantidQtWidgetsRefDetectorViewQt4
-    MantidQtWidgetsSpectrumViewerQt4
-    MantidQtWidgetsInstrumentViewQt4
-    ${CORE_MANTIDLIBS}
-    ${POCO_LIBRARIES}
-    ${Boost_LIBRARIES}
-    Qt4::QtCore
-    Qt4::QtGui
-    Qt4::QtOpenGL
-    Qwt5
-    ${PYTHON_LIBRARIES}
-  FOLDER Qt4
-  OSX_INSTALL_RPATH
-    @loader_path/../Contents/MacOS
-  LINUX_INSTALL_RPATH
-    "\$ORIGIN/../${LIB_DIR}"
-)
-
-if ( MSVC )
-  # Windows: Python library name needs to end in .pyd for Windows
-  # Debug python library expects imported module names to end in _d
-  # For a debug build copy the special PyQt4 debug build to the bin directory
-  add_custom_command (
-    TARGET mantidqtpython
-    POST_BUILD
-    COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND}
-      -E copy_directory ${PYTHON_DIR}/msvc-site-packages/debug/PyQt4 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt4
-    COMMENT "Copying debug PyQt4 to bin"
   )
-endif ()
 
-###########################################################################
+mtd_add_sip_module(MODULE_NAME mantidqtpython
+                   TARGET_NAME mantidqtpython
+                   SIP_SRCS mantidqtpython_def.sip
+                   HEADER_DEPS
+                     ${HEADER_DEPENDS}
+                   INCLUDE_DIRS
+                     ${CMAKE_CURRENT_LIST_DIR}
+                     ${COMMON_SIP_DIR}
+                     ${PYTHON_INCLUDE_PATH}
+                     ../../../Framework/PythonInterface/core/inc
+                   PYQT_VERSION 4
+                   LINK_LIBS
+                     ${TCMALLOC_LIBRARIES_LINKTIME}
+                     MantidQtWidgetsCommonQt4
+                     MantidQtWidgetsLegacyQwtQt4
+                     MantidQtWidgetsSliceViewerQt4
+                     MantidQtWidgetsFactoryQt4
+                     MantidQtWidgetsRefDetectorViewQt4
+                     MantidQtWidgetsSpectrumViewerQt4
+                     MantidQtWidgetsInstrumentViewQt4
+                     ${CORE_MANTIDLIBS}
+                     ${POCO_LIBRARIES}
+                     ${Boost_LIBRARIES}
+                     Qt4::QtCore
+                     Qt4::QtGui
+                     Qt4::QtOpenGL
+                     Qwt5
+                     ${PYTHON_LIBRARIES}
+                   FOLDER Qt4
+                   OSX_INSTALL_RPATH
+                     @loader_path/../Contents/MacOS
+                   LINUX_INSTALL_RPATH
+                     "\$ORIGIN/../${LIB_DIR}")
+
+if(MSVC)
+  # Windows: Python library name needs to end in .pyd for Windows Debug python
+  # library expects imported module names to end in _d For a debug build copy
+  # the special PyQt4 debug build to the bin directory
+  add_custom_command(
+    TARGET mantidqtpython
+	POST_BUILD
+    COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
+            ${PYTHON_DIR}/msvc-site-packages/debug/PyQt4
+            ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt4
+    COMMENT "Copying debug PyQt4 to bin")
+endif()
+
+#
 # Installation settings
-###########################################################################
+#
 
-install ( TARGETS mantidqtpython DESTINATION ${BIN_DIR} )
+install(TARGETS mantidqtpython DESTINATION ${BIN_DIR})


### PR DESCRIPTION
**Description of work.**
This PR formats the CMake files to make them easier to read. This has been done using [cmake_format](https://github.com/cheshirekow/cmake_format). This is for the files in qt from applications to python.

**To test:**
Read through and check it is easy to read and that no changes have been made that will effect the functionality of the file.

Fixes #25003 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
