### PR TITLE
No longer clears the tracked algorithm on any Algorithm end

### DIFF
--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressModel.cpp
@@ -82,7 +82,7 @@ void AlgorithmProgressModel::errorHandle(const Mantid::API::IAlgorithm *alg,
 /// @param alg The algorithm that has to be removed from the presenters
 void AlgorithmProgressModel::removeFrom(const Mantid::API::IAlgorithm *alg) {
   this->stopObserving(alg);
-  m_mainWindowPresenter->algorithmEnded(nullptr);
+  m_mainWindowPresenter->algorithmEnded(alg->getAlgorithmID());
   if (m_dialogPresenter) {
     m_dialogPresenter->algorithmEnded(alg->getAlgorithmID());
   }

--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenter.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressPresenter.cpp
@@ -27,8 +27,10 @@ void AlgorithmProgressPresenter::algorithmStartedSlot(
 
 void AlgorithmProgressPresenter::algorithmEndedSlot(
     Mantid::API::AlgorithmID alg) {
-  m_algorithm = alg;
-  m_view->algorithmEnded();
+  if (alg == this->m_algorithm) {
+    m_algorithm = nullptr;
+    m_view->algorithmEnded();
+  }
 }
 
 /// This slot is triggered whenever an algorithm reports progress.


### PR DESCRIPTION
**Description of work.**

Previously the AlgorithmProgressPresenter would clear the tracked
AlgorithmID pointer on any Algorithm ending, this meant that child
algorithms would clear their parent's pointer.

This change adds a check to see if the algorithm ending is
the one being tracked, this way child algorithms that are not
tracked, do not clear anything.



**To test:**
Issue discovered in https://github.com/mantidproject/mantid/pull/25504, run the script from there and the progress bar should mostly show progress from the EnggFocus algorithm. Without this change the progress bar mostly shows "Idle.".

Pasted script from mentioned issue:

```python
import os.path as osp
import Engineering.EnginX as Enginx
Enginx.main("236516", "auto-reduce", "299080",directory=osp.expanduser("~/.mantid/enginxtest/"))
```
Note: this might take a few minutes, and will save out files at `"~/.mantid/enginxtest/"`. I am not sure if an error is shown if the directory does not exist.

Fixes #25509

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
