### PR TITLE
Add MDEvent support to Sliceviewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -408,7 +408,7 @@ def pcolor(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-            _setLabels2D(axes, workspace, transpose)
+            _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolor(x, y, z, *args, **kwargs)
 
 
@@ -452,7 +452,7 @@ def pcolorfast(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolorfast(x, y, z, *args, **kwargs)
 
 
@@ -496,7 +496,7 @@ def pcolormesh(axes, workspace, *args, **kwargs):
             return _pcolorpieces(axes, workspace, distribution, *args, **kwargs)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.pcolormesh(x, y, z, *args, **kwargs)
 
 
@@ -539,7 +539,7 @@ def imshow(axes, workspace, *args, **kwargs):
             (x, y, z) = get_matrix_2d_ragged(workspace, distribution, histogram2D=True, transpose=transpose)
         else:
             (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=True, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     if 'extent' not in kwargs:
         if x.ndim == 2 and y.ndim == 2:
             kwargs['extent'] = [x[0, 0], x[0, -1], y[0, 0], y[-1, 0]]
@@ -586,7 +586,7 @@ def tripcolor(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     return axes.tripcolor(x.ravel(), y.ravel(), z.ravel(), *args, **kwargs)
 
 
@@ -629,7 +629,7 @@ def tricontour(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     # tricontour segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167
     x = x.ravel()
@@ -681,7 +681,7 @@ def tricontourf(axes, workspace, *args, **kwargs):
     else:
         (distribution, kwargs) = get_distribution(workspace, **kwargs)
         (x, y, z) = get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=transpose)
-        _setLabels2D(axes, workspace, transpose)
+        _setLabels2D(axes, workspace, transpose=transpose)
     # tricontourf segfaults if many z values are not finite
     # https://github.com/matplotlib/matplotlib/issues/10167
     x = x.ravel()

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -15,6 +15,7 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
 from mantidqt.MPLwidgets import FigureCanvas
 from matplotlib.colors import Normalize, SymLogNorm, PowerNorm
+import numpy as np
 
 
 NORM_OPTS = ["Linear", "SymmetricLog10", "Power"]
@@ -150,9 +151,13 @@ class ColorbarWidget(QWidget):
         if self.autoscale.isChecked():
             data = self.colorbar.mappable.get_array()
             try:
-                self.cmin_value = data[~data.mask].min()
-                self.cmax_value = data[~data.mask].max()
-            except ValueError:
+                try:
+                    self.cmin_value = data[~data.mask].min()
+                    self.cmax_value = data[~data.mask].max()
+                except AttributeError:
+                    self.cmin_value = np.nanmin(data)
+                    self.cmax_value = np.nanmax(data)
+            except (ValueError, RuntimeWarning):
                 # all values mask
                 pass
             self.update_clim_text()

--- a/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -8,7 +8,7 @@
 #
 #
 from __future__ import (absolute_import, division, print_function)
-from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QPushButton, QSlider, QDoubleSpinBox
+from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QLabel, QPushButton, QSlider, QDoubleSpinBox, QSpinBox
 from qtpy.QtCore import Qt, Signal
 from mantid.py3compat.enum import Enum
 
@@ -44,11 +44,16 @@ class DimensionWidget(QWidget):
 
         self.dims = []
         for n, dim in enumerate(dims_info):
-            self.dims.append(Dimension(dim, number=n, parent=self))
+            if dim['type'] == 'MDE':
+                self.dims.append(DimensionMDE(dim, number=n, parent=self))
+            else:
+                self.dims.append(Dimension(dim, number=n, parent=self))
 
         for widget in self.dims:
             widget.stateChanged.connect(self.change_dims)
             widget.valueChanged.connect(self.valueChanged)
+            if hasattr(widget, 'binningChanged'):
+                widget.binningChanged.connect(self.dimensionsChanged)
             self.layout.addWidget(widget)
 
         self.set_initial_states()
@@ -93,6 +98,9 @@ class DimensionWidget(QWidget):
 
     def get_slicepoint(self):
         return [None if d.get_state() in (State.X, State.Y) else d.get_value() for d in self.dims]
+
+    def get_bin_params(self):
+        return [d.get_bins() if d.get_state() in (State.X, State.Y) else d.get_thickness() for d in self.dims]
 
 
 class Dimension(QWidget):
@@ -232,3 +240,70 @@ class Dimension(QWidget):
 
     def get_value(self):
         return self.value
+
+
+class DimensionMDE(Dimension):
+    binningChanged = Signal()
+    """
+    MDEventWorkspace has additional properties for either number_of_bins or thickness
+
+    from mantidqt.widgets.sliceviewer.dimensionwidget import DimensionMDE
+    from qtpy.QtWidgets import QApplication
+    app = QApplication([])
+    window = DimensionMDE({'minimum':-1.1, 'number_of_bins':11, 'width':0.2, 'name':'Dim0', 'units':'A'})
+    window.show()
+    app.exec_()
+    """
+    def __init__(self, dim_info, number=0, state=State.NONE, parent=None):
+
+        # hack in a number_of_bins for MDEventWorkspace
+        dim_info['number_of_bins'] = 1000
+        dim_info['width'] = (dim_info['maximum']-dim_info['minimum'])/1000
+
+        self.spinBins = QSpinBox()
+        self.spinBins.setRange(2,9999)
+        self.spinBins.setValue(100)
+        self.spinBins.hide()
+        self.spinBins.setMinimumWidth(110)
+        self.spinThick = QDoubleSpinBox()
+        self.spinThick.setRange(0.001,999)
+        self.spinThick.setValue(0.1)
+        self.spinThick.setSingleStep(0.1)
+        self.spinThick.setDecimals(3)
+        self.spinThick.setMinimumWidth(110)
+        self.rebinLabel = QLabel("thick")
+        self.rebinLabel.setMinimumWidth(44)
+
+        super(DimensionMDE, self).__init__(dim_info, number, state, parent)
+
+        self.spinBins.valueChanged.connect(self.binningChanged)
+        self.spinThick.valueChanged.connect(self.valueChanged)
+
+        self.layout.addWidget(self.spinBins)
+        self.layout.addWidget(self.spinThick)
+        self.layout.addWidget(self.rebinLabel)
+
+    def get_bins(self):
+        return int(self.spinBins.value())
+
+    def get_thickness(self):
+        return float(self.spinThick.value())
+
+    def set_state(self, state):
+        super(DimensionMDE, self).set_state(state)
+        if self.state == State.X:
+            self.spinBins.show()
+            self.spinThick.hide()
+            self.rebinLabel.setText('bins')
+        elif self.state == State.Y:
+            self.spinBins.show()
+            self.spinThick.hide()
+            self.rebinLabel.setText('bins')
+        elif self.state == State.NONE:
+            self.spinBins.hide()
+            self.spinThick.show()
+            self.rebinLabel.setText('thick')
+        else:
+            self.spinBins.hide()
+            self.spinThick.hide()
+            self.rebinLabel.hide()

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -10,65 +10,100 @@
 from __future__ import (absolute_import, division, print_function)
 from mantid.plots.helperfunctions import get_indices
 from mantid.api import MatrixWorkspace, MultipleExperimentInfos
-import numpy as np
+from mantid.simpleapi import BinMD
 from mantid.py3compat.enum import Enum
+import numpy as np
 
 
 class WS_TYPE(Enum):
-        MDE = 0
-        MDH = 1
-        MATRIX = 2
+    MDE = 0
+    MDH = 1
+    MATRIX = 2
 
 
 class SliceViewerModel(object):
     """Store the workspace to be plotted. Can be MatrixWorkspace, MDEventWorkspace or MDHistoWorkspace"""
     def __init__(self, ws):
         if isinstance(ws, MatrixWorkspace):
-                if ws.getNumberHistograms() < 2:
-                        raise ValueError("workspace must contain at least 2 spectrum")
-                if ws.getDimension(0).getNBins() < 2: # Check number of x bins
-                        raise ValueError("workspace must contain at least 2 bin")
-        elif ws.isMDHistoWorkspace():
+            if ws.getNumberHistograms() < 2:
+                raise ValueError("workspace must contain at least 2 spectrum")
+            if ws.getDimension(0).getNBins() < 2: # Check number of x bins
+                raise ValueError("workspace must contain at least 2 bin")
+        elif isinstance(ws, MultipleExperimentInfos):
+            if ws.isMDHistoWorkspace():
                 if len(ws.getNonIntegratedDimensions()) < 2:
-                        raise ValueError("workspace must have at least 2 non-integrated dimensions")
+                    raise ValueError("workspace must have at least 2 non-integrated dimensions")
+            else:
+                if ws.getNumDims() < 2:
+                    raise ValueError("workspace must have at least 2 dimensions")
         else:
-                raise ValueError("currenly only works for MatrixWorkspace and MDHistoWorkspace")
+            raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
         self._ws = ws
 
-    def get_ws(self):
+        if self.get_ws_type() == WS_TYPE.MDE:
+            self.get_ws = self.get_ws_MDE
+            self.get_data = self.get_data_MDE
+        else:
+            self.get_ws = self._get_ws
+            self.get_data = self.get_data_MDH
+
+    def _get_ws(self):
         return self._ws
 
-    def get_data(self, slicepoint, transpose=False):
+    def get_ws_MDE(self, slicepoint, bin_params):
+        params = {}
+        for n in range(self._get_ws().getNumDims()):
+            if slicepoint[n] is None:
+                params['AlignedDim{}'.format(n)] = '{},{},{},{}'.format(self._get_ws().getDimension(n).name,
+                                                                        self._get_ws().getDimension(n).getMinimum(),
+                                                                        self._get_ws().getDimension(n).getMaximum(),
+                                                                        bin_params[n])
+            else:
+                params['AlignedDim{}'.format(n)] = '{},{},{},{}'.format(self._get_ws().getDimension(n).name,
+                                                                        slicepoint[n]-bin_params[n]/2,
+                                                                        slicepoint[n]+bin_params[n]/2,
+                                                                        1)
+        return BinMD(InputWorkspace=self._get_ws(),
+                     OutputWorkspace=self._get_ws().name()+'_rebinned', **params)
+
+    def get_data_MDH(self, slicepoint, transpose=False):
         indices, _ = get_indices(self.get_ws(), slicepoint=slicepoint)
         if transpose:
             return np.ma.masked_invalid(self.get_ws().getSignalArray()[indices]).T
         else:
             return np.ma.masked_invalid(self.get_ws().getSignalArray()[indices])
 
+    def get_data_MDE(self, slicepoint, bin_params, transpose=False):
+        if transpose:
+            return np.ma.masked_invalid(self.get_ws_MDE(slicepoint, bin_params).getSignalArray().squeeze()).T
+        else:
+            return np.ma.masked_invalid(self.get_ws_MDE(slicepoint, bin_params).getSignalArray().squeeze())
+
     def get_dim_info(self, n):
         """
         returns dict of (minimum, maximun, number_of_bins, width, name, units) for dimension n
         """
-        dim = self.get_ws().getDimension(n)
+        dim = self._get_ws().getDimension(n)
         return {'minimum': dim.getMinimum(),
                 'maximum': dim.getMaximum(),
                 'number_of_bins': dim.getNBins(),
                 'width': dim.getBinWidth(),
                 'name': dim.name,
-                'units': dim.getUnits()}
+                'units': dim.getUnits(),
+                'type': self.get_ws_type().name}
 
     def get_dimensions_info(self):
         """
         returns a list of dict for each dimension conainting dim_info
         """
-        return [self.get_dim_info(n) for n in range(self.get_ws().getNumDims())]
+        return [self.get_dim_info(n) for n in range(self._get_ws().getNumDims())]
 
     def get_ws_type(self):
-        if isinstance(self.get_ws(), MatrixWorkspace):
+        if isinstance(self._get_ws(), MatrixWorkspace):
             return WS_TYPE.MATRIX
-        elif isinstance(self.get_ws(), MultipleExperimentInfos):
-            if self.get_ws().isMDHistoWorkspace():
+        elif isinstance(self._get_ws(), MultipleExperimentInfos):
+            if self._get_ws().isMDHistoWorkspace():
                 return WS_TYPE.MDH
             else:
                 return WS_TYPE.MDE

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -26,7 +26,7 @@ class SliceViewerModel(object):
         if isinstance(ws, MatrixWorkspace):
                 if ws.getNumberHistograms() < 2:
                         raise ValueError("workspace must contain at least 2 spectrum")
-                if ws.blocksize() < 2:
+                if ws.getDimension(0).getNBins() < 2: # Check number of x bins
                         raise ValueError("workspace must contain at least 2 bin")
         elif ws.isMDHistoWorkspace():
                 if len(ws.getNonIntegratedDimensions()) < 2:

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -8,7 +8,7 @@
 #
 #
 from __future__ import (absolute_import, division, print_function)
-from .model import SliceViewerModel
+from .model import SliceViewerModel, WS_TYPE
 from .view import SliceViewerView
 
 
@@ -16,12 +16,21 @@ class SliceViewer(object):
     def __init__(self, ws, parent=None, model=None, view=None):
         # Create model and view, or accept mocked versions
         self.model = model if model else SliceViewerModel(ws)
+
+        if self.model.get_ws_type() == WS_TYPE.MDH:
+            self.new_plot = self.new_plot_MDH
+        else:
+            self.new_plot = self.new_plot_matrix
+
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(), parent)
 
         self.new_plot()
 
-    def new_plot(self):
-        self.view.plot(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
+    def new_plot_MDH(self):
+        self.view.plot_MDH(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
+
+    def new_plot_matrix(self):
+        self.view.plot_matrix(self.model.get_ws())
 
     def update_plot_data(self):
         self.view.update_plot_data(self.model.get_data(self.view.dimensions.get_slicepoint(), self.view.dimensions.transpose))

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -19,6 +19,10 @@ class SliceViewer(object):
 
         if self.model.get_ws_type() == WS_TYPE.MDH:
             self.new_plot = self.new_plot_MDH
+            self.update_plot_data = self.update_plot_data_MDH
+        elif self.model.get_ws_type() == WS_TYPE.MDE:
+            self.new_plot = self.new_plot_MDE
+            self.update_plot_data = self.update_plot_data_MDE
         else:
             self.new_plot = self.new_plot_matrix
 
@@ -29,8 +33,17 @@ class SliceViewer(object):
     def new_plot_MDH(self):
         self.view.plot_MDH(self.model.get_ws(), slicepoint=self.view.dimensions.get_slicepoint())
 
+    def new_plot_MDE(self):
+        self.view.plot_MDH(self.model.get_ws(slicepoint=self.view.dimensions.get_slicepoint(),
+                                             bin_params=self.view.dimensions.get_bin_params()))
+
     def new_plot_matrix(self):
         self.view.plot_matrix(self.model.get_ws())
 
-    def update_plot_data(self):
+    def update_plot_data_MDH(self):
         self.view.update_plot_data(self.model.get_data(self.view.dimensions.get_slicepoint(), self.view.dimensions.transpose))
+
+    def update_plot_data_MDE(self):
+        self.view.update_plot_data(self.model.get_data(slicepoint=self.view.dimensions.get_slicepoint(),
+                                                       bin_params=self.view.dimensions.get_bin_params(),
+                                                       transpose=self.view.dimensions.transpose))

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -9,9 +9,9 @@
 #
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.simpleapi import CreateMDHistoWorkspace, CreateWorkspace
+from mantid.simpleapi import CreateMDHistoWorkspace, CreateWorkspace, CreateMDWorkspace, FakeMDEventData
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 import numpy as np
 import unittest
 
@@ -27,7 +27,11 @@ class SliceViewerModelTest(unittest.TestCase):
                                                NumberOfBins='5,5,4',
                                                Names='Dim1,Dim2,Dim3',
                                                Units='MomentumTransfer,EnergyTransfer,Angstrom',
-                                               OutputWorkspace='ws_MD_2d')
+                                               OutputWorkspace='ws_MD_3D')
+        self.ws_MDE_3D = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-4,4,-5,5', Names='h,k,l',
+                                           Units='rlu,rlu,rlu', SplitInto='4', OutputWorkspace='ws_MDE_3D')
+        FakeMDEventData('ws_MDE_3D', PeakParams='100000,0,0,0,0.1', RandomSeed='63759', RandomizeSignal='1')
+        FakeMDEventData('ws_MDE_3D', PeakParams='40000,1,0,0,0.1', RandomSeed='63759', RandomizeSignal='1')
         self.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
                                           DataY=[2, 3, 4, 5],
                                           DataE=[1, 2, 3, 4],
@@ -56,6 +60,7 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 1.2)
         self.assertEqual(dim_info['name'], 'Dim1')
         self.assertEqual(dim_info['units'], 'MomentumTransfer')
+        self.assertEqual(dim_info['type'], 'MDH')
 
         dim_infos = model.get_dimensions_info()
         self.assertEqual(len(dim_infos), 3)
@@ -67,8 +72,67 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 0.5)
         self.assertEqual(dim_info['name'], 'Dim3')
         self.assertEqual(dim_info['units'], 'Angstrom')
+        self.assertEqual(dim_info['type'], 'MDH')
 
-    def test_model_Histo(self):
+    def test_model_MDE(self):
+
+        model = SliceViewerModel(self.ws_MDE_3D)
+
+        self.assertNotEqual(model.get_ws((0,0,0), (1,1,1)), self.ws_MDE_3D)
+        self.assertEqual(model._get_ws(), self.ws_MDE_3D)
+        self.assertEqual(model.get_ws_type(), WS_TYPE.MDE)
+
+        dim_info = model.get_dim_info(0)
+        self.assertEqual(dim_info['minimum'], -3)
+        self.assertEqual(dim_info['maximum'], 3)
+        self.assertEqual(dim_info['number_of_bins'], 1)
+        self.assertAlmostEqual(dim_info['width'], 6)
+        self.assertEqual(dim_info['name'], 'h')
+        self.assertEqual(dim_info['units'], 'rlu')
+        self.assertEqual(dim_info['type'], 'MDE')
+
+        dim_infos = model.get_dimensions_info()
+        self.assertEqual(len(dim_infos), 3)
+
+        dim_info = dim_infos[2]
+        self.assertEqual(dim_info['minimum'], -5)
+        self.assertEqual(dim_info['maximum'], 5)
+        self.assertEqual(dim_info['number_of_bins'], 1)
+        self.assertAlmostEqual(dim_info['width'], 10)
+        self.assertEqual(dim_info['name'], 'l')
+        self.assertEqual(dim_info['units'], 'rlu')
+        self.assertEqual(dim_info['type'], 'MDE')
+
+        mdh = model.get_ws((None,0,None), (3,0.001,3))
+        assert_allclose(mdh.getSignalArray().squeeze(), [[0, 0, 0],
+                                                         [0, 692.237618, 0],
+                                                         [0, 118.362777, 0]])
+
+        d0 = mdh.getDimension(0)
+        d1 = mdh.getDimension(1)
+        d2 = mdh.getDimension(2)
+        self.assertEqual(d0.name, 'h')
+        self.assertEqual(d0.getNBins(), 3)
+        self.assertEqual(d0.getMinimum(), -3)
+        self.assertEqual(d0.getMaximum(), 3)
+        self.assertEqual(d1.name, 'k')
+        self.assertEqual(d1.getNBins(), 1)
+        self.assertAlmostEqual(d1.getMinimum(), -0.0005)
+        self.assertAlmostEqual(d1.getMaximum(), 0.0005)
+        self.assertEqual(d2.name, 'l')
+        self.assertEqual(d2.getNBins(), 3)
+        self.assertEqual(d2.getMinimum(), -5)
+        self.assertEqual(d2.getMaximum(), 5)
+
+        assert_allclose(model.get_data((None,0,None), (3,0.001,3)), [[0, 0, 0],
+                                                                     [0, 692.237618, 0],
+                                                                     [0, 118.362777, 0]])
+
+        assert_allclose(model.get_data((None,0,None), (3,0.001,3), transpose=True), [[0, 0, 0],
+                                                                                     [0, 692.237618, 118.362777],
+                                                                                     [0, 0, 0]])
+
+    def test_model_matrix(self):
 
         model = SliceViewerModel(self.ws2d_histo)
 
@@ -82,6 +146,7 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 10)
         self.assertEqual(dim_info['name'], 'Wavelength')
         self.assertEqual(dim_info['units'], 'Angstrom')
+        self.assertEqual(dim_info['type'], 'MATRIX')
 
         dim_infos = model.get_dimensions_info()
         self.assertEqual(len(dim_infos), 2)
@@ -93,6 +158,7 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 2)
         self.assertEqual(dim_info['name'], 'Energy transfer')
         self.assertEqual(dim_info['units'], 'meV')
+        self.assertEqual(dim_info['type'], 'MATRIX')
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -9,8 +9,8 @@
 #
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.simpleapi import CreateMDHistoWorkspace
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from mantid.simpleapi import CreateMDHistoWorkspace, CreateWorkspace
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from numpy.testing import assert_equal
 import numpy as np
 import unittest
@@ -28,12 +28,22 @@ class SliceViewerModelTest(unittest.TestCase):
                                                Names='Dim1,Dim2,Dim3',
                                                Units='MomentumTransfer,EnergyTransfer,Angstrom',
                                                OutputWorkspace='ws_MD_2d')
+        self.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
+                                          DataY=[2, 3, 4, 5],
+                                          DataE=[1, 2, 3, 4],
+                                          NSpec=2,
+                                          Distribution=True,
+                                          UnitX='Wavelength',
+                                          VerticalAxisUnit='DeltaE',
+                                          VerticalAxisValues=[4, 6, 8],
+                                          OutputWorkspace='ws2d_histo')
 
     def test_model_MDH(self):
 
         model = SliceViewerModel(self.ws_MD_3D)
 
         self.assertEqual(model.get_ws(), self.ws_MD_3D)
+        self.assertEqual(model.get_ws_type(), WS_TYPE.MDH)
 
         assert_equal(model.get_data((None, 2, 2)), range(90,95))
         assert_equal(model.get_data((1, 2, None)), range(18,118,25))
@@ -57,6 +67,32 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertAlmostEqual(dim_info['width'], 0.5)
         self.assertEqual(dim_info['name'], 'Dim3')
         self.assertEqual(dim_info['units'], 'Angstrom')
+
+    def test_model_Histo(self):
+
+        model = SliceViewerModel(self.ws2d_histo)
+
+        self.assertEqual(model.get_ws(), self.ws2d_histo)
+        self.assertEqual(model.get_ws_type(), WS_TYPE.MATRIX)
+
+        dim_info = model.get_dim_info(0)
+        self.assertEqual(dim_info['minimum'], 10)
+        self.assertEqual(dim_info['maximum'], 30)
+        self.assertEqual(dim_info['number_of_bins'], 2)
+        self.assertAlmostEqual(dim_info['width'], 10)
+        self.assertEqual(dim_info['name'], 'Wavelength')
+        self.assertEqual(dim_info['units'], 'Angstrom')
+
+        dim_infos = model.get_dimensions_info()
+        self.assertEqual(len(dim_infos), 2)
+
+        dim_info = dim_infos[1]
+        self.assertEqual(dim_info['minimum'], 4)
+        self.assertEqual(dim_info['maximum'], 8)
+        self.assertEqual(dim_info['number_of_bins'], 2)
+        self.assertAlmostEqual(dim_info['width'], 2)
+        self.assertEqual(dim_info['name'], 'Energy transfer')
+        self.assertEqual(dim_info['units'], 'meV')
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -26,6 +26,8 @@ class SliceViewerTest(unittest.TestCase):
         self.view.dimensions = mock.Mock()
 
         self.model = mock.Mock(spec=SliceViewerModel)
+        self.model.get_ws = mock.Mock()
+        self.model.get_data = mock.Mock()
 
     def test_sliceviewer_MDH(self):
 
@@ -53,6 +55,37 @@ class SliceViewerTest(unittest.TestCase):
         presenter.update_plot_data()
         self.assertEqual(self.model.get_data.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.update_plot_data.call_count, 1)
+
+    def test_sliceviewer_MDE(self):
+
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDE)
+
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+
+        # setup calls
+        self.assertEqual(self.model.get_dimensions_info.call_count, 0)
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_bin_params.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
+
+        # new_plot
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.new_plot()
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_bin_params.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
+
+        # update_plot_data
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.update_plot_data()
+        self.assertEqual(self.model.get_data.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_bin_params.call_count, 1)
         self.assertEqual(self.view.update_plot_data.call_count, 1)
 
     def test_sliceviewer_matrix(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -14,7 +14,7 @@ matplotlib.use('Agg') # noqa: E402
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.widgets.sliceviewer.model import SliceViewerModel
+from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
 from mantidqt.widgets.sliceviewer.view import SliceViewerView
 
@@ -27,7 +27,9 @@ class SliceViewerTest(unittest.TestCase):
 
         self.model = mock.Mock(spec=SliceViewerModel)
 
-    def test_sliceviewer(self):
+    def test_sliceviewer_MDH(self):
+
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MDH)
 
         presenter = SliceViewer(None, model=self.model, view=self.view)
 
@@ -35,7 +37,7 @@ class SliceViewerTest(unittest.TestCase):
         self.assertEqual(self.model.get_dimensions_info.call_count, 0)
         self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
-        self.assertEqual(self.view.plot.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
 
         # new_plot
         self.model.reset_mock()
@@ -43,7 +45,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.new_plot()
         self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
-        self.assertEqual(self.view.plot.call_count, 1)
+        self.assertEqual(self.view.plot_MDH.call_count, 1)
 
         # update_plot_data
         self.model.reset_mock()
@@ -52,6 +54,26 @@ class SliceViewerTest(unittest.TestCase):
         self.assertEqual(self.model.get_data.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 1)
         self.assertEqual(self.view.update_plot_data.call_count, 1)
+
+    def test_sliceviewer_matrix(self):
+
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+
+        # setup calls
+        self.assertEqual(self.model.get_dimensions_info.call_count, 0)
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 0)
+        self.assertEqual(self.view.plot_matrix.call_count, 1)
+
+        # new_plot
+        self.model.reset_mock()
+        self.view.reset_mock()
+        presenter.new_plot()
+        self.assertEqual(self.model.get_ws.call_count, 1)
+        self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 0)
+        self.assertEqual(self.view.plot_matrix.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -63,10 +63,7 @@ class SliceViewerView(QWidget):
         self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
                                  transpose=self.dimensions.transpose,
                                  norm=self.colorbar.get_norm(), **kwargs)
-        self.ax.set_title('')
-        self.colorbar.set_mappable(self.im)
-        self.mpl_toolbar.update() # clear nav stack
-        self.canvas.draw_idle()
+        self.draw_plot()
 
     def plot_matrix(self, ws, **kwargs):
         """
@@ -74,14 +71,16 @@ class SliceViewerView(QWidget):
         """
         self.ax.clear()
         if use_imshow(ws):
-            self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
-                                     transpose=self.dimensions.transpose,
-                                     norm=self.colorbar.get_norm(), **kwargs)
+            self.plot_MDH(ws, **kwargs) # Make same call to imshow as MDHistoWorkspace
         else:
             self.im = self.ax.pcolormesh(ws, transpose=self.dimensions.transpose,
                                          norm=self.colorbar.get_norm(), **kwargs)
+            self.draw_plot()
+
+    def draw_plot(self):
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
+        self.colorbar.update_clim()
         self.mpl_toolbar.update() # clear nav stack
         self.canvas.draw_idle()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -14,6 +14,7 @@ from mantidqt.MPLwidgets import FigureCanvas, NavigationToolbar2QT as Navigation
 from matplotlib.figure import Figure
 from .dimensionwidget import DimensionWidget
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from mantidqt.plotting.functions import use_imshow
 
 
 class SliceViewerView(QWidget):
@@ -54,14 +55,29 @@ class SliceViewerView(QWidget):
 
         self.show()
 
-    def plot(self, ws, **kwargs):
+    def plot_MDH(self, ws, **kwargs):
         """
-        clears the plot and creates a new one using the workspace
+        clears the plot and creates a new one using a MDHistoWorkspace
         """
         self.ax.clear()
         self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
                                  transpose=self.dimensions.transpose,
                                  norm=self.colorbar.get_norm(), **kwargs)
+        self.ax.set_title('')
+        self.colorbar.set_mappable(self.im)
+        self.mpl_toolbar.update() # clear nav stack
+        self.canvas.draw_idle()
+
+    def plot_matrix(self, ws, **kwargs):
+        """
+        clears the plot and creates a new one using a MatrixWorkspace
+        """
+        self.ax.clear()
+        if use_imshow(ws):
+            self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
+                                     norm=self.colorbar.get_norm(), **kwargs)
+        else:
+            self.im = self.ax.pcolormesh(ws, norm=self.colorbar.get_norm(), **kwargs)
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
         self.mpl_toolbar.update() # clear nav stack

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -75,9 +75,11 @@ class SliceViewerView(QWidget):
         self.ax.clear()
         if use_imshow(ws):
             self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
+                                     transpose=self.dimensions.transpose,
                                      norm=self.colorbar.get_norm(), **kwargs)
         else:
-            self.im = self.ax.pcolormesh(ws, norm=self.colorbar.get_norm(), **kwargs)
+            self.im = self.ax.pcolormesh(ws, transpose=self.dimensions.transpose,
+                                         norm=self.colorbar.get_norm(), **kwargs)
         self.ax.set_title('')
         self.colorbar.set_mappable(self.im)
         self.mpl_toolbar.update() # clear nav stack

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -113,6 +113,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           matrixWS->getInstrument() &&
           !matrixWS->getInstrument()->getName().empty());
       menu->addAction(m_sampleLogs);
+      menu->addAction(m_sliceViewer);
     } else if (boost::dynamic_pointer_cast<ITableWorkspace>(workspace)) {
       menu->addAction(m_showData);
       menu->addAction(m_showAlgorithmHistory);


### PR DESCRIPTION
This requires #25635 to be merged in first.

All MDEvent data is binned on demand as the binning parameters of slicepoint changes.

**To test:**

Load any MDEvent file and try viewing it in sliceviewer

Closes #25600 


*This does not require release notes* because it will be included in the sliceviewer release notes.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
