### PR TITLE
Add header required for AppleClang 7

### DIFF
--- a/Framework/CurveFitting/src/Functions/CubicSpline.cpp
+++ b/Framework/CurveFitting/src/Functions/CubicSpline.cpp
@@ -12,6 +12,7 @@
 #include "MantidKernel/Logger.h"
 
 #include <algorithm>
+#include <ostream>
 #include <stdexcept>
 #include <vector>
 


### PR DESCRIPTION
**Description of work.**

A change in [CubicSpline](https://github.com/mantidproject/mantid/pull/25582/files#diff-f0df79007d2f072d98e84bcb7df0c4f3) in #25582 is caused [builds](https://builds.mantidproject.org/job/pull_requests-osx/28992/console) to fail to compile on AppleClang 7.

This adds the actual header required rather than relying on `<boost/lexical_cast.hpp>` as it was doing before.

I verified this works on the builder itself.

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
