### PR TITLE
Changed python executor name in workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -344,7 +344,7 @@ class MainWindow(QMainWindow):
         self.populate_interfaces_menu()
 
     def launch_custom_python_gui(self, filename):
-        self.executioner.execute(open(filename).read(), filename)
+        self.interface_executor.execute(open(filename).read(), filename)
 
     def launch_custom_cpp_gui(self, interface_name):
         interface = self.interface_manager.createSubWindow(interface_name)


### PR DESCRIPTION
**Description of work.**

Currently python interfaces will not open on the workbench. This is because the name of the python executor object has been changed but not updated in the launch custom GUI function. This PR updates the name so that custom python interfaces should not successfully launch.

**To test:**

Build the workbench and try to open the ISIS SANS GUI. If it successfully opens the fix is working.



*There is no associated issue.*

*This does not require release notes* because this is an issue introduced in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
