### PR TITLE
Prevent S(Q,E) being flagged as temporary

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -831,8 +831,9 @@ the first two hours"""
                     .format(self._nxspe_psi_angle_log)
                 self.log().error(error_message)
 
-        wsSqwName = prefix + '_divided_sqw' \
-            if isSample and self._doNorm else wsName + '_sqw'
+        wsSqwName = prefix if isSample is True else wsName
+        wsSqwName += '_divided_sqw' if self._doNorm is True else '_sqw'
+
         sapi.SofQW3(InputWorkspace=wsName,
                     QAxisBinning=self._qBins,
                     EMode='Indirect',


### PR DESCRIPTION
Work done:
- [x] Correct source

**To test:**
Run the following script in MantidPlot

```
BASISReduction(RunNumbers='90146',
               DoFluxNormalization=True,
               FluxNormalizationType='Monitor',
               ReflectionType='silicon_311',
               EnergyBins=[-330,0.4,330],
               MomentumTransferBins=[3.05,4.30,3.05],
               RemoveTemp=False)
```

Verify that all workspace names begin with `_t_` except for workspace `BSS_90146_sqw`. This indicates `BSS_90146_sqw` is the only non-temporary workspace.

Fixes #25586

This pull request does not require release notes because it deals with a bug in the nightly version, not in the latest stable release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
