### PR TITLE
Indirect Reduction - Group output option

### DIFF
--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -129,6 +129,9 @@ Run
 Plot Output
   Allows the result to be plotted as either a spectrum plot or contour plot.
 
+Group Output
+  This will place the output reduced files from a reduction into a group workspace.
+
 Fold Multiple Frames
   This option is only relevant for TOSCA. If checked, then multiple-framed data
   will be folded back into a single spectra, if unchecked the frames will be

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -57,6 +57,10 @@ Bug Fixes
 Data Reduction Interface
 ------------------------
 
+Improvements
+############
+- Added an option called *Group Output* to group the output files from a reduction on ISISEnergyTransfer.
+
 Bug Fixes
 #########
 - Fixed a bug in the :ref:`Integration <algm-Integration>` algorithm causing the Moments tab to crash.

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -398,8 +398,15 @@ void ISISEnergyTransfer::run() {
     reductionAlg->setProperty("GroupingString", grouping.second);
 
   reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
-  reductionAlg->setProperty("OutputWorkspace",
-                            "IndirectEnergyTransfer_Workspaces");
+
+  std::transform(grouping.first.begin(), grouping.first.end(),
+                 grouping.first.begin(), std::tolower);
+  m_outputGroupName = instName.toLower().toStdString() +
+                      m_uiForm.dsRunFiles->getText().toStdString() + "_" +
+                      getAnalyserName().toStdString() +
+                      getReflectionName().toStdString() + "_" + grouping.first +
+                      "_Reduced";
+  reductionAlg->setProperty("OutputWorkspace", m_outputGroupName);
 
   m_batchAlgoRunner->addAlgorithm(reductionAlg, reductionRuntimeProps);
 
@@ -421,10 +428,8 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
              SLOT(algorithmComplete(bool)));
 
-  auto const outputName("IndirectEnergyTransfer_Workspaces");
-
-  if (!error && doesExistInADS(outputName)) {
-    if (auto const outputGroup = getADSWorkspaceGroup(outputName)) {
+  if (!error && doesExistInADS(m_outputGroupName)) {
+    if (auto const outputGroup = getADSWorkspaceGroup(m_outputGroupName)) {
       m_outputWorkspaces = outputGroup->getNames();
       m_pythonExportWsName = m_outputWorkspaces[0];
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -399,13 +399,10 @@ void ISISEnergyTransfer::run() {
 
   reductionAlg->setProperty("FoldMultipleFrames", m_uiForm.ckFold->isChecked());
 
-  std::transform(grouping.first.begin(), grouping.first.end(),
-                 grouping.first.begin(), std::tolower);
   m_outputGroupName = instName.toLower().toStdString() +
                       m_uiForm.dsRunFiles->getText().toStdString() + "_" +
                       getAnalyserName().toStdString() +
-                      getReflectionName().toStdString() + "_" + grouping.first +
-                      "_Reduced";
+                      getReflectionName().toStdString() + "_Reduced";
   reductionAlg->setProperty("OutputWorkspace", m_outputGroupName);
 
   m_batchAlgoRunner->addAlgorithm(reductionAlg, reductionRuntimeProps);
@@ -451,17 +448,13 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
 }
 
 int ISISEnergyTransfer::getGroupingOptionIndex(QString const &option) {
-  for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
-    if (m_uiForm.cbGroupingOptions->itemText(i) == option)
-      return i;
-  return 0;
+  auto const index = m_uiForm.cbGroupingOptions->findText(option);
+  return index >= 0 ? index : 0;
 }
 
 bool ISISEnergyTransfer::isOptionHidden(QString const &option) {
-  for (auto i = 0; i < m_uiForm.cbGroupingOptions->count(); ++i)
-    if (m_uiForm.cbGroupingOptions->itemText(i) == option)
-      return false;
-  return true;
+  auto const index = m_uiForm.cbGroupingOptions->findText(option);
+  return index == -1;
 }
 
 void ISISEnergyTransfer::setCurrentGroupingOption(QString const &option) {

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -428,7 +428,8 @@ void ISISEnergyTransfer::algorithmComplete(bool error) {
       m_outputWorkspaces = outputGroup->getNames();
       m_pythonExportWsName = m_outputWorkspaces[0];
 
-      ungroupWorkspace(outputGroup->getName());
+      if (!m_uiForm.ckGroupOutput->isChecked())
+        ungroupWorkspace(outputGroup->getName());
 
       // Enable plotting and saving
       m_uiForm.pbPlot->setEnabled(true);

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -70,14 +70,11 @@ private:
                                      QMap<QString, QString> const &instDetails,
                                      QString const &instrumentProperty);
 
-  Ui::ISISEnergyTransfer m_uiForm;
-
   std::pair<std::string, std::string> createMapFile(
       const std::string
           &groupType); ///< create the mapping file with which to group results
   std::vector<std::string> getSaveFormats(); ///< get a vector of save formats
-  std::vector<std::string>
-      m_outputWorkspaces; ///< get a vector of workspaces to plot
+
   bool numberInCorrectRange(std::size_t const &spectraNumber) const;
   QString checkCustomGroupingNumbersInRange(
       std::vector<std::size_t> const &customGroupingNumbers) const;
@@ -90,6 +87,10 @@ private:
   void setSaveEnabled(bool enable);
   void setPlotIsPlotting(bool plotting);
   void setPlotTimeIsPlotting(bool plotting);
+
+  std::string m_outputGroupName;
+  std::vector<std::string> m_outputWorkspaces;
+  Ui::ISISEnergyTransfer m_uiForm;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -1075,6 +1075,13 @@
          </spacer>
         </item>
         <item>
+         <widget class="QCheckBox" name="ckGroupOutput">
+          <property name="text">
+           <string>Group Output</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="ckFold">
           <property name="enabled">
            <bool>true</bool>


### PR DESCRIPTION
**Description of work.**
This PR allows you to group the output workspaces from a reduction on ISISEnergyTransfer. This is done by ticking the `Group Output` checkbox.

**To test:**
1. `Interfaces`->`Indirect`->`Data Reduction`->`ISISEnergyTransfer` tab
2. Select the `TOSCA` instrument
3. Run numbers `22841-22843` (make sure search data archive is switched on)
4. Tick `Group Output` (in the Output Options at the bottom of the interface)
5. Click `Run` and wait.

The output reduced files should be in a group workspace with name `tosca22841-22843_graphite002_Reduced`.

Fixes #25526

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
