### PR TITLE
Dis/Enable SANS output modes when reduction mode changes

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -18,3 +18,4 @@ Improvements
 ############
 
 - Increased font size in run table.
+- canSAS output mode will be disable if 2D reduction mode is selected to avoid accidental errors with data dimension.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -134,6 +134,10 @@ class SANSDataProcessorGui(QMainWindow,
             pass
 
         @abstractmethod
+        def on_reduction_dimensionality_changed(self, is_1d):
+            pass
+
+        @abstractmethod
         def on_data_changed(self, row, column, new_value, old_value):
             pass
 
@@ -228,6 +232,7 @@ class SANSDataProcessorGui(QMainWindow,
         self.save_other_pushButton.clicked.connect(self._on_save_other_button_pressed)
 
         self.save_can_checkBox.clicked.connect(self._on_save_can_clicked)
+        self.reduction_dimensionality_1D.toggled.connect(self._on_reduction_dimensionality_changed)
 
         # Attach validators
         self._attach_validators()
@@ -553,6 +558,9 @@ class SANSDataProcessorGui(QMainWindow,
     def _on_save_can_clicked(self, value):
         self.save_can_checkBox.setChecked(value)
         set_setting(self.__generic_settings, self.__save_can_key, value)
+
+    def _on_reduction_dimensionality_changed(self, is_1d):
+        self._call_settings_listeners(lambda listener: listener.on_reduction_dimensionality_changed(is_1d))
 
     def _on_user_file_load(self):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -109,6 +109,9 @@ class RunTabPresenter(object):
         def on_multi_period_selection(self, show_periods):
             self._presenter.on_multiperiod_changed(show_periods)
 
+        def on_reduction_dimensionality_changed(self, is_1d):
+            self._presenter.verify_output_modes(is_1d)
+
         def on_data_changed(self, row, column, new_value, old_value):
             self._presenter.on_data_changed(row, column, new_value, old_value)
 
@@ -549,6 +552,21 @@ class RunTabPresenter(object):
             self.on_processing_finished(None)
             self.sans_logger.error("Process halted due to: {}".format(str(e)))
             self.display_warning_box('Warning', 'Process halted', str(e))
+
+    def verify_output_modes(self, is_1d):
+        """
+        Unchecks and disabled canSAS output mode if switching to 2D reduction.
+        Enabled canSAS if switching to 1D.
+        :param is_1d: bool. If true then switching TO 1D reduction.
+        """
+        if is_1d:
+            self._view.can_sas_checkbox.setEnabled(True)
+        else:
+            if self._view.can_sas_checkbox.isChecked():
+                self._view.can_sas_checkbox.setChecked(False)
+                self.sans_logger.information("2D reductions are incompatible with canSAS output. "
+                                             "canSAS output has been unchecked.")
+            self._view.can_sas_checkbox.setEnabled(False)
 
     def on_process_all_clicked(self):
         """


### PR DESCRIPTION
**Description of work.**
ISIS SANS is capable of 1D and 2D reductions. Of the 3 output file types available in ISIS SANS, canSAS is only compatible with 1D reductions.
This PR introduces a check that will uncheck and disable the canSAS button if you switch to 2D reduction and re-enable it if you switch to 1D.

**Report to:** Steve King ISIS

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Set your logger level to information or below
3. At the bottom of the main tab, check `canSAS`
4. Click the `2D` data reduction radio button
5. in the logger you should see a message at information level informing you that canSAS output has been disable because it does not support 2D data.
6. The canSAS button should be unchecked and disabled
7. Switch back to 1D reduction
8. canSAS should be enabled, but not checked

Fixes #25252 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
