### PR TITLE
include `workbench` in conda-recipe-update

### DIFF
--- a/buildconfig/CMake/conda_update_recipe.py.in
+++ b/buildconfig/CMake/conda_update_recipe.py.in
@@ -39,7 +39,7 @@ def update_meta_yaml(repo_path, recipe_path=None):
 
 def commit(repo_path):
     # commit
-    cmd = 'git commit -m "update version and git_rev" framework/meta.yaml'
+    cmd = 'git commit -m "update version and git_rev" .'
     sp.check_call(shlex.split(cmd), cwd=repo_path)
     return
 
@@ -54,7 +54,11 @@ def push(repo_path):
 def main():
     repo_path = 'conda-recipes'
     checkout(repo_path)
-    if update_meta_yaml(repo_path):
+    pkgs = ['framework', 'workbench']
+    updated = False
+    for pkg in pkgs:
+        updated = updated or update_meta_yaml(repo_path, pkg)
+    if updated:
         commit(repo_path)
         push(repo_path)
     return


### PR DESCRIPTION
**Description of work.**

Improve buildconfig/CMake/conda-update-recipe.py.in so that it includes `workbench` in updates. 
(In mantid Jenkins, the conda-recipe-update script is generated by http://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-rhel7/ and executed by  http://builds.mantidproject.org/view/Master%20Pipeline/job/master_condarecipes_update/)

**To test locally:**
Fresh cmake

```
$ cd /path/to/BUILD
$ cmake -DENABLE_CONDA=TRUE -DENABLE_MANTIDPLOT=FALSE /path/to/SRC
```

Then make

```
$ make conda-update-recipe
```
If an update is available, the conda recipes (SHA in meta.yaml files) at https://github.com/mantidproject/conda-recipes will be updated.

*There is no associated issue.*

No release notes necessary. Just an update of Jenkins build


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
