### PR TITLE
 add function isCommonLogBins 

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -418,6 +418,9 @@ public:
   /// always safe to assume it is just 2
   size_t numberOfAxis() const;
 
+  /// Returns true if the workspace contains common X bins with log spacing
+  virtual bool isCommonLogBins() const;
+
   /// Returns true if the workspace contains data in histogram form (as
   /// opposed to point-like)
   virtual bool isHistogramData() const;

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -900,9 +900,16 @@ bool MatrixWorkspace::isCommonLogBins() const {
   }
 
   double diff = x0[1] / x0[0];
+  if (!std::isfinite(diff)) {
+    return false;
+  }
   // ignore final bin, since it may be a different size
   for (size_t i = 1; i < x0.size() - 2; ++i) {
-    if (std::abs(x0[i + 1] / x0[i] - diff) > EPSILON) {
+    if (std::isfinite(x0[i + 1]) && std::isfinite(x0[i])) {
+      if (std::abs(x0[i + 1] / x0[i] - diff) > EPSILON) {
+        return false;
+      }
+    } else {
       return false;
     }
   }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -876,7 +876,6 @@ void MatrixWorkspace::replaceAxis(const std::size_t &axisIndex,
   m_axes[axisIndex] = newAxis;
 }
 
-
 /**
  *  Whether the workspace contains common X bins with logarithmic spacing
  *  @return whether the workspace contains common X bins with log spacing

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -900,7 +900,8 @@ bool MatrixWorkspace::isCommonLogBins() const {
   }
 
   double diff = x0[1] / x0[0];
-  for (size_t i = 1; i < x0.size() - 1; ++i) {
+  // ignore final bin, since it may be a different size
+  for (size_t i = 1; i < x0.size() - 2; ++i) {
     if (x0[i + 1] / x0[i] != diff) {
       return false;
     }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -902,7 +902,7 @@ bool MatrixWorkspace::isCommonLogBins() const {
   double diff = x0[1] / x0[0];
   // ignore final bin, since it may be a different size
   for (size_t i = 1; i < x0.size() - 2; ++i) {
-    if (x0[i + 1] / x0[i] != diff) {
+    if (std::abs(x0[i + 1] / x0[i] - diff) > EPSILON) {
       return false;
     }
   }

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -876,6 +876,39 @@ void MatrixWorkspace::replaceAxis(const std::size_t &axisIndex,
   m_axes[axisIndex] = newAxis;
 }
 
+
+/**
+ *  Whether the workspace contains common X bins with logarithmic spacing
+ *  @return whether the workspace contains common X bins with log spacing
+ */
+bool MatrixWorkspace::isCommonLogBins() const {
+  if (!this->isCommonBins()) {
+    return false;
+  }
+
+  if (this->getNumberHistograms() == 0) {
+    return false;
+  }
+
+  const auto &x0 = this->x(0);
+  if (x0.size() < 2) {
+    return false;
+  }
+
+  // guard against all axis elements being equal
+  if (x0[1] == x0[0]) {
+    return false;
+  }
+
+  double diff = x0[1] / x0[0];
+  for (size_t i = 1; i < x0.size() - 1; ++i) {
+    if (x0[i + 1] / x0[i] != diff) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /**
  * Return the number of Axis stored by this workspace
  * @return int

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -429,7 +429,9 @@ void export_MatrixWorkspace() {
       .def("clearMonitorWorkspace", &clearMonitorWorkspace, args("self"),
            "Forget about monitor workspace, attached to the current workspace")
       .def("isCommonBins", &MatrixWorkspace::isCommonBins,
-           "Returns true if the workspace has common X bins.");
+           "Returns true if the workspace has common X bins.")
+      .def("isCommonLogBins", &MatrixWorkspace::isCommonLogBins,
+           "Returns true if the workspace has common X bins with log spacing.");
 
   RegisterWorkspacePtrToPython<MatrixWorkspace>();
 }

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -428,6 +428,9 @@ class MatrixWorkspaceTest(unittest.TestCase):
     def test_isCommonBins(self):
         self.assertTrue(self._test_ws.isCommonBins())
 
+    def test_isCommonLogBins(self):
+        self.assertFalse(self._test_ws.isCommonLogBins())
+
     def test_hasMaskedBins(self):
         numBins = 10
         numHist=11

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -10,11 +10,11 @@ import unittest
 import sys
 import math
 from testhelpers import create_algorithm, run_algorithm, can_be_instantiated, WorkspaceCreationHelper
-
 from mantid.api import (MatrixWorkspace, MatrixWorkspaceProperty, WorkspaceProperty, Workspace,
                         ExperimentInfo, AnalysisDataService, WorkspaceFactory)
 from mantid.geometry import Detector
 from mantid.kernel import Direction, V3D
+from mantid.simpleapi import CreateSampleWorkspace, Rebin
 import numpy as np
 from six.moves import range
 
@@ -430,6 +430,11 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_isCommonLogBins(self):
         self.assertFalse(self._test_ws.isCommonLogBins())
+        ws=CreateSampleWorkspace('Event')
+        ws=Rebin(ws, '1,-1,10000')
+        self.assertTrue(ws.isCommonLogBins())
+        ws=Rebin(ws, '1,-0.1,10000')
+        self.assertTrue(ws.isCommonLogBins())
 
     def test_hasMaskedBins(self):
         numBins = 10

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -35,6 +35,7 @@ Removed
 
 Data Objects
 ------------
+- Added method `isCommonLogBins` to check if the `MatrixWorkspace` contains common X bins with logarithmic spacing.
 
 Python
 ------


### PR DESCRIPTION
**Description of work.**

Add function `MatrixWorkspace::isCommonLogBins` to determine whether the bins are common and have log spacing. The initial use case is to check for this special case when plotting.

Exposing to Python is trivial, adding that to this PR. 

**To test:**

<!-- Instructions for testing. -->

Review code & unit tests

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
