### PR TITLE
Track now uses Line instead of defining its own vector

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
@@ -14,6 +14,7 @@
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidKernel/Tolerance.h"
+#include "MantidGeometry/Surfaces/Line.h"
 #include <iosfwd>
 #include <list>
 
@@ -166,9 +167,9 @@ public:
   /// Clear the current set of intersection results
   void clearIntersectionResults();
   /// Returns the starting point
-  const Kernel::V3D &startPoint() const { return m_startPoint; }
+  const Kernel::V3D startPoint() const { return m_line.getOrigin(); }
   /// Returns the direction as a unit vector
-  const Kernel::V3D &direction() const { return m_unitVector; }
+  const Kernel::V3D direction() const { return m_line.getDirect(); }
   /// Returns an interator to the start of the set of links
   LType::iterator begin() { return m_links.begin(); }
   /// Returns an interator to one-past-the-end of the set of links
@@ -197,8 +198,7 @@ public:
   int nonComplete() const;
 
 private:
-  Kernel::V3D m_startPoint; ///< Start Point
-  Kernel::V3D m_unitVector; ///< unit vector to direction
+  Line m_line;              ///< Line object containing origin and direction
   LType m_links;            ///< Track units
   PType m_surfPoints;       ///< Intersection points
 };

--- a/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
@@ -167,9 +167,9 @@ public:
   /// Clear the current set of intersection results
   void clearIntersectionResults();
   /// Returns the starting point
-  const Kernel::V3D startPoint() const { return m_line.getOrigin(); }
+  const Kernel::V3D &startPoint() const { return m_line.getOrigin(); }
   /// Returns the direction as a unit vector
-  const Kernel::V3D direction() const { return m_line.getDirect(); }
+  const Kernel::V3D &direction() const { return m_line.getDirect(); }
   /// Returns an interator to the start of the set of links
   LType::iterator begin() { return m_links.begin(); }
   /// Returns an interator to one-past-the-end of the set of links

--- a/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
@@ -13,8 +13,8 @@
 #include "MantidGeometry/DllConfig.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Objects/IObject.h"
-#include "MantidKernel/Tolerance.h"
 #include "MantidGeometry/Surfaces/Line.h"
+#include "MantidKernel/Tolerance.h"
 #include <iosfwd>
 #include <list>
 
@@ -198,9 +198,9 @@ public:
   int nonComplete() const;
 
 private:
-  Line m_line;              ///< Line object containing origin and direction
-  LType m_links;            ///< Track units
-  PType m_surfPoints;       ///< Intersection points
+  Line m_line;        ///< Line object containing origin and direction
+  LType m_links;      ///< Track units
+  PType m_surfPoints; ///< Intersection points
 };
 
 } // NAMESPACE Geometry

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Line.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Line.h
@@ -57,10 +57,14 @@ public:
   Line *clone() const;
 
   Kernel::V3D getPoint(const double lambda) const; ///< gets the point O+lam*N
-  Kernel::V3D getOrigin() const { return Origin; } ///< returns the origin
-  Kernel::V3D getDirect() const { return Direct; } ///< returns the direction
-  double distance(const Kernel::V3D &) const;      ///< distance from line
-  int isValid(const Kernel::V3D &) const;          ///< Is the point on the line
+  const Kernel::V3D &getOrigin() const {
+    return Origin;
+  } ///< returns the origin
+  const Kernel::V3D &getDirect() const {
+    return Direct;
+  }                                           ///< returns the direction
+  double distance(const Kernel::V3D &) const; ///< distance from line
+  int isValid(const Kernel::V3D &) const;     ///< Is the point on the line
   void print() const;
 
   void rotate(const Kernel::Matrix<double> &);

--- a/Framework/Geometry/src/Objects/Track.cpp
+++ b/Framework/Geometry/src/Objects/Track.cpp
@@ -124,8 +124,8 @@ void Track::removeCojoins() {
  */
 void Track::addPoint(const TrackDirection direction, const V3D &endPoint,
                      const IObject &obj, const ComponentID compID) {
-  IntersectionPoint newPoint(direction, endPoint,
-                             endPoint.distance(m_line.getOrigin()), obj, compID);
+  IntersectionPoint newPoint(
+      direction, endPoint, endPoint.distance(m_line.getOrigin()), obj, compID);
   auto lowestPtr =
       std::lower_bound(m_surfPoints.begin(), m_surfPoints.end(), newPoint);
   m_surfPoints.insert(lowestPtr, newPoint);

--- a/Framework/Geometry/src/Objects/Track.cpp
+++ b/Framework/Geometry/src/Objects/Track.cpp
@@ -21,7 +21,7 @@ using Kernel::V3D;
 /**
  * Default constructor
  */
-Track::Track() : m_startPoint(), m_unitVector(0., 0., 1.) {}
+Track::Track() : m_line(V3D(), V3D(0., 0., 1.)) {}
 
 /**
  * Constructor
@@ -29,7 +29,7 @@ Track::Track() : m_startPoint(), m_unitVector(0., 0., 1.) {}
  * @param unitVector :: Directional vector. It must be unit vector.
  */
 Track::Track(const V3D &startPt, const V3D &unitVector)
-    : m_startPoint(startPt), m_unitVector(unitVector) {
+    : m_line(startPt, unitVector) {
   if (!unitVector.unitVector()) {
     throw std::invalid_argument(
         "Failed to construct track: direction is not a unit vector.");
@@ -46,8 +46,7 @@ void Track::reset(const V3D &startPoint, const V3D &direction) {
     throw std::invalid_argument(
         "Failed to reset track: direction is not a unit vector.");
   }
-  m_startPoint = startPoint;
-  m_unitVector = direction;
+  m_line.setLine(startPoint, direction);
 }
 
 /**
@@ -68,7 +67,7 @@ int Track::nonComplete() const {
     return 0;
   }
   auto ac = m_links.cbegin();
-  if (m_startPoint.distance(ac->entryPoint) > Tolerance) {
+  if (m_line.getOrigin().distance(ac->entryPoint) > Tolerance) {
     return 1;
   }
   auto bc = ac;
@@ -126,7 +125,7 @@ void Track::removeCojoins() {
 void Track::addPoint(const TrackDirection direction, const V3D &endPoint,
                      const IObject &obj, const ComponentID compID) {
   IntersectionPoint newPoint(direction, endPoint,
-                             endPoint.distance(m_startPoint), obj, compID);
+                             endPoint.distance(m_line.getOrigin()), obj, compID);
   auto lowestPtr =
       std::lower_bound(m_surfPoints.begin(), m_surfPoints.end(), newPoint);
   m_surfPoints.insert(lowestPtr, newPoint);
@@ -181,7 +180,7 @@ void Track::buildLink() {
          ac->direction != TrackDirection::ENTERING) // stepping from an object.
   {
     if (ac->direction == TrackDirection::LEAVING) {
-      addLink(m_startPoint, ac->endPoint, ac->distFromStart, *ac->object,
+      addLink(m_line.getOrigin(), ac->endPoint, ac->distFromStart, *ac->object,
               ac->componentID); // from the void
     }
     ++ac;


### PR DESCRIPTION
**Description of work.**
Instead of defining new member variables to implement a vector, Track now uses a Line to serve the same purpose.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


<!-- Instructions for testing. -->

Fixes #25629 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
