### PR TITLE
mantid.plots get_indices - Change indices from list to tuple

### DIFF
--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -82,6 +82,7 @@ def get_indices(md_workspace, **kwargs):
                 indices.append(slice(None))
             else:
                 indices.append(pointToIndex(md_workspace.getDimension(n), p))
+        indices = tuple(indices)
     elif 'indices' in kwargs:
         indices = kwargs.pop('indices')
         assert md_workspace.getNumDims() == len(indices), "indices provided do not match the dimensions of the workspace"


### PR DESCRIPTION
This fixes the following warning that appears in some cases when using the SliceViewer from the work in #25531:

> Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.

*This does not require release notes* because it was only added this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
