### PR TITLE
Remove unused variable that snuck in FindReplace dialog PR

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -125,7 +125,6 @@ class PythonFileInterpreter(QWidget):
         font = font if font is not None else QFont()
         self.editor = CodeEditor("AlternateCSPython", font, self)
         self.find_replace_dialog = None
-        self.find_replace_dialog_shown = False
         self.status = QStatusBar(self)
         self.layout = QVBoxLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
**Description of work.**
Removes a variable. It was moved to `mantidqt.widgets.embedded_find_replace_dialog.presenter.visible`, but I never deleted this variable.

**To test:**
Builds should pass.


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
