### PR TITLE
Indirect Analysis - Enable Plot options after saving only when the workspace is plottable

### DIFF
--- a/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitOutputOptionsModel.h
@@ -30,6 +30,8 @@ public:
 
   virtual void removePDFWorkspace() = 0;
 
+  virtual bool
+  isSelectedGroupPlottable(std::string const &selectedGroup) const = 0;
   virtual bool isResultGroupPlottable() const = 0;
   virtual bool isPDFGroupPlottable() const = 0;
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -201,7 +201,7 @@
          <enum>Qt::LeftToRight</enum>
         </property>
         <property name="text">
-         <string>Mode:</string>
+         <string>Grouping:</string>
         </property>
         <property name="buddy">
          <cstring>cbGroupingOptions</cstring>

--- a/qt/scientific_interfaces/Indirect/IndirectBayesTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectBayesTab.cpp
@@ -13,9 +13,6 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-//----------------------------------------------------------------------------------------------
-/** Constructor
- */
 IndirectBayesTab::IndirectBayesTab(QWidget *parent)
     : IndirectTab(parent), m_propTree(new QtTreePropertyBrowser()) {
   m_propTree->setFactoryForManager(m_dblManager, m_dblEdFac);
@@ -25,9 +22,6 @@ IndirectBayesTab::IndirectBayesTab(QWidget *parent)
           SLOT(updateProperties(QtProperty *, double)));
 }
 
-//----------------------------------------------------------------------------------------------
-/** Destructor
- */
 IndirectBayesTab::~IndirectBayesTab() {}
 
 /**
@@ -39,5 +33,22 @@ IndirectBayesTab::~IndirectBayesTab() {}
 void IndirectBayesTab::runPythonScript(const QString &pyInput) {
   emit runAsPythonScript(pyInput, true);
 }
+
+/**
+ * Format the tree widget so its easier to read the contents. It changes the
+ * background colour and item indentation.
+ *
+ * @param treeWidget :: The tree widget to format
+ * @param properties :: The properties within the tree widget
+ */
+void IndirectBayesTab::formatTreeWidget(
+    QtTreePropertyBrowser *treeWidget,
+    QMap<QString, QtProperty *> const &properties) const {
+  treeWidget->setIndentation(0);
+  for (auto const &item : properties)
+    treeWidget->setBackgroundColor(treeWidget->topLevelItem(item),
+                                   QColor(246, 246, 246));
+}
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectBayesTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectBayesTab.h
@@ -75,6 +75,9 @@ protected slots:
 protected:
   /// Function to run a string as python code
   void runPythonScript(const QString &pyInput);
+  /// Formats the tree widget to make it easier to read
+  void formatTreeWidget(QtTreePropertyBrowser *treeWidget,
+                        QMap<QString, QtProperty *> const &properties) const;
   /// Tree of the properties
   QtTreePropertyBrowser *m_propTree;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -998,7 +998,7 @@ void IndirectFitAnalysisTab::enableOutputOptions(bool enable) {
     m_outOptionsPresenter->setMultiWorkspaceOptionsVisible(enable);
 
   m_outOptionsPresenter->setPlotEnabled(
-      enable && m_outOptionsPresenter->isResultGroupPlottable());
+      enable && m_outOptionsPresenter->isSelectedGroupPlottable());
   m_outOptionsPresenter->setEditResultEnabled(enable);
   m_outOptionsPresenter->setSaveEnabled(enable);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.cpp
@@ -211,6 +211,12 @@ WorkspaceGroup_sptr IndirectFitOutputOptionsModel::getPDFWorkspace() const {
 
 void IndirectFitOutputOptionsModel::removePDFWorkspace() { m_pdfGroup.reset(); }
 
+bool IndirectFitOutputOptionsModel::isSelectedGroupPlottable(
+    std::string const &selectedGroup) const {
+  return isResultGroupSelected(selectedGroup) ? isResultGroupPlottable()
+                                              : isPDFGroupPlottable();
+}
+
 bool IndirectFitOutputOptionsModel::isResultGroupPlottable() const {
   if (m_resultGroup)
     return containsPlottableWorkspace(m_resultGroup);

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsModel.h
@@ -35,6 +35,8 @@ public:
 
   void removePDFWorkspace() override;
 
+  bool
+  isSelectedGroupPlottable(std::string const &selectedGroup) const override;
   bool isResultGroupPlottable() const override;
   bool isPDFGroupPlottable() const override;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.cpp
@@ -51,8 +51,7 @@ void IndirectFitOutputOptionsPresenter::setAvailablePlotOptions(
   auto const resultSelected = m_model->isResultGroupSelected(selectedGroup);
   setPlotTypes(selectedGroup);
   m_view->setWorkspaceComboBoxVisible(!resultSelected);
-  m_view->setPlotEnabled(resultSelected ? isResultGroupPlottable()
-                                        : isPDFGroupPlottable());
+  m_view->setPlotEnabled(isSelectedGroupPlottable());
 }
 
 void IndirectFitOutputOptionsPresenter::setResultWorkspace(
@@ -116,12 +115,8 @@ void IndirectFitOutputOptionsPresenter::saveResult() {
   setSaving(false);
 }
 
-bool IndirectFitOutputOptionsPresenter::isResultGroupPlottable() {
-  return m_model->isResultGroupPlottable();
-}
-
-bool IndirectFitOutputOptionsPresenter::isPDFGroupPlottable() {
-  return m_model->isPDFGroupPlottable();
+bool IndirectFitOutputOptionsPresenter::isSelectedGroupPlottable() const {
+  return m_model->isSelectedGroupPlottable(m_view->getSelectedGroupWorkspace());
 }
 
 void IndirectFitOutputOptionsPresenter::setPlotting(bool plotting) {
@@ -140,7 +135,7 @@ void IndirectFitOutputOptionsPresenter::setSaving(bool saving) {
 }
 
 void IndirectFitOutputOptionsPresenter::setPlotEnabled(bool enable) {
-  m_view->setPlotEnabled(enable);
+  m_view->setPlotEnabled(enable && isSelectedGroupPlottable());
 }
 
 void IndirectFitOutputOptionsPresenter::setEditResultEnabled(bool enable) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutputOptionsPresenter.h
@@ -37,8 +37,7 @@ public:
 
   void removePDFWorkspace();
 
-  bool isResultGroupPlottable();
-  bool isPDFGroupPlottable();
+  bool isSelectedGroupPlottable() const;
 
   void setPlotting(bool plotting);
   void setPlotEnabled(bool enable);

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -207,6 +207,12 @@ void Iqt::setup() {
 
   m_iqtTree->setFactoryForManager(m_dblManager, m_dblEdFac);
 
+  // Format the tree widget so its easier to read the contents
+  m_iqtTree->setIndentation(0);
+  for (auto const &item : m_properties)
+    m_iqtTree->setBackgroundColor(m_iqtTree->topLevelItem(item),
+                                  QColor(246, 246, 246));
+
   auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
 
   // signals / slots & validators

--- a/qt/scientific_interfaces/Indirect/Quasi.cpp
+++ b/qt/scientific_interfaces/Indirect/Quasi.cpp
@@ -40,6 +40,8 @@ Quasi::Quasi(QWidget *parent) : IndirectBayesTab(parent), m_previewSpec(0) {
   m_propTree->addProperty(m_properties["SampleBinning"]);
   m_propTree->addProperty(m_properties["ResBinning"]);
 
+  formatTreeWidget(m_propTree, m_properties);
+
   // Set default values
   m_dblManager->setValue(m_properties["SampleBinning"], 1);
   m_dblManager->setMinimum(m_properties["SampleBinning"], 1);

--- a/qt/scientific_interfaces/Indirect/ResNorm.cpp
+++ b/qt/scientific_interfaces/Indirect/ResNorm.cpp
@@ -58,6 +58,8 @@ ResNorm::ResNorm(QWidget *parent) : IndirectBayesTab(parent), m_previewSpec(0) {
   m_propTree->addProperty(m_properties["EMin"]);
   m_propTree->addProperty(m_properties["EMax"]);
 
+  formatTreeWidget(m_propTree, m_properties);
+
   // Connect data selector to handler method
   connect(m_uiForm.dsVanadium, SIGNAL(dataReady(const QString &)), this,
           SLOT(handleVanadiumInputReady(const QString &)));

--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -65,6 +65,8 @@ Stretch::Stretch(QWidget *parent)
   m_propTree->addProperty(m_properties["Sigma"]);
   m_propTree->addProperty(m_properties["Beta"]);
 
+  formatTreeWidget(m_propTree, m_properties);
+
   // default values
   m_dblManager->setValue(m_properties["Sigma"], 50);
   m_dblManager->setMinimum(m_properties["Sigma"], 1);

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsModelTest.h
@@ -260,6 +260,17 @@ public:
   }
 
   void
+  test_that_isSelectedGroupSelected_returns_true_when_passed_the_result_group_string_with_a_result_group_set() {
+    m_model->setResultWorkspace(m_groupWorkspace);
+    TS_ASSERT(m_model->isSelectedGroupPlottable("Result Group"));
+  }
+
+  void
+  test_that_isSelectedGroupSelected_returns_false_when_passed_the_pdf_group_string_when_a_pdf_group_is_not_set() {
+    TS_ASSERT(!m_model->isSelectedGroupPlottable("PDF Group"));
+  }
+
+  void
   test_that_isResultGroupSelected_returns_true_when_passed_the_result_group_string() {
     TS_ASSERT(m_model->isResultGroupSelected("Result Group"));
   }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputOptionsPresenterTest.h
@@ -89,6 +89,8 @@ public:
 
   MOCK_METHOD0(removePDFWorkspace, void());
 
+  MOCK_CONST_METHOD1(isSelectedGroupPlottable,
+                     bool(std::string const &selectedGroup));
   MOCK_CONST_METHOD0(isResultGroupPlottable, bool());
   MOCK_CONST_METHOD0(isPDFGroupPlottable, bool());
 
@@ -191,12 +193,12 @@ public:
     std::string const selectedGroup("Result Group");
     auto const isPlottable(true);
 
-    ON_CALL(*m_model, isResultGroupSelected(selectedGroup))
-        .WillByDefault(Return(true));
-    ON_CALL(*m_model, isResultGroupPlottable())
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
         .WillByDefault(Return(isPlottable));
 
-    EXPECT_CALL(*m_model, isResultGroupPlottable())
+    EXPECT_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
         .Times(1)
         .WillOnce(Return(isPlottable));
     EXPECT_CALL(*m_view, setPlotEnabled(isPlottable)).Times(1);
@@ -209,11 +211,14 @@ public:
     std::string const selectedGroup("PDF Group");
     auto const isPlottable(true);
 
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
     ON_CALL(*m_model, isResultGroupSelected(selectedGroup))
         .WillByDefault(Return(false));
-    ON_CALL(*m_model, isPDFGroupPlottable()).WillByDefault(Return(isPlottable));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
+        .WillByDefault(Return(isPlottable));
 
-    EXPECT_CALL(*m_model, isPDFGroupPlottable())
+    EXPECT_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
         .Times(1)
         .WillOnce(Return(isPlottable));
     EXPECT_CALL(*m_view, setPlotEnabled(isPlottable)).Times(1);
@@ -288,6 +293,13 @@ public:
 
   void
   test_that_the_saveClicked_signal_will_try_to_disable_and_then_enable_the_save_and_plot_buttons() {
+    auto const selectedGroup("Result Group");
+
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
+        .WillByDefault(Return(true));
+
     ExpectationSet buttonEnabling =
         EXPECT_CALL(*m_view, setSaveText(QString("Saving..."))).Times(1);
     buttonEnabling += EXPECT_CALL(*m_view, setPlotEnabled(false)).Times(1);
@@ -373,15 +385,14 @@ public:
   }
 
   void
-  test_that_isResultGroupPlottable_will_invoke_isResultGroupPlottable_in_the_model() {
-    EXPECT_CALL(*m_model, isResultGroupPlottable()).Times(1);
-    m_presenter->isResultGroupPlottable();
-  }
+  test_that_isSelectedGroupPlottable_will_invoke_isSelectedGroupPlottable_in_the_model() {
+    std::string const selectedGroup("Result Group");
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
 
-  void
-  test_that_isPDFGroupPlottable_will_invoke_isPDFGroupPlottable_in_the_model() {
-    EXPECT_CALL(*m_model, isPDFGroupPlottable()).Times(1);
-    m_presenter->isPDFGroupPlottable();
+    EXPECT_CALL(*m_model, isSelectedGroupPlottable(selectedGroup)).Times(1);
+
+    m_presenter->isSelectedGroupPlottable();
   }
 
   void
@@ -399,6 +410,12 @@ public:
   void
   test_that_setPlotting_will_attempt_to_set_the_plot_button_text_and_enable_all_buttons_when_passed_false() {
     auto const isPlotting(false);
+    auto const selectedGroup("Result Group");
+
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
+        .WillByDefault(Return(true));
 
     EXPECT_CALL(*m_view, setPlotText(QString("Plot"))).Times(1);
     EXPECT_CALL(*m_view, setPlotEnabled(!isPlotting)).Times(1);
@@ -409,7 +426,25 @@ public:
   }
 
   void test_that_setPlotEnabled_will_invoke_setPlotEnabled_in_the_view() {
+    auto const selectedGroup("Result Group");
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
+        .WillByDefault(Return(true));
+
     EXPECT_CALL(*m_view, setPlotEnabled(true)).Times(1);
+    m_presenter->setPlotEnabled(true);
+  }
+
+  void
+  test_that_setPlotEnabled_will_disable_the_plot_options_if_the_selected_workspace_is_not_plottable() {
+    auto const selectedGroup("Result Group");
+    ON_CALL(*m_view, getSelectedGroupWorkspace())
+        .WillByDefault(Return(selectedGroup));
+    ON_CALL(*m_model, isSelectedGroupPlottable(selectedGroup))
+        .WillByDefault(Return(false));
+
+    EXPECT_CALL(*m_view, setPlotEnabled(false)).Times(1);
     m_presenter->setPlotEnabled(true);
   }
 


### PR DESCRIPTION
**Description of work.**
This PR ensures the plot options in indirect Data analysis are kept disabled after saving when the workspace stored only has one data point to plot.

It also changes the colour of the property trees in Iqt and Bayes so they are easier to read.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`ConvFit`
2. Load data below
3. `One Lorentzian` as fit type
4. Click `Run`. The plot options should be enabled.
5. Click `Fit Single Spectrum`. The plot options should be disabled.
6. Click `Save Result`. The plot options should remain disabled.

**Data Files**
Sample:
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3058278/irs26176_graphite002_red.zip)
Resolution:
[irs26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/3058283/irs26173_graphite002_res.zip)

No release notes are required as this is a small fix which likely won't be noticed

Fixes #25486

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
