### PR TITLE
Minor Fixes to SANS BeamCentreFinder tab

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -210,7 +210,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
             residueTB.append(self._calculate_residuals(sample_quartiles[MaskingQuadrant.Top],
                                                        sample_quartiles[MaskingQuadrant.Bottom]))
             if j == 0:
-                self.logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
+                self.logger.notice("Itr {0}: ( {1: .3f}, {2: .3f} )  SX={3:.5f}  SY={4:.5f}".
                                    format(j, self.scale_1 * centre1,
                                           self.scale_2 * centre2, residueLR[j], residueTB[j]))
                 if do_plotting:
@@ -226,7 +226,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
                 if residueTB[j] > residueTB[j-1]:
                     position_2_step = - position_2_step / 2
 
-                self.logger.notice("Itr {0}: ( {1}, {2} )  SX={3:.5g}  SY={4:.5g}".
+                self.logger.notice("Itr {0}: ( {1: .3f}, {2: .3f} )  SX={3:.5f}  SY={4:.5f}".
                                    format(j, self.scale_1 * centre1,
                                           self.scale_2 * centre2, residueLR[j], residueTB[j]))
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -210,7 +210,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
             residueTB.append(self._calculate_residuals(sample_quartiles[MaskingQuadrant.Top],
                                                        sample_quartiles[MaskingQuadrant.Bottom]))
             if j == 0:
-                self.logger.notice("Itr {0}: ( {1: .3f}, {2: .3f} )  SX={3:.5f}  SY={4:.5f}".
+                self.logger.notice("Itr {0}: ( {1:.3f}, {2:.3f} )  SX={3:.5f}  SY={4:.5f}".
                                    format(j, self.scale_1 * centre1,
                                           self.scale_2 * centre2, residueLR[j], residueTB[j]))
                 if do_plotting:
@@ -226,7 +226,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
                 if residueTB[j] > residueTB[j-1]:
                     position_2_step = - position_2_step / 2
 
-                self.logger.notice("Itr {0}: ( {1: .3f}, {2: .3f} )  SX={3:.5f}  SY={4:.5f}".
+                self.logger.notice("Itr {0}: ( {1:.3f}, {2:.3f} )  SX={3:.5f}  SY={4:.5f}".
                                    format(j, self.scale_1 * centre1,
                                           self.scale_2 * centre2, residueLR[j], residueTB[j]))
 

--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -247,6 +247,13 @@
            </layout>
           </widget>
          </item>
+         <item row="8" column="3">
+          <widget class="QLabel" name="tolerance_units_label">
+           <property name="text">
+            <string>mm</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
       </item>


### PR DESCRIPTION
**Description of work.**
This PR makes very minor changes to the beamcentrefinder tab in ISIS SANS:
1. Beam centre coordinates are reported using a constant number of decimal places
2. Units of the "tolerance" variable are made more clear by adding a label next to the tooltip

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Load the user and batch file attached
3. Go onto the beam centre tab (LHS) and click process
4. In the ISIS SANS beam centre tab logger you should see a series of `Itr number: ( x, y) SX: some_val, SY: some_other_val`
5. x and y should always have 3d.p, SX and SY should have 5. The final reported coordinates are not held to these contraints
6. Is it clear that Tolerance is in millimetres?

**Data:**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/3008641/loqPRData.zip)

Fixes #25251 

*This does not require release notes* because **very minor changes not raised by users**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
