### PR TITLE
Add OffsetData to SNSPowderReduction

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Scale.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Scale.h
@@ -37,6 +37,7 @@ public:
     return "Scales an input workspace by the given factor, which can be either "
            "multiplicative or additive.";
   }
+  std::map<std::string, std::string> validateInputs() override;
 
   /// Algorithm's version
   int version() const override { return (1); }

--- a/docs/source/algorithms/SNSPowderReduction-v1.rst
+++ b/docs/source/algorithms/SNSPowderReduction-v1.rst
@@ -9,6 +9,21 @@
 Description
 -----------
 
+Manipulating the data with constants
+####################################
+
+There are three properties which will modify the data after it is
+reduced: ``PushDataPositive``, ``ScaleData``, ``OffsetData``. These
+options are all performed on the data after all other operations. They
+will be done as
+
+.. math:: wksp = ScaleData * wksp + OffsetData
+
+followed by :ref:`ResetNegatives <algm-ResetNegatives>` with
+``AddMinimum`` being ``True`` if
+``PushDataPositive='AddMinimum'``. :ref:`ResetNegatives
+<algm-ResetNegatives>` is not run when ``PushDataPositive='None'``.
+
 About Filter Wall
 #################
 

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -16,6 +16,7 @@ Improvements
 ############
 
 - The Polaris scripts can now detect the chopper mode if none is provided using the frequency block logs.
+- :ref:`SNSPowderReduction <algm-SNSPowderReduction>` has a new property, ``OffsetData``, which adds a constant to the data at the very end of the reduction
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
The POWGEN team requested the ability to optionally set a fixed offset to the data rather than using the automatically determined value from `PushPositive`. The change to the code is to apply `PushPositive` last so the "by hand" offset can account for the majority of shift (likely all of it).

**Report to:** POWGEN instrument team

**To test:**

Try the algorithm with and without `OffsetData` specified. The result should be shifted by the amount requested.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
