### PR TITLE
Indirect Reduction - Load detailed balance from Sample logs

### DIFF
--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -107,7 +107,8 @@ Background Removal
 
 Detailed Balance
   Gives the option to perform an exponential correction on the data once it has
-  been converted to Energy based on the temperature.
+  been converted to Energy based on the temperature. This is automatically loaded 
+  from the sample logs of the input file if available.
 
 Scale by Factor
   Gives the option to scale the output by a given factor.

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -84,6 +84,7 @@ Data Reduction Interface
 Improvements
 ############
 - Added an option called *Group Output* to group the output files from a reduction on ISISEnergyTransfer.
+- Improved ISISEnergyTransfer by automatically loading the Detailed Balance from the sample logs if available.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -114,25 +114,25 @@ void deleteWorkspace(std::string const &name) {
   deleter->execute();
 }
 
-double getSampleLog(std::string const &workspaceName,
+double getSampleLog(MatrixWorkspace_const_sptr workspace,
                     std::string const &logName, double const &defaultValue) {
   try {
-    return getADSMatrixWorkspace(workspaceName)->getLogAsSingleValue(logName);
+    return workspace->getLogAsSingleValue(logName);
   } catch (std::exception const &) {
     return defaultValue;
   }
 }
 
-double getSampleLog(std::string const &workspaceName,
+double getSampleLog(MatrixWorkspace_const_sptr workspace,
                     std::vector<std::string> const &logNames,
                     double const &defaultValue) {
   double value(defaultValue);
   for (auto const &logName : logNames) {
-    value = getSampleLog(workspaceName, logName, defaultValue);
+    value = getSampleLog(workspace, logName, defaultValue);
     if (value != defaultValue)
       break;
   }
-  deleteWorkspace(workspaceName);
+  deleteWorkspace(workspace->getName());
   return value;
 }
 
@@ -143,7 +143,8 @@ double loadSampleLog(std::string const &filename,
   auto loader = loadAlgorithm(filename, temporaryWorkspace);
   loader->execute();
 
-  return getSampleLog(temporaryWorkspace, logNames, defaultValue);
+  return getSampleLog(getADSMatrixWorkspace(temporaryWorkspace), logNames,
+                      defaultValue);
 }
 
 } // namespace

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -82,6 +82,8 @@ private:
   QString validateDetectorGrouping() const;
   std::string getDetectorGroupingString() const;
 
+  void loadDetailedBalance(std::string const &filename);
+
   void setRunEnabled(bool enable);
   void setPlotEnabled(bool enable);
   void setPlotTimeEnabled(bool enable);


### PR DESCRIPTION
**Description of work.**
This PR ensures the Detailed Balance on ISISEnergyTransfer is automatically loaded into the interface from the Sample Logs of the first raw file. If the relevant sample log cannot be found, a default value of `300K` is used instead.

**To test:**
1. `Interfaces`->`Indirect`->`Data Reduction`->ISISEnergy Transfer
2. Instrument `IRIS`, Analyser `graphite`, Reflection `002`
3. Run number `60000` and press enter.
4. The detailed balance should change to be `245.253K`
5. Change Run number to `26176`. A default detailed balance of `300K` should be set

Fixes #25647

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
