### PR TITLE
Indirect Data Analysis - Adjustable plot sizes

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -32,6 +32,8 @@ Improvements
 ############
 - Improved the output options of MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit so that Chi_squared can now be plotted.
 - Improved the I(Q, t) tab by adding more validation checks for the input data.
+- Improved the Fit and Difference plots in MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit. It is now possible to adjust their
+  relative sizes by dragging a 'handle' between the plots.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
@@ -217,8 +217,6 @@ background: transparent;
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../resources/icons/SliceViewerIcons.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
@@ -32,10 +32,7 @@
       <string>Mini-plots</string>
      </property>
      <widget class="QWidget" name="dockWidgetContents_2">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="spacing">
-        <number>0</number>
-       </property>
+      <layout class="QGridLayout" name="gridLayout">
        <property name="leftMargin">
         <number>0</number>
        </property>
@@ -48,56 +45,64 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <item>
-        <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlotTop" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>10</verstretch>
-          </sizepolicy>
+       <item row="0" column="0">
+        <widget class="QSplitter" name="splitter">
+         <property name="styleSheet">
+          <string notr="true">QSplitter::handle {
+background: transparent;
+}</string>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>125</height>
-          </size>
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <property name="showLegend" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="canvasColour" stdset="0">
-          <color>
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlotBottom" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>6</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>75</height>
-          </size>
-         </property>
-         <property name="showLegend" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="canvasColour" stdset="0">
-          <color>
-           <red>255</red>
-           <green>255</green>
-           <blue>255</blue>
-          </color>
-         </property>
+         <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlotTop" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>10</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>125</height>
+           </size>
+          </property>
+          <property name="showLegend" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="canvasColour" stdset="0">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+         </widget>
+         <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlotBottom" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>6</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>75</height>
+           </size>
+          </property>
+          <property name="showLegend" stdset="0">
+           <bool>true</bool>
+          </property>
+          <property name="canvasColour" stdset="0">
+           <color>
+            <red>255</red>
+            <green>255</green>
+            <blue>255</blue>
+           </color>
+          </property>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
@@ -217,6 +217,8 @@ background: transparent;
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../resources/icons/SliceViewerIcons.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
**Description of work.**
This PR allows you to adjust the sizes of the Fit and Difference plots in MSDFit, IqtFit, ConvFit and JumpFit. Their sizes can be adjusted by dragging the handle of the QSplitter layout.

The decision to make the handle transparent was made as it makes the interface look less cluttered.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`ConvFit` tab (or one of the other tabs listed above)
2. Find the handle of the QSplitter (between the two plots) and then drag it up or down to adjust the plot sizes.
3. The Plots should also be collapsible by dragging the slider all the way up or all the way down.

Fixes #25520

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
