### PR TITLE
Move qtpy import outside beamcentrefinder

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -16,6 +16,7 @@ from mantid import AnalysisDataService
 from mantid.api import (DataProcessorAlgorithm, MatrixWorkspaceProperty, AlgorithmFactory, PropertyMode, Progress)
 from mantid.kernel import (Direction, PropertyManagerProperty, StringListValidator, Logger)
 from mantid.simpleapi import CloneWorkspace, GroupWorkspaces
+from sans.algorithm_detail.beamcentrefinder_plotting import can_plot_beamcentrefinder
 from sans.algorithm_detail.crop_helper import get_component_name
 from sans.algorithm_detail.single_execution import perform_can_subtraction
 from sans.algorithm_detail.strip_end_nans_and_infs import strip_end_nans
@@ -26,25 +27,7 @@ from sans.common.general_functions import create_child_algorithm
 from sans.common.xml_parsing import get_named_elements_from_ipf_file
 from sans.state.state_base import create_deserialized_sans_state_from_property_manager
 
-PYQT4 = False
-IN_MANTIDPLOT = False
-WITHOUT_GUI = False
-try:
-    from qtpy import PYQT4
-except ImportError:
-    pass  # it is already false
-if PYQT4:
-    try:
-        import mantidplot
-        IN_MANTIDPLOT = True
-    except (Exception, Warning):
-        pass
-else:
-    try:
-        from mantidqt.plotting.functions import plot
-    except ImportError:
-        WITHOUT_GUI = True
-
+PYQT4, IN_MANTIDPLOT, WITHOUT_GUI = can_plot_beamcentrefinder()
 do_plotting = not PYQT4 or IN_MANTIDPLOT
 
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -16,7 +16,7 @@ from mantid import AnalysisDataService
 from mantid.api import (DataProcessorAlgorithm, MatrixWorkspaceProperty, AlgorithmFactory, PropertyMode, Progress)
 from mantid.kernel import (Direction, PropertyManagerProperty, StringListValidator, Logger)
 from mantid.simpleapi import CloneWorkspace, GroupWorkspaces
-from sans.algorithm_detail.beamcentrefinder_plotting import can_plot_beamcentrefinder
+from sans.algorithm_detail.beamcentrefinder_plotting import can_plot_beamcentrefinder, plot_workspace_quartiles
 from sans.algorithm_detail.crop_helper import get_component_name
 from sans.algorithm_detail.single_execution import perform_can_subtraction
 from sans.algorithm_detail.strip_end_nans_and_infs import strip_end_nans
@@ -26,9 +26,6 @@ from sans.common.file_information import get_instrument_paths_for_sans_file
 from sans.common.general_functions import create_child_algorithm
 from sans.common.xml_parsing import get_named_elements_from_ipf_file
 from sans.state.state_base import create_deserialized_sans_state_from_property_manager
-
-PYQT4, IN_MANTIDPLOT, WITHOUT_GUI = can_plot_beamcentrefinder()
-do_plotting = not PYQT4 or IN_MANTIDPLOT
 
 
 class SANSBeamCentreFinder(DataProcessorAlgorithm):
@@ -166,8 +163,11 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         residueTB = []
         centre_1_hold = x_start
         centre_2_hold = y_start
+
+        do_plotting = can_plot_beamcentrefinder()
+
         for j in range(0, max_iterations + 1):
-            if(j != 0):
+            if j != 0:
                 centre1 += position_1_step
                 centre2 += position_2_step
 
@@ -234,16 +234,12 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
     def _plot_workspaces(self, output_workspaces, sample_scatter):
         try:
             # Check for NaNs in workspaces
-            output_workspaces_matplotlib = self._validate_workspaces(output_workspaces)
+            self._validate_workspaces(output_workspaces)
         except ValueError as e:
             self.logger.notice("Stopping process: {}. Check radius limits.".format(str(e)))
             return True
         else:
-            if not PYQT4:
-                # matplotlib plotting can take a list of workspaces (not names)
-                self._plot_quartiles_matplotlib(output_workspaces_matplotlib, sample_scatter)
-            elif IN_MANTIDPLOT:
-                self._plot_quartiles(output_workspaces, sample_scatter)
+            plot_workspace_quartiles(output_workspaces, sample_scatter)
         return False
 
     def _rename_and_group_workspaces(self, index, output_workspaces):
@@ -260,29 +256,6 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
             AnalysisDataService.addOrReplace(MaskingQuadrant.to_string(key), sample_quartiles[key])
 
         return output_workspaces
-
-    def _plot_quartiles(self, output_workspaces, sample_scatter):
-        title = '{}_beam_centre_finder'.format(sample_scatter)
-        graph_handle = mantidplot.plotSpectrum(output_workspaces, 0)
-        graph_handle.activeLayer().logLogAxes()
-        graph_handle.activeLayer().setTitle(title)
-        graph_handle.setName(title)
-        return graph_handle
-
-    def _plot_quartiles_matplotlib(self, output_workspaces, sample_scatter):
-        title = '{}_beam_centre_finder'.format(sample_scatter)
-        ax_properties = {'xscale': 'log',
-                         'yscale': 'log'}
-
-        plot_kwargs = {"scalex": True,
-                       "scaley": True}
-
-        if not isinstance(output_workspaces, list):
-            output_workspaces = [output_workspaces]
-
-        if not WITHOUT_GUI:
-            plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
-                 plot_kwargs=plot_kwargs, window_title=title)
 
     @staticmethod
     def _validate_workspaces(workspaces):

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -5,25 +5,57 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 
+PYQT4 = False
+IN_MANTIDPLOT = False
+WITHOUT_GUI = False
+try:
+    from qtpy import PYQT4
+except ImportError:
+    pass  # it is already false
+if PYQT4:
+    try:
+        import mantidplot
+        IN_MANTIDPLOT = True
+    except (Exception, Warning):
+        pass
+else:
+    try:
+        from mantidqt.plotting.functions import plot
+    except ImportError:
+        WITHOUT_GUI = True
+
 
 def can_plot_beamcentrefinder():
-    PYQT4 = False
-    IN_MANTIDPLOT = False
-    WITHOUT_GUI = False
-    try:
-        from qtpy import PYQT4
-    except ImportError:
-        pass  # it is already false
-    if PYQT4:
-        try:
-            import mantidplot
-            IN_MANTIDPLOT = True
-        except (Exception, Warning):
-            pass
-    else:
-        try:
-            from mantidqt.plotting.functions import plot
-        except ImportError:
-            WITHOUT_GUI = True
+    return not PYQT4 or IN_MANTIDPLOT
 
-    return PYQT4, IN_MANTIDPLOT, WITHOUT_GUI
+
+def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
+    title = '{}_beam_centre_finder'.format(sample_scatter)
+    ax_properties = {'xscale': 'log',
+                     'yscale': 'log'}
+
+    plot_kwargs = {"scalex": True,
+                   "scaley": True}
+
+    if not isinstance(output_workspaces, list):
+        output_workspaces = [output_workspaces]
+
+    if not WITHOUT_GUI:
+        plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
+             plot_kwargs=plot_kwargs, window_title=title)
+
+
+def _plot_quartiles(output_workspaces, sample_scatter):
+    title = '{}_beam_centre_finder'.format(sample_scatter)
+    graph_handle = mantidplot.plotSpectrum(output_workspaces, 0)
+    graph_handle.activeLayer().logLogAxes()
+    graph_handle.activeLayer().setTitle(title)
+    graph_handle.setName(title)
+    return graph_handle
+
+
+def plot_workspace_quartiles(output_workspaces, sample_scatter):
+    if not PYQT4:
+        _plot_quartiles_matplotlib(output_workspaces, sample_scatter)
+    elif IN_MANTIDPLOT:
+        _plot_quartiles(output_workspaces, sample_scatter)

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -1,0 +1,29 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+
+
+def can_plot_beamcentrefinder():
+    PYQT4 = False
+    IN_MANTIDPLOT = False
+    WITHOUT_GUI = False
+    try:
+        from qtpy import PYQT4
+    except ImportError:
+        pass  # it is already false
+    if PYQT4:
+        try:
+            import mantidplot
+            IN_MANTIDPLOT = True
+        except (Exception, Warning):
+            pass
+    else:
+        try:
+            from mantidqt.plotting.functions import plot
+        except ImportError:
+            WITHOUT_GUI = True
+
+    return PYQT4, IN_MANTIDPLOT, WITHOUT_GUI

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -4,29 +4,27 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+import sys
 
-PYQT4 = False
+PYQT5 = False
 IN_MANTIDPLOT = False
-WITHOUT_GUI = False
+
 try:
-    from qtpy import PYQT4
-except ImportError:
-    pass  # it is already false
-if PYQT4:
-    try:
-        import mantidplot
-        IN_MANTIDPLOT = True
-    except (Exception, Warning):
-        pass
+    import mantidplot
+    IN_MANTIDPLOT = True
+except (Exception, Warning):
+    pass
 else:
-    try:
-        from mantidqt.plotting.functions import plot
-    except ImportError:
-        WITHOUT_GUI = True
+    if "workbench.app.mainwindow" in sys.modules:
+        PYQT5 = True
+        try:
+            from mantidqt.plotting.functions import plot
+        except ImportError:
+            pass
 
 
 def can_plot_beamcentrefinder():
-    return not PYQT4 or IN_MANTIDPLOT
+    return PYQT5 or IN_MANTIDPLOT
 
 
 def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
@@ -40,9 +38,8 @@ def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
     if not isinstance(output_workspaces, list):
         output_workspaces = [output_workspaces]
 
-    if not WITHOUT_GUI:
-        plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
-             plot_kwargs=plot_kwargs, window_title=title)
+    plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
+         plot_kwargs=plot_kwargs, window_title=title)
 
 
 def _plot_quartiles(output_workspaces, sample_scatter):
@@ -55,7 +52,7 @@ def _plot_quartiles(output_workspaces, sample_scatter):
 
 
 def plot_workspace_quartiles(output_workspaces, sample_scatter):
-    if not PYQT4:
+    if PYQT5:
         _plot_quartiles_matplotlib(output_workspaces, sample_scatter)
     elif IN_MANTIDPLOT:
         _plot_quartiles(output_workspaces, sample_scatter)


### PR DESCRIPTION
**Description of work.**
Moves qtpy import and plotting functionality outside the SANSBeamCentreFinder algorithm.

**To test:**
1. Open workbench
2. Interfaces -> SANS -> ISIS SANS
3. Load the attached user file and batch file (ISIS data archive required)
4. In the beam centre tab and click `run`
5. After a few seconds a plot should appear. This will change as the next iteration of the algorithm completes
6. Close workbench and do the same in mantidplot. The plots will look different, but everything should work the same in general

*There is no associated issue.*

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
