### PR TITLE
Buffered Kafka event decoder

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -546,6 +546,10 @@ public:
 
   void invalidateCachedSpectrumNumbers();
 
+  /// Invalidates the commons bins flag.  This is generally called when a method
+  /// could allow the X values to be changed.
+  void invalidateCommonBinsFlag() { m_isCommonBinsFlagValid.store(false); }
+
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
   MatrixWorkspace(const MatrixWorkspace &other);
@@ -560,10 +564,6 @@ protected:
   virtual void init(const HistogramData::Histogram &histogram) = 0;
 
   virtual ISpectrum &getSpectrumWithoutInvalidation(const size_t index) = 0;
-
-  /// Invalidates the commons bins flag.  This is generally called when a method
-  /// could allow the X values to be changed.
-  void invalidateCommonBinsFlag() { m_isCommonBinsFlagValid.store(false); }
 
   void updateCachedDetectorGrouping(const size_t index) const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventWorkspace.h
@@ -77,6 +77,7 @@ public:
     return getSpectrumWithoutInvalidation(index);
   }
   const EventList &getSpectrum(const size_t index) const override;
+  EventList *getSpectrumUnsafe(const size_t index);
 
   //------------------------------------------------------------
 

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -184,6 +184,21 @@ const EventList &EventWorkspace::getSpectrum(const size_t index) const {
   return *data[index];
 }
 
+/**
+ * Returns a pointer to the EventList for a given spectrum in a timely manner.
+ *
+ * Very minimal checking and preprocessing is performed by this function and it
+ * should only be used in tight loops where getSpectrum is too costly.
+ *
+ * See the implementation of the non-const getSpectrum to see what is missing.
+ *
+ * @param index Workspace index
+ * @return Pointer to EventList
+ */
+EventList *EventWorkspace::getSpectrumUnsafe(const size_t index) {
+  return data[index].get();
+}
+
 double EventWorkspace::getTofMin() const { return this->getEventXMin(); }
 
 double EventWorkspace::getTofMax() const { return this->getEventXMax(); }

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.h
@@ -137,7 +137,8 @@ protected:
   /// Subscriber for the data stream
   std::unique_ptr<IKafkaStreamSubscriber> m_dataStream;
   /// Mapping of spectrum number to workspace index.
-  spec2index_map m_specToIdx;
+  std::vector<size_t> m_specToIdx;
+  specnum_t m_specToIdxOffset;
   /// Start time of the run
   Types::Core::DateAndTime m_runStart;
   /// Subscriber for the run info stream

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
@@ -31,7 +31,7 @@ class KafkaEventStreamDecoder;
  */
 class DLLExport KafkaEventListener : public API::LiveListener {
 public:
-  KafkaEventListener() = default;
+  KafkaEventListener();
   ~KafkaEventListener() override = default;
 
   //----------------------------------------------------------------------

--- a/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
@@ -20,6 +20,12 @@ namespace LiveData {
 
 DECLARE_LISTENER(KafkaEventListener)
 
+KafkaEventListener::KafkaEventListener() : API::LiveListener() {
+  declareProperty("BufferThreshold", static_cast<uint64_t>(1000000),
+                  "Threshold number of events at which the intermediate event "
+                  "buffer will be flushed to the buffered EventWorkspace.");
+}
+
 void KafkaEventListener::setAlgorithm(
     const Mantid::API::IAlgorithm &callingAlgorithm) {
   this->updatePropertyValues(callingAlgorithm);
@@ -38,6 +44,8 @@ bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
     g_log.error(
         "KafkaEventListener::connect requires a non-empty instrument name");
   }
+
+  const std::size_t bufferThreshold = getProperty("BufferThreshold");
   auto broker = std::make_shared<KafkaBroker>(address.toString());
   try {
     const std::string eventTopic(m_instrumentName +
@@ -48,7 +56,8 @@ bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
         sampleEnvTopic(m_instrumentName +
                        KafkaTopicSubscriber::SAMPLE_ENV_TOPIC_SUFFIX);
     m_decoder = std::make_unique<KafkaEventStreamDecoder>(
-        broker, eventTopic, runInfoTopic, spDetInfoTopic, sampleEnvTopic);
+        broker, eventTopic, runInfoTopic, spDetInfoTopic, sampleEnvTopic,
+        bufferThreshold);
   } catch (std::exception &exc) {
     g_log.error() << "KafkaEventListener::connect - Connection Error: "
                   << exc.what() << "\n";

--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -118,7 +118,12 @@ KafkaEventStreamDecoder::KafkaEventStreamDecoder(
     const std::string &sampleEnvTopic, const std::size_t bufferThreshold)
     : IKafkaStreamDecoder(broker, eventTopic, runInfoTopic, spDetTopic,
                           sampleEnvTopic),
-      m_intermediateBufferFlushThreshold(bufferThreshold) {}
+      m_intermediateBufferFlushThreshold(bufferThreshold) {
+#ifndef _OPENMP
+  g_log.warning() << "Multithreading is not available on your system. This "
+                     "is likely to be an issue with high event counts.\n";
+#endif
+}
 
 /**
  * Destructor.

--- a/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaHistoStreamDecoder.cpp
@@ -251,7 +251,8 @@ void KafkaHistoStreamDecoder::initLocalCaches(
       new Kernel::TimeSeriesProperty<double>(PROTON_CHARGE_PROPERTY));
 
   // Cache spec->index mapping. We assume it is the same across all periods
-  m_specToIdx = histoBuffer->getSpectrumToWorkspaceIndexMap();
+  m_specToIdx =
+      histoBuffer->getSpectrumToWorkspaceIndexVector(m_specToIdxOffset);
 
   // Buffers for each period
   const size_t nperiods = runStartData.nPeriods;

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -934,12 +934,18 @@
   </instrument>
 
 </facility>
+
 <!--  ESS  -->
 <facility name="ESS" FileExtensions=".nxs,.hdf5">
- <timezone>Europe/Copenhagen</timezone>
+  <timezone>Europe/Copenhagen</timezone>
+
   <instrument name="LOKI">
     <technique>Small Angle Scattering</technique>
+    <livedata>
+      <connection name="test_event" address="localhost:9092" listener="KafkaEventListener" />
+    </livedata>
   </instrument>
+
 </facility>
 
 </facilities>


### PR DESCRIPTION
**Description of work.**

Implements an intermediate buffer in the Kafka event stream decoder that performs a grouped parallel insertion to the `EventWorkspace`.

Instead of received events (from the Kafka stream) being immediately inserted into an `EventWorkspace` they are instead stored in a buffer held by the decoder.
When this buffer is full (where full is a number of events set by the user) it is sorted to place events from the same detector in the same period adjacent to one another.
This locality is then used to allow those events to be inserted into the `EventWorkspace` in parallel (as division of the work across threads can guarantee no `EventList` is accessed on multiple threads).

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
