### PR TITLE
Fix doctest for SpectrumInfo.rst

### DIFF
--- a/docs/source/api/python/mantid/api/SpectrumInfo.rst
+++ b/docs/source/api/python/mantid/api/SpectrumInfo.rst
@@ -116,7 +116,8 @@ The returned object can then be used to call other methods that belong to ``Spec
 
 	# Get a SpectrumDefinition object
 	spectrumDefinition = info.getSpectrumDefinition(0)
-	print(type(spectrumDefinition))
+	from mantid.api import SpectrumDefinition
+	print("The type is SpectrumDefinition: {}".format(isinstance(spectrumDefinition, SpectrumDefinition)))
 
 Output:
 
@@ -124,7 +125,7 @@ Output:
 
 	10.0
 	[0,0,-10]
-	<class '_api.SpectrumDefinition'>
+	The type is SpectrumDefinition: True
 
 
 *bases:* :py:obj:`mantid.api.SpectrumInfo`
@@ -135,4 +136,3 @@ Output:
     :members:
     :undoc-members:
     :inherited-members:
-


### PR DESCRIPTION
**Description of work.**

Using setuptools for `mantid` caused a doctests to fail when running the doctests on a [package build]
(https://builds.mantidproject.org/job/master_doctests/label=rhel7-build/lastCompletedBuild/testReport/docs/api_python_mantid_api_SpectrumInfo/CallMethods/). This switches the use of `type` to `isinstance`.

**To test:**

Review code.

*There is no associated issue.*

*This does not require release notes* because **it relates to internal testing.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
