### PR TITLE
Suppress get states warnings from Masking Table Presenter

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -19,3 +19,4 @@ Improvements
 
 - Increased font size in run table.
 - For ZOOM, SHIFT user file command now moves monitor 5.
+- The warning message raised when you have supplied a transmission run without a direct run has been suppressed when data is still being input. The warning will still be raised if you load or process the data.

--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -170,7 +170,7 @@ class MaskingTablePresenter(object):
 
     def on_row_changed(self):
         row_index = self._view.get_current_row()
-        state = self.get_state(row_index, file_lookup=False)
+        state = self.get_state(row_index, file_lookup=False, suppress_warnings=True)
         if state:
             self.display_masking_information(state)
 
@@ -248,8 +248,9 @@ class MaskingTablePresenter(object):
         self._view.update_rows([])
         self.display_masking_information(state=None)
 
-    def get_state(self, index, file_lookup=True):
-        return self._parent_presenter.get_state_for_row(index, file_lookup=file_lookup)
+    def get_state(self, index, file_lookup=True, suppress_warnings=False):
+        return self._parent_presenter.get_state_for_row(index, file_lookup=file_lookup,
+                                                        suppress_warnings=suppress_warnings)
 
     @staticmethod
     def _append_single_spectrum_mask(spectrum_mask, container, detector_name, prefix):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -848,11 +848,14 @@ class RunTabPresenter(object):
         return selected_rows
 
     @log_times
-    def get_states(self, row_index=None, file_lookup=True):
+    def get_states(self, row_index=None, file_lookup=True, suppress_warnings=False):
         """
         Gathers the state information for all rows.
         :param row_index: if a single row is selected, then only this row is returned,
                           else all the state for all rows is returned.
+        :param suppress_warnings: bool. If true don't propagate errors.
+                                  This variable is introduced to stop repeated errors
+                                  when filling in a row in the table.
         :return: a list of states.
         """
         # 1. Update the state model
@@ -868,20 +871,22 @@ class RunTabPresenter(object):
                                            row_index=row_index,
                                            file_lookup=file_lookup)
 
-        if errors:
+        if errors and not suppress_warnings:
             self.sans_logger.warning("Errors in getting states...")
             for _, v in errors.items():
                 self.sans_logger.warning("{}".format(v))
 
         return states, errors
 
-    def get_state_for_row(self, row_index, file_lookup=True):
+    def get_state_for_row(self, row_index, file_lookup=True, suppress_warnings=False):
         """
         Creates the state for a particular row.
         :param row_index: the row index
+        :param suppress_warnings: bool. If True don't propagate errors from get_states.
         :return: a state if the index is valid and there is a state else None
         """
-        states, errors = self.get_states(row_index=[row_index], file_lookup=file_lookup)
+        states, errors = self.get_states(row_index=[row_index], file_lookup=file_lookup,
+                                         suppress_warnings=suppress_warnings)
         if states is None:
             self.sans_logger.warning(
                 "There does not seem to be data for a row {}.".format(row_index))

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -856,6 +856,9 @@ class RunTabPresenter(object):
         :param suppress_warnings: bool. If true don't propagate errors.
                                   This variable is introduced to stop repeated errors
                                   when filling in a row in the table.
+                                  This parameter is a temporary fix to the problem of errors being reported
+                                  while data is still being input. A long-term fix is to reassess how frequently
+                                  SANS calls get_states.
         :return: a list of states.
         """
         # 1. Update the state model
@@ -883,6 +886,9 @@ class RunTabPresenter(object):
         Creates the state for a particular row.
         :param row_index: the row index
         :param suppress_warnings: bool. If True don't propagate errors from get_states.
+                                  This parameter is a temporary fix to the problem of errors being reported
+                                  while data is still being input. A long-term fix is to reassess how frequently
+                                  SANS calls get_states.
         :return: a state if the index is valid and there is a state else None
         """
         states, errors = self.get_states(row_index=[row_index], file_lookup=file_lookup,

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -234,11 +234,11 @@ class FakeState(object):
         return self.dummy_state
 
 
-def get_state_for_row_mock(row_index, file_lookup=True):
+def get_state_for_row_mock(row_index, file_lookup=True, suppress_warnings=False):
     return FakeState() if row_index == 3 else ""
 
 
-def get_state_for_row_mock_with_real_state(row_index, file_lookup=True):
+def get_state_for_row_mock_with_real_state(row_index, file_lookup=True, suppress_warnings=False):
     _ = row_index  # noqa
     test_director = TestDirector()
     return test_director.construct()


### PR DESCRIPTION
**Description of work.**
For ISIS SANS reductions, if you supply a transmission run you **must** also supply a direct run. A warning is raised during the method `get_states` if one is supplied without the other. In practice, this means that if you type in a transmission run you receive a warning before you've had a chance to type in a direct run.

This PR adds an optional boolean flag to suppress the warnings to the logger (default is that warnings are posted). This flag is switched on only for the methods which cause the error mid-typing.

This is a bit of a hacky fix to the issue; in my investigation I found that the ISIS SANS gui makes a lot of calls to `get_states` - far more than is necessary. A long-term fix would be to re-address how many calls we make and to not make calls while data is still being input. This is being tracked in #25426 

**To test:**
1. interfaces -> SANS -> ISIS SANS
2. Load the attached user file
3. In the table, type 74044 in the first and second columns. You should not see a warning posted in the logger, despite having supplied a transmission run without a direct run.
4. Click process all. You should now see a pop-up telling you there was an issue getting states, and the warning should be posted to the logger.

Fixes #25040 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
