### PR TITLE
SaveIsawPeaks uses child algorithm

### DIFF
--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -543,11 +543,10 @@ void LoadIsawPeaks::appendFile(PeaksWorkspace_sptr outWS,
     prog.report(in.tellg());
   }
   if (m_isModulatedStructure) {
-    FindUBUsingIndexedPeaks alg2;
-    alg2.initialize();
-    alg2.setPropertyValue("ToleranceForSatellite", "0.05");
-    alg2.setProperty("PeaksWorkspace", outWS);
-    alg2.execute();
+    IAlgorithm_sptr findUB = createChildAlgorithm("FindUBUsingIndexedPeaks");
+    findUB->setPropertyValue("ToleranceForSatellite", "0.05");
+    findUB->setProperty<PeaksWorkspace_sptr>("PeaksWorkspace", outWS);
+    findUB->executeAsChildAlg();
 
     if (outWS->mutableSample().hasOrientedLattice()) {
       OrientedLattice o_lattice = outWS->mutableSample().getOrientedLattice();

--- a/Framework/Crystal/src/LoadIsawPeaks.cpp
+++ b/Framework/Crystal/src/LoadIsawPeaks.cpp
@@ -12,7 +12,6 @@
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidCrystal/CalibrationHelpers.h"
-#include "MantidCrystal/FindUBUsingIndexedPeaks.h"
 #include "MantidCrystal/SCDCalibratePanels.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"


### PR DESCRIPTION
**Description of work.**
Loading modulated peaks had error, "Add data object with empty name". Changed to child algorithm to remove error.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [Shiyun Jin]
-->

**To test:**
````python
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-18749/shared/7147A_load_peaks_2/24281_combined.integrate', OutputWorkspace='24281')
````

Fixes #25657 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **minor bug in software in development**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
