### PR TITLE
Load to recognise NXCanSAS files

### DIFF
--- a/Framework/DataHandling/src/LoadNXcanSAS.cpp
+++ b/Framework/DataHandling/src/LoadNXcanSAS.cpp
@@ -405,7 +405,7 @@ bool findDefinition(::NeXus::File &file) {
   auto entries = file.getEntries();
 
   for (auto &entry : entries) {
-    if (entry.second == sasEntryClassAttr) {
+    if (entry.second == sasEntryClassAttr || entry.second == nxEntryClassAttr) {
       file.openGroup(entry.first, entry.second);
       file.openData(sasEntryDefinition);
       auto definitionFromFile = file.getStrData();

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -28,3 +28,4 @@ Bug Fixes
 - Fixed the error seen when saving to file with event slice data. Event slice output files now contain transmission workspaces.
 - Exporting table as a batch file is fixed for Mantid Workbench.
 - The warning message raised when you have supplied a transmission run without a direct run has been suppressed when data is still being input. The warning will still be raised if you load or process the data.
+- The algorithm :ref:`Load <algm-Load>` can now load NXcanSAS files.


### PR DESCRIPTION
**Description of work.**
The confidence calculation for LoadNXcanSAS algorithm has been changed so Load can correctly identify an NXcanSAS file

**Report to:** Steve King ISIS

**To test:**
In mantid, set your log level to debug and attempt to `Load` the attached file.
This should load, and looking at the logs you should see that LoadNXCanSAS was selected as the load algorithm

Fixes #25253 

**Data:**
[line_1_reduction.zip](https://github.com/mantidproject/mantid/files/3111913/line_1_reduction.zip)


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
