### PR TITLE
Always attempt to kill Xvfb in Jenkins jobs

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -10,18 +10,45 @@
 # PARAVIEW_DIR should be set in the configuration of each slave.
 ###############################################################################
 SCRIPT_DIR=$(dirname "$0")
+XVFB_SERVER_NUM=101
+ULIMIT_CORE_ORIG=$(ulimit -c)
+
+if [ $(command -v xvfb-run) ]; then
+  X11_RUNNER="xvfb-run"
+  X11_RUNNER_ARGS1=--server-args="-screen 0 640x480x24"
+  X11_RUNNER_ARGS2=--server-num=${XVFB_SERVER_NUM}
+else
+  X11_RUNNER="eval"
+  X11_RUNNER_ARGS1=""
+  X11_RUNNER_ARGS2=""
+fi
+
+###############################################################################
+# Functions
+###############################################################################
+
+function onexit {
+  if [[ ${USE_CORE_DUMPS} == true ]]; then
+    ulimit -c $ULIMIT_CORE_ORIG
+  fi
+}
+
+function run_with_xvfb {
+  ${X11_RUNNER} "${X11_RUNNER_ARGS1}" "${X11_RUNNER_ARGS2}" $@
+}
+
 
 ###############################################################################
 # Terminate existing Xvfb sessions
 ###############################################################################
-if [[ -n ${CLEAN_XVFB} && "${CLEAN_XVFB}" == true ]] && [ $(command -v xvfb-run) ]; then
+if [ $(command -v xvfb-run) ]; then
   echo "Terminating existing Xvfb sessions"
 
   # Kill Xvfb processes
   killall Xvfb || true
 
   # Remove Xvfb X server lock files
-  rm -f /tmp/.X*-lock
+  rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
 fi
 
 ###############################################################################
@@ -40,29 +67,12 @@ fi
 ###############################################################################
 # Script cleanup
 ###############################################################################
-ULIMIT_CORE_ORIG=$(ulimit -c)
-function onexit {
-  if [[ ${USE_CORE_DUMPS} == true ]]; then
-    ulimit -c $ULIMIT_CORE_ORIG
-  fi
-}
 trap onexit INT TERM EXIT
 
 ###############################################################################
 # All nodes currently have PARAVIEW_DIR and PARAVIEW_NEXT_DIR set
 ###############################################################################
 export PARAVIEW_DIR=${PARAVIEW_DIR}
-
-###############################################################################
-# Wraps calls for gui emulation
-###############################################################################
-if [ $(command -v xvfb-run) ]; then
-  X11_RUNNER="xvfb-run"
-  X11_RUNNER_ARGS=--server-args="-screen 0 640x480x24"
-else
-  X11_RUNNER="eval"
-  X11_RUNNER_ARGS=""
-fi
 
 ###############################################################################
 # Print out the versions of things we are using
@@ -378,7 +388,7 @@ userprops_file=$userconfig_dir/Mantid.user.properties
 echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
-  ${X11_RUNNER} "${X11_RUNNER_ARGS}" $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+  run_with_xvfb $CTEST_EXE -j${BUILD_THREADS:?} --schedule-random --output-on-failure
 fi
 
 ###############################################################################
@@ -393,8 +403,8 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
     rm -fr $BUILD_DIR/docs/doctrees/*
   fi
   # Build HTML to verify that no referencing errors have crept in.
-  ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-html
-  ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-test
+  run_with_xvfb ${CMAKE_EXE} --build . --target docs-html
+  run_with_xvfb ${CMAKE_EXE} --build . --target docs-test
 fi
 
 ###############################################################################
@@ -413,7 +423,7 @@ fi
 # documentation
 ###############################################################################
 if [[ ${DO_BUILD_PKG} == true ]]; then
-  ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-qthelp
+  run_with_xvfb ${CMAKE_EXE} --build . --target docs-qthelp
   ${CPACK_EXE}
 
   # Source tarball on clean build (arbitrarily choose rhel7)
@@ -421,7 +431,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
   # and labelled by the commit id it was built with. This assumes the Jenkins git plugin
   # has set the GIT_COMMIT environment variable
   if [[ ${CLEANBUILD} == true && ${ON_RHEL7} == true ]]; then
-    ${X11_RUNNER} "${X11_RUNNER_ARGS}" ${CMAKE_EXE} --build . --target docs-html
+    run_with_xvfb ${CMAKE_EXE} --build . --target docs-html
     tar -cjf mantiddocs-g${GIT_COMMIT:0:7}.tar.bz2 --exclude='*.buildinfo' --exclude="MantidProject.q*" docs/html
     # The ..._PREFIX argument avoids opt/Mantid directories at the top of the tree
     ${CPACK_EXE} --config CPackSourceConfig.cmake -D CPACK_PACKAGING_INSTALL_PREFIX=


### PR DESCRIPTION
**Description of work.**

If Jenkins jobs are cancelled then xvfb is unable to start on the next job. This attempts to kill the existing processes and remove the locks at the start of every run.

**To test:**

Code review.

*This does not require release notes* because **it is buildsystem change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
