### PR TITLE
Indirect Reduction - Disable Plot Time while running

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -59,15 +59,10 @@ private slots:
   void plotClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
-  void setPlotEnabled(bool enabled);
-  void setSaveEnabled(bool enabled);
-  void setOutputButtonsEnabled(std::string const &enableOutputButtons);
   void updateRunButton(bool enabled = true,
                        std::string const &enableOutputButtons = "unchanged",
                        QString const message = "Run",
                        QString const tooltip = "");
-  void setPlotIsPlotting(bool plotting);
 
 private:
   Ui::ISISEnergyTransfer m_uiForm;
@@ -83,6 +78,13 @@ private:
       std::vector<std::size_t> const &customGroupingNumbers) const;
   QString validateDetectorGrouping() const;
   std::string getDetectorGroupingString() const;
+
+  void setRunEnabled(bool enable);
+  void setPlotEnabled(bool enable);
+  void setPlotTimeEnabled(bool enable);
+  void setSaveEnabled(bool enable);
+  void setPlotIsPlotting(bool plotting);
+  void setPlotTimeIsPlotting(bool plotting);
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt


### PR DESCRIPTION
**Description of work.**
This PR ensures the `Plot` time button in Indirect Data Reduction Energy Transfer is disabled while running the tab.

**To test:**
1.`Interfaces`->`Indirect`->`Data Reduction` ->`ISIS Energy Transfer`
2. Instrument is `TOSCA`
3. Run number is `22841`
4. Click `Run`
5. The `Plot` button above the run button should be disabled while it is running.
6. The `Run` and output options should also be disabled while plotting is taking place using the `Plot` time button.

*No release notes required as this is unlikely to be noticed by users*

Fixes #25380

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
