### PR TITLE
Normalised fit composite members output

### DIFF
--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <numeric>
 
 namespace Mantid {
 namespace CurveFitting {
@@ -436,13 +437,11 @@ FitMW::createOutputWorkspace(const std::string &baseName,
 
   if (m_normalise && m_matrixWorkspace->isHistogramData()) {
     const auto &X = mws.x(0);
-    auto &Ycal = mws.mutableY(1);
-    auto &Diff = mws.mutableY(2);
-    const size_t nData = values->size();
-    for (size_t i = 0; i < nData; ++i) {
-      double binWidth = X[i + 1] - X[i];
-      Ycal[i] *= binWidth;
-      Diff[i] *= binWidth;
+    std::vector<double> binWidths(X.size());
+    std::adjacent_difference(X.begin(), X.end(), binWidths.begin());
+    for (size_t ispec = 1; ispec < mws.getNumberHistograms(); ++ispec) {
+      auto &Y = mws.mutableY(ispec);
+      std::transform(binWidths.begin() + 1, binWidths.end(), Y.begin(), Y.begin(), std::multiplies<double>());
     }
   }
   return ws;

--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -441,7 +441,8 @@ FitMW::createOutputWorkspace(const std::string &baseName,
     std::adjacent_difference(X.begin(), X.end(), binWidths.begin());
     for (size_t ispec = 1; ispec < mws.getNumberHistograms(); ++ispec) {
       auto &Y = mws.mutableY(ispec);
-      std::transform(binWidths.begin() + 1, binWidths.end(), Y.begin(), Y.begin(), std::multiplies<double>());
+      std::transform(binWidths.begin() + 1, binWidths.end(), Y.begin(),
+                     Y.begin(), std::multiplies<double>());
     }
   }
   return ws;

--- a/Framework/CurveFitting/test/FitMWTest.h
+++ b/Framework/CurveFitting/test/FitMWTest.h
@@ -1301,16 +1301,19 @@ public:
 
   void test_normalised_composite_member_output() {
     auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(
-      [](double x, int) { return 0.1 + exp(-0.5*pow(x/0.5, 2)); }, 1, -2.0, 2.0, 0.2, true);
+        [](double x, int) { return 0.1 + exp(-0.5 * pow(x / 0.5, 2)); }, 1,
+        -2.0, 2.0, 0.2, true);
     Fit fit;
     fit.initialize();
-    fit.setProperty("Function", "name=FlatBackground;name=Gaussian,Height=1,Sigma=0.5");
+    fit.setProperty("Function",
+                    "name=FlatBackground;name=Gaussian,Height=1,Sigma=0.5");
     fit.setProperty("InputWorkspace", ws);
     fit.setProperty("Output", "out");
     fit.setProperty("OutputCompositeMembers", true);
     fit.setProperty("Normalise", true);
     fit.execute();
-    auto out_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out_Workspace");
+    auto out_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+        "out_Workspace");
     auto const &y1 = out_ws->readY(1);
     auto const &y3 = out_ws->readY(3);
     auto const &y4 = out_ws->readY(4);
@@ -1319,7 +1322,6 @@ public:
     }
     AnalysisDataService::Instance().clear();
   }
-
 };
 
 class FitMWTestPerformance : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/test/FitMWTest.h
+++ b/Framework/CurveFitting/test/FitMWTest.h
@@ -1298,6 +1298,28 @@ public:
     TS_ASSERT_EQUALS(values->getFitWeight(9), 1);
     TS_ASSERT_EQUALS(values->getFitWeight(10), 1);
   }
+
+  void test_normalised_composite_member_output() {
+    auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(
+      [](double x, int) { return 0.1 + exp(-0.5*pow(x/0.5, 2)); }, 1, -2.0, 2.0, 0.2, true);
+    Fit fit;
+    fit.initialize();
+    fit.setProperty("Function", "name=FlatBackground;name=Gaussian,Height=1,Sigma=0.5");
+    fit.setProperty("InputWorkspace", ws);
+    fit.setProperty("Output", "out");
+    fit.setProperty("OutputCompositeMembers", true);
+    fit.setProperty("Normalise", true);
+    fit.execute();
+    auto out_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out_Workspace");
+    auto const &y0 = out_ws->readY(0);
+    auto const &y3 = out_ws->readY(3);
+    auto const &y4 = out_ws->readY(4);
+    for (size_t i = 0; i < y0.size(); ++i) {
+      TS_ASSERT_DELTA(y0[i], y3[i] + y4[i], 1e-10);
+    }
+    AnalysisDataService::Instance().clear();
+  }
+
 };
 
 class FitMWTestPerformance : public CxxTest::TestSuite {

--- a/Framework/CurveFitting/test/FitMWTest.h
+++ b/Framework/CurveFitting/test/FitMWTest.h
@@ -1311,11 +1311,11 @@ public:
     fit.setProperty("Normalise", true);
     fit.execute();
     auto out_ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("out_Workspace");
-    auto const &y0 = out_ws->readY(0);
+    auto const &y1 = out_ws->readY(1);
     auto const &y3 = out_ws->readY(3);
     auto const &y4 = out_ws->readY(4);
-    for (size_t i = 0; i < y0.size(); ++i) {
-      TS_ASSERT_DELTA(y0[i], y3[i] + y4[i], 1e-10);
+    for (size_t i = 0; i < y1.size(); ++i) {
+      TS_ASSERT_DELTA(y1[i], y3[i] + y4[i], 1e-10);
     }
     AnalysisDataService::Instance().clear();
   }


### PR DESCRIPTION
**Description of work.**
Scale all output spectra according to input workspace's normalisation.

**Report to:** Rob Dalgliesh

**To test:**
Run the script from the issue description. Check that all output spectra have sensible values.

Fixes #25446

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
