### PR TITLE
Pass SANS user file to canSAS files

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSingleReduction.py
@@ -234,7 +234,7 @@ class SANSSingleReduction(DistributedDataProcessorAlgorithm):
         # Set the output workspaces
         # --------------------------------------------------------------------------------------------------------------
         # Set sample logs
-        # Todo: Set sample log -> Userfile and unfitted transmission workspace. Should probably set on
+        # Todo: Set sample log -> unfitted transmission workspace. Should probably set on
         # higher level (SANSBatch)
         # Set the output workspaces
         self.set_output_workspaces(reduction_mode_vs_output_workspaces)

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -24,6 +24,7 @@ Improvements
 - Batch files created by exporting the runs table have the same order of keys as in the table.
 - Batch files no longer require an output name to load. When processing, an auto-generated name is used instead.
 - When the main save directory is changed, the add runs save directory is also updated. Add runs save directory can be still changed independently of the main save directory.
+- The path to the user file used to reduce the data is now added to the workspace sample logs. This user file path is added to canSAS file metadata.
 
 Bug Fixes
 #########

--- a/scripts/SANS/sans/gui_logic/models/create_state.py
+++ b/scripts/SANS/sans/gui_logic/models/create_state.py
@@ -16,12 +16,14 @@ from sans.state.state import State
 sans_logger = Logger("SANS")
 
 
-def create_states(state_model, table_model, instrument, facility, row_index=None, file_lookup=True):
+def create_states(state_model, table_model, instrument, facility, row_index=None,
+                  file_lookup=True, user_file=""):
     """
     Here we create the states based on the settings in the models
     :param state_model: the state model object
     :param table_model: the table model object
     :param row_index: the selected row, if None then all rows are generated
+    :param user_file: the user file under which the data is reduced
     """
     number_of_rows = table_model.get_number_of_rows()
     rows = [x for x in row_index if x < number_of_rows]
@@ -33,7 +35,8 @@ def create_states(state_model, table_model, instrument, facility, row_index=None
     for row in rows:
         if file_lookup:
             table_model.wait_for_file_information(row)
-        state = _create_row_state(row, table_model, state_model, facility, instrument, file_lookup, gui_state_director)
+        state = _create_row_state(row, table_model, state_model, facility, instrument, file_lookup,
+                                  gui_state_director, user_file)
         if isinstance(state, State):
             states.update({row: state})
         elif isinstance(state, str):
@@ -41,7 +44,8 @@ def create_states(state_model, table_model, instrument, facility, row_index=None
     return states, errors
 
 
-def _create_row_state(row, table_model, state_model, facility, instrument, file_lookup, gui_state_director):
+def _create_row_state(row, table_model, state_model, facility, instrument, file_lookup,
+                      gui_state_director, user_file):
     try:
         sans_logger.information("Generating state for row {}".format(row))
         state = None
@@ -57,9 +61,11 @@ def _create_row_state(row, table_model, state_model, facility, instrument, file_
             if row_user_file:
                 row_state_model = create_gui_state_from_userfile(row_user_file, state_model)
                 row_gui_state_director = GuiStateDirector(table_model, row_state_model, facility)
-                state = row_gui_state_director.create_state(row, instrument=instrument, file_lookup=file_lookup)
+                state = row_gui_state_director.create_state(row, instrument=instrument, file_lookup=file_lookup,
+                                                            user_file=row_user_file)
             else:
-                state = gui_state_director.create_state(row, instrument=instrument, file_lookup=file_lookup)
+                state = gui_state_director.create_state(row, instrument=instrument, file_lookup=file_lookup,
+                                                        user_file=user_file)
         return state
     except (ValueError, RuntimeError) as e:
         return "{}".format(str(e))

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -29,7 +29,8 @@ class GuiStateDirector(object):
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
-    def create_state(self, row, file_lookup=True, instrument=SANSInstrument.SANS2D):
+    def create_state(self, row, file_lookup=True, instrument=SANSInstrument.SANS2D,
+                     user_file=""):
         # 1. Get the data settings, such as sample_scatter, etc... and create the data state.
         table_index_model = self._table_model.get_table_entry(row)
         if file_lookup:
@@ -37,7 +38,7 @@ class GuiStateDirector(object):
         else:
             file_information = SANSFileInformationMock(instrument=instrument, facility=self._facility)
 
-        data_builder = get_data_builder(self._facility, file_information)
+        data_builder = get_data_builder(self._facility, file_information, user_file)
 
         self._set_data_entry(data_builder.set_sample_scatter, table_index_model.sample_scatter)
         self._set_data_period_entry(data_builder.set_sample_scatter_period, table_index_model.sample_scatter_period)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -917,7 +917,8 @@ class RunTabPresenter(object):
                                            self._view.instrument,
                                            self._facility,
                                            row_index=row_index,
-                                           file_lookup=file_lookup)
+                                           file_lookup=file_lookup,
+                                           user_file=self._view.get_user_file_path())
 
         if errors and not suppress_warnings:
             self.sans_logger.warning("Errors in getting states...")

--- a/scripts/SANS/sans/state/data.py
+++ b/scripts/SANS/sans/state/data.py
@@ -48,6 +48,8 @@ class StateData(StateBase):
     idf_file_path = StringParameter()
     ipf_file_path = StringParameter()
 
+    user_file = StringParameter()
+
     def __init__(self):
         super(StateData, self).__init__()
 
@@ -64,6 +66,7 @@ class StateData(StateBase):
         # in case this is not set, for example by not using the builders.
         self.instrument = SANSInstrument.NoInstrument
         self.facility = SANSFacility.NoFacility
+        self.user_file = ""
 
     def validate(self):
         is_invalid = dict()
@@ -111,7 +114,7 @@ class StateData(StateBase):
 # ----------------------------------------------------------------------------------------------------------------------
 # Builder
 # ----------------------------------------------------------------------------------------------------------------------
-def set_information_from_file(data_info, file_information):
+def set_information_from_file(data_info, file_information, user_file):
     instrument = file_information.get_instrument()
     facility = file_information.get_facility()
     run_number = file_information.get_run_number()
@@ -121,14 +124,16 @@ def set_information_from_file(data_info, file_information):
     data_info.sample_scatter_is_multi_period = file_information.get_number_of_periods() > 1
     data_info.idf_file_path = file_information.get_idf_file_path()
     data_info.ipf_file_path = file_information.get_ipf_file_path()
+    data_info.user_file = user_file
 
 
 class StateDataBuilder(object):
     @automatic_setters(StateData)
-    def __init__(self, file_information):
+    def __init__(self, file_information, user_file):
         super(StateDataBuilder, self).__init__()
         self.state = StateData()
         self._file_information = file_information
+        self._user_file = user_file
 
     def build(self):
         # Make sure that the product is in a valid state, ie not incomplete
@@ -138,7 +143,7 @@ class StateDataBuilder(object):
         #  This is currently:
         # 1. instrument
         # 2. sample_scatter_run_number
-        set_information_from_file(self.state, self._file_information)
+        set_information_from_file(self.state, self._file_information, self._user_file)
 
         return copy.copy(self.state)
 
@@ -146,9 +151,9 @@ class StateDataBuilder(object):
 # ------------------------------------------
 # Factory method for StateDataBuilder
 # ------------------------------------------
-def get_data_builder(facility, file_information=None):
+def get_data_builder(facility, file_information=None, user_file=""):
     if facility is SANSFacility.ISIS:
-        return StateDataBuilder(file_information)
+        return StateDataBuilder(file_information, user_file)
     else:
         raise NotImplementedError("StateDataBuilder: The selected facility {0} does not seem"
                                   " to exist".format(str(facility)))

--- a/scripts/test/SANS/user_file/state_director_test.py
+++ b/scripts/test/SANS/user_file/state_director_test.py
@@ -25,9 +25,9 @@ from sans.test_helper.file_information_mock import SANSFileInformationMock
 # -----------------------------------------------------------------
 class UserFileStateDirectorISISTest(unittest.TestCase):
     def _assert_data(self, state):
-        # The only item which can be set by the director in the data state is the tube calibration file
         data = state.data
         self.assertTrue(data.calibration == "TUBE_SANS2D_BOTH_31681_25Sept15.nxs")
+        self.assertTrue(data.user_file == "USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT.txt")
 
     def _assert_move(self, state):
         move = state.move
@@ -177,7 +177,8 @@ class UserFileStateDirectorISISTest(unittest.TestCase):
     def test_state_can_be_created_from_valid_user_file_with_data_information(self):
         # Arrange
         file_information = SANSFileInformationMock(instrument=SANSInstrument.SANS2D, run_number=22024)
-        data_builder = get_data_builder(SANSFacility.ISIS, file_information)
+        data_builder = get_data_builder(SANSFacility.ISIS, file_information,
+                                        user_file="USER_SANS2D_154E_2p4_4m_M3_Xpress_8mm_SampleChanger_FRONT.txt")
         data_builder.set_sample_scatter("SANS2D00022024")
         data_builder.set_sample_scatter_period(3)
         data_state = data_builder.build()


### PR DESCRIPTION
**Description of work.**
Since the SANS reduction workflow had been changed for the new gui, the information about the user file used to reduce the data was not passed through to the metadata in canSAS files.

This PR passes the user file through the sans reduction algorithms and adds it to the logs of reduced workspaces. The logic to add the user file to the canSAS file was already present in `saveCanSAS.cpp`

**Report to:** Steve King ISIS

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Load the attached user and batch files
3. At the bottom of the gui, check the "Both" radio button, check "canSAS" and uncheck "NXcanSAS"
4. Click process all (at the top of the gui)
5. In the workspace `first_time` now in the ADS, look at the sample logs. There should be a property `UserFile` attached to the path to the user file you loaded
6. In your default save directory, open up the xml file the reduction created. Scroll to the bottom. There should be a tag `user_file` with the same value as in the logs

Fixes #25455 

**Data:**
[loqPRData.zip](https://github.com/mantidproject/mantid/files/3116298/loqPRData.zip)


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
