### PR TITLE
New SliceViewer for workbench

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -22,6 +22,7 @@ from mantid.kernel import logger
 from mantidqt.plotting.functions import can_overplot, pcolormesh, plot, plot_from_names
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
+from mantidqt.widgets.sliceviewer.presenter import SliceViewer
 from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDisplay
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqt.widgets.workspacewidget.algorithmhistorywindow import AlgorithmHistoryWindow
@@ -54,6 +55,7 @@ class WorkspaceWidget(PluginWidget):
                                                                                errors=True, overplot=True))
         self.workspacewidget.plotColorfillClicked.connect(self._do_plot_colorfill)
         self.workspacewidget.sampleLogsClicked.connect(self._do_sample_logs)
+        self.workspacewidget.sliceViewerClicked.connect(self._do_slice_viewer)
         self.workspacewidget.showDataClicked.connect(self._do_show_data)
         self.workspacewidget.showInstrumentClicked.connect(self._do_show_instrument)
         self.workspacewidget.showAlgorithmHistoryClicked.connect(self._do_show_algorithm_history)
@@ -116,6 +118,21 @@ class WorkspaceWidget(PluginWidget):
                 SampleLogs(ws=ws, parent=self)
             except Exception as exception:
                 logger.warning("Could not open sample logs for workspace '{}'."
+                               "".format(ws.name()))
+                logger.debug("{}: {}".format(type(exception).__name__,
+                                             exception))
+
+    def _do_slice_viewer(self, names):
+        """
+        Show the sliceviewer window for the given workspaces
+
+        :param names: A list of workspace names
+        """
+        for ws in self._ads.retrieveWorkspaces(names, unrollGroups=True):
+            try:
+                SliceViewer(ws=ws, parent=self)
+            except Exception as exception:
+                logger.warning("Could not open slice viewer for workspace '{}'."
                                "".format(ws.name()))
                 logger.debug("{}: {}".format(type(exception).__name__,
                                              exception))

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -90,6 +90,8 @@ if(ENABLE_WORKBENCH)
     mantidqt/widgets/test/test_fitpropertybrowser.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_model.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
+    mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+    mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
     mantidqt/widgets/observers/test/test_ads_observer.py
     mantidqt/widgets/observers/test/test_observing_presenter.py
     mantidqt/widgets/observers/test/test_observing_view.py
@@ -122,6 +124,7 @@ if(ENABLE_WORKBENCH)
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+    mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
     mantidqt/widgets/test/test_jupyterconsole.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
     mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -290,6 +290,7 @@ signals:
   void overplotSpectrumWithErrorsClicked(const QStringList & workspaceNames);
   void plotColorfillClicked(const QStringList &workspaceNames);
   void sampleLogsClicked(const QStringList &workspaceNames);
+  void sliceViewerClicked(const QStringList &workspaceNames);
   void showInstrumentClicked(const QStringList &workspaceNames);
   void showAlgorithmHistoryClicked(const QStringList &workspaceNames);
 };

--- a/qt/python/mantidqt/widgets/sliceviewer/__init__.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/__init__.py
@@ -7,3 +7,13 @@
 #  This file is part of the mantid workbench.
 #
 #
+# Can be launch from python by _e.g_
+#
+#
+# from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+# from mantid.simpleapi import LoadMD
+# from qtpy.QtWidgets import QApplication
+# ws = LoadMD('ExternalData/Testing/SystemTests/tests/analysis/reference/ConvertWANDSCDtoQTest_HKL.nxs')
+# app = QApplication([])
+# window = SliceViewer(ws)
+# app.exec_()

--- a/qt/python/mantidqt/widgets/sliceviewer/__init__.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/__init__.py
@@ -1,0 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -1,0 +1,208 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QPushButton, QSlider, QDoubleSpinBox
+from qtpy.QtCore import Qt, Signal
+from mantid.py3compat.enum import Enum
+
+
+class State(Enum):
+    X = 0
+    Y = 1
+    NONE = 2
+
+
+class DimensionWidget(QWidget):
+    dimensionsChanged = Signal()
+    valueChanged = Signal()
+    """
+    Hold all the individual dimensions
+
+
+    from mantidqt.widgets.sliceviewer.dimensionwidget import DimensionWidget
+    from qtpy.QtWidgets import QApplication
+    app = QApplication([])
+    dims = [{'minimum':-1.1, 'number_of_bins':11, 'width':0.2, 'name':'Dim0', 'units':'A'},
+            {'minimum':-2.1, 'number_of_bins':21, 'width':0.2, 'name':'Dim1', 'units':'B'},
+            {'minimum':-10.05, 'number_of_bins':201, 'width':0.1, 'name':'Dim2', 'units':'C'}]
+    window = DimensionWidget(dims)
+    window.show()
+    app.exec_()
+    """
+    def __init__(self, dims_info, parent=None):
+        super(DimensionWidget, self).__init__(parent)
+
+        self.layout = QVBoxLayout(self)
+
+        self.dims = []
+        for n, dim in enumerate(dims_info):
+            if n == 0:
+                state = State.X
+            elif n == 1:
+                state = State.Y
+            else:
+                state = State.NONE
+            self.dims.append(Dimension(dim, number=n, state=state, parent=self))
+
+        for widget in self.dims:
+            widget.stateChanged.connect(self.change_dims)
+            widget.valueChanged.connect(self.valueChanged)
+            self.layout.addWidget(widget)
+
+    def change_dims(self, number):
+        states = [d.get_state() for n, d in enumerate(self.dims)]
+
+        if states.count(State.X) == 0:
+            for n, d in enumerate(self.dims):
+                if n != number and d.get_state() == State.Y:
+                    d.set_state(State.X)
+        elif states.count(State.Y) == 0:
+            for n, d in enumerate(self.dims):
+                if n != number and d.get_state() == State.X:
+                    d.set_state(State.Y)
+        elif states.count(State.X) == 2:
+            for n, d in enumerate(self.dims):
+                if n != number and d.get_state() == State.X:
+                    d.set_state(State.NONE)
+        elif states.count(State.Y) == 2:
+            for n, d in enumerate(self.dims):
+                if n != number and d.get_state() == State.Y:
+                    d.set_state(State.NONE)
+
+        self.dimensionsChanged.emit()
+
+    def get_slicepoint(self):
+        return [None if d.get_state() in (State.X, State.Y) else d.get_value() for d in self.dims]
+
+
+class Dimension(QWidget):
+    stateChanged = Signal(int)
+    valueChanged = Signal()
+    """
+    pass in dimension
+
+    state: one of (State.X, State.Y, State.NONE)
+
+    Can be run independently by:
+
+    from mantidqt.widgets.sliceviewer.dimensionwidget import Dimension
+    from qtpy.QtWidgets import QApplication
+    app = QApplication([])
+    window = Dimension({'minimum':-1.1, 'number_of_bins':11, 'width':0.2, 'name':'Dim0', 'units':'A'})
+    window.show()
+    app.exec_()
+    """
+    def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
+        super(Dimension, self).__init__(parent)
+
+        self.minimum = dim_info['minimum']
+        self.nbins = dim_info['number_of_bins']
+        self.width = dim_info['width']
+        self.number = number
+
+        self.layout = QHBoxLayout(self)
+
+        self.name = QLabel(dim_info['name'])
+        self.units = QLabel(dim_info['units'])
+
+        self.x = QPushButton('X')
+        self.x.setFixedSize(32,32)
+        self.x.setCheckable(True)
+        self.x.clicked.connect(self.x_clicked)
+
+        self.y = QPushButton('Y')
+        self.y.setFixedSize(32,32)
+        self.y.setCheckable(True)
+        self.y.clicked.connect(self.y_clicked)
+
+        self.slider = QSlider(Qt.Horizontal)
+        self.slider.setRange(0, self.nbins-1)
+        self.slider.valueChanged.connect(self.slider_changed)
+
+        self.spinbox = QDoubleSpinBox()
+        self.spinbox.setDecimals(3)
+        self.spinbox.setRange(self.get_bin_center(0), self.get_bin_center(self.nbins-1))
+        self.spinbox.setSingleStep(self.width)
+        self.spinbox.valueChanged.connect(self.spinbox_changed)
+
+        self.layout.addWidget(self.name)
+        self.layout.addWidget(self.x)
+        self.layout.addWidget(self.y)
+        self.layout.addWidget(self.slider, stretch=1)
+        self.layout.addStretch(0)
+        self.layout.addWidget(self.spinbox)
+        self.layout.addWidget(self.units)
+
+        self.set_value(0)
+        self.set_state(state)
+
+    def set_state(self, state):
+        self.state = state
+        if self.state == State.X:
+            self.x.setChecked(True)
+            self.y.setChecked(False)
+            self.slider.hide()
+            self.spinbox.hide()
+            self.units.hide()
+        elif self.state == State.Y:
+            self.x.setChecked(False)
+            self.y.setChecked(True)
+            self.slider.hide()
+            self.spinbox.hide()
+            self.units.hide()
+        else:
+            self.x.setChecked(False)
+            self.y.setChecked(False)
+            self.slider.show()
+            self.spinbox.show()
+            self.units.show()
+
+    def get_state(self):
+        return self.state
+
+    def x_clicked(self):
+        old_state = self.state
+        self.set_state(State.X)
+        if self.state != old_state:
+            self.stateChanged.emit(self.number)
+
+    def y_clicked(self):
+        old_state = self.state
+        self.set_state(State.Y)
+        if self.state != old_state:
+            self.stateChanged.emit(self.number)
+
+    def spinbox_changed(self):
+        self.value = self.spinbox.value()
+        self.update_slider()
+        self.valueChanged.emit()
+
+    def slider_changed(self):
+        self.value = self.get_bin_center(self.slider.value())
+        self.update_spinbox()
+        self.valueChanged.emit()
+
+    def get_bin_center(self, n):
+        return (n+0.5)*self.width+self.minimum
+
+    def update_slider(self):
+        i = (self.value-self.minimum)/self.width
+        self.slider.setValue(int(min(max(i, 0), self.nbins-1)))
+
+    def update_spinbox(self):
+        self.spinbox.setValue(self.value)
+
+    def set_value(self, value):
+        self.value = value
+        self.update_slider()
+        self.update_spinbox()
+
+    def get_value(self):
+        return self.value

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -1,0 +1,49 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from mantid.plots.helperfunctions import get_indices
+import numpy as np
+
+
+class SliceViewerModel(object):
+    """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
+    def __init__(self, ws):
+        if ws.getNumDims() < 2:
+            raise ValueError("workspace must have at least 2 dimensions")
+
+        if not ws.isMDHistoWorkspace():
+            raise ValueError("currenly only works for MDHistoWorkspace")
+
+        self._ws = ws
+
+    def get_ws(self):
+        return self._ws
+
+    def get_data(self, slicepoint):
+        indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
+        return np.ma.masked_invalid(self.get_ws().getSignalArray()[indices])
+
+    def get_dim_info(self, n):
+        """
+        returns dict of (minimum, maximun, number_of_bins, width, name, units) for dimension n
+        """
+        dim = self.get_ws().getDimension(n)
+        return {'minimum': dim.getMinimum(),
+                'maximum': dim.getMaximum(),
+                'number_of_bins': dim.getNBins(),
+                'width': dim.getBinWidth(),
+                'name': dim.name,
+                'units': dim.getUnits()}
+
+    def get_dimensions_info(self):
+        """
+        returns a list of dict for each dimension conainting dim_info
+        """
+        return [self.get_dim_info(n) for n in range(self.get_ws().getNumDims())]

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -16,9 +16,7 @@ class SliceViewer(object):
     def __init__(self, ws, parent=None):
         self.model = SliceViewerModel(ws)
 
-        self.view = SliceViewerView(self.model.get_dimensions_info(), parent)
-        self.view.dimensionsChanged.connect(self.new_plot)
-        self.view.valueChanged.connect(self.update_plot_data)
+        self.view = SliceViewerView(self, self.model.get_dimensions_info(), parent)
 
         self.new_plot()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -13,10 +13,10 @@ from .view import SliceViewerView
 
 
 class SliceViewer(object):
-    def __init__(self, ws, parent=None):
-        self.model = SliceViewerModel(ws)
-
-        self.view = SliceViewerView(self, self.model.get_dimensions_info(), parent)
+    def __init__(self, ws, parent=None, model=None, view=None):
+        # Create model and view, or accept mocked versions
+        self.model = model if model else SliceViewerModel(ws)
+        self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(), parent)
 
         self.new_plot()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -1,0 +1,29 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from .model import SliceViewerModel
+from .view import SliceViewerView
+
+
+class SliceViewer(object):
+    def __init__(self, ws, parent=None):
+        self.model = SliceViewerModel(ws)
+
+        self.view = SliceViewerView(self.model.get_dimensions_info(), parent)
+        self.view.dimensionsChanged.connect(self.new_plot)
+        self.view.valueChanged.connect(self.update_plot_data)
+
+        self.new_plot()
+
+    def new_plot(self):
+        self.view.plot(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
+
+    def update_plot_data(self):
+        self.view.update_plot_data(self.model.get_data(self.view.dimensions.get_slicepoint()))

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -1,0 +1,63 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+
+from mantid.simpleapi import CreateMDHistoWorkspace
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from numpy.testing import assert_equal
+import numpy as np
+import unittest
+
+
+class SliceViewerModelTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        self.ws_MD_3D = CreateMDHistoWorkspace(Dimensionality=3,
+                                               Extents='-3,3,-10,10,-1,1',
+                                               SignalInput=range(100),
+                                               ErrorInput=range(100),
+                                               NumberOfBins='5,5,4',
+                                               Names='Dim1,Dim2,Dim3',
+                                               Units='MomentumTransfer,EnergyTransfer,Angstrom',
+                                               OutputWorkspace='ws_MD_2d')
+
+    def test_model_MDH(self):
+
+        model = SliceViewerModel(self.ws_MD_3D)
+
+        self.assertEqual(model.get_ws(), self.ws_MD_3D)
+
+        assert_equal(model.get_data((None, 2, 2)), range(90,95))
+        assert_equal(model.get_data((1, 2, None)), range(18,118,25))
+        assert_equal(model.get_data((None, None, 0)), np.reshape(range(50,75), (5,5)).T)
+
+        dim_info = model.get_dim_info(0)
+        self.assertEqual(dim_info['minimum'], -3)
+        self.assertEqual(dim_info['maximum'], 3)
+        self.assertEqual(dim_info['number_of_bins'], 5)
+        self.assertAlmostEqual(dim_info['width'], 1.2)
+        self.assertEqual(dim_info['name'], 'Dim1')
+        self.assertEqual(dim_info['units'], 'MomentumTransfer')
+
+        dim_infos = model.get_dimensions_info()
+        self.assertEqual(len(dim_infos), 3)
+
+        dim_info = dim_infos[2]
+        self.assertEqual(dim_info['minimum'], -1)
+        self.assertEqual(dim_info['maximum'], 1)
+        self.assertEqual(dim_info['number_of_bins'], 4)
+        self.assertAlmostEqual(dim_info['width'], 0.5)
+        self.assertEqual(dim_info['name'], 'Dim3')
+        self.assertEqual(dim_info['units'], 'Angstrom')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -1,0 +1,58 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+
+import matplotlib
+matplotlib.use('Agg') # noqa: E402
+import unittest
+
+from mantid.py3compat import mock
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+from mantidqt.widgets.sliceviewer.view import SliceViewerView
+
+
+class SliceViewerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.view = mock.Mock(spec=SliceViewerView)
+        self.view.dimensions = mock.Mock()
+
+        self.model = mock.Mock(spec=SliceViewerModel)
+
+    def test_sliceviewer(self):
+
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+
+        # setup calls
+        self.assertEqual(self.model.get_dimensions_info.call_count, 0)
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.plot.call_count, 1)
+
+        # new_plot
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.new_plot()
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.plot.call_count, 1)
+
+        # update_plot_data
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.update_plot_data()
+        self.assertEqual(self.model.get_data.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.update_plot_data.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -1,0 +1,34 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+from qtpy.QtWidgets import QApplication
+
+import matplotlib as mpl
+mpl.use('Agg')  # noqa
+from mantid.simpleapi import CreateMDHistoWorkspace
+from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+
+
+class SliceViewerViewTest(GuiTest, QtWidgetFinder):
+    def test_deleted_on_close(self):
+        ws = CreateMDHistoWorkspace(Dimensionality=3,
+                                    Extents='-3,3,-10,10,-1,1',
+                                    SignalInput=range(100),
+                                    ErrorInput=range(100),
+                                    NumberOfBins='5,5,4',
+                                    Names='Dim1,Dim2,Dim3',
+                                    Units='MomentumTransfer,EnergyTransfer,Angstrom',
+                                    OutputWorkspace='ws_MD_2d')
+        pres = SliceViewer(ws)
+        self.assert_widget_created()
+        pres.view.close()
+
+        QApplication.processEvents()
+
+        self.assert_no_toplevel_widgets()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -9,18 +9,17 @@
 #
 from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import QWidget, QVBoxLayout
-from qtpy.QtCore import Signal, Qt
+from qtpy.QtCore import Qt
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_qt5agg import FigureCanvas, NavigationToolbar2QT as NavigationToolbar
 from .dimensionwidget import DimensionWidget
 
 
 class SliceViewerView(QWidget):
-    dimensionsChanged = Signal()
-    valueChanged =  Signal()
-
-    def __init__(self, dims_info, parent=None):
+    def __init__(self, presenter, dims_info, parent=None):
         super(SliceViewerView, self).__init__(parent)
+
+        self.presenter = presenter
 
         self.setWindowTitle("SliceViewer")
         self.setWindowFlags(Qt.Window)
@@ -28,8 +27,8 @@ class SliceViewerView(QWidget):
 
         # Dimension widget
         self.dimensions = DimensionWidget(dims_info, parent=self)
-        self.dimensions.dimensionsChanged.connect(self.dimensionsChanged)
-        self.dimensions.valueChanged.connect(self.valueChanged)
+        self.dimensions.dimensionsChanged.connect(self.presenter.new_plot)
+        self.dimensions.valueChanged.connect(self.presenter.update_plot_data)
 
         # MPL figure
         self.fig = Figure()

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -1,0 +1,76 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+from __future__ import (absolute_import, division, print_function)
+from qtpy.QtWidgets import QWidget, QVBoxLayout
+from qtpy.QtCore import Signal, Qt
+from matplotlib.figure import Figure
+from matplotlib.backends.backend_qt5agg import FigureCanvas, NavigationToolbar2QT as NavigationToolbar
+from .dimensionwidget import DimensionWidget
+
+
+class SliceViewerView(QWidget):
+    dimensionsChanged = Signal()
+    valueChanged =  Signal()
+
+    def __init__(self, dims_info, parent=None):
+        super(SliceViewerView, self).__init__(parent)
+
+        self.setWindowTitle("SliceViewer")
+        self.setWindowFlags(Qt.Window)
+        self.setAttribute(Qt.WA_DeleteOnClose, True)
+
+        # Dimension widget
+        self.dimensions = DimensionWidget(dims_info, parent=self)
+        self.dimensions.dimensionsChanged.connect(self.dimensionsChanged)
+        self.dimensions.valueChanged.connect(self.valueChanged)
+
+        # MPL figure
+        self.fig = Figure()
+        self.fig.set_tight_layout(True)
+        self.canvas = FigureCanvas(self.fig)
+        self.ax = self.fig.add_subplot(111, projection='mantid')
+
+        # MPL toolbar
+        self.mpl_toolbar = NavigationToolbar(self.canvas, self)
+
+        # layout
+        self.layout = QVBoxLayout(self)
+        self.layout.addWidget(self.dimensions)
+        self.layout.addWidget(self.mpl_toolbar)
+        self.layout.addWidget(self.canvas, stretch=1)
+
+        self.show()
+
+    def plot(self, ws, **kwargs):
+        """
+        clears the plot and creates a new one using the workspace
+        """
+        self.ax.clear()
+        try:
+            self.colorbar.remove()
+        except AttributeError:
+            pass
+        self.im = self.ax.imshow(ws, origin='lower', **kwargs)
+        self.ax.set_title('')
+        self.colorbar = self.fig.colorbar(self.im)
+        self.mpl_toolbar.update() # clear nav stack
+        self.fig.canvas.draw_idle()
+
+    def update_plot_data(self, data):
+        """
+        This just updates the plot data without creating a new plot
+        """
+        self.im.set_data(data.T)
+        self.im.set_clim(data.min(), data.max())
+        self.fig.canvas.draw_idle()
+
+    def closeEvent(self, event):
+        self.deleteLater()
+        super(SliceViewerView, self).closeEvent(event)

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -48,6 +48,7 @@ signals:
   void overplotSpectrumWithErrorsClicked(const QStringList &workspaceNames);
   void plotColorfillClicked(const QStringList &workspaceNames);
   void sampleLogsClicked(const QStringList &workspaceName);
+  void sliceViewerClicked(const QStringList &workspaceName);
   void showInstrumentClicked(const QStringList &workspaceNames);
   void showDataClicked(const QStringList &workspaceNames);
   void showAlgorithmHistoryClicked(const QStringList &workspaceNames);
@@ -62,6 +63,7 @@ private slots:
   void onOverplotSpectrumWithErrorsClicked();
   void onPlotColorfillClicked();
   void onSampleLogsClicked();
+  void onSliceViewerClicked();
   void onShowInstrumentClicked();
   void onShowDataClicked();
   void onShowAlgorithmHistoryClicked();
@@ -69,7 +71,7 @@ private slots:
 private:
   QAction *m_plotSpectrum, *m_overplotSpectrum, *m_plotSpectrumWithErrs,
       *m_overplotSpectrumWithErrs, *m_plotColorfill, *m_sampleLogs,
-      *m_showInstrument, *m_showData, *m_showAlgorithmHistory;
+      *m_sliceViewer, *m_showInstrument, *m_showData, *m_showAlgorithmHistory;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -35,6 +35,7 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
           new QAction("Overplot spectrum with errors...", this)),
       m_plotColorfill(new QAction("Colorfill", this)),
       m_sampleLogs(new QAction("Show Sample Logs", this)),
+      m_sliceViewer(new QAction("Show Slice Viewer", this)),
       m_showInstrument(new QAction("Show Instrument", this)),
       m_showData(new QAction("Show Data", this)),
       m_showAlgorithmHistory(new QAction("Show History", this)) {
@@ -55,6 +56,8 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
   connect(m_plotColorfill, SIGNAL(triggered()), this,
           SLOT(onPlotColorfillClicked()));
   connect(m_sampleLogs, SIGNAL(triggered()), this, SLOT(onSampleLogsClicked()));
+  connect(m_sliceViewer, SIGNAL(triggered()), this,
+          SLOT(onSliceViewerClicked()));
   connect(m_showInstrument, SIGNAL(triggered()), this,
           SLOT(onShowInstrumentClicked()));
   connect(m_showData, SIGNAL(triggered()), this, SLOT(onShowDataClicked()));
@@ -116,6 +119,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     } else if (boost::dynamic_pointer_cast<IMDWorkspace>(workspace)) {
       menu->addAction(m_showAlgorithmHistory);
       menu->addAction(m_sampleLogs);
+      menu->addAction(m_sliceViewer);
     }
 
     menu->addSeparator();
@@ -152,6 +156,10 @@ void WorkspaceTreeWidgetSimple::onPlotColorfillClicked() {
 
 void WorkspaceTreeWidgetSimple::onSampleLogsClicked() {
   emit sampleLogsClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onSliceViewerClicked() {
+  emit sliceViewerClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 void WorkspaceTreeWidgetSimple::onShowInstrumentClicked() {


### PR DESCRIPTION
This requires #25531 to be merged in first.

You should see something like:
![sv](https://user-images.githubusercontent.com/5595210/56762046-e5bcdf00-676c-11e9-819e-bfde6b05b0d6.png)


This currently only works with MDHistoWorkspaces

To Test:
Load a MDHistoWorkspace in the workbench and right-click->show sliceviewer

Or run as stand alone:

```python
from mantidqt.widgets.sliceviewer.presenter import SliceViewer
from mantid.simpleapi import LoadMD
from qtpy.QtWidgets import QApplication

ws = LoadMD('filename')

app = QApplication([])
window = SliceViewer(ws)
app.exec_()
```

Closes #25569 

SliceViewer will be added to the release notes once functionality has reached the Minimum viable product #25568 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
