### PR TITLE
Add sample geometries for POWGEN

### DIFF
--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -24,6 +24,7 @@ Improvements
 ############
 
 - Changed focus to save out .his files in the format <run-number><instrument> as opposed to <run-number>_<instrument> to allow for better compatibility with opengenie.
+- Added sample environment file for POWGEN that includes many of the standard sample containers
 
 Bug Fixes
 #########

--- a/instrument/sampleenvironments/SNS/POWGEN/InAir.xml
+++ b/instrument/sampleenvironments/SNS/POWGEN/InAir.xml
@@ -1,0 +1,125 @@
+<!-- Definition of containers without sample environment -->
+<!-- the names in this file match what are used in ITEMS with the spaces removed -->
+<environmentspec>
+  <materials>
+    <material id="vanadium" formula="V" numberdensity="0.0721"/>
+    <material id="quartz" formula="Si O2" massdensity="2.196"/>
+  </materials>
+  <components>
+    <containers>
+
+      <!-- TODO need dimensions for NIST06 can -->
+      <!-- TODO need dimensions for NIST08 can -->
+      <!-- TODO need dimensions for NIST10 can -->
+      <!-- TODO need dimensions for QuartzTube02 -->
+      <!-- TODO need dimensions for QuartzTube05 -->
+      <!-- TODO need dimensions for thin walled 3mm QuartzTube -->
+
+      <!-- 3mm quartz capillary -->
+      <container id="QuartzTube03" material="quartz">
+	<geometry>
+	  <hollow-cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.035" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <inner-radius val="0.0014" />
+	    <outer-radius val="0.0015" />
+	    <height val="0.07" />
+	  </hollow-cylinder>
+	</geometry>
+	<samplegeometry>
+	  <cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.035" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <radius val="0.0014" />
+	    <height val="0.07" />
+	  </cylinder>
+	</samplegeometry>
+      </container>
+
+      <!-- 3mm PAC can -->
+      <container id="PAC03" material="vanadium">
+	<geometry>
+	  <hollow-cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <inner-radius val="0.00135" />
+	    <outer-radius val="0.0015875" />
+	    <height val="0.0568" />
+	  </hollow-cylinder>
+	</geometry>
+	<samplegeometry>
+	  <cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <radius val="0.00135" />
+	    <height val="0.0568" />
+	  </cylinder>
+	</samplegeometry>
+      </container>
+
+      <!-- 6mm PAC can -->
+      <container id="PAC06" material="vanadium">
+	<geometry>
+	  <hollow-cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <inner-radius val="0.00295" />
+	    <outer-radius val="0.00315" />
+	    <height val="0.0568" />
+	  </hollow-cylinder>
+	</geometry>
+	<samplegeometry>
+	  <cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <radius val="0.00295" />
+	    <height val="0.0568" />
+	  </cylinder>
+	</samplegeometry>
+      </container>
+
+      <!-- 8mm PAC can -->
+      <container id="PAC08" material="vanadium">
+	<geometry>
+	  <hollow-cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.02835" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <inner-radius val="0.00385" />
+	    <outer-radius val="0.00395" />
+	    <height val="0.0567" />
+	  </hollow-cylinder>
+	</geometry>
+	<samplegeometry>
+	  <cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.02835" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <radius val="0.00385" />
+	    <height val="0.0567" />
+	  </cylinder>
+	</samplegeometry>
+      </container>
+
+      <!-- 10mm PAC can -->
+      <container id="PAC10" material="vanadium">
+	<geometry>
+	  <hollow-cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <inner-radius val="0.0046" />
+	    <outer-radius val="0.0047625" />
+	    <height val="0.0568" />
+	  </hollow-cylinder>
+	</geometry>
+	<samplegeometry>
+	  <cylinder id="cyla">
+	    <centre-of-bottom-base x="0.0" y="-0.0284" z="0.0"/>
+	    <axis x="0.0" y="1" z="0" />
+	    <radius val="0.0046" />
+	    <height val="0.0568" />
+	  </cylinder>
+	</samplegeometry>
+      </container>
+
+    </containers>
+  </components>
+</environmentspec>


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Create a workspace with the powgen instrument
2. `SetSample` with the various options of `PAC06`, `PAC08`, and `QuartzTube03`

In script form:

```python
LoadEmptyInstrument(InstrumentName='POWGEN', OutputWorkspace='PG3')
SetSample(InputWorkspace='PG3',
          Material={'ChemicalFormula': 'Si','SampleMassDensity': 1.2},
          Environment={'Name':'InAir', 'Container':'PAC06'})
mtd['PG3'].sample().getShape().volume()
```
where the "container" is changed to the other values. Unfortunately, there isn't a terribly good way to see what the primative shape is, but this will show the sample volume.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
