### PR TITLE
Clang-tidy readability-named-parameter to qt

### DIFF
--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.h
@@ -144,7 +144,7 @@ private:
   void groupWorkspaces(const std::vector<std::string> &workspaceNames,
                        const std::string &outputWSName);
 
-  size_t guessBankID(Mantid::API::MatrixWorkspace_const_sptr) const;
+  size_t guessBankID(Mantid::API::MatrixWorkspace_const_sptr /*ws*/) const;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
@@ -35,8 +35,9 @@ public slots:
   void doRefinements();
 
 signals:
-  void refinementsComplete(Mantid::API::IAlgorithm_sptr /*_t1*/,
-                           std::vector<GSASIIRefineFitPeaksOutputProperties> /*_t2*/);
+  void refinementsComplete(
+      Mantid::API::IAlgorithm_sptr /*_t1*/,
+      std::vector<GSASIIRefineFitPeaksOutputProperties> /*_t2*/);
 
   void refinementSuccessful(Mantid::API::IAlgorithm_sptr /*_t1*/,
                             GSASIIRefineFitPeaksOutputProperties /*_t2*/);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingWorker.h
@@ -35,13 +35,13 @@ public slots:
   void doRefinements();
 
 signals:
-  void refinementsComplete(Mantid::API::IAlgorithm_sptr,
-                           std::vector<GSASIIRefineFitPeaksOutputProperties>);
+  void refinementsComplete(Mantid::API::IAlgorithm_sptr /*_t1*/,
+                           std::vector<GSASIIRefineFitPeaksOutputProperties> /*_t2*/);
 
-  void refinementSuccessful(Mantid::API::IAlgorithm_sptr,
-                            GSASIIRefineFitPeaksOutputProperties);
+  void refinementSuccessful(Mantid::API::IAlgorithm_sptr /*_t1*/,
+                            GSASIIRefineFitPeaksOutputProperties /*_t2*/);
 
-  void refinementFailed(std::string);
+  void refinementFailed(std::string /*_t1*/);
 
   void refinementCancelled();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.cpp
@@ -93,7 +93,7 @@ void EnggDiffractionViewQtGUI::initLayout() {
   // This is created from a QWidget* -> use null-deleter to prevent double-free
   // with Qt
   boost::shared_ptr<EnggDiffractionViewQtGUI> sharedView(
-      this, [](EnggDiffractionViewQtGUI *) {});
+      this, [](EnggDiffractionViewQtGUI * /*unused*/) {});
   m_fittingWidget =
       new EnggDiffFittingViewQtWidget(m_ui.tabMain, sharedView, sharedView,
                                       fullPres, fullPres, sharedView, fullPres);
@@ -1054,7 +1054,7 @@ void EnggDiffractionViewQtGUI::setPrefix(std::string prefix) {
   m_uiTabPreproc.MWRunFiles_preproc_run_num->setInstrumentOverride(prefixInput);
 }
 
-void EnggDiffractionViewQtGUI::showEvent(QShowEvent *) {
+void EnggDiffractionViewQtGUI::showEvent(QShowEvent * /*unused*/) {
   // make sure that the RB number is checked on interface startup/show
   m_presenter->notify(IEnggDiffractionPresenter::RBNumberChange);
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionViewQtGUI.h
@@ -223,7 +223,7 @@ private:
   void saveSettings() const override;
 
   // when the interface is shown
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
 
   // window (custom interface) close
   void closeEvent(QCloseEvent *ev) override;

--- a/qt/scientific_interfaces/General/Background.h
+++ b/qt/scientific_interfaces/General/Background.h
@@ -34,8 +34,8 @@ public:
 
 private:
   void initLayout();
-  void showEvent(QShowEvent *) override;
-  void closeEvent(QCloseEvent *) override;
+  void showEvent(QShowEvent * /*e*/) override;
+  void closeEvent(QCloseEvent * /*event*/) override;
   bool sanityCheck();
 
 private:

--- a/qt/scientific_interfaces/General/MantidEV.h
+++ b/qt/scientific_interfaces/General/MantidEV.h
@@ -216,7 +216,8 @@ public:
 
 public slots:
   /// Slot for Q-Point selection notification
-  void QPointSelection_slot(bool /*lab_coords*/, double /*qx*/, double /*qy*/, double /*qz*/);
+  void QPointSelection_slot(bool /*lab_coords*/, double /*qx*/, double /*qy*/,
+                            double /*qz*/);
 
 private slots:
 

--- a/qt/scientific_interfaces/General/MantidEV.h
+++ b/qt/scientific_interfaces/General/MantidEV.h
@@ -216,7 +216,7 @@ public:
 
 public slots:
   /// Slot for Q-Point selection notification
-  void QPointSelection_slot(bool, double, double, double);
+  void QPointSelection_slot(bool /*lab_coords*/, double /*qx*/, double /*qy*/, double /*qz*/);
 
 private slots:
 

--- a/qt/scientific_interfaces/General/StepScan.h
+++ b/qt/scientific_interfaces/General/StepScan.h
@@ -32,9 +32,9 @@ public:
   ~StepScan() override;
 
 signals:
-  void logsAvailable(const Mantid::API::MatrixWorkspace_const_sptr &);
-  void logsUpdated(const Mantid::API::MatrixWorkspace_const_sptr &);
-  void updatePlot(const QString &);
+  void logsAvailable(const Mantid::API::MatrixWorkspace_const_sptr & /*_t1*/);
+  void logsUpdated(const Mantid::API::MatrixWorkspace_const_sptr & /*_t1*/);
+  void updatePlot(const QString & /*_t1*/);
 
 private slots:
   void triggerLiveListener(bool checked);

--- a/qt/scientific_interfaces/ISISReflectometry/MeasurementItem.h
+++ b/qt/scientific_interfaces/ISISReflectometry/MeasurementItem.h
@@ -45,7 +45,7 @@ public:
   std::string label() const;
   double angle() const;
   std::string angleStr() const;
-  MeasurementItem &operator=(const MeasurementItem &);
+  MeasurementItem &operator=(const MeasurementItem & /*other*/);
 
 private:
   /// Constructor

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSaveTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSaveTabView.h
@@ -62,9 +62,11 @@ public:
   /// Clears the 'List of Logged Parameters' widget
   void clearParametersList() const override;
   /// Sets the 'List of workspaces' widget
-  void setWorkspaceList(const std::vector<std::string> & /*unused*/) const override;
+  void
+  setWorkspaceList(const std::vector<std::string> & /*unused*/) const override;
   /// Sets the 'List of logged parameters' widget
-  void setParametersList(const std::vector<std::string> & /*unused*/) const override;
+  void
+  setParametersList(const std::vector<std::string> & /*unused*/) const override;
 
   void disallowAutosave() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/QtReflSaveTabView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/QtReflSaveTabView.h
@@ -62,9 +62,9 @@ public:
   /// Clears the 'List of Logged Parameters' widget
   void clearParametersList() const override;
   /// Sets the 'List of workspaces' widget
-  void setWorkspaceList(const std::vector<std::string> &) const override;
+  void setWorkspaceList(const std::vector<std::string> & /*unused*/) const override;
   /// Sets the 'List of logged parameters' widget
-  void setParametersList(const std::vector<std::string> &) const override;
+  void setParametersList(const std::vector<std::string> & /*unused*/) const override;
 
   void disallowAutosave() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflRunsTabPresenter.h
@@ -82,7 +82,7 @@ public:
   void settingsChanged(int group) override;
   void completedGroupReductionSuccessfully(
       MantidWidgets::DataProcessor::GroupData const &group,
-      std::string const &) override;
+      std::string const & /*workspaceName*/) override;
   void completedRowReductionSuccessfully(
       MantidWidgets::DataProcessor::GroupData const &group,
       std::string const &workspaceNames) override;

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSearchModel.cpp
@@ -97,7 +97,9 @@ int ReflSearchModel::rowCount(const QModelIndex & /*parent*/) const {
 /**
 @return the number of columns in the model.
 */
-int ReflSearchModel::columnCount(const QModelIndex & /*parent*/) const { return 3; }
+int ReflSearchModel::columnCount(const QModelIndex & /*parent*/) const {
+  return 3;
+}
 
 /**
 Overrident data method, allows consuming view to extract data for an index and

--- a/qt/scientific_interfaces/ISISReflectometry/ReflSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/ReflSearchModel.cpp
@@ -90,14 +90,14 @@ void ReflSearchModel::addDataFromTable(
 /**
 @return the row count.
 */
-int ReflSearchModel::rowCount(const QModelIndex &) const {
+int ReflSearchModel::rowCount(const QModelIndex & /*parent*/) const {
   return static_cast<int>(m_runs.size());
 }
 
 /**
 @return the number of columns in the model.
 */
-int ReflSearchModel::columnCount(const QModelIndex &) const { return 3; }
+int ReflSearchModel::columnCount(const QModelIndex & /*parent*/) const { return 3; }
 
 /**
 Overrident data method, allows consuming view to extract data for an index and

--- a/qt/scientific_interfaces/ISISSANS/SANSAddFiles.cpp
+++ b/qt/scientific_interfaces/ISISSANS/SANSAddFiles.cpp
@@ -403,7 +403,7 @@ void SANSAddFiles::new2AddBrowse() {
 /** Normally in responce to an edit this sets data associated with the cell
  *  to the cells text and removes the tooltip
  */
-void SANSAddFiles::setCellData(QListWidgetItem *) {
+void SANSAddFiles::setCellData(QListWidgetItem * /*unused*/) {
   QListWidgetItem *editting = m_SANSForm->toAdd_List->currentItem();
   if (editting) {
     editting->setData(Qt::WhatsThisRole, QVariant(editting->text()));

--- a/qt/scientific_interfaces/ISISSANS/SANSAddFiles.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSAddFiles.h
@@ -84,7 +84,7 @@ private slots:
   /// this slot opens a browser to select a new file to add
   void new2AddBrowse();
   /// sets data associated with the cell
-  void setCellData(QListWidgetItem *);
+  void setCellData(QListWidgetItem * /*unused*/);
   /// clears the table that contains the names of the files to add
   void clearClicked();
   /// clears the contents of the selected row
@@ -95,7 +95,7 @@ private slots:
   /// for event data
   void onCurrentIndexChangedForHistogramChoice(int index);
   /// reacts to changes of the overlay check box
-  void onStateChangedForOverlayCheckBox(int);
+  void onStateChangedForOverlayCheckBox(int /*state*/);
   /// checks if a file corresponds to a histogram worksapce
   bool isEventWorkspace(QString file_name);
   /// checks if the files which are to be added are all based on event

--- a/qt/scientific_interfaces/ISISSANS/SANSEventSlicing.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSEventSlicing.h
@@ -43,7 +43,7 @@ private:
   void raiseWarning(QString title, QString message);
 
 protected:
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
 private slots:
 
   /// Apply the slice for the SANS data, and update the view with the last

--- a/qt/scientific_interfaces/ISISSANS/SANSPlotSpecial.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSPlotSpecial.h
@@ -82,14 +82,14 @@ public:
   ~SANSPlotSpecial() override;
 
 public slots:
-  void rangeChanged(double, double);
+  void rangeChanged(double /*low*/, double /*high*/);
   void plot();
-  void updateAxisLabels(const QString &);
+  void updateAxisLabels(const QString & /*value*/);
   void clearTable();
   void calculateDerivatives();
   void tableUpdated(int row, int column);
   void clearInterceptDerived();
-  void scalePlot(double, double);
+  void scalePlot(double /*start*/, double /*end*/);
   void resetSelectors();
 
 private:
@@ -110,7 +110,7 @@ private:
   void deriveKratky();
   void derivePorod();
 
-  double getValue(QTableWidgetItem *);
+  double getValue(QTableWidgetItem * /*item*/);
   QPair<QStringList, QMap<QString, double>>
   getProperties(const QString &transform);
 

--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
@@ -75,7 +75,7 @@ signals:
   // signal  to notify mask file loaded
   void userfileLoaded();
   /// signal to send gemoetry information
-  void sendGeometryInformation(QString &, QString &, QString &, QString &);
+  void sendGeometryInformation(QString & /*_t1*/, QString & /*_t2*/, QString & /*_t3*/, QString & /*_t4*/);
 
 private:
   /// Stores the batch or single run mode selection
@@ -263,7 +263,7 @@ private slots:
   void enableOrDisableDefaultSave();
   /// connected to the Multi-period check box it shows or hides the multi-period
   /// boxes on the file widgets
-  void disOrEnablePeriods(const int);
+  void disOrEnablePeriods(const int /*tickState*/);
   /// Switch mode
   void switchMode();
   /// Paste to batch table
@@ -281,7 +281,7 @@ private slots:
   /// Adds a warning message to the tab title
   void setLoggerTabTitleToWarn();
   /// Handle selection of the transmission
-  void transSelectorChanged(int);
+  void transSelectorChanged(int /*currindex*/);
   void loadTransmissionSettings();
 
   void handleSlicePushButton();

--- a/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
+++ b/qt/scientific_interfaces/ISISSANS/SANSRunWindow.h
@@ -75,7 +75,8 @@ signals:
   // signal  to notify mask file loaded
   void userfileLoaded();
   /// signal to send gemoetry information
-  void sendGeometryInformation(QString & /*_t1*/, QString & /*_t2*/, QString & /*_t3*/, QString & /*_t4*/);
+  void sendGeometryInformation(QString & /*_t1*/, QString & /*_t2*/,
+                               QString & /*_t3*/, QString & /*_t4*/);
 
 private:
   /// Stores the batch or single run mode selection

--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.h
@@ -29,8 +29,8 @@ private slots:
   void plotClicked();
   void runClicked();
   void getParameterDefaults(QString const &dataName);
-  void changeSampleDensityUnit(int);
-  void changeCanDensityUnit(int);
+  void changeSampleDensityUnit(int /*index*/);
+  void changeCanDensityUnit(int /*index*/);
   UserInputValidator doValidation();
 
 private:

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.h
@@ -29,8 +29,8 @@ private slots:
   void saveClicked();
   void plotClicked();
   void runClicked();
-  void changeSampleDensityUnit(int);
-  void changeCanDensityUnit(int);
+  void changeSampleDensityUnit(int /*index*/);
+  void changeCanDensityUnit(int /*index*/);
 
 private:
   void setup() override;

--- a/qt/scientific_interfaces/Indirect/Elwin.h
+++ b/qt/scientific_interfaces/Indirect/Elwin.h
@@ -24,7 +24,7 @@ private slots:
   void newInputFiles();
   void newPreviewFileSelected(int index);
   void plotInput();
-  void twoRanges(QtProperty *prop, bool);
+  void twoRanges(QtProperty *prop, bool /*val*/);
   void minChanged(double val);
   void maxChanged(double val);
   void updateRS(QtProperty *prop, double val);

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -51,8 +51,8 @@ public slots:
   virtual void displayWarning(std::string const &warning) = 0;
 
 signals:
-  void sampleLoaded(QString const &);
-  void resolutionLoaded(QString const &);
+  void sampleLoaded(QString const & /*_t1*/);
+  void resolutionLoaded(QString const & /*_t1*/);
   void addClicked();
   void removeClicked();
   void multipleDataViewSelected();

--- a/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitPlotView.h
@@ -86,17 +86,17 @@ public slots:
   virtual void setHWHMMinimum(double maximum) = 0;
 
 signals:
-  void selectedFitDataChanged(std::size_t);
+  void selectedFitDataChanged(std::size_t /*_t1*/);
   void plotCurrentPreview();
-  void plotSpectrumChanged(std::size_t);
-  void plotGuessChanged(bool);
+  void plotSpectrumChanged(std::size_t /*_t1*/);
+  void plotGuessChanged(bool /*_t1*/);
   void fitSelectedSpectrum();
-  void startXChanged(double);
-  void endXChanged(double);
-  void hwhmMinimumChanged(double);
-  void hwhmMaximumChanged(double);
-  void hwhmChanged(double, double);
-  void backgroundChanged(double);
+  void startXChanged(double /*_t1*/);
+  void endXChanged(double /*_t1*/);
+  void hwhmMinimumChanged(double /*_t1*/);
+  void hwhmMaximumChanged(double /*_t1*/);
+  void hwhmChanged(double /*_t1*/, double /*_t2*/);
+  void backgroundChanged(double /*_t1*/);
 };
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -54,9 +54,9 @@ private slots:
   void algorithmComplete(bool error);
   void calPlotRaw();
   void calPlotEnergy();
-  void calMinChanged(double);
-  void calMaxChanged(double);
-  void calUpdateRS(QtProperty *, double);
+  void calMinChanged(double /*val*/);
+  void calMaxChanged(double /*val*/);
+  void calUpdateRS(QtProperty * /*prop*/, double /*val*/);
   void calSetDefaultResolution(Mantid::API::MatrixWorkspace_const_sptr ws);
   void resCheck(bool state); ///< handles checking/unchecking of "Create RES
   /// File" checkbox

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.cpp
@@ -360,7 +360,7 @@ void ISISDiagnostics::handleNewFile() {
  *
  * @param state :: True to show the second range selectors, false to hide
  */
-void ISISDiagnostics::sliceTwoRanges(QtProperty *, bool state) {
+void ISISDiagnostics::sliceTwoRanges(QtProperty * /*unused*/, bool state) {
   m_uiForm.ppRawPlot->getRangeSelector("SliceBackground")->setVisible(state);
 }
 

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.h
@@ -52,10 +52,10 @@ public:
 private slots:
   void algorithmComplete(bool error);
   void handleNewFile();
-  void sliceTwoRanges(QtProperty *, bool);
+  void sliceTwoRanges(QtProperty * /*unused*/, bool /*state*/);
   void sliceCalib(bool state);
-  void rangeSelectorDropped(double, double);
-  void doublePropertyChanged(QtProperty *, double);
+  void rangeSelectorDropped(double /*min*/, double /*max*/);
+  void doublePropertyChanged(QtProperty * /*prop*/, double /*val*/);
   void setDefaultInstDetails();
   void sliceAlgDone(bool error);
   void

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
@@ -59,7 +59,7 @@ void IndirectBayes::initLayout() {}
 /**
  * @param :: the detected close event
  */
-void IndirectBayes::closeEvent(QCloseEvent *) {
+void IndirectBayes::closeEvent(QCloseEvent * /*unused*/) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.h
@@ -57,7 +57,7 @@ private slots:
 
 private:
   /// Called upon a close event.
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   /// handle POCO event
   void
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
@@ -54,7 +54,7 @@ IndirectCorrections::IndirectCorrections(QWidget *parent)
 /**
  * @param :: the detected close event
  */
-void IndirectCorrections::closeEvent(QCloseEvent *) {
+void IndirectCorrections::closeEvent(QCloseEvent * /*unused*/) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.h
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.h
@@ -66,7 +66,7 @@ private:
   void loadSettings();
 
   /// Called upon a close event.
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   /// handle POCO event
   void
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp
@@ -53,7 +53,7 @@ IndirectDataAnalysis::IndirectDataAnalysis(QWidget *parent)
 /**
  * @param :: the detected close event
  */
-void IndirectDataAnalysis::closeEvent(QCloseEvent *) {
+void IndirectDataAnalysis::closeEvent(QCloseEvent * /*unused*/) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.h
@@ -65,7 +65,7 @@ private:
   void loadSettings();
 
   /// Called upon a close event.
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   /// handle POCO event
   void
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
@@ -32,7 +32,8 @@ const QString MASK_LIST =
 
 class ExcludeRegionDelegate : public QItemDelegate {
 public:
-  QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem & /*option*/,
+  QWidget *createEditor(QWidget *parent,
+                        const QStyleOptionViewItem & /*option*/,
                         const QModelIndex & /*index*/) const override {
     auto lineEdit = Mantid::Kernel::make_unique<QLineEdit>(parent);
     auto validator = Mantid::Kernel::make_unique<QRegExpValidator>(

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
@@ -32,8 +32,8 @@ const QString MASK_LIST =
 
 class ExcludeRegionDelegate : public QItemDelegate {
 public:
-  QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &,
-                        const QModelIndex &) const override {
+  QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem & /*option*/,
+                        const QModelIndex & /*index*/) const override {
     auto lineEdit = Mantid::Kernel::make_unique<QLineEdit>(parent);
     auto validator = Mantid::Kernel::make_unique<QRegExpValidator>(
         QRegExp(Regexes::MASK_LIST), parent);
@@ -53,7 +53,7 @@ public:
   }
 
   void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option,
-                            const QModelIndex &) const override {
+                            const QModelIndex & /*index*/) const override {
     editor->setGeometry(option.rect);
   }
 };

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
@@ -40,9 +40,9 @@ public:
                   int spectrumIndex);
 
 signals:
-  void startXChanged(double, std::size_t, std::size_t);
-  void endXChanged(double, std::size_t, std::size_t);
-  void excludeRegionChanged(const std::string &, std::size_t, std::size_t);
+  void startXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void endXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
 
 public slots:
   void addData(std::size_t index);

--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.h
@@ -42,7 +42,8 @@ public:
 signals:
   void startXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
   void endXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
-  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/,
+                            std::size_t /*_t3*/);
 
 public slots:
   void addData(std::size_t index);

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -453,7 +453,7 @@ void IndirectFitAnalysisTab::tableEndXChanged(double endX,
   }
 }
 
-void IndirectFitAnalysisTab::tableExcludeChanged(const std::string &,
+void IndirectFitAnalysisTab::tableExcludeChanged(const std::string & /*unused*/,
                                                  std::size_t dataIndex,
                                                  std::size_t spectrum) {
   if (isRangeCurrentlySelected(dataIndex, spectrum))

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -138,7 +138,7 @@ protected:
 
 signals:
   void functionChanged();
-  void parameterChanged(const Mantid::API::IFunction *);
+  void parameterChanged(const Mantid::API::IFunction * /*_t1*/);
   void customBoolChanged(const QString &key, bool value);
   void updateAvailableFitTypes();
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -61,7 +61,7 @@ private:
 };
 
 struct CheckZeroSpectrum : boost::static_visitor<bool> {
-  bool operator()(const std::pair<std::size_t, std::size_t> &) const {
+  bool operator()(const std::pair<std::size_t, std::size_t> & /*unused*/) const {
     return false;
   }
   bool operator()(const DiscontinuousSpectra<std::size_t> &spectra) const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitData.cpp
@@ -61,7 +61,8 @@ private:
 };
 
 struct CheckZeroSpectrum : boost::static_visitor<bool> {
-  bool operator()(const std::pair<std::size_t, std::size_t> & /*unused*/) const {
+  bool
+  operator()(const std::pair<std::size_t, std::size_t> & /*unused*/) const {
     return false;
   }
   bool operator()(const DiscontinuousSpectra<std::size_t> &spectra) const {

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -63,7 +63,8 @@ signals:
   void dataChanged();
   void startXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
   void endXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
-  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/,
+                            std::size_t /*_t3*/);
   void multipleDataViewSelected();
   void singleDataViewSelected();
   void requestedAddWorkspaceDialog();

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -61,9 +61,9 @@ signals:
   void dataAdded();
   void dataRemoved();
   void dataChanged();
-  void startXChanged(double, std::size_t, std::size_t);
-  void endXChanged(double, std::size_t, std::size_t);
-  void excludeRegionChanged(const std::string &, std::size_t, std::size_t);
+  void startXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void endXChanged(double /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
+  void excludeRegionChanged(const std::string & /*_t1*/, std::size_t /*_t2*/, std::size_t /*_t3*/);
   void multipleDataViewSelected();
   void singleDataViewSelected();
   void requestedAddWorkspaceDialog();

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotPresenter.h
@@ -33,8 +33,8 @@ public:
   void setFitSingleSpectrumEnabled(bool enable);
 
 public slots:
-  void setStartX(double);
-  void setEndX(double);
+  void setStartX(double /*startX*/);
+  void setEndX(double /*endX*/);
   void updatePlotSpectrum(int spectrum);
   void hideMultipleDataSelection();
   void showMultipleDataSelection();
@@ -50,14 +50,14 @@ public slots:
   void disablePlotGuessInSeparateWindow();
 
 signals:
-  void selectedFitDataChanged(std::size_t);
+  void selectedFitDataChanged(std::size_t /*_t1*/);
   void noFitDataSelected();
-  void plotSpectrumChanged(std::size_t);
-  void fitSingleSpectrum(std::size_t, std::size_t);
-  void startXChanged(double);
-  void endXChanged(double);
-  void fwhmChanged(double);
-  void backgroundChanged(double);
+  void plotSpectrumChanged(std::size_t /*_t1*/);
+  void fitSingleSpectrum(std::size_t /*_t1*/, std::size_t /*_t2*/);
+  void startXChanged(double /*_t1*/);
+  void endXChanged(double /*_t1*/);
+  void fwhmChanged(double /*_t1*/);
+  void backgroundChanged(double /*_t1*/);
   void runAsPythonScript(const QString &code, bool noOutput = false);
 
 private slots:

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -84,10 +84,10 @@ public slots:
   void setHWHMMinimum(double maximum) override;
 
 private slots:
-  void emitPlotSpectrumChanged(int);
+  void emitPlotSpectrumChanged(int /*spectrum*/);
   void emitPlotSpectrumChanged(const QString &spectrum);
-  void emitSelectedFitDataChanged(int);
-  void emitPlotGuessChanged(int);
+  void emitSelectedFitDataChanged(int /*index*/);
+  void emitPlotGuessChanged(int /*doPlotGuess*/);
 
 private:
   std::string getSpectrumText() const;

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -250,7 +250,7 @@ void cleanTemporaries(const std::string &base,
                       const std::unique_ptr<IndirectFitData> &fitData) {
   removeFromADSIfExists(base);
 
-  const auto clean = [&](std::size_t index, std::size_t) {
+  const auto clean = [&](std::size_t index, std::size_t /*unused*/) {
     cleanTemporaries(base + "_" + std::to_string(index));
   };
   fitData->applyEnumeratedSpectra(clean);
@@ -717,7 +717,7 @@ IndirectFittingModel::mapDefaultParameterNames() const {
 }
 
 std::unordered_map<std::string, ParameterValue>
-IndirectFittingModel::createDefaultParameters(std::size_t) const {
+IndirectFittingModel::createDefaultParameters(std::size_t /*unused*/) const {
   return std::unordered_map<std::string, ParameterValue>();
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.h
@@ -27,7 +27,7 @@ public:
   void loadSettings(const QSettings &settings) override;
 
 private slots:
-  void versionSelected(const QString &);
+  void versionSelected(const QString & /*version*/);
   void runClicked();
   void plotClicked();
   void saveClicked();

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -36,7 +36,7 @@ public:
 
 protected slots:
   // Handle when a file/workspace is ready for plotting
-  void handleSampleInputReady(const QString &);
+  void handleSampleInputReady(const QString & /*filename*/);
   /// Slot for when the range selector changes
   void rangeChanged(double min, double max);
   /// Slot to update the guides when the range properties change

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
@@ -67,7 +67,7 @@ void IndirectSimulation::initLayout() {
  *
  * @param :: the detected close event
  */
-void IndirectSimulation::closeEvent(QCloseEvent *) {
+void IndirectSimulation::closeEvent(QCloseEvent * /*unused*/) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.h
@@ -58,7 +58,7 @@ private:
   /// Load default interface settings for each tab
   void loadSettings();
   /// Called upon a close event.
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   /// handle POCO event
   void
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionPresenter.h
@@ -33,8 +33,8 @@ public:
   UserInputValidator &validate(UserInputValidator &validator);
 
 signals:
-  void spectraChanged(std::size_t);
-  void maskChanged(std::string const &);
+  void spectraChanged(std::size_t /*_t1*/);
+  void maskChanged(std::string const & /*_t1*/);
   void invalidSpectraString(QString const &errorMessage);
   void invalidMaskBinsString(QString const &errorMessage);
 

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelectionView.h
@@ -74,10 +74,10 @@ public slots:
   void clearMaskString();
 
 signals:
-  void selectedSpectraChanged(const std::string &);
-  void selectedSpectraChanged(std::size_t, std::size_t);
-  void maskSpectrumChanged(int);
-  void maskChanged(const std::string &);
+  void selectedSpectraChanged(const std::string & /*_t1*/);
+  void selectedSpectraChanged(std::size_t /*_t1*/, std::size_t /*_t2*/);
+  void maskSpectrumChanged(int /*_t1*/);
+  void maskChanged(const std::string & /*_t1*/);
 
 private slots:
   void emitMaskChanged();

--- a/qt/scientific_interfaces/Indirect/IndirectTools.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.cpp
@@ -61,7 +61,7 @@ void IndirectTools::initLayout() {
  *
  * @param :: the detected close event
  */
-void IndirectTools::closeEvent(QCloseEvent *) {
+void IndirectTools::closeEvent(QCloseEvent * /*unused*/) {
   Mantid::Kernel::ConfigService::Instance().removeObserver(m_changeObserver);
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectTools.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.h
@@ -60,7 +60,7 @@ private:
   /// Load default interface settings for each tab
   void loadSettings();
   /// Called upon a close event.
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   /// Handle POCO event
   void
   handleDirectoryChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);

--- a/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFitModel.cpp
@@ -285,7 +285,7 @@ IqtFitModel::createFunctionWithGlobalBeta(IFunction_sptr function) const {
       new MultiDomainFunction);
   const auto functionString = function->asString();
   for (auto i = 0u; i < numberOfWorkspaces(); ++i) {
-    auto addDomains = [&](std::size_t) {
+    auto addDomains = [&](std::size_t /*unused*/) {
       const auto index = multiDomainFunction->nFunctions();
       multiDomainFunction->addFunction(createFunction(functionString));
       multiDomainFunction->setDomainIndex(index, index);

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -212,7 +212,7 @@ namespace CustomInterfaces {
 namespace IDA {
 
 void JumpFitModel::addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
-                                const Spectra &) {
+                                const Spectra & /*spectra*/) {
   const auto name = getHWHMName(workspace->getName());
   const auto parameters = addJumpFitParameters(workspace.get(), name);
 

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -25,7 +25,7 @@ public:
   using IndirectFittingModel::addWorkspace;
 
   void addWorkspace(Mantid::API::MatrixWorkspace_sptr workspace,
-                    const Spectra &) override;
+                    const Spectra & /*spectra*/) override;
   void removeWorkspace(std::size_t index) override;
   void setFitType(const std::string &fitType);
 

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFAddWorkspaceDialog.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFAddWorkspaceDialog.h
@@ -26,7 +26,7 @@ public:
 private slots:
   void accept() override;
   void reject() override;
-  void workspaceNameChanged(const QString &);
+  void workspaceNameChanged(const QString & /*wsName*/);
   void selectAllSpectra(int state);
 
 private:

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.cpp
@@ -234,7 +234,9 @@ std::pair<double, double> DataController::getFittingRange(int i) const {
 }
 
 /// Inform the others that a dataset was updated.
-void DataController::updateDataset(int row, int /*unused*/) { emit dataSetUpdated(row); }
+void DataController::updateDataset(int row, int /*unused*/) {
+  emit dataSetUpdated(row);
+}
 
 /// Object's parent cast to MultiDatasetFit.
 MultiDatasetFit *DataController::owner() const {

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.cpp
@@ -234,7 +234,7 @@ std::pair<double, double> DataController::getFittingRange(int i) const {
 }
 
 /// Inform the others that a dataset was updated.
-void DataController::updateDataset(int row, int) { emit dataSetUpdated(row); }
+void DataController::updateDataset(int row, int /*unused*/) { emit dataSetUpdated(row); }
 
 /// Object's parent cast to MultiDatasetFit.
 MultiDatasetFit *DataController::owner() const {

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFDataController.h
@@ -55,19 +55,19 @@ public:
 signals:
   void dataTableUpdated();
   void dataSetUpdated(int i);
-  void hasSelection(bool);
-  void spectraRemoved(QList<int>);
+  void hasSelection(bool /*_t1*/);
+  void spectraRemoved(QList<int> /*_t1*/);
   void spectraAdded(int n);
 
 public slots:
-  void setFittingRangeGlobal(bool);
-  void setFittingRange(int, double, double);
+  void setFittingRangeGlobal(bool /*on*/);
+  void setFittingRange(int /*i*/, double /*startX*/, double /*endX*/);
 
 private slots:
   void addWorkspace();
   void workspaceSelectionChanged();
   void removeSelectedSpectra();
-  void updateDataset(int, int);
+  void updateDataset(int /*row*/, int /*unused*/);
 
 private:
   MultiDatasetFit *owner() const;

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFEditLocalParameterDialog.h
@@ -47,18 +47,18 @@ public:
   bool isLogCheckboxTicked() const;
 
 signals:
-  void logOptionsChecked(bool);
+  void logOptionsChecked(bool /*_t1*/);
 
 private slots:
-  void valueChanged(int, int);
-  void setAllValues(double);
-  void fixParameter(int, bool);
-  void setAllFixed(bool);
-  void setTie(int, QString);
-  void setTieAll(QString);
+  void valueChanged(int /*row*/, int /*col*/);
+  void setAllValues(double /*value*/);
+  void fixParameter(int /*index*/, bool /*fix*/);
+  void setAllFixed(bool /*fix*/);
+  void setTie(int /*index*/, QString /*tie*/);
+  void setTieAll(QString /*tie*/);
   void copy();
   void paste();
-  void setValueToLog(int);
+  void setValueToLog(int /*i*/);
   void setAllValuesToLog();
 
 private:

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterEditor.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterEditor.cpp
@@ -198,7 +198,7 @@ void LocalParameterEditor::removeAllTies() {
 void LocalParameterEditor::setToLog() { emit setValueToLog(m_index); }
 
 /// Filter events in the line editor to emulate a shortcut (F to fix/unfix).
-bool LocalParameterEditor::eventFilter(QObject *, QEvent *evn) {
+bool LocalParameterEditor::eventFilter(QObject * /*unused*/, QEvent *evn) {
   if (evn->type() == QEvent::KeyPress) {
     auto keyEvent = static_cast<QKeyEvent *>(evn);
     if (keyEvent->key() == Qt::Key_F &&

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterEditor.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterEditor.h
@@ -28,12 +28,12 @@ public:
                        QString tie, bool othersFixed, bool allOthersFixed,
                        bool othersTied, bool logOptionsEnabled);
 signals:
-  void setAllValues(double);
-  void fixParameter(int, bool);
-  void setAllFixed(bool);
-  void setTie(int, QString);
-  void setTieAll(QString);
-  void setValueToLog(int);
+  void setAllValues(double /*_t1*/);
+  void fixParameter(int /*_t1*/, bool /*_t2*/);
+  void setAllFixed(bool /*_t1*/);
+  void setTie(int /*_t1*/, QString /*_t2*/);
+  void setTieAll(QString /*_t1*/);
+  void setValueToLog(int /*_t1*/);
   void setAllValuesToLog();
 private slots:
   void setAll();

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
@@ -21,10 +21,9 @@ LocalParameterItemDelegate::LocalParameterItemDelegate(
     : QStyledItemDelegate(parent), m_currentEditor(nullptr) {}
 
 /// Create a custom editor LocalParameterEditor.
-QWidget *
-LocalParameterItemDelegate::createEditor(QWidget *parent,
-                                         const QStyleOptionViewItem & /*option*/,
-                                         const QModelIndex &index) const {
+QWidget *LocalParameterItemDelegate::createEditor(
+    QWidget *parent, const QStyleOptionViewItem & /*option*/,
+    const QModelIndex &index) const {
   auto row = index.row();
   m_currentEditor = new LocalParameterEditor(
       parent, row, owner()->getValue(row), owner()->isFixed(row),
@@ -53,8 +52,8 @@ LocalParameterItemDelegate::createEditor(QWidget *parent,
 }
 
 /// Initialize the editor with the current data in the cell.
-void LocalParameterItemDelegate::setEditorData(QWidget * /*editor*/,
-                                               const QModelIndex & /*index*/) const {
+void LocalParameterItemDelegate::setEditorData(
+    QWidget * /*editor*/, const QModelIndex & /*index*/) const {
   // Needs to be empty to prevent Qt's default behaviour.
 }
 

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.cpp
@@ -23,7 +23,7 @@ LocalParameterItemDelegate::LocalParameterItemDelegate(
 /// Create a custom editor LocalParameterEditor.
 QWidget *
 LocalParameterItemDelegate::createEditor(QWidget *parent,
-                                         const QStyleOptionViewItem &,
+                                         const QStyleOptionViewItem & /*option*/,
                                          const QModelIndex &index) const {
   auto row = index.row();
   m_currentEditor = new LocalParameterEditor(
@@ -53,8 +53,8 @@ LocalParameterItemDelegate::createEditor(QWidget *parent,
 }
 
 /// Initialize the editor with the current data in the cell.
-void LocalParameterItemDelegate::setEditorData(QWidget *,
-                                               const QModelIndex &) const {
+void LocalParameterItemDelegate::setEditorData(QWidget * /*editor*/,
+                                               const QModelIndex & /*index*/) const {
   // Needs to be empty to prevent Qt's default behaviour.
 }
 

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFLocalParameterItemDelegate.h
@@ -38,12 +38,12 @@ public:
   void prepareForPastedData();
 
 signals:
-  void setAllValues(double);
-  void fixParameter(int, bool);
-  void setAllFixed(bool);
-  void setTie(int, QString);
-  void setTieAll(QString);
-  void setValueToLog(int);
+  void setAllValues(double /*_t1*/);
+  void fixParameter(int /*_t1*/, bool /*_t2*/);
+  void setAllFixed(bool /*_t1*/);
+  void setTie(int /*_t1*/, QString /*_t2*/);
+  void setTieAll(QString /*_t1*/);
+  void setValueToLog(int /*_t1*/);
   void setAllValuesToLog();
 
 protected:
@@ -51,7 +51,7 @@ protected:
              const QModelIndex &index) const override;
 
 private slots:
-  void doSetValueToLog(int);
+  void doSetValueToLog(int /*i*/);
   void doSetAllValuesToLog();
 
 private:

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFPlotController.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFPlotController.h
@@ -65,14 +65,14 @@ public:
   void setGuessFunction(const QString &funStr);
   void updateGuessFunction(const Mantid::API::IFunction &fun);
 signals:
-  void currentIndexChanged(int);
-  void fittingRangeChanged(int, double, double);
+  void currentIndexChanged(int /*_t1*/);
+  void fittingRangeChanged(int /*_t1*/, double /*_t2*/, double /*_t3*/);
 public slots:
   void enableZoom();
   void enablePan();
   void enableRange();
   void updateRange(int index);
-  void showDataErrors(bool);
+  void showDataErrors(bool /*on*/);
   void resetRange();
   void zoomToRange();
   void exportCurrentPlot();
@@ -82,7 +82,7 @@ private slots:
   void tableUpdated();
   void prevPlot();
   void nextPlot();
-  void plotDataSet(int);
+  void plotDataSet(int /*index*/);
   void updateFittingRange(double startX, double endX);
   void updateGuessPlot();
 

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -830,7 +830,7 @@ void MultiDatasetFit::showParameterPlot() {
   runPythonCode(pyInput);
 }
 
-void MultiDatasetFit::updateGuessFunction(const QString &, const QString &) {
+void MultiDatasetFit::updateGuessFunction(const QString & /*unused*/, const QString & /*unused*/) {
   auto fun = m_functionBrowser->getFunction();
   auto composite =
       boost::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -830,7 +830,8 @@ void MultiDatasetFit::showParameterPlot() {
   runPythonCode(pyInput);
 }
 
-void MultiDatasetFit::updateGuessFunction(const QString & /*unused*/, const QString & /*unused*/) {
+void MultiDatasetFit::updateGuessFunction(const QString & /*unused*/,
+                                          const QString & /*unused*/) {
   auto fun = m_functionBrowser->getFunction();
   auto composite =
       boost::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -93,7 +93,7 @@ public slots:
 private slots:
   void fit();
   void editLocalParameterValues(const QString &parName);
-  void finishFit(bool);
+  void finishFit(bool /*error*/);
   void enableZoom();
   void enablePan();
   void enableRange();
@@ -103,7 +103,7 @@ private slots:
   void setLogNames();
   void setParameterNamesForPlotting();
   void invalidateOutput();
-  void updateGuessFunction(const QString &, const QString &);
+  void updateGuessFunction(const QString & /*unused*/, const QString & /*unused*/);
 
 protected:
   void initLayout() override;

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.h
@@ -103,7 +103,8 @@ private slots:
   void setLogNames();
   void setParameterNamesForPlotting();
   void invalidateOutput();
-  void updateGuessFunction(const QString & /*unused*/, const QString & /*unused*/);
+  void updateGuessFunction(const QString & /*unused*/,
+                           const QString & /*unused*/);
 
 protected:
   void initLayout() override;

--- a/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysis.cpp
@@ -2983,7 +2983,7 @@ bool MuonAnalysis::isOverwriteEnabled() {
 /**
  * Executed when interface gets hidden or closed
  */
-void MuonAnalysis::hideEvent(QHideEvent *) {
+void MuonAnalysis::hideEvent(QHideEvent * /*unused*/) {
   // Show toolbars if were chosen to be hidden by user
   if (m_uiForm.hideToolbars->isChecked())
     emit setToolbarsHidden(false);
@@ -2996,7 +2996,7 @@ void MuonAnalysis::hideEvent(QHideEvent *) {
 /**
  * Executed when interface gets shown
  */
-void MuonAnalysis::showEvent(QShowEvent *) {
+void MuonAnalysis::showEvent(QShowEvent * /*unused*/) {
   // Hide toolbars if requested by user
   if (m_uiForm.hideToolbars->isChecked())
     emit setToolbarsHidden(true);

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.h
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableTab.h
@@ -45,8 +45,8 @@ signals:
 
 private slots:
   void helpResultsClicked();
-  void selectAllLogs(bool);
-  void selectAllFittings(bool);
+  void selectAllLogs(bool /*state*/);
+  void selectAllFittings(bool /*state*/);
 
   /// Executed when "Create table" button is clicked
   void onCreateTableClicked();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmDialog.h
@@ -251,7 +251,7 @@ protected:
   /// GenericDialogDemo.cpp
 public:
   /// Set the algorithm associated with this dialog
-  void setAlgorithm(Mantid::API::IAlgorithm_sptr);
+  void setAlgorithm(Mantid::API::IAlgorithm_sptr /*alg*/);
   /// Set a list of suggested values
   void setPresetValues(const QHash<QString, QString> &presetValues);
   /// Set whether this is intended for use from a script or not

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
@@ -97,7 +97,7 @@ class AlgExecSummaryGrpBox : public QGroupBox {
   Q_OBJECT
 public:
   explicit AlgExecSummaryGrpBox(QWidget *w);
-  AlgExecSummaryGrpBox(QString, QWidget *w);
+  AlgExecSummaryGrpBox(QString /*title*/, QWidget *w);
   ~AlgExecSummaryGrpBox() override;
   void setData(const double execDuration,
                const Mantid::Types::Core::DateAndTime execDate);
@@ -118,7 +118,7 @@ class AlgEnvHistoryGrpBox : public QGroupBox {
   Q_OBJECT
 public:
   explicit AlgEnvHistoryGrpBox(QWidget *w);
-  AlgEnvHistoryGrpBox(QString, QWidget *w);
+  AlgEnvHistoryGrpBox(QString /*title*/, QWidget *w);
   ~AlgEnvHistoryGrpBox() override;
 
   QLineEdit *getosNameEdit() const { return m_osNameEdit; }
@@ -144,7 +144,7 @@ signals:
 
 public:
   AlgorithmHistoryWindow(QWidget *parent,
-                         const boost::shared_ptr<const Mantid::API::Workspace>);
+                         const boost::shared_ptr<const Mantid::API::Workspace> /*wsptr*/);
   AlgorithmHistoryWindow(QWidget *parent, const QString &workspaceName);
   ~AlgorithmHistoryWindow() override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
@@ -143,8 +143,9 @@ signals:
   void updateAlgorithmHistoryWindow(QString algName);
 
 public:
-  AlgorithmHistoryWindow(QWidget *parent,
-                         const boost::shared_ptr<const Mantid::API::Workspace> /*wsptr*/);
+  AlgorithmHistoryWindow(
+      QWidget *parent,
+      const boost::shared_ptr<const Mantid::API::Workspace> /*wsptr*/);
   AlgorithmHistoryWindow(QWidget *parent, const QString &workspaceName);
   ~AlgorithmHistoryWindow() override;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
@@ -35,8 +35,8 @@ public:
                                    AlgorithmProgressModel &model);
 
   void algorithmStartedSlot(Mantid::API::AlgorithmID /*unused*/) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/, double /*unused*/,
-                             QString /*unused*/) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/,
+                             double /*unused*/, QString /*unused*/) override;
   void algorithmEndedSlot(Mantid::API::AlgorithmID /*unused*/) override;
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressDialogPresenter.h
@@ -34,10 +34,10 @@ public:
                                    AlgorithmProgressDialogWidget *view,
                                    AlgorithmProgressModel &model);
 
-  void algorithmStartedSlot(Mantid::API::AlgorithmID) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID, double,
-                             QString) override;
-  void algorithmEndedSlot(Mantid::API::AlgorithmID) override;
+  void algorithmStartedSlot(Mantid::API::AlgorithmID /*unused*/) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/, double /*unused*/,
+                             QString /*unused*/) override;
+  void algorithmEndedSlot(Mantid::API::AlgorithmID /*unused*/) override;
 
 private:
   AlgorithmProgressDialogWidget *m_view;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressModel.h
@@ -55,7 +55,7 @@ public:
                    const std::string &what) override;
   /// Removes itself as an observer from the algorithm
   void removeFrom(const Mantid::API::IAlgorithm *alg);
-  void setDialog(AlgorithmProgressDialogPresenter *);
+  void setDialog(AlgorithmProgressDialogPresenter * /*presenter*/);
 
 private:
   QPointer<AlgorithmProgressDialogPresenter> m_dialogPresenter;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
@@ -35,11 +35,12 @@ class AlgorithmProgressPresenter : public AlgorithmProgressPresenterBase {
   Q_OBJECT
 
 public:
-  AlgorithmProgressPresenter(QWidget *parent, AlgorithmProgressWidget * /*view*/);
+  AlgorithmProgressPresenter(QWidget *parent,
+                             AlgorithmProgressWidget * /*view*/);
 
   void algorithmStartedSlot(Mantid::API::AlgorithmID /*unused*/) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/, double /*unused*/,
-                             QString /*unused*/) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/,
+                             double /*unused*/, QString /*unused*/) override;
   void algorithmEndedSlot(Mantid::API::AlgorithmID /*unused*/) override;
 
   AlgorithmProgressModel &model() { return m_model; }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenter.h
@@ -35,12 +35,12 @@ class AlgorithmProgressPresenter : public AlgorithmProgressPresenterBase {
   Q_OBJECT
 
 public:
-  AlgorithmProgressPresenter(QWidget *parent, AlgorithmProgressWidget *);
+  AlgorithmProgressPresenter(QWidget *parent, AlgorithmProgressWidget * /*view*/);
 
-  void algorithmStartedSlot(Mantid::API::AlgorithmID) override;
-  void updateProgressBarSlot(Mantid::API::AlgorithmID, double,
-                             QString) override;
-  void algorithmEndedSlot(Mantid::API::AlgorithmID) override;
+  void algorithmStartedSlot(Mantid::API::AlgorithmID /*unused*/) override;
+  void updateProgressBarSlot(Mantid::API::AlgorithmID /*unused*/, double /*unused*/,
+                             QString /*unused*/) override;
+  void algorithmEndedSlot(Mantid::API::AlgorithmID /*unused*/) override;
 
   AlgorithmProgressModel &model() { return m_model; }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
@@ -42,9 +42,11 @@ public:
   void algorithmEnded(Mantid::API::AlgorithmID /*alg*/);
   /// Signals to the presenters that there has been progress in one of the
   /// algorithms
-  void updateProgressBar(Mantid::API::AlgorithmID /*alg*/, double /*progress*/, const std::string & /*msg*/);
+  void updateProgressBar(Mantid::API::AlgorithmID /*alg*/, double /*progress*/,
+                         const std::string & /*msg*/);
   /// Sets the parameter progress bar to show the progress and message
-  void setProgressBar(QProgressBar * /*progressBar*/, double /*progress*/, const QString & /*message*/);
+  void setProgressBar(QProgressBar * /*progressBar*/, double /*progress*/,
+                      const QString & /*message*/);
 
 public slots:
   virtual void algorithmStartedSlot(Mantid::API::AlgorithmID) = 0;
@@ -54,7 +56,8 @@ public slots:
 
 signals:
   void algorithmStartedSignal(Mantid::API::AlgorithmID /*_t1*/);
-  void updateProgressBarSignal(Mantid::API::AlgorithmID /*_t1*/, double /*_t2*/, QString /*_t3*/);
+  void updateProgressBarSignal(Mantid::API::AlgorithmID /*_t1*/, double /*_t2*/,
+                               QString /*_t3*/);
   void algorithmEndedSignal(Mantid::API::AlgorithmID /*_t1*/);
 };
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmProgress/AlgorithmProgressPresenterBase.h
@@ -37,14 +37,14 @@ public:
   AlgorithmProgressPresenterBase(QObject *parent);
 
   /// Signals to the presenters that an algorithm has started.
-  void algorithmStarted(Mantid::API::AlgorithmID);
+  void algorithmStarted(Mantid::API::AlgorithmID /*alg*/);
   /// Signals to the presenters that an algorithm has ended.
-  void algorithmEnded(Mantid::API::AlgorithmID);
+  void algorithmEnded(Mantid::API::AlgorithmID /*alg*/);
   /// Signals to the presenters that there has been progress in one of the
   /// algorithms
-  void updateProgressBar(Mantid::API::AlgorithmID, double, const std::string &);
+  void updateProgressBar(Mantid::API::AlgorithmID /*alg*/, double /*progress*/, const std::string & /*msg*/);
   /// Sets the parameter progress bar to show the progress and message
-  void setProgressBar(QProgressBar *, double, const QString &);
+  void setProgressBar(QProgressBar * /*progressBar*/, double /*progress*/, const QString & /*message*/);
 
 public slots:
   virtual void algorithmStartedSlot(Mantid::API::AlgorithmID) = 0;
@@ -53,9 +53,9 @@ public slots:
   virtual void algorithmEndedSlot(Mantid::API::AlgorithmID) = 0;
 
 signals:
-  void algorithmStartedSignal(Mantid::API::AlgorithmID);
-  void updateProgressBarSignal(Mantid::API::AlgorithmID, double, QString);
-  void algorithmEndedSignal(Mantid::API::AlgorithmID);
+  void algorithmStartedSignal(Mantid::API::AlgorithmID /*_t1*/);
+  void updateProgressBarSignal(Mantid::API::AlgorithmID /*_t1*/, double /*_t2*/, QString /*_t3*/);
+  void algorithmEndedSignal(Mantid::API::AlgorithmID /*_t1*/);
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmSelectorWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmSelectorWidget.h
@@ -67,7 +67,7 @@ public:
   SelectedAlgorithm getSelectedAlgorithm();
   void setSelectedAlgorithm(QString &algName);
   bool showExecuteButton() const;
-  void showExecuteButton(const bool);
+  void showExecuteButton(const bool /*val*/);
 
 public slots:
   void update();
@@ -77,8 +77,8 @@ public slots:
 
 signals:
   void algorithmFactoryUpdateReceived();
-  void executeAlgorithm(const QString &, int);
-  void algorithmSelectionChanged(const QString &, int);
+  void executeAlgorithm(const QString & /*_t1*/, int /*_t2*/);
+  void algorithmSelectionChanged(const QString & /*_t1*/, int /*_t2*/);
 
 protected:
   AlgorithmTreeWidget *m_tree;
@@ -88,7 +88,7 @@ protected:
 private:
   /// Callback for AlgorithmFactory update notifications
   void handleAlgorithmFactoryUpdate(
-      Mantid::API::AlgorithmFactoryUpdateNotification_ptr);
+      Mantid::API::AlgorithmFactoryUpdateNotification_ptr /*unused*/);
   /// Observes algorithm factory update notifications
   Poco::NObserver<AlgorithmSelectorWidget,
                   Mantid::API::AlgorithmFactoryUpdateNotification>
@@ -116,7 +116,7 @@ public slots:
 
 signals:
   /// Signal emitted when the widget requests that we execute that algorithm
-  void executeAlgorithm(const QString &, int);
+  void executeAlgorithm(const QString & /*_t1*/, int /*_t2*/);
 
 private:
   QPoint m_dragStartPosition;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
@@ -111,7 +111,7 @@ protected:
   void enableFiltering();
 
 protected slots:
-  void commitData(QWidget *) override;
+  void commitData(QWidget * /*editor*/) override;
 
 private:
   // The view property values for an uneditable, unselectable cell.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/equal.hpp
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/equal.hpp
@@ -28,7 +28,7 @@ namespace detail {
     template <class RandomAccessIterator1, class RandomAccessIterator2, class BinaryPredicate>
     bool equal ( RandomAccessIterator1 first1, RandomAccessIterator1 last1,
                  RandomAccessIterator2 first2, RandomAccessIterator2 last2, BinaryPredicate pred,
-                 std::random_access_iterator_tag, std::random_access_iterator_tag )
+                 std::random_access_iterator_tag /*unused*/, std::random_access_iterator_tag  /*unused*/)
     {
     //  Random-access iterators let is check the sizes in constant time
         if ( std::distance ( first1, last1 ) != std::distance ( first2, last2 ))
@@ -40,7 +40,7 @@ namespace detail {
     template <class InputIterator1, class InputIterator2, class BinaryPredicate>
     bool equal ( InputIterator1 first1, InputIterator1 last1,
                  InputIterator2 first2, InputIterator2 last2, BinaryPredicate pred,
-                 std::input_iterator_tag, std::input_iterator_tag )
+                 std::input_iterator_tag /*unused*/, std::input_iterator_tag  /*unused*/)
     {
     for (; first1 != last1 && first2 != last2; ++first1, ++first2 )
         if ( !pred(*first1, *first2 ))

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
@@ -73,7 +73,7 @@ signals:
 
 private:
   /// Implementation of algorithm runner
-  bool executeBatchAsyncImpl(const Poco::Void &);
+  bool executeBatchAsyncImpl(const Poco::Void & /*unused*/);
   /// Sets up and executes an algorithm
   bool executeAlgo(ConfiguredAlgorithm algorithm);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
@@ -36,46 +36,46 @@ public:
 
   /// Notify this receiver with the list of table workspaces in the ADS that can
   /// be loaded into the interface
-  virtual void notifyADSChanged(const QSet<QString> &, int) {}
+  virtual void notifyADSChanged(const QSet<QString> & /*unused*/, int /*unused*/) {}
 
   /// Return global options for pre-processing
-  virtual ColumnOptionsQMap getPreprocessingOptions(int) const {
+  virtual ColumnOptionsQMap getPreprocessingOptions(int /*unused*/) const {
     return ColumnOptionsQMap();
   }
   /// Return global options for reduction
-  virtual OptionsQMap getProcessingOptions(int) const { return OptionsQMap(); }
+  virtual OptionsQMap getProcessingOptions(int /*unused*/) const { return OptionsQMap(); }
   /// Return global options for post-processing as a string
-  virtual QString getPostprocessingOptionsAsString(int) const {
+  virtual QString getPostprocessingOptionsAsString(int /*unused*/) const {
     return QString();
   }
   /// Return time-slicing values
-  virtual QString getTimeSlicingValues(int) const { return QString(); }
+  virtual QString getTimeSlicingValues(int /*unused*/) const { return QString(); }
   /// Return time-slicing type
-  virtual QString getTimeSlicingType(int) const { return QString(); }
+  virtual QString getTimeSlicingType(int /*unused*/) const { return QString(); }
   /// Return transmission runs for a particular angle
-  virtual OptionsQMap getOptionsForAngle(const double, int) const {
+  virtual OptionsQMap getOptionsForAngle(const double /*unused*/, int /*unused*/) const {
     return OptionsQMap();
   }
   /// Return true if there are per-angle transmission runs set
-  virtual bool hasPerAngleOptions(int) const { return false; }
+  virtual bool hasPerAngleOptions(int /*unused*/) const { return false; }
 
   /// Return true if autoreduction is in progress for any group
   virtual bool isAutoreducing() const { return false; }
   /// Return true if autoreduction is in progress for a specific group
-  virtual bool isAutoreducing(int) const { return false; }
+  virtual bool isAutoreducing(int /*unused*/) const { return false; }
 
   /// Handle data reduction paused/resumed
-  virtual void pause(int) {}
-  virtual void resume(int) const {}
+  virtual void pause(int /*unused*/) {}
+  virtual void resume(int /*unused*/) const {}
 
   /// Handle data reduction paused/resumed confirmation
-  virtual void confirmReductionCompleted(int) {}
-  virtual void confirmReductionPaused(int){};
-  virtual void confirmReductionResumed(int){};
-  virtual void completedGroupReductionSuccessfully(GroupData const &,
-                                                   std::string const &){};
-  virtual void completedRowReductionSuccessfully(GroupData const &,
-                                                 std::string const &){};
+  virtual void confirmReductionCompleted(int /*unused*/) {}
+  virtual void confirmReductionPaused(int /*unused*/){};
+  virtual void confirmReductionResumed(int /*unused*/){};
+  virtual void completedGroupReductionSuccessfully(GroupData const & /*unused*/,
+                                                   std::string const & /*unused*/){};
+  virtual void completedRowReductionSuccessfully(GroupData const & /*unused*/,
+                                                 std::string const & /*unused*/){};
 };
 } // namespace DataProcessor
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/DataProcessorMainPresenter.h
@@ -36,24 +36,30 @@ public:
 
   /// Notify this receiver with the list of table workspaces in the ADS that can
   /// be loaded into the interface
-  virtual void notifyADSChanged(const QSet<QString> & /*unused*/, int /*unused*/) {}
+  virtual void notifyADSChanged(const QSet<QString> & /*unused*/,
+                                int /*unused*/) {}
 
   /// Return global options for pre-processing
   virtual ColumnOptionsQMap getPreprocessingOptions(int /*unused*/) const {
     return ColumnOptionsQMap();
   }
   /// Return global options for reduction
-  virtual OptionsQMap getProcessingOptions(int /*unused*/) const { return OptionsQMap(); }
+  virtual OptionsQMap getProcessingOptions(int /*unused*/) const {
+    return OptionsQMap();
+  }
   /// Return global options for post-processing as a string
   virtual QString getPostprocessingOptionsAsString(int /*unused*/) const {
     return QString();
   }
   /// Return time-slicing values
-  virtual QString getTimeSlicingValues(int /*unused*/) const { return QString(); }
+  virtual QString getTimeSlicingValues(int /*unused*/) const {
+    return QString();
+  }
   /// Return time-slicing type
   virtual QString getTimeSlicingType(int /*unused*/) const { return QString(); }
   /// Return transmission runs for a particular angle
-  virtual OptionsQMap getOptionsForAngle(const double /*unused*/, int /*unused*/) const {
+  virtual OptionsQMap getOptionsForAngle(const double /*unused*/,
+                                         int /*unused*/) const {
     return OptionsQMap();
   }
   /// Return true if there are per-angle transmission runs set
@@ -72,10 +78,12 @@ public:
   virtual void confirmReductionCompleted(int /*unused*/) {}
   virtual void confirmReductionPaused(int /*unused*/){};
   virtual void confirmReductionResumed(int /*unused*/){};
-  virtual void completedGroupReductionSuccessfully(GroupData const & /*unused*/,
-                                                   std::string const & /*unused*/){};
-  virtual void completedRowReductionSuccessfully(GroupData const & /*unused*/,
-                                                 std::string const & /*unused*/){};
+  virtual void
+  completedGroupReductionSuccessfully(GroupData const & /*unused*/,
+                                      std::string const & /*unused*/){};
+  virtual void
+  completedRowReductionSuccessfully(GroupData const & /*unused*/,
+                                    std::string const & /*unused*/){};
 };
 } // namespace DataProcessor
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
@@ -40,18 +40,18 @@ class EXPORT_OPT_MANTIDQT_COMMON QDataProcessorWidget
 public:
   QDataProcessorWidget(std::unique_ptr<DataProcessorPresenter> presenter,
                        QWidget *parent = nullptr);
-  QDataProcessorWidget(const WhiteList &, QWidget *parent, int group = 0);
-  QDataProcessorWidget(const WhiteList &, const ProcessingAlgorithm &,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, QWidget *parent, int group = 0);
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, const ProcessingAlgorithm & /*algorithm*/,
                        QWidget *parent, int group = 0);
-  QDataProcessorWidget(const WhiteList &, const PreprocessMap &,
-                       const ProcessingAlgorithm &, QWidget *parent,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, const PreprocessMap & /*preprocessMap*/,
+                       const ProcessingAlgorithm & /*algorithm*/, QWidget *parent,
                        int group = 0);
-  QDataProcessorWidget(const WhiteList &, const ProcessingAlgorithm &,
-                       const PostprocessingAlgorithm &, QWidget *parent,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, const ProcessingAlgorithm & /*algorithm*/,
+                       const PostprocessingAlgorithm & /*postprocessor*/, QWidget *parent,
                        int group = 0);
-  QDataProcessorWidget(const WhiteList &, const PreprocessMap &,
-                       const ProcessingAlgorithm &,
-                       const PostprocessingAlgorithm &, QWidget *parent,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, const PreprocessMap & /*preprocessMap*/,
+                       const ProcessingAlgorithm & /*algorithm*/,
+                       const PostprocessingAlgorithm & /*postprocessor*/, QWidget *parent,
                        int group = 0);
   ~QDataProcessorWidget() override;
 
@@ -122,7 +122,7 @@ public:
   QString getCurrentInstrument() const override;
 
   // Forward a main presenter to this view's presenter
-  void accept(DataProcessorMainPresenter *);
+  void accept(DataProcessorMainPresenter * /*mainPresenter*/);
 
   // Force re-processing of rows
   void setForcedReProcessing(bool forceReProcessing) override;
@@ -150,7 +150,7 @@ signals:
   void processButtonClicked();
   void processingFinished();
   void instrumentHasChanged();
-  void dataChanged(const QModelIndex &, const QModelIndex &);
+  void dataChanged(const QModelIndex & /*_t1*/, const QModelIndex & /*_t2*/);
 
 private:
   // initialise the interface

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QDataProcessorWidget.h
@@ -40,19 +40,24 @@ class EXPORT_OPT_MANTIDQT_COMMON QDataProcessorWidget
 public:
   QDataProcessorWidget(std::unique_ptr<DataProcessorPresenter> presenter,
                        QWidget *parent = nullptr);
-  QDataProcessorWidget(const WhiteList & /*whitelist*/, QWidget *parent, int group = 0);
-  QDataProcessorWidget(const WhiteList & /*whitelist*/, const ProcessingAlgorithm & /*algorithm*/,
-                       QWidget *parent, int group = 0);
-  QDataProcessorWidget(const WhiteList & /*whitelist*/, const PreprocessMap & /*preprocessMap*/,
-                       const ProcessingAlgorithm & /*algorithm*/, QWidget *parent,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/, QWidget *parent,
                        int group = 0);
-  QDataProcessorWidget(const WhiteList & /*whitelist*/, const ProcessingAlgorithm & /*algorithm*/,
-                       const PostprocessingAlgorithm & /*postprocessor*/, QWidget *parent,
-                       int group = 0);
-  QDataProcessorWidget(const WhiteList & /*whitelist*/, const PreprocessMap & /*preprocessMap*/,
+  QDataProcessorWidget(const WhiteList & /*whitelist*/,
                        const ProcessingAlgorithm & /*algorithm*/,
-                       const PostprocessingAlgorithm & /*postprocessor*/, QWidget *parent,
-                       int group = 0);
+                       QWidget *parent, int group = 0);
+  QDataProcessorWidget(const WhiteList & /*whitelist*/,
+                       const PreprocessMap & /*preprocessMap*/,
+                       const ProcessingAlgorithm & /*algorithm*/,
+                       QWidget *parent, int group = 0);
+  QDataProcessorWidget(const WhiteList & /*whitelist*/,
+                       const ProcessingAlgorithm & /*algorithm*/,
+                       const PostprocessingAlgorithm & /*postprocessor*/,
+                       QWidget *parent, int group = 0);
+  QDataProcessorWidget(const WhiteList & /*whitelist*/,
+                       const PreprocessMap & /*preprocessMap*/,
+                       const ProcessingAlgorithm & /*algorithm*/,
+                       const PostprocessingAlgorithm & /*postprocessor*/,
+                       QWidget *parent, int group = 0);
   ~QDataProcessorWidget() override;
 
   // Add actions to the toolbar

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
@@ -86,7 +86,8 @@ public:
   // Transfer rows into the table
   void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
-  void tableDataUpdated(const QModelIndex & /*unused*/, const QModelIndex & /*unused*/);
+  void tableDataUpdated(const QModelIndex & /*unused*/,
+                        const QModelIndex & /*unused*/);
 
 private:
   /// Update all cached row data from the table data

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QOneLevelTreeModel.h
@@ -86,7 +86,7 @@ public:
   // Transfer rows into the table
   void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
-  void tableDataUpdated(const QModelIndex &, const QModelIndex &);
+  void tableDataUpdated(const QModelIndex & /*unused*/, const QModelIndex & /*unused*/);
 
 private:
   /// Update all cached row data from the table data

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
@@ -96,7 +96,8 @@ public:
   // Transfer rows into the table
   void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
-  void tableDataUpdated(const QModelIndex & /*topLeft*/, const QModelIndex & /*bottomRight*/);
+  void tableDataUpdated(const QModelIndex & /*topLeft*/,
+                        const QModelIndex & /*bottomRight*/);
 
 private:
   void updateGroupData(const int groupIdx, const int start, const int end);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataProcessorUI/QTwoLevelTreeModel.h
@@ -96,7 +96,7 @@ public:
   // Transfer rows into the table
   void transfer(const std::vector<std::map<QString, QString>> &runs) override;
 private slots:
-  void tableDataUpdated(const QModelIndex &, const QModelIndex &);
+  void tableDataUpdated(const QModelIndex & /*topLeft*/, const QModelIndex & /*bottomRight*/);
 
 private:
   void updateGroupData(const int groupIdx, const int start, const int end);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -93,17 +93,17 @@ public:
   /// Get file problem, empty string means no error.
   QString getProblem() const;
   /// Read settings from the given group
-  void readSettings(const QString &);
+  void readSettings(const QString & /*group*/);
   /// Save settings in the given group
-  void saveSettings(const QString &);
+  void saveSettings(const QString & /*group*/);
   /// Gets if optional
   bool isOptional() const;
   /// Sets if optional
-  void isOptional(bool);
+  void isOptional(bool /*optional*/);
   /// Gets will auto load
   bool willAutoLoad() const;
   /// Sets will auto load
-  void setAutoLoad(bool);
+  void setAutoLoad(bool /*load*/);
   /// Check if the widget will show the load button
   bool willShowLoad();
   /// Set if the load button should be shown
@@ -111,7 +111,7 @@ public:
   /// Gets the load button text
   QString getLoadBtnText() const;
   /// Sets the load button text
-  void setLoadBtnText(const QString &);
+  void setLoadBtnText(const QString & /*text*/);
 
   // These are accessors/modifiers of the child MWRunFiles
   /**
@@ -403,9 +403,9 @@ signals:
 
 protected:
   // Method for handling drop events
-  void dropEvent(QDropEvent *) override;
+  void dropEvent(QDropEvent * /*unused*/) override;
   // called when a drag event enters the class
-  void dragEnterEvent(QDragEnterEvent *) override;
+  void dragEnterEvent(QDragEnterEvent * /*unused*/) override;
 
 private slots:
   /// Slot called when the current view is changed

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DoubleSpinBox.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DoubleSpinBox.h
@@ -71,7 +71,7 @@ public:
 signals:
   void valueChanged(double d);
   //! Signal emitted when the spin box gains focus
-  void activated(DoubleSpinBox *);
+  void activated(DoubleSpinBox * /*_t1*/);
 
 private slots:
   void interpretText(bool notify = true);
@@ -79,7 +79,7 @@ private slots:
 protected:
   void stepBy(int steps) override;
   StepEnabled stepEnabled() const override;
-  void focusInEvent(QFocusEvent *) override;
+  void focusInEvent(QFocusEvent * /*event*/) override;
 
 private:
   char d_format;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesWorker.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesWorker.h
@@ -67,7 +67,7 @@ public:
 signals:
   /// Signal emitted after the search is finished, regardless of whether
   /// any file was found.
-  void finished(const FindFilesSearchResults &);
+  void finished(const FindFilesSearchResults & /*_t1*/);
 
 public slots:
   void disconnectWorker();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitOptionsBrowser.h
@@ -77,7 +77,7 @@ protected:
   void displaySequentialFitProperties();
 
 private slots:
-  void enumChanged(QtProperty *);
+  void enumChanged(QtProperty * /*prop*/);
   void doubleChanged(QtProperty *property);
 
 private:
@@ -101,19 +101,19 @@ private:
   void removeProperty(const QString &name);
 
   //  Setters and getters
-  QString getMinimizer(QtProperty *) const;
-  void setMinimizer(QtProperty *, const QString &);
+  QString getMinimizer(QtProperty * /*unused*/) const;
+  void setMinimizer(QtProperty * /*unused*/, const QString & /*value*/);
 
-  QString getIntProperty(QtProperty *) const;
-  void setIntProperty(QtProperty *, const QString &);
-  QString getDoubleProperty(QtProperty *) const;
-  void setDoubleProperty(QtProperty *, const QString &);
-  QString getBoolProperty(QtProperty *) const;
-  void setBoolProperty(QtProperty *, const QString &);
-  QString getStringEnumProperty(QtProperty *) const;
-  void setStringEnumProperty(QtProperty *, const QString &);
-  QString getStringProperty(QtProperty *) const;
-  void setStringProperty(QtProperty *, const QString &);
+  QString getIntProperty(QtProperty * /*prop*/) const;
+  void setIntProperty(QtProperty * /*prop*/, const QString & /*value*/);
+  QString getDoubleProperty(QtProperty * /*prop*/) const;
+  void setDoubleProperty(QtProperty * /*prop*/, const QString & /*value*/);
+  QString getBoolProperty(QtProperty * /*prop*/) const;
+  void setBoolProperty(QtProperty * /*prop*/, const QString & /*value*/);
+  QString getStringEnumProperty(QtProperty * /*prop*/) const;
+  void setStringEnumProperty(QtProperty * /*prop*/, const QString & /*value*/);
+  QString getStringProperty(QtProperty * /*prop*/) const;
+  void setStringProperty(QtProperty * /*prop*/, const QString & /*value*/);
 
   void setPropertyEnumValues(QtProperty *prop, const QStringList &values);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -569,7 +569,8 @@ private:
   QtProperty *getTieProperty(QtProperty *parProp) const;
 
   /// Callback for FunctionFactory update notifications
-  void handleFactoryUpdate(Mantid::API::FunctionFactoryUpdateNotification_ptr /*notice*/);
+  void handleFactoryUpdate(
+      Mantid::API::FunctionFactoryUpdateNotification_ptr /*notice*/);
   /// Observes algorithm factory update notifications
   Poco::NObserver<FitPropertyBrowser,
                   Mantid::API::FunctionFactoryUpdateNotification>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -150,7 +150,7 @@ public:
   /// Get the output name
   virtual std::string outputName() const;
   /// Set the output name
-  void setOutputName(const std::string &);
+  void setOutputName(const std::string & /*name*/);
   /// Get the minimizer
   std::string minimizer(bool withProperties = false) const;
   /// Get the ignore invalid data option
@@ -295,47 +295,47 @@ public slots:
   void clearBrowser();
   void setPeakToolOn(bool on);
   void findPeaks();
-  virtual void executeFitMenu(const QString &);
-  void executeDisplayMenu(const QString &);
-  void executeSetupMenu(const QString &);
-  void executeSetupManageMenu(const QString &);
+  virtual void executeFitMenu(const QString & /*item*/);
+  void executeDisplayMenu(const QString & /*item*/);
+  void executeSetupMenu(const QString & /*item*/);
+  void executeSetupManageMenu(const QString & /*item*/);
 
 signals:
   void currentChanged() const;
   void functionRemoved();
-  void algorithmFinished(const QString &);
+  void algorithmFinished(const QString & /*_t1*/);
   void workspaceIndexChanged(int index);
   void updatePlotSpectrum(int index);
-  void workspaceNameChanged(const QString &);
+  void workspaceNameChanged(const QString & /*_t1*/);
 
-  void wsChangePPAssign(const QString &);
+  void wsChangePPAssign(const QString & /*_t1*/);
   void functionChanged();
 
-  void startXChanged(double);
-  void endXChanged(double);
-  void xRangeChanged(double, double);
-  void parameterChanged(const Mantid::API::IFunction *);
+  void startXChanged(double /*_t1*/);
+  void endXChanged(double /*_t1*/);
+  void xRangeChanged(double /*_t1*/, double /*_t2*/);
+  void parameterChanged(const Mantid::API::IFunction * /*_t1*/);
   void changedParameterOf(const QString &prefix);
   void functionCleared();
   void plotGuess();
   void plotCurrentGuess();
   void removeGuess();
   void removeCurrentGuess();
-  void changeWindowTitle(const QString &);
-  void removePlotSignal(MantidQt::MantidWidgets::PropertyHandler *);
+  void changeWindowTitle(const QString & /*_t1*/);
+  void removePlotSignal(MantidQt::MantidWidgets::PropertyHandler * /*_t1*/);
   void removeFitCurves();
 
-  void executeFit(QString, QHash<QString, QString>,
-                  Mantid::API::AlgorithmObserver *);
+  void executeFit(QString /*_t1*/, QHash<QString, QString> /*_t2*/,
+                  Mantid::API::AlgorithmObserver * /*_t3*/);
   void multifitFinished();
 
   /// signal which can optionally be caught for customization after a fit has
   /// been done
-  void fittingDone(const QString &);
+  void fittingDone(const QString & /*_t1*/);
   void functionFactoryUpdateReceived();
   void errorsEnabled(bool enabled);
   void fitUndone();
-  void functionLoaded(const QString &);
+  void functionLoaded(const QString & /*_t1*/);
   void fitResultsChanged(const QString &status);
 
 protected slots:
@@ -356,7 +356,7 @@ private slots:
   void stringChanged(QtProperty *prop);
   void filenameChanged(QtProperty *prop);
   void columnChanged(QtProperty *prop);
-  void currentItemChanged(QtBrowserItem *);
+  void currentItemChanged(QtBrowserItem * /*current*/);
   void vectorDoubleChanged(QtProperty *prop);
   void vectorSizeChanged(QtProperty *prop);
   void addTie();
@@ -394,7 +394,7 @@ private slots:
   void
   browserHelp(); ///< Open a web page with description of FitPropertyBrowser
 
-  void popupMenu(const QPoint &);
+  void popupMenu(const QPoint & /*unused*/);
   /* Context menu slots */
   void addFunction();
   void deleteFunction();
@@ -543,7 +543,7 @@ private:
   /// save function
   void saveFunction(const QString &fnName);
   /// Check if the workspace can be used in the fit
-  virtual bool isWorkspaceValid(Mantid::API::Workspace_sptr) const;
+  virtual bool isWorkspaceValid(Mantid::API::Workspace_sptr /*ws*/) const;
   /// Find QtBrowserItem for a property prop among the chidren of
   QtBrowserItem *findItem(QtBrowserItem *parent, QtProperty *prop) const;
 
@@ -569,7 +569,7 @@ private:
   QtProperty *getTieProperty(QtProperty *parProp) const;
 
   /// Callback for FunctionFactory update notifications
-  void handleFactoryUpdate(Mantid::API::FunctionFactoryUpdateNotification_ptr);
+  void handleFactoryUpdate(Mantid::API::FunctionFactoryUpdateNotification_ptr /*notice*/);
   /// Observes algorithm factory update notifications
   Poco::NObserver<FitPropertyBrowser,
                   Mantid::API::FunctionFactoryUpdateNotification>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FlowLayout.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FlowLayout.h
@@ -61,7 +61,7 @@ public:
   int verticalSpacing() const;
   Qt::Orientations expandingDirections() const override;
   bool hasHeightForWidth() const override;
-  int heightForWidth(int) const override;
+  int heightForWidth(int /*unused*/) const override;
   int count() const override;
   QLayoutItem *itemAt(int index) const override;
   QSize minimumSize() const override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -347,7 +347,8 @@ protected slots:
   /// Called when a constraint property changes
   void constraintChanged(QtProperty * /*prop*/);
   /// Called when "Global" check-box was clicked
-  void globalChanged(QtProperty * /*unused*/, const QString & /*unused*/, bool /*unused*/);
+  void globalChanged(QtProperty * /*unused*/, const QString & /*unused*/,
+                     bool /*unused*/);
   /// Set value of an attribute (as a property) to a function
   void setAttributeToFunction(Mantid::API::IFunction &fun, QtProperty *prop);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -302,7 +302,7 @@ protected:
 
 protected slots:
   /// Show the context menu
-  void popupMenu(const QPoint &);
+  void popupMenu(const QPoint & /*unused*/);
   /// Add a function
   void addFunction();
   /// Remove a function
@@ -333,21 +333,21 @@ protected slots:
   //   Property change slots
 
   /// Called when a function attribute property is changed
-  void attributeChanged(QtProperty *);
+  void attributeChanged(QtProperty * /*prop*/);
   /// Called when a member of a vector attribute is changed
-  void attributeVectorDoubleChanged(QtProperty *);
+  void attributeVectorDoubleChanged(QtProperty * /*prop*/);
   /// Called when the size of a vector attribute is changed
-  void attributeVectorSizeChanged(QtProperty *);
+  void attributeVectorSizeChanged(QtProperty * /*prop*/);
   /// Called when a function parameter property is changed
-  void parameterChanged(QtProperty *);
+  void parameterChanged(QtProperty * /*prop*/);
   /// Called when button in local parameter editor was clicked
-  void parameterButtonClicked(QtProperty *);
+  void parameterButtonClicked(QtProperty * /*prop*/);
   /// Called when a tie property changes
-  void tieChanged(QtProperty *);
+  void tieChanged(QtProperty * /*prop*/);
   /// Called when a constraint property changes
-  void constraintChanged(QtProperty *);
+  void constraintChanged(QtProperty * /*prop*/);
   /// Called when "Global" check-box was clicked
-  void globalChanged(QtProperty *, const QString &, bool);
+  void globalChanged(QtProperty * /*unused*/, const QString & /*unused*/, bool /*unused*/);
   /// Set value of an attribute (as a property) to a function
   void setAttributeToFunction(Mantid::API::IFunction &fun, QtProperty *prop);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InputController.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InputController.h
@@ -40,15 +40,15 @@ public:
   explicit InputController(QObject *parent, bool contextAllowed = true);
   ~InputController() override {}
 
-  virtual void mousePressEvent(QMouseEvent *) {}
-  virtual void mouseMoveEvent(QMouseEvent *) {}
-  virtual void mouseReleaseEvent(QMouseEvent *) {}
-  virtual void wheelEvent(QWheelEvent *) {}
-  virtual void keyPressEvent(QKeyEvent *) {}
-  virtual void enterEvent(QEvent *) {}
-  virtual void leaveEvent(QEvent *) {}
+  virtual void mousePressEvent(QMouseEvent * /*unused*/) {}
+  virtual void mouseMoveEvent(QMouseEvent * /*unused*/) {}
+  virtual void mouseReleaseEvent(QMouseEvent * /*unused*/) {}
+  virtual void wheelEvent(QWheelEvent * /*unused*/) {}
+  virtual void keyPressEvent(QKeyEvent * /*unused*/) {}
+  virtual void enterEvent(QEvent * /*unused*/) {}
+  virtual void leaveEvent(QEvent * /*unused*/) {}
   /// To be called after the owner widget has drawn its content
-  virtual void onPaint(QPainter &) {}
+  virtual void onPaint(QPainter & /*unused*/) {}
   /// To be called when this controller takes control of the input. By default
   /// emits enabled() signal.
   virtual void onEnabled() { emit enabled(); }
@@ -79,10 +79,10 @@ class EXPORT_OPT_MANTIDQT_COMMON InputController3DMove
 
 public:
   InputController3DMove(QObject *parent);
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void wheelEvent(QWheelEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
+  void wheelEvent(QWheelEvent * /*unused*/) override;
 
 signals:
   /// Init zooming. x and y is the zoom starting point on the screen.
@@ -114,14 +114,14 @@ class EXPORT_OPT_MANTIDQT_COMMON InputControllerPick : public InputController {
 
 public:
   InputControllerPick(QObject *parent);
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
 
 signals:
-  void pickPointAt(int, int);
-  void touchPointAt(int, int);
-  void setSelection(const QRect &);
+  void pickPointAt(int /*_t1*/, int /*_t2*/);
+  void touchPointAt(int /*_t1*/, int /*_t2*/);
+  void setSelection(const QRect & /*_t1*/);
   void finishSelection();
 
 private:
@@ -138,11 +138,11 @@ class EXPORT_OPT_MANTIDQT_COMMON InputControllerDrawShape
 
 public:
   InputControllerDrawShape(QObject *parent);
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void keyPressEvent(QKeyEvent *) override;
-  void leaveEvent(QEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
+  void keyPressEvent(QKeyEvent * /*unused*/) override;
+  void leaveEvent(QEvent * /*unused*/) override;
 
 signals:
   /// Deselect all selected shapes
@@ -152,23 +152,23 @@ signals:
                 const QColor &fillColor);
   /// Resize the current shape by moving the right-bottom control point to a
   /// location on the screen
-  void moveRightBottomTo(int, int);
+  void moveRightBottomTo(int /*_t1*/, int /*_t2*/);
   /// Select a shape or a conrol point at a location on the screen.
-  void selectAt(int, int);
+  void selectAt(int /*_t1*/, int /*_t2*/);
   /// Select a shape with ctrl key pressed at a location on the screen.
-  void selectCtrlAt(int, int);
+  void selectCtrlAt(int /*_t1*/, int /*_t2*/);
   /// Move selected shape or a control point by a displacement vector.
-  void moveBy(int, int);
+  void moveBy(int /*_t1*/, int /*_t2*/);
   /// Sent when the mouse is moved to a new position with the buttons up
-  void touchPointAt(int, int);
+  void touchPointAt(int /*_t1*/, int /*_t2*/);
   /// Remove the selected shapes
   void removeSelectedShapes();
   /// Restore the cursor to its default image
   void restoreOverrideCursor();
   /// Update the rubber band selection
-  void setSelection(const QRect &);
+  void setSelection(const QRect & /*_t1*/);
   /// Rubber band selection is done
-  void finishSelection(const QRect &);
+  void finishSelection(const QRect & /*_t1*/);
 
 public slots:
   void startCreatingShape2D(const QString &type, const QColor &borderColor,
@@ -193,12 +193,12 @@ class EXPORT_OPT_MANTIDQT_COMMON InputControllerMoveUnwrapped
 
 public:
   InputControllerMoveUnwrapped(QObject *parent);
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
 
 signals:
-  void setSelectionRect(const QRect &);
+  void setSelectionRect(const QRect & /*_t1*/);
   void zoom();
   void resetZoom();
   void unzoom();
@@ -217,13 +217,13 @@ class EXPORT_OPT_MANTIDQT_COMMON InputControllerDraw : public InputController {
 public:
   InputControllerDraw(QObject *parent);
   ~InputControllerDraw() override;
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void wheelEvent(QWheelEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
+  void wheelEvent(QWheelEvent * /*unused*/) override;
 
-  void enterEvent(QEvent *) override;
-  void leaveEvent(QEvent *) override;
+  void enterEvent(QEvent * /*unused*/) override;
+  void leaveEvent(QEvent * /*unused*/) override;
 
 protected:
   int cursorSize() const { return m_size; }
@@ -257,10 +257,10 @@ class EXPORT_OPT_MANTIDQT_COMMON InputControllerSelection
 public:
   InputControllerSelection(QObject *parent, QPixmap *icon);
   ~InputControllerSelection() override;
-  void onPaint(QPainter &) override;
+  void onPaint(QPainter & /*unused*/) override;
 
 signals:
-  void selection(const QRect &);
+  void selection(const QRect & /*_t1*/);
 
 private:
   void drawCursor(QPixmap *cursor) override;
@@ -283,8 +283,8 @@ public:
   InputControllerDrawAndErase(QObject *parent);
 
 signals:
-  void draw(const QPolygonF &);
-  void erase(const QPolygonF &);
+  void draw(const QPolygonF & /*_t1*/);
+  void erase(const QPolygonF & /*_t1*/);
   void addShape(const QPolygonF &poly, const QColor &borderColor,
                 const QColor &fillColor);
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
@@ -67,7 +67,8 @@ signals:
   /// Indicate that the instrument selection has changed. The parameter will
   /// contain the new name
   void instrumentSelectionChanged(const QString & /*_t1*/);
-  void configValueChanged(const QString & /*_t1*/, const QString & /*_t2*/, const QString & /*_t3*/);
+  void configValueChanged(const QString & /*_t1*/, const QString & /*_t2*/,
+                          const QString & /*_t3*/);
   /// Signals that the list of instruments has been updated
   void instrumentListUpdated();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
@@ -66,8 +66,8 @@ public slots:
 signals:
   /// Indicate that the instrument selection has changed. The parameter will
   /// contain the new name
-  void instrumentSelectionChanged(const QString &);
-  void configValueChanged(const QString &, const QString &, const QString &);
+  void instrumentSelectionChanged(const QString & /*_t1*/);
+  void configValueChanged(const QString & /*_t1*/, const QString & /*_t2*/, const QString & /*_t3*/);
   /// Signals that the list of instruments has been updated
   void instrumentListUpdated();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/LineEditWithClear.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/LineEditWithClear.h
@@ -26,7 +26,7 @@ public:
   LineEditWithClear(QWidget *parent = nullptr);
 
 protected:
-  void resizeEvent(QResizeEvent *) override;
+  void resizeEvent(QResizeEvent * /*unused*/) override;
 
 private slots:
   void updateCloseButton(const QString &text);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.h
@@ -85,20 +85,20 @@ public:
 
   // property accessors/modifiers
   bool isForRunFiles() const;
-  void isForRunFiles(bool);
+  void isForRunFiles(bool /*mode*/);
   bool isForDirectory() const;
-  void isForDirectory(bool);
+  void isForDirectory(bool /*mode*/);
   QString getLabelText() const;
   void setLabelText(const QString &text);
-  void setLabelMinWidth(int);
+  void setLabelMinWidth(int /*width*/);
   bool allowMultipleFiles() const;
-  void allowMultipleFiles(bool);
+  void allowMultipleFiles(bool /*allow*/);
   bool isOptional() const;
-  void isOptional(bool);
+  void isOptional(bool /*optional*/);
   ButtonOpts doButtonOpt() const;
   void doButtonOpt(ButtonOpts buttonOpt);
   bool doMultiEntry() const;
-  void doMultiEntry(bool);
+  void doMultiEntry(bool /*multiEntry*/);
   QString getAlgorithmProperty() const;
   void setAlgorithmProperty(const QString &name);
   QStringList getFileExtensions() const;
@@ -106,10 +106,10 @@ public:
   bool extsAsSingleOption() const;
   void extsAsSingleOption(bool value);
   LiveButtonOpts liveButtonState() const;
-  void liveButtonState(LiveButtonOpts);
+  void liveButtonState(LiveButtonOpts /*option*/);
 
   // Standard setters/getters
-  void liveButtonSetChecked(bool);
+  void liveButtonSetChecked(bool /*checked*/);
   bool liveButtonIsChecked() const;
   bool isEmpty() const;
   QString getText() const;
@@ -156,7 +156,7 @@ public:
 
 signals:
   /// Emitted when the file text changes
-  void fileTextChanged(const QString &);
+  void fileTextChanged(const QString & /*_t1*/);
   /// Emitted when the editing has finished
   void fileEditingFinished();
   /// Emitted when files finding starts.
@@ -170,7 +170,7 @@ signals:
   /// found).
   void fileFindingFinished();
   /// Emitted when the live button is toggled
-  void liveButtonPressed(bool);
+  void liveButtonPressed(bool /*_t1*/);
   /// Emitted when inspection of any found files is completed
   void fileInspectionFinished();
 
@@ -189,9 +189,9 @@ public slots:
 
 public:
   // Method for handling drop events
-  void dropEvent(QDropEvent *) override;
+  void dropEvent(QDropEvent * /*unused*/) override;
   // called when a drag event enters the class
-  void dragEnterEvent(QDragEnterEvent *) override;
+  void dragEnterEvent(QDragEnterEvent * /*unused*/) override;
 
 private:
   /// Create a file filter from a list of extensions

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidDialog.h
@@ -66,7 +66,7 @@ public:
   static bool handle(QObject *receiver, const std::exception &e);
 
 signals:
-  void runAsPythonScript(const QString &code, bool);
+  void runAsPythonScript(const QString &code, bool /*_t2*/);
 
 protected:
   /// Run python code that is passed to it and, optionally, return anything it

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidDisplayBase.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidDisplayBase.h
@@ -123,7 +123,7 @@ public:
                              bool showTiledOpt, bool isAdvanced = false) = 0;
 
   virtual void updateProject() = 0;
-  virtual void showCritical(const QString &) {}
+  virtual void showCritical(const QString & /*unused*/) {}
 #ifdef MAKE_VATES
   virtual bool doesVatesSupportOpenGL() = 0;
 #endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeModel.h
@@ -87,7 +87,7 @@ public slots:
   void importBoxDataTable() override;
   void showListData() override;
   void importTransposed() override;
-  void renameWorkspace(QStringList  /*unused*/= QStringList()) override;
+  void renameWorkspace(QStringList /*unused*/ = QStringList()) override;
 
   // Algorithm Display and Execution Methods
   void showAlgorithmDialog(const QString &algName, int version = -1) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeModel.h
@@ -87,7 +87,7 @@ public slots:
   void importBoxDataTable() override;
   void showListData() override;
   void importTransposed() override;
-  void renameWorkspace(QStringList = QStringList()) override;
+  void renameWorkspace(QStringList  /*unused*/= QStringList()) override;
 
   // Algorithm Display and Execution Methods
   void showAlgorithmDialog(const QString &algName, int version = -1) override;
@@ -136,7 +136,7 @@ public slots:
       bool showPlotAll, bool showTiledOpt, bool isAdvanced = false) override;
 
   void updateProject() override;
-  void showCritical(const QString &) override;
+  void showCritical(const QString & /*unused*/) override;
 
 #ifdef MAKE_VATES
   bool doesVatesSupportOpenGL() override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidget.h
@@ -36,11 +36,11 @@ public:
   chooseSpectrumFromSelected(bool showWaterfallOpt = true,
                              bool showPlotAll = true, bool showTiledOpt = true,
                              bool isAdvanced = false) const;
-  void setSortScheme(MantidItemSortScheme);
-  void setSortOrder(Qt::SortOrder);
+  void setSortScheme(MantidItemSortScheme /*sortScheme*/);
+  void setSortOrder(Qt::SortOrder /*sortOrder*/);
   MantidItemSortScheme getSortScheme() const;
   Qt::SortOrder getSortOrder() const;
-  void logWarningMessage(const std::string &);
+  void logWarningMessage(const std::string & /*msg*/);
   void disableNodes(bool);
   void sort();
   void dropEvent(QDropEvent *de) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
@@ -22,8 +22,8 @@ class MantidTreeWidget;
  */
 class EXPORT_OPT_MANTIDQT_COMMON MantidTreeWidgetItem : public QTreeWidgetItem {
 public:
-  explicit MantidTreeWidgetItem(MantidTreeWidget *);
-  MantidTreeWidgetItem(QStringList, MantidTreeWidget *);
+  explicit MantidTreeWidgetItem(MantidTreeWidget * /*parent*/);
+  MantidTreeWidgetItem(QStringList /*list*/, MantidTreeWidget * /*parent*/);
   void disableIfNode(bool);
   void setSortPos(int o) { m_sortPos = o; }
   int getSortPos() const { return m_sortPos; }
@@ -32,7 +32,7 @@ private:
   bool operator<(const QTreeWidgetItem &other) const override;
   MantidTreeWidget *m_parent;
   static Mantid::Types::Core::DateAndTime
-  getLastModified(const QTreeWidgetItem *);
+  getLastModified(const QTreeWidgetItem * /*item*/);
   std::size_t getMemorySize() const;
   int m_sortPos;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
@@ -73,15 +73,15 @@ public:
   /// Constructor - starting at start and ending at end.
   Interval(int start, int end);
   /// Constructor - attempts to parse given string to find start and end.
-  explicit Interval(QString);
+  explicit Interval(QString /*intervalString*/);
   /// Copy constructor
-  Interval(const Interval &);
+  Interval(const Interval & /*copy*/);
 
   /// Attempts to merge the given Interval with this Interval
-  bool merge(const Interval &);
+  bool merge(const Interval & /*other*/);
   /// Returns true if it is possible to merge the given Interval with this
   /// Interval, else false.
-  bool canMerge(const Interval &) const;
+  bool canMerge(const Interval & /*other*/) const;
   /// Returns the int marking the start of this Interval
   int start() const;
   /// Returns the int marking the end of this Interval
@@ -95,7 +95,7 @@ public:
   /// Returns true if this interval completely contains the interval passed
   /// to
   /// it, else false.
-  bool contains(const Interval &) const;
+  bool contains(const Interval & /*other*/) const;
 
   /// Returns a string which represents the start and end of this Interval
   std::string toStdString() const;
@@ -104,7 +104,7 @@ public:
 
 private:
   /// Initialise the Interval, given the specified start and end ints
-  void init(int, int);
+  void init(int /*start*/, int /*end*/);
 
   /// The start and end of the interval.
   int m_start, m_end;
@@ -115,11 +115,11 @@ public:
   /// Constructor - with empty list.
   IntervalList(void);
   /// Constructor - with a list created by parsing the input string
-  explicit IntervalList(QString);
+  explicit IntervalList(QString /*intervals*/);
   /// Constructor - with a list containing a single Interval
-  explicit IntervalList(Interval);
+  explicit IntervalList(Interval /*interval*/);
   /// Copy Constructor
-  IntervalList(const IntervalList &);
+  IntervalList(const IntervalList & /*copy*/);
 
   /// Returns a reference to the list of Intervals.
   const QList<Interval> &getList() const;
@@ -137,17 +137,17 @@ public:
   /// Add an interval starting and ending at single.
   void addInterval(int single);
   /// Add an interval
-  void addInterval(Interval);
+  void addInterval(Interval /*interval*/);
   /// Add an interval starting at start and ending at end.
   void addInterval(int start, int end);
   /// Attempts to parse the given string into a IntervalList to add.
-  void addIntervals(QString);
+  void addIntervals(QString /*intervals*/);
   /// Adds an IntervalList to this IntervalList.
-  void addIntervalList(const IntervalList &);
+  void addIntervalList(const IntervalList & /*intervals*/);
   /// Replaces the current list with the list belonging to given
   /// IntervalList
   /// object.
-  void setIntervalList(const IntervalList &);
+  void setIntervalList(const IntervalList & /*intervals*/);
   /// Clears the interval list
   void clear();
 
@@ -157,27 +157,27 @@ public:
   /// Returns true if this interval list completely contains the interval
   /// passed
   /// to it, else false.
-  bool contains(const Interval &) const;
+  bool contains(const Interval & /*other*/) const;
   /// Returns true if this interval list completely contains the interval
   /// list
   /// passed to it, else false.
-  bool contains(const IntervalList &) const;
+  bool contains(const IntervalList & /*other*/) const;
 
   /// Returns true if the QString can be parsed into an IntervalList, else
   /// false.
-  static bool isParsable(const QString &);
+  static bool isParsable(const QString & /*input*/);
   /// Returns true if the QString can be parsed into an IntervalList which
   /// can
   /// then be contained
   /// in the IntervalList given, else false.
-  static bool isParsable(const QString &, const IntervalList &);
+  static bool isParsable(const QString & /*input*/, const IntervalList & /*container*/);
 
   /// Returns an IntervalList which is the intersection of the given
   /// IntervalList and Interval
-  static IntervalList intersect(const IntervalList &, const Interval &);
+  static IntervalList intersect(const IntervalList & /*aList*/, const Interval & /*bInterval*/);
   /// Returns an IntervalList which is the intersection of the given
   /// IntervalLists
-  static IntervalList intersect(const IntervalList &, const IntervalList &);
+  static IntervalList intersect(const IntervalList & /*a*/, const IntervalList & /*b*/);
 
 private:
   /// A list of all the Intervals in this IntervalList
@@ -193,7 +193,7 @@ public:
   IntervalListValidator(QObject *parent, const IntervalList &intervals);
 
   /// Overriden method to validate a given QString, at a particular position
-  State validate(QString &, int &) const override;
+  State validate(QString & /*unused*/, int & /*unused*/) const override;
 
 private:
   /// The IntervalList against which to validate.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWSIndexDialog.h
@@ -170,14 +170,17 @@ public:
   /// can
   /// then be contained
   /// in the IntervalList given, else false.
-  static bool isParsable(const QString & /*input*/, const IntervalList & /*container*/);
+  static bool isParsable(const QString & /*input*/,
+                         const IntervalList & /*container*/);
 
   /// Returns an IntervalList which is the intersection of the given
   /// IntervalList and Interval
-  static IntervalList intersect(const IntervalList & /*aList*/, const Interval & /*bInterval*/);
+  static IntervalList intersect(const IntervalList & /*aList*/,
+                                const Interval & /*bInterval*/);
   /// Returns an IntervalList which is the intersection of the given
   /// IntervalLists
-  static IntervalList intersect(const IntervalList & /*a*/, const IntervalList & /*b*/);
+  static IntervalList intersect(const IntervalList & /*a*/,
+                                const IntervalList & /*b*/);
 
 private:
   /// A list of all the Intervals in this IntervalList

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidWidget.h
@@ -40,7 +40,7 @@ public:
   virtual void setUserInput(const QVariant &value) { Q_UNUSED(value); }
 
 signals:
-  void runAsPythonScript(const QString &code, bool);
+  void runAsPythonScript(const QString &code, bool /*_t2*/);
 
 protected:
   /// Default constructor

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MultifitSetupDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MultifitSetupDialog.h
@@ -35,7 +35,7 @@ private slots:
 
   /// Setup the function and close dialog
   void accept() override;
-  void cellChanged(int, int);
+  void cellChanged(int /*row*/, int /*col*/);
 
 private:
   /// The form generated with Qt Designer

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitDataSelector.h
@@ -90,7 +90,7 @@ public slots:
   void fitTypeChanged(bool state);
   /// Called when group/period box selection changes
   void checkForMultiGroupPeriodSelection();
-  void updateNormalizationFromDropDown(int);
+  void updateNormalizationFromDropDown(int /*j*/);
 signals:
   /// Edited the start or end fields
   void dataPropertiesChanged();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
@@ -180,7 +180,7 @@ private:
   /// Get the registered function names
   void populateFunctionNames() override;
   /// Check if the workspace can be used in the fit
-  bool isWorkspaceValid(Mantid::API::Workspace_sptr) const override;
+  bool isWorkspaceValid(Mantid::API::Workspace_sptr /*unused*/) const override;
   /// After a simultaneous fit, add information to results table and group
   /// workspaces
   void finishAfterSimultaneousFit(const Mantid::API::IAlgorithm *fitAlg,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ProgressPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ProgressPresenter.h
@@ -29,7 +29,7 @@ public:
                                          static_cast<int>(end));
   }
 
-  void doReport(const std::string &) override {
+  void doReport(const std::string & /*msg*/) override {
     if (m_progressableView->isPercentageIndicator())
       m_progressableView->setProgress(static_cast<int>(m_i));
   }

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PythonRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PythonRunner.h
@@ -36,7 +36,7 @@ public:
   /// Converts a list of strings into a string recognised by Python as a tuple
   static const QString stringList2Tuple(const QStringList &list);
 signals:
-  void runAsPythonScript(const QString &code, bool);
+  void runAsPythonScript(const QString &code, bool /*_t2*/);
 };
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/ButtonEditorFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/ButtonEditorFactory.h
@@ -19,7 +19,7 @@ public:
     connect(this, SIGNAL(clicked()), this, SLOT(sendClickedSignal()));
   }
 Q_SIGNALS:
-  void buttonClicked(QtProperty *);
+  void buttonClicked(QtProperty * /*_t1*/);
 private Q_SLOTS:
   void sendClickedSignal() { emit buttonClicked(m_property); }
 
@@ -64,7 +64,7 @@ public:
       : ButtonEditorFactory<ParameterPropertyManager>(parent) {}
 
 Q_SIGNALS:
-  void buttonClicked(QtProperty *);
+  void buttonClicked(QtProperty * /*_t1*/);
 };
 
 #endif // BUTTONEDITORFACTORY_H

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h
@@ -25,7 +25,7 @@ class DoubleDialogEditor : public QWidget {
 public:
   DoubleDialogEditor(QtProperty *property, QWidget *parent);
 signals:
-  void buttonClicked(QtProperty *);
+  void buttonClicked(QtProperty * /*_t1*/);
   void closeEditor();
 
 protected slots:
@@ -38,7 +38,7 @@ protected slots:
   QString getText() const;
 
 private:
-  bool eventFilter(QObject *, QEvent *) override;
+  bool eventFilter(QObject * /*obj*/, QEvent * /*evt*/) override;
   DoubleEditor *m_editor;
   QPushButton *m_button;
   QtProperty *m_property;
@@ -58,7 +58,7 @@ class DoubleDialogEditorFactory
 public:
   DoubleDialogEditorFactory(QObject *parent = nullptr)
       : QtAbstractEditorFactory<ParameterPropertyManager>(parent) {}
-  QWidget *createEditorForManager(ParameterPropertyManager *,
+  QWidget *createEditorForManager(ParameterPropertyManager * /*manager*/,
                                   QtProperty *property,
                                   QWidget *parent) override {
     auto editor = new DoubleDialogEditor(property, parent);
@@ -69,12 +69,12 @@ public:
     return editor;
   }
 signals:
-  void buttonClicked(QtProperty *);
+  void buttonClicked(QtProperty * /*_t1*/);
   void closeEditor();
 
 protected:
-  void connectPropertyManager(ParameterPropertyManager *) override {}
-  void disconnectPropertyManager(ParameterPropertyManager *) override {}
+  void connectPropertyManager(ParameterPropertyManager * /*manager*/) override {}
+  void disconnectPropertyManager(ParameterPropertyManager * /*manager*/) override {}
 };
 
 #endif // DOUBLEDIALOGEDITORFACTORY_H

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/DoubleDialogEditor.h
@@ -73,8 +73,10 @@ signals:
   void closeEditor();
 
 protected:
-  void connectPropertyManager(ParameterPropertyManager * /*manager*/) override {}
-  void disconnectPropertyManager(ParameterPropertyManager * /*manager*/) override {}
+  void connectPropertyManager(ParameterPropertyManager * /*manager*/) override {
+  }
+  void
+  disconnectPropertyManager(ParameterPropertyManager * /*manager*/) override {}
 };
 
 #endif // DOUBLEDIALOGEDITORFACTORY_H

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/FormulaDialogEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/FormulaDialogEditor.h
@@ -34,7 +34,7 @@ public:
       : StringDialogEditorFactory(parent) {}
 
 protected:
-  QWidget *createEditorForManager(QtStringPropertyManager *,
+  QWidget *createEditorForManager(QtStringPropertyManager * /*manager*/,
                                   QtProperty *property,
                                   QWidget *parent) override {
     return new FormulaDialogEditor(property, parent);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h
@@ -24,7 +24,8 @@ protected:
   QWidget *createEditorForManager(QtStringPropertyManager *manager,
                                   QtProperty *property,
                                   QWidget *parent) override;
-  void disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
+  void
+  disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
 };
 
 class StringEditor : public QLineEdit {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h
@@ -20,11 +20,11 @@ public:
 protected:
   using QtAbstractEditorFactoryBase::createEditor; // Avoid Intel compiler
                                                    // warning
-  void connectPropertyManager(QtStringPropertyManager *) override {}
+  void connectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
   QWidget *createEditorForManager(QtStringPropertyManager *manager,
                                   QtProperty *property,
                                   QWidget *parent) override;
-  void disconnectPropertyManager(QtStringPropertyManager *) override {}
+  void disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
 };
 
 class StringEditor : public QLineEdit {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/WorkspaceEditorFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/WorkspaceEditorFactory.h
@@ -27,7 +27,8 @@ protected:
   QWidget *createEditorForManager(QtStringPropertyManager *manager,
                                   QtProperty *property,
                                   QWidget *parent) override;
-  void disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
+  void
+  disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
 };
 
 class WorkspaceEditor : public WorkspaceSelector {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/WorkspaceEditorFactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/WorkspaceEditorFactory.h
@@ -23,11 +23,11 @@ public:
 protected:
   using QtAbstractEditorFactoryBase::createEditor; // Avoid Intel compiler
                                                    // warning
-  void connectPropertyManager(QtStringPropertyManager *) override {}
+  void connectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
   QWidget *createEditorForManager(QtStringPropertyManager *manager,
                                   QtProperty *property,
                                   QWidget *parent) override;
-  void disconnectPropertyManager(QtStringPropertyManager *) override {}
+  void disconnectPropertyManager(QtStringPropertyManager * /*manager*/) override {}
 };
 
 class WorkspaceEditor : public WorkspaceSelector {

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
@@ -701,8 +701,8 @@ class QtEnumEditorFactoryPrivate : public EditorFactoryPrivate<QComboBox> {
   Q_DECLARE_PUBLIC(QtEnumEditorFactory)
 public:
   void slotPropertyChanged(QtProperty *property, int value);
-  void slotEnumNamesChanged(QtProperty *property, const QStringList &);
-  void slotEnumIconsChanged(QtProperty *property, const QMap<int, QIcon> &);
+  void slotEnumNamesChanged(QtProperty *property, const QStringList & /*enumNames*/);
+  void slotEnumIconsChanged(QtProperty *property, const QMap<int, QIcon> & /*enumIcons*/);
   void slotSetValue(int value);
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h
@@ -701,8 +701,10 @@ class QtEnumEditorFactoryPrivate : public EditorFactoryPrivate<QComboBox> {
   Q_DECLARE_PUBLIC(QtEnumEditorFactory)
 public:
   void slotPropertyChanged(QtProperty *property, int value);
-  void slotEnumNamesChanged(QtProperty *property, const QStringList & /*enumNames*/);
-  void slotEnumIconsChanged(QtProperty *property, const QMap<int, QIcon> & /*enumIcons*/);
+  void slotEnumNamesChanged(QtProperty *property,
+                            const QStringList & /*enumNames*/);
+  void slotEnumIconsChanged(QtProperty *property,
+                            const QMap<int, QIcon> & /*enumIcons*/);
   void slotSetValue(int value);
 };
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h
@@ -332,10 +332,10 @@ public:
   void unsetFactoryForManager(QtAbstractPropertyManager *manager);
 
   QtBrowserItem *currentItem() const;
-  void setCurrentItem(QtBrowserItem *);
+  void setCurrentItem(QtBrowserItem * /*item*/);
 
 Q_SIGNALS:
-  void currentItemChanged(QtBrowserItem *);
+  void currentItemChanged(QtBrowserItem * /*_t1*/);
 
 public Q_SLOTS:
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowserutils_p.h
@@ -160,7 +160,7 @@ public:
   bool blockCheckBoxSignals(bool block);
 
 Q_SIGNALS:
-  void toggled(bool);
+  void toggled(bool /*_t1*/);
 
 protected:
   void mousePressEvent(QMouseEvent *event) override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
@@ -165,7 +165,7 @@ Q_SIGNALS:
 
   void collapsed(QtBrowserItem *item);
   void expanded(QtBrowserItem *item);
-  void optionChanged(QtProperty *, const QString &, bool);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
 
 public Q_SLOTS:
 
@@ -197,7 +197,7 @@ public:
         m_checked(property->checkOption(optionName)) {
     setFocusPolicy(Qt::StrongFocus);
   }
-  void paintEvent(QPaintEvent *) override {
+  void paintEvent(QPaintEvent * /*unused*/) override {
     QStyleOptionButton opt;
     auto state = isChecked() ? QStyle::State_On : QStyle::State_Off;
     opt.state |= state;
@@ -217,7 +217,7 @@ public:
   void setChecked(bool on) { m_checked = on; }
   bool isChecked() const { return m_checked; }
 signals:
-  void optionChanged(QtProperty *, const QString &, bool);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
 
 private:
   QtProperty *m_property;
@@ -287,7 +287,7 @@ public:
   void disableItem(QtBrowserItem *item);
 
   void slotCurrentBrowserItemChanged(QtBrowserItem *item);
-  void slotCurrentTreeItemChanged(QTreeWidgetItem *newItem, QTreeWidgetItem *);
+  void slotCurrentTreeItemChanged(QTreeWidgetItem *newItem, QTreeWidgetItem * /*unused*/);
 
   QTreeWidgetItem *editedItem() const;
   void closeEditor();
@@ -337,10 +337,10 @@ public:
   QSize sizeHint(const QStyleOptionViewItem &option,
                  const QModelIndex &index) const override;
 
-  void setModelData(QWidget *, QAbstractItemModel *,
-                    const QModelIndex &) const override {}
+  void setModelData(QWidget * /*editor*/, QAbstractItemModel * /*model*/,
+                    const QModelIndex & /*index*/) const override {}
 
-  void setEditorData(QWidget *, const QModelIndex &) const override {}
+  void setEditorData(QWidget * /*editor*/, const QModelIndex & /*index*/) const override {}
 
   bool eventFilter(QObject *object, QEvent *event) override;
   void closeEditor(QtProperty *property);
@@ -348,7 +348,7 @@ public:
   QTreeWidgetItem *editedItem() const { return m_editedItem; }
 
 signals:
-  void optionChanged(QtProperty *, const QString &, bool);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
 
 private slots:
   void slotEditorDestroyed(QObject *object);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h
@@ -165,7 +165,8 @@ Q_SIGNALS:
 
   void collapsed(QtBrowserItem *item);
   void expanded(QtBrowserItem *item);
-  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/,
+                     bool /*_t3*/);
 
 public Q_SLOTS:
 
@@ -217,7 +218,8 @@ public:
   void setChecked(bool on) { m_checked = on; }
   bool isChecked() const { return m_checked; }
 signals:
-  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/,
+                     bool /*_t3*/);
 
 private:
   QtProperty *m_property;
@@ -287,7 +289,8 @@ public:
   void disableItem(QtBrowserItem *item);
 
   void slotCurrentBrowserItemChanged(QtBrowserItem *item);
-  void slotCurrentTreeItemChanged(QTreeWidgetItem *newItem, QTreeWidgetItem * /*unused*/);
+  void slotCurrentTreeItemChanged(QTreeWidgetItem *newItem,
+                                  QTreeWidgetItem * /*unused*/);
 
   QTreeWidgetItem *editedItem() const;
   void closeEditor();
@@ -340,7 +343,8 @@ public:
   void setModelData(QWidget * /*editor*/, QAbstractItemModel * /*model*/,
                     const QModelIndex & /*index*/) const override {}
 
-  void setEditorData(QWidget * /*editor*/, const QModelIndex & /*index*/) const override {}
+  void setEditorData(QWidget * /*editor*/,
+                     const QModelIndex & /*index*/) const override {}
 
   bool eventFilter(QObject *object, QEvent *event) override;
   void closeEditor(QtProperty *property);
@@ -348,7 +352,8 @@ public:
   QTreeWidgetItem *editedItem() const { return m_editedItem; }
 
 signals:
-  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/, bool /*_t3*/);
+  void optionChanged(QtProperty * /*_t1*/, const QString & /*_t2*/,
+                     bool /*_t3*/);
 
 private slots:
   void slotEditorDestroyed(QObject *object);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/RenameParDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/RenameParDialog.h
@@ -29,8 +29,8 @@ public:
                   QWidget *parent = nullptr);
   std::vector<std::string> setOutput() const;
 protected slots:
-  void uniqueIndexedNames(bool);
-  void doNotRename(bool);
+  void uniqueIndexedNames(bool /*ok*/);
+  void doNotRename(bool /*ok*/);
 
 protected:
   bool isUnique(const QString &name) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/RepoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/RepoModel.h
@@ -135,8 +135,8 @@ class RepoModel : public QAbstractItemModel {
     QString author();
     QString comment();
     bool saveInfo();
-    void setEmail(const QString &);
-    void setAuthor(const QString &);
+    void setEmail(const QString & /*email*/);
+    void setAuthor(const QString & /*author*/);
     void lastSaveOption(bool option);
 
   protected:
@@ -201,7 +201,7 @@ public:
   QString author(const QModelIndex &index);
 
 signals:
-  void executingThread(bool);
+  void executingThread(bool /*_t1*/);
 
 private:
   /// auxiliary method to populate the model

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/RepoTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/RepoTreeView.h
@@ -28,7 +28,7 @@ public:
   ~RepoTreeView() override{};
 
 signals:
-  void currentCell(const QModelIndex &);
+  void currentCell(const QModelIndex & /*_t1*/);
 
 protected slots:
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
@@ -71,7 +71,7 @@ public:
   void writeSettings();
 
   /// Set a new code lexer for this object
-  void setLexer(QsciLexer *) override;
+  void setLexer(QsciLexer * /*codelexer*/) override;
   // Make the object resize to margin to fit the contents
   void setAutoMarginResize();
   /// Enable the auto complete. Default is for backwards compatability
@@ -136,9 +136,9 @@ public slots:
 
 signals:
   /// Inform observers that undo information is available
-  void undoAvailable(bool);
+  void undoAvailable(bool /*_t1*/);
   /// Inform observers that redo information is available
-  void redoAvailable(bool);
+  void redoAvailable(bool /*_t1*/);
   /// Emitted when a zoom in is requested
   void textZoomedIn();
   /// Emitted when a zoom out is requested

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptRepositoryView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptRepositoryView.h
@@ -72,16 +72,16 @@ public:
 
 signals:
   // allow Mantid Plot to open a python file to be seen
-  void loadScript(const QString);
+  void loadScript(const QString /*_t1*/);
 
 protected slots:
   // allow to interact with the cells, in order to update the description of the
   // files
-  void cell_activated(const QModelIndex &);
+  void cell_activated(const QModelIndex & /*in*/);
   void updateModel();
   void currentChanged(const QModelIndex &current);
   void helpClicked();
-  void openFolderLink(QString);
+  void openFolderLink(QString /*link*/);
 
 private:
   Ui::ScriptRepositoryView *ui;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectionNotificationService.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectionNotificationService.h
@@ -35,7 +35,7 @@ public:
   void sendQPointSelection(bool lab_coords, double qx, double qy, double qz);
 
 signals:
-  void QPointSelection_signal(bool, double, double, double);
+  void QPointSelection_signal(bool /*_t1*/, double /*_t2*/, double /*_t3*/, double /*_t4*/);
 
 private:
   /// private constructor, since SelectionNotificationService is a singleton

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SelectionNotificationService.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SelectionNotificationService.h
@@ -35,7 +35,8 @@ public:
   void sendQPointSelection(bool lab_coords, double qx, double qy, double qz);
 
 signals:
-  void QPointSelection_signal(bool /*_t1*/, double /*_t2*/, double /*_t3*/, double /*_t4*/);
+  void QPointSelection_signal(bool /*_t1*/, double /*_t2*/, double /*_t3*/,
+                              double /*_t4*/);
 
 private:
   /// private constructor, since SelectionNotificationService is a singleton

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SequentialFitDialog.h
@@ -47,8 +47,8 @@ signals:
 
   /// This signal is fired from finishHandle running in the algorithm's thread
   /// and caught by showPlot slot in the GUI thread
-  void needShowPlot(Ui::SequentialFitDialog *,
-                    MantidQt::MantidWidgets::FitPropertyBrowser *);
+  void needShowPlot(Ui::SequentialFitDialog * /*_t1*/,
+                    MantidQt::MantidWidgets::FitPropertyBrowser * /*_t2*/);
 
 private slots:
 
@@ -74,7 +74,7 @@ private slots:
   /// called when selection in the workspace table changes
   void selectionChanged();
 
-  void plotAgainstLog(bool);
+  void plotAgainstLog(bool /*yes*/);
 
 private:
   /// Checks that the logs in workspace wsName are consistent

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SlicingAlgorithmDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SlicingAlgorithmDialog.h
@@ -55,7 +55,7 @@ protected:
   Ui::SlicingAlgorithmDialog ui;
 
   /// Common slice md setup
-  void commonSliceMDSetup(const bool);
+  void commonSliceMDSetup(const bool /*isSliceMD*/);
 
   /// Build dimension inputs.
   void buildDimensionInputs(const bool bForceForget = false);
@@ -64,11 +64,11 @@ protected slots:
 
   void onWorkspaceChanged();
 
-  void onAxisAlignedChanged(bool);
+  void onAxisAlignedChanged(bool /*unused*/);
 
   void onBrowse();
 
-  void onMaxFromInput(bool);
+  void onMaxFromInput(bool /*unused*/);
 
   void onRebuildDimensions();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SlitCalculator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SlitCalculator.h
@@ -35,7 +35,7 @@ private:
   Mantid::Geometry::Instrument_const_sptr instrument;
   std::string currentInstrumentName;
   void setupSlitCalculatorWithInstrumentValues(
-      Mantid::Geometry::Instrument_const_sptr);
+      Mantid::Geometry::Instrument_const_sptr /*instrument*/);
   std::string getCurrentInstrumentName();
   Mantid::Geometry::Instrument_const_sptr getInstrument();
   void setInstrument(std::string instrumentName);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/SyncedCheckboxes.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/SyncedCheckboxes.h
@@ -39,11 +39,11 @@ public:
 
 signals:
   /// Signal emitted when the check box is toggled
-  void toggled(bool);
+  void toggled(bool /*_t1*/);
 
 public slots:
-  void on_menu_toggled(bool);
-  void on_button_toggled(bool);
+  void on_menu_toggled(bool /*val*/);
+  void on_button_toggled(bool /*val*/);
 
 private:
   QAction *m_menu;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserSubWindow.h
@@ -88,7 +88,7 @@ public:
 
 signals:
   /// Emitted to start a (generally small) script running
-  void runAsPythonScript(const QString &code, bool);
+  void runAsPythonScript(const QString &code, bool /*_t2*/);
 
   /// Thrown when used fit property browser should be changed to given one
   void

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceObserver.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceObserver.h
@@ -231,7 +231,7 @@ protected:
   Poco::NObserver<WorkspaceObserver, Mantid::API::ClearADSNotification>
       m_clearADSObserver;
   /// ADS clear notification
-  void _clearADSHandle(Mantid::API::ClearADSNotification_ptr) {
+  void _clearADSHandle(Mantid::API::ClearADSNotification_ptr /*unused*/) {
     m_proxy->adsCleared();
   }
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -171,7 +171,7 @@ private:
   whichCriteria(SortCriteria criteria);
 
 public slots:
-  void clickedWorkspace(QTreeWidgetItem *, int);
+  void clickedWorkspace(QTreeWidgetItem * /*item*/, int /*unused*/);
   void saveWorkspaceCollection();
   void onClickDeleteWorkspaces();
   void renameWorkspace();
@@ -182,7 +182,7 @@ public slots:
   void chooseByName();
   void chooseByLastModified();
   void chooseByMemorySize();
-  void keyPressEvent(QKeyEvent *) override;
+  void keyPressEvent(QKeyEvent * /*unused*/) override;
 
 protected slots:
   void popupMenu(const QPoint &pos);
@@ -270,11 +270,11 @@ private:
   mutable QMutex m_mutex;
 
 private slots:
-  void handleUpdateTree(const TopLevelItems &);
+  void handleUpdateTree(const TopLevelItems & /*items*/);
   void handleClearView();
 signals:
   void signalClearView();
-  void signalUpdateTree(const TopLevelItems &);
+  void signalUpdateTree(const TopLevelItems & /*_t1*/);
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspaceSelector.h
@@ -101,9 +101,9 @@ private:
 
 protected:
   // Method for handling drop events
-  void dropEvent(QDropEvent *) override;
+  void dropEvent(QDropEvent * /*unused*/) override;
   // called when a drag event enters the class
-  void dragEnterEvent(QDragEnterEvent *) override;
+  void dragEnterEvent(QDragEnterEvent * /*unused*/) override;
 
 private:
   /// Poco Observers for ADS Notifications

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/pqHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/pqHelpWindow.h
@@ -94,7 +94,7 @@ public slots:
 
 signals:
   /// fired to relay warning messages from the help system.
-  void helpWarnings(const QString &);
+  void helpWarnings(const QString & /*_t1*/);
 
 protected slots:
   void search();

--- a/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmSelectorWidget.cpp
@@ -174,7 +174,7 @@ void AlgorithmSelectorWidget::setSelectedAlgorithm(QString &algName) {
  *
  */
 void AlgorithmSelectorWidget::handleAlgorithmFactoryUpdate(
-    Mantid::API::AlgorithmFactoryUpdateNotification_ptr) {
+    Mantid::API::AlgorithmFactoryUpdateNotification_ptr /*unused*/) {
   emit algorithmFactoryUpdateReceived();
 }
 

--- a/qt/widgets/common/src/Batch/QtStandardItemTreeAdapter.cpp
+++ b/qt/widgets/common/src/Batch/QtStandardItemTreeAdapter.cpp
@@ -108,7 +108,7 @@ std::vector<Cell> QtStandardItemTreeModelAdapter::cellsAtRow(
   cells.reserve(m_model.columnCount());
   enumerateCellsInRow(
       firstCellIndex, m_model.columnCount(),
-      [this, &cells](QModelIndexForMainModel const &cellIndex, int) -> void {
+      [this, &cells](QModelIndexForMainModel const &cellIndex, int /*unused*/) -> void {
         cells.emplace_back(cellFromCellIndex(cellIndex));
       });
   return cells;

--- a/qt/widgets/common/src/Batch/QtStandardItemTreeAdapter.cpp
+++ b/qt/widgets/common/src/Batch/QtStandardItemTreeAdapter.cpp
@@ -106,11 +106,11 @@ std::vector<Cell> QtStandardItemTreeModelAdapter::cellsAtRow(
     QModelIndexForMainModel const &firstCellIndex) const {
   auto cells = std::vector<Cell>();
   cells.reserve(m_model.columnCount());
-  enumerateCellsInRow(
-      firstCellIndex, m_model.columnCount(),
-      [this, &cells](QModelIndexForMainModel const &cellIndex, int /*unused*/) -> void {
-        cells.emplace_back(cellFromCellIndex(cellIndex));
-      });
+  enumerateCellsInRow(firstCellIndex, m_model.columnCount(),
+                      [this, &cells](QModelIndexForMainModel const &cellIndex,
+                                     int /*unused*/) -> void {
+                        cells.emplace_back(cellFromCellIndex(cellIndex));
+                      });
   return cells;
 }
 

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -86,7 +86,7 @@ void BatchAlgorithmRunner::executeBatchAsync() {
 /**
  * Implementation of sequential algorithm scheduler.
  */
-bool BatchAlgorithmRunner::executeBatchAsyncImpl(const Poco::Void &) {
+bool BatchAlgorithmRunner::executeBatchAsyncImpl(const Poco::Void & /*unused*/) {
   bool cancelFlag = false;
 
   for (auto it = m_algorithms.begin(); it != m_algorithms.end(); ++it) {

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -86,7 +86,8 @@ void BatchAlgorithmRunner::executeBatchAsync() {
 /**
  * Implementation of sequential algorithm scheduler.
  */
-bool BatchAlgorithmRunner::executeBatchAsyncImpl(const Poco::Void & /*unused*/) {
+bool BatchAlgorithmRunner::executeBatchAsyncImpl(
+    const Poco::Void & /*unused*/) {
   bool cancelFlag = false;
 
   for (auto it = m_algorithms.begin(); it != m_algorithms.end(); ++it) {

--- a/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/GenericDataProcessorPresenter.cpp
@@ -697,10 +697,10 @@ void GenericDataProcessorPresenter::processNextItem() {
 }
 
 void GenericDataProcessorPresenter::completedGroupReductionSuccessfully(
-    GroupData const &, std::string const &) {}
+    GroupData const & /*unused*/, std::string const & /*unused*/) {}
 
 void GenericDataProcessorPresenter::completedRowReductionSuccessfully(
-    GroupData const &, std::string const &) {}
+    GroupData const & /*unused*/, std::string const & /*unused*/) {}
 
 /*
 Reduce the current row asynchronously

--- a/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QOneLevelTreeModel.cpp
@@ -363,8 +363,8 @@ void QOneLevelTreeModel::updateAllRowData() {
 /** Called when the data in the table has changed. Updates the
  * table values in the cached RowData
  */
-void QOneLevelTreeModel::tableDataUpdated(const QModelIndex &,
-                                          const QModelIndex &) {
+void QOneLevelTreeModel::tableDataUpdated(const QModelIndex & /*unused*/,
+                                          const QModelIndex & /*unused*/) {
   updateAllRowData();
 }
 

--- a/qt/widgets/common/src/DoubleSpinBox.cpp
+++ b/qt/widgets/common/src/DoubleSpinBox.cpp
@@ -169,7 +169,7 @@ QString DoubleSpinBox::textFromValue(double value) const {
   return locale().toString(value, d_format, 6);
 }
 
-QValidator::State DoubleSpinBox::validate(QString &, int &) const {
+QValidator::State DoubleSpinBox::validate(QString & /*input*/, int & /*pos*/) const {
   return QValidator::Acceptable;
 }
 

--- a/qt/widgets/common/src/DoubleSpinBox.cpp
+++ b/qt/widgets/common/src/DoubleSpinBox.cpp
@@ -169,7 +169,8 @@ QString DoubleSpinBox::textFromValue(double value) const {
   return locale().toString(value, d_format, 6);
 }
 
-QValidator::State DoubleSpinBox::validate(QString & /*input*/, int & /*pos*/) const {
+QValidator::State DoubleSpinBox::validate(QString & /*input*/,
+                                          int & /*pos*/) const {
   return QValidator::Acceptable;
 }
 

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -523,7 +523,7 @@ void FitOptionsBrowser::setProperty(const QString &name, const QString &value) {
 /**
  * Get the value of the Minimizer property.
  */
-QString FitOptionsBrowser::getMinimizer(QtProperty *) const {
+QString FitOptionsBrowser::getMinimizer(QtProperty * /*unused*/) const {
   int i = m_enumManager->value(m_minimizer);
   QString minimStr = m_enumManager->enumNames(m_minimizer)[i];
 
@@ -560,7 +560,7 @@ QString FitOptionsBrowser::getMinimizer(QtProperty *) const {
  * Set new value to the Minimizer property.
  * @param value :: The new value.
  */
-void FitOptionsBrowser::setMinimizer(QtProperty *, const QString &value) {
+void FitOptionsBrowser::setMinimizer(QtProperty * /*unused*/, const QString &value) {
   QStringList terms = value.split(',');
   int i = m_enumManager->enumNames(m_minimizer).indexOf(terms[0]);
   m_enumManager->setValue(m_minimizer, i);

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -560,7 +560,8 @@ QString FitOptionsBrowser::getMinimizer(QtProperty * /*unused*/) const {
  * Set new value to the Minimizer property.
  * @param value :: The new value.
  */
-void FitOptionsBrowser::setMinimizer(QtProperty * /*unused*/, const QString &value) {
+void FitOptionsBrowser::setMinimizer(QtProperty * /*unused*/,
+                                     const QString &value) {
   QStringList terms = value.split(',');
   int i = m_enumManager->enumNames(m_minimizer).indexOf(terms[0]);
   m_enumManager->setValue(m_minimizer, i);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -848,7 +848,7 @@ FitPropertyBrowser::tryCreateFitFunction(const QString &str) {
   }
 }
 
-void FitPropertyBrowser::popupMenu(const QPoint &) {
+void FitPropertyBrowser::popupMenu(const QPoint & /*unused*/) {
   QtBrowserItem *ci = m_browser->currentItem();
   if (!ci)
     return;

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -2436,7 +2436,9 @@ void FunctionBrowser::setColumnSizes(int s0, int s1, int s2) {
 /**
  * Emit a signal when any of the Global options change.
  */
-void FunctionBrowser::globalChanged(QtProperty * /*unused*/, const QString & /*unused*/, bool /*unused*/) {
+void FunctionBrowser::globalChanged(QtProperty * /*unused*/,
+                                    const QString & /*unused*/,
+                                    bool /*unused*/) {
   emit globalsChanged();
 }
 

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -1175,7 +1175,7 @@ QString FunctionBrowser::getConstraint(const QString &paramName,
 /**
  * Show a pop up menu.
  */
-void FunctionBrowser::popupMenu(const QPoint &) {
+void FunctionBrowser::popupMenu(const QPoint & /*unused*/) {
   auto item = m_browser->currentItem();
   if (!item) {
     QMenu context(this);
@@ -2436,7 +2436,7 @@ void FunctionBrowser::setColumnSizes(int s0, int s1, int s2) {
 /**
  * Emit a signal when any of the Global options change.
  */
-void FunctionBrowser::globalChanged(QtProperty *, const QString &, bool) {
+void FunctionBrowser::globalChanged(QtProperty * /*unused*/, const QString & /*unused*/, bool /*unused*/) {
   emit globalsChanged();
 }
 

--- a/qt/widgets/common/src/InputController.cpp
+++ b/qt/widgets/common/src/InputController.cpp
@@ -66,7 +66,7 @@ void InputController3DMove::mouseMoveEvent(QMouseEvent *event) {
  * Process the mouse release event.
  * Finalize the interaction.
  */
-void InputController3DMove::mouseReleaseEvent(QMouseEvent *) {
+void InputController3DMove::mouseReleaseEvent(QMouseEvent * /*unused*/) {
   m_isButtonPressed = false;
   emit finish();
 }
@@ -114,7 +114,7 @@ void InputControllerPick::mouseMoveEvent(QMouseEvent *event) {
 /**
  * Process the mouse release event.
  */
-void InputControllerPick::mouseReleaseEvent(QMouseEvent *) {
+void InputControllerPick::mouseReleaseEvent(QMouseEvent * /*unused*/) {
   m_isButtonPressed = false;
   emit finishSelection();
 }
@@ -171,7 +171,7 @@ void InputControllerDrawShape::mouseMoveEvent(QMouseEvent *event) {
 /**
  * Process the mouse button release event.
  */
-void InputControllerDrawShape::mouseReleaseEvent(QMouseEvent *) {
+void InputControllerDrawShape::mouseReleaseEvent(QMouseEvent * /*unused*/) {
   m_isButtonPressed = false;
   m_creating = false;
   m_shapeType = "";
@@ -193,7 +193,7 @@ void InputControllerDrawShape::keyPressEvent(QKeyEvent *event) {
 /**
  * Process event of the mouse leaving the widget.
  */
-void InputControllerDrawShape::leaveEvent(QEvent *) {
+void InputControllerDrawShape::leaveEvent(QEvent * /*unused*/) {
   emit restoreOverrideCursor();
 }
 
@@ -323,13 +323,13 @@ void InputControllerDraw::wheelEvent(QWheelEvent *event) {
   }
 }
 
-void InputControllerDraw::enterEvent(QEvent *) {
+void InputControllerDraw::enterEvent(QEvent * /*unused*/) {
   redrawCursor();
   QApplication::setOverrideCursor(QCursor(*m_cursor, 0, 0));
   m_isActive = true;
 }
 
-void InputControllerDraw::leaveEvent(QEvent *) {
+void InputControllerDraw::leaveEvent(QEvent * /*unused*/) {
   QApplication::restoreOverrideCursor();
   m_isActive = false;
 }

--- a/qt/widgets/common/src/LineEditWithClear.cpp
+++ b/qt/widgets/common/src/LineEditWithClear.cpp
@@ -35,7 +35,7 @@ LineEditWithClear::LineEditWithClear(QWidget *parent) : QLineEdit(parent) {
            clearButton->sizeHint().height() + frameWidth * 2 + 2));
 }
 
-void LineEditWithClear::resizeEvent(QResizeEvent *) {
+void LineEditWithClear::resizeEvent(QResizeEvent * /*unused*/) {
   QSize sz = clearButton->sizeHint();
   int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
   clearButton->move(rect().right() - frameWidth - sz.width(),

--- a/qt/widgets/common/src/MWDiag.cpp
+++ b/qt/widgets/common/src/MWDiag.cpp
@@ -541,7 +541,7 @@ QString MWDiag::openFileDialog(const bool save, const QStringList &exts) {
  *  @return this method catches most exceptions and this return is main way that
  * errors are reported
  */
-QString MWDiag::run(const QString &, const bool) {
+QString MWDiag::run(const QString & /*unused*/, const bool /*unused*/) {
   // close any result window that is still there from a previous run, there
   // might be nothing
   closeDialog();

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -745,7 +745,7 @@ protected:
     m_browser->m_changeSlotsEnabled = true;
   }
   /// Set vector property
-  void apply(const std::vector<double> &) const override {
+  void apply(const std::vector<double> & /*unused*/) const override {
     // this method is supposed to be called when corresponding
     // property value changes but it doesn't have a value because
     // it's a group property

--- a/qt/widgets/common/src/QtPropertyBrowser/StringDialogEditor.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/StringDialogEditor.cpp
@@ -17,13 +17,13 @@
  * Do nothing to connect a manager.
  */
 void StringDialogEditorFactory::connectPropertyManager(
-    QtStringPropertyManager *) {}
+    QtStringPropertyManager * /*manager*/) {}
 
 /**
  * Do nothing to disconnect a manager - it was never connected.
  */
 void StringDialogEditorFactory::disconnectPropertyManager(
-    QtStringPropertyManager *) {}
+    QtStringPropertyManager * /*manager*/) {}
 
 /**
  * Constructor.

--- a/qt/widgets/common/src/QtPropertyBrowser/StringEditorFactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/StringEditorFactory.cpp
@@ -6,9 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h"
 
-QWidget *StringEditorFactory::createEditorForManager(QtStringPropertyManager * /*manager*/,
-                                                     QtProperty *property,
-                                                     QWidget *parent) {
+QWidget *StringEditorFactory::createEditorForManager(
+    QtStringPropertyManager * /*manager*/, QtProperty *property,
+    QWidget *parent) {
   return new StringEditor(property, parent);
 }
 

--- a/qt/widgets/common/src/QtPropertyBrowser/StringEditorFactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/StringEditorFactory.cpp
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/QtPropertyBrowser/StringEditorFactory.h"
 
-QWidget *StringEditorFactory::createEditorForManager(QtStringPropertyManager *,
+QWidget *StringEditorFactory::createEditorForManager(QtStringPropertyManager * /*manager*/,
                                                      QtProperty *property,
                                                      QWidget *parent) {
   return new StringEditor(property, parent);

--- a/qt/widgets/common/src/QtPropertyBrowser/WorkspaceEditorFactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/WorkspaceEditorFactory.cpp
@@ -10,7 +10,8 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 QWidget *WorkspaceEditorFactory::createEditorForManager(
-    QtStringPropertyManager * /*manager*/, QtProperty *property, QWidget *parent) {
+    QtStringPropertyManager * /*manager*/, QtProperty *property,
+    QWidget *parent) {
   return new WorkspaceEditor(property, parent);
 }
 

--- a/qt/widgets/common/src/QtPropertyBrowser/WorkspaceEditorFactory.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/WorkspaceEditorFactory.cpp
@@ -10,7 +10,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 QWidget *WorkspaceEditorFactory::createEditorForManager(
-    QtStringPropertyManager *, QtProperty *property, QWidget *parent) {
+    QtStringPropertyManager * /*manager*/, QtProperty *property, QWidget *parent) {
   return new WorkspaceEditor(property, parent);
 }
 

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -257,7 +257,7 @@ void QtPropertyEditorDelegate::closeEditor(QtProperty *property) {
 
 QWidget *
 QtPropertyEditorDelegate::createEditor(QWidget *parent,
-                                       const QStyleOptionViewItem &,
+                                       const QStyleOptionViewItem & /*option*/,
                                        const QModelIndex &index) const {
   if (index.column() == 1 && m_editorPrivate) {
     QtProperty *property = m_editorPrivate->indexToProperty(index);
@@ -677,7 +677,7 @@ void QtTreePropertyBrowserPrivate::slotCurrentBrowserItemChanged(
 }
 
 void QtTreePropertyBrowserPrivate::slotCurrentTreeItemChanged(
-    QTreeWidgetItem *newItem, QTreeWidgetItem *) {
+    QTreeWidgetItem *newItem, QTreeWidgetItem * /*unused*/) {
   QtBrowserItem *browserItem = newItem ? m_itemToIndex.value(newItem) : 0;
   m_browserChangedBlocked = true;
   q_ptr->setCurrentItem(browserItem);

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -359,7 +359,8 @@ void SequentialFitDialog::populateParameters() {
 
 void SequentialFitDialog::functionChanged() { populateParameters(); }
 
-void SequentialFitDialog::finishHandle(const Mantid::API::IAlgorithm * /*alg*/) {
+void SequentialFitDialog::finishHandle(
+    const Mantid::API::IAlgorithm * /*alg*/) {
   emit needShowPlot(&ui, m_fitBrowser);
 }
 

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -359,7 +359,7 @@ void SequentialFitDialog::populateParameters() {
 
 void SequentialFitDialog::functionChanged() { populateParameters(); }
 
-void SequentialFitDialog::finishHandle(const Mantid::API::IAlgorithm *) {
+void SequentialFitDialog::finishHandle(const Mantid::API::IAlgorithm * /*alg*/) {
   emit needShowPlot(&ui, m_fitBrowser);
 }
 

--- a/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
+++ b/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
@@ -133,7 +133,7 @@ formattedAlignedDimensionInput(Mantid::Geometry::IMDDimension_const_sptr dim) {
  @return : empty string.
 */
 QString
-formatNonAlignedDimensionInput(Mantid::Geometry::IMDDimension_const_sptr) {
+formatNonAlignedDimensionInput(Mantid::Geometry::IMDDimension_const_sptr /*unused*/) {
   // Deliberately return an empty string here, because it's not obvious how the
   // basis vectors could be automatically formed.
   return QString("");
@@ -382,7 +382,7 @@ Event handler for the axis changed event.
 This event handler allows us to continually dynamically provide inputs depending
 upon the dimensionality.
 */
-void SlicingAlgorithmDialog::onAxisAlignedChanged(bool) {
+void SlicingAlgorithmDialog::onAxisAlignedChanged(bool /*unused*/) {
   buildDimensionInputs(this->doAutoFillDimensions());
 }
 
@@ -391,7 +391,7 @@ Event handler for changes so that recursion depth for the ouput workspace is
 either taken
 from the input workspace or from an external field.
 */
-void SlicingAlgorithmDialog::onMaxFromInput(bool) {
+void SlicingAlgorithmDialog::onMaxFromInput(bool /*unused*/) {
   const bool takeFromInputWorkspace = ui.ck_max_from_input->isChecked();
   ui.txt_resursion_depth->setEnabled(!takeFromInputWorkspace);
   ui.lbl_resursion_depth->setEnabled(!takeFromInputWorkspace);
@@ -404,7 +404,7 @@ void SlicingAlgorithmDialog::onRebuildDimensions() {
   buildDimensionInputs(true);
 }
 
-void SlicingAlgorithmDialog::onCalculateChanged(bool) {
+void SlicingAlgorithmDialog::onCalculateChanged(bool /*unused*/) {
   if (ui.ck_axis_aligned->isChecked())
     buildDimensionInputs(true);
 }

--- a/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
+++ b/qt/widgets/common/src/SlicingAlgorithmDialog.cpp
@@ -132,8 +132,8 @@ formattedAlignedDimensionInput(Mantid::Geometry::IMDDimension_const_sptr dim) {
 
  @return : empty string.
 */
-QString
-formatNonAlignedDimensionInput(Mantid::Geometry::IMDDimension_const_sptr /*unused*/) {
+QString formatNonAlignedDimensionInput(
+    Mantid::Geometry::IMDDimension_const_sptr /*unused*/) {
   // Deliberately return an empty string here, because it's not obvious how the
   // basis vectors could be automatically formed.
   return QString("");

--- a/qt/widgets/common/src/WorkspacePresenter/ADSAdapter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/ADSAdapter.cpp
@@ -76,7 +76,8 @@ std::string ADSAdapter::getOldName() const { return m_oldName; }
 std::string ADSAdapter::getNewName() const { return m_newName; }
 
 // ADS Observation methods
-void ADSAdapter::handleAddWorkspace(Mantid::API::WorkspaceAddNotification_ptr /*unused*/) {
+void ADSAdapter::handleAddWorkspace(
+    Mantid::API::WorkspaceAddNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspaceLoaded);
@@ -96,7 +97,8 @@ void ADSAdapter::handleDeleteWorkspace(
       WorkspaceProviderNotifiable::Flag::WorkspaceDeleted);
 }
 
-void ADSAdapter::handleClearADS(Mantid::API::ClearADSNotification_ptr /*unused*/) {
+void ADSAdapter::handleClearADS(
+    Mantid::API::ClearADSNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspacesCleared);

--- a/qt/widgets/common/src/WorkspacePresenter/ADSAdapter.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/ADSAdapter.cpp
@@ -76,27 +76,27 @@ std::string ADSAdapter::getOldName() const { return m_oldName; }
 std::string ADSAdapter::getNewName() const { return m_newName; }
 
 // ADS Observation methods
-void ADSAdapter::handleAddWorkspace(Mantid::API::WorkspaceAddNotification_ptr) {
+void ADSAdapter::handleAddWorkspace(Mantid::API::WorkspaceAddNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspaceLoaded);
 }
 
 void ADSAdapter::handleReplaceWorkspace(
-    Mantid::API::WorkspaceAfterReplaceNotification_ptr) {
+    Mantid::API::WorkspaceAfterReplaceNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::GenericUpdateNotification);
 }
 
 void ADSAdapter::handleDeleteWorkspace(
-    Mantid::API::WorkspacePostDeleteNotification_ptr) {
+    Mantid::API::WorkspacePostDeleteNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspaceDeleted);
 }
 
-void ADSAdapter::handleClearADS(Mantid::API::ClearADSNotification_ptr) {
+void ADSAdapter::handleClearADS(Mantid::API::ClearADSNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspacesCleared);
@@ -113,21 +113,21 @@ void ADSAdapter::handleRenameWorkspace(
 }
 
 void ADSAdapter::handleGroupWorkspaces(
-    Mantid::API::WorkspacesGroupedNotification_ptr) {
+    Mantid::API::WorkspacesGroupedNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspacesGrouped);
 }
 
 void ADSAdapter::handleUnGroupWorkspace(
-    Mantid::API::WorkspaceUnGroupingNotification_ptr) {
+    Mantid::API::WorkspaceUnGroupingNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspacesUngrouped);
 }
 
 void ADSAdapter::handleWorkspaceGroupUpdate(
-    Mantid::API::GroupUpdatedNotification_ptr) {
+    Mantid::API::GroupUpdatedNotification_ptr /*unused*/) {
   auto presenter = lockPresenter();
   presenter->notifyFromWorkspaceProvider(
       WorkspaceProviderNotifiable::Flag::WorkspaceGroupUpdated);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -1147,7 +1147,7 @@ void WorkspaceTreeWidget::onClickDeleteWorkspaces() {
   m_presenter->notifyFromView(ViewNotifiable::Flag::DeleteWorkspaces);
 }
 
-void WorkspaceTreeWidget::clickedWorkspace(QTreeWidgetItem *item, int) {
+void WorkspaceTreeWidget::clickedWorkspace(QTreeWidgetItem *item, int /*unused*/) {
   Q_UNUSED(item);
 }
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -1147,7 +1147,8 @@ void WorkspaceTreeWidget::onClickDeleteWorkspaces() {
   m_presenter->notifyFromView(ViewNotifiable::Flag::DeleteWorkspaces);
 }
 
-void WorkspaceTreeWidget::clickedWorkspace(QTreeWidgetItem *item, int /*unused*/) {
+void WorkspaceTreeWidget::clickedWorkspace(QTreeWidgetItem *item,
+                                           int /*unused*/) {
   Q_UNUSED(item);
 }
 

--- a/qt/widgets/common/src/WorkspaceSelector.cpp
+++ b/qt/widgets/common/src/WorkspaceSelector.cpp
@@ -196,7 +196,7 @@ void WorkspaceSelector::handleRemEvent(
 }
 
 void WorkspaceSelector::handleClearEvent(
-    Mantid::API::ClearADSNotification_ptr) {
+    Mantid::API::ClearADSNotification_ptr /*unused*/) {
   this->clear();
   emit emptied();
 }

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BinDialog.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BinDialog.h
@@ -34,11 +34,11 @@ class BinDialog : public QDialog {
 public:
   explicit BinDialog(QWidget *parent = nullptr);
   ~BinDialog() override;
-  void setIntegralMinMax(double, double, bool);
+  void setIntegralMinMax(double /*minBin*/, double /*maxBin*/, bool /*useEverything*/);
 signals:
   /// This signal is sent when changing the bin range selected.
   /// Parameters are: min, max, and a bool set to true to mean "everything"
-  void IntegralMinMax(double, double, bool);
+  void IntegralMinMax(double /*_t1*/, double /*_t2*/, bool /*_t3*/);
 
 public slots:
   void btnOKClicked();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BinDialog.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/BinDialog.h
@@ -34,7 +34,8 @@ class BinDialog : public QDialog {
 public:
   explicit BinDialog(QWidget *parent = nullptr);
   ~BinDialog() override;
-  void setIntegralMinMax(double /*minBin*/, double /*maxBin*/, bool /*useEverything*/);
+  void setIntegralMinMax(double /*minBin*/, double /*maxBin*/,
+                         bool /*useEverything*/);
 signals:
   /// This signal is sent when changing the bin range selected.
   /// Parameters are: min, max, and a bool set to true to mean "everything"

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/CollapsiblePanel.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/CollapsiblePanel.h
@@ -24,7 +24,7 @@ public:
   void collapse();
   void expand();
 signals:
-  void collapseOrExpand(bool);
+  void collapseOrExpand(bool /*_t1*/);
 
 private:
   bool m_collapsed;
@@ -47,7 +47,7 @@ public slots:
   void collapse();
   void expand();
 private slots:
-  void collapseOrExpand(bool);
+  void collapseOrExpand(bool /*collapse*/);
 
 private:
   QWidget *m_widget;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
@@ -34,7 +34,7 @@ public:
   /// Set all four values atomically
   void set(float red, float green, float blue, float alpha);
   /// Retrieve the component colours
-  void get(float &, float &, float &, float &) const;
+  void get(float & /*red*/, float & /*green*/, float & /*blue*/, float & /*alpha*/) const;
   void get(unsigned char &r, unsigned char &g, unsigned char &b) const;
   /// Retrieve the component colours
   void getUB3(unsigned char *c) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
@@ -34,7 +34,8 @@ public:
   /// Set all four values atomically
   void set(float red, float green, float blue, float alpha);
   /// Retrieve the component colours
-  void get(float & /*red*/, float & /*green*/, float & /*blue*/, float & /*alpha*/) const;
+  void get(float & /*red*/, float & /*green*/, float & /*blue*/,
+           float & /*alpha*/) const;
   void get(unsigned char &r, unsigned char &g, unsigned char &b) const;
   /// Retrieve the component colours
   void getUB3(unsigned char *c) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -72,7 +72,7 @@ public:
   /// Set a component (and all its children) visible.
   void setComponentVisible(size_t componentIndex);
   /// Set visibilit of all components.
-  void setAllComponentsVisibility(bool);
+  void setAllComponentsVisibility(bool /*on*/);
   /// Check if any child is visible
   bool hasChildVisible() const;
   /// Get the underlying instrument
@@ -104,15 +104,15 @@ public:
   /// Get the color map.
   const ColorMap &getColorMap() const;
   /// Load a new color map from a file
-  void loadColorMap(const QString &, bool reset_colors = true);
+  void loadColorMap(const QString & /*fname*/, bool reset_colors = true);
   /// Change the colormap scale type.
-  void changeScaleType(int);
+  void changeScaleType(int /*type*/);
   /// Change the colormap power scale exponent.
-  void changeNthPower(double);
+  void changeNthPower(double /*nth_power*/);
   /// Get the file name of the current color map.
   QString getCurrentColorMap() const { return m_currentCMap; }
   /// Toggle colormap scale autoscaling.
-  void setAutoscaling(bool);
+  void setAutoscaling(bool /*on*/);
   /// extracts a mask workspace from the visualised workspace
   Mantid::API::MatrixWorkspace_sptr extractCurrentMask() const;
 
@@ -171,7 +171,7 @@ public:
   /// current integration range.
   void updateColors();
   /// Toggle display of the guide and other non-detector instrument components
-  void showGuides(bool);
+  void showGuides(bool /*on*/);
   /// Get the guide visibility status
   bool areGuidesShown() const { return m_showGuides; }
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h
@@ -40,9 +40,9 @@ public:
   QStringList
   findExpandedComponents(const QModelIndex &parent = QModelIndex()) const;
 public slots:
-  void sendComponentSelectedSignal(const QModelIndex);
+  void sendComponentSelectedSignal(const QModelIndex /*index*/);
 signals:
-  void componentSelected(size_t);
+  void componentSelected(size_t /*_t1*/);
 
 private:
   InstrumentWidget *m_instrWidget;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -157,20 +157,20 @@ public:
   std::string saveToProject() const;
 
 signals:
-  void enableLighting(bool);
-  void plot1D(const QString &, const std::set<int> &, bool);
-  void createDetectorTable(const QString &, const std::vector<int> &, bool);
-  void needSetIntegrationRange(double, double);
-  void surfaceTypeChanged(int);
+  void enableLighting(bool /*_t1*/);
+  void plot1D(const QString & /*_t1*/, const std::set<int> & /*_t2*/, bool /*_t3*/);
+  void createDetectorTable(const QString & /*_t1*/, const std::vector<int> & /*_t2*/, bool /*_t3*/);
+  void needSetIntegrationRange(double /*_t1*/, double /*_t2*/);
+  void surfaceTypeChanged(int /*_t1*/);
   void colorMapChanged();
-  void colorMapMinValueChanged(double);
-  void colorMapMaxValueChanged(double);
-  void colorMapRangeChanged(double, double);
-  void scaleTypeChanged(int);
-  void nthPowerChanged(double);
-  void integrationRangeChanged(double, double);
-  void glOptionChanged(bool);
-  void requestSelectComponent(const QString &);
+  void colorMapMinValueChanged(double /*_t1*/);
+  void colorMapMaxValueChanged(double /*_t1*/);
+  void colorMapRangeChanged(double /*_t1*/, double /*_t2*/);
+  void scaleTypeChanged(int /*_t1*/);
+  void nthPowerChanged(double /*_t1*/);
+  void integrationRangeChanged(double /*_t1*/, double /*_t2*/);
+  void glOptionChanged(bool /*_t1*/);
+  void requestSelectComponent(const QString & /*_t1*/);
   void preDeletingHandle();
   void clearingHandle();
   void maskedWorkspaceOverlayed();
@@ -183,31 +183,31 @@ protected:
   bool eventFilter(QObject *obj, QEvent *ev) override;
 
 public slots:
-  void tabChanged(int);
+  void tabChanged(int /*unused*/);
   void componentSelected(size_t componentIndex);
-  void executeAlgorithm(const QString &, const QString &);
-  void executeAlgorithm(Mantid::API::IAlgorithm_sptr);
+  void executeAlgorithm(const QString & /*unused*/, const QString & /*unused*/);
+  void executeAlgorithm(Mantid::API::IAlgorithm_sptr /*alg*/);
 
   void setupColorMap();
 
   void changeColormap(const QString &cmapNameOrPath = ""); // Deprecated
-  void changeScaleType(int);                               // Deprecated
-  void changeNthPower(double);
+  void changeScaleType(int /*type*/);                               // Deprecated
+  void changeNthPower(double /*nth_power*/);
   void changeColorMapMinValue(double minValue);               // Deprecated
   void changeColorMapMaxValue(double maxValue);               // Deprecated
   void changeColorMapRange(double minValue, double maxValue); // Deprecated
-  void setIntegrationRange(double, double);
-  void setBinRange(double, double);
+  void setIntegrationRange(double /*xmin*/, double /*xmax*/);
+  void setBinRange(double /*xmin*/, double /*xmax*/);
   void disableColorMapAutoscaling(); // Deprecated
-  void setColorMapAutoscaling(bool); // Deprecated
+  void setColorMapAutoscaling(bool /*on*/); // Deprecated
 
-  void setViewDirection(const QString &);
+  void setViewDirection(const QString & /*input*/);
   void pickBackgroundColor();
   void saveImage(QString filename);
-  void setInfoText(const QString &);
-  void set3DAxesState(bool);
-  void setSurfaceType(int);
-  void setWireframe(bool);
+  void setInfoText(const QString & /*text*/);
+  void set3DAxesState(bool /*on*/);
+  void setSurfaceType(int /*type*/);
+  void setWireframe(bool /*on*/);
 
   /// Overlay a workspace with the given name
   bool overlay(const QString &wsName);
@@ -319,7 +319,7 @@ private:
   /// overlay a masked workspace on the projection surface
   void overlayMaskedWorkspace(Mantid::API::IMaskWorkspace_sptr ws);
   /// overlay a table workspace with shape parameters on the projection surface
-  void overlayShapesWorkspace(Mantid::API::ITableWorkspace_sptr);
+  void overlayShapesWorkspace(Mantid::API::ITableWorkspace_sptr /*ws*/);
   /// get a workspace from the ADS
   Mantid::API::Workspace_sptr getWorkspaceFromADS(const std::string &name);
   /// get a handle to the unwrapped surface

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -158,8 +158,10 @@ public:
 
 signals:
   void enableLighting(bool /*_t1*/);
-  void plot1D(const QString & /*_t1*/, const std::set<int> & /*_t2*/, bool /*_t3*/);
-  void createDetectorTable(const QString & /*_t1*/, const std::vector<int> & /*_t2*/, bool /*_t3*/);
+  void plot1D(const QString & /*_t1*/, const std::set<int> & /*_t2*/,
+              bool /*_t3*/);
+  void createDetectorTable(const QString & /*_t1*/,
+                           const std::vector<int> & /*_t2*/, bool /*_t3*/);
   void needSetIntegrationRange(double /*_t1*/, double /*_t2*/);
   void surfaceTypeChanged(int /*_t1*/);
   void colorMapChanged();
@@ -191,14 +193,14 @@ public slots:
   void setupColorMap();
 
   void changeColormap(const QString &cmapNameOrPath = ""); // Deprecated
-  void changeScaleType(int /*type*/);                               // Deprecated
+  void changeScaleType(int /*type*/);                      // Deprecated
   void changeNthPower(double /*nth_power*/);
   void changeColorMapMinValue(double minValue);               // Deprecated
   void changeColorMapMaxValue(double maxValue);               // Deprecated
   void changeColorMapRange(double minValue, double maxValue); // Deprecated
   void setIntegrationRange(double /*xmin*/, double /*xmax*/);
   void setBinRange(double /*xmin*/, double /*xmax*/);
-  void disableColorMapAutoscaling(); // Deprecated
+  void disableColorMapAutoscaling();        // Deprecated
   void setColorMapAutoscaling(bool /*on*/); // Deprecated
 
   void setViewDirection(const QString & /*input*/);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -80,10 +80,10 @@ public:
   virtual std::string saveToProject() const override;
 
 signals:
-  void executeAlgorithm(const QString &, const QString &);
+  void executeAlgorithm(const QString & /*_t1*/, const QString & /*_t2*/);
 
 public slots:
-  void changedIntegrationRange(double, double);
+  void changedIntegrationRange(double /*unused*/, double /*unused*/);
 
 protected slots:
   void setActivity();
@@ -111,13 +111,13 @@ protected slots:
   void sumDetsToWorkspace();
   void saveIncludeGroupToFile();
   void saveExcludeGroupToFile();
-  void showSaveMenuTooltip(QAction *);
+  void showSaveMenuTooltip(QAction * /*action*/);
   void toggleMaskGroup();
   void enableApplyButtons();
-  void doubleChanged(QtProperty *);
+  void doubleChanged(QtProperty * /*prop*/);
 
 protected:
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
 
   void clearProperties();
   void setProperties();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -87,7 +87,7 @@ public:
   void initSurface() override;
   void saveSettings(QSettings &settings) const override;
   void loadSettings(const QSettings &settings) override;
-  bool addToDisplayContextMenu(QMenu &) const override;
+  bool addToDisplayContextMenu(QMenu & /*unused*/) const override;
   void selectTool(const ToolType tool);
   boost::shared_ptr<ProjectionSurface> getSurface() const;
   const InstrumentWidget *getInstrumentWidget() const;
@@ -98,7 +98,7 @@ public:
 
 public slots:
   void setTubeXUnits(int units);
-  void changedIntegrationRange(double, double);
+  void changedIntegrationRange(double /*unused*/, double /*unused*/);
 private slots:
   void plotContextMenu();
   void sumDetectors();
@@ -106,7 +106,7 @@ private slots:
   void setPlotCaption();
   void setSelectionType();
   void storeCurve();
-  void removeCurve(const QString &);
+  void removeCurve(const QString & /*label*/);
   void singleComponentTouched(size_t pickID);
   void singleComponentPicked(size_t pickID);
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> &planePeaks,
@@ -120,7 +120,7 @@ private slots:
   void savePlotToWorkspace();
 
 private:
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
   QColor getShapeBorderColor() const;
 
   /* Pick tab controls */

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
@@ -49,7 +49,9 @@ public:
   void setScaleType(ColorMap::ScaleType type);
   void setAxis(const QString &axisName);
   bool areAxesOn() const;
-  void setupColorBar(const ColorMap & /*cmap*/, double /*minValue*/, double /*maxValue*/, double /*minPositive*/, bool /*autoscaling*/);
+  void setupColorBar(const ColorMap & /*cmap*/, double /*minValue*/,
+                     double /*maxValue*/, double /*minPositive*/,
+                     bool /*autoscaling*/);
   /// Load the render window tab settings from file.
   virtual void loadFromProject(const std::string &lines) override;
   /// Save the render window tab settings to file.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetRenderTab.h
@@ -42,14 +42,14 @@ public:
   explicit InstrumentWidgetRenderTab(InstrumentWidget *instrWindow);
   ~InstrumentWidgetRenderTab();
   void initSurface() override;
-  void saveSettings(QSettings &) const override;
-  void loadSettings(const QSettings &) override;
+  void saveSettings(QSettings & /*unused*/) const override;
+  void loadSettings(const QSettings & /*unused*/) override;
   // legacy interface for MantidPlot python api
   ColorMap::ScaleType getScaleType() const;
   void setScaleType(ColorMap::ScaleType type);
   void setAxis(const QString &axisName);
   bool areAxesOn() const;
-  void setupColorBar(const ColorMap &, double, double, double, bool);
+  void setupColorBar(const ColorMap & /*cmap*/, double /*minValue*/, double /*maxValue*/, double /*minPositive*/, bool /*autoscaling*/);
   /// Load the render window tab settings from file.
   virtual void loadFromProject(const std::string &lines) override;
   /// Save the render window tab settings to file.
@@ -57,7 +57,7 @@ public:
 
 signals:
   void rescaleColorMap();
-  void setAutoscaling(bool);
+  void setAutoscaling(bool /*_t1*/);
 
 public slots:
   void setMinValue(double value, bool apply = true);
@@ -66,31 +66,31 @@ public slots:
   void showAxes(bool on);
   void displayDetectorsOnly(bool yes);
   void enableGL(bool on);
-  void setColorMapAutoscaling(bool);
+  void setColorMapAutoscaling(bool /*on*/);
   void changeColorMap(const QString &filename = "");
-  void setSurfaceType(int);
-  void flipUnwrappedView(bool);
+  void setSurfaceType(int /*index*/);
+  void flipUnwrappedView(bool /*on*/);
   void saveImage(QString filename = "");
 
 private slots:
 
-  void showResetView(int);
-  void showFlipControl(int);
+  void showResetView(int /*iv*/);
+  void showFlipControl(int /*iv*/);
   /// Called before the display setting menu opens. Filters out menu options.
   void displaySettingsAboutToshow();
   /// Change the type of the surfac
   void surfaceTypeChanged(int index);
   void colorMapChanged();
-  void scaleTypeChanged(int);
-  void nthPowerChanged(double);
-  void glOptionChanged(bool);
-  void showMenuToolTip(QAction *);
+  void scaleTypeChanged(int /*type*/);
+  void nthPowerChanged(double /*nth_power*/);
+  void glOptionChanged(bool /*on*/);
+  void showMenuToolTip(QAction * /*action*/);
   void setUCorrection();
   void toggleLayerDisplay(bool on);
   void setVisibleLayer(int layer);
 
 private: // methods
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
   QMenu *createPeaksMenu();
   QFrame *setupAxisFrame();
   void setPrecisionMenuItemChecked(int n);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
@@ -34,13 +34,13 @@ public:
   /// Use it for surface-specific initialization
   virtual void initSurface() {}
   /// Save tab's persistent settings to the provided QSettings instance
-  virtual void saveSettings(QSettings &) const {}
+  virtual void saveSettings(QSettings & /*unused*/) const {}
   /// Load (read and apply) tab's persistent settings from the provided
   /// QSettings instance
-  virtual void loadSettings(const QSettings &) {}
+  virtual void loadSettings(const QSettings & /*unused*/) {}
   /// Add tab-specific items to the context menu
   /// Return true if at least 1 item was added or false otherwise.
-  virtual bool addToDisplayContextMenu(QMenu &) const { return false; }
+  virtual bool addToDisplayContextMenu(QMenu & /*unused*/) const { return false; }
   /// Get the projection surface
   boost::shared_ptr<ProjectionSurface> getSurface() const;
   /// Load state for the widget tab from a project file

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTab.h
@@ -40,7 +40,9 @@ public:
   virtual void loadSettings(const QSettings & /*unused*/) {}
   /// Add tab-specific items to the context menu
   /// Return true if at least 1 item was added or false otherwise.
-  virtual bool addToDisplayContextMenu(QMenu & /*unused*/) const { return false; }
+  virtual bool addToDisplayContextMenu(QMenu & /*unused*/) const {
+    return false;
+  }
   /// Get the projection surface
   boost::shared_ptr<ProjectionSurface> getSurface() const;
   /// Load state for the widget tab from a project file

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h
@@ -32,7 +32,7 @@ public slots:
   void selectComponentByName(const QString &name);
 
 private:
-  void showEvent(QShowEvent *) override;
+  void showEvent(QShowEvent * /*unused*/) override;
   /// Widget to display instrument tree
   InstrumentTreeWidget *m_instrumentTree;
   friend class InstrumentWidgetEncoder;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MantidGLWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MantidGLWidget.h
@@ -31,13 +31,13 @@ public:
   void setSurface(boost::shared_ptr<ProjectionSurface> surface);
   boost::shared_ptr<ProjectionSurface> getSurface() { return m_surface; }
 
-  void setBackgroundColor(QColor);
+  void setBackgroundColor(QColor /*input*/);
   QColor currentBackgroundColor() const;
   void saveToFile(const QString &filename);
   // int getLightingState() const {return m_lightingState;}
 
 public slots:
-  void enableLighting(bool);
+  void enableLighting(bool /*on*/);
   void updateView(bool picking = true);
   void updateDetectors();
   void componentSelected(size_t componentIndex);
@@ -47,16 +47,16 @@ protected:
   void resetWidget();
   void MakeObject();
   void paintEvent(QPaintEvent *event) override;
-  void resizeGL(int, int) override;
-  void contextMenuEvent(QContextMenuEvent *) override;
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void wheelEvent(QWheelEvent *) override;
-  void keyPressEvent(QKeyEvent *) override;
-  void keyReleaseEvent(QKeyEvent *) override;
-  void enterEvent(QEvent *) override;
-  void leaveEvent(QEvent *) override;
+  void resizeGL(int /*w*/, int /*h*/) override;
+  void contextMenuEvent(QContextMenuEvent * /*unused*/) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
+  void wheelEvent(QWheelEvent * /*unused*/) override;
+  void keyPressEvent(QKeyEvent * /*unused*/) override;
+  void keyReleaseEvent(QKeyEvent * /*unused*/) override;
+  void enterEvent(QEvent * /*unused*/) override;
+  void leaveEvent(QEvent * /*unused*/) override;
   void draw();
   void checkGLError(const QString &funName);
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotMpl.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotMpl.h
@@ -57,7 +57,7 @@ public slots:
 
 signals:
   void showContextMenu();
-  void clickedAt(double, double);
+  void clickedAt(double /*_t1*/, double /*_t2*/);
 
 protected:
   bool eventFilter(QObject *watched, QEvent *evt) override;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotQwt.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/MiniPlotQwt.h
@@ -35,7 +35,7 @@ public:
                QString curveLabel);
   QString label() const { return m_label; }
   void setYAxisLabelRotation(double degrees);
-  void addPeakLabel(const PeakMarker2D *);
+  void addPeakLabel(const PeakMarker2D * /*marker*/);
   void clearPeakLabels();
   bool hasCurve() const;
   void store();
@@ -57,13 +57,13 @@ public slots:
   void clearAll();
 signals:
   void showContextMenu();
-  void clickedAt(double, double);
+  void clickedAt(double /*_t1*/, double /*_t2*/);
 
 protected:
   void resizeEvent(QResizeEvent *e) override;
   void contextMenuEvent(QContextMenuEvent *e) override;
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
 
 private:
   QwtPlotCurve *m_curve;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -54,7 +54,8 @@ public:
                 const Mantid::Kernel::V3D &axis);
   ~PanelsSurface() override;
   void init() override;
-  void project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/, double & /*uscale*/,
+  void project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/,
+               double & /*v*/, double & /*uscale*/,
                double & /*vscale*/) const override;
 
 protected:

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -54,8 +54,8 @@ public:
                 const Mantid::Kernel::V3D &axis);
   ~PanelsSurface() override;
   void init() override;
-  void project(const Mantid::Kernel::V3D &, double &, double &, double &,
-               double &) const override;
+  void project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/, double & /*uscale*/,
+               double & /*vscale*/) const override;
 
 protected:
   boost::optional<std::pair<std::vector<size_t>, Mantid::Kernel::V3D>>

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PeakOverlay.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PeakOverlay.h
@@ -127,7 +127,7 @@ public:
   ~PeakOverlay() override {}
   /// Override the drawing method
   void draw(QPainter &painter) const override;
-  void removeShapes(const QList<Shape2D *> &) override;
+  void removeShapes(const QList<Shape2D *> & /*unused*/) override;
   void clear() override;
 
   /// Create the markers
@@ -135,7 +135,7 @@ public:
   void addMarker(PeakMarker2D *m);
   QList<PeakMarker2D *> getMarkersWithID(int detID) const;
   int getNumberPeaks() const;
-  Mantid::Geometry::IPeak &getPeak(int);
+  Mantid::Geometry::IPeak &getPeak(int /*i*/);
   QList<PeakMarker2D *> getSelectedPeakMarkers();
   /// Return PeaksWorkspace associated with this overlay.
   boost::shared_ptr<Mantid::API::IPeaksWorkspace> getPeaksWorkspace() {
@@ -150,7 +150,7 @@ public:
   void setPeakVisibility(double xmin, double xmax, QString units);
 
 signals:
-  void executeAlgorithm(Mantid::API::IAlgorithm_sptr);
+  void executeAlgorithm(Mantid::API::IAlgorithm_sptr /*_t1*/);
 
 private:
   /// A WorkspaceObserver handle implemented.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
@@ -47,7 +47,7 @@ public:
   void componentSelected(size_t componentIndex) override;
   void getSelectedDetectors(std::vector<size_t> &detIndices) override;
   void getMaskedDetectors(std::vector<size_t> &detIndices) const override;
-  void resize(int, int) override;
+  void resize(int /*unused*/, int /*unused*/) override;
   QString getInfoText() const override;
   /// Load settings for the 3D projection from a project file
   virtual void loadFromProject(const std::string &lines) override;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -286,8 +286,9 @@ signals:
   void peaksWorkspaceDeleted();
   void alignPeaks(const std::vector<Mantid::Kernel::V3D> & /*_t1*/,
                   const Mantid::Geometry::IPeak * /*_t2*/);
-  void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                    std::vector<Mantid::Geometry::IPeak *>> & /*_t1*/);
+  void comparePeaks(
+      const std::pair<std::vector<Mantid::Geometry::IPeak *>,
+                      std::vector<Mantid::Geometry::IPeak *>> & /*_t1*/);
 
   // other
   void redrawRequired(); ///< request redrawing of self

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -94,7 +94,7 @@ public:
   /// draw the surface onto a normal widget
   virtual void drawSimple(QWidget *widget) const;
   /// called when the gl widget gets resized
-  virtual void resize(int, int);
+  virtual void resize(int /*unused*/, int /*unused*/);
   /// redraw surface without recalulationg of colours, etc
   virtual void updateView(bool picking = true);
   /// full update and redraw of the surface
@@ -102,13 +102,13 @@ public:
   /// returns the bounding rectangle in the real coordinates
   virtual RectF getSurfaceBounds() const { return m_viewRect; }
 
-  virtual void mousePressEvent(QMouseEvent *);
-  virtual void mouseMoveEvent(QMouseEvent *);
-  virtual void mouseReleaseEvent(QMouseEvent *);
-  virtual void wheelEvent(QWheelEvent *);
-  virtual void keyPressEvent(QKeyEvent *);
-  virtual void enterEvent(QEvent *);
-  virtual void leaveEvent(QEvent *);
+  virtual void mousePressEvent(QMouseEvent * /*e*/);
+  virtual void mouseMoveEvent(QMouseEvent * /*e*/);
+  virtual void mouseReleaseEvent(QMouseEvent * /*e*/);
+  virtual void wheelEvent(QWheelEvent * /*e*/);
+  virtual void keyPressEvent(QKeyEvent * /*e*/);
+  virtual void enterEvent(QEvent * /*e*/);
+  virtual void leaveEvent(QEvent * /*e*/);
 
   /// return true if any of the detectors have been selected
   virtual bool hasSelection() const;
@@ -264,8 +264,8 @@ public:
 signals:
 
   // detector selection
-  void singleComponentTouched(size_t);
-  void singleComponentPicked(size_t);
+  void singleComponentTouched(size_t /*_t1*/);
+  void singleComponentPicked(size_t /*_t1*/);
 
   // shape manipulation
   void signalToStartCreatingShape2D(const QString &type,
@@ -284,16 +284,16 @@ signals:
   // peaks
   void peaksWorkspaceAdded();
   void peaksWorkspaceDeleted();
-  void alignPeaks(const std::vector<Mantid::Kernel::V3D> &,
-                  const Mantid::Geometry::IPeak *);
+  void alignPeaks(const std::vector<Mantid::Kernel::V3D> & /*_t1*/,
+                  const Mantid::Geometry::IPeak * /*_t2*/);
   void comparePeaks(const std::pair<std::vector<Mantid::Geometry::IPeak *>,
-                                    std::vector<Mantid::Geometry::IPeak *>> &);
+                                    std::vector<Mantid::Geometry::IPeak *>> & /*_t1*/);
 
   // other
   void redrawRequired(); ///< request redrawing of self
   void updateInfoText(); ///< request update of the info string at bottom of
   /// InstrumentWindow
-  void executeAlgorithm(Mantid::API::IAlgorithm_sptr);
+  void executeAlgorithm(Mantid::API::IAlgorithm_sptr /*_t1*/);
 
 protected slots:
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
@@ -90,12 +90,12 @@ public:
   /// Set new bounding rect.
   virtual void setBoundingRect(const RectF &rect);
   /// will the shape be selected if clicked at a point? By default return false.
-  virtual bool selectAt(const QPointF &) const { return false; }
+  virtual bool selectAt(const QPointF & /*unused*/) const { return false; }
   /// is a point inside the shape (closed line)? By default return false.
-  virtual bool contains(const QPointF &) const { return false; }
+  virtual bool contains(const QPointF & /*unused*/) const { return false; }
   /// is a point "masked" by the shape. Only filled regions of a shape mask a
   /// point
-  virtual bool isMasked(const QPointF &) const;
+  virtual bool isMasked(const QPointF & /*p*/) const;
   /// Set border color.
   virtual void setColor(const QColor &color) { m_color = color; }
   /// Get border color.
@@ -165,10 +165,10 @@ protected:
   virtual size_t getShapeNControlPoints() const { return 0; }
   // returns position of a shape specific control point, 0 < i <
   // getShapeNControlPoints()
-  virtual QPointF getShapeControlPoint(size_t) const { return QPointF(); }
+  virtual QPointF getShapeControlPoint(size_t /*unused*/) const { return QPointF(); }
   // sets position of a shape specific control point, 0 < i <
   // getShapeNControlPoints()
-  virtual void setShapeControlPoint(size_t, const QPointF &) {}
+  virtual void setShapeControlPoint(size_t /*unused*/, const QPointF & /*unused*/) {}
   // make sure the bounding box is correct
   virtual void resetBoundingRect() {}
 
@@ -287,7 +287,7 @@ public:
 
 protected:
   void drawShape(QPainter &painter) const override;
-  void addToPath(QPainterPath &) const override {}
+  void addToPath(QPainterPath & /*path*/) const override {}
   void refit() override;
   void resetBoundingRect() override;
   size_t getShapeNControlPoints() const override { return 4; }

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
@@ -165,10 +165,13 @@ protected:
   virtual size_t getShapeNControlPoints() const { return 0; }
   // returns position of a shape specific control point, 0 < i <
   // getShapeNControlPoints()
-  virtual QPointF getShapeControlPoint(size_t /*unused*/) const { return QPointF(); }
+  virtual QPointF getShapeControlPoint(size_t /*unused*/) const {
+    return QPointF();
+  }
   // sets position of a shape specific control point, 0 < i <
   // getShapeNControlPoints()
-  virtual void setShapeControlPoint(size_t /*unused*/, const QPointF & /*unused*/) {}
+  virtual void setShapeControlPoint(size_t /*unused*/,
+                                    const QPointF & /*unused*/) {}
   // make sure the bounding box is correct
   virtual void resetBoundingRect() {}
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -52,12 +52,12 @@ public:
   Shape2D *clone() const override { return nullptr; }
   void setWindow(const RectF &surface, const QRect &viewport) const;
   void draw(QPainter &painter) const override;
-  virtual void addShape(Shape2D *, bool slct = false);
-  virtual void removeShape(Shape2D *, bool sendSignal = true);
-  virtual void removeShapes(const QList<Shape2D *> &);
+  virtual void addShape(Shape2D * /*shape*/, bool slct = false);
+  virtual void removeShape(Shape2D * /*shape*/, bool sendSignal = true);
+  virtual void removeShapes(const QList<Shape2D *> & /*shapeList*/);
   virtual void clear();
 
-  void keyPressEvent(QKeyEvent *);
+  void keyPressEvent(QKeyEvent * /*e*/);
 
   bool selectAtXY(int x, int y, bool edit = true);
   bool selectAtXY(const QPointF &point, bool edit = true);
@@ -116,10 +116,10 @@ signals:
 public slots:
   void addShape(const QString &type, int x, int y, const QColor &borderColor,
                 const QColor &fillColor);
-  void addFreeShape(const QPolygonF &, const QColor &borderColor,
+  void addFreeShape(const QPolygonF & /*poly*/, const QColor &borderColor,
                     const QColor &fillColor);
   void deselectAll();
-  void moveRightBottomTo(int, int);
+  void moveRightBottomTo(int /*x*/, int /*y*/);
   void selectShapeOrControlPointAt(int x, int y);
   void addToSelectionShapeAt(int x, int y);
   void moveShapeOrControlPointBy(int dx, int dy);
@@ -130,8 +130,8 @@ public slots:
   void eraseFree(const QPolygonF &polygon);
 
 protected:
-  void drawShape(QPainter &) const override {} // never called
-  void addToPath(QPainterPath &) const override {}
+  void drawShape(QPainter & /*painter*/) const override {} // never called
+  void addToPath(QPainterPath & /*path*/) const override {}
   void refit() override;
   void resetBoundingRect() override;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/SimpleWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/SimpleWidget.h
@@ -36,15 +36,15 @@ public:
   void saveToFile(const QString &filename);
 
 protected:
-  void paintEvent(QPaintEvent *) override;
-  void resizeEvent(QResizeEvent *) override;
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
-  void wheelEvent(QWheelEvent *) override;
-  void keyPressEvent(QKeyEvent *) override;
-  void enterEvent(QEvent *) override;
-  void leaveEvent(QEvent *) override;
+  void paintEvent(QPaintEvent * /*unused*/) override;
+  void resizeEvent(QResizeEvent * /*unused*/) override;
+  void mousePressEvent(QMouseEvent * /*event*/) override;
+  void mouseMoveEvent(QMouseEvent * /*event*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*event*/) override;
+  void wheelEvent(QWheelEvent * /*event*/) override;
+  void keyPressEvent(QKeyEvent * /*event*/) override;
+  void enterEvent(QEvent * /*event*/) override;
+  void leaveEvent(QEvent * /*event*/) override;
   ///< The projection surface
   boost::shared_ptr<ProjectionSurface> m_surface;
 };

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
@@ -147,7 +147,7 @@ protected:
   /// Called in non-picking drawSimpleToImage to draw something other than
   /// detectors
   /// Useful for debuging
-  virtual void drawCustom(QPainter *) const {}
+  virtual void drawCustom(QPainter * /*unused*/) const {}
   //@}
 
   /** @name Protected methods */

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -56,7 +56,8 @@ public:
   /// Return the projection type.
   ProjectionType getProjectionType() const;
   /// Set a projection.
-  void setProjection(double /*l*/, double /*r*/, double /*b*/, double /*t*/, double /*nearz*/, double /*farz*/,
+  void setProjection(double /*l*/, double /*r*/, double /*b*/, double /*t*/,
+                     double /*nearz*/, double /*farz*/,
                      ProjectionType type = Viewport::ORTHO);
   /// Set a projection.
   void setProjection(const Mantid::Kernel::V3D &minBounds,
@@ -114,8 +115,9 @@ public:
   void setTranslation(double /*xval*/, double /*yval*/);
 
   // void getProjection(double&,double&,double&,double&,double&,double&);
-  void getInstantProjection(double & /*xmin*/, double & /*xmax*/, double & /*ymin*/, double & /*ymax*/, double & /*zmin*/,
-                            double & /*zmax*/) const;
+  void getInstantProjection(double & /*xmin*/, double & /*xmax*/,
+                            double & /*ymin*/, double & /*ymax*/,
+                            double & /*zmin*/, double & /*zmax*/) const;
 
   /// Apply the transformation to a vector
   void transform(Mantid::Kernel::V3D &pos) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -50,13 +50,13 @@ public:
   Viewport(int w,
            int h); ///< Constructor with Width (w) and Height(h) as inputs
                    /// Called by the display device when viewport is resized
-  void resize(int, int);
+  void resize(int /*w*/, int /*h*/);
   /// Get the viewport width and height.
   void getViewport(int &w, int &h) const;
   /// Return the projection type.
   ProjectionType getProjectionType() const;
   /// Set a projection.
-  void setProjection(double, double, double, double, double, double,
+  void setProjection(double /*l*/, double /*r*/, double /*b*/, double /*t*/, double /*nearz*/, double /*farz*/,
                      ProjectionType type = Viewport::ORTHO);
   /// Set a projection.
   void setProjection(const Mantid::Kernel::V3D &minBounds,
@@ -107,15 +107,15 @@ public:
   /* Translation */
 
   /// Call when the mouse button is pressed to start translation
-  void initTranslateFrom(int, int);
+  void initTranslateFrom(int /*a*/, int /*b*/);
   /// Call when the mouse is moving during a translation
-  void generateTranslationTo(int, int);
+  void generateTranslationTo(int /*a*/, int /*b*/);
   /// Set translation programmatically
-  void setTranslation(double, double);
+  void setTranslation(double /*xval*/, double /*yval*/);
 
   // void getProjection(double&,double&,double&,double&,double&,double&);
-  void getInstantProjection(double &, double &, double &, double &, double &,
-                            double &) const;
+  void getInstantProjection(double & /*xmin*/, double & /*xmax*/, double & /*ymin*/, double & /*ymax*/, double & /*zmin*/,
+                            double & /*zmax*/) const;
 
   /// Apply the transformation to a vector
   void transform(Mantid::Kernel::V3D &pos) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/XIntegrationControl.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/XIntegrationControl.h
@@ -31,8 +31,8 @@ public:
   double getWidth() const;
   void set(double minimum, double maximum);
 signals:
-  void changed(double, double);
-  void running(double, double);
+  void changed(double /*_t1*/, double /*_t2*/);
+  void running(double /*_t1*/, double /*_t2*/);
 
 protected:
   void mouseMoveEvent(QMouseEvent *e) override;
@@ -68,12 +68,12 @@ public:
   double getMaximum() const;
   double getWidth() const;
 signals:
-  void changed(double, double);
+  void changed(double /*_t1*/, double /*_t2*/);
 public slots:
   void setWholeRange();
 private slots:
-  void sliderChanged(double, double);
-  void sliderRunning(double, double);
+  void sliderChanged(double /*minimum*/, double /*maximum*/);
+  void sliderRunning(double /*minimum*/, double /*maximum*/);
   void setMinimum();
   void setMaximum();
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -537,7 +537,7 @@ void InstrumentWidget::setupColorMap() { emit colorMapChanged(); }
 /**
  * Connected to QTabWidget::currentChanged signal
  */
-void InstrumentWidget::tabChanged(int) { updateInfoText(); }
+void InstrumentWidget::tabChanged(int /*unused*/) { updateInfoText(); }
 
 /**
  * Change color map button slot. This provides the file dialog box to select
@@ -865,7 +865,7 @@ void InstrumentWidget::componentSelected(size_t componentIndex) {
   }
 }
 
-void InstrumentWidget::executeAlgorithm(const QString &, const QString &) {
+void InstrumentWidget::executeAlgorithm(const QString & /*unused*/, const QString & /*unused*/) {
   // emit execMantidAlgorithm(alg_name, param_list, this);
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -865,7 +865,8 @@ void InstrumentWidget::componentSelected(size_t componentIndex) {
   }
 }
 
-void InstrumentWidget::executeAlgorithm(const QString & /*unused*/, const QString & /*unused*/) {
+void InstrumentWidget::executeAlgorithm(const QString & /*unused*/,
+                                        const QString & /*unused*/) {
   // emit execMantidAlgorithm(alg_name, param_list, this);
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -1193,7 +1193,8 @@ void InstrumentWidgetMaskTab::storeMask() {
   }
 }
 
-void InstrumentWidgetMaskTab::changedIntegrationRange(double /*unused*/, double /*unused*/) {
+void InstrumentWidgetMaskTab::changedIntegrationRange(double /*unused*/,
+                                                      double /*unused*/) {
   enableApplyButtons();
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -535,7 +535,7 @@ void InstrumentWidgetMaskTab::clearShapes() {
   setSelectActivity();
 }
 
-void InstrumentWidgetMaskTab::showEvent(QShowEvent *) {
+void InstrumentWidgetMaskTab::showEvent(QShowEvent * /*unused*/) {
   setActivity();
   m_instrWidget->setMouseTracking(true);
   enableApplyButtons();
@@ -1193,7 +1193,7 @@ void InstrumentWidgetMaskTab::storeMask() {
   }
 }
 
-void InstrumentWidgetMaskTab::changedIntegrationRange(double, double) {
+void InstrumentWidgetMaskTab::changedIntegrationRange(double /*unused*/, double /*unused*/) {
   enableApplyButtons();
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -496,7 +496,7 @@ void InstrumentWidgetPickTab::setSelectionType() {
 /**
  * Respond to the show event.
  */
-void InstrumentWidgetPickTab::showEvent(QShowEvent *) {
+void InstrumentWidgetPickTab::showEvent(QShowEvent * /*unused*/) {
   // Make the state of the display view consistent with the current selection
   // type
   setSelectionType();
@@ -542,7 +542,7 @@ QColor InstrumentWidgetPickTab::getShapeBorderColor() const {
 /**
  * Do something when the time bin integraion range has changed.
  */
-void InstrumentWidgetPickTab::changedIntegrationRange(double, double) {
+void InstrumentWidgetPickTab::changedIntegrationRange(double /*unused*/, double /*unused*/) {
   m_plotController->updatePlot();
   auto surface = m_instrWidget->getSurface();
   if (surface) {

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -542,7 +542,8 @@ QColor InstrumentWidgetPickTab::getShapeBorderColor() const {
 /**
  * Do something when the time bin integraion range has changed.
  */
-void InstrumentWidgetPickTab::changedIntegrationRange(double /*unused*/, double /*unused*/) {
+void InstrumentWidgetPickTab::changedIntegrationRange(double /*unused*/,
+                                                      double /*unused*/) {
   m_plotController->updatePlot();
   auto surface = m_instrWidget->getSurface();
   if (surface) {

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -580,7 +580,7 @@ void InstrumentWidgetRenderTab::enableGL(bool on) {
   enable3DSurface(on);
 }
 
-void InstrumentWidgetRenderTab::showEvent(QShowEvent *) {
+void InstrumentWidgetRenderTab::showEvent(QShowEvent * /*unused*/) {
   auto surface = getSurface();
   if (surface) {
     surface->setInteractionMode(ProjectionSurface::MoveMode);

--- a/qt/widgets/instrumentview/src/InstrumentWidgetTreeTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetTreeTab.cpp
@@ -62,7 +62,7 @@ void InstrumentWidgetTreeTab::selectComponentByName(const QString &name) {
 /**
  * Update surface when tab becomes visible.
  */
-void InstrumentWidgetTreeTab::showEvent(QShowEvent *) {
+void InstrumentWidgetTreeTab::showEvent(QShowEvent * /*unused*/) {
   getSurface()->setInteractionMode(ProjectionSurface::MoveMode);
 }
 

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -264,8 +264,8 @@ void PanelsSurface::init() {
   m_v_max = m_viewRect.y1();
 }
 
-void PanelsSurface::project(const Mantid::Kernel::V3D &, double &, double &,
-                            double &, double &) const {
+void PanelsSurface::project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/,
+                            double & /*uscale*/, double & /*vscale*/) const {
   throw std::runtime_error(
       "Cannot project an arbitrary point to this surface.");
 }

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -264,8 +264,9 @@ void PanelsSurface::init() {
   m_v_max = m_viewRect.y1();
 }
 
-void PanelsSurface::project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/,
-                            double & /*uscale*/, double & /*vscale*/) const {
+void PanelsSurface::project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/,
+                            double & /*v*/, double & /*uscale*/,
+                            double & /*vscale*/) const {
   throw std::runtime_error(
       "Cannot project an arbitrary point to this surface.");
 }

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -91,7 +91,7 @@ void Projection3D::resize(int w, int h) {
 /**
  * Draw the instrument on MantidGLWidget.
  */
-void Projection3D::drawSurface(MantidGLWidget *, bool picking) const {
+void Projection3D::drawSurface(MantidGLWidget * /*widget*/, bool picking) const {
   OpenGLError::check("GL3DWidget::draw3D()[begin]");
 
   glEnable(GL_DEPTH_TEST);

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -91,7 +91,8 @@ void Projection3D::resize(int w, int h) {
 /**
  * Draw the instrument on MantidGLWidget.
  */
-void Projection3D::drawSurface(MantidGLWidget * /*widget*/, bool picking) const {
+void Projection3D::drawSurface(MantidGLWidget * /*widget*/,
+                               bool picking) const {
   OpenGLError::check("GL3DWidget::draw3D()[begin]");
 
   glEnable(GL_DEPTH_TEST);

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -285,14 +285,14 @@ void ProjectionSurface::drawSimple(QWidget *widget) const {
   painter.end();
 }
 
-void ProjectionSurface::resize(int, int) { updateView(); }
+void ProjectionSurface::resize(int /*unused*/, int /*unused*/) { updateView(); }
 
 /**
  * Draw the surface onto an image without OpenGL
  * @param image :: Image to draw on.
  * @param picking :: If true draw a picking image.
  */
-void ProjectionSurface::drawSimpleToImage(QImage *, bool) const {}
+void ProjectionSurface::drawSimpleToImage(QImage * /*unused*/, bool /*unused*/) const {}
 
 void ProjectionSurface::mousePressEvent(QMouseEvent *e) {
   getController()->mousePressEvent(e);

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -292,7 +292,8 @@ void ProjectionSurface::resize(int /*unused*/, int /*unused*/) { updateView(); }
  * @param image :: Image to draw on.
  * @param picking :: If true draw a picking image.
  */
-void ProjectionSurface::drawSimpleToImage(QImage * /*unused*/, bool /*unused*/) const {}
+void ProjectionSurface::drawSimpleToImage(QImage * /*unused*/,
+                                          bool /*unused*/) const {}
 
 void ProjectionSurface::mousePressEvent(QMouseEvent *e) {
   getController()->mousePressEvent(e);

--- a/qt/widgets/instrumentview/src/SimpleWidget.cpp
+++ b/qt/widgets/instrumentview/src/SimpleWidget.cpp
@@ -59,13 +59,13 @@ void SimpleWidget::saveToFile(const QString &filename) {
   image.save(filename);
 }
 
-void SimpleWidget::paintEvent(QPaintEvent *) {
+void SimpleWidget::paintEvent(QPaintEvent * /*unused*/) {
   if (m_surface) {
     m_surface->drawSimple(this);
   }
 }
 
-void SimpleWidget::resizeEvent(QResizeEvent *) {
+void SimpleWidget::resizeEvent(QResizeEvent * /*unused*/) {
   if (m_surface) {
     m_surface->updateView();
   }

--- a/qt/widgets/instrumentview/src/XIntegrationControl.cpp
+++ b/qt/widgets/instrumentview/src/XIntegrationControl.cpp
@@ -38,7 +38,7 @@ XIntegrationScrollBar::XIntegrationScrollBar(QWidget *parent)
   m_slider->setToolTip("Resize to change integration range");
 }
 
-void XIntegrationScrollBar::resizeEvent(QResizeEvent *) {
+void XIntegrationScrollBar::resizeEvent(QResizeEvent * /*unused*/) {
   if (!m_init) {
     m_slider->resize(width(), height());
     m_init = true;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ColorBarWidget.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ColorBarWidget.h
@@ -33,7 +33,7 @@ public:
   }
 
 signals:
-  void mouseMoved(QPoint, double);
+  void mouseMoved(QPoint /*_t1*/, double /*_t2*/);
 };
 
 //=============================================================================
@@ -79,9 +79,9 @@ public:
   bool getLog();
 
   int getScale() const;
-  void setScale(int);
+  void setScale(int /*type*/);
 
-  void setExponent(double);
+  void setExponent(double /*nth_power*/);
   double getExponent() const;
 
   /// Set the label text for Auto Scale on Load checkbox label
@@ -114,9 +114,9 @@ public:
 public slots:
   void changedMinimum();
   void changedMaximum();
-  void colorBarMouseMoved(QPoint, double);
-  void changedScaleType(int);
-  void changedExponent(double);
+  void colorBarMouseMoved(QPoint /*globalPos*/, double /*fraction*/);
+  void changedScaleType(int /*type*/);
+  void changedExponent(double /*nth_power*/);
 
 signals:
   /// Signal sent when the range or log mode of the color scale changes.

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/DraggableColorBarWidget.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/DraggableColorBarWidget.h
@@ -30,42 +30,42 @@ class EXPORT_OPT_MANTIDQT_LEGACYQWT DraggableColorBarWidget : public QFrame {
 public:
   DraggableColorBarWidget(QWidget *parent,
                           const double &minPositiveValue = 0.0001);
-  void setupColorBarScaling(const MantidColorMap &);
+  void setupColorBarScaling(const MantidColorMap & /*colorMap*/);
   void setClim(double vmin, double vmax);
-  void setMinValue(double);
-  void setMaxValue(double);
+  void setMinValue(double /*value*/);
+  void setMaxValue(double /*value*/);
   QString getMinValue() const;
   QString getMaxValue() const;
   QString getNthPower() const;
-  void setMinPositiveValue(double);
+  void setMinPositiveValue(double /*value*/);
   int getScaleType() const;
-  void setScaleType(int);
-  void setNthPower(double);
+  void setScaleType(int /*type*/);
+  void setNthPower(double /*nth_power*/);
   /// Load the state of the actor from a Mantid project file.
   void loadFromProject(const std::string &lines);
   /// Save the state of the actor to a Mantid project file.
   std::string saveToProject() const;
 signals:
-  void scaleTypeChanged(int);
-  void minValueChanged(double);
-  void maxValueChanged(double);
-  void nthPowerChanged(double);
+  void scaleTypeChanged(int /*_t1*/);
+  void minValueChanged(double /*_t1*/);
+  void maxValueChanged(double /*_t1*/);
+  void nthPowerChanged(double /*_t1*/);
 
   // Edited signals only emitted when manual editing of that field
   // occurs
-  void minValueEdited(double);
-  void maxValueEdited(double);
+  void minValueEdited(double /*_t1*/);
+  void maxValueEdited(double /*_t1*/);
 
 protected:
-  void mousePressEvent(QMouseEvent *) override;
-  void mouseMoveEvent(QMouseEvent *) override;
-  void mouseReleaseEvent(QMouseEvent *) override;
+  void mousePressEvent(QMouseEvent * /*unused*/) override;
+  void mouseMoveEvent(QMouseEvent * /*unused*/) override;
+  void mouseReleaseEvent(QMouseEvent * /*unused*/) override;
   void updateScale();
-  void setMinValueText(double);
-  void setMaxValueText(double);
+  void setMinValueText(double /*value*/);
+  void setMaxValueText(double /*value*/);
 private slots:
-  void scaleOptionsChanged(int);
-  void nPowerChanged(double);
+  void scaleOptionsChanged(int /*i*/);
+  void nPowerChanged(double /*nth_power*/);
   void minValueChanged();
   void maxValueChanged();
 

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h
@@ -35,7 +35,7 @@ public:
       bool isDistribution = false);
 
   MantidQwtIMDWorkspaceData(const MantidQwtIMDWorkspaceData &data);
-  MantidQwtIMDWorkspaceData &operator=(const MantidQwtIMDWorkspaceData &);
+  MantidQwtIMDWorkspaceData &operator=(const MantidQwtIMDWorkspaceData & /*data*/);
   ~MantidQwtIMDWorkspaceData() override;
 
   QwtData *copy() const override;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtIMDWorkspaceData.h
@@ -35,7 +35,8 @@ public:
       bool isDistribution = false);
 
   MantidQwtIMDWorkspaceData(const MantidQwtIMDWorkspaceData &data);
-  MantidQwtIMDWorkspaceData &operator=(const MantidQwtIMDWorkspaceData & /*data*/);
+  MantidQwtIMDWorkspaceData &
+  operator=(const MantidQwtIMDWorkspaceData & /*data*/);
   ~MantidQwtIMDWorkspaceData() override;
 
   QwtData *copy() const override;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtWorkspaceData.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/MantidQwtWorkspaceData.h
@@ -26,7 +26,7 @@ class EXPORT_OPT_MANTIDQT_LEGACYQWT MantidQwtWorkspaceData : public QwtData {
 public:
   MantidQwtWorkspaceData(bool logScaleY);
   MantidQwtWorkspaceData(const MantidQwtWorkspaceData &data);
-  MantidQwtWorkspaceData &operator=(const MantidQwtWorkspaceData &);
+  MantidQwtWorkspaceData &operator=(const MantidQwtWorkspaceData & /*data*/);
 
   virtual QString getXAxisLabel() const = 0;
   virtual QString getYAxisLabel() const = 0;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PowerScaleEngine.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PowerScaleEngine.h
@@ -40,7 +40,7 @@ class EXPORT_OPT_MANTIDQT_LEGACYQWT PowerScaleTransformation
 public:
   PowerScaleTransformation(const ScaleEngine *engine)
       : ScaleTransformation(engine), nth_power(engine->nthPower()){};
-  double xForm(double x, double, double, double p1, double p2) const override;
+  double xForm(double x, double /*unused*/, double /*unused*/, double p1, double p2) const override;
   double invXForm(double x, double s1, double s2, double p1,
                   double p2) const override;
   QwtScaleTransformation *copy() const override;
@@ -68,14 +68,14 @@ public:
   ~PowerScaleEngine() override;
 
 protected:
-  QwtDoubleInterval align(const QwtDoubleInterval &, double stepSize) const;
+  QwtDoubleInterval align(const QwtDoubleInterval & /*interval*/, double stepSize) const;
 
 private:
-  void buildTicks(const QwtDoubleInterval &, double stepSize, int maxMinSteps,
+  void buildTicks(const QwtDoubleInterval & /*interval*/, double stepSize, int maxMinSteps,
                   QwtValueList ticks[QwtScaleDiv::NTickTypes]) const;
 
   void buildMinorTicks(const QwtValueList &majorTicks, int maxMinMark,
-                       double step, QwtValueList &, QwtValueList &) const;
+                       double step, QwtValueList & /*minorTicks*/, QwtValueList & /*mediumTicks*/) const;
 
   QwtValueList buildMajorTicks(const QwtDoubleInterval &interval,
                                double stepSize) const;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PowerScaleEngine.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PowerScaleEngine.h
@@ -40,7 +40,8 @@ class EXPORT_OPT_MANTIDQT_LEGACYQWT PowerScaleTransformation
 public:
   PowerScaleTransformation(const ScaleEngine *engine)
       : ScaleTransformation(engine), nth_power(engine->nthPower()){};
-  double xForm(double x, double /*unused*/, double /*unused*/, double p1, double p2) const override;
+  double xForm(double x, double /*unused*/, double /*unused*/, double p1,
+               double p2) const override;
   double invXForm(double x, double s1, double s2, double p1,
                   double p2) const override;
   QwtScaleTransformation *copy() const override;
@@ -68,14 +69,17 @@ public:
   ~PowerScaleEngine() override;
 
 protected:
-  QwtDoubleInterval align(const QwtDoubleInterval & /*interval*/, double stepSize) const;
+  QwtDoubleInterval align(const QwtDoubleInterval & /*interval*/,
+                          double stepSize) const;
 
 private:
-  void buildTicks(const QwtDoubleInterval & /*interval*/, double stepSize, int maxMinSteps,
+  void buildTicks(const QwtDoubleInterval & /*interval*/, double stepSize,
+                  int maxMinSteps,
                   QwtValueList ticks[QwtScaleDiv::NTickTypes]) const;
 
   void buildMinorTicks(const QwtValueList &majorTicks, int maxMinMark,
-                       double step, QwtValueList & /*minorTicks*/, QwtValueList & /*mediumTicks*/) const;
+                       double step, QwtValueList & /*minorTicks*/,
+                       QwtValueList & /*mediumTicks*/) const;
 
   QwtValueList buildMajorTicks(const QwtDoubleInterval &interval,
                                double stepSize) const;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PreviewPlot.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/PreviewPlot.h
@@ -98,7 +98,7 @@ signals:
   /// Signals that the axis scale has been changed
   void axisScaleChanged();
   /// Signals that workspace has been removed
-  void workspaceRemoved(Mantid::API::MatrixWorkspace_sptr);
+  void workspaceRemoved(Mantid::API::MatrixWorkspace_sptr /*_t1*/);
 
 public slots:
   void showLegend(bool show);

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtRasterDataMD.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtRasterDataMD.h
@@ -54,7 +54,7 @@ public:
 
   double value(double x, double y) const override;
 
-  QSize rasterHint(const QwtDoubleRect &) const override;
+  QSize rasterHint(const QwtDoubleRect & /*unused*/) const override;
 
   void setFastMode(bool fast);
 

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtWorkspaceBinData.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtWorkspaceBinData.h
@@ -43,7 +43,7 @@ public:
 
 protected:
   // Assignment operator.
-  QwtWorkspaceBinData &operator=(const QwtWorkspaceBinData &);
+  QwtWorkspaceBinData &operator=(const QwtWorkspaceBinData & /*rhs*/);
   /**
   Return the x value of data point i
   @param i :: Index

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtWorkspaceSpectrumData.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/QwtWorkspaceSpectrumData.h
@@ -70,7 +70,7 @@ public:
 protected:
   // Assignment operator (virtualized). MSVC not happy with compiler generated
   // one
-  QwtWorkspaceSpectrumData &operator=(const QwtWorkspaceSpectrumData &);
+  QwtWorkspaceSpectrumData &operator=(const QwtWorkspaceSpectrumData & /*rhs*/);
 
 private:
   friend class MantidMatrixCurve;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/RangeSelector.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/RangeSelector.h
@@ -56,8 +56,8 @@ public slots:
   void setRange(double /*min*/, double /*max*/);
   void setMinimum(double /*val*/); ///< outside setting of value
   void setMaximum(double /*val*/); ///< outside setting of value
-  void reapply();          ///< re-apply the range selector lines
-  void detach();           ///< Detach range selector lines from the plot
+  void reapply();                  ///< re-apply the range selector lines
+  void detach(); ///< Detach range selector lines from the plot
   void setColour(QColor colour);
   void setInfoOnly(bool state);
   void setVisible(bool state);

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/RangeSelector.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/RangeSelector.h
@@ -46,16 +46,16 @@ public:
   bool isVisible() { return m_visible; }
 
 signals:
-  void minValueChanged(double);
-  void maxValueChanged(double);
-  void rangeChanged(double, double);
-  void selectionChanged(double, double);
-  void selectionChangedLazy(double, double);
+  void minValueChanged(double /*_t1*/);
+  void maxValueChanged(double /*_t1*/);
+  void rangeChanged(double /*_t1*/, double /*_t2*/);
+  void selectionChanged(double /*_t1*/, double /*_t2*/);
+  void selectionChangedLazy(double /*_t1*/, double /*_t2*/);
 
 public slots:
-  void setRange(double, double);
-  void setMinimum(double); ///< outside setting of value
-  void setMaximum(double); ///< outside setting of value
+  void setRange(double /*min*/, double /*max*/);
+  void setMinimum(double /*val*/); ///< outside setting of value
+  void setMaximum(double /*val*/); ///< outside setting of value
   void reapply();          ///< re-apply the range selector lines
   void detach();           ///< Detach range selector lines from the plot
   void setColour(QColor colour);
@@ -67,13 +67,13 @@ private:
   void setMin(double val);
   void setMax(double val);
   void setMaxMin(const double min, const double max);
-  void setMinLinePos(double);
-  void setMaxLinePos(double);
+  void setMinLinePos(double /*val*/);
+  void setMaxLinePos(double /*val*/);
   void verify();
-  bool inRange(double);
-  bool changingMin(double, double);
-  bool changingMax(double, double);
-  bool eventFilter(QObject *, QEvent *) override;
+  bool inRange(double /*x*/);
+  bool changingMin(double /*x*/, double /*xPlusdx*/);
+  bool changingMax(double /*x*/, double /*xPlusdx*/);
+  bool eventFilter(QObject * /*unused*/, QEvent * /*unused*/) override;
 
   // MEMBER ATTRIBUTES
   SelectType m_type; ///< type of selection widget is for

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ScaleEngine.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ScaleEngine.h
@@ -44,7 +44,7 @@ public:
 
   ScaleTransformation(const ScaleEngine *engine)
       : QwtScaleTransformation(Other), d_engine(engine){};
-  double xForm(double x, double, double, double p1, double p2) const override;
+  double xForm(double x, double /*s1*/, double /*s2*/, double p1, double p2) const override;
   double invXForm(double x, double s1, double s2, double p1,
                   double p2) const override;
   QwtScaleTransformation *copy() const override;

--- a/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ScaleEngine.h
+++ b/qt/widgets/legacyqwt/inc/MantidQtWidgets/LegacyQwt/ScaleEngine.h
@@ -44,7 +44,8 @@ public:
 
   ScaleTransformation(const ScaleEngine *engine)
       : QwtScaleTransformation(Other), d_engine(engine){};
-  double xForm(double x, double /*s1*/, double /*s2*/, double p1, double p2) const override;
+  double xForm(double x, double /*s1*/, double /*s2*/, double p1,
+               double p2) const override;
   double invXForm(double x, double s1, double s2, double p1,
                   double p2) const override;
   QwtScaleTransformation *copy() const override;

--- a/qt/widgets/legacyqwt/src/ErrorCurve.cpp
+++ b/qt/widgets/legacyqwt/src/ErrorCurve.cpp
@@ -49,7 +49,7 @@ void ErrorCurve::setErrorBars(const std::vector<double> &errors) {
 
 /// Draw this curve
 void ErrorCurve::draw(QPainter *painter, const QwtScaleMap &xMap,
-                      const QwtScaleMap &yMap, const QRect &) const {
+                      const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
   if (m_e.empty())
     return;
   painter->save();

--- a/qt/widgets/legacyqwt/src/ErrorCurve.cpp
+++ b/qt/widgets/legacyqwt/src/ErrorCurve.cpp
@@ -49,7 +49,8 @@ void ErrorCurve::setErrorBars(const std::vector<double> &errors) {
 
 /// Draw this curve
 void ErrorCurve::draw(QPainter *painter, const QwtScaleMap &xMap,
-                      const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
+                      const QwtScaleMap &yMap,
+                      const QRect & /*canvasRect*/) const {
   if (m_e.empty())
     return;
   painter->save();

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
@@ -45,24 +45,24 @@ public:
   QString getMinValue() const;
   QString getMaxValue() const;
   QString getNthPower() const;
-  void setMinPositiveValue(double) { /*Unused in this implementation*/
+  void setMinPositiveValue(double /*unused*/) { /*Unused in this implementation*/
   }
   int getScaleType() const;
-  void setScaleType(int);
-  void setNthPower(double);
-  void loadFromProject(const std::string &) {}
+  void setScaleType(int /*index*/);
+  void setNthPower(double /*gamma*/);
+  void loadFromProject(const std::string & /*unused*/) {}
   std::string saveToProject() const { return ""; }
 signals:
   // Changed signals emitted for any change
-  void scaleTypeChanged(int);
-  void minValueChanged(double);
-  void maxValueChanged(double);
-  void nthPowerChanged(double);
+  void scaleTypeChanged(int /*_t1*/);
+  void minValueChanged(double /*_t1*/);
+  void maxValueChanged(double /*_t1*/);
+  void nthPowerChanged(double /*_t1*/);
 
   // Edited signals only emitted when manual editing of that field
   // occurs
-  void minValueEdited(double);
-  void maxValueEdited(double);
+  void minValueEdited(double /*_t1*/);
+  void maxValueEdited(double /*_t1*/);
   ///@}
 
 private slots:

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/ColorbarWidget.h
@@ -45,7 +45,8 @@ public:
   QString getMinValue() const;
   QString getMaxValue() const;
   QString getNthPower() const;
-  void setMinPositiveValue(double /*unused*/) { /*Unused in this implementation*/
+  void
+  setMinPositiveValue(double /*unused*/) { /*Unused in this implementation*/
   }
   int getScaleType() const;
   void setScaleType(int /*index*/);

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/ConvertTableToMatrixWorkspaceDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/ConvertTableToMatrixWorkspaceDialog.h
@@ -44,7 +44,7 @@ public:
 
 private slots:
   /// Update the column name widgets
-  void fillColumnNames(const QString &);
+  void fillColumnNames(const QString & /*qWSName*/);
 
 private:
   /// Initialize the layout

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h
@@ -61,7 +61,7 @@ public:
 private slots:
   /// Override the help button clicked method
   // void helpClicked();
-  void workspaceChanged(const QString &);
+  void workspaceChanged(const QString & /*unused*/);
   void functionChanged();
   /// Create InputWorkspaceWidgets and populate the tabs of the tab widget
   void createInputWorkspaceWidgets();

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/PlotAsymmetryByLogValueDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/PlotAsymmetryByLogValueDialog.h
@@ -55,7 +55,7 @@ private slots:
   /// Opens a file dialog. Updates the QLineEdit provided when the dialog is
   /// closed.
   void openFileDialog(const QString &filePropName);
-  void fillLogBox(const QString &);
+  void fillLogBox(const QString & /*unused*/);
 
   /// Show or hide Dead Time file widget depending on which Dead Time type is
   /// selected.

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SortTableWorkspaceDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SortTableWorkspaceDialog.h
@@ -44,7 +44,7 @@ private slots:
   /// Add GUI elements to set a new column as a sorting key
   void addColumn();
   /// Sync the GUI after a sorting column name changes
-  void changedColumnName(int);
+  void changedColumnName(int /*unused*/);
   /// Remove a column to sort by.
   void removeColumn();
   /// Clear the GUI form the workspace specific data/elements

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
@@ -36,10 +36,10 @@ public slots:
   void chkPreserveEventsToggled();
 
 private slots:
-  void setDefaultAccumulationMethod(const QString &);
-  void updateUiElements(const QString &);
+  void setDefaultAccumulationMethod(const QString & /*listener*/);
+  void updateUiElements(const QString & /*inst*/);
   void accept() override;
-  void initListenerPropLayout(const QString &);
+  void initListenerPropLayout(const QString & /*listener*/);
   void updateConnectionChoices(const QString &inst_name);
   void updateConnectionDetails(const QString &connection);
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
@@ -631,7 +631,8 @@ void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
                                    const QModelIndex & /*bottomRight*/) {
 #else
 void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
-                                   const QModelIndex & /*bottomRight*/, const QVector<int> & /*roles*/) {
+                                   const QModelIndex & /*bottomRight*/,
+                                   const QVector<int> & /*roles*/) {
 #endif
   emit treeDataChange(
       dynamic_cast<BinaryTreeWidgetItem *>(itemFromIndex(topLeft)),
@@ -698,8 +699,8 @@ void ComboBoxDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
  * @param option :: The style option
  * @param index :: The index for the model given
  */
-void ComboBoxDelegate::updateEditorGeometry(QWidget *editor,
-                                            const QStyleOptionViewItem &option,
-                                            const QModelIndex & /*index*/) const {
+void ComboBoxDelegate::updateEditorGeometry(
+    QWidget *editor, const QStyleOptionViewItem &option,
+    const QModelIndex & /*index*/) const {
   editor->setGeometry(option.rect);
 }

--- a/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
@@ -631,7 +631,7 @@ void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
                                    const QModelIndex & /*bottomRight*/) {
 #else
 void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
-                                   const QModelIndex &, const QVector<int> &) {
+                                   const QModelIndex & /*bottomRight*/, const QVector<int> & /*roles*/) {
 #endif
   emit treeDataChange(
       dynamic_cast<BinaryTreeWidgetItem *>(itemFromIndex(topLeft)),

--- a/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/CreateSampleShapeDialog.cpp
@@ -628,7 +628,7 @@ void BinaryTreeWidget::traverseInPostOrder(
 
 #if QT_VERSION < 0x050000
 void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
-                                   const QModelIndex &) {
+                                   const QModelIndex & /*bottomRight*/) {
 #else
 void BinaryTreeWidget::dataChanged(const QModelIndex &topLeft,
                                    const QModelIndex &, const QVector<int> &) {
@@ -653,8 +653,8 @@ ComboBoxDelegate::ComboBoxDelegate(QWidget *parent) : QItemDelegate(parent) {}
  * @param option :: unused argument
  */
 QWidget *ComboBoxDelegate::createEditor(QWidget *parent,
-                                        const QStyleOptionViewItem &,
-                                        const QModelIndex &) const {
+                                        const QStyleOptionViewItem & /*option*/,
+                                        const QModelIndex & /*index*/) const {
   QComboBox *editor = new QComboBox(parent);
   editor->addItem("intersection");
   editor->addItem("union");
@@ -700,6 +700,6 @@ void ComboBoxDelegate::setModelData(QWidget *editor, QAbstractItemModel *model,
  */
 void ComboBoxDelegate::updateEditorGeometry(QWidget *editor,
                                             const QStyleOptionViewItem &option,
-                                            const QModelIndex &) const {
+                                            const QModelIndex & /*index*/) const {
   editor->setGeometry(option.rect);
 }

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -484,7 +484,9 @@ void FitDialog::setWorkspaceName(int i, const QString &wsName) {
     tab->setWorkspaceName(wsName);
 }
 
-void FitDialog::workspaceChanged(const QString & /*unused*/) { this->setPropertyValues(); }
+void FitDialog::workspaceChanged(const QString & /*unused*/) {
+  this->setPropertyValues();
+}
 
 void FitDialog::functionChanged() {
   // this->setPropertyValues();

--- a/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/FitDialog.cpp
@@ -484,7 +484,7 @@ void FitDialog::setWorkspaceName(int i, const QString &wsName) {
     tab->setWorkspaceName(wsName);
 }
 
-void FitDialog::workspaceChanged(const QString &) { this->setPropertyValues(); }
+void FitDialog::workspaceChanged(const QString & /*unused*/) { this->setPropertyValues(); }
 
 void FitDialog::functionChanged() {
   // this->setPropertyValues();

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDAEDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDAEDialog.cpp
@@ -24,9 +24,9 @@ DECLARE_DIALOG(LoadDAEDialog)
 class NoDeleting {
 public:
   /// Does nothing
-  void operator()(void *) {}
+  void operator()(void * /*unused*/) {}
   /// Does nothing
-  void operator()(const void *) {}
+  void operator()(const void * /*unused*/) {}
 };
 
 LoadDAEDialog::LoadDAEDialog(QWidget *parent)

--- a/qt/widgets/plugins/algorithm_dialogs/src/PlotAsymmetryByLogValueDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/PlotAsymmetryByLogValueDialog.cpp
@@ -141,7 +141,7 @@ void PlotAsymmetryByLogValueDialog::openFileDialog(
  * Fill m_uiForm.logBox with names of the log values read from one of the input
  * files
  */
-void PlotAsymmetryByLogValueDialog::fillLogBox(const QString &) {
+void PlotAsymmetryByLogValueDialog::fillLogBox(const QString & /*unused*/) {
   QString nexusFileName = m_uiForm.firstRunBox->text();
   QFileInfo file(nexusFileName);
   if (!file.exists()) {

--- a/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/SortTableWorkspaceDialog.cpp
@@ -88,7 +88,7 @@ void SortTableWorkspaceDialog::parseInput() {
  * Tie static widgets to their properties
  * @param readHistory :: If true then the history will be re read.
  */
-void SortTableWorkspaceDialog::tieStaticWidgets(const bool) {
+void SortTableWorkspaceDialog::tieStaticWidgets(const bool /*unused*/) {
   QStringList allowedTypes;
   allowedTypes << "TableWorkspace";
   m_form.workspace->setWorkspaceTypes(allowedTypes);
@@ -215,7 +215,7 @@ void SortTableWorkspaceDialog::addColumn() {
 /**
  * Sync column names in the combo-boxes and m_sortColumns.
  */
-void SortTableWorkspaceDialog::changedColumnName(int) {
+void SortTableWorkspaceDialog::changedColumnName(int /*unused*/) {
   // don't try to figure out which column changed - just reset all cached names
   auto n = m_sortColumns.size();
   for (int i = 0; i < n; ++i) {

--- a/qt/widgets/refdetectorview/inc/MantidQtWidgets/RefDetectorView/RefIVConnections.h
+++ b/qt/widgets/refdetectorview/inc/MantidQtWidgets/RefDetectorView/RefIVConnections.h
@@ -78,7 +78,7 @@ public slots:
   void spectrumColorScale();
 
 signals:
-  void peakBackTofRangeUpdate(double, double, double, double, double, double);
+  void peakBackTofRangeUpdate(double /*_t1*/, double /*_t2*/, double /*_t3*/, double /*_t4*/, double /*_t5*/, double /*_t6*/);
 
 private:
   RefIVConnections() {}

--- a/qt/widgets/refdetectorview/inc/MantidQtWidgets/RefDetectorView/RefIVConnections.h
+++ b/qt/widgets/refdetectorview/inc/MantidQtWidgets/RefDetectorView/RefIVConnections.h
@@ -78,7 +78,8 @@ public slots:
   void spectrumColorScale();
 
 signals:
-  void peakBackTofRangeUpdate(double /*_t1*/, double /*_t2*/, double /*_t3*/, double /*_t4*/, double /*_t5*/, double /*_t6*/);
+  void peakBackTofRangeUpdate(double /*_t1*/, double /*_t2*/, double /*_t3*/,
+                              double /*_t4*/, double /*_t5*/, double /*_t6*/);
 
 private:
   RefIVConnections() {}

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CompositePeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CompositePeaksPresenter.h
@@ -43,15 +43,15 @@ class EXPORT_OPT_MANTIDQT_SLICEVIEWER CompositePeaksPresenter
 public:
   // Overrriden methods from Peaks Presenter
   void update() override;
-  void updateWithSlicePoint(const PeakBoundingBox &) override;
+  void updateWithSlicePoint(const PeakBoundingBox & /*unused*/) override;
   bool changeShownDim(size_t dimX, size_t dimY) override;
   void setNonOrthogonal(bool nonOrthogonalEnabled) override;
   bool isLabelOfFreeAxis(const std::string &label) const override;
   SetPeaksWorkspaces presentedWorkspaces() const override;
-  virtual void setForegroundColor(const PeakViewColor) override {
+  virtual void setForegroundColor(const PeakViewColor /*unused*/) override {
     /*Do nothing*/
   }
-  virtual void setBackgroundColor(const PeakViewColor) override {
+  virtual void setBackgroundColor(const PeakViewColor /*unused*/) override {
     /*Do nothing*/
   }
   /// Get the foreground colour. This should never be used on the composite
@@ -66,9 +66,9 @@ public:
                        "composite presenter");
     return PeakViewColor();
   }
-  void showBackgroundRadius(const bool) override { /*Do nothing*/
+  void showBackgroundRadius(const bool /*shown*/) override { /*Do nothing*/
   }
-  void setShown(const bool) override { /*Do nothing*/
+  void setShown(const bool /*shown*/) override { /*Do nothing*/
   }
   PeakBoundingBox getBoundingBox(const int peakIndex) const override {
     return m_default->getBoundingBox(peakIndex);
@@ -76,12 +76,12 @@ public:
   bool getShowBackground() const override {
     return m_default->getShowBackground();
   }
-  void zoomToPeak(const int) override { /* Do nothing */
+  void zoomToPeak(const int /*peakIndex*/) override { /* Do nothing */
   }
   std::string getTransformName() const override;
   bool isHidden() const override { return m_default->isHidden(); }
   void reInitialize(
-      boost::shared_ptr<Mantid::API::IPeaksWorkspace>) override { /*Do nothing*/
+      boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/) override { /*Do nothing*/
   }
   bool deletePeaksIn(PeakBoundingBox box) override;
   bool addPeakAt(double plotCoordsPointX, double plotCoordsPointY) override;
@@ -110,11 +110,11 @@ public:
   void peakEditMode(EditMode mode) override;
   void
   setForegroundColor(boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws,
-                     const PeakViewColor);
+                     const PeakViewColor /*color*/);
   /// Change the background representation for the peaks of this workspace
   void
   setBackgroundColor(boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws,
-                     const PeakViewColor);
+                     const PeakViewColor /*color*/);
   /// Get the foreground colour corresponding to the workspace
   PeakViewColor getForegroundPeakViewColor(
       boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws) const;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CompositePeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CompositePeaksPresenter.h
@@ -80,8 +80,8 @@ public:
   }
   std::string getTransformName() const override;
   bool isHidden() const override { return m_default->isHidden(); }
-  void reInitialize(
-      boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/) override { /*Do nothing*/
+  void reInitialize(boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/)
+      override { /*Do nothing*/
   }
   bool deletePeaksIn(PeakBoundingBox box) override;
   bool addPeakAt(double plotCoordsPointX, double plotCoordsPointY) override;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/ConcretePeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/ConcretePeaksPresenter.h
@@ -48,11 +48,11 @@ public:
   void updateWithSlicePoint(const PeakBoundingBox &slicePoint) override;
   bool isLabelOfFreeAxis(const std::string &label) const override;
   SetPeaksWorkspaces presentedWorkspaces() const override;
-  void setForegroundColor(const PeakViewColor) override;
-  void setBackgroundColor(const PeakViewColor) override;
+  void setForegroundColor(const PeakViewColor /*color*/) override;
+  void setBackgroundColor(const PeakViewColor /*color*/) override;
   std::string getTransformName() const override;
   void setShown(const bool shown) override;
-  PeakBoundingBox getBoundingBox(const int) const override;
+  PeakBoundingBox getBoundingBox(const int /*peakIndex*/) const override;
   void setPeakSizeOnProjection(const double fraction) override;
   void setPeakSizeIntoProjection(const double fraction) override;
   double getPeakSizeOnProjection() const override;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CustomTools.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/CustomTools.h
@@ -27,7 +27,7 @@ namespace SliceViewer {
 //========================================================================
 class PickerMachine : public QwtPickerMachine {
 public:
-  QwtPickerMachine::CommandList transition(const QwtEventPattern &,
+  QwtPickerMachine::CommandList transition(const QwtEventPattern & /*unused*/,
                                            const QEvent *e) override {
     QwtPickerMachine::CommandList cmdList;
     if (e->type() == QEvent::MouseMove)
@@ -59,9 +59,9 @@ class CustomPicker : public QwtPlotPicker {
 public:
   CustomPicker(int xAxis, int yAxis, QwtPlotCanvas *canvas);
   void widgetMouseMoveEvent(QMouseEvent *e) override;
-  void widgetLeaveEvent(QEvent *) override;
+  void widgetLeaveEvent(QEvent * /*unused*/) override;
 
-  QwtPickerMachine *stateMachine(int) const override {
+  QwtPickerMachine *stateMachine(int /*unused*/) const override {
     return new PickerMachine;
   }
 

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineOverlay.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineOverlay.h
@@ -79,9 +79,9 @@ public:
 
 signals:
   /// Signal sent while the line is being dragged
-  void lineChanging(QPointF, QPointF, double);
+  void lineChanging(QPointF /*_t1*/, QPointF /*_t2*/, double /*_t3*/);
   /// Signal sent once the drag is completed
-  void lineChanged(QPointF, QPointF, double);
+  void lineChanged(QPointF /*_t1*/, QPointF /*_t2*/, double /*_t3*/);
 
 private:
   QPoint transform(QPointF coords) const;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineViewer.h
@@ -91,7 +91,8 @@ signals:
   /// Signal emitted when the planar width changes
   void changedPlanarWidth(double /*_t1*/);
   /// Signal emitted when the start or end position has changed
-  void changedStartOrEnd(Mantid::Kernel::VMD /*_t1*/, Mantid::Kernel::VMD /*_t2*/);
+  void changedStartOrEnd(Mantid::Kernel::VMD /*_t1*/,
+                         Mantid::Kernel::VMD /*_t2*/);
   /// Signal emitted when changing fixed bin width mode
   void changedFixedBinWidth(bool /*_t1*/, double /*_t2*/);
 

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/LineViewer.h
@@ -89,11 +89,11 @@ public slots:
 
 signals:
   /// Signal emitted when the planar width changes
-  void changedPlanarWidth(double);
+  void changedPlanarWidth(double /*_t1*/);
   /// Signal emitted when the start or end position has changed
-  void changedStartOrEnd(Mantid::Kernel::VMD, Mantid::Kernel::VMD);
+  void changedStartOrEnd(Mantid::Kernel::VMD /*_t1*/, Mantid::Kernel::VMD /*_t2*/);
   /// Signal emitted when changing fixed bin width mode
-  void changedFixedBinWidth(bool, double);
+  void changedFixedBinWidth(bool /*_t1*/, double /*_t2*/);
 
 private:
   Mantid::API::IAlgorithm_sptr

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/NullPeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/NullPeaksPresenter.h
@@ -31,14 +31,18 @@ public:
   void setNonOrthogonal(bool nonOrthogonalEnabled) override {
     (void)nonOrthogonalEnabled;
   }
-  bool isLabelOfFreeAxis(const std::string & /*label*/) const override { return false; }
+  bool isLabelOfFreeAxis(const std::string & /*label*/) const override {
+    return false;
+  }
   SetPeaksWorkspaces presentedWorkspaces() const override {
     SetPeaksWorkspaces empty;
     return empty;
   }
-  void setForegroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
+  void
+  setForegroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
   }
-  void setBackgroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
+  void
+  setBackgroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
   }
   PeakViewColor getBackgroundPeakViewColor() const override {
     return PeakViewColor();
@@ -54,9 +58,11 @@ public:
   PeakBoundingBox getBoundingBox(const int /*peakIndex*/) const override {
     return PeakBoundingBox();
   }
-  void setPeakSizeOnProjection(const double /*fraction*/) override { /*Do Nothing*/
+  void
+  setPeakSizeOnProjection(const double /*fraction*/) override { /*Do Nothing*/
   }
-  void setPeakSizeIntoProjection(const double /*fraction*/) override { /*Do Nothing*/
+  void
+  setPeakSizeIntoProjection(const double /*fraction*/) override { /*Do Nothing*/
   }
   double getPeakSizeOnProjection() const override { return 0; }
   double getPeakSizeIntoProjection() const override { return 0; }
@@ -64,17 +70,20 @@ public:
   void registerOwningPresenter(UpdateableOnDemand * /*owner*/) override {}
   void zoomToPeak(const int /*peakIndex*/) override {}
   bool isHidden() const override { return true; }
-  void reInitialize(
-      boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/) override { /*Do nothing*/
+  void reInitialize(boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/)
+      override { /*Do nothing*/
   }
-  bool contentsDifferent(const PeaksPresenter * /*other*/) const override { return true; }
+  bool contentsDifferent(const PeaksPresenter * /*other*/) const override {
+    return true;
+  }
 
   void peakEditMode(EditMode /*mode*/) override { /*Do nothing*/
   }
   bool deletePeaksIn(PeakBoundingBox /*plotCoordsBox*/) override {
     return false; /*Do nothing. Delete nothing.*/
   }
-  bool addPeakAt(double /*plotCoordsPointX*/, double /*plotCoordsPointY*/) override {
+  bool addPeakAt(double /*plotCoordsPointX*/,
+                 double /*plotCoordsPointY*/) override {
     return false; /*Do nothing. Add nothing.*/
   }
 };

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/NullPeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/NullPeaksPresenter.h
@@ -22,7 +22,7 @@ class EXPORT_OPT_MANTIDQT_SLICEVIEWER NullPeaksPresenter
     : public PeaksPresenter {
 public:
   void update() override {}
-  void updateWithSlicePoint(const PeakBoundingBox &) override {}
+  void updateWithSlicePoint(const PeakBoundingBox & /*unused*/) override {}
   bool changeShownDim(size_t dimX, size_t dimY) override {
     (void)dimX;
     (void)dimY;
@@ -31,14 +31,14 @@ public:
   void setNonOrthogonal(bool nonOrthogonalEnabled) override {
     (void)nonOrthogonalEnabled;
   }
-  bool isLabelOfFreeAxis(const std::string &) const override { return false; }
+  bool isLabelOfFreeAxis(const std::string & /*label*/) const override { return false; }
   SetPeaksWorkspaces presentedWorkspaces() const override {
     SetPeaksWorkspaces empty;
     return empty;
   }
-  void setForegroundColor(const PeakViewColor) override { /*Do nothing*/
+  void setForegroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
   }
-  void setBackgroundColor(const PeakViewColor) override { /*Do nothing*/
+  void setBackgroundColor(const PeakViewColor /*unused*/) override { /*Do nothing*/
   }
   PeakViewColor getBackgroundPeakViewColor() const override {
     return PeakViewColor();
@@ -47,34 +47,34 @@ public:
     return PeakViewColor();
   }
   std::string getTransformName() const override { return ""; }
-  void showBackgroundRadius(const bool) override { /*Do nothing*/
+  void showBackgroundRadius(const bool /*shown*/) override { /*Do nothing*/
   }
-  void setShown(const bool) override { /*Do nothing*/
+  void setShown(const bool /*shown*/) override { /*Do nothing*/
   }
-  PeakBoundingBox getBoundingBox(const int) const override {
+  PeakBoundingBox getBoundingBox(const int /*peakIndex*/) const override {
     return PeakBoundingBox();
   }
-  void setPeakSizeOnProjection(const double) override { /*Do Nothing*/
+  void setPeakSizeOnProjection(const double /*fraction*/) override { /*Do Nothing*/
   }
-  void setPeakSizeIntoProjection(const double) override { /*Do Nothing*/
+  void setPeakSizeIntoProjection(const double /*fraction*/) override { /*Do Nothing*/
   }
   double getPeakSizeOnProjection() const override { return 0; }
   double getPeakSizeIntoProjection() const override { return 0; }
   bool getShowBackground() const override { return false; }
-  void registerOwningPresenter(UpdateableOnDemand *) override {}
-  void zoomToPeak(const int) override {}
+  void registerOwningPresenter(UpdateableOnDemand * /*owner*/) override {}
+  void zoomToPeak(const int /*peakIndex*/) override {}
   bool isHidden() const override { return true; }
   void reInitialize(
-      boost::shared_ptr<Mantid::API::IPeaksWorkspace>) override { /*Do nothing*/
+      boost::shared_ptr<Mantid::API::IPeaksWorkspace> /*peaksWS*/) override { /*Do nothing*/
   }
-  bool contentsDifferent(const PeaksPresenter *) const override { return true; }
+  bool contentsDifferent(const PeaksPresenter * /*other*/) const override { return true; }
 
-  void peakEditMode(EditMode) override { /*Do nothing*/
+  void peakEditMode(EditMode /*mode*/) override { /*Do nothing*/
   }
-  bool deletePeaksIn(PeakBoundingBox) override {
+  bool deletePeaksIn(PeakBoundingBox /*plotCoordsBox*/) override {
     return false; /*Do nothing. Delete nothing.*/
   }
-  bool addPeakAt(double, double) override {
+  bool addPeakAt(double /*plotCoordsPointX*/, double /*plotCoordsPointY*/) override {
     return false; /*Do nothing. Add nothing.*/
   }
 };

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakOverlayView.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakOverlayView.h
@@ -38,7 +38,7 @@ public:
   virtual void
   movePosition(Mantid::Geometry::PeakTransform_sptr peakTransform) = 0;
   /// Show the background radius
-  virtual void showBackgroundRadius(const bool) {}
+  virtual void showBackgroundRadius(const bool /*unused*/) {}
   virtual void
   movePositionNonOrthogonal(Mantid::Geometry::PeakTransform_sptr peakTransform,
                             NonOrthogonalAxis &info) = 0;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakPalette.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakPalette.h
@@ -25,8 +25,8 @@ public:
   PeakPalette &operator=(const PeakPalette &other);
   C foregroundIndexToColour(const int index) const;
   C backgroundIndexToColour(const int index) const;
-  void setForegroundColour(const int index, const C);
-  void setBackgroundColour(const int index, const C);
+  void setForegroundColour(const int index, const C /*colour*/);
+  void setBackgroundColour(const int index, const C /*colour*/);
   int paletteSize() const;
   bool operator==(const PeakPalette &other) const;
   ~PeakPalette();

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationCross.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationCross.h
@@ -32,7 +32,7 @@ public:
   PeakRepresentationCross(const Mantid::Kernel::V3D &origin, const double &maxZ,
                           const double &minZ);
   /// Setter for the slice point
-  void setSlicePoint(const double &) override;
+  void setSlicePoint(const double & /*z*/) override;
   /// Transform the coordinates.
   void
   movePosition(Mantid::Geometry::PeakTransform_sptr peakTransform) override;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationEllipsoid.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationEllipsoid.h
@@ -27,7 +27,7 @@ public:
           calculator);
 
   /// Setter for the slice point
-  void setSlicePoint(const double &) override;
+  void setSlicePoint(const double & /*z*/) override;
   /// Transform the coordinates.
   void
   movePosition(Mantid::Geometry::PeakTransform_sptr peakTransform) override;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationSphere.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakRepresentationSphere.h
@@ -23,7 +23,7 @@ public:
                            const double &backgroundOuterRadius);
 
   /// Setter for the slice point
-  void setSlicePoint(const double &) override;
+  void setSlicePoint(const double & /*z*/) override;
   /// Transform the coordinates.
   void
   movePosition(Mantid::Geometry::PeakTransform_sptr peakTransform) override;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakView.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeakView.h
@@ -79,7 +79,7 @@ public:
   bool isBackgroundShown() const override;
 
   /// Take settings from another view
-  void takeSettingsFrom(const PeakOverlayView *const) override;
+  void takeSettingsFrom(const PeakOverlayView *const /*source*/) override;
 
   /// Change foreground colour -- overload for PeakViewColor
   void changeForegroundColour(const PeakViewColor peakViewColor) override;
@@ -95,7 +95,7 @@ public:
 
 private:
   /// Draw the peak representations. Pure virtual on base class.
-  void doPaintPeaks(QPaintEvent *) override;
+  void doPaintPeaks(QPaintEvent * /*event*/) override;
 
   /// The actual peak objects
   VecPeakRepresentation m_peaks;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewer.h
@@ -59,11 +59,15 @@ public:
 public slots:
   void onPeakColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
                           PeakViewColor /*newColor*/);
-  void onBackgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
-                                PeakViewColor /*newColor*/);
-  void onBackgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/, bool /*show*/);
+  void onBackgroundColorChanged(
+      Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
+      PeakViewColor /*newColor*/);
+  void
+  onBackgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
+                          bool /*show*/);
   void onRemoveWorkspace(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/);
-  void onHideInPlot(Mantid::API::IPeaksWorkspace_const_sptr peaksWS, bool /*hide*/);
+  void onHideInPlot(Mantid::API::IPeaksWorkspace_const_sptr peaksWS,
+                    bool /*hide*/);
   void onZoomToPeak(Mantid::API::IPeaksWorkspace_const_sptr peaksWS,
                     int peakIndex);
   void showPeaksTableColumnOptions();

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewer.h
@@ -57,13 +57,13 @@ public:
   std::string saveToProject() const;
 
 public slots:
-  void onPeakColorChanged(Mantid::API::IPeaksWorkspace_const_sptr,
-                          PeakViewColor);
-  void onBackgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr,
-                                PeakViewColor);
-  void onBackgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr, bool);
-  void onRemoveWorkspace(Mantid::API::IPeaksWorkspace_const_sptr);
-  void onHideInPlot(Mantid::API::IPeaksWorkspace_const_sptr peaksWS, bool);
+  void onPeakColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
+                          PeakViewColor /*newColor*/);
+  void onBackgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/,
+                                PeakViewColor /*newColor*/);
+  void onBackgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/, bool /*show*/);
+  void onRemoveWorkspace(Mantid::API::IPeaksWorkspace_const_sptr /*peaksWS*/);
+  void onHideInPlot(Mantid::API::IPeaksWorkspace_const_sptr peaksWS, bool /*hide*/);
   void onZoomToPeak(Mantid::API::IPeaksWorkspace_const_sptr peaksWS,
                     int peakIndex);
   void showPeaksTableColumnOptions();

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewerOverlayDialog.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksViewerOverlayDialog.h
@@ -25,7 +25,7 @@ public:
                                     QWidget *parent = nullptr);
   ~PeaksViewerOverlayDialog() override;
 
-  void closeEvent(QCloseEvent *) override;
+  void closeEvent(QCloseEvent * /*unused*/) override;
   void reject() override;
 
 private slots:

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksWorkspaceWidget.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksWorkspaceWidget.h
@@ -43,14 +43,19 @@ public:
   void exitClearPeaksMode();
   void exitAddPeaksMode();
 signals:
-  void peakColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, QColor /*_t2*/);
-  void peakColorchanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, PeakViewColor /*_t2*/);
-  void backgroundColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, QColor /*_t2*/);
+  void peakColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                         QColor /*_t2*/);
+  void peakColorchanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                        PeakViewColor /*_t2*/);
+  void backgroundColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                               QColor /*_t2*/);
   void backgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
                               PeakViewColor /*_t2*/);
-  void backgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, bool /*_t2*/);
+  void backgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                             bool /*_t2*/);
   void removeWorkspace(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/);
-  void hideInPlot(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, bool /*_t2*/);
+  void hideInPlot(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                  bool /*_t2*/);
   void zoomToPeak(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, int /*_t2*/);
 
 private:

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksWorkspaceWidget.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/PeaksWorkspaceWidget.h
@@ -43,15 +43,15 @@ public:
   void exitClearPeaksMode();
   void exitAddPeaksMode();
 signals:
-  void peakColourChanged(Mantid::API::IPeaksWorkspace_const_sptr, QColor);
-  void peakColorchanged(Mantid::API::IPeaksWorkspace_const_sptr, PeakViewColor);
-  void backgroundColourChanged(Mantid::API::IPeaksWorkspace_const_sptr, QColor);
-  void backgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr,
-                              PeakViewColor);
-  void backgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr, bool);
-  void removeWorkspace(Mantid::API::IPeaksWorkspace_const_sptr);
-  void hideInPlot(Mantid::API::IPeaksWorkspace_const_sptr, bool);
-  void zoomToPeak(Mantid::API::IPeaksWorkspace_const_sptr, int);
+  void peakColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, QColor /*_t2*/);
+  void peakColorchanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, PeakViewColor /*_t2*/);
+  void backgroundColourChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, QColor /*_t2*/);
+  void backgroundColorChanged(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/,
+                              PeakViewColor /*_t2*/);
+  void backgroundRadiusShown(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, bool /*_t2*/);
+  void removeWorkspace(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/);
+  void hideInPlot(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, bool /*_t2*/);
+  void zoomToPeak(Mantid::API::IPeaksWorkspace_const_sptr /*_t1*/, int /*_t2*/);
 
 private:
   /// Populate the widget with model data.
@@ -88,12 +88,12 @@ private slots:
   void onBackgroundColorEllipsoidClicked();
   void onForegroundColorEllipsoidClicked();
 
-  void onShowBackgroundChanged(bool);
+  void onShowBackgroundChanged(bool /*show*/);
   void onRemoveWorkspaceClicked();
   void onToggleHideInPlot();
-  void onCurrentChanged(QModelIndex, QModelIndex);
-  void onClearPeaksToggled(bool);
-  void onAddPeaksToggled(bool);
+  void onCurrentChanged(QModelIndex /*index*/, QModelIndex /*unused*/);
+  void onClearPeaksToggled(bool /*on*/);
+  void onAddPeaksToggled(bool /*on*/);
 };
 
 } // namespace SliceViewer

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/ProxyCompositePeaksPresenter.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/ProxyCompositePeaksPresenter.h
@@ -35,11 +35,11 @@ public:
 
   void
   setForegroundColor(boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws,
-                     PeakViewColor);
+                     PeakViewColor /*color*/);
   /// Change the background representation for the peaks of this workspace
   void
   setBackgroundColor(boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws,
-                     PeakViewColor);
+                     PeakViewColor /*color*/);
   /// Get the foreground colour corresponding to the workspace
   PeakViewColor getForegroundPeakViewColor(
       boost::shared_ptr<const Mantid::API::IPeaksWorkspace> ws) const;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/QPeaksTableModel.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/QPeaksTableModel.h
@@ -52,7 +52,7 @@ public:
   void setPeaksWorkspace(
       boost::shared_ptr<const Mantid::API::IPeaksWorkspace> peaksWS);
 signals:
-  void peaksSorted(const std::string &, const bool);
+  void peaksSorted(const std::string & /*_t1*/, const bool /*_t2*/);
 
 private:
   using ColumnNameType = QString;

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewer.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewer.h
@@ -119,7 +119,7 @@ public:
   QwtDoubleInterval getYLimits() const;
   void setXYCenter(double x, double y);
   void openFromXML(const QString &xml);
-  void toggleLineMode(bool);
+  void toggleLineMode(bool /*lineMode*/);
   void setNormalization(Mantid::API::MDNormalization norm, bool update = true);
   Mantid::API::MDNormalization getNormalization() const;
   void setColorBarAutoScale(bool autoscale);
@@ -161,9 +161,9 @@ signals:
   /// Signal emitted when the slice point moves
   void changedSlicePoint(Mantid::Kernel::VMD slicePoint);
   /// Signal emitted when the LineViewer should be shown/hidden.
-  void showLineViewer(bool);
+  void showLineViewer(bool /*_t1*/);
   /// Signal emitted when the PeaksViewer should be shown/hidden.
-  void showPeaksViewer(bool);
+  void showPeaksViewer(bool /*_t1*/);
   /// Signal emitted when someone uses setWorkspace() on SliceViewer
   void workspaceChanged();
   /// Signal emitted when someone wants to see the options dialog
@@ -174,7 +174,7 @@ public slots:
   void helpLineViewer();
   void helpPeaksViewer();
   void setFastRender(bool fast);
-  void showInfoAt(double, double);
+  void showInfoAt(double /*x*/, double /*y*/);
   // Change in view slots
   void checkForHKLDimension();
   void switchQWTRaster(bool useNonOrthogonal);
@@ -186,8 +186,8 @@ public slots:
   void zoomInSlot();
   void zoomOutSlot();
   void zoomRectSlot(const QwtDoubleRect &rect);
-  void panned(int, int);
-  void magnifierRescaled(double);
+  void panned(int /*unused*/, int /*unused*/);
+  void magnifierRescaled(double /*unused*/);
 
   // Color scale slots
   void setColorScaleAutoFull();
@@ -210,10 +210,10 @@ public slots:
   void setNonOrthogonalbtn();
   void disableOrthogonalAnalysisTools(bool checked);
   // Synced checkboxes
-  void LineMode_toggled(bool);
-  void SnapToGrid_toggled(bool);
-  void RebinMode_toggled(bool);
-  void autoRebin_toggled(bool);
+  void LineMode_toggled(bool /*checked*/);
+  void SnapToGrid_toggled(bool /*checked*/);
+  void RebinMode_toggled(bool /*checked*/);
+  void autoRebin_toggled(bool /*checked*/);
 
   // Dynamic rebinning
   void rebinParamsChanged();

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewerWindow.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewerWindow.h
@@ -70,7 +70,8 @@ protected slots:
   void changedSlicePoint(Mantid::Kernel::VMD /*slice*/);
   void lineChanging(QPointF start, QPointF end, double width);
   void lineChanged(QPointF start, QPointF end, double width);
-  void changeStartOrEnd(Mantid::Kernel::VMD /*start*/, Mantid::Kernel::VMD /*end*/);
+  void changeStartOrEnd(Mantid::Kernel::VMD /*start*/,
+                        Mantid::Kernel::VMD /*end*/);
   void changePlanarWidth(double /*width*/);
   void resizeWindow();
   void lineViewer_changedFixedBinWidth(bool fixed, double binWidth);

--- a/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewerWindow.h
+++ b/qt/widgets/sliceviewer/inc/MantidQtWidgets/SliceViewer/SliceViewerWindow.h
@@ -67,15 +67,15 @@ protected slots:
   void closeWindow();
   void updateWorkspace();
   void slicerWorkspaceChanged();
-  void changedSlicePoint(Mantid::Kernel::VMD);
+  void changedSlicePoint(Mantid::Kernel::VMD /*slice*/);
   void lineChanging(QPointF start, QPointF end, double width);
   void lineChanged(QPointF start, QPointF end, double width);
-  void changeStartOrEnd(Mantid::Kernel::VMD, Mantid::Kernel::VMD);
-  void changePlanarWidth(double);
+  void changeStartOrEnd(Mantid::Kernel::VMD /*start*/, Mantid::Kernel::VMD /*end*/);
+  void changePlanarWidth(double /*width*/);
   void resizeWindow();
   void lineViewer_changedFixedBinWidth(bool fixed, double binWidth);
-  void showLineViewer(bool);
-  void showPeaksViewer(bool);
+  void showLineViewer(bool /*visible*/);
+  void showPeaksViewer(bool /*visible*/);
 
 protected:
   void

--- a/qt/widgets/sliceviewer/src/CustomTools.cpp
+++ b/qt/widgets/sliceviewer/src/CustomTools.cpp
@@ -34,7 +34,7 @@ void CustomPicker::widgetMouseMoveEvent(QMouseEvent *e) {
   QwtPlotPicker::widgetMouseMoveEvent(e);
 }
 
-void CustomPicker::widgetLeaveEvent(QEvent *) { end(); }
+void CustomPicker::widgetLeaveEvent(QEvent * /*unused*/) { end(); }
 
 void CustomMagnifier::rescale(double factor) {
   if (factor != 0.0) {

--- a/qt/widgets/sliceviewer/src/PeakRepresentationCross.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationCross.cpp
@@ -117,7 +117,8 @@ std::shared_ptr<PeakPrimitives> PeakRepresentationCross::getDrawingInformation(
 }
 
 void PeakRepresentationCross::doDraw(
-    QPainter &painter, PeakViewColor &foregroundColor, PeakViewColor & /*backgroundColor*/,
+    QPainter &painter, PeakViewColor &foregroundColor,
+    PeakViewColor & /*backgroundColor*/,
     std::shared_ptr<PeakPrimitives> drawingInformation,
     PeakRepresentationViewInformation viewInformation) {
   auto drawingInformationCross =

--- a/qt/widgets/sliceviewer/src/PeakRepresentationCross.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationCross.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<PeakPrimitives> PeakRepresentationCross::getDrawingInformation(
 }
 
 void PeakRepresentationCross::doDraw(
-    QPainter &painter, PeakViewColor &foregroundColor, PeakViewColor &,
+    QPainter &painter, PeakViewColor &foregroundColor, PeakViewColor & /*backgroundColor*/,
     std::shared_ptr<PeakPrimitives> drawingInformation,
     PeakRepresentationViewInformation viewInformation) {
   auto drawingInformationCross =
@@ -159,7 +159,7 @@ const Mantid::Kernel::V3D &PeakRepresentationCross::getOrigin() const {
   return m_origin;
 }
 
-void PeakRepresentationCross::showBackgroundRadius(const bool) {
+void PeakRepresentationCross::showBackgroundRadius(const bool /*show*/) {
   // Do nothing
 }
 } // namespace SliceViewer

--- a/qt/widgets/sliceviewer/src/PeakRepresentationEllipsoid.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationEllipsoid.cpp
@@ -186,11 +186,11 @@ double PeakRepresentationEllipsoid::getEffectiveRadius() const {
   return m_showBackgroundRadii ? m_backgroundOuterRadii[0] : m_peakRadii[0];
 }
 
-void PeakRepresentationEllipsoid::setOccupancyInView(const double) {
+void PeakRepresentationEllipsoid::setOccupancyInView(const double /*fraction*/) {
   // DO NOTHING
 }
 
-void PeakRepresentationEllipsoid::setOccupancyIntoView(const double) {
+void PeakRepresentationEllipsoid::setOccupancyIntoView(const double /*fraction*/) {
   // DO NOTHING
 }
 
@@ -200,7 +200,7 @@ const Mantid::Kernel::V3D &PeakRepresentationEllipsoid::getOrigin() const {
 
 std::shared_ptr<PeakPrimitives>
 PeakRepresentationEllipsoid::getDrawingInformation(
-    PeakRepresentationViewInformation) {
+    PeakRepresentationViewInformation /*viewInformation*/) {
   auto drawingInformation = std::make_shared<PeakPrimitivesEllipse>(
       Mantid::Kernel::V3D() /*peakOrigin*/, 0.0 /*peakOpacityAtDistance*/,
       0 /* peakLineWidth */, 0.0 /*peakInnerRadiusMajorAxis*/,

--- a/qt/widgets/sliceviewer/src/PeakRepresentationEllipsoid.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationEllipsoid.cpp
@@ -186,11 +186,13 @@ double PeakRepresentationEllipsoid::getEffectiveRadius() const {
   return m_showBackgroundRadii ? m_backgroundOuterRadii[0] : m_peakRadii[0];
 }
 
-void PeakRepresentationEllipsoid::setOccupancyInView(const double /*fraction*/) {
+void PeakRepresentationEllipsoid::setOccupancyInView(
+    const double /*fraction*/) {
   // DO NOTHING
 }
 
-void PeakRepresentationEllipsoid::setOccupancyIntoView(const double /*fraction*/) {
+void PeakRepresentationEllipsoid::setOccupancyIntoView(
+    const double /*fraction*/) {
   // DO NOTHING
 }
 

--- a/qt/widgets/sliceviewer/src/PeakRepresentationSphere.cpp
+++ b/qt/widgets/sliceviewer/src/PeakRepresentationSphere.cpp
@@ -115,11 +115,11 @@ double PeakRepresentationSphere::getEffectiveRadius() const {
   return m_showBackgroundRadius ? m_backgroundOuterRadius : m_peakRadius;
 }
 
-void PeakRepresentationSphere::setOccupancyInView(const double) {
+void PeakRepresentationSphere::setOccupancyInView(const double /*fraction*/) {
   // DO NOTHING
 }
 
-void PeakRepresentationSphere::setOccupancyIntoView(const double) {
+void PeakRepresentationSphere::setOccupancyIntoView(const double /*fraction*/) {
   // DO NOTHING
 }
 

--- a/qt/widgets/sliceviewer/src/PeakView.cpp
+++ b/qt/widgets/sliceviewer/src/PeakView.cpp
@@ -29,7 +29,7 @@ PeakView::PeakView(PeaksPresenter *const presenter, QwtPlot *plot,
 
 PeakView::~PeakView() {}
 
-void PeakView::doPaintPeaks(QPaintEvent *) {
+void PeakView::doPaintPeaks(QPaintEvent * /*event*/) {
   const auto windowHeight = height();
   const auto windowWidth = width();
   const auto viewHeight =

--- a/qt/widgets/sliceviewer/src/PeaksViewer.cpp
+++ b/qt/widgets/sliceviewer/src/PeaksViewer.cpp
@@ -24,7 +24,7 @@ PeaksViewer::PeaksViewer(QWidget *parent) : QWidget(parent) {
       "Feature", "SliceViewer->PeaksViewer", false);
 }
 
-void PeaksViewer::setPeaksWorkspaces(const SetPeaksWorkspaces &) {}
+void PeaksViewer::setPeaksWorkspaces(const SetPeaksWorkspaces & /*unused*/) {}
 
 /**
  * Remove the layout

--- a/qt/widgets/sliceviewer/src/PeaksWorkspaceWidget.cpp
+++ b/qt/widgets/sliceviewer/src/PeaksWorkspaceWidget.cpp
@@ -359,7 +359,8 @@ void PeaksWorkspaceWidget::workspaceUpdate(
  * @brief PeaksWorkspaceWidget::onCurrentChanged
  * @param index : Index of the table newly selected
  */
-void PeaksWorkspaceWidget::onCurrentChanged(QModelIndex index, QModelIndex /*unused*/) {
+void PeaksWorkspaceWidget::onCurrentChanged(QModelIndex index,
+                                            QModelIndex /*unused*/) {
   if (index.isValid()) {
     index = m_tableModel->mapToSource(index);
     emit zoomToPeak(this->m_ws, index.row());

--- a/qt/widgets/sliceviewer/src/PeaksWorkspaceWidget.cpp
+++ b/qt/widgets/sliceviewer/src/PeaksWorkspaceWidget.cpp
@@ -359,7 +359,7 @@ void PeaksWorkspaceWidget::workspaceUpdate(
  * @brief PeaksWorkspaceWidget::onCurrentChanged
  * @param index : Index of the table newly selected
  */
-void PeaksWorkspaceWidget::onCurrentChanged(QModelIndex index, QModelIndex) {
+void PeaksWorkspaceWidget::onCurrentChanged(QModelIndex index, QModelIndex /*unused*/) {
   if (index.isValid()) {
     index = m_tableModel->mapToSource(index);
     emit zoomToPeak(this->m_ws, index.row());

--- a/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
+++ b/qt/widgets/sliceviewer/src/QPeaksTableModel.cpp
@@ -273,14 +273,14 @@ void QPeaksTableModel::setPeaksWorkspace(
 /**
 @return the row count.
 */
-int QPeaksTableModel::rowCount(const QModelIndex &) const {
+int QPeaksTableModel::rowCount(const QModelIndex & /*parent*/) const {
   return static_cast<int>(m_peaksWS->rowCount());
 }
 
 /**
 @return the number of columns in the model.
 */
-int QPeaksTableModel::columnCount(const QModelIndex &) const {
+int QPeaksTableModel::columnCount(const QModelIndex & /*parent*/) const {
   return static_cast<int>(m_dataLookup.size());
 }
 

--- a/qt/widgets/sliceviewer/src/SliceViewer.cpp
+++ b/qt/widgets/sliceviewer/src/SliceViewer.cpp
@@ -2387,7 +2387,7 @@ void SliceViewer::dynamicRebinComplete(bool error) {
 /**
 Event handler for plot panning.
 */
-void SliceViewer::panned(int, int) {
+void SliceViewer::panned(int /*unused*/, int /*unused*/) {
   autoRebinIfRequired();
 
   applyColorScalingForCurrentSliceIfRequired();
@@ -2397,7 +2397,7 @@ void SliceViewer::panned(int, int) {
 /**
 Event handler for changing magnification.
 */
-void SliceViewer::magnifierRescaled(double) {
+void SliceViewer::magnifierRescaled(double /*unused*/) {
   autoRebinIfRequired();
   this->updatePeaksOverlay();
 }

--- a/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
+++ b/qt/widgets/spectrumviewer/inc/MantidQtWidgets/SpectrumViewer/SpectrumView.h
@@ -79,7 +79,7 @@ public:
   std::string getWindowType() override;
 
 signals:
-  void spectrumDisplayChanged(SpectrumDisplay *);
+  void spectrumDisplayChanged(SpectrumDisplay * /*_t1*/);
 
 protected slots:
   void closeWindow();

--- a/qt/widgets/spectrumviewer/src/SpectrumPlotItem.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumPlotItem.cpp
@@ -82,7 +82,7 @@ void SpectrumPlotItem::setIntensityTable(std::vector<double> *intensityTable) {
  *                      passed in when QWT calls this method.
  */
 void SpectrumPlotItem::draw(QPainter *painter, const QwtScaleMap &xMap,
-                            const QwtScaleMap &yMap, const QRect &) const {
+                            const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
   // If no color table, the data is not yet set, so just return
   if (!m_positiveColorTable)
     return;

--- a/qt/widgets/spectrumviewer/src/SpectrumPlotItem.cpp
+++ b/qt/widgets/spectrumviewer/src/SpectrumPlotItem.cpp
@@ -82,7 +82,8 @@ void SpectrumPlotItem::setIntensityTable(std::vector<double> *intensityTable) {
  *                      passed in when QWT calls this method.
  */
 void SpectrumPlotItem::draw(QPainter *painter, const QwtScaleMap &xMap,
-                            const QwtScaleMap &yMap, const QRect & /*canvasRect*/) const {
+                            const QwtScaleMap &yMap,
+                            const QRect & /*canvasRect*/) const {
   // If no color table, the data is not yet set, so just return
   if (!m_positiveColorTable)
     return;


### PR DESCRIPTION
**Description of work.**
This PR applies clang-tidy readability-named-parameter fix to qt files.
This check will add text such as `\*unused*\` if a variable is supplied without a name, to make it clearer what the variable should be.

If a variable name was not given a name in the function definition but was, for example, called a_var in the function declaration, the definition will be changed to `func(const int \*a_var*\)`

**To test:**
Code review

Fixes #15452 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
