### PR TITLE
Plot workspaces with Log binning on a log axis.

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -58,7 +58,7 @@ def _setLabels2D(axes, workspace, indices=None, transpose=False):
         axes.set_xlabel(labels[1])
         axes.set_ylabel(labels[2])
     axes.set_title(labels[-1])
-    if workspace.isCommonLogBins():
+    if hasattr(workspace, 'isCommonLogBins') and workspace.isCommonLogBins():
         axes.set_xscale('log')
 
 

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -712,7 +712,6 @@ def update_colorplot_datalimits(axes, mappables):
         xmin, xmax, ymin, ymax = get_colorplot_extents(mappable)
         xmin_all, xmax_all = min(xmin_all, xmin), max(xmax_all, xmax)
         ymin_all, ymax_all = min(ymin_all, ymin), max(ymax_all, ymax)
-
     axes.update_datalim(((xmin_all, ymin_all), (xmax_all, ymax_all)))
     axes.autoscale()
 

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -58,6 +58,8 @@ def _setLabels2D(axes, workspace, indices=None, transpose=False):
         axes.set_xlabel(labels[1])
         axes.set_ylabel(labels[2])
     axes.set_title(labels[-1])
+    if workspace.isCommonLogBins():
+        axes.set_xscale('log')
 
 
 def _get_data_for_plot(axes, workspace, kwargs, with_dy=False, with_dx=False):

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -124,13 +124,13 @@ class PlotFunctionsTest(unittest.TestCase):
     def _do_update_colorplot_datalimits(self, color_func):
         fig, ax = plt.subplots()
         mesh = color_func(ax, self.ws2d_histo)
-        ax.set_xlim(-0.05, 0.05)
+        ax.set_xlim(0.01, 0.05)
         ax.set_ylim(-0.05, 0.05)
         funcs.update_colorplot_datalimits(ax, mesh)
         self.assertAlmostEqual(10.0, ax.get_xlim()[0])
         self.assertAlmostEqual(30.0, ax.get_xlim()[1])
-        #self.assertAlmostEqual(4.0, ax.get_ylim()[0])
-        #self.assertAlmostEqual(8.0, ax.get_ylim()[1])
+        self.assertAlmostEqual(4.0, ax.get_ylim()[0])
+        self.assertAlmostEqual(8.0, ax.get_ylim()[1])
 
     def test_update_colorplot_datalimits_for_pcolormesh(self):
         self._do_update_colorplot_datalimits(funcs.pcolormesh)

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -130,7 +130,7 @@ class PlotFunctionsTest(unittest.TestCase):
         self.assertAlmostEqual(10.0, ax.get_xlim()[0])
         from distutils.version import LooseVersion
         #different results with 1.5.3 and 2.1.1
-        if LooseVersion(matplotlib.__version__) < LooseVersion("2"):
+        if color_func.__name__ != 'imshow' and LooseVersion(matplotlib.__version__) < LooseVersion("2"):
             self.assertAlmostEqual(100.0, ax.get_xlim()[1])
         else:
             self.assertAlmostEqual(30.0, ax.get_xlim()[1])

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -128,7 +128,12 @@ class PlotFunctionsTest(unittest.TestCase):
         ax.set_ylim(-0.05, 0.05)
         funcs.update_colorplot_datalimits(ax, mesh)
         self.assertAlmostEqual(10.0, ax.get_xlim()[0])
-        self.assertAlmostEqual(30.0, ax.get_xlim()[1])
+        from distutils.version import LooseVersion
+        #different results with 1.5.3 and 2.1.1
+        if LooseVersion(matplotlib.__version__) < LooseVersion("2"):
+            self.assertAlmostEqual(100.0, ax.get_xlim()[1])
+        else:
+            self.assertAlmostEqual(30.0, ax.get_xlim()[1])
         self.assertAlmostEqual(4.0, ax.get_ylim()[0])
         self.assertAlmostEqual(8.0, ax.get_ylim()[1])
 

--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -15,6 +15,7 @@ Improvements
 - You can now plot workspaces on top of figures you've created using scripts. Simply create a matplotlib figure in the
   script window, then drag and drop a workspace on top of it.
 - Mantid's offline help is now available in Workbench.
+- A colorfill plot of a workspace with logarithmic bins is plotted on a log scale.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -250,7 +250,7 @@ def use_imshow(ws):
     y = ws.getAxis(1).extractValues()
     difference = np.diff(y)
     try:
-        return np.all(np.isclose(difference[:-1], difference[0]))
+        return np.all(np.isclose(difference[:-1], difference[0])) and not ws.isCommonLogBins()
     except IndexError:
         return False
 

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -250,7 +250,8 @@ def use_imshow(ws):
     y = ws.getAxis(1).extractValues()
     difference = np.diff(y)
     try:
-        return np.all(np.isclose(difference[:-1], difference[0])) and not ws.isCommonLogBins()
+        commonLogBins = hasattr(ws, 'isCommonLogBins') and ws.isCommonLogBins()
+        return np.all(np.isclose(difference[:-1], difference[0])) and not commonLogBins
     except IndexError:
         return False
 


### PR DESCRIPTION
**Description of work.**

Sets the x axis to log when `MatrixWorkspace::isCommonLogBins` returns `true`

Avoid using imshow for for log scale plots. The [behavior in v2.0+](https://github.com/matplotlib/matplotlib/issues/7661/) isn't what the want 

**To test:**

<!-- Instructions for testing. -->

```python
LoadEventNexus(Filename="PG3_37861", OutputWorkspace="ws1")
ConvertUnits(InputWorkspace="ws1", OutputWorkspace="ws2", target="dSpacing")
Rebin(InputWorkspace="ws2", OutputWorkspace="ws3", Params='-0.5', PreserveEvents=False)
Rebin(InputWorkspace="ws2", OutputWorkspace="ws4", Params='0.5', PreserveEvents=False)
```

Verify that `ws3->plot->colorfill` has the xscale set to log
Verify that `ws4->plot->colorfill` has the xscale set to linear 

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
