### PR TITLE
Refactored Track to use boost::container::small_vector with optimised vector size

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/Track.h
@@ -14,6 +14,9 @@
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Surfaces/Line.h"
 #include "MantidKernel/Tolerance.h"
+
+#include <boost/container/small_vector.hpp>
+
 #include <iosfwd>
 #include <list>
 
@@ -141,8 +144,8 @@ struct IntersectionPoint {
  */
 class MANTID_GEOMETRY_DLL Track {
 public:
-  using LType = std::vector<Link>;
-  using PType = std::vector<IntersectionPoint>;
+  using LType = boost::container::small_vector<Link, 5>;
+  using PType = boost::container::small_vector<IntersectionPoint, 5>;
 
 public:
   /// Default constructor
@@ -160,7 +163,6 @@ public:
   void removeCojoins();
   /// Construct links between added points
   void buildLink();
-
   /// Set a starting point and direction
   void reset(const Kernel::V3D &startPoint, const Kernel::V3D &direction);
   /// Clear the current set of intersection results

--- a/Framework/Geometry/src/Objects/Track.cpp
+++ b/Framework/Geometry/src/Objects/Track.cpp
@@ -9,6 +9,7 @@
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/Tolerance.h"
 #include "MantidKernel/V3D.h"
+#include <boost/iterator/distance.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -77,7 +78,7 @@ int Track::nonComplete() const {
 
   while (bc != m_links.end()) {
     if ((ac->exitPoint).distance(bc->entryPoint) > Tolerance) {
-      return (static_cast<int>(distance(m_links.begin(), bc)) + 1);
+      return (static_cast<int>(boost::distance(m_links.begin(), bc)) + 1);
     }
     ++ac;
     ++bc;


### PR DESCRIPTION
**Description of work.**
I Refactored Track to use `boost::container::small_vector` with an optimised vector size of 5.
The run times for the Montecarlo algorithms when running the script in #25628 for various vector sizes are:
N - Time
1            - 10 mins 55.01 secs
4            - 10 mins 47.06 secs
**5            - 10 mins 30.44 secs**
6            - 10 mins 38.16 secs
7            - 10 mins 41.17 secs
10          - 10 mins 41.29 secs
100        - 10 mins 35.27 secs

Using `std::vector`, the same script takes 11 minutes 7.76 seconds.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

<!-- Instructions for testing. -->

Fixes #25642 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
