### PR TITLE
Indirect Iqt - Extra validation of input data

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TransformToIqt.py
@@ -237,8 +237,9 @@ class TransformToIqt(PythonAlgorithm):
         from IndirectCommon import CheckHistZero, CheckHistSame
 
         # Process resolution data
-        num_res_hist = CheckHistZero(self._resolution)[0]
-        if num_res_hist > 1:
+        res_number_of_histograms = CheckHistZero(self._resolution)[0]
+        sample_number_of_histograms = CheckHistZero(self._sample)[0]
+        if res_number_of_histograms > 1 and sample_number_of_histograms is not res_number_of_histograms:
             CheckHistSame(
                 self._sample,
                 'Sample',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
@@ -31,8 +31,6 @@ class TransformToIqtTest(unittest.TestCase):
         self._param_table.addColumn('float', 'Resolution')
         self._param_table.addColumn('int', 'ResolutionBins')
 
-        self._param_table.addRow([1725, 10.0, 172, -0.5, 0.5, 0.00581395, 0.01845, 6])
-
 
     def test_with_can_reduction(self):
         """
@@ -46,6 +44,7 @@ class TransformToIqtTest(unittest.TestCase):
                                      ResolutionWorkspace=can,
                                      BinReductionFactor=10)
 
+        self._param_table.addRow([1725, 10.0, 172, -0.5, 0.5, 0.00581395, 0.01845, 6])
         self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
@@ -61,6 +60,7 @@ class TransformToIqtTest(unittest.TestCase):
                                      ResolutionWorkspace=resolution,
                                      BinReductionFactor=10)
 
+        self._param_table.addRow([1725, 10.0, 172, -0.5, 0.5, 0.00581395, 0.01845, 6])
         self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
@@ -76,10 +76,8 @@ class TransformToIqtTest(unittest.TestCase):
                                      ResolutionWorkspace=resolution,
                                      BinReductionFactor=10)
 
-        expected_param_table = Load('TransformToIqt_ParamTable_Expected')
-        expected_iqt = Load('TransformToIqt_Iqt_Expected')
-        self.assertTrue(CompareWorkspaces(params, expected_param_table, 1e-8)[0])
-        self.assertTrue(CompareWorkspaces(iqt, expected_iqt, 1e-8)[0])
+        self._param_table.addRow([1724, 10.0, 172, -0.5, 0.5, 0.00581395, 0.0175, 6])
+        self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TransformToIqtTest.py
@@ -64,5 +64,23 @@ class TransformToIqtTest(unittest.TestCase):
         self.assertTrue(CompareWorkspaces(params, self._param_table, 1e-8)[0])
 
 
+    def test_TransformToIqt_using_workspaces_with_equal_numbers_of_histograms_but_different_x_lengths(self):
+        """
+        Tests running TransformToIqt using a sample and resolution with the same number of histograms but different
+        x lengths.
+        """
+        sample = Load('iris26184_multi_graphite002_red')
+        resolution = Load('irs26176_graphite002_red')
+
+        params, iqt = TransformToIqt(SampleWorkspace=sample,
+                                     ResolutionWorkspace=resolution,
+                                     BinReductionFactor=10)
+
+        expected_param_table = Load('TransformToIqt_ParamTable_Expected')
+        expected_iqt = Load('TransformToIqt_Iqt_Expected')
+        self.assertTrue(CompareWorkspaces(params, expected_param_table, 1e-8)[0])
+        self.assertTrue(CompareWorkspaces(iqt, expected_iqt, 1e-8)[0])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Testing/Data/UnitTest/iris26184_multi_graphite002_red.nxs.md5
+++ b/Testing/Data/UnitTest/iris26184_multi_graphite002_red.nxs.md5
@@ -1,0 +1,1 @@
+c5f16d21ecfe1d859da1b20e5fcd1f80

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -27,6 +27,7 @@ Data Analysis Interface
 Improvements
 ############
 - Improved the output options of MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit so that Chi_squared can now be plotted.
+- Improved the I(Q, t) tab by adding more validation checks for the input data.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -5,7 +5,6 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "Iqt.h"
-#include "../General/UserInputValidator.h"
 
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -18,6 +17,8 @@
 #include <tuple>
 
 using namespace Mantid::API;
+using namespace Mantid::Geometry;
+using namespace MantidQt::CustomInterfaces;
 
 namespace {
 Mantid::Kernel::Logger g_log("Iqt");
@@ -31,12 +32,69 @@ std::size_t getWsNumberOfSpectra(std::string const &workspaceName) {
   return getADSMatrixWorkspace(workspaceName)->getNumberHistograms();
 }
 
-bool checkADSForWorkspace(std::string const &workspaceName) {
+bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }
 
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
   return workspace->y(0).size() > 1;
+}
+
+std::string
+checkInstrumentParametersMatch(Instrument_const_sptr sampleInstrument,
+                               Instrument_const_sptr resolutionInstrument,
+                               std::string const &parameter) {
+  if (!sampleInstrument->hasParameter(parameter))
+    return "Could not find the " + parameter + " for the sample workspace.";
+  if (!resolutionInstrument->hasParameter(parameter))
+    return "Could not find the " + parameter +
+           " for the resolution workspaces.";
+  if (sampleInstrument->getStringParameter(parameter)[0] !=
+      resolutionInstrument->getStringParameter(parameter)[0])
+    return "The sample and resolution must have matching " + parameter + "s.";
+  return "";
+}
+
+std::string checkParametersMatch(MatrixWorkspace_const_sptr sampleWorkspace,
+                                 MatrixWorkspace_const_sptr resolutionWorkspace,
+                                 std::string const &parameter) {
+  auto const sampleInstrument = sampleWorkspace->getInstrument();
+  auto const resolutionInstrument = resolutionWorkspace->getInstrument();
+  return checkInstrumentParametersMatch(sampleInstrument, resolutionInstrument,
+                                        parameter);
+}
+
+std::string checkParamsMatch(std::string const &sampleName,
+                             std::string const &resolutionName,
+                             std::string const &parameter) {
+  auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
+  auto const resolutionWorkspace = getADSMatrixWorkspace(resolutionName);
+  return checkParametersMatch(sampleWorkspace, resolutionWorkspace, parameter);
+}
+
+std::string
+checkInstrumentsMatch(MatrixWorkspace_const_sptr sampleWorkspace,
+                      MatrixWorkspace_const_sptr resolutionWorkspace) {
+  auto const sampleInstrument = sampleWorkspace->getInstrument();
+  auto const resolutionInstrument = resolutionWorkspace->getInstrument();
+  if (sampleInstrument->getName() != resolutionInstrument->getName())
+    return "The sample and resolution must have matching instruments.";
+  return "";
+}
+
+std::string
+validateNumberOfHistograms(MatrixWorkspace_const_sptr sampleWorkspace,
+                           MatrixWorkspace_const_sptr resolutionWorkspace) {
+  auto const sampleSize = sampleWorkspace->getNumberHistograms();
+  auto const resolutionSize = resolutionWorkspace->getNumberHistograms();
+  if (resolutionSize > 1 && sampleSize != resolutionSize)
+    return "Resolution must have either one or as many spectra as the sample.";
+  return "";
+}
+
+void addErrorMessage(UserInputValidator &uiv, std::string const &message) {
+  if (!message.empty())
+    uiv.addErrorMessage(QString::fromStdString(message) + "\n");
 }
 
 void cloneWorkspace(std::string const &workspaceName,
@@ -71,16 +129,17 @@ void cropWorkspace(std::string const &name, std::string const &newName,
  * otherwise they are undefined.
  */
 std::tuple<bool, float, int, int>
-calculateBinParameters(QString wsName, QString resName, double energyMin,
-                       double energyMax, double binReductionFactor) {
+calculateBinParameters(std::string const &wsName, std::string const &resName,
+                       double energyMin, double energyMax,
+                       double binReductionFactor) {
   ITableWorkspace_sptr propsTable;
   const auto paramTableName = "__IqtProperties_temp";
   try {
     auto toIqt = AlgorithmManager::Instance().createUnmanaged("TransformToIqt");
     toIqt->initialize();
     toIqt->setChild(true); // record this as internal
-    toIqt->setProperty("SampleWorkspace", wsName.toStdString());
-    toIqt->setProperty("ResolutionWorkspace", resName.toStdString());
+    toIqt->setProperty("SampleWorkspace", wsName);
+    toIqt->setProperty("ResolutionWorkspace", resName);
     toIqt->setProperty("ParameterWorkspace", paramTableName);
     toIqt->setProperty("EnergyMin", energyMin);
     toIqt->setProperty("EnergyMax", energyMax);
@@ -312,7 +371,7 @@ void Iqt::plotTiled() {
   auto const lastTiledPlot = m_uiForm.spTiledPlotLast->text().toInt();
 
   // Clone workspace before cropping to keep in ADS
-  if (!checkADSForWorkspace(tiledPlotWsName))
+  if (!doesExistInADS(tiledPlotWsName))
     cloneWorkspace(outWs->getName(), tiledPlotWsName);
 
   // Get first x value which corresponds to a y value below 1
@@ -353,43 +412,33 @@ bool Iqt::validate() {
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
   uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
 
-  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
-  auto const resolutionName =
-      m_uiForm.dsResolution->getCurrentDataName().toStdString();
-
   auto const eLow = m_dblManager->value(m_properties["ELow"]);
   auto const eHigh = m_dblManager->value(m_properties["EHigh"]);
 
   if (eLow >= eHigh)
-    uiv.addErrorMessage("ELow must be strictly less than EHigh.\n");
+    uiv.addErrorMessage("ELow must be less than EHigh.\n");
 
-  if (!validWorkspaceProperty(sampleName, resolutionName, "analyser"))
-    uiv.addErrorMessage("The sample and resolution workspaces must have the "
-                        "same analyser.\n");
+  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
+  auto const resolutionName =
+      m_uiForm.dsResolution->getCurrentDataName().toStdString();
 
-  if (!validWorkspaceProperty(sampleName, resolutionName, "reflection"))
-    uiv.addErrorMessage("The sample and resolution workspaces must have the "
-                        "same reflection.\n");
+  if (doesExistInADS(sampleName) && doesExistInADS(resolutionName)) {
+    auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
+    auto const resWorkspace = getADSMatrixWorkspace(resolutionName);
 
-  QString message = uiv.generateErrorMessage();
+    addErrorMessage(uiv, checkInstrumentsMatch(sampleWorkspace, resWorkspace));
+    addErrorMessage(
+        uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "analyser"));
+    addErrorMessage(
+        uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "reflection"));
+    addErrorMessage(uiv,
+                    validateNumberOfHistograms(sampleWorkspace, resWorkspace));
+  }
 
+  auto const message = uiv.generateErrorMessage();
   showMessageBox(message);
 
   return message.isEmpty();
-}
-
-bool Iqt::validWorkspaceProperty(std::string const &sampleName,
-                                 std::string const &resolutionName,
-                                 std::string const &parameter) const {
-  auto const sample = getADSMatrixWorkspace(sampleName);
-  auto const resolution = getADSMatrixWorkspace(resolutionName);
-
-  auto const sampleValue =
-      sample->getInstrument()->getStringParameter(parameter)[0];
-  auto const resolutionValue =
-      resolution->getInstrument()->getStringParameter(parameter)[0];
-
-  return sampleValue == resolutionValue;
 }
 
 /**
@@ -431,15 +480,14 @@ void Iqt::updatePropertyValues(QtProperty *prop, double val) {
  * Calculates binning parameters.
  */
 void Iqt::updateDisplayedBinParameters() {
-  QString wsName = m_uiForm.dsInput->getCurrentDataName();
-  QString resName = m_uiForm.dsResolution->getCurrentDataName();
-  if (wsName.isEmpty() || resName.isEmpty())
+  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
+  auto const resolutionName =
+      m_uiForm.dsResolution->getCurrentDataName().toStdString();
+  if (!doesExistInADS(sampleName) || !doesExistInADS(resolutionName))
     return;
 
-  auto const sampleName = wsName.toStdString();
-  auto const resolutionName = resName.toStdString();
-  if (!validWorkspaceProperty(sampleName, resolutionName, "analyser") ||
-      !validWorkspaceProperty(sampleName, resolutionName, "reflection"))
+  if (!checkParamsMatch(sampleName, resolutionName, "analyser").empty() ||
+      !checkParamsMatch(sampleName, resolutionName, "reflection").empty())
     return;
 
   double energyMin = m_dblManager->value(m_properties["ELow"]);
@@ -455,7 +503,8 @@ void Iqt::updateDisplayedBinParameters() {
   float energyWidth(0.0f);
   int resolutionBins(0), sampleBins(0);
   std::tie(success, energyWidth, sampleBins, resolutionBins) =
-      calculateBinParameters(wsName, resName, energyMin, energyMax, numBins);
+      calculateBinParameters(sampleName, resolutionName, energyMin, energyMax,
+                             numBins);
   if (success) {
     disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
                SLOT(updatePropertyValues(QtProperty *, double)));
@@ -468,9 +517,8 @@ void Iqt::updateDisplayedBinParameters() {
 
     // Warn for low number of resolution bins
     if (resolutionBins < 5)
-      showMessageBox(
-          "Number of resolution bins is less than 5.\nResults may be "
-          "inaccurate.");
+      showMessageBox("Results may be inaccurate as ResolutionBins is "
+                     "less than 5.\nLower the SampleBinning.");
   }
 }
 
@@ -480,6 +528,9 @@ void Iqt::loadSettings(const QSettings &settings) {
 }
 
 void Iqt::plotInput(const QString &wsname) {
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updatePropertyValues(QtProperty *, double)));
+
   MatrixWorkspace_sptr workspace;
   try {
     workspace = Mantid::API::AnalysisDataService::Instance()
@@ -533,6 +584,9 @@ void Iqt::plotInput(const QString &wsname) {
   } catch (std::invalid_argument &exc) {
     showMessageBox(exc.what());
   }
+
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updatePropertyValues(QtProperty *, double)));
 
   updateDisplayedBinParameters();
 }

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -12,6 +12,8 @@
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 #include "MantidQtWidgets/LegacyQwt/RangeSelector.h"
 
+#include "../General/UserInputValidator.h"
+
 #include <qwt_plot.h>
 
 #include <tuple>

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -34,10 +34,6 @@ std::size_t getWsNumberOfSpectra(std::string const &workspaceName) {
   return getADSMatrixWorkspace(workspaceName)->getNumberHistograms();
 }
 
-bool doesExistInADS(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().doesExist(workspaceName);
-}
-
 bool isWorkspacePlottable(MatrixWorkspace_sptr workspace) {
   return workspace->y(0).size() > 1;
 }
@@ -66,9 +62,9 @@ std::string checkParametersMatch(MatrixWorkspace_const_sptr sampleWorkspace,
                                         parameter);
 }
 
-std::string checkParamsMatch(std::string const &sampleName,
-                             std::string const &resolutionName,
-                             std::string const &parameter) {
+std::string checkParametersMatch(std::string const &sampleName,
+                                 std::string const &resolutionName,
+                                 std::string const &parameter) {
   auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
   auto const resolutionWorkspace = getADSMatrixWorkspace(resolutionName);
   return checkParametersMatch(sampleWorkspace, resolutionWorkspace, parameter);
@@ -373,7 +369,7 @@ void Iqt::plotTiled() {
   auto const lastTiledPlot = m_uiForm.spTiledPlotLast->text().toInt();
 
   // Clone workspace before cropping to keep in ADS
-  if (!doesExistInADS(tiledPlotWsName))
+  if (!AnalysisDataService::Instance().doesExist(tiledPlotWsName))
     cloneWorkspace(outWs->getName(), tiledPlotWsName);
 
   // Get first x value which corresponds to a y value below 1
@@ -424,7 +420,8 @@ bool Iqt::validate() {
   auto const resolutionName =
       m_uiForm.dsResolution->getCurrentDataName().toStdString();
 
-  if (doesExistInADS(sampleName) && doesExistInADS(resolutionName)) {
+  auto &ads = AnalysisDataService::Instance();
+  if (ads.doesExist(sampleName) && ads.doesExist(resolutionName)) {
     auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
     auto const resWorkspace = getADSMatrixWorkspace(resolutionName);
 
@@ -485,11 +482,13 @@ void Iqt::updateDisplayedBinParameters() {
   auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
   auto const resolutionName =
       m_uiForm.dsResolution->getCurrentDataName().toStdString();
-  if (!doesExistInADS(sampleName) || !doesExistInADS(resolutionName))
+
+  auto &ads = AnalysisDataService::Instance();
+  if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
     return;
 
-  if (!checkParamsMatch(sampleName, resolutionName, "analyser").empty() ||
-      !checkParamsMatch(sampleName, resolutionName, "reflection").empty())
+  if (!checkParametersMatch(sampleName, resolutionName, "analyser").empty() ||
+      !checkParametersMatch(sampleName, resolutionName, "reflection").empty())
     return;
 
   double energyMin = m_dblManager->value(m_properties["ELow"]);

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -10,8 +10,6 @@
 #include "IndirectDataAnalysisTab.h"
 #include "ui_Iqt.h"
 
-#include "../General/UserInputValidator.h"
-
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -10,6 +10,8 @@
 #include "IndirectDataAnalysisTab.h"
 #include "ui_Iqt.h"
 
+#include "../General/UserInputValidator.h"
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
@@ -23,9 +25,6 @@ private:
   void run() override;
   void setup() override;
   bool validate() override;
-  bool validWorkspaceProperty(std::string const &sampleName,
-                              std::string const &resolutionName,
-                              std::string const &parameter) const;
   void loadSettings(const QSettings &settings) override;
   void setBrowserWorkspace() override{};
 


### PR DESCRIPTION
**Description of work.**
This PR adds extra validation to the Iqt tab in Data Analysis so that a useful message is displayed to the user when the number of histogram in the resolution is invalid.

**To test:**
1.`Interfaces`->`Indierct`->`Data Analysis`->`Iqt` tab
2. Load the data below
3. Click `Run`
A useful error message should appear.

**Data Files**
Sample:
[iris26184_multi_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3002203/iris26184_multi_graphite002_red.zip)
Resolution:
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3032969/iris26176_graphite002_red.zip)

Fixes #25349

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
