### PR TITLE
Indirect Iqt - Asymmetric energy range

### DIFF
--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -305,6 +305,9 @@ SampleBinning
 Symmetric Energy Range
   Untick to allow an asymmetric energy range.
 
+Spectrum
+  Changes the spectrum displayed in the preview plot.
+
 Plot Current Preview
   Plots the currently selected preview plot in a separate external window
 

--- a/docs/source/interfaces/Indirect Data Analysis.rst
+++ b/docs/source/interfaces/Indirect Data Analysis.rst
@@ -302,6 +302,9 @@ ELow, EHigh
 SampleBinning
   The number of neighbouring bins are summed.
 
+Symmetric Energy Range
+  Untick to allow an asymmetric energy range.
+
 Plot Current Preview
   Plots the currently selected preview plot in a separate external window
 

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -34,6 +34,7 @@ Improvements
 - Improved the I(Q, t) tab by adding more validation checks for the input data.
 - Improved the Fit and Difference plots in MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit. It is now possible to adjust their
   relative sizes by dragging a 'handle' between the plots.
+- Improved the I(Q,T) tab by allowing an asymmetric energy range.
 
 Bug Fixes
 #########

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -34,7 +34,7 @@ Improvements
 - Improved the I(Q, t) tab by adding more validation checks for the input data.
 - Improved the Fit and Difference plots in MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit. It is now possible to adjust their
   relative sizes by dragging a 'handle' between the plots.
-- Improved the I(Q,T) tab by allowing an asymmetric energy range.
+- Improved the I(Q,T) tab by allowing an asymmetric energy range by unticking 'Symmetric Energy Range'.
 
 Bug Fixes
 #########

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -34,7 +34,8 @@ Improvements
 - Improved the I(Q, t) tab by adding more validation checks for the input data.
 - Improved the Fit and Difference plots in MSD Fit, Iqt Fit, Conv Fit and F(Q)Fit. It is now possible to adjust their
   relative sizes by dragging a 'handle' between the plots.
-- Improved the I(Q,T) tab by allowing an asymmetric energy range by unticking 'Symmetric Energy Range'.
+- Improved the I(Q, t) tab by allowing an asymmetric energy range by unticking 'Symmetric Energy Range'.
+- Improved the I(Q, t) tab by adding the ability to change the plotted spectrum using the 'Spectrum' spin box.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectSpectrumSelector.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSpectrumSelector.ui
@@ -16,6 +16,9 @@
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
     <widget class="QLabel" name="lbSelectionMode">
+     <property name="toolTip">
+      <string>Choose the spectra you want to fit.</string>
+     </property>
      <property name="text">
       <string>Fit Spectra</string>
      </property>
@@ -23,6 +26,9 @@
    </item>
    <item>
     <widget class="QComboBox" name="cbSelectionMode">
+     <property name="toolTip">
+      <string>Choose Range to select a continuous range of spectra. Choose String to specify a discontinuous collection of spectra (e.g. 0-3, 6, 8-10).</string>
+     </property>
      <item>
       <property name="text">
        <string>Range</string>

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -456,10 +456,23 @@ void Iqt::updatePropertyValues(QtProperty *prop, double val) {
   disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
              SLOT(updatePropertyValues(QtProperty *, double)));
 
-  if (prop == m_properties["EHigh"] && val < 0)
-    m_dblManager->setValue(m_properties["EHigh"], -val);
-  else if (prop == m_properties["ELow"] && val > 0)
-    m_dblManager->setValue(m_properties["ELow"], -val);
+  if (prop == m_properties["EHigh"]) {
+    if (val < 0) {
+      val = -val;
+      m_dblManager->setValue(m_properties["EHigh"], val);
+    }
+
+    if (m_uiForm.ckSymmetricEnergy->isChecked())
+      m_dblManager->setValue(m_properties["ELow"], -val);
+  } else if (prop == m_properties["ELow"]) {
+    if (val > 0) {
+      val = -val;
+      m_dblManager->setValue(m_properties["ELow"], val);
+    }
+
+    if (m_uiForm.ckSymmetricEnergy->isChecked())
+      m_dblManager->setValue(m_properties["EHigh"], -val);
+  }
 
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(updatePropertyValues(QtProperty *, double)));

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -213,6 +213,8 @@ void Iqt::setup() {
     m_iqtTree->setBackgroundColor(m_iqtTree->topLevelItem(item),
                                   QColor(246, 246, 246));
 
+  setPreviewSpectrumMaximum(0);
+
   auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
 
   // signals / slots & validators

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -246,6 +246,9 @@ void Iqt::setup() {
           SLOT(setSelectedSpectrum(int)));
   connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this,
           SLOT(plotInput()));
+
+  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this,
+          SLOT(updateEnergyRange(int)));
 }
 
 void Iqt::run() {
@@ -637,6 +640,13 @@ void Iqt::updateRS(QtProperty *prop, double val) {
     xRangeSelector->setMinimum(val);
   else if (prop == m_properties["EHigh"])
     xRangeSelector->setMaximum(val);
+}
+
+void Iqt::updateEnergyRange(int state) {
+  if (state != 0) {
+    auto const value = m_dblManager->value(m_properties["ELow"]);
+    m_dblManager->setValue(m_properties["EHigh"], -value);
+  }
 }
 
 void Iqt::setTiledPlotFirstPlot(int value) {

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -447,7 +447,7 @@ bool Iqt::validate() {
 }
 
 /**
- * Ensures that absolute min and max energy are equal.
+ * Ensures that the min energy is below zero and the max energy is above zero
  *
  * @param prop Qt property that was changed
  * @param val New value of that property
@@ -456,24 +456,10 @@ void Iqt::updatePropertyValues(QtProperty *prop, double val) {
   disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
              SLOT(updatePropertyValues(QtProperty *, double)));
 
-  if (prop == m_properties["EHigh"]) {
-    // If the user enters a negative value for EHigh assume they did not mean to
-    // add a -
-    if (val < 0) {
-      val = -val;
-      m_dblManager->setValue(m_properties["EHigh"], val);
-    }
-
-    m_dblManager->setValue(m_properties["ELow"], -val);
-  } else if (prop == m_properties["ELow"]) {
-    // If the user enters a positive value for ELow, assume they meant to add a
-    if (val > 0) {
-      val = -val;
-      m_dblManager->setValue(m_properties["ELow"], val);
-    }
-
+  if (prop == m_properties["EHigh"] && val < 0)
     m_dblManager->setValue(m_properties["EHigh"], -val);
-  }
+  else if (prop == m_properties["ELow"] && val > 0)
+    m_dblManager->setValue(m_properties["ELow"], -val);
 
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(updatePropertyValues(QtProperty *, double)));
@@ -602,7 +588,7 @@ void Iqt::plotInput(const QString &wsname) {
  * Updates the range selectors and properties when range selector is moved.
  *
  * @param min Range selector min value
- * @param max Range selector amx value
+ * @param max Range selector max value
  */
 void Iqt::rsRangeChangedLazy(double min, double max) {
   double oldMin = m_dblManager->value(m_properties["ELow"]);

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -67,6 +67,7 @@ private slots:
   void plotClicked();
   void errorsClicked();
   void plotTiled();
+  void updateEnergyRange(int state);
 
 private:
   void setPreviewSpectrumMaximum(int value);

--- a/qt/scientific_interfaces/Indirect/Iqt.h
+++ b/qt/scientific_interfaces/Indirect/Iqt.h
@@ -54,6 +54,7 @@ private:
 
 private slots:
   void algorithmComplete(bool error);
+  void plotInput();
   void plotInput(const QString &wsname);
   void rsRangeChangedLazy(double min, double max);
   void updateRS(QtProperty *prop, double val);
@@ -68,6 +69,8 @@ private slots:
   void plotTiled();
 
 private:
+  void setPreviewSpectrumMaximum(int value);
+
   Ui::Iqt m_uiForm;
   QtTreePropertyBrowser *m_iqtTree;
   bool m_iqtResFileType;

--- a/qt/scientific_interfaces/Indirect/Iqt.ui
+++ b/qt/scientific_interfaces/Indirect/Iqt.ui
@@ -119,7 +119,67 @@
       <layout class="QVBoxLayout" name="properties"/>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" stretch="5,0,3">
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="0,5,3">
+       <item>
+        <widget class="QFrame" name="frame_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <property name="leftMargin">
+           <number>30</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="ckSymmetricEnergy">
+            <property name="maximumSize">
+             <size>
+              <width>140</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Untick to allow an asymmetric energy range.</string>
+            </property>
+            <property name="text">
+             <string>Symmetric Energy Range</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="lbSpectrum">
+            <property name="text">
+             <string>Spectrum:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="spPreviewSpec"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item>
         <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlot" native="true">
          <property name="sizePolicy">
@@ -144,56 +204,6 @@
          <property name="showLegend" stdset="0">
           <bool>true</bool>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QFrame" name="frame_2">
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <item>
-           <spacer name="horizontalSpacer_7">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="ckSymmetricEnergy">
-            <property name="maximumSize">
-             <size>
-              <width>140</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="toolTip">
-             <string>Untick to allow an asymmetric energy range.</string>
-            </property>
-            <property name="text">
-             <string>Symmetric Energy Range</string>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </widget>
        </item>
        <item>

--- a/qt/scientific_interfaces/Indirect/Iqt.ui
+++ b/qt/scientific_interfaces/Indirect/Iqt.ui
@@ -114,12 +114,12 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="loFury">
+    <layout class="QHBoxLayout" name="loFury" stretch="1,1">
      <item>
       <layout class="QVBoxLayout" name="properties"/>
      </item>
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout" stretch="5,3">
+      <layout class="QVBoxLayout" name="verticalLayout" stretch="5,0,3">
        <item>
         <widget class="MantidQt::MantidWidgets::PreviewPlot" name="ppPlot" native="true">
          <property name="sizePolicy">
@@ -144,6 +144,56 @@
          <property name="showLegend" stdset="0">
           <bool>true</bool>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QFrame" name="frame_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="ckSymmetricEnergy">
+            <property name="maximumSize">
+             <size>
+              <width>140</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="toolTip">
+             <string>Untick to allow an asymmetric energy range.</string>
+            </property>
+            <property name="text">
+             <string>Symmetric Energy Range</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>
@@ -231,6 +281,9 @@
          </property>
          <item>
           <widget class="QCheckBox" name="cbCalculateErrors">
+           <property name="toolTip">
+            <string>Untick to skip the calculation of errors.</string>
+           </property>
            <property name="text">
             <string>Calculate Errors</string>
            </property>
@@ -275,6 +328,9 @@
              <width>60</width>
              <height>26</height>
             </size>
+           </property>
+           <property name="toolTip">
+            <string>The number of iterations to use when calculating errors.</string>
            </property>
            <property name="minimum">
             <number>3</number>


### PR DESCRIPTION
**Description of work.**
This PR ensures that the Iqt tab of Indirect Data Analysis allows an asymmetric energy range. It also gives the option to change the spectrum displayed in the preview plot using a spin box.

**To test:**
1. `Interfaces`->`Indirect`->`Data Analysis`->`Iqt` tab
2. Load the data below
4. Untick `Symmetric Energy Range`
3. Attempt to change the energy range to that seen in the image below:
![image](https://user-images.githubusercontent.com/40830825/56220863-114f1380-6061-11e9-8e21-6e4216960f9c.png)
4. Click `Run`. If the run is successful, a workspace ending in `_iqt` should be produced.

**Spectrum Spin Box Test**
1. Make sure the data below is loaded.
2. Attempt to change the plotted spectrum using the `Spectrum` spin box. It should be able to go between 0 and 17.

**Data Files**
Sample:
[iris26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3085500/iris26176_graphite002_red.zip)
Resolution:
[iris26173_graphite002_res.zip](https://github.com/mantidproject/mantid/files/3085501/iris26173_graphite002_res.zip)

Fixes #25551

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
