### PR TITLE
Add MatrixWorkspace support to SliceViewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -408,7 +408,7 @@ def pcolor(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-            _setLabels2D(axes, workspace, transpose)
+            _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolor(x, y, z, *args, **kwargs)
 
 
@@ -452,7 +452,7 @@ def pcolorfast(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolorfast(x, y, z, *args, **kwargs)
 
 
@@ -496,7 +496,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolormesh(x, y, z, *args, **kwargs)
 
 
@@ -539,7 +539,7 @@ def imshow(axes, workspace, *args, **kwargs):
             (x, y, z) = get_matrix_2d_ragged(workspace, distribution, histogram2D=True, transpose=transpose)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     if 'extent' not in kwargs:
         if x.ndim == 2 and y.ndim == 2:
             kwargs['extent'] = [x[0, 0], x[0, -1], y[0, 0], y[-1, 0]]
@@ -586,7 +586,7 @@ def tripcolor(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.tripcolor(x.ravel(), y.ravel(), z.ravel(), *args, **kwargs)
 
 
@@ -629,7 +629,7 @@ def tricontour(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     # tricontour segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167
     x = x.ravel()
@@ -681,7 +681,7 @@ def tricontourf(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     # tricontourf segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167
     x = x.ravel()

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -15,6 +15,7 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
 from mantidqt.MPLwidgets import FigureCanvas
 from matplotlib.colors import Normalize, SymLogNorm, PowerNorm
+import numpy as np
 
 
 NORM_OPTS = ["Linear", "SymmetricLog10", "Power"]
@@ -150,9 +151,13 @@ class ColorbarWidget(QWidget):
         if self.autoscale.isChecked():
             data = self.colorbar.mappable.get_array()
             try:
-                self.cmin_value = data[~data.mask].min()
-                self.cmax_value = data[~data.mask].max()
-            except ValueError:
+                try:
+                    self.cmin_value = data[~data.mask].min()
+                    self.cmax_value = data[~data.mask].max()
+                except AttributeError:
+                    self.cmin_value = np.nanmin(data)
+                    self.cmax_value = np.nanmax(data)
+            except (ValueError, RuntimeWarning):
                 # all values mask
                 pass
             self.update_clim_text()

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -26,7 +26,7 @@ class SliceViewerModel(object):
         if isinstance(ws, MatrixWorkspace):
                 if ws.getNumberHistograms() < 2:
                         raise ValueError("workspace must contain at least 2 spectrum")
-                if ws.blocksize() < 2:
+                if ws.getDimension(0).getNBins() < 2: # Check number of x bins
                         raise ValueError("workspace must contain at least 2 bin")
         elif ws.isMDHistoWorkspace():
                 if len(ws.getNonIntegratedDimensions()) < 2:

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -8,7 +8,7 @@
 #
 #
 from __future__ import (absolute_import, division, print_function)
-from .model import SliceViewerModel
+from .model import SliceViewerModel, WS_TYPE
 from .view import SliceViewerView
 
 
@@ -16,12 +16,21 @@ class SliceViewer(object):
     def __init__(self, ws, parent=None, model=None, view=None):
         # Create model and view, or accept mocked versions
         self.model = model if model else SliceViewerModel(ws)
+
+        if self.model.get_ws_type() == WS_TYPE.MDH:
+            self.new_plot = self.new_plot_MDH
+        else:
+            self.new_plot = self.new_plot_matrix
+
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(), parent)
 
         self.new_plot()
 
-    def new_plot(self):
-        self.view.plot(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
+    def new_plot_MDH(self):
+        self.view.plot_MDH(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
+
+    def new_plot_matrix(self):
+        self.view.plot_matrix(self.model.get_ws())
 
     def update_plot_data(self):
         self.view.update_plot_data(self.model.get_data(self.view.dimensions.get_slicepoint(), self.view.dimensions.transpose))

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -9,8 +9,8 @@
 #
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.simpleapi import CreateMDHistoWorkspace
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from mantid.simpleapi import CreateMDHistoWorkspace, CreateWorkspace
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from numpy.testing import assert_equal
 import numpy as np
 import unittest
@@ -28,12 +28,22 @@ class SliceViewerModelTest(unittest.TestCase):
                                                Names='Dim1,Dim2,Dim3',
                                                Units='MomentumTransfer,EnergyTransfer,Angstrom',
                                                OutputWorkspace='ws_MD_2d')
+        self.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
+                                          DataY=[2, 3, 4, 5],
+                                          DataE=[1, 2, 3, 4],
+                                          NSpec=2,
+                                          Distribution=True,
+                                          UnitX='Wavelength',
+                                          VerticalAxisUnit='DeltaE',
+                                          VerticalAxisValues=[4, 6, 8],
+                                          OutputWorkspace='ws2d_histo')
 
     def test_model_MDH(self):
 
         model = SliceViewerModel(self.ws_MD_3D)
 
         self.assertEqual(model.get_ws(), self.ws_MD_3D)
+        self.assertEqual(model.get_ws_type(), WS_TYPE.MDH)
 
         assert_equal(model.get_data((None, 2, 2)), range(90,95))
         assert_equal(model.get_data((1, 2, None)), range(18,118,25))
@@ -57,6 +67,32 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 0.5)
         self.assertEqual(dim_info['name'], 'Dim3')
         self.assertEqual(dim_info['units'], 'Angstrom')
+
+    def test_model_Histo(self):
+
+        model = SliceViewerModel(self.ws2d_histo)
+
+        self.assertEqual(model.get_ws(), self.ws2d_histo)
+        self.assertEqual(model.get_ws_type(), WS_TYPE.MATRIX)
+
+        dim_info = model.get_dim_info(0)
+        self.assertEqual(dim_info['minimum'], 10)
+        self.assertEqual(dim_info['maximum'], 30)
+        self.assertEqual(dim_info['number_of_bins'], 2)
+        self.assertAlmostEqual(dim_info['width'], 10)
+        self.assertEqual(dim_info['name'], 'Wavelength')
+        self.assertEqual(dim_info['units'], 'Angstrom')
+
+        dim_infos = model.get_dimensions_info()
+        self.assertEqual(len(dim_infos), 2)
+
+        dim_info = dim_infos[1]
+        self.assertEqual(dim_info['minimum'], 4)
+        self.assertEqual(dim_info['maximum'], 8)
+        self.assertEqual(dim_info['number_of_bins'], 2)
+        self.assertAlmostEqual(dim_info['width'], 2)
+        self.assertEqual(dim_info['name'], 'Energy transfer')
+        self.assertEqual(dim_info['units'], 'meV')
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -14,7 +14,7 @@ matplotlib.use('Agg') # noqa: E402
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
 from mantidqt.widgets.sliceviewer.view import SliceViewerView
 
@@ -27,7 +27,9 @@ class SliceViewerTest(unittest.TestCase):
 
         self.model = mock.Mock(spec=SliceViewerModel)
 
-    def test_sliceviewer(self):
+    def test_sliceviewer_MDH(self):
+
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDH)
 
         presenter = SliceViewer(None, model=self.model, view=self.view)
 
@@ -35,7 +37,7 @@ class SliceViewerTest(unittest.TestCase):
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
         self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
-        self.assertEqual(self.view.plot.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
 
         # new_plot
         self.model.reset_mock()
@@ -43,7 +45,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.new_plot()
         self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
-        self.assertEqual(self.view.plot.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
 
         # update_plot_data
         self.model.reset_mock()
@@ -52,6 +54,26 @@ class SliceViewerTest(unittest.TestCase):
         self.assertEqual(self.model.get_data.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.update_plot_data.call_count, 1)
+
+    def test_sliceviewer_matrix(self):
+
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+
+        # setup calls
+        self.assertEqual(self.model.get_dimensions_info.call_count, 0)
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 0)
+        self.assertEqual(self.view.plot_matrix.call_count, 1)
+
+        # new_plot
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.new_plot()
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 0)
+        self.assertEqual(self.view.plot_matrix.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -63,10 +63,7 @@ class SliceViewerView(QWidget):
         self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
                                  transpose=self.dimensions.transpose,
                                  norm=self.colorbar.get_norm(), **kwargs)
-        self.ax.set_title('')
-        self.colorbar.set_mappable(self.im)
-        self.mpl_toolbar.update() # clear nav stack
-        self.canvas.draw_idle()
+        self.draw_plot()
 
     def plot_matrix(self, ws, **kwargs):
         """
@@ -74,14 +71,16 @@ class SliceViewerView(QWidget):
         """
         self.ax.clear()
         if use_imshow(ws):
-            self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
-                                     transpose=self.dimensions.transpose,
-                                     norm=self.colorbar.get_norm(), **kwargs)
+            self.plot_MDH(ws, **kwargs) # Make same call to imshow as MDHistoWorkspace
         else:
             self.im = self.ax.pcolormesh(ws, transpose=self.dimensions.transpose,
                                          norm=self.colorbar.get_norm(), **kwargs)
+            self.draw_plot()
+
+    def draw_plot(self):
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
+        self.colorbar.update_clim()
         self.mpl_toolbar.update() # clear nav stack
         self.canvas.draw_idle()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -14,6 +14,7 @@ from mantidqt.MPLwidgets import FigureCanvas, NavigationToolbar2QT as Navigation
 from matplotlib.figure import Figure
 from .dimensionwidget import DimensionWidget
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from mantidqt.plotting.functions import use_imshow
 
 
 class SliceViewerView(QWidget):
@@ -54,14 +55,29 @@ class SliceViewerView(QWidget):
 
         self.show()
 
-    def plot(self, ws, **kwargs):
+    def plot_MDH(self, ws, **kwargs):
         """
-        clears the plot and creates a new one using the workspace
+        clears the plot and creates a new one using a MDHistoWorkspace
         """
         self.ax.clear()
         self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
                                  transpose=self.dimensions.transpose,
                                  norm=self.colorbar.get_norm(), **kwargs)
+        self.ax.set_title('')
+        self.colorbar.set_mappable(self.im)
+        self.mpl_toolbar.update() # clear nav stack
+        self.canvas.draw_idle()
+
+    def plot_matrix(self, ws, **kwargs):
+        """
+        clears the plot and creates a new one using a MatrixWorkspace
+        """
+        self.ax.clear()
+        if use_imshow(ws):
+            self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
+                                     norm=self.colorbar.get_norm(), **kwargs)
+        else:
+            self.im = self.ax.pcolormesh(ws, norm=self.colorbar.get_norm(), **kwargs)
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
         self.mpl_toolbar.update() # clear nav stack

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -75,9 +75,11 @@ class SliceViewerView(QWidget):
         self.ax.clear()
         if use_imshow(ws):
             self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
+                                     transpose=self.dimensions.transpose,
                                      norm=self.colorbar.get_norm(), **kwargs)
         else:
-            self.im = self.ax.pcolormesh(ws, norm=self.colorbar.get_norm(), **kwargs)
+            self.im = self.ax.pcolormesh(ws, transpose=self.dimensions.transpose,
+                                         norm=self.colorbar.get_norm(), **kwargs)
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
         self.mpl_toolbar.update() # clear nav stack

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -113,6 +113,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           matrixWS->getInstrument() &&
           !matrixWS->getInstrument()->getName().empty());
       menu->addAction(m_sampleLogs);
+      menu->addAction(m_sliceViewer);
     } else if (boost::dynamic_pointer_cast<ITableWorkspace>(workspace)) {
       menu->addAction(m_showData);
       menu->addAction(m_showAlgorithmHistory);


### PR DESCRIPTION
**Description of work.**

This adds the ability to open a MatrixWorkspace in the SliceViewer #25602

MDEvent will be added soon.


**To test:**
Check that different Workspace2D and EventWorkspaces open in the sliceviewer, there is little more to check. I suggest trying only smaller datasets as anything too large can be slow to load.


*This does not require release notes* because release notes for sliceviewer will be added later.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
