### PR TITLE
directtools: fix non-transposed plotting of S(Q,W)

### DIFF
--- a/docs/source/release/v4.1.0/direct_geometry.rst
+++ b/docs/source/release/v4.1.0/direct_geometry.rst
@@ -29,6 +29,14 @@ Improvements
 Bugfixes
 ########
 
+Python
+------
+
+Improvements
+############
+
+- :func:`directtools.plotSofQW` now supports plotting of transposed and non-transposed workspaces.
+
 - In :ref:`PyChop <PyChop>`, the sample-size effect calculation was improved to account for the annular shape.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -715,7 +715,8 @@ def plotSofQW(workspace, QMin=0., QMax=None, EMin=None, EMax=None, VMin=0., VMax
     if not _validate._isSofQW(workspace):
         logger.warning("The workspace '{}' does not look like proper S(Q,W) data. Trying to plot nonetheless.".format(str(workspace)))
     qHorizontal = workspace.getAxis(0).getUnit().name() == 'q'
-    isSusceptibility = workspace.YUnit() == 'Dynamic susceptibility'
+    isSusceptibility = workspace.YUnitLabel() == 'Dynamic susceptibility'
+    print(workspace.YUnit())
     figure, axes = subplots()
     if QMin is None:
         QMin = 0.

--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -55,7 +55,7 @@ def _configurematplotlib(params):
 def _chooseylabel(workspace, axes):
     """Set the correct y label for profile axes."""
     yUnitLabel = workspace.YUnitLabel()
-    if yUnitLabel == "X''(Q,E)":
+    if yUnitLabel == "Dynamic susceptibility":
         axes.set_ylabel(r"$\chi''(Q,E)$")
     elif yUnitLabel == 'g^{neutron}(E) (arb. units)':
         axes.set_ylabel(r'$g(E)$')
@@ -615,8 +615,7 @@ def plotcuts(direction, workspaces, cuts, widths, quantity, unit, style='l', kee
                 if wsStr == '':
                     wsStr = str(wsCount)
                 quantityStr = _clearmath(quantity)
-                unitStr = _clearmath(unit)
-                wsName = 'cut_{}_{}={}+-{}{}'.format(wsStr, quantityStr, cut, width, unitStr)
+                wsName = 'cut_{}_{}={}+-{}'.format(wsStr, quantityStr, cut, width,)
                 if keepCutWorkspaces:
                     cutWSList.append(wsName)
                 line = LineProfile(ws, cut, width, Direction=direction,
@@ -726,7 +725,6 @@ def plotSofQW(workspace, QMin=0., QMax=None, EMin=None, EMax=None, VMin=0., VMax
         logger.warning("The workspace '{}' does not look like proper S(Q,W) data. Trying to plot nonetheless.".format(str(workspace)))
     qHorizontal = workspace.getAxis(0).getUnit().name() == 'q'
     isSusceptibility = workspace.YUnitLabel() == 'Dynamic susceptibility'
-    print(workspace.YUnit())
     figure, axes = subplots()
     if QMin is None:
         QMin = 0.

--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -178,6 +178,16 @@ def _instrumentname(logs):
         return None
 
 
+def _singlecutinfo(cuts, widths):
+    """Return False if there are more than one cut and width."""
+    isSingleCutInfo = True
+    if isinstance(cuts, collections.Iterable):
+        isSingleCutInfo = len(cuts) == 1
+    if isinstance(widths, collections.Iterable):
+        isSingleCutInfo = len(widths) == 1
+    return isSingleCutInfo
+
+
 def _label(ws, cut, width, singleWS, singleCut, singleWidth, quantity, units):
     """Return a line label for a line profile."""
     ws = _normws(ws)
@@ -243,21 +253,21 @@ def _mantidsubplotsetup():
     return {'projection': 'mantid'}
 
 
-def _profiletitle(workspaces, cuts, scan, units, axes):
+def _profiletitle(workspaces, cuts, isSingleCutInfo, scan, units, axes):
     """Add title to line profile axes."""
     workspaces = _normwslist(workspaces)
     cuts = _normwslist(cuts)
     if len(workspaces) == 1:
         title = _singledatatitle(workspaces[0])
-        centre, width = _cutcentreandwidth(cuts[0])
-        if len(cuts) == 1:
-            title = title + '\n' + scan + r' = {:0.2f} $\pm$ {:0.2f}'.format(centre, width) + ' ' + units
     else:
         title = _plottingtime()
         logs = workspaces[0].run()
         instrument = _instrumentname(logs)
         if instrument is not None:
             title = instrument + ' ' + title
+    if isSingleCutInfo:
+        centre, width = _cutcentreandwidth(cuts[0])
+        title = title + '\n' + scan + r' = {:0.2f} $\pm$ {:0.2f}'.format(centre, width) + ' ' + units
     axes.set_title(title)
 
 
@@ -500,7 +510,7 @@ def plotconstE(workspaces, E, dE, style='l', keepCutWorkspaces=True, xscale='lin
             raise RuntimeError("Cannot cut in const E. The workspace '{}' is not in units of energy transfer.".format(str(ws)))
     figure, axes, cutWSList = plotcuts(direction, workspaces, E, dE, r'$E$', 'meV', style, keepCutWorkspaces,
                                        xscale, yscale)
-    _profiletitle(workspaces, cutWSList, r'$E$', 'meV', axes)
+    _profiletitle(workspaces, cutWSList, _singlecutinfo(E, dE), r'$E$', 'meV', axes)
     if len(cutWSList) > 1:
         axes.legend()
     _finalizeprofileE(axes)
@@ -546,7 +556,7 @@ def plotconstQ(workspaces, Q, dQ, style='l', keepCutWorkspaces=True, xscale='lin
             raise RuntimeError("Cannot cut in const Q. The workspace '{}' is not in units of momentum transfer.".format(str(ws)))
     figure, axes, cutWSList = plotcuts(direction, workspaces, Q, dQ, r'$Q$', r'$\mathrm{\AA}^{-1}$', style, keepCutWorkspaces,
                                        xscale, yscale)
-    _profiletitle(workspaces, cutWSList, r'$Q$', r'$\mathrm{\AA}^{-1}$', axes)
+    _profiletitle(workspaces, cutWSList, _singlecutinfo(Q, dQ), r'$Q$', r'$\mathrm{\AA}^{-1}$', axes)
     if len(cutWSList) > 1:
         axes.legend()
     _finalizeprofileQ(workspaces, axes)

--- a/scripts/directtools/__init__.py
+++ b/scripts/directtools/__init__.py
@@ -41,9 +41,9 @@ def _choosemarker(markers, index):
 
 def _clearmath(s):
     """Return string s with special math characters removed."""
+    s = s.replace(r'\AA', 'A')
     for c in ['%', '_', '$', '&',  '\\', '^', '{', '}',]:
         s = s.replace(c, '')
-    s = s.replace(u'\u00c5', 'A')
     return s
 
 
@@ -125,7 +125,7 @@ def _finalizeprofileE(axes):
     """Set axes for const E axes."""
     if axes.get_xscale() == 'linear':
         axes.set_xlim(xmin=0.)
-    axes.set_xlabel(u'$Q$ (\u00c5$^{-1}$)')
+    axes.set_xlabel(r'$Q$ ($\mathrm{\AA}^{-1}$)')
     if axes.get_yscale() == 'linear':
         axes.set_ylim(0.)
 
@@ -544,9 +544,9 @@ def plotconstQ(workspaces, Q, dQ, style='l', keepCutWorkspaces=True, xscale='lin
     for ws in workspaces:
         if ws.getAxis(axisIndex).getUnit().unitID() != qID:
             raise RuntimeError("Cannot cut in const Q. The workspace '{}' is not in units of momentum transfer.".format(str(ws)))
-    figure, axes, cutWSList = plotcuts(direction, workspaces, Q, dQ, r'$Q$', u'\u00c5$^{-1}$', style, keepCutWorkspaces,
+    figure, axes, cutWSList = plotcuts(direction, workspaces, Q, dQ, r'$Q$', r'$\mathrm{\AA}^{-1}$', style, keepCutWorkspaces,
                                        xscale, yscale)
-    _profiletitle(workspaces, cutWSList, r'$Q$', u'\u00c5$^{-1}$', axes)
+    _profiletitle(workspaces, cutWSList, r'$Q$', r'$\mathrm{\AA}^{-1}$', axes)
     if len(cutWSList) > 1:
         axes.legend()
     _finalizeprofileQ(workspaces, axes)
@@ -759,7 +759,7 @@ def plotSofQW(workspace, QMin=0., QMax=None, EMin=None, EMax=None, VMin=0., VMax
         yLimits = {'bottom': EMin}
         if EMax is not None:
             yLimits['top'] = EMax
-        xLabel = u'$Q$ (\u00c5$^{-1}$)'
+        xLabel = r'$Q$ ($\mathrm{\AA}^{-1}$)'
         yLabel = 'Energy (meV)'
     else:
         xLimits = {'left': EMin}
@@ -767,7 +767,7 @@ def plotSofQW(workspace, QMin=0., QMax=None, EMin=None, EMax=None, VMin=0., VMax
             xLimits['right'] = EMax
         yLimits = {'bottom': QMin, 'top': QMax}
         xLabel = 'Energy (meV)'
-        yLabel = u'$Q$ (\u00c5$^{-1}$)'
+        yLabel = r'$Q$ ($\mathrm{\AA}^{-1}$)'
     axes.set_xlim(**xLimits)
     axes.set_ylim(**yLimits)
     axes.set_xlabel(xLabel)

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -212,7 +212,7 @@ class DirectToolsTest(unittest.TestCase):
         }
         figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstE, **kwargs)
         hangles, labels = axes.get_legend_handles_labels()
-        self.assertEquals(labels, [u' $E$ = -1.00 $\\pm$ 0.57 meV', u' $E$ = -1.01 $\\pm$ 1.02 meV'])
+        self.assertEquals(labels, [r' $E$ = -1.00 $\pm$ 0.57 meV', u' $E$ = -1.01 $\pm$ 1.02 meV'])
 
     def test_plotconstQ_nonListArgsExecutes(self):
         kwargs = {
@@ -269,7 +269,8 @@ class DirectToolsTest(unittest.TestCase):
         }
         figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
         handles, labels = axes.get_legend_handles_labels()
-        self.assertEquals(labels, [u' $Q$ = 1.91 $\\pm$ 0.21 \xc5$^{-1}$', u' $Q$ = 1.91 $\\pm$ 0.41 \xc5$^{-1}$'])
+        self.assertEquals(labels, [r' $Q$ = 1.91 $\pm$ 0.21 $\mathrm{\AA}^{-1}$',
+                                   r' $Q$ = 1.91 $\pm$ 0.41 $\mathrm{\AA}^{-1}$'])
 
     def test_plotconstQ_titles(self):
         kwargs = {
@@ -390,7 +391,7 @@ class DirectToolsTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=1, UnitX='MomentumTransfer', StoreInADS=False)
         kwargs = {'workspaces': ws}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotprofiles, **kwargs)
-        self.assertEquals(axes.get_xlabel(), u'$Q$ (\u00c5$^{-1}$)')
+        self.assertEquals(axes.get_xlabel(), r'$Q$ ($\mathrm{\AA}^{-1}$)')
         self.assertEquals(axes.get_ylabel(), '$S(Q,E)$')
         numpy.testing.assert_equal(axes.get_lines()[0].get_data()[0], (xs[1:] + xs[:-1])/2)
         numpy.testing.assert_equal(axes.get_lines()[0].get_data()[1], ys)
@@ -413,8 +414,8 @@ class DirectToolsTest(unittest.TestCase):
         stw = ComputeIncoherentDOS(ws, StoreInADS=False)
         kwargs = {'workspaces': stw}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotDOS, **kwargs)
-        self.assertEquals(axes.get_xlabel(), u'Energy transfer ($meV$)')
-        self.assertEquals(axes.get_ylabel(), u'$g(E)$')
+        self.assertEquals(axes.get_xlabel(), 'Energy transfer ($meV$)')
+        self.assertEquals(axes.get_ylabel(), '$g(E)$')
 
     def test_plotDOS_PlotMultiple(self):
         ws = CreateSampleWorkspace(NumBanks=1, XUnit='DeltaE', XMin=-12., XMax=12., BinWidth=0.2, StoreInADS=False)
@@ -425,8 +426,8 @@ class DirectToolsTest(unittest.TestCase):
         stw = ComputeIncoherentDOS(ws)
         kwargs = {'workspaces': [stw, 'stw']}
         figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotDOS, **kwargs)
-        self.assertEquals(axes.get_xlabel(), u'Energy transfer ($meV$)')
-        self.assertEquals(axes.get_ylabel(), u'$g(E)$')
+        self.assertEquals(axes.get_xlabel(), 'Energy transfer ($meV$)')
+        self.assertEquals(axes.get_ylabel(), '$g(E)$')
 
     def test_plotSofQW(self):
         wsName = 'ws'

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -204,6 +204,16 @@ class DirectToolsTest(unittest.TestCase):
         self.assertEquals(axes.get_xscale(), 'log')
         self.assertEquals(axes.get_yscale(), 'log')
 
+    def test_plotconstE_legendLabels(self):
+        kwargs = {
+            'workspaces': self._sqw,
+            'E' : -1.,
+            'dE' : [0.5, 1.0],
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstE, **kwargs)
+        hangles, labels = axes.get_legend_handles_labels()
+        self.assertEquals(labels, [u' $E$ = -1.00 $\\pm$ 0.57 meV', u' $E$ = -1.01 $\\pm$ 1.02 meV'])
+
     def test_plotconstQ_nonListArgsExecutes(self):
         kwargs = {
             'workspaces': self._sqw,
@@ -250,6 +260,50 @@ class DirectToolsTest(unittest.TestCase):
         figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
         self.assertEquals(axes.get_xscale(), 'log')
         self.assertEquals(axes.get_yscale(), 'log')
+
+    def test_plotconstQ_legendLabels(self):
+        kwargs = {
+            'workspaces': self._sqw,
+            'Q' : 1.9,
+            'dQ' : [0.2, 0.4],
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
+        handles, labels = axes.get_legend_handles_labels()
+        self.assertEquals(labels, [u' $Q$ = 1.91 $\\pm$ 0.21 \xc5$^{-1}$', u' $Q$ = 1.91 $\\pm$ 0.41 \xc5$^{-1}$'])
+
+    def test_plotconstQ_titles(self):
+        kwargs = {
+            'workspaces': self._sqw,
+            'Q' : 1.9,
+            'dQ' : 0.2,
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
+        titleLines = axes.get_title().split('\n')
+        self.assertEquals(len(titleLines), 4)
+        kwargs = {
+            'workspaces': self._sqw,
+            'Q' : [0.9, 1.9],
+            'dQ' : 0.2,
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
+        titleLines = axes.get_title().split('\n')
+        self.assertEquals(len(titleLines), 3)
+        kwargs = {
+            'workspaces': [self._sqw, self._sqw],
+            'Q' : 0.9,
+            'dQ' : 0.2,
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
+        titleLines = axes.get_title().split('\n')
+        self.assertEquals(len(titleLines), 1)
+        kwargs = {
+            'workspaces': [self._sqw, self._sqw],
+            'Q' : [0.9, 1.9],
+            'dQ' : 0.2,
+        }
+        figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
+        titleLines = axes.get_title().split('\n')
+        self.assertEquals(len(titleLines), 1)
 
     def test_plotconstE_and_plotconstQ_plot_equal_value_at_crossing(self):
         Q = 2.512

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -296,7 +296,7 @@ class DirectToolsTest(unittest.TestCase):
         }
         figure, axes, cuts = testhelpers.assertRaisesNothing(self, directtools.plotconstQ, **kwargs)
         titleLines = axes.get_title().split('\n')
-        self.assertEquals(len(titleLines), 1)
+        self.assertEquals(len(titleLines), 2)
         kwargs = {
             'workspaces': [self._sqw, self._sqw],
             'Q' : [0.9, 1.9],

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -15,7 +15,7 @@ import directtools
 from mantid.api import mtd
 from mantid.simpleapi import (AddSampleLog, CloneWorkspace, ComputeIncoherentDOS, ConvertSpectrumAxis, CreateSampleWorkspace,
                               CreateWorkspace, DirectILLCollectData, DeleteWorkspace, DirectILLReduction, LoadILLTOF,
-                              MoveInstrumentComponent, SetInstrumentParameter)
+                              MoveInstrumentComponent, SetInstrumentParameter, Transpose)
 import numpy
 import numpy.testing
 import testhelpers
@@ -383,6 +383,16 @@ class DirectToolsTest(unittest.TestCase):
         kwargs = {'workspace': self._sqw}
         testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
 
+    def test_plotSofQW_transposed(self):
+        wsName = 'ws'
+        CloneWorkspace(self._sqw, OutputWorkspace=wsName)
+        Transpose(wsName, OutputWorkspace=wsName)
+        kwargs = {'workspace': wsName}
+        testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+        DeleteWorkspace(wsName)
+        kwargs = {'workspace': self._sqw}
+        testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+
     def test_subplots(self):
         testhelpers.assertRaisesNothing(self, directtools.subplots)
 
@@ -393,7 +403,8 @@ class DirectToolsTest(unittest.TestCase):
         ys[nPoints] = numpy.nan
         ys[2 * nPoints - 1] = numpy.nan
         vertAxis = numpy.array([-3, -1, 2, 4])
-        ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=3, VerticalAxisUnit='Degrees', VerticalAxisValues=vertAxis, StoreInADS=False)
+        ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=3, UnitX='MomentumTransfer',
+                             VerticalAxisUnit='Degrees', VerticalAxisValues=vertAxis, StoreInADS=False)
         qMin, qMax = directtools.validQ(ws, -2.5)
         self.assertEqual(qMin, xs[0])
         self.assertEqual(qMax, xs[-1])

--- a/scripts/test/directtools/DirectToolsTest.py
+++ b/scripts/test/directtools/DirectToolsTest.py
@@ -436,7 +436,10 @@ class DirectToolsTest(unittest.TestCase):
         testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
         DeleteWorkspace(wsName)
         kwargs = {'workspace': self._sqw}
-        testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+        figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+        self.assertEquals(len(figure.axes), 2)
+        colorbar_axes = figure.axes[-1]
+        self.assertEquals(colorbar_axes.get_ylabel(), r'$S(Q,E)$ (arb. units)')
 
     def test_plotSofQW_transposed(self):
         wsName = 'ws'
@@ -447,6 +450,20 @@ class DirectToolsTest(unittest.TestCase):
         DeleteWorkspace(wsName)
         kwargs = {'workspace': self._sqw}
         testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+
+    def test_plotSofQW_dynamicsusceptibility(self):
+        xs = numpy.array([-2, -1, 0, 1, 2])
+        ys = numpy.tile(numpy.array([1, 1, 1 ,1 , 1]), 10)
+        vertX = numpy.array([-4, -3, -2, -1, 0, 1, 2, 3, 4, 5])
+        ws = CreateWorkspace(DataX=xs, DataY=ys, NSpec=10, UnitX='MomentumTransfer', VerticalAxisUnit='DeltaE', VerticalAxisValues=vertX,
+                             StoreInADS=False)
+        wsOut = directtools.dynamicsusceptibility(ws, 100.)
+        kwargs = {'workspace': wsOut}
+        figure, axes = testhelpers.assertRaisesNothing(self, directtools.plotSofQW, **kwargs)
+        self.assertEquals(len(figure.axes), 2)
+        colorbar_axes = figure.axes[-1]
+        self.assertEquals(colorbar_axes.get_ylabel(), r"$\chi''(Q,E)$ (arb. units)")
+        self.assertEquals(axes.get_ylim()[0], 0.)
 
     def test_subplots(self):
         testhelpers.assertRaisesNothing(self, directtools.subplots)


### PR DESCRIPTION
This PR adds support to plot non-transposed S(Q,W) workspaces to `directtools.plotSofQW()`.

**Report to:** Björn Fåk/ILL.

**To test:**

The test data is available in the unit test data directory. Run the script below with both `'Transposing ON'` and `'Transposing OFF'` options:
```python
import directtools as dt

ws = DirectILLCollectData('ILL/IN4/084447')
sqw = DirectILLReduction(ws, Transposing='Transposing ON')
fig, ax = dt.plotSofQW(sqw)
fig.show()
```

Check that the axes, labels etc. are OK in both figures.

Fixes #24011.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
