### PR TITLE
Added interface execution enviroment as class property

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -170,6 +170,9 @@ class MainWindow(QMainWindow):
         self.project = None
         self.project_recovery = None
 
+        # Interface Runner
+        self.executioner = None
+
     def setup(self):
         # menus must be done first so they can be filled by the
         # plugins in register_plugin
@@ -310,9 +313,11 @@ class MainWindow(QMainWindow):
         add_actions(self.view_menu, self.view_menu_actions)
 
     def launch_custom_gui(self, filename):
-        executioner = PythonCodeExecution()
-        executioner.sig_exec_error.connect(lambda errobj: logger.warning(str(errobj)))
-        executioner.execute(open(filename).read(), filename)
+        if self.executioner is None:
+            self.executioner = PythonCodeExecution()
+            self.executioner.sig_exec_error.connect(lambda errobj: logger.warning(str(errobj)))
+
+        self.executioner.execute(open(filename).read(), filename)
 
     def populate_interfaces_menu(self):
         interface_dir = ConfigService['mantidqt.python_interfaces_directory']


### PR DESCRIPTION
**Description of work.**

This updates the python interface launcher so a reference to it is kept in the mainwindow. This prevents interfaces being automatically closed when this goes out of scope.

**To test:**

Currently if you try and run something like the following script from an interface launch script. The window will remain open for the sleep time and then close. After the changes the window should remain open until closed.

```
from qtpy import QtWidgets
import time

test_widget = QtWidgets.QMainWindow()
test_widget.show()
time.sleep(1)
```

<!-- Instructions for testing. -->

*There is no associated issue.*



*This does not require release notes* because this is an internal developer changes.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
