### PR TITLE
Return script editor exit code when workbench called with -xq

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -602,21 +602,32 @@ def start_workbench(app, command_line_options):
     main_window.set_splash('Initializing mantid framework')
     FrameworkManagerImpl.Instance()
     main_window.post_mantid_init()
-    main_window.show()
-    main_window.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
 
     if main_window.splash:
         main_window.splash.hide()
 
+    sys.path.append("c:\\users\\qbr77747\\apps\\miniconda3\\lib\\site-packages")
+    import pydevd
+    pydevd.settrace('localhost', port=44445, stdoutToServer=True, stderrToServer=True)
+
     if command_line_options.script is not None:
         main_window.editor.open_file_in_new_tab(command_line_options.script)
+        editor_task = None
         if command_line_options.execute:
-            main_window.editor.execute_current_async()  # TODO use the result as an exit code
+            # if the quit flag is not specified, this task reference will be
+            # GC'ed, and the task will be finished alongside the GUI startup
+            editor_task = main_window.editor.execute_current_async()
 
         if command_line_options.quit:
-            main_window.close()
-            return 0
+            # wait for the code interpreter thread to finish executing the script
+            editor_task.join()
 
+            main_window.close()
+            # for task exit code descriptions see the classes AsyncTask and TaskExitCode
+            return int(editor_task.exit_code) if editor_task else 0
+
+    main_window.show()
+    main_window.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
     # Project Recovey on startup
     main_window.project_recovery.repair_checkpoints()
     if main_window.project_recovery.check_for_recover_checkpoint():

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -606,10 +606,6 @@ def start_workbench(app, command_line_options):
     if main_window.splash:
         main_window.splash.hide()
 
-    sys.path.append("c:\\users\\qbr77747\\apps\\miniconda3\\lib\\site-packages")
-    import pydevd
-    pydevd.settrace('localhost', port=44445, stdoutToServer=True, stderrToServer=True)
-
     if command_line_options.script is not None:
         main_window.editor.open_file_in_new_tab(command_line_options.script)
         editor_task = None
@@ -621,8 +617,8 @@ def start_workbench(app, command_line_options):
         if command_line_options.quit:
             # wait for the code interpreter thread to finish executing the script
             editor_task.join()
-
             main_window.close()
+
             # for task exit code descriptions see the classes AsyncTask and TaskExitCode
             return int(editor_task.exit_code) if editor_task else 0
 

--- a/qt/python/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/utils/asynchronous.py
@@ -24,6 +24,7 @@ class TaskExitCode(Enum):
     ERROR = 1
     SYNTAX_ERROR = 2
 
+
 class AsyncTask(threading.Thread):
     def __init__(self, target, args=(), kwargs=None,
                  success_cb=None, error_cb=None,

--- a/qt/python/mantidqt/utils/test/test_async.py
+++ b/qt/python/mantidqt/utils/test/test_async.py
@@ -108,7 +108,7 @@ class AsyncTaskTest(unittest.TestCase):
 
         self.assertEqual(2, len(recv.task_exc_stack))
         # line number of self.target in asynchronous.py
-        self.assertEqual(50, recv.task_exc_stack[0][1])
+        self.assertEqual(65, recv.task_exc_stack[0][1])
         # line number of raise statement above
         self.assertEqual(95, recv.task_exc_stack[1][1])
 

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -180,7 +180,7 @@ class PythonFileInterpreter(QWidget):
         self._presenter.req_abort()
 
     def execute_async(self, ignore_selection=False):
-        self._presenter.req_execute_async(ignore_selection)
+        return self._presenter.req_execute_async(ignore_selection)
 
     def execute_async_blocking(self):
         self._presenter.req_execute_async_blocking()
@@ -301,7 +301,7 @@ class PythonFileInterpreterPresenter(QObject):
             self.view.set_status_message(ABORTED_STATUS_MSG)
 
     def req_execute_async(self, ignore_selection):
-        self._req_execute_impl(blocking=False, ignore_selection=ignore_selection)
+        return self._req_execute_impl(blocking=False, ignore_selection=ignore_selection)
 
     def req_execute_async_blocking(self):
         self._req_execute_impl(blocking=True)

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -175,7 +175,7 @@ class MultiPythonFileInterpreter(QWidget):
         Execute content of the current file. If a selection is active
         then only this portion of code is executed, this is completed asynchronously
         """
-        self.current_editor().execute_async()
+        return self.current_editor().execute_async()
 
     def execute_async(self):
         """
@@ -183,7 +183,7 @@ class MultiPythonFileInterpreter(QWidget):
         Selection is ignored.
         This is completed asynchronously.
         """
-        self.current_editor().execute_async(ignore_selection=True)
+        return self.current_editor().execute_async(ignore_selection=True)
 
     @Slot()
     def execute_current_async_blocking(self):


### PR DESCRIPTION
**Description of work.**
Added field to `AsyncTask` to store the exit code, depending on the code path of `AsyncTask.run()`. Currently supports: OK (0), ERROR (1), SYNTAX_ERROR (2).

If the `-xq` (`--execute` and `--quit`) flags are specified, the editor task is waited to finish, the main window close event ran, and the exit code returned.

**To test:**
Run `workbench.exe -xq some_file`. Contents for testing:
- `print('working example')` - should give OK (0)
- `raise NotImplementedError()` - should give ERROR (1)
- `print('syntax err` - should give SYNTAX_ERROR (2)

Getting last exit code:
- Bash
- PowerShell

Fixes #24818

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
