### PR TITLE
Do not compress ctest output in Jenkins build script

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -396,7 +396,7 @@ userprops_file=$userconfig_dir/Mantid.user.properties
 echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
-  run_with_xvfb $CTEST_EXE -T Test -j${BUILD_THREADS:?} --schedule-random --output-on-failure
+  run_with_xvfb $CTEST_EXE --no-compress-output -T Test -j${BUILD_THREADS:?} --schedule-random --output-on-failure
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -214,7 +214,7 @@ mkdir %CONFIGDIR%\mantid
 :: use a fixed number of openmp threads to avoid overloading the system
 echo MultiThreaded.MaxCores=2 > %USERPROPS%
 
-call ctest.exe -C %BUILD_CONFIG% -T Test -j%BUILD_THREADS% --schedule-random --output-on-failure
+call ctest.exe -C %BUILD_CONFIG%  --no-compress-output -T Test -j%BUILD_THREADS% --schedule-random --output-on-failure
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::


### PR DESCRIPTION
**Description of work.**

Jenkins does not know how to decode compressed ctest output. If run without the `--no-compress-output` a [failed test](https://builds.mantidproject.org/view/Pull%20Requests/job/pull_requests-osx/29221/testReport/junit/projectroot.qt/python/mantidqt_qt5_test_jupyterconsole_test_jupyterconsole/) gives useless output. This adds the no compression option as described in the [documentation](https://cmake.org/cmake/help/v3.14/manual/ctest.1.html) and by [this issue](https://issues.jenkins-ci.org/browse/JENKINS-21737).

**To test:**

Check the builds still pass and Jenkins parses the unit test results.

<!-- delete this if you added release notes
*This does not require release notes* because **it is a developer change.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
