### PR TITLE
Avoiding lexical cast and locale issue when using getPropertyValueAsType<double>

### DIFF
--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -488,8 +488,11 @@ ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUnit,
       // try and get the value from the run parameters
       const API::Run &run = inputWS->run();
       if (run.hasProperty("Ei")) {
-        Kernel::Property *prop = run.getProperty("Ei");
-        efixedProp = boost::lexical_cast<double, std::string>(prop->value());
+        try {
+          efixedProp = run.getPropertyValueAsType<double>("Ei");
+        } catch (Kernel::Exception::NotFoundError &) {
+          throw std::runtime_error("Cannot retrieve Ei value from the logs");
+        }
       } else {
         if (needEfixed) {
           throw std::invalid_argument(

--- a/Framework/MDAlgorithms/src/ConvertToMDMinMaxGlobal.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToMDMinMaxGlobal.cpp
@@ -189,8 +189,7 @@ void ConvertToMDMinMaxGlobal::exec() {
                                PhysicalConstants::meV * 1e-20 /
                                (PhysicalConstants::h * PhysicalConstants::h);
       if (GeometryMode == "Direct") {
-        double Ei = boost::lexical_cast<double, std::string>(
-            ws->run().getProperty("Ei")->value());
+        const double Ei = ws->run().getPropertyValueAsType<double>("Ei");
         qmax =
             std::sqrt(energyToK * Ei) + std::sqrt(energyToK * (Ei - deltaEmin));
       } else // indirect

--- a/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
@@ -913,7 +913,8 @@ void DgsReduction::exec() {
     // Collect information
     std::string sqwWsName = outputWsName + "_pd_sqw";
     std::vector<double> qBinning = this->getProperty("PowderMomTransferRange");
-    const double initialEnergy = outputWS->run().getPropertyValueAsType<double>("Ei");
+    const double initialEnergy =
+        outputWS->run().getPropertyValueAsType<double>("Ei");
 
     IAlgorithm_sptr sofqw = this->createChildAlgorithm("SofQW3");
     sofqw->setProperty("InputWorkspace", outputWS);

--- a/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
+++ b/Framework/WorkflowAlgorithms/src/DgsReduction.cpp
@@ -913,8 +913,7 @@ void DgsReduction::exec() {
     // Collect information
     std::string sqwWsName = outputWsName + "_pd_sqw";
     std::vector<double> qBinning = this->getProperty("PowderMomTransferRange");
-    const double initialEnergy =
-        boost::lexical_cast<double>(outputWS->run().getProperty("Ei")->value());
+    const double initialEnergy = outputWS->run().getPropertyValueAsType<double>("Ei");
 
     IAlgorithm_sptr sofqw = this->createChildAlgorithm("SofQW3");
     sofqw->setProperty("InputWorkspace", outputWS);

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -25,6 +25,7 @@ Improvements
   Try :code:`ws_group[-1]` to get the last workspace in the WorkspaceGroup :code:`ws_group`.
 - :ref:`GenerateEventsFilter <algm-GenerateEventsFilter>` is able to accept any `MatrixWorkspace`, as long as it has run objects loaded from `LoadNexusLogs <algm-LoadNexusLogs>`, other than `EventWorkspace`.
 - :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` has a new property `ScatterFrom` which allows for calculating the correction for the other components (i.e. container and environment)
+- An error due to the locale issue may appear when reading the incident energy Ei value from the logs in :ref:`ConvertUnits <algm-ConvertUnits>`, :ref:`algm-DgsReduction`, and :ref:`algm-ConvertToMDMinMaxGlobal`.
 
 Removed
 #######


### PR DESCRIPTION
In `ConvertUnits`, `ConvertToMDMinMaxGlobal`, and `DgsReduction` a lexical cast of a string value to double was performed. This can be avoided. And then also does not mess up with different locale settings.

Code review should be sufficient. No new tests added, I think it is a code improvement.

Maybe release notes are needed since I could not build the documentation of the DirectILL*.

Fixes #25572.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
