### PR TITLE
New format for modulated UB output

### DIFF
--- a/Framework/Crystal/src/SaveIsawUB.cpp
+++ b/Framework/Crystal/src/SaveIsawUB.cpp
@@ -166,7 +166,7 @@ void SaveIsawUB::exec() {
       out << "Modulation Vector 1 error:   " << setw(6) << setprecision(4)
           << lattice.getdherr(0) << setw(12) << setprecision(4)
           << lattice.getdkerr(0) << setw(12) << setprecision(4)
-          << lattice.getdlerr(0) << " \n\n";
+          << lattice.getdlerr(0) << " \n";
     }
     if (ModDim >= 2) {
       out << "Modulation Vector 2:   " << setw(12) << setprecision(4)
@@ -176,7 +176,7 @@ void SaveIsawUB::exec() {
       out << "Modulation Vector 2 error:   " << setw(6) << setprecision(4)
           << lattice.getdherr(1) << setw(12) << setprecision(4)
           << lattice.getdkerr(1) << setw(12) << setprecision(4)
-          << lattice.getdlerr(1) << " \n\n";
+          << lattice.getdlerr(1) << " \n";
     }
     if (ModDim == 3) {
       out << "Modulation Vector 3:   " << setw(12) << setprecision(4)
@@ -186,8 +186,9 @@ void SaveIsawUB::exec() {
       out << "Modulation Vector 3 error:   " << setw(6) << setprecision(4)
           << lattice.getdherr(2) << setw(12) << setprecision(4)
           << lattice.getdkerr(2) << setw(12) << setprecision(4)
-          << lattice.getdlerr(2) << " \n\n";
+          << lattice.getdlerr(2) << " \n";
     }
+    out << "\n";
     if (ModDim >= 1) {
       out << "Max Order:        " << lattice.getMaxOrder() << " \n";
       out << "Cross Terms:      " << lattice.getCrossTerm() << " \n";

--- a/Framework/Crystal/src/SaveIsawUB.cpp
+++ b/Framework/Crystal/src/SaveIsawUB.cpp
@@ -188,8 +188,8 @@ void SaveIsawUB::exec() {
           << lattice.getdkerr(2) << setw(12) << setprecision(4)
           << lattice.getdlerr(2) << " \n";
     }
-    out << "\n";
     if (ModDim >= 1) {
+      out << "\n";
       out << "Max Order:        " << lattice.getMaxOrder() << " \n";
       out << "Cross Terms:      " << lattice.getCrossTerm() << " \n";
     }


### PR DESCRIPTION
**Description of work.**
Change format of modulation vectors in UB file.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** Shiyun Jin
-->

**To test:**
````python
peaks = LoadIsawPeaks("test.peaks")
LoadIsawUB(peaks,'test.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_1mod', ModVector1='-0.49367,-0.440224,0.388', MaxOrder=1)
SaveIsawUB(InputWorkspace='fractional_peaks_1mod', Filename='1mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_1mod', Filename='1mod.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_2mod', ModVector1='-0.49367,-0.440224,0.388', ModVector2='-0.25,-0.22,0.19',MaxOrder=1)
SaveIsawUB(InputWorkspace='fractional_peaks_2mod', Filename='2mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_2mod', Filename='2mod.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_3mod', ModVector1='-0.49367,-0.440224,0.388', ModVector2='-0.25,-0.22,0.19', ModVector3='0.1,0.1,0.1', MaxOrder=1)
SaveIsawUB(InputWorkspace='fractional_peaks_3mod', Filename='3mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_3mod', Filename='3mod.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_1mod', ModVector1='-0.49367,-0.440224,0.388', MaxOrder=1,CrossTerms=True)
SaveIsawUB(InputWorkspace='fractional_peaks_1mod', Filename='1mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_1mod', Filename='1mod.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_2mod', ModVector1='-0.49367,-0.440224,0.388', ModVector2='-0.25,-0.22,0.19',MaxOrder=1,CrossTerms=True)
SaveIsawUB(InputWorkspace='fractional_peaks_2mod', Filename='2mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_2mod', Filename='2mod.mat')
PredictSatellitePeaks(Peaks='peaks', SatellitePeaks='fractional_peaks_3mod', ModVector1='-0.49367,-0.440224,0.388', ModVector2='-0.25,-0.22,0.19', ModVector3='0.1,0.1,0.1', MaxOrder=1,CrossTerms=True)
SaveIsawUB(InputWorkspace='fractional_peaks_3mod', Filename='3mod.mat')
LoadIsawUB(InputWorkspace='fractional_peaks_3mod', Filename='3mod.mat')
````
Fixes #25678
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it is a minor change to code in development


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
