### PR TITLE
Run git clean (with exclusions) on all jenkins builds

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -75,6 +75,17 @@ trap onexit INT TERM EXIT
 export PARAVIEW_DIR=${PARAVIEW_DIR}
 
 ###############################################################################
+# Some preprocessing steps on the workspace
+###############################################################################
+BUILD_DIR_REL=build
+BUILD_DIR=$WORKSPACE/$BUILD_DIR_REL
+
+# Clean the source tree to remove stale configured files but make sure to
+# leave external/ and the BUILD_DIR directory intact.
+# There is a later check to see if this is a clean build and remove BUILD_DIR.
+git clean -d -x --force --exclude=${BUILD_DIR_REL} --exclude=".Xauthority-*"
+
+###############################################################################
 # Print out the versions of things we are using
 ###############################################################################
 # we use cmake3 on rhel because cmake is too old
@@ -159,14 +170,11 @@ fi
 # For a clean build the entire thing is removed to guarantee it is clean. All
 # other build types are assumed to be incremental and the following items
 # are removed to ensure stale build objects don't interfere with each other:
-#   - those removed by git clean -fdx --exclude=`basename $BUILD_DIR`
 #   - build/bin/**: if libraries are removed from cmake they are not deleted
 #                   from bin and can cause random failures
 #   - build/ExternalData/**: data files will change over time and removing
 #                            the links helps keep it fresh
 ###############################################################################
-BUILD_DIR_REL=build
-BUILD_DIR=$WORKSPACE/$BUILD_DIR_REL
 if [ -z "$BUILD_DIR" ]; then
   echo "Build directory not set. Cannot continue"
   exit 1
@@ -176,7 +184,6 @@ if [[ "$CLEANBUILD" == true ]]; then
   rm -rf $BUILD_DIR
 fi
 if [ -d $BUILD_DIR ]; then
-  git clean -fdx --exclude=${BUILD_DIR_REL} --exclude=".Xauthority-*"
   rm -rf ${BUILD_DIR:?}/bin ${BUILD_DIR:?}/ExternalData
   find ${BUILD_DIR:?} -name 'TEST-*.xml' -delete
   if [[ -n ${CLEAN_EXTERNAL_PROJECTS} && "${CLEAN_EXTERNAL_PROJECTS}" == true ]]; then

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -45,9 +45,17 @@ set PARAVIEW_DIR=%PARAVIEW_DIR%
 if EXIST %WORKSPACE%\external\src\ThirdParty\.git (
   cd %WORKSPACE%\external\src\ThirdParty
   git reset --hard HEAD
-  git clean -fdx
+  git clean -d -x --force
   cd %WORKSPACE%
 )
+
+set BUILD_DIR_REL=build
+set BUILD_DIR=%WORKSPACE%\%BUILD_DIR_REL%
+
+:: Clean the source tree to remove stale configured files but make sure to
+:: leave external/ and the BUILD_DIR directory intact.
+:: There is a later check to see if this is a clean build and remove BUILD_DIR.
+git clean -d -x --force --exclude=external --exclude=%BUILD_DIR_REL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Set up the location for local object store outside of the build and source
@@ -89,15 +97,11 @@ if not "%JOB_NAME%" == "%JOB_NAME:debug=%" (
 :: For a clean build the entire thing is removed to guarantee it is clean. All
 :: other build types are assumed to be incremental and the following items
 :: are removed to ensure stale build objects don't interfere with each other:
-::   - those removed by git clean -fdx --exclude=build
 ::   - build/bin: if libraries are removed from cmake they are not deleted
 ::                   from bin and can cause random failures
 ::   - build/ExternalData/**: data files will change over time and removing
 ::                            the links helps keep it fresh
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
-set BUILD_DIR_REL=build
-set BUILD_DIR=%WORKSPACE%\%BUILD_DIR_REL%
-
 if EXIST %BUILD_DIR%\CMakeCache.txt (
   call "%_grep_exe%" CMAKE_GENERATOR:INTERNAL %BUILD_DIR%\CMakeCache.txt > %BUILD_DIR%\cmake_generator.log
   call "%_grep_exe%" -q "%CM_GENERATOR%" %BUILD_DIR%\cmake_generator.log
@@ -117,7 +121,6 @@ if "!CLEANBUILD!" == "yes" (
 )
 
 if EXIST %BUILD_DIR% (
-  git clean -fdx --exclude=external --exclude=%BUILD_DIR_REL%
   rmdir /S /Q %BUILD_DIR%\bin %BUILD_DIR%\ExternalData
   for /f %%F in ('dir /b /a-d /S "TEST-*.xml"') do del /Q %%F >/nul
   if "!CLEAN_EXTERNAL_PROJECTS!" == "true" (


### PR DESCRIPTION
**Description of work.**

A recent [build](https://builds.mantidproject.org/job/pull_requests-win7/29636) failed due to python files left from a previous pull request that had been tested where a module was turned into a package. The remaining package structure confused the Python import system. This only happened because the `CLEAN=True` parameter was specified and we only ran `git clean` 
for non CLEAN builds.

These changes run `git clean` (with exclusions) on Jenkins before doing much else.

**To test:**

Code review and verify the builds pass.

*This does not require release notes* because **this is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
