### PR TITLE
Indirect Elwin Crash when changing Preview Spectrum after running

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -194,7 +194,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
         else:
             if not workspaces_have_same_size(q_workspaces) or not workspaces_have_same_size(q2_workspaces):
                 raise RuntimeError('The ElasticWindow algorithm produced differently sized workspaces. Please check '
-                                   'the input files are of the same type.')
+                                   'the input files are compatible.')
             q_workspace = _append_all(q_workspaces)
             q2_workspace = _append_all(q2_workspaces)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -13,6 +13,12 @@ from mantid.api import *
 import numpy as np
 
 
+def workspaces_have_same_size(workspaces):
+    first_size = len(workspaces[0].readY(0))
+    differently_sized_workspaces = [workspace for workspace in workspaces[1:] if len(workspace.readY(0)) != first_size]
+    return len(differently_sized_workspaces) == 0
+
+
 def _normalize_by_index(workspace, index):
     """
     Normalize each spectra of the specified workspace by the
@@ -186,6 +192,9 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
             q_workspace = q_workspaces[0]
             q2_workspace = q2_workspaces[0]
         else:
+            if not workspaces_have_same_size(q_workspaces) or not workspaces_have_same_size(q2_workspaces):
+                raise RuntimeError('The ElasticWindow algorithm produced differently sized workspaces. Please check '
+                                   'the input files are of the same type.')
             q_workspace = _append_all(q_workspaces)
             q2_workspace = _append_all(q2_workspaces)
 

--- a/Testing/SystemTests/tests/analysis/ISISIndirectAnalysisTest.py
+++ b/Testing/SystemTests/tests/analysis/ISISIndirectAnalysisTest.py
@@ -6,10 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #pylint: disable=no-init,attribute-defined-outside-init
 import systemtesting
-from mantid.simpleapi import *
+from mantid.simpleapi import (ElasticWindowMultiple, GroupWorkspaces, Load)
 
 
-class ElasticWindowMultipleTest(systemtesting.MantidSystemTest):
+class ElasticWindowMultipleOSIRISTest(systemtesting.MantidSystemTest):
 
     def runTest(self):
         Load(Filename='osi92762_graphite002_red.nxs,osi92763_graphite002_red.nxs',
@@ -31,3 +31,25 @@ class ElasticWindowMultipleTest(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 1e-10
         return '__ElWinMulti_OutputWS', 'II.AnalysisElwinMulti.nxs'
+
+
+class ElasticWindowMultipleIRISTest(systemtesting.MantidSystemTest):
+
+    def runTest(self):
+        input_files = Load(Filename='irs26173_graphite002_red.nxs,irs26176_graphite002_red.nxs')
+
+        ElasticWindowMultiple(InputWorkspaces=input_files,
+                              IntegrationRangeStart=-0.2,
+                              IntegrationRangeEnd=0.2,
+                              BackgroundRangeStart='-0.24',
+                              BackgroundRangeEnd='-0.22',
+                              OutputInQ='eq',
+                              OutputInQSquared='eq2',
+                              OutputELF='elf')
+
+        GroupWorkspaces(InputWorkspaces=['eq', 'eq2', 'elf'],
+                        OutputWorkspace='__ElwinResultsGroup')
+
+    def validate(self):
+        self.tolerance = 1e-10
+        return '__ElwinResultsGroup', 'II.IRISElasticWindowMultiple.nxs'

--- a/Testing/SystemTests/tests/analysis/reference/II.IRISElasticWindowMultiple.nxs.md5
+++ b/Testing/SystemTests/tests/analysis/reference/II.IRISElasticWindowMultiple.nxs.md5
@@ -1,0 +1,1 @@
+cb6288a47ab414d71cbdf1a294b543fb

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -31,6 +31,7 @@ Improvements
 Bug Fixes
 #########
 - Fixed an error caused by loading a Sample into ConvFit which does not have a resolution parameter for the analyser.
+- Fixed a crash caused by changing the Preview Spectrum on Elwin after clicking Run.
 
 
 Data Reduction Interface

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -74,7 +74,7 @@ template <typename T, typename Predicate>
 void removeElementsIf(std::vector<T> &vector, Predicate const &filter) {
   auto const iter = std::remove_if(vector.begin(), vector.end(), filter);
   if (iter != vector.end())
-    vector.erase(iter);
+    vector.erase(iter, vector.end());
 }
 
 std::vector<std::string> extractSuffixes(QStringList const &files,

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -33,6 +33,7 @@ private slots:
   void runClicked();
   void saveClicked();
   void plotClicked();
+  void updateIntegrationRange();
 
 private:
   void run() override;
@@ -43,6 +44,8 @@ private:
   void setDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws,
                             const QPair<double, double> &range);
   void setDefaultSampleLog(Mantid::API::MatrixWorkspace_const_sptr ws);
+
+  void checkForELTWorkspace();
 
   QString getOutputBasename();
 

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -47,6 +47,7 @@ private:
 
   void checkForELTWorkspace();
 
+  std::vector<std::string> getOutputWorkspaceNames();
   QString getOutputBasename();
 
   void updatePlotSpectrumOptions();

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.cpp
@@ -66,7 +66,7 @@ void IndirectDataAnalysisTab::inputChanged() { validate(); }
  * @return  The input workspace to be used in data analysis.
  */
 MatrixWorkspace_sptr IndirectDataAnalysisTab::inputWorkspace() const {
-  return m_inputWorkspace.lock();
+  return m_inputWorkspace;
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -154,7 +154,7 @@ private:
 
   /// A pointer to the parent (friend) IndirectDataAnalysis object.
   IndirectDataAnalysis *m_parent;
-  boost::weak_ptr<Mantid::API::MatrixWorkspace> m_inputWorkspace;
+  Mantid::API::MatrixWorkspace_sptr m_inputWorkspace;
   boost::weak_ptr<Mantid::API::MatrixWorkspace> m_previewPlotWorkspace;
   int m_selectedSpectrum;
   int m_minSpectrum;


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash which occurs after doing and run and then trying to change the Preview Spectrum.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`Elwin` tab
2. Load the data below
3. Click `Run`
4. Try to change the `Preview Spectrum`
There should be no crash.

**Test 2**
1. Load the data below
2. Click `Run` and wait.
3. Click `Save`. No error message should appear.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3004434/irs26176_graphite002_red.zip)

Fixes #25350

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
