### PR TITLE
Activate testing mode when running ctest

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -154,6 +154,8 @@ fi
 #                   from bin and can cause random failures
 #   - build/ExternalData/**: data files will change over time and removing
 #                            the links helps keep it fresh
+#   - build/Testing/**: old ctest xml files will change over time and removing
+#                       the links helps keep it fresh
 ###############################################################################
 BUILD_DIR_REL=build
 BUILD_DIR=$WORKSPACE/$BUILD_DIR_REL
@@ -167,7 +169,7 @@ if [[ "$CLEANBUILD" == true ]]; then
 fi
 if [ -d $BUILD_DIR ]; then
   git clean -fdx --exclude=${BUILD_DIR_REL} --exclude=".Xauthority-*"
-  rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData
+  rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData ${BUILD_DIR:?}/Testing
   find ${BUILD_DIR:?} -name 'TEST-*.xml' -delete
   if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then
       rm -rf $BUILD_DIR/eigen-*
@@ -378,7 +380,7 @@ userprops_file=$userconfig_dir/Mantid.user.properties
 echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
-  ${X11_RUNNER} "${X11_RUNNER_ARGS}" $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+  ${X11_RUNNER} "${X11_RUNNER_ARGS}" $CTEST_EXE -T Test -j${BUILD_THREADS:?} --schedule-random --output-on-failure
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -94,6 +94,8 @@ if not "%JOB_NAME%" == "%JOB_NAME:debug=%" (
 ::                   from bin and can cause random failures
 ::   - build/ExternalData/**: data files will change over time and removing
 ::                            the links helps keep it fresh
+::   - build/Testing/**: old ctest xml files will change over time and removing
+::                       the links helps keep it fresh
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 set BUILD_DIR_REL=build
 set BUILD_DIR=%WORKSPACE%\%BUILD_DIR_REL%
@@ -118,7 +120,7 @@ if "!CLEANBUILD!" == "yes" (
 
 if EXIST %BUILD_DIR% (
   git clean -fdx --exclude=external --exclude=%BUILD_DIR_REL%
-  rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData
+  rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData %BUILD_DIR%\Testing
   for /f %%F in ('dir /b /a-d /S "TEST-*.xml"') do del /Q %%F >/nul
   if "!CLEAN_EXTERNAL_PROJECTS!" == "true" (
     rmdir /S /Q %BUILD_DIR%\eigen-prefix
@@ -210,7 +212,7 @@ mkdir %CONFIGDIR%\mantid
 :: use a fixed number of openmp threads to avoid overloading the system
 echo MultiThreaded.MaxCores=2 > %USERPROPS%
 
-call ctest.exe -C %BUILD_CONFIG% -j%BUILD_THREADS% --schedule-random --output-on-failure
+call ctest.exe -C %BUILD_CONFIG% -T Test -j%BUILD_THREADS% --schedule-random --output-on-failure
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
**Description of work.**

xUnit reports are written to a Testing directory of the build, which can be parsed by Jenkins. This enables the output catch errors such as failues in Python tests and segfaults before the C++ test
suites run.

**To test:**

TODO

*There is no associated issue.*

*This does not require release notes* because **changes for developer testing**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
