### PR TITLE
Fixed SetSample not setting sample material number density

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
@@ -403,7 +403,7 @@ PropertyWithValue<TYPE>::setValueFromProperty(const Property &right) {
   if (auto prop = dynamic_cast<const PropertyWithValue<TYPE> *>(&right)) {
     m_value = prop->m_value;
     return "";
-  }else{
+  } else {
     return setValue(right.value());
   }  
 }

--- a/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
+++ b/Framework/Kernel/inc/MantidKernel/PropertyWithValue.tcc
@@ -399,12 +399,13 @@ void PropertyWithValue<TYPE>::replaceValidator(IValidator_sptr newValidator) {
 template <typename TYPE>
 std::string
 PropertyWithValue<TYPE>::setValueFromProperty(const Property &right) {
-  auto prop = dynamic_cast<const PropertyWithValue<TYPE> *>(&right);
-  if (!prop) {
-    return "Could not set value: properties have different type.";
-  }
-  m_value = prop->m_value;
-  return "";
+  
+  if (auto prop = dynamic_cast<const PropertyWithValue<TYPE> *>(&right)) {
+    m_value = prop->m_value;
+    return "";
+  }else{
+    return setValue(right.value());
+  }  
 }
 
 /**

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/IPropertyManager.h"
 #include "MantidKernel/IPropertySettings.h"
-#include "MantidKernel/Logger.h"
 #include "MantidKernel/OptionalBool.h"
 
 ///@cond
@@ -31,9 +30,6 @@ DEFINE_IPROPERTYMANAGER_GETVALUE(std::vector<std::vector<std::string>>)
 
 namespace Mantid {
 namespace Kernel {
-namespace {
-Logger g_log("property manager");
-}
 // This template implementation has been left in because although you can't
 // assign to an existing string
 // via the getProperty() method, you can construct a local variable by saying,

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -6,8 +6,8 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/IPropertyManager.h"
 #include "MantidKernel/IPropertySettings.h"
-#include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Logger.h"
+#include "MantidKernel/OptionalBool.h"
 
 ///@cond
 DEFINE_IPROPERTYMANAGER_GETVALUE(int16_t)
@@ -31,8 +31,9 @@ DEFINE_IPROPERTYMANAGER_GETVALUE(std::vector<std::vector<std::string>>)
 
 namespace Mantid {
 namespace Kernel {
-namespace{
-Logger g_log("property manager");}
+namespace {
+Logger g_log("property manager");
+}
 // This template implementation has been left in because although you can't
 // assign to an existing string
 // via the getProperty() method, you can construct a local variable by saying,
@@ -82,8 +83,9 @@ void IPropertyManager::updatePropertyValues(const IPropertyManager &other) {
   for (auto &prop : props) {
     const std::string propName = (*prop).name();
     if (other.existsProperty(propName)) {
-      auto err = (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
-      if(err!="")
+      auto err =
+          (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
+      if (err != "")
         g_log.error(err);
     }
   }

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -83,10 +83,7 @@ void IPropertyManager::updatePropertyValues(const IPropertyManager &other) {
   for (auto &prop : props) {
     const std::string propName = (*prop).name();
     if (other.existsProperty(propName)) {
-      auto err =
-          (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
-      if (err != "")
-        g_log.error(err);
+      (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
     }
   }
 }

--- a/Framework/Kernel/src/IPropertyManager.cpp
+++ b/Framework/Kernel/src/IPropertyManager.cpp
@@ -7,6 +7,7 @@
 #include "MantidKernel/IPropertyManager.h"
 #include "MantidKernel/IPropertySettings.h"
 #include "MantidKernel/OptionalBool.h"
+#include "MantidKernel/Logger.h"
 
 ///@cond
 DEFINE_IPROPERTYMANAGER_GETVALUE(int16_t)
@@ -30,6 +31,8 @@ DEFINE_IPROPERTYMANAGER_GETVALUE(std::vector<std::vector<std::string>>)
 
 namespace Mantid {
 namespace Kernel {
+namespace{
+Logger g_log("property manager");}
 // This template implementation has been left in because although you can't
 // assign to an existing string
 // via the getProperty() method, you can construct a local variable by saying,
@@ -79,7 +82,9 @@ void IPropertyManager::updatePropertyValues(const IPropertyManager &other) {
   for (auto &prop : props) {
     const std::string propName = (*prop).name();
     if (other.existsProperty(propName)) {
-      (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
+      auto err = (*prop).setValueFromProperty(*other.getPointerToProperty(propName));
+      if(err!="")
+        g_log.error(err);
     }
   }
 }

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -440,6 +440,34 @@ public:
     TS_ASSERT_EQUALS(mgr.propertyCount(), 0);
   }
 
+  void testUpdatePropertyValues() {
+    PropertyManagerHelper mgr1;
+    mgr1.declareProperty("aProp", 10);
+    PropertyManagerHelper mgr2;
+    mgr2.declareProperty("aProp", 0);
+    mgr2.updatePropertyValues(mgr1);
+    const std::vector<Property *> &props1 = mgr1.getProperties();
+    const std::vector<Property *> &props2 = mgr2.getProperties();
+    TS_ASSERT_EQUALS(props1.size(), props2.size());
+    TS_ASSERT_DIFFERS(&props1[0], &props2[0]);
+    TS_ASSERT_EQUALS(props1[0]->name(), props2[0]->name());
+    TS_ASSERT_EQUALS(props1[0]->value(), props2[0]->value());
+  }
+
+  void testUpdatePropertyValuesWithStringConversion() {
+    PropertyManagerHelper mgr1;
+    mgr1.declareProperty("aProp", "10");
+    PropertyManagerHelper mgr2;
+    mgr2.declareProperty("aProp", 0);
+    mgr2.updatePropertyValues(mgr1);
+    const std::vector<Property *> &props1 = mgr1.getProperties();
+    const std::vector<Property *> &props2 = mgr2.getProperties();
+    TS_ASSERT_EQUALS(props1.size(), props2.size());
+    TS_ASSERT_DIFFERS(&props1[0], &props2[0]);
+    TS_ASSERT_EQUALS(props1[0]->name(), props2[0]->name());
+    TS_ASSERT_EQUALS(props1[0]->value(), props2[0]->value());
+  }
+
   void test_asStringWithNotEnabledProperty() {
     PropertyManagerHelper mgr;
     TS_ASSERT_THROWS_NOTHING(mgr.declareProperty("Semaphor", true));

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -30,6 +30,11 @@ Improvements
 - :code:`indices` and :code:`slicepoint` options have been added to :ref:`mantid.plots <mantid.plots>` to allow selection of which plane to plot from an MDHistoWorkspace. :code:`transpose` has also been added to transpose the axes of any 2D plot.
 - :ref:`Pseudo-Voigt <func-PseudoVoigt>` has been modified to be more in line with FULLPROF and GSAS.  One of its basic parameter, Height, is changed to Intensity.
 
+
+Bug fixes
+#########
+- :ref: `SetSample <algm-SetSample>` now correctly handles the Sample number density being passed as a string, before the algorithm would execute, but silently ignored the provided number density, the number density is now properly used.
+
 Removed
 #######
 


### PR DESCRIPTION
**Description of work.**
if the sample number density was passed in as a string to `setsample`, it was accepted but ignored, this fixes it so that its properly passes through to `setSampleMaterial`

**To test:**
run the following script
```
CreateSampleWorkspace(OutputWorkspace='ws')
SetSample(InputWorkspace='ws', Geometry='{"Axis":1,"Center":[0,0,0],"Height":4,"Radius":1,"Shape":"Cylinder"}', Material='{"ChemicalFormula":"V","SampleNumberDensity":"0.1"}')
```
then check the sample material, it should have a number density of 0.1, not 0.07

Fixes #25498 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
