### PR TITLE
Add CylinderAxis property to cylinder absorption algorithm

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CylinderAbsorption.h
@@ -96,11 +96,12 @@ private:
   void initialiseCachedDistances() override;
   void getShapeFromSample(const Geometry::IObject &sampleShape,
                           bool updateHeight, bool updateRadius);
-
-  double m_cylHeight; ///< The height of the cylindrical sample in m
-  double m_cylRadius; ///< The radius of the cylindrical sample in m
-  int m_numSlices;    ///< The number of slices
-  int m_numAnnuli;    ///< The number of annuli
+  std::map<std::string, std::string> validateInputs() override;
+  Kernel::V3D m_cylAxis; ///< The axis orientation of the cylinder
+  double m_cylHeight;    ///< The height of the cylindrical sample in m
+  double m_cylRadius;    ///< The radius of the cylindrical sample in m
+  int m_numSlices;       ///< The number of slices
+  int m_numAnnuli;       ///< The number of annuli
   bool m_useSampleShape;
 };
 

--- a/docs/source/release/v4.1.0/direct_geometry.rst
+++ b/docs/source/release/v4.1.0/direct_geometry.rst
@@ -23,6 +23,11 @@ New Algorithms
 
 - :ref:`algm-FlippingRatioCorrectionMD` algorithm was introduced to account for polarization effects on HYSPEC, but it's not instrument specific.
 
+Improvements
+############
+
+- :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now has a `CylinderAxis` property to set the direction of the cylinder axis.
+
 Removed
 #######
 

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -47,6 +47,7 @@ Improvements
 - All the ILL nexus file loaders were speeded up due to parallelization of the loading.
 - :ref:`algm-SumOverlappingTubes` was speeded up due to parallelization of the actual histogramming step.
 - Updated the clone method of IFunction to copy parameter errors across as well as parameter values.
+- :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now has a `CylinderAxis` property to set the direction of the cylinder axis.
 
 Instrument Definition Files
 ###########################


### PR DESCRIPTION
**Description of work.**
I added a CylinderAxis property to the cylinder absorption algorithm.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
<!-- Instructions for testing. -->
Run the following script with different values for `CylinderAxis`
```python
ws = CreateSampleWorkspace()
ws = ConvertUnits(ws,"Wavelength")
SetSampleMaterial(ws,ChemicalFormula='Cd')

wsOut = CylinderAbsorption(ws,
    NumberOfWavelengthPoints=5, CylinderSampleHeight=4, CylinderAxis=[0,1,0],
    CylinderSampleRadius=0.4, NumberOfSlices=2, NumberOfAnnuli=2)

print ("  over %i bins, ranging from  %.2f to %.2f" %
    (wsOut.blocksize(),
    wsOut.readY(0)[0],
    wsOut.readY(0)[wsOut.blocksize()-1]))
```
For the unit tests, I obtained the output workspace result values using MC absoprtion for the same sample and orientation. I then compared the results with the output for cylinder absorption.
Fixes #25648 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
