### PR TITLE
Fix cppcheck 1.87 warnings in TestHelpers

### DIFF
--- a/Framework/TestHelpers/src/ComponentCreationHelper.cpp
+++ b/Framework/TestHelpers/src/ComponentCreationHelper.cpp
@@ -318,10 +318,10 @@ createRingOfCylindricalDetectors(const double R_min, const double R_max,
   std::vector<boost::shared_ptr<const IDetector>> groupMembers;
   groupMembers.reserve(vecOfDetectors.size());
   for (auto &det : vecOfDetectors) {
-    groupMembers.push_back(boost::shared_ptr<const IDetector>(std::move(det)));
+    groupMembers.emplace_back(std::move(det));
   }
 
-  return boost::make_shared<DetectorGroup>(groupMembers);
+  return boost::make_shared<DetectorGroup>(std::move(groupMembers));
 }
 
 Instrument_sptr createTestInstrumentCylindrical(

--- a/Framework/TestHelpers/src/ReflectometryHelper.cpp
+++ b/Framework/TestHelpers/src/ReflectometryHelper.cpp
@@ -143,9 +143,6 @@ void applyPolarizationEfficiencies(WorkspaceGroup_sptr ws) {
   auto Pa = createHistoWS(nBins, startX, endX, {0.7});
   auto Aa = createHistoWS(nBins, startX, endX, {0.6});
 
-  auto Rho = Pa / Pp;
-  auto Alpha = Aa / Ap;
-
   auto Ipp = (Rpp * (Pp + 1.0) * (Ap + 1.0) +
               Raa * (Pp * (-1.0) + 1.0) * (Ap * (-1.0) + 1.0) +
               Rpa * (Pp + 1.0) * (Ap * (-1.0) + 1.0) +


### PR DESCRIPTION
Fix `cppcheck` 1.87 warnings in the TestHelpers module.

**To test:**

Code review

Fixes partially #22912. 

*This does not require release notes* because this is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
