### PR TITLE
SliceViewer Disable x-y selection of integrated dimensions

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -15,8 +15,8 @@ import numpy as np
 class SliceViewerModel(object):
     """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
     def __init__(self, ws):
-        if ws.getNumDims() < 2:
-            raise ValueError("workspace must have at least 2 dimensions")
+        if len(ws.getNonIntegratedDimensions()) < 2:
+            raise ValueError("workspace must have at least 2 non-integrated dimensions")
 
         if not ws.isMDHistoWorkspace():
             raise ValueError("currenly only works for MDHistoWorkspace")


### PR DESCRIPTION
This disables the buttons and spinbox, and hides the slider when the dimension only has 1 bin.

**To test.**

Try example in #25620

of create a MDHisto _e.g._

```python
ws=CreateMDHistoWorkspace(Dimensionality=4, Extents='-3,3,0,10,0,2,0,1', SignalInput=range(200), ErrorInput=range(200), NumberOfBins='20,1,2,5', Names='Dim1,Dim2,Dim3,Dim2', Units='AAA,BBB,CCC,DDD')
```
and plot in sliceviewer and see that the correct axes are disabled. Should look like
![dims](https://user-images.githubusercontent.com/5595210/56918738-d7343780-6a8c-11e9-97d7-6e831bdd8fb6.png)



*This does not require release notes* because new sliceviewer hasn't been added yet


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
