### PR TITLE
Make Create States Error Box More Helpful

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -486,10 +486,10 @@ class RunTabPresenter(object):
         which occur.
         """
         states, errors = self.get_states(row_index=rows)
-        error_msg = ""
+        error_msg = "\n\n"
         for row, error in errors.items():
             self.on_processing_error(row, error)
-            error_msg += "\n{}".format(error)
+            error_msg += "{}\n".format(error)
         return states, error_msg
 
     def _plot_graph(self):
@@ -520,6 +520,7 @@ class RunTabPresenter(object):
         """
         Processes a list of rows. Any errors cause the row to be coloured red.
         """
+        error_msg = ""
         try:
             for row in rows:
                 self._table_model.reset_row_state(row)
@@ -550,8 +551,7 @@ class RunTabPresenter(object):
         except Exception as e:
             self.on_processing_finished(None)
             self.sans_logger.error("Process halted due to: {}".format(str(e)))
-            warning_box_text = str(e) + "\n\n" + error_msg
-            self.display_warning_box('Warning', 'Process halted', warning_box_text)
+            self.display_warning_box('Warning', 'Process halted', str(e) + error_msg)
 
     def on_process_all_clicked(self):
         """
@@ -585,6 +585,7 @@ class RunTabPresenter(object):
         self._processing = False
 
     def on_load_clicked(self):
+        error_msg = "\n\n"
         try:
             self._view.disable_buttons()
             self._processing = True
@@ -596,6 +597,7 @@ class RunTabPresenter(object):
 
             for row, error in errors.items():
                 self.on_processing_error(row, error)
+                error_msg += "{}\n".format(error)
 
             if not states:
                 self.on_processing_finished(None)
@@ -608,7 +610,7 @@ class RunTabPresenter(object):
         except Exception as e:
             self._view.enable_buttons()
             self.sans_logger.error("Process halted due to: {}".format(str(e)))
-            self.display_warning_box("Warning", "Process halted", str(e))
+            self.display_warning_box("Warning", "Process halted", str(e) + error_msg)
 
     def on_export_table_clicked(self):
         non_empty_rows = self.get_row_indices()

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -486,9 +486,11 @@ class RunTabPresenter(object):
         which occur.
         """
         states, errors = self.get_states(row_index=rows)
+        error_msg = ""
         for row, error in errors.items():
             self.on_processing_error(row, error)
-        return states
+            error_msg += "\n{}".format(error)
+        return states, error_msg
 
     def _plot_graph(self):
         """
@@ -527,7 +529,7 @@ class RunTabPresenter(object):
             self._processing = True
             self.sans_logger.information("Starting processing of batch table.")
 
-            states = self._handle_get_states(rows)
+            states, error_msg = self._handle_get_states(rows)
             if not states:
                 raise Exception("No states found")
 
@@ -548,7 +550,8 @@ class RunTabPresenter(object):
         except Exception as e:
             self.on_processing_finished(None)
             self.sans_logger.error("Process halted due to: {}".format(str(e)))
-            self.display_warning_box('Warning', 'Process halted', str(e))
+            warning_box_text = str(e) + "\n\n" + error_msg
+            self.display_warning_box('Warning', 'Process halted', warning_box_text)
 
     def on_process_all_clicked(self):
         """


### PR DESCRIPTION
**Description of work.**
This PR makes error messages created while trying to collect data in the ISIS SANS interface more obvious.
Prior to this PR, a warning box would pop-up with the message "No states found", and the more helpful, specific error messages were posted to the logger.

However, error reports would often include this warning box only, and the helpful error messages were missed/hidden on a different logger level.

This PR includes the helpful error messages in the pop-up, to make it clearer what the error is.

**To test:**
1. In `create_sate.py`, change line 36 to something like `state = "An error message"
2. Load the attached user and batch file
3. Click process all. A warning box should pop up with the text 
"No states found   

An error message
An error message"
(The message repeats because we added one error for each row).

**Data:**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/3017007/loqPRData.zip)

Fixes #25131 

*This does not require release notes* because **Small change not noticed by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
