### PR TITLE
localPointInCylinder now uses correct basis vectors for random point generation

### DIFF
--- a/Framework/Geometry/src/RandomPoint.cpp
+++ b/Framework/Geometry/src/RandomPoint.cpp
@@ -26,11 +26,20 @@ Kernel::V3D localPointInCylinder(const Kernel::V3D &basis,
                                  const Kernel::V3D &alongAxis,
                                  double polarAngle, double radialLength) {
   using boost::math::pow;
-  Mantid::Kernel::V3D basis2{1., 0., 0.};
-  if (basis.X() != 0. && basis.Z() != 0) {
-    const auto inverseXZSumSq = 1. / (pow<2>(basis.X()) + pow<2>(basis.Z()));
-    basis2.setX(std::sqrt(1. - pow<2>(basis.X()) * inverseXZSumSq));
-    basis2.setZ(basis.X() * std::sqrt(inverseXZSumSq));
+  // Use basis to get a second perpendicular vector to define basis2
+  Mantid::Kernel::V3D basis2;
+  if (basis.X() == 0) {
+    Mantid::Kernel::V3D x{1., 0., 0.};
+    basis2 = x;
+  } else if (basis.Y() == 0) {
+    Mantid::Kernel::V3D y{0., 1., 0.};
+    basis2 = y;
+  } else if (basis.Z() == 0) {
+    Mantid::Kernel::V3D z{0., 0., 1.};
+    basis2 = z;
+  } else {
+    Mantid::Kernel::V3D v{-basis.Y(), basis.X(), 0.};
+    basis2 = Mantid::Kernel::normalize(v);
   }
   const Kernel::V3D basis3{basis.cross_prod(basis2)};
   const Kernel::V3D localPoint{
@@ -100,8 +109,8 @@ Kernel::V3D inHollowCylinder(const detail::ShapeInfo &shapeInfo,
   const double c2 = geometry.radius * geometry.radius;
   const double r{std::sqrt(c1 + (c2 - c1) * r2)};
   const double z{geometry.height * r3};
+  const Kernel::V3D basis1{geometry.axis};
   const Kernel::V3D alongAxis{geometry.axis * z};
-  const Kernel::V3D &basis1{geometry.axis};
   auto localPoint = localPointInCylinder(basis1, alongAxis, polar, r);
   return localPoint + geometry.centreOfBottomBase;
 }

--- a/Framework/Geometry/src/RandomPoint.cpp
+++ b/Framework/Geometry/src/RandomPoint.cpp
@@ -25,21 +25,18 @@ namespace RandomPoint {
 Kernel::V3D localPointInCylinder(const Kernel::V3D &basis,
                                  const Kernel::V3D &alongAxis,
                                  double polarAngle, double radialLength) {
-  using boost::math::pow;
   // Use basis to get a second perpendicular vector to define basis2
-  Mantid::Kernel::V3D basis2;
+  Kernel::V3D basis2;
   if (basis.X() == 0) {
-    Mantid::Kernel::V3D x{1., 0., 0.};
-    basis2 = x;
+    basis2.setX(1.);
   } else if (basis.Y() == 0) {
-    Mantid::Kernel::V3D y{0., 1., 0.};
-    basis2 = y;
+    basis2.setY(1.);
   } else if (basis.Z() == 0) {
-    Mantid::Kernel::V3D z{0., 0., 1.};
-    basis2 = z;
+    basis2.setZ(1.);
   } else {
-    Mantid::Kernel::V3D v{-basis.Y(), basis.X(), 0.};
-    basis2 = Mantid::Kernel::normalize(v);
+    basis2.setX(-basis.Y());
+    basis2.setY(basis.X());
+    basis2.normalize();
   }
   const Kernel::V3D basis3{basis.cross_prod(basis2)};
   const Kernel::V3D localPoint{
@@ -85,8 +82,7 @@ Kernel::V3D inCylinder(const detail::ShapeInfo &shapeInfo,
   const double r{geometry.radius * std::sqrt(r2)};
   const double z{geometry.height * r3};
   const Kernel::V3D alongAxis{geometry.axis * z};
-  const Kernel::V3D &basis1{geometry.axis};
-  auto localPoint = localPointInCylinder(basis1, alongAxis, polar, r);
+  auto localPoint = localPointInCylinder(geometry.axis, alongAxis, polar, r);
   return localPoint + geometry.centreOfBottomBase;
 }
 

--- a/Framework/Geometry/src/RandomPoint.cpp
+++ b/Framework/Geometry/src/RandomPoint.cpp
@@ -105,9 +105,8 @@ Kernel::V3D inHollowCylinder(const detail::ShapeInfo &shapeInfo,
   const double c2 = geometry.radius * geometry.radius;
   const double r{std::sqrt(c1 + (c2 - c1) * r2)};
   const double z{geometry.height * r3};
-  const Kernel::V3D basis1{geometry.axis};
   const Kernel::V3D alongAxis{geometry.axis * z};
-  auto localPoint = localPointInCylinder(basis1, alongAxis, polar, r);
+  auto localPoint = localPointInCylinder(geometry.axis, alongAxis, polar, r);
   return localPoint + geometry.centreOfBottomBase;
 }
 

--- a/Framework/Geometry/test/RandomPointTest.h
+++ b/Framework/Geometry/test/RandomPointTest.h
@@ -284,11 +284,21 @@ public:
     constexpr double polarAngle{0.4};
     constexpr V3D alongAxis{0., 0., 1.};
     constexpr V3D basis{1., 1., 1.}; // X and Z elements are not 0 here
-
-    Mantid::Kernel::V3D basis2{1., 0., 0.};
-    const auto inverseXZSumSq = 1. / (pow<2>(basis.X()) + pow<2>(basis.Z()));
-    basis2.setX(std::sqrt(1. - pow<2>(basis.X()) * inverseXZSumSq));
-    basis2.setZ(basis.X() * std::sqrt(inverseXZSumSq));
+    
+    Mantid::Kernel::V3D basis2;
+    if (basis.X() == 0) {
+      Mantid::Kernel::V3D x{1., 0., 0.};
+      basis2 = x;
+    } else if (basis.Y() == 0) {
+      Mantid::Kernel::V3D y{0., 1., 0.};
+      basis2 = y;
+    } else if (basis.Z() == 0) {
+      Mantid::Kernel::V3D z{0., 0., 1.};
+      basis2 = z;
+    } else {
+      Mantid::Kernel::V3D v{-basis.Y(), basis.X(), 0.};
+      basis2 = Mantid::Kernel::normalize(v);
+    }
     const Mantid::Kernel::V3D basis3{basis.cross_prod(basis2)};
 
     auto localPoint =

--- a/Framework/Geometry/test/RandomPointTest.h
+++ b/Framework/Geometry/test/RandomPointTest.h
@@ -287,17 +287,15 @@ public:
 
     Mantid::Kernel::V3D basis2;
     if (basis.X() == 0) {
-      Mantid::Kernel::V3D x{1., 0., 0.};
-      basis2 = x;
+      basis2.setX(1.);
     } else if (basis.Y() == 0) {
-      Mantid::Kernel::V3D y{0., 1., 0.};
-      basis2 = y;
+      basis2.setY(1.);
     } else if (basis.Z() == 0) {
-      Mantid::Kernel::V3D z{0., 0., 1.};
-      basis2 = z;
+      basis2.setZ(1.);
     } else {
-      Mantid::Kernel::V3D v{-basis.Y(), basis.X(), 0.};
-      basis2 = Mantid::Kernel::normalize(v);
+      basis2.setX(-basis.Y());
+      basis2.setY(basis.X());
+      basis2.normalize();
     }
     const Mantid::Kernel::V3D basis3{basis.cross_prod(basis2)};
 

--- a/Framework/Geometry/test/RandomPointTest.h
+++ b/Framework/Geometry/test/RandomPointTest.h
@@ -284,7 +284,7 @@ public:
     constexpr double polarAngle{0.4};
     constexpr V3D alongAxis{0., 0., 1.};
     constexpr V3D basis{1., 1., 1.}; // X and Z elements are not 0 here
-    
+
     Mantid::Kernel::V3D basis2;
     if (basis.X() == 0) {
       Mantid::Kernel::V3D x{1., 0., 0.};


### PR DESCRIPTION
**Description of work.**
I modified localPointInCylinder to use correct basis vectors and included unit tests.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
One way to test this is to perform the scatter plots as described in #25595. It is also possible to compare the results of a Montecarlo absorption correction and observe that the results are the same.
<!-- Instructions for testing. -->

Fixes #25595. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
