### PR TITLE
IndexUB with commonUB only for no modulation vector

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -414,7 +414,7 @@ void IndexPeaks::exec() {
       average_sate_error = 0;
   }
 
-  if (o_lattice.getMaxOrder() == 0 || commonUB) {
+  if (o_lattice.getMaxOrder() == 0) {
     // tell the user how many were indexed overall and the overall average error
     g_log.notice() << "ALL Runs: indexed " << total_indexed << " Peaks out of "
                    << n_peaks << " with tolerance of " << tolerance << '\n';

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -107,7 +107,7 @@ void IndexPeaks::exec() {
   double average_sate_error;
   double tolerance = this->getProperty("Tolerance");
 
-  if (commonUB && offsets1 == V3D(0, 0, 0)) {
+  if (commonUB && o_lattice.getModVec(0) == V3D(0, 0, 0)) {
     std::vector<V3D> miller_indices;
     std::vector<V3D> q_vectors;
 

--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -107,7 +107,7 @@ void IndexPeaks::exec() {
   double average_sate_error;
   double tolerance = this->getProperty("Tolerance");
 
-  if (commonUB) {
+  if (commonUB && offsets1 == V3D(0, 0, 0)) {
     std::vector<V3D> miller_indices;
     std::vector<V3D> q_vectors;
 


### PR DESCRIPTION
**Description of work.**
IndexUB does not use commonUB for satellite peaks
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** Shiyun Jin
-->

**To test:**
````python
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-18749/shared/7147A_load_peaks_2/24281_combined.integrate', OutputWorkspace='24281')
IndexPeaks(PeaksWorkspace='24281', CommonUB=True)
````
Fixes #25659 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **minor bug for software in development**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
