### PR TITLE
Abins atom-resolved spectrum

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -96,8 +96,7 @@ class Abins(PythonAlgorithm):
         self.declareProperty(name="Instrument",
                              direction=Direction.Input,
                              defaultValue="TOSCA",
-                             # validator=StringListValidator(AbinsModules.AbinsConstants.ALL_INSTRUMENTS)
-                             validator=StringListValidator(["TOSCA"]),
+                             validator=StringListValidator(AbinsModules.AbinsConstants.ALL_INSTRUMENTS),
                              doc="Name of an instrument for which analysis should be performed.")
 
         self.declareProperty(StringArrayProperty("Atoms", Direction.Input),
@@ -206,22 +205,40 @@ class Abins(PythonAlgorithm):
         all_atms_smbls.sort()
 
         if len(self._atoms) == 0:  # case: all atoms
-            atoms_symbol = all_atms_smbls
+            atom_symbols = all_atms_smbls
+            atom_numbers = []
         else:  # case selected atoms
             if len(self._atoms) != len(set(self._atoms)):  # only different types
                 raise ValueError("Not all user defined atoms are unique.")
 
-            for atom_symbol in self._atoms:
+            # Specific atoms are identified with prefix and integer index, e.g 'atom_5'. Other items are element symbols
+            prefix = AbinsModules.AbinsConstants.ATOM_PREFIX
+            atom_symbols = [item for item in self._atoms if item[:len(prefix)] != prefix]
+            atom_numbers = [item[len(prefix):] for item in self._atoms if item[:len(prefix)] == prefix]
+
+            for atom_symbol in atom_symbols:
                 if atom_symbol not in all_atms_smbls:
-                    raise ValueError("User defined atom not present in the system.")
-            atoms_symbol = self._atoms
+                    raise ValueError("User defined atom selection (by element) '%s': not present in the system." %
+                                     atom_symbol)
+            for atom_number in atom_numbers:
+                try:
+                    atom_number = int(atom_number)
+                except ValueError:
+                    raise ValueError("Invalid user atom selection (by number) '%s': could not convert to integer" %
+                                     atom_number)
+                if atom_number < 1 or atom_number > num_atoms:
+                    raise ValueError("Invalid user atom selection (by number) '%s%s': out of range (%s - %s)" %
+                                     (prefix, atom_number, 1, num_atoms))
+            atom_numbers = list(map(int, atom_numbers))
+
         prog_reporter.report("Atoms, for which dynamical structure factors should be plotted, have been determined.")
 
         # at the moment only types of atom, e.g, for  benzene three options -> 1) C, H;  2) C; 3) H
         # 5) create workspaces for atoms in interest
         workspaces = []
         if self._sample_form == "Powder":
-            workspaces.extend(self._create_partial_s_per_type_workspaces(atoms_symbols=atoms_symbol, s_data=s_data))
+            workspaces.extend(self._create_partial_s_per_type_workspaces(atoms_symbols=atom_symbols, s_data=s_data))
+            workspaces.extend(self._create_partial_s_per_type_workspaces(atom_numbers=atom_numbers, s_data=s_data))
         prog_reporter.report("Workspaces with partial dynamical structure factors have been constructed.")
 
         # 6) Create a workspace with sum of all atoms if required
@@ -232,7 +249,7 @@ class Abins(PythonAlgorithm):
                     total_atom_workspaces.append(ws)
             total_workspace = self._create_total_workspace(partial_workspaces=total_atom_workspaces)
             workspaces.insert(0, total_workspace)
-            prog_reporter.report("Workspace with total S  has been constructed.")
+            prog_reporter.report("Workspace with total S has been constructed.")
 
         # 7) add experimental data if available to the collection of workspaces
         if self._experimental_file != "":
@@ -253,25 +270,31 @@ class Abins(PythonAlgorithm):
         self.setProperty('OutputWorkspace', self._out_ws_name)
         prog_reporter.report("Group workspace with all required  dynamical structure factors has been constructed.")
 
-    def _create_workspaces(self, atoms_symbols=None, s_data=None):
+    def _create_workspaces(self, atoms_symbols=None, atom_numbers=None, s_data=None):
         """
         Creates workspaces for all types of atoms. Creates both partial and total workspaces for all types of atoms.
 
-        :param atoms_symbols: list of atom types for which S should be created
-        :param s_data: dynamical factor data of type SData
+        :param atoms_symbols: atom types (i.e. element symbols) for which S should be created.
+        :type iterable of str:
+
+        :param atom_numbers: indices of individual atoms for which S should be created
+        :type iterable of int:
+
+        :param s_data: dynamical factor data
+        :type AbinsModules.SData.SData
+
         :returns: workspaces for list of atoms types, S for the particular type of atom
         """
         s_data_extracted = s_data.extract()
+
+        # Create appropriately-shaped arrays to be used in-place by _atom_type_s - avoid repeated slow instantiation
         shape = [self._num_quantum_order_events]
         shape.extend(list(s_data_extracted["atom_0"]["s"]["order_1"].shape))
-
         s_atom_data = np.zeros(shape=tuple(shape), dtype=AbinsModules.AbinsConstants.FLOAT_TYPE)
-        shape.pop(0)
-
-        num_atoms = len([key for key in s_data_extracted.keys() if "atom" in key])
         temp_s_atom_data = np.copy(s_atom_data)
 
-        result = []
+        num_atoms = len([key for key in s_data_extracted.keys() if "atom" in key])
+
         masses = {}
         for i in range(num_atoms):
             symbol = self._extracted_ab_initio_data["atom_%s" % i]["symbol"]
@@ -286,15 +309,66 @@ class Abins(PythonAlgorithm):
         for s in masses:
             masses[s] = sorted(list(set(masses[s])))
 
-        for symbol in atoms_symbols:
+        result = []
 
-            sub = len(masses[symbol]) > one_m or abs(Atom(symbol=symbol).mass - masses[symbol][0]) > eps
-            for m in masses[symbol]:
-                result.extend(self._atom_type_s(num_atoms=num_atoms, mass=m, s_data_extracted=s_data_extracted,
-                                                element_symbol=symbol, temp_s_atom_data=temp_s_atom_data,
-                                                s_atom_data=s_atom_data, substitution=sub))
-
+        if atoms_symbols is not None:
+            for symbol in atoms_symbols:
+                sub = len(masses[symbol]) > one_m or abs(Atom(symbol=symbol).mass - masses[symbol][0]) > eps
+                for m in masses[symbol]:
+                    result.extend(self._atom_type_s(num_atoms=num_atoms, mass=m, s_data_extracted=s_data_extracted,
+                                                    element_symbol=symbol, temp_s_atom_data=temp_s_atom_data,
+                                                    s_atom_data=s_atom_data, substitution=sub))
+        if atom_numbers is not None:
+                for atom_number in atom_numbers:
+                        result.extend(self._atom_number_s(atom_number=atom_number, s_data_extracted=s_data_extracted,
+                                                          s_atom_data=s_atom_data))
         return result
+
+    def _atom_number_s(self, atom_number=None, s_data_extracted=None, s_atom_data=None):
+        """
+        Helper function for calculating S for the given atomic index
+
+        :param atom_number: Index of atom in s_data e.g. 1 to select 'atom_1'
+        :type atom_number: int
+
+        :param s_data_extracted: Collection of precalculated S for all atoms and quantum orders, obtained from extract()
+            method of AbinsModules.SData.SData object.
+        :type s_data: dict
+
+        :param s_atom_data: helper array to accumulate S (outer loop over atoms); does not transport
+            information but is used in-place to save on time instantiating large arrays. First dimension is quantum
+            order; following dimensions should match arrays in s_data.
+        :type s_atom_data: numpy.ndarray
+
+        :param
+
+        :returns: mantid workspaces of S for atom (total) and individual quantum orders
+        :returntype: list of Workspace2D
+        """
+        atom_workspaces = []
+        s_atom_data.fill(0.0)
+        atom_label = "atom_%s" % atom_number
+        symbol = self._extracted_ab_initio_data["atom_%s" % atom_number]["symbol"]
+        mass = self._extracted_ab_initio_data["atom_%s" % atom_number]["mass"]
+        z_number = Atom(symbol=symbol).z_number
+
+        for i, order in enumerate(range(AbinsModules.AbinsConstants.FUNDAMENTALS,
+                                        self._num_quantum_order_events + AbinsModules.AbinsConstants.S_LAST_INDEX)):
+
+            s_atom_data[i] = s_data_extracted[atom_label]["s"]["order_%s" % order]
+
+        total_s_atom_data = np.sum(s_atom_data, axis=0)
+
+        atom_workspaces = []
+        atom_workspaces.append(self._create_workspace(atom_name=atom_label,
+                                                      s_points=np.copy(total_s_atom_data),
+                                                      optional_name="_total", protons_number=z_number))
+        atom_workspaces.append(self._create_workspace(atom_name=atom_label,
+                                                      s_points=np.copy(s_atom_data),
+                                                      protons_number=z_number))
+        return atom_workspaces
+
+
 
     def _atom_type_s(self, num_atoms=None, mass=None, s_data_extracted=None, element_symbol=None, temp_s_atom_data=None,
                      s_atom_data=None, substitution=None):
@@ -304,8 +378,10 @@ class Abins(PythonAlgorithm):
         :param num_atoms: number of atoms in the system
         :param s_data_extracted: data with all S
         :param element_symbol: label for the type of atom
-        :param temp_s_atom_data: helper array to store S
-        :param s_atom_data: stores all S for the given type of atom
+        :param temp_s_atom_data: helper array to accumulate S (inner loop over quantum order); does not transport
+            information but is used in-place to save on time instantiating large arrays.
+        :param s_atom_data: helper array to accumulate S (outer loop over atoms); does not transport
+            information but is used in-place to save on time instantiating large arrays.
         :param substitution: True if isotope substitution and False otherwise
         """
         atom_workspaces = []
@@ -354,18 +430,25 @@ class Abins(PythonAlgorithm):
 
         return atom_workspaces
 
-    def _create_partial_s_per_type_workspaces(self, atoms_symbols=None, s_data=None):
+    def _create_partial_s_per_type_workspaces(self, atoms_symbols=None, atom_numbers=None, s_data=None):
         """
         Creates workspaces for all types of atoms. Each workspace stores quantum order events for S for the given
         type of atom. It also stores total workspace for the given type of atom.
 
-        :param atoms_symbols: list of atom types for which quantum order events of S  should be calculated
-        :param s_data: dynamical factor data of type SData
+        :param atoms_symbols: atom types (i.e. element symbols) for which S should be created.
+        :type iterable of str:
+
+        :param atom_numbers: indices of individual atoms for which S should be created
+        :type iterable of int:
+
+        :param s_data: dynamical factor data
+        :type AbinsModules.SData.SData
+
         :returns: workspaces for list of atoms types, each workspace contains  quantum order events of
                  S for the particular atom type
         """
 
-        return self._create_workspaces(atoms_symbols=atoms_symbols, s_data=s_data)
+        return self._create_workspaces(atoms_symbols=atoms_symbols, atom_numbers=atom_numbers, s_data=s_data)
 
     def _fill_s_workspace(self, s_points=None, workspace=None, protons_number=None, nucleons_number=None):
         """

--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -229,16 +229,18 @@ class Abins(PythonAlgorithm):
                 if atom_symbol not in all_atms_smbls:
                     raise ValueError("User defined atom selection (by element) '%s': not present in the system." %
                                      atom_symbol)
+
             for atom_number in atom_numbers:
-                try:
-                    atom_number = int(atom_number)
-                except ValueError:
-                    raise ValueError("Invalid user atom selection (by number) '%s': could not convert to integer" %
-                                     atom_number)
                 if atom_number < 1 or atom_number > num_atoms:
                     raise ValueError("Invalid user atom selection (by number) '%s%s': out of range (%s - %s)" %
                                      (prefix, atom_number, 1, num_atoms))
-            atom_numbers = list(map(int, atom_numbers))
+
+            # Final sanity check that everything in "atoms" field was understood
+            if len(atom_symbols) + len (atom_numbers) < len(self._atoms):
+                elements_report = " Symbols: " + ", ".join(atom_symbols) if len(atom_symbols) else ""
+                numbers_report = " Numbers: " + ", ".join(atom_numbers) if len(atom_numbers) else ""
+                raise ValueError("Not all user atom selections ('atoms' option) were understood." +
+                                 elements_report + numbers_report)
 
         prog_reporter.report("Atoms, for which dynamical structure factors should be plotted, have been determined.")
 

--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -319,9 +319,9 @@ class Abins(PythonAlgorithm):
                                                     element_symbol=symbol, temp_s_atom_data=temp_s_atom_data,
                                                     s_atom_data=s_atom_data, substitution=sub))
         if atom_numbers is not None:
-                for atom_number in atom_numbers:
-                        result.extend(self._atom_number_s(atom_number=atom_number, s_data_extracted=s_data_extracted,
-                                                          s_atom_data=s_atom_data))
+            for atom_number in atom_numbers:
+                result.extend(self._atom_number_s(atom_number=atom_number, s_data_extracted=s_data_extracted,
+                                                  s_atom_data=s_atom_data))
         return result
 
     def _atom_number_s(self, atom_number=None, s_data_extracted=None, s_atom_data=None):
@@ -349,7 +349,6 @@ class Abins(PythonAlgorithm):
         s_atom_data.fill(0.0)
         atom_label = "atom_%s" % atom_number
         symbol = self._extracted_ab_initio_data["atom_%s" % atom_number]["symbol"]
-        mass = self._extracted_ab_initio_data["atom_%s" % atom_number]["mass"]
         z_number = Atom(symbol=symbol).z_number
 
         for i, order in enumerate(range(AbinsModules.AbinsConstants.FUNDAMENTALS,
@@ -367,8 +366,6 @@ class Abins(PythonAlgorithm):
                                                       s_points=np.copy(s_atom_data),
                                                       protons_number=z_number))
         return atom_workspaces
-
-
 
     def _atom_type_s(self, num_atoms=None, mass=None, s_data_extracted=None, element_symbol=None, temp_s_atom_data=None,
                      s_atom_data=None, substitution=None):

--- a/Framework/PythonInterface/plugins/algorithms/Abins.py
+++ b/Framework/PythonInterface/plugins/algorithms/Abins.py
@@ -209,17 +209,21 @@ class Abins(PythonAlgorithm):
             atom_symbols = all_atms_smbls
             atom_numbers = []
         else:  # case selected atoms
-            if len(self._atoms) != len(set(self._atoms)):  # only different types
-                raise ValueError("Not all user defined atoms are unique.")
-
             # Specific atoms are identified with prefix and integer index, e.g 'atom_5'. Other items are element symbols
             # A regular expression match is used to make the underscore separator optional and check the index format
             prefix = AbinsModules.AbinsConstants.ATOM_PREFIX
             atom_symbols = [item for item in self._atoms if item[:len(prefix)] != prefix]
+            if len(atom_symbols) != len(set(atom_symbols)):  # only different types
+                raise ValueError("User atom selection (by symbol) contains repeated species. This is not permitted as "
+                                 "Abins cannot create multiple workspaces with the same name.")
 
             numbered_atom_test = re.compile('^' + prefix + '_?(\d+)$')
             atom_numbers = [numbered_atom_test.findall(item) for item in self._atoms]  # Matches will be lists of str
             atom_numbers = [int(match[0]) for match in atom_numbers if match]  # Remove empty matches, cast rest to int
+
+            if len(atom_numbers) != len(set(atom_numbers)):
+                raise ValueError("User atom selection (by number) contains repeated atom. This is not permitted as Abins"
+                                 " cannot create multiple workspaces with the same name.")
 
             for atom_symbol in atom_symbols:
                 if atom_symbol not in all_atms_smbls:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -11,7 +11,7 @@ from mantid import logger
 from mantid.simpleapi import mtd, Abins, Scale, CompareWorkspaces, Load, DeleteWorkspace
 from AbinsModules import AbinsConstants, AbinsTestHelpers
 import numpy as np
-
+from numpy.testing import assert_array_almost_equal
 
 class AbinsBasicTest(unittest.TestCase):
 
@@ -86,8 +86,19 @@ class AbinsBasicTest(unittest.TestCase):
         """Test scenario in which  a user requests to create workspaces for atoms which do not exist in the system.
            In that case Abins should terminate and give a user a meaningful message about wrong atoms to analyse.
         """
-        # In _squaricn there is no C atoms
+        # In _squaricn there are no N atoms
         self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._squaricn + ".phonon", Atoms="N",
+                          OutputWorkspace=self._workspace_name)
+
+    def test_atom_index_limits(self):
+        """Individual atoms may be indexed (counting from 1); if the index falls outside number of atoms, Abins should
+           terminate with a useful error message.
+        """
+        self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._squaricn + ".phonon",
+                          Atoms=AbinsConstants.ATOM_PREFIX + "0",
+                          OutputWorkspace=self._workspace_name)
+        self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._squaricn + ".phonon",
+                          Atoms=AbinsConstants.ATOM_PREFIX + "61",
                           OutputWorkspace=self._workspace_name)
 
     def test_scale(self):
@@ -200,6 +211,37 @@ class AbinsBasicTest(unittest.TestCase):
                                                    Tolerance=self._tolerance)
             self.assertEqual(result, True)
 
+    def test_numbered(self):
+        # Can request workspaces by atom number; these should add up to the usual elemental totals
+
+        wrk_ref = Abins(AbInitioProgram=self._ab_initio_program,
+                        VibrationalOrPhononFile=self._squaricn + ".phonon",
+                        Atoms=self._atoms,
+                        QuantumOrderEventsNumber=self._quantum_order_events_number,
+                        ScaleByCrossSection=self._cross_section_factor,
+                        OutputWorkspace=self._squaricn + "_ref")
+
+        numbered_workspace_name = "numbered"
+        h_indices = ("1", "2", "3", "4")
+        wks_numbered_atoms = Abins(VibrationalOrPhononFile=self._squaricn + ".phonon",
+                                   Atoms=", ".join([AbinsConstants.ATOM_PREFIX + s for s in h_indices]),
+                                   SumContributions=self._sum_contributions,
+                                   QuantumOrderEventsNumber=self._quantum_order_events_number,
+                                   ScaleByCrossSection=self._cross_section_factor,
+                                   OutputWorkspace=numbered_workspace_name)
+
+        wrk_ref_names = list(wrk_ref.getNames())
+        wrk_h_total = wrk_ref[wrk_ref_names.index(self._squaricn + "_ref_H_total")]
+
+        wks_numbered_atom_names = list(wks_numbered_atoms.getNames())
+        wrk_atom_totals = [wks_numbered_atoms[wks_numbered_atom_names.index(name)]
+                           for name in
+                           ['_'.join((numbered_workspace_name, AbinsConstants.ATOM_PREFIX, s, 'total')) for s in h_indices]]
+
+        assert_array_almost_equal(wrk_h_total.extractX(), wrk_atom_totals[0].extractX())
+
+        assert_array_almost_equal(wrk_h_total.extractY(),
+                                  sum((wrk.extractY() for wrk in wrk_atom_totals)))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -75,11 +75,18 @@ class AbinsBasicTest(unittest.TestCase):
                           OutputWorkspace=self._workspace_name)
 
     # test if intermediate results are consistent
-    def test_non_unique_atoms(self):
-        """Test scenario in which a user specifies non unique atoms (for example in squaricn that would be "C,C,H").
+    def test_non_unique_elements(self):
+        """Test scenario in which a user specifies non-unique elements (for example in squaricn that would be "C,C,H").
            In that case Abins should terminate and print a meaningful message.
         """
         self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._squaricn + ".phonon", Atoms="C,C,H",
+                          OutputWorkspace=self._workspace_name)
+
+    def test_non_unique_atoms(self):
+        """Test scenario in which a user specifies non-unique atoms (for example "atom_1,atom_2,atom1").
+           In that case Abins should terminate and print a meaningful message.
+        """
+        self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._squaricn + ".phonon", Atoms="atom_1,atom_2,atom1",
                           OutputWorkspace=self._workspace_name)
 
     def test_non_existing_atoms(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsBasicTest.py
@@ -180,8 +180,8 @@ class AbinsBasicTest(unittest.TestCase):
                                                Tolerance=self._tolerance)
         self.assertEqual(result, True)
 
-    def test_partial(self):
-        # By default workspaces for all atoms should be created. Test this default behaviour.
+    def test_partial_by_element(self):
+        """Check results of INS spectrum resolved by elements: default should match explicit list of elements"""
 
         experimental_file = ""
 
@@ -229,8 +229,8 @@ class AbinsBasicTest(unittest.TestCase):
                                                    Tolerance=self._tolerance)
             self.assertEqual(result, True)
 
-    def test_numbered(self):
-        # Can request workspaces by atom number; these should add up to the usual elemental totals
+    def test_partial_by_number(self):
+        """Simulated INS spectrum can also be resolved by numbered atoms. Check consistency with element totals"""
 
         wrk_ref = Abins(AbInitioProgram=self._ab_initio_program,
                         VibrationalOrPhononFile=self._squaricn + ".phonon",
@@ -260,39 +260,6 @@ class AbinsBasicTest(unittest.TestCase):
 
         assert_array_almost_equal(wrk_h_total.extractY(),
                                   sum((wrk.extractY() for wrk in wrk_atom_totals)))
-
-    def test_numbered(self):
-        # Can request workspaces by atom number; these should add up to the usual elemental totals
-
-        wrk_ref = Abins(AbInitioProgram=self._ab_initio_program,
-                        VibrationalOrPhononFile=self._squaricn + ".phonon",
-                        Atoms=self._atoms,
-                        QuantumOrderEventsNumber=self._quantum_order_events_number,
-                        ScaleByCrossSection=self._cross_section_factor,
-                        OutputWorkspace=self._squaricn + "_ref")
-
-        numbered_workspace_name = "numbered"
-        h_indices = ("1", "2", "3", "4")
-        wks_numbered_atoms = Abins(VibrationalOrPhononFile=self._squaricn + ".phonon",
-                                   Atoms=", ".join([AbinsConstants.ATOM_PREFIX + s for s in h_indices]),
-                                   SumContributions=self._sum_contributions,
-                                   QuantumOrderEventsNumber=self._quantum_order_events_number,
-                                   ScaleByCrossSection=self._cross_section_factor,
-                                   OutputWorkspace=numbered_workspace_name)
-
-        wrk_ref_names = list(wrk_ref.getNames())
-        wrk_h_total = wrk_ref[wrk_ref_names.index(self._squaricn + "_ref_H_total")]
-
-        wks_numbered_atom_names = list(wks_numbered_atoms.getNames())
-        wrk_atom_totals = [wks_numbered_atoms[wks_numbered_atom_names.index(name)]
-                           for name in
-                           ['_'.join((numbered_workspace_name, AbinsConstants.ATOM_PREFIX, s, 'total')) for s in h_indices]]
-
-        assert_array_almost_equal(wrk_h_total.extractX(), wrk_atom_totals[0].extractX())
-
-        assert_array_almost_equal(wrk_h_total.extractY(),
-                                  sum((wrk.extractY() for wrk in wrk_atom_totals)))
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/algorithms/Abins-v1.rst
+++ b/docs/source/algorithms/Abins-v1.rst
@@ -98,7 +98,7 @@ Output:
     wrk_verbose=Abins(AbInitioProgram="CASTEP", VibrationalOrPhononFile="benzene.phonon",
                       ExperimentalFile="benzene_experimental.dat",
                       TemperatureInKelvin=10, BinWidthInWavenumber=1.0, SampleForm="Powder", Instrument="TOSCA",
-                      Atoms="H", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent")
+                      Atoms="H, atom1, atom2", SumContributions=True, QuantumOrderEventsNumber="1", ScaleByCrossSection="Incoherent")
 
     for name in wrk_verbose.getNames():
         print(name)
@@ -111,6 +111,10 @@ Output:
     wrk_verbose_total
     wrk_verbose_H_total
     wrk_verbose_H
+    wrk_verbose_atom_1_total
+    wrk_verbose_atom_1
+    wrk_verbose_atom_2_total
+    wrk_verbose_atom_2
 
 .. categories::
 

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -42,6 +42,7 @@ Improvements
 - :ref:`BASISReduction <algm-BASISReduction>` permits now retaining events only within a time window.
 - :ref:`BASISReduction <algm-BASISReduction>` can output now the powder diffraction spectra.
 - :ref:`BASISCrystalDiffraction <algm-BASISCrystalDiffraction>` resolves between run with old and new DAS.
+- :ref:`Abins <algm-Abins>` permits individual numbered atom contributions to simulated INS spectrum to be specified, alongside the existing option to select by element.
 
 
 Data Analysis Interface

--- a/scripts/AbinsModules/AbinsConstants.py
+++ b/scripts/AbinsModules/AbinsConstants.py
@@ -68,6 +68,9 @@ ALL_KEYWORDS_ATOMS_S_DATA = ["s"]
 S_LABEL = "s"
 ATOM_LABEL = "atom"
 
+# user syntax for specifying atoms
+ATOM_PREFIX = "atom_"
+
 FLOAT_ID = np.dtype(np.float64).num
 FLOAT_TYPE = np.dtype(np.float64)
 

--- a/scripts/AbinsModules/AbinsConstants.py
+++ b/scripts/AbinsModules/AbinsConstants.py
@@ -69,7 +69,7 @@ S_LABEL = "s"
 ATOM_LABEL = "atom"
 
 # user syntax for specifying atoms
-ATOM_PREFIX = "atom_"
+ATOM_PREFIX = "atom"
 
 FLOAT_ID = np.dtype(np.float64).num
 FLOAT_TYPE = np.dtype(np.float64)


### PR DESCRIPTION
**Description of work.**

Modification/extension of the Abins algorithm to allow individual atom contributions to be selected. This is implemented with a prefix (`"atom_"` , set by AbinsModules.AbinsConstants.ATOM_PREFIX), using the existing API/GUI algorithm option "atoms". The existing behaviour is that "atoms" is a list of element names; under the modified behaviour elements and atoms may be mixed e.g. by entering "Si,atom_1,atom_2,Cl" in the corresponding GUI field. When Abins is used to calculate simulated S data, it returns a WorkspaceGroup including summations over Si and Cl atoms as well as spectra corresponding to the first and second atoms. These 1-indexed identifiers correspond to the atom order in the _ab initio_ input data file. This feature allows the contributions of inequivalent atomic sites to be examined even when they are the same isotope.

(*Update:* the underscore is now optional and should not be included in the ATOM_PREFIX variable. It will still be include din the workspace name.)

**To test:**
Unit tests and doctests have been updated.

To try out the changes, use strings as described above with sample data. The _squaricn.phonon_ file is suitable as it contains a variety of elements and inequivalent atomic sites; this is named "squaricn_sum_Abins.phonon" and is found (as an MD5 reference) under Testing/Data/UnitTest. The corresponding file in the data folder is MD5/189ef0c498b11e77aef83e5bc9940289, but it needs to be copied and renamed with an appropriate file extension (i.e. _*.phonon_) to be accepted by the Abins interface. GUI example below:
  
![abins_atomindex_example](https://user-images.githubusercontent.com/2511383/58643745-c8dd7380-82f7-11e9-85fb-6c36549c9c38.png)

This should run pretty quickly and give sensible errors if using a zero index or an unacceptable name (i.e. not a known element, atom_INT or atomINT).

*There is no associated issue.*

I'm not sure what the procedure is for adding release notes? A short summary of this change would be:
"Simulated INS spectra from Abins may be decomposed into specific atomic contributions, selected by their order in the imported _ab initio_ data. These selections are made in addition to the existing selection of element-wise contributions."

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
