### PR TITLE
Add unit tests for TimeSeriesProperty::cloneWithTimeShift

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -55,6 +55,8 @@ TimeSeriesProperty<TYPE>::cloneWithTimeShift(const double timeShift) const {
   auto times = timeSeriesProperty->timesAsVector();
   // Shift the time
   for (auto it = times.begin(); it != times.end(); ++it) {
+    // There is a known issue which can cause cloneWithTimeShift to be called with a large (~9e+9 s) shift.
+    // Actual shifting is capped to be ~4.6e+19 seconds in DateAndTime::operator+=
     (*it) += timeShift;
   }
   timeSeriesProperty->clear();

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -55,8 +55,9 @@ TimeSeriesProperty<TYPE>::cloneWithTimeShift(const double timeShift) const {
   auto times = timeSeriesProperty->timesAsVector();
   // Shift the time
   for (auto it = times.begin(); it != times.end(); ++it) {
-    // There is a known issue which can cause cloneWithTimeShift to be called with a large (~9e+9 s) shift.
-    // Actual shifting is capped to be ~4.6e+19 seconds in DateAndTime::operator+=
+    // There is a known issue which can cause cloneWithTimeShift to be called
+    // with a large (~9e+9 s) shift. Actual shifting is capped to be ~4.6e+19
+    // seconds in DateAndTime::operator+=
     (*it) += timeShift;
   }
   timeSeriesProperty->clear();

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -1345,6 +1345,38 @@ public:
     return;
   }
 
+    /*
+     * Test cloneWithTimeShift
+     */
+  void test_cloneWithTimeShift() {
+    TimeSeriesProperty<int> *time_series = new TimeSeriesProperty<int>("IntUnixTest");
+    time_series->addValue("2019-02-10T16:17:00", 1);
+
+    TimeSeriesProperty<int> *time_series_small_shift =
+            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(100.));
+    std::vector<DateAndTime> small_shift_times = time_series_small_shift->timesAsVector();
+    TS_ASSERT_EQUALS(small_shift_times[0], DateAndTime("2019-02-10T16:18:40"));
+
+    TimeSeriesProperty<int> *time_series_large_shift =
+            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(1234.));
+    std::vector<DateAndTime> large_shift_times = time_series_large_shift->timesAsVector();
+    TS_ASSERT_EQUALS(large_shift_times[0], DateAndTime("2019-02-10T16:37:34"));
+
+    TimeSeriesProperty<int> *time_series_negative_shift =
+            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(-1234.));
+    std::vector<DateAndTime> negative_shift_times = time_series_negative_shift->timesAsVector();
+    TS_ASSERT_EQUALS(negative_shift_times[0], DateAndTime("2019-02-10T15:56:26"));
+
+    // There is a known issue which can cause cloneWithTimeShift to be called with a large (~9e+9 s) shift.
+    // Actual shifting is capped to be ~4.6e+19 seconds in DateAndTime::operator+=
+    // Typical usage of this method is with shifts in the range tested here.
+
+    delete time_series;
+    delete time_series_small_shift;
+    delete time_series_large_shift;
+    delete time_series_negative_shift;
+  }
+
   /*
    * Test countSize()
    */

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -1345,31 +1345,40 @@ public:
     return;
   }
 
-    /*
-     * Test cloneWithTimeShift
-     */
+  /*
+   * Test cloneWithTimeShift
+   */
   void test_cloneWithTimeShift() {
-    TimeSeriesProperty<int> *time_series = new TimeSeriesProperty<int>("IntUnixTest");
+    TimeSeriesProperty<int> *time_series =
+        new TimeSeriesProperty<int>("IntUnixTest");
     time_series->addValue("2019-02-10T16:17:00", 1);
 
     TimeSeriesProperty<int> *time_series_small_shift =
-            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(100.));
-    std::vector<DateAndTime> small_shift_times = time_series_small_shift->timesAsVector();
+        dynamic_cast<TimeSeriesProperty<int> *>(
+            time_series->cloneWithTimeShift(100.));
+    std::vector<DateAndTime> small_shift_times =
+        time_series_small_shift->timesAsVector();
     TS_ASSERT_EQUALS(small_shift_times[0], DateAndTime("2019-02-10T16:18:40"));
 
     TimeSeriesProperty<int> *time_series_large_shift =
-            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(1234.));
-    std::vector<DateAndTime> large_shift_times = time_series_large_shift->timesAsVector();
+        dynamic_cast<TimeSeriesProperty<int> *>(
+            time_series->cloneWithTimeShift(1234.));
+    std::vector<DateAndTime> large_shift_times =
+        time_series_large_shift->timesAsVector();
     TS_ASSERT_EQUALS(large_shift_times[0], DateAndTime("2019-02-10T16:37:34"));
 
     TimeSeriesProperty<int> *time_series_negative_shift =
-            dynamic_cast<TimeSeriesProperty<int> *>(time_series->cloneWithTimeShift(-1234.));
-    std::vector<DateAndTime> negative_shift_times = time_series_negative_shift->timesAsVector();
-    TS_ASSERT_EQUALS(negative_shift_times[0], DateAndTime("2019-02-10T15:56:26"));
+        dynamic_cast<TimeSeriesProperty<int> *>(
+            time_series->cloneWithTimeShift(-1234.));
+    std::vector<DateAndTime> negative_shift_times =
+        time_series_negative_shift->timesAsVector();
+    TS_ASSERT_EQUALS(negative_shift_times[0],
+                     DateAndTime("2019-02-10T15:56:26"));
 
-    // There is a known issue which can cause cloneWithTimeShift to be called with a large (~9e+9 s) shift.
-    // Actual shifting is capped to be ~4.6e+19 seconds in DateAndTime::operator+=
-    // Typical usage of this method is with shifts in the range tested here.
+    // There is a known issue which can cause cloneWithTimeShift to be called
+    // with a large (~9e+9 s) shift. Actual shifting is capped to be ~4.6e+19
+    // seconds in DateAndTime::operator+= Typical usage of this method is with
+    // shifts in the range tested here.
 
     delete time_series;
     delete time_series_small_shift;

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -1349,28 +1349,22 @@ public:
    * Test cloneWithTimeShift
    */
   void test_cloneWithTimeShift() {
-    TimeSeriesProperty<int> *time_series =
-        new TimeSeriesProperty<int>("IntUnixTest");
+    auto time_series = std::make_unique<TimeSeriesProperty<int>>("IntUnixTest");
     time_series->addValue("2019-02-10T16:17:00", 1);
 
-    TimeSeriesProperty<int> *time_series_small_shift =
-        dynamic_cast<TimeSeriesProperty<int> *>(
-            time_series->cloneWithTimeShift(100.));
-    std::vector<DateAndTime> small_shift_times =
-        time_series_small_shift->timesAsVector();
+    auto time_series_small_shift = dynamic_cast<TimeSeriesProperty<int> *>(
+        time_series->cloneWithTimeShift(100.));
+    const auto &small_shift_times = time_series_small_shift->timesAsVector();
     TS_ASSERT_EQUALS(small_shift_times[0], DateAndTime("2019-02-10T16:18:40"));
 
-    TimeSeriesProperty<int> *time_series_large_shift =
-        dynamic_cast<TimeSeriesProperty<int> *>(
-            time_series->cloneWithTimeShift(1234.));
-    std::vector<DateAndTime> large_shift_times =
-        time_series_large_shift->timesAsVector();
+    auto time_series_large_shift = dynamic_cast<TimeSeriesProperty<int> *>(
+        time_series->cloneWithTimeShift(1234.));
+    const auto &large_shift_times = time_series_large_shift->timesAsVector();
     TS_ASSERT_EQUALS(large_shift_times[0], DateAndTime("2019-02-10T16:37:34"));
 
-    TimeSeriesProperty<int> *time_series_negative_shift =
-        dynamic_cast<TimeSeriesProperty<int> *>(
-            time_series->cloneWithTimeShift(-1234.));
-    std::vector<DateAndTime> negative_shift_times =
+    auto time_series_negative_shift = dynamic_cast<TimeSeriesProperty<int> *>(
+        time_series->cloneWithTimeShift(-1234.));
+    const auto &negative_shift_times =
         time_series_negative_shift->timesAsVector();
     TS_ASSERT_EQUALS(negative_shift_times[0],
                      DateAndTime("2019-02-10T15:56:26"));
@@ -1380,7 +1374,6 @@ public:
     // seconds in DateAndTime::operator+= Typical usage of this method is with
     // shifts in the range tested here.
 
-    delete time_series;
     delete time_series_small_shift;
     delete time_series_large_shift;
     delete time_series_negative_shift;


### PR DESCRIPTION
**Description of work.**
While investigating a bug caused by adding event workspaces containing erroneous pulse timestamps, it was necessary to test `TimeSeriesProperty::cloneWithTimeShift`.

As it turns out, there were no existing unit tests for this method. Now there are.

I've also included a note on the bug I was investigating, to avoid the next person wasting time looking there. (I originally thought it could have somehow been caused by shifting a time over unix time 0, however this is not the case)

**To test:**
Code review and check that `TimeSeriesPropertyTest` passes

*This does not require release notes* because **internal change to test code**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
