### PR TITLE
ErrorReporter added check before adding empty directory to path

### DIFF
--- a/scripts/ErrorReporter/error_dialog_app.py
+++ b/scripts/ErrorReporter/error_dialog_app.py
@@ -17,7 +17,8 @@ parser.add_argument('--application', dest='application')
 
 command_line_args = parser.parse_args()
 
-sys.path.insert(0, command_line_args.directory)
+if command_line_args.directory:
+    sys.path.insert(0, command_line_args.directory)
 
 import mantid  # noqa
 


### PR DESCRIPTION
**Description of work.**

When Mantid hard crashes on Linux systems the errorreporter is failing to launch. This is because an empty entry is added to the python system path when no directory is specified. 

This directory flag is currently used on windows but not on Linux. In the long term it may be better to make it unnecessary on windows. For now I have just added a check that the directory object is truthy before it is added to the python path list which fixes the issue on linux.

**To test:**

On linux open up the workbench and run the segfault algorithm. Check that no error is thrown (beyond the expected) and if usage reporting is enabled that the window appears.

Ideally also test on a windows package build that the errorreporter still works there. I don't think this change should affect anything but may be worth checking. 

There is no associated issue.

This does not require release notes because this is a bug introduced in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
