### PR TITLE
Turn off clang-tidy for MantidPlot

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -816,8 +816,11 @@ target_link_libraries ( MantidPlot LINK_PRIVATE
   ${OPENGL_gl_LIBRARY}
 )
 if (WIN32)
-  set_target_properties ( MantidPlot PROPERTIES COMPILE_DEFINITIONS "PSAPI_VERSION=1" )
+  set_target_properties ( MantidPlot PROPERTIES COMPILE_DEFINITIONS "PSAPI_VERSION=1"
+                                                CXX_CLANG_TIDY "" )
   target_link_libraries ( MantidPlot PRIVATE Psapi.lib )
+else()
+  set_target_properties ( MantidPlot PROPERTIES CXX_CLANG_TIDY "" )
 endif ()
 
 if(MAKE_VATES)


### PR DESCRIPTION
**Description of work.**
This PR stops Mantidplot files from being touched when running clang-tidy through cmake.
We are not actively developing Mantidplot code so we do not want to expend time and effort making the code pretty.
Requested review from @martyngigg as his suggested improvement

**To test:**
Must be tested on Ubuntu as cmake clang-tidy doesn't work on windows (and I'm not sure about other OS)
1. Open cmake-gui
2. Search for "clang"
3. Check `ENABLE_CLANG_TIDY` and set `CLANG_TIDY_CHECKS` to `-*,modernize-loop-convert`
4. configure and generate
5. build
6. See that no warnings were raised for files in Mantidplot

*There is no associated issue.*

*This does not require release notes* because **Internal change to developer setup**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
