### PR TITLE
Fixed bugs in engineering gui

### DIFF
--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -15,6 +15,13 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
+Bug Fixes
+#########
+
+-Prevented crash caused by canceling algorithms called by GUI.
+
+-Prevented GUI breaking bug caused by entering files from the wrong instrument to calibration.
+
 Single Crystal Diffraction
 --------------------------
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -7,12 +7,12 @@
 #include "EnggDiffFittingPresenter.h"
 #include "EnggDiffFittingPresWorker.h"
 #include "IEnggDiffFittingModel.h"
+#include "MantidAPI/Algorithm.h"
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidQtWidgets/LegacyQwt/QwtHelper.h"
-#include "MantidAPI/Algorithm.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -509,7 +509,7 @@ void EnggDiffFittingPresenter::doFitting(const std::vector<RunLabel> &runLabels,
       g_log.error() << "Fit terminated by user.\n";
       return;
     }
-    
+
     const auto outFilename = userHDFRunFilename(runLabel.runNumber);
     m_model->saveFitResultsToHDF5({runLabel}, outFilename);
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -12,6 +12,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidQtWidgets/LegacyQwt/QwtHelper.h"
+#include "MantidAPI/Algorithm.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
@@ -504,8 +505,11 @@ void EnggDiffFittingPresenter::doFitting(const std::vector<RunLabel> &runLabels,
       // A userError should be used for this message once the threading has been
       // looked into
       return;
+    } catch (Mantid::API::Algorithm::CancelException) {
+      g_log.error() << "Fit terminated by user.\n";
+      return;
     }
-
+    
     const auto outFilename = userHDFRunFilename(runLabel.runNumber);
     m_model->saveFitResultsToHDF5({runLabel}, outFilename);
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -984,7 +984,7 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
     g_log.error()
         << "The calibration calculations failed. Some input properties "
            "were not valid. See log messages for details. \n";
-  } catch (Mantid::API::Algorithm::CancelException&) {
+  } catch (Mantid::API::Algorithm::CancelException &) {
     m_calibFinishedOK = false;
     g_log.error() << "Execution terminated by user. \n";
   }
@@ -1592,7 +1592,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &runNo,
                           ") for run " + runNo + " into: "
                    << effectiveFilenames[idx] << '\n';
     try {
-      
+
       doFocusing(cs, RunLabel(std::stoi(runNo), bankIDs[idx]), specs[idx],
                  dgFile);
       m_focusFinishedOK = true;
@@ -1609,7 +1609,7 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &runNo,
                        "were not valid. "
                        "See log messages for details. Error: "
                     << ia.what() << '\n';
-    }catch (Mantid::API::Algorithm::CancelException) {
+    } catch (Mantid::API::Algorithm::CancelException) {
       m_focusFinishedOK = false;
       g_log.error() << "Focus terminated by user.\n";
     }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1592,21 +1592,26 @@ void EnggDiffractionPresenter::doFocusRun(const std::string &runNo,
                           ") for run " + runNo + " into: "
                    << effectiveFilenames[idx] << '\n';
     try {
-      m_focusFinishedOK = false;
+      
       doFocusing(cs, RunLabel(std::stoi(runNo), bankIDs[idx]), specs[idx],
                  dgFile);
       m_focusFinishedOK = true;
     } catch (std::runtime_error &rexc) {
+      m_focusFinishedOK = false;
       g_log.error() << "The focusing calculations failed. One of the algorithms"
                        "did not execute correctly. See log messages for "
                        "further details. Error: " +
                            std::string(rexc.what())
                     << '\n';
     } catch (std::invalid_argument &ia) {
+      m_focusFinishedOK = false;
       g_log.error() << "The focusing failed. Some input properties "
                        "were not valid. "
                        "See log messages for details. Error: "
                     << ia.what() << '\n';
+    }catch (Mantid::API::Algorithm::CancelException) {
+      m_focusFinishedOK = false;
+      g_log.error() << "Focus terminated by user.\n";
     }
   }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -980,9 +980,13 @@ void EnggDiffractionPresenter::doNewCalibration(const std::string &outFilename,
                std::string(rexc.what())
         << '\n';
   } catch (std::invalid_argument &) {
+    m_calibFinishedOK = false;
     g_log.error()
         << "The calibration calculations failed. Some input properties "
            "were not valid. See log messages for details. \n";
+  } catch (Mantid::API::Algorithm::CancelException&) {
+    m_calibFinishedOK = false;
+    g_log.error() << "Execution terminated by user. \n";
   }
   // restore normal data search paths
   conf.setDataSearchDirs(tmpDirs);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -420,9 +420,9 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
               m_uiTabCalib.lineEdit_current_calib_filename->text());
 
   qs.setValue("user-params-new-vanadium-num",
-              m_uiTabCalib.MWRunFiles_new_vanadium_num->getText());
+              "");
   qs.setValue("user-params-new-ceria-num",
-              m_uiTabCalib.MWRunFiles_new_ceria_num->getText());
+              "");
 
   qs.setValue("user-params-calib-cropped-group-checkbox",
               m_uiTabCalib.groupBox_calib_cropped->isChecked());

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -419,10 +419,8 @@ void EnggDiffractionViewQtGUI::saveSettings() const {
   qs.setValue("current-calib-filename",
               m_uiTabCalib.lineEdit_current_calib_filename->text());
 
-  qs.setValue("user-params-new-vanadium-num",
-              "");
-  qs.setValue("user-params-new-ceria-num",
-              "");
+  qs.setValue("user-params-new-vanadium-num", "");
+  qs.setValue("user-params-new-ceria-num", "");
 
   qs.setValue("user-params-calib-cropped-group-checkbox",
               m_uiTabCalib.groupBox_calib_cropped->isChecked());


### PR DESCRIPTION
**Description of work.**
Fixed a hard crash on canceling an algorithm called from the calibration, focus or fitting tabs of the gui. 
Prevented the GUI breaking bug caused by running a calibration on non engineering data. 
**To test:**
*Requires the ISIS Data archive*
go to `Interfaces->Diffraction->Engineering Diffraction`
On the calibration tab enter an rb number i.e. 1, then start a calibration using
ceria `241391` and vanadium `236516` (you may need to set a calibration directory in the settings tab first) go to Algorithm progress and click cancel, the logger should report `Execution terminated by user. `
`The calibration did not finish correctly. Please check previous log messages for details.` but not crash, now run the calibration again but do not cancel it.
go to the focus tab and enter `236516` and click focus, once again going and canceling it, the logger should print `Focus terminated by user.`
`The focusing did not finish correctly. Check previous log messages for details`
but again not crash. now run the focus again but do not cancel it. Open the fitting tab, and browse to one of the files you just focused (likely in `EnginX_Mantid/User/RBNumber/Focus` click load, select the run, once again, go to cancel this as it runs, (this runs very quickly, so it may be easier to do in time if you already have algorithm progress open) this should again, not cause a crash.

Finally go back to the calibration tab, click browse on the vanadium, and load in non enginx data, do the same for the vanadium and click calibrate. the calibration will take some time before failing, however closing and re-opening the GUI once this is complete (or closing mantid and reopening it before it finishes) should both lead to the vanadium and calibration boxes for `make new calibration` having been cleared, and therefore the gui will not get caught in a loop of trying to load files it cant find.

Fixes #22492 Partially Refs #24242 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
