### PR TITLE
SNS theta sign

### DIFF
--- a/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
+++ b/Framework/Geometry/src/Instrument/InstrumentDefinitionParser.cpp
@@ -966,14 +966,20 @@ void InstrumentDefinitionParser::setValidityRange(
   }
 }
 
-PointingAlong axisNameToAxisType(std::string &input) {
+PointingAlong axisNameToAxisType(const std::string &label, std::string &input) {
   PointingAlong direction;
   if (input == "x") {
     direction = X;
   } else if (input == "y") {
     direction = Y;
-  } else {
+  } else if (input == "z") {
     direction = Z;
+  } else {
+    std::stringstream msg;
+    msg << "Cannot create \"" << label
+        << "\" with axis direction other than \"x\", \"y\", or \"z\", found \""
+        << input << "\"";
+    throw Kernel::Exception::InstrumentDefinitionError(msg.str());
   }
   return direction;
 }
@@ -1079,9 +1085,9 @@ void InstrumentDefinitionParser::readDefaults(Poco::XML::Element *defaults) {
     }
 
     // Convert to input types
-    PointingAlong alongBeam = axisNameToAxisType(s_alongBeam);
-    PointingAlong pointingUp = axisNameToAxisType(s_pointingUp);
-    PointingAlong thetaSign = axisNameToAxisType(s_thetaSign);
+    PointingAlong alongBeam = axisNameToAxisType("along-beam", s_alongBeam);
+    PointingAlong pointingUp = axisNameToAxisType("pointing-up", s_pointingUp);
+    PointingAlong thetaSign = axisNameToAxisType("theta-sign", s_thetaSign);
     Handedness handedness = s_handedness == "right" ? Right : Left;
 
     // Overwrite the default reference frame.

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -29,6 +29,7 @@ Improvements
 - Prevent an error due to the locale settings which may appear when reading, for instance, the incident energy Ei value from the logs in :ref:`ConvertUnits <algm-ConvertUnits>` and many other algorithms.
 - :code:`indices` and :code:`slicepoint` options have been added to :ref:`mantid.plots <mantid.plots>` to allow selection of which plane to plot from an MDHistoWorkspace
 - :ref:`Pseudo-Voigt <func-PseudoVoigt>` has been modified to be more in line with FULLPROF and GSAS.  One of its basic parameter, Height, is changed to Intensity.
+- ARCS, CNCS, HYSPEC, NOMAD, POWGEN, SEQUOIA, SNAP, and VULCAN have had the axis that signed two-theta is calculated against changed from ``+y`` to ``+x``
 
 Removed
 #######

--- a/instrument/ARCS_Definition_20121011-.xml
+++ b/instrument/ARCS_Definition_20121011-.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='ASCII'?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
- name="ARCS" valid-from   ="2012-10-11 12:54:01"
+            name="ARCS" valid-from   ="2012-10-11 12:54:01"
                         valid-to     ="2100-01-31 23:59:59"
-		        last-modified="2012-10-16 21:55:00">
-			
+		        last-modified="2019-05-03 11:30:00">
+
   <!--Created by Michael Reuter-->
   <defaults>
     <length unit="metre"/>
@@ -16,6 +16,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
     <default-view view="cylindrical_y"/>
   </defaults>

--- a/instrument/CNCS_Definition.xml
+++ b/instrument/CNCS_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-01-28 21:07:40.224172" name="CNCS" valid-from="2019-02-01 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-05-03 11:30:00" name="CNCS" valid-from="2019-02-01 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Andrei Savici-->
   <defaults>
     <length unit="metre"/>
@@ -8,6 +8,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!--SOURCE AND SAMPLE POSITION-->

--- a/instrument/HYSPEC_Definition.xml
+++ b/instrument/HYSPEC_Definition.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
- valid-to="2100-01-31 23:59:59" name="HYSPEC" valid-from="2011-07-20 17:02:48.437294" last-modified="2012-08-01 14:28:00">
+ valid-to="2100-01-31 23:59:59" name="HYSPEC" valid-from="2011-07-20 17:02:48.437294" last-modified="2019-05-03 11:30:00">
   <defaults>
     <length unit="meter"/>
     <angle unit="degree"/>
@@ -10,6 +10,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
     <default-view view="cylindrical_y"/>
   </defaults>

--- a/instrument/NOMAD_Definition.xml
+++ b/instrument/NOMAD_Definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-05-31 14:51:39.590134" name="NOMAD" valid-from="2017-02-01 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-05-03 11:30:00" name="NOMAD" valid-from="2017-02-01 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!-- Created by Peter Peterson-->
   <!--DEFAULTS-->
   <defaults>
@@ -9,6 +9,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!--SOURCE-->

--- a/instrument/NOMAD_Definition_20120801-20170131.xml
+++ b/instrument/NOMAD_Definition_20120801-20170131.xml
@@ -2,7 +2,7 @@
 <instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
- last-modified="2013-10-24 11:23:56.045220" valid-to="2012-04-02 23:59:59" name="NOMAD" valid-from="2012-08-01 00:00:01">
+ last-modified="2019-05-03 11:30:00" valid-to="2017-04-02 23:59:59" name="NOMAD" valid-from="2012-08-01 00:00:01">
   <!-- Created by Peter Peterson and Vickie Lynch-->
   <!--DEFAULTS-->
   <defaults>

--- a/instrument/POWGEN_Definition_2018-05-05.xml
+++ b/instrument/POWGEN_Definition_2018-05-05.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2018-06-04 16:59:33.567432" name="PG3" valid-from="2018-05-05 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-05-03 11:30:00" name="PG3" valid-from="2018-05-05 00:00:01" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
   <!--Created by Peter Peterson, Stuart Campbell, Vickie Lynch, Janik Zikovsky-->
   <!--DEFAULTS-->
   <defaults>
@@ -9,6 +9,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!--SOURCE-->

--- a/instrument/SEQUOIA_Definition.xml
+++ b/instrument/SEQUOIA_Definition.xml
@@ -2,9 +2,9 @@
 <instrument
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="http://www.mantidproject.org/IDF/1.0"
-    last-modified="2019-04-04 10:30:48.173260"
+    last-modified="2019-05-03 11:30:00"
     name="SEQUOIA"
-    valid-from="2019-04-04 00:00:00"
+    valid-from="2019-04-04 00:00:01"
     valid-to="2100-01-31 23:59:59"
     xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
     >
@@ -16,6 +16,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!--SOURCE AND SAMPLE POSITION-->

--- a/instrument/SNAP_Definition.xml
+++ b/instrument/SNAP_Definition.xml
@@ -6,7 +6,7 @@
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
             name="SNAP" valid-from   ="2018-05-01 00:00:01"
                         valid-to     ="2100-01-31 23:59:59"
-		        last-modified="2018-11-07 14:00:00">
+		        last-modified="2019-05-03 11:30:00">
   <!--Data taken from /SNS/SNAP/2010_2_3_CAL/calibrations/SNAP_geom_2010_03_22.xml-->
   <!--Created by Vickie Lynch, modified by Janik Zikovsky -->
   <!-- Modified by Vickie Lynch, Feb 17,2011 Bank names changed from local_name to name -->
@@ -18,6 +18,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
 

--- a/instrument/VULCAN_Definition.xml
+++ b/instrument/VULCAN_Definition.xml
@@ -1,12 +1,12 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<!-- For help on the notation used to specify an Instrument Definition File 
+<!-- For help on the notation used to specify an Instrument Definition File
      see http://www.mantidproject.org/IDF -->
-<instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
+<instrument xmlns="http://www.mantidproject.org/IDF/1.0"
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
- name="VULCAN" valid-from   ="1900-01-31 23:59:59"
+            name="VULCAN" valid-from   ="2006-01-31 23:59:59"
                           valid-to     ="2100-01-31 23:59:59"
-		          last-modified="2011-09-16 10:30:00">
+		          last-modified="2019-05-03 11:30:00">
   <!--Data taken from VULCAN_geom_2010_06_03.xml-->
   <!--Created by Vickie Lynch-->
   <!--DEFAULTS-->
@@ -17,6 +17,7 @@
       <along-beam axis="z"/>
       <pointing-up axis="y"/>
       <handedness val="right"/>
+      <theta-sign axis="x"/>
     </reference-frame>
   </defaults>
   <!--SOURCE-->
@@ -136,4 +137,3 @@
     <id val="-2"/>
   </idlist>
 </instrument>
-


### PR DESCRIPTION
This changes the value of [`theta-sign`](https://docs.mantidproject.org/nightly/concepts/InstrumentDefinitionFile.html#using-defaults) in a bunch of IDFs so the sign indicates left/right of the beam rather than above/below the scattering plane (mantid default).

**The new IDFs need to be sent to the SNS DAS group once this is merged.**

**To test:**

See that the new field is in the file. There is a system test to see that they are all correctly formatted.

```python
ws=mtd['NOMAD']

instr=ws.getInstrument()

d87500=instr.getDetector(87500)
print(np.degrees(ws.detectorSignedTwoTheta(d87500)))

d112500=instr.getDetector(112500)
print(np.degrees(ws.detectorSignedTwoTheta(d112500)))
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
