### PR TITLE
SANS Add Runs Save Mirrors Default Save

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -23,6 +23,7 @@ Improvements
 - **Load Batch File** opens to the directory of your last selected batch file. **Load User File** opens to the directory of your last selected user file.
 - Batch files created by exporting the runs table have the same order of keys as in the table.
 - Batch files no longer require an output name to load. When processing, an auto-generated name is used instead.
+- When the main save directory is changed, the add runs save directory is also updated. Add runs save directory can be still changed independently of the main save directory.
 
 Bug Fixes
 #########

--- a/scripts/Interface/ui/sans_isis/add_runs_page.ui
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>973</width>
+    <width>1017</width>
     <height>667</height>
    </rect>
   </property>
@@ -14,27 +14,24 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item alignment="Qt::AlignTop">
-    <widget class="QGroupBox" name="saveDirectoryGroup">
+   <item>
+    <widget class="QWidget" name="saveDirectoryWidget" native="true">
      <property name="minimumSize">
       <size>
-       <width>50</width>
-       <height>0</height>
+       <width>0</width>
+       <height>30</height>
       </size>
      </property>
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change the save directory for added runs. This can be separate from Mantid's default save directory, however this will be updated to the defaultsave whenever defaultsave is changed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="title">
-      <string>Save Directory</string>
-     </property>
-     <widget class="QWidget" name="">
+     <widget class="QWidget" name="horizontalLayoutWidget">
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>20</y>
-        <width>955</width>
-        <height>27</height>
+        <y>0</y>
+        <width>991</width>
+        <height>31</height>
        </rect>
       </property>
       <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -47,7 +44,7 @@
           </size>
          </property>
          <property name="text">
-          <string>Save Directory:</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save Directory:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/scripts/Interface/ui/sans_isis/add_runs_page.ui
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.ui
@@ -14,6 +14,70 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignTop">
+    <widget class="QGroupBox" name="saveDirectoryGroup">
+     <property name="minimumSize">
+      <size>
+       <width>50</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Change the save directory for added runs. This can be separate from Mantid's default save directory, however this will be updated to the defaultsave whenever defaultsave is changed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Save Directory</string>
+     </property>
+     <widget class="QWidget" name="">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>20</y>
+        <width>955</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="outputDirectoryLabel">
+         <property name="maximumSize">
+          <size>
+           <width>937</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>Save Directory:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="saveDirectoryButton">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a directory to save summed runs into. This directory is different to Mantid's default save directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Select Save Directory</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
    <item>
     <widget class="RunSelectorWidget" name="run_selector" native="true">
      <property name="sizePolicy">
@@ -61,46 +125,6 @@
       <property name="bottomMargin">
        <number>6</number>
       </property>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <widget class="QLabel" name="outputDirectoryLabel">
-          <property name="maximumSize">
-           <size>
-            <width>937</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Save Directory:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="saveDirectoryButton">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a directory to save summed runs into. This directory is different to Mantid's default save directory.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Select Save Directory</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
       <item>
        <widget class="QLineEdit" name="fileNameEdit"/>
       </item>

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -571,13 +571,13 @@ class SANSDataProcessorGui(QMainWindow,
                   self.get_user_file_path)
 
         # Set full user file path for default loading
-        self.gui_properties_handler.update_default("user_file", self.get_user_file_path())
+        self.gui_properties_handler.set_setting("user_file", self.get_user_file_path())
 
         # Notify presenters
         self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
     def on_user_file_load_failure(self):
-        self.gui_properties_handler.update_default("user_file", "")
+        self.gui_properties_handler.set_setting("user_file", "")
         self.user_file_line_edit.setText("")
 
     def set_out_default_user_file(self):

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -9,7 +9,6 @@ import os
 from qtpy.QtCore import QSettings
 from qtpy.QtWidgets import QFileDialog
 
-from mantid.kernel import Logger
 from sans.common.enums import SANSInstrument, ISISReductionMode, DetectorType
 
 
@@ -285,13 +284,6 @@ class SANSGuiPropertiesHandler(object):
                     pass
             load_func(*args)
 
-    def update_default(self, gui_property, value):
-        if gui_property in self.keys:
-            self._set_setting(self.__generic_settings, gui_property, value)
-        else:
-            Logger("SANSPropertyHandler").information("Trying to set property {} for which a default property "
-                                                      "does not exist".format(gui_property))
-
     @staticmethod
     def _load_default_file(line_edit_field, q_settings_group_key, q_settings_key):
         settings = QSettings()
@@ -310,9 +302,8 @@ class SANSGuiPropertiesHandler(object):
 
         return default_property
 
-    @staticmethod
-    def _set_setting(q_settings_group_key, q_settings_key, value):
+    def set_setting(self, q_settings_key, value):
         settings = QSettings()
-        settings.beginGroup(q_settings_group_key)
+        settings.beginGroup(self.__generic_settings)
         settings.setValue(q_settings_key, value)
         settings.endGroup()

--- a/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/add_runs_presenter.py
@@ -130,8 +130,16 @@ class AddRunsPagePresenter(object):
     def _handle_output_directory_changed(self):
         directory = self._view.display_save_directory_box("Save sum runs", self.save_directory)
         directory = os.path.join(directory, '')  # Add an OS specific trailing slash if it doesn't already exist
+        self.handle_new_save_directory(directory)
+
+    def handle_new_save_directory(self, directory):
+        """
+        This method is called when a new save directory is selected on the add runs page, but is also called
+        in the run_tab_presenter when a new default save directory is selected through Manage Directories.
+        :param directory: A string. The new path to the save directory
+        """
         self.set_output_directory(directory)
-        self.gui_properties_handler.update_default("add_runs_output_directory", directory)
+        self.gui_properties_handler.set_setting("add_runs_output_directory", directory)
 
     def _handle_sum(self):
         run_selection = self._run_selector_presenter.run_selection()

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -261,6 +261,10 @@ class RunTabPresenter(object):
         :return:
         """
         self._view.set_out_file_directory(new_directory)
+        # Update add runs save location. We want distinct reduction save/add runs save locations,
+        # but the add runs directory change when the main directory is, to avoid users having to
+        # remember to update in two places.
+        self._view.add_runs_presenter.handle_new_save_directory(new_directory)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Table + Actions

--- a/scripts/SANS/sans/test_helper/mock_objects.py
+++ b/scripts/SANS/sans/test_helper/mock_objects.py
@@ -118,6 +118,9 @@ def create_mock_view(user_file_path, batch_file_path=None, row_user_file_path=""
     # Mock objects used in the properties handler
     view.user_file_line_edit = mock.Mock()
 
+    # Mock the add runs presenter
+    view.add_runs_presenter = mock.Mock()
+
     # ---------------------
     # Mocking properties
     # ---------------------

--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -255,13 +255,13 @@ class SummationConfigurationTest(SelectionMockingTestCase):
                                          'LOQ00003-add')
 
     def test_shows_error_when_empty_default_directory(self):
-        ConfigService["defaultsave.directory"] = ""
         summation_settings_model = self._summation_settings_with_save_directory('')
         self._summation_settings_presenter.settings.return_value = summation_settings_model
         self.presenter = self._make_presenter(
             mock.Mock(),
             self._just_use_run_selector_presenter(),
             self._just_use_summation_settings_presenter())
+        self.presenter.save_directory = ""
 
         self.view.sum.emit()
         assert_called(self.view.no_save_directory)
@@ -443,12 +443,13 @@ class AddRunsDefaultSettingsTest(unittest.TestCase):
     def test_that_presenter_calls_properties_handler_to_update_directory_on_directory_changed(self):
         new_dir_name = os.path.join("some", "dir", "path")
         self.presenter._view.display_save_directory_box = mock.Mock(return_value=new_dir_name)
-        self.presenter.gui_properties_handler.update_default = mock.Mock()
+        self.presenter.gui_properties_handler.set_setting = mock.Mock()
         self.presenter.set_output_directory = mock.Mock()
 
         self.presenter._handle_output_directory_changed()
-        self.presenter.gui_properties_handler.update_default.assert_called_once_with("add_runs_output_directory",
-                                                                                     new_dir_name + os.sep)
+        self.presenter.gui_properties_handler.set_setting.assert_called_once_with("add_runs_output_directory",
+                                                                                  new_dir_name + os.sep)
+        self.presenter.set_output_directory.assert_called_once_with(new_dir_name + os.sep)
 
     def test_that_if_output_directory_is_empty_default_save_directory_is_used_instead(self):
         default_dir = os.path.join("default", "save", "directory")
@@ -461,6 +462,14 @@ class AddRunsDefaultSettingsTest(unittest.TestCase):
                          "Because directory input was an empty string, we expected the output directory "
                          "to use the default save directory {} instead. "
                          "Directory actually used was {}".format(default_dir, output_dir))
+        self.assertEqual(self.presenter.save_directory, default_dir)
+
+    def test_that_if_output_directory_is_not_empty_it_is_used(self):
+        dir = os.path.join("a", "save", "directory")
+        output_dir = self.presenter.set_output_directory(dir)
+
+        self.assertEqual(output_dir, dir)
+        self.assertEqual(self.presenter.save_directory, dir)
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -1022,11 +1022,7 @@ class RunTabPresenterTest(unittest.TestCase):
         presenter.set_view(view)
 
         presenter._handle_output_directory_changed("a_new_directory")
-        calls = presenter._view.add_runs_presenter.handle_new_save_directory.call_args_list
-        self.assertEqual(len(calls), 1)
-
-        args = calls[0][0]
-        self.assertEqual(args, ("a_new_directory",))
+        presenter._view.add_runs_presenter.handle_new_save_directory.assert_called_once_with("a_new_directory")
 
     @staticmethod
     def _clear_property_manager_data_service():

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -1014,6 +1014,20 @@ class RunTabPresenterTest(unittest.TestCase):
         args, _ = presenter._view.can_sas_checkbox.setEnabled.call_args_list[-1]
         self.assertTrue(args[0], "Can SAS checkbox should have been enabled, since we switched to 1D reduction mode.")
 
+    def test_that_updating_default_save_directory_also_updates_add_runs_save_directory(self):
+        """This test checks that add runs presenter's save directory update method is called
+        when the defaultsave directory is updated."""
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        view = mock.MagicMock()
+        presenter.set_view(view)
+
+        presenter._handle_output_directory_changed("a_new_directory")
+        calls = presenter._view.add_runs_presenter.handle_new_save_directory.call_args_list
+        self.assertEqual(len(calls), 1)
+
+        args = calls[0][0]
+        self.assertEqual(args, ("a_new_directory",))
+
     @staticmethod
     def _clear_property_manager_data_service():
         for element in PropertyManagerDataService.getObjectNames():


### PR DESCRIPTION
**Description of work.**
In a previous PR, the save directory for added runs in the ISIS SANS gui was separated from the default save directory. This PR modifies this directory's behaviour slightly. When the default save is updated, the added runs directory is also updated, however, the add runs directory can be changed independently of default save


**Report to:** Sarah SANS2D ISIS

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Click the sum runs tab on the left hand side
3. At the top of the page, click `Select Save Directory` and select a directory
4. The label at the top of the page should change to reflect your selection
5. Click the runs tab. The `Save Directory` label should not display the add runs directory (unless this is also your default save)
6. Click `Manage Directories` at the top of the page and select a default save which is different to your add runs directory
7. The `Save Directory` label on the Runs page should display the default save directory
8. Go back to the Sum Runs tab. The label should display the default save directory

Fixes #25537 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
