### PR TITLE
SpectrumInfo two-theta calc for groups

### DIFF
--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -81,10 +81,10 @@ double SpectrumInfo::l2(const size_t index) const {
  * Throws an exception if the spectrum is a monitor.
  */
 double SpectrumInfo::twoTheta(const size_t index) const {
-  double twoTheta{0.0};
-  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
-    twoTheta += m_detectorInfo.twoTheta(detIndex);
-  return twoTheta / static_cast<double>(spectrumDefinition(index).size());
+  V3D avPos = position(index);
+  auto beamLine = samplePosition() - sourcePosition();
+  auto detLine = avPos - samplePosition();
+  return detLine.angle(beamLine);
 }
 
 /** Returns the signed scattering angle 2 theta in radians (angle w.r.t. to beam


### PR DESCRIPTION
Imagine averaging the two theta scattering angle in a square bank. The beam passes through the centre of the square bank. The detector in the centre clearly has a scattering angle of 0. Now imagine grouping the detectors into columns. The centre spectrum should still have a position (average) of (0,0,z) and a scattering angle of 0. The position average is correct, but the scattering angle is incorrect because the scattering angle across the detectors of the group varies as theta = acos(bl.dl/|bl*dl|).

Note that that the current behaviour is also historical. See https://github.com/mantidproject/mantid/blob/master/Framework/Geometry/src/Instrument/DetectorGroup.cpp#L107-L115

WIP