### PR TITLE
Fixed Engineering gui ignoring browsed to file

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_PowderPolarisTest.py
@@ -64,8 +64,8 @@ class CreateVanadiumTest(systemtesting.MantidSystemTest):
         splined_ws, unsplined_ws = self.calibration_results
         for ws in splined_ws+unsplined_ws:
             self.assertEqual(ws.sample().getMaterial().name(), 'V')
-        return (unsplined_ws.getName(), "ISIS_Powder-POLARIS00098533_unsplined.nxs",
-                splined_ws.getName(), "ISIS_Powder-POLARIS00098533_splined.nxs")
+        return (unsplined_ws.name(), "ISIS_Powder-POLARIS00098533_unsplined.nxs",
+                splined_ws.name(), "ISIS_Powder-POLARIS00098533_splined.nxs")
 
     def cleanup(self):
         try:
@@ -93,7 +93,7 @@ class FocusTest(systemtesting.MantidSystemTest):
         for ws in self.focus_results:
             self.assertEqual(ws.sample().getMaterial().name(), 'Si')
         self.tolerance = 1e-7
-        return self.focus_results.getName(), "ISIS_Powder-POLARIS98533_FocusSempty.nxs"
+        return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusSempty.nxs"
 
     def cleanup(self):
         try:
@@ -124,7 +124,7 @@ class FocusTestChopperMode(systemtesting.MantidSystemTest):
         # this needs to be put in due to rounding errors between OS' for the proton_charge_by_period log
         self.disableChecking.append('Sample')
         self.tolerance = 1e-7
-        return self.focus_results.getName(), "ISIS_Powder-POLARIS98533_Auto_chopper.nxs"
+        return self.focus_results.name(), "ISIS_Powder-POLARIS98533_Auto_chopper.nxs"
 
     def cleanup(self):
         try:

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -36,6 +36,8 @@ Bug Fixes
 
 - Prevented issue with reading CSV files on python 3
 
+- GUI now correctly loads the file browsed to instead of looking for a run number in every folder along the path to that file.
+
 Single Crystal Diffraction
 --------------------------
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -496,8 +496,11 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
     loadWorkspace(filename, temporaryWSName);
 
     API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
-    const auto ws = ADS.retrieveWS<API::MatrixWorkspace>(temporaryWSName);
-
+    auto ws_test = ADS.retrieveWS<API::Workspace>(temporaryWSName);
+    const auto ws = boost::dynamic_pointer_cast<API::MatrixWorkspace>(ws_test);
+    if(!ws){
+      throw std::invalid_argument("Workspace is not a matrix workspace.");
+    }
     const auto bank = guessBankID(ws);
     const int runNumber = ws->getRunNumber();
     RunLabel runLabel(runNumber, bank);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -498,7 +498,7 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
     API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
     auto ws_test = ADS.retrieveWS<API::Workspace>(temporaryWSName);
     const auto ws = boost::dynamic_pointer_cast<API::MatrixWorkspace>(ws_test);
-    if(!ws){
+    if (!ws) {
       throw std::invalid_argument("Workspace is not a matrix workspace.");
     }
     const auto bank = guessBankID(ws);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingModel.cpp
@@ -134,16 +134,15 @@ void EnggDiffFittingModel::saveFitResultsToHDF5(
     const std::vector<RunLabel> &runLabels, const std::string &filename) const {
   std::vector<std::string> inputWorkspaces;
   inputWorkspaces.reserve(runLabels.size());
-  std::vector<long> runNumbers;
+  std::vector<std::string> runNumbers;
   runNumbers.reserve(runLabels.size());
   std::vector<long> bankIDs;
   bankIDs.reserve(runLabels.size());
 
   for (const auto &runLabel : runLabels) {
     const auto ws = getFitResults(runLabel);
-    const auto clonedWSName = "enggggui_fit_params_" +
-                              std::to_string(runLabel.runNumber) + "_" +
-                              std::to_string(runLabel.bank);
+    const auto clonedWSName = "enggggui_fit_params_" + runLabel.runNumber +
+                              "_" + std::to_string(runLabel.bank);
     cloneWorkspace(ws, clonedWSName);
     inputWorkspaces.emplace_back(clonedWSName);
     runNumbers.emplace_back(runLabel.runNumber);
@@ -502,7 +501,7 @@ void EnggDiffFittingModel::loadWorkspaces(const std::string &filenamesString) {
       throw std::invalid_argument("Workspace is not a matrix workspace.");
     }
     const auto bank = guessBankID(ws);
-    const int runNumber = ws->getRunNumber();
+    const auto runNumber = std::to_string(ws->getRunNumber());
     RunLabel runLabel(runNumber, bank);
 
     addFocusedWorkspace(runLabel, ws, filename);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -322,7 +322,6 @@ void EnggDiffFittingPresenter::processLoad() {
     warnFileNotFound(ex);
     return;
   }
-  
 
   const auto runLabels = m_model->getRunLabels();
   std::vector<std::string> listWidgetLabels;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -661,7 +661,7 @@ void EnggDiffFittingPresenter::warnFileNotFound(const std::exception &ex) {
   m_view->showStatus("Error while loading focused run");
   m_view->userWarning("Invalid file selected",
                       "Mantid could not load the selected file, "
-                      "or was unable to get nessecary information."
+                      "or was unable to get necessary information."
                       "See the logger for more information");
   g_log.error("Failed to load file. Error message: ");
   g_log.error(ex.what());

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -318,10 +318,11 @@ void EnggDiffFittingPresenter::processLoad() {
   } catch (std::invalid_argument &ex) {
     warnFileNotFound(ex);
     return;
-  } catch (Mantid::Kernel::Exception::NotFoundError &ex) {
+  } catch (std::runtime_error &ex) {
     warnFileNotFound(ex);
     return;
   }
+  
 
   const auto runLabels = m_model->getRunLabels();
   std::vector<std::string> listWidgetLabels;
@@ -661,8 +662,8 @@ bool EnggDiffFittingPresenter::isDigit(const std::string &text) const {
 void EnggDiffFittingPresenter::warnFileNotFound(const std::exception &ex) {
   m_view->showStatus("Error while loading focused run");
   m_view->userWarning("Invalid file selected",
-                      "Mantid could not load the selected file. "
-                      "Are you sure it exists? "
+                      "Mantid could not load the selected file, "
+                      "or was unable to get nessecary information."
                       "See the logger for more information");
   g_log.error("Failed to load file. Error message: ");
   g_log.error(ex.what());

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -37,11 +37,11 @@ RunLabel runLabelFromListWidgetLabel(const std::string &listLabel) {
   const auto runNumber = listLabel.substr(0, underscorePosition);
   const auto bank = listLabel.substr(underscorePosition + 1);
 
-  return RunLabel(std::atoi(runNumber.c_str()), std::atoi(bank.c_str()));
+  return RunLabel(runNumber, std::atoi(bank.c_str()));
 }
 
 std::string listWidgetLabelFromRunLabel(const RunLabel &runLabel) {
-  return std::to_string(runLabel.runNumber) + "_" +
+  return runLabel.runNumber + "_" +
          std::to_string(runLabel.bank);
 }
 
@@ -203,7 +203,7 @@ EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) const {
 }
 
 std::string
-EnggDiffFittingPresenter::userHDFRunFilename(const int runNumber) const {
+EnggDiffFittingPresenter::userHDFRunFilename(const std::string runNumber) const {
   return m_mainParam->userHDFRunFilename(runNumber);
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -41,8 +41,7 @@ RunLabel runLabelFromListWidgetLabel(const std::string &listLabel) {
 }
 
 std::string listWidgetLabelFromRunLabel(const RunLabel &runLabel) {
-  return runLabel.runNumber + "_" +
-         std::to_string(runLabel.bank);
+  return runLabel.runNumber + "_" + std::to_string(runLabel.bank);
 }
 
 // Remove commas at the start and end of the string,
@@ -202,8 +201,8 @@ EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) const {
   return m_mainParam->outFilesUserDir(addToDir);
 }
 
-std::string
-EnggDiffFittingPresenter::userHDFRunFilename(const std::string runNumber) const {
+std::string EnggDiffFittingPresenter::userHDFRunFilename(
+    const std::string runNumber) const {
   return m_mainParam->userHDFRunFilename(runNumber);
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.cpp
@@ -202,7 +202,7 @@ EnggDiffFittingPresenter::outFilesUserDir(const std::string &addToDir) const {
 }
 
 std::string EnggDiffFittingPresenter::userHDFRunFilename(
-    const std::string runNumber) const {
+    const std::string &runNumber) const {
   return m_mainParam->userHDFRunFilename(runNumber);
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -56,7 +56,7 @@ public:
   Poco::Path outFilesUserDir(const std::string &addToDir) const override;
   //@}
 
-  std::string userHDFRunFilename(const std::string runNumber) const override;
+  std::string userHDFRunFilename(const std::string &runNumber) const override;
   std::string userHDFMultiRunFilename(
       const std::vector<RunLabel> &runLabels) const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffFittingPresenter.h
@@ -56,7 +56,7 @@ public:
   Poco::Path outFilesUserDir(const std::string &addToDir) const override;
   //@}
 
-  std::string userHDFRunFilename(const int runNumber) const override;
+  std::string userHDFRunFilename(const std::string runNumber) const override;
   std::string userHDFMultiRunFilename(
       const std::vector<RunLabel> &runLabels) const override;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -93,12 +93,12 @@ void EnggDiffGSASFittingModel::addSigma(const RunLabel &runLabel,
 namespace {
 
 std::string generateFittedPeaksWSName(const RunLabel &runLabel) {
-  return std::to_string(runLabel.runNumber) + "_" +
+  return runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) + "_gsasii_fitted_peaks";
 }
 
 std::string generateLatticeParamsName(const RunLabel &runLabel) {
-  return std::to_string(runLabel.runNumber) + "_" +
+  return runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) + "_lattice_params";
 }
 } // namespace
@@ -279,7 +279,7 @@ void EnggDiffGSASFittingModel::saveRefinementResultsToHDF5(
   const auto numRuns = refinementResultSets.size();
   std::vector<std::string> latticeParamWSNames;
   latticeParamWSNames.reserve(numRuns);
-  std::vector<long> runNumbers;
+  std::vector<std::string> runNumbers;
   runNumbers.reserve(numRuns);
   std::vector<long> bankIDs;
   bankIDs.reserve(numRuns);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -93,13 +93,13 @@ void EnggDiffGSASFittingModel::addSigma(const RunLabel &runLabel,
 namespace {
 
 std::string generateFittedPeaksWSName(const RunLabel &runLabel) {
-  return runLabel.runNumber + "_" +
-         std::to_string(runLabel.bank) + "_gsasii_fitted_peaks";
+  return runLabel.runNumber + "_" + std::to_string(runLabel.bank) +
+         "_gsasii_fitted_peaks";
 }
 
 std::string generateLatticeParamsName(const RunLabel &runLabel) {
-  return runLabel.runNumber + "_" +
-         std::to_string(runLabel.bank) + "_lattice_params";
+  return runLabel.runNumber + "_" + std::to_string(runLabel.bank) +
+         "_lattice_params";
 }
 } // namespace
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -229,8 +229,9 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) const {
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
   auto wsTest = ADS.retrieveWS<API::Workspace>(wsName);
   const auto ws = boost::dynamic_pointer_cast<API::MatrixWorkspace>(wsTest);
-  if(!ws){
-      throw std::invalid_argument("Invalid Workspace loaded, are you sure it has been focused?");
+  if (!ws) {
+    throw std::invalid_argument(
+        "Invalid Workspace loaded, are you sure it has been focused?");
   }
   return ws;
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingModel.cpp
@@ -227,7 +227,11 @@ EnggDiffGSASFittingModel::loadFocusedRun(const std::string &filename) const {
   loadAlg->execute();
 
   API::AnalysisDataServiceImpl &ADS = API::AnalysisDataService::Instance();
-  const auto ws = ADS.retrieveWS<API::MatrixWorkspace>(wsName);
+  auto wsTest = ADS.retrieveWS<API::Workspace>(wsName);
+  const auto ws = boost::dynamic_pointer_cast<API::MatrixWorkspace>(wsTest);
+  if(!ws){
+      throw std::invalid_argument("Invalid Workspace loaded, are you sure it has been focused?");
+  }
   return ws;
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -14,8 +14,7 @@ std::string addRunNumberToGSASIIProjectFile(
     const std::string &filename,
     const MantidQt::CustomInterfaces::RunLabel &runLabel) {
   const auto dotPosition = filename.find_last_of(".");
-  return filename.substr(0, dotPosition) + "_" +
-         runLabel.runNumber + "_" +
+  return filename.substr(0, dotPosition) + "_" + runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) +
          filename.substr(dotPosition, filename.length());
 }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffGSASFittingPresenter.cpp
@@ -15,7 +15,7 @@ std::string addRunNumberToGSASIIProjectFile(
     const MantidQt::CustomInterfaces::RunLabel &runLabel) {
   const auto dotPosition = filename.find_last_of(".");
   return filename.substr(0, dotPosition) + "_" +
-         std::to_string(runLabel.runNumber) + "_" +
+         runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) +
          filename.substr(dotPosition, filename.length());
 }
@@ -144,7 +144,7 @@ void EnggDiffGSASFittingPresenter::displayFitResults(const RunLabel &runLabel) {
     m_view->userError("Invalid run identifier",
                       "Unexpectedly tried to display fit results for invalid "
                       "run, run number = " +
-                          std::to_string(runLabel.runNumber) +
+                          runLabel.runNumber +
                           ", bank ID = " + std::to_string(runLabel.bank) +
                           ". Please contact the development team");
     return;
@@ -240,7 +240,7 @@ void EnggDiffGSASFittingPresenter::processDoRefinement() {
     m_view->userError(
         "Invalid run selected for refinement",
         "Tried to run refinement on invalid focused run, run number " +
-            std::to_string(runLabel->runNumber) + " and bank ID " +
+            runLabel->runNumber + " and bank ID " +
             std::to_string(runLabel->bank) +
             ". Please contact the development team with this message");
     return;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingQtWidget.cpp
@@ -18,7 +18,7 @@ parseListWidgetItem(const QString &listWidgetItem) {
         "Unexpected run label: \"" + listWidgetItem.toStdString() +
         "\". Please contact the development team with this message");
   }
-  return MantidQt::CustomInterfaces::RunLabel(pieces[0].toInt(),
+  return MantidQt::CustomInterfaces::RunLabel(pieces[0].toStdString(),
                                               pieces[1].toUInt());
 }
 
@@ -85,7 +85,7 @@ void EnggDiffMultiRunFittingQtWidget::reportPlotInvalidFittedPeaks(
     const RunLabel &runLabel) {
   userError("Invalid fitted peaks identifier",
             "Tried to plot invalid fitted peaks, run number " +
-                std::to_string(runLabel.runNumber) + " and bank ID " +
+                runLabel.runNumber + " and bank ID " +
                 std::to_string(runLabel.bank) +
                 ". Please contact the development team with this message");
 }
@@ -94,7 +94,7 @@ void EnggDiffMultiRunFittingQtWidget::reportPlotInvalidFocusedRun(
     const RunLabel &runLabel) {
   userError("Invalid focused run identifier",
             "Tried to plot invalid focused run, run number " +
-                std::to_string(runLabel.runNumber) + " and bank ID " +
+                runLabel.runNumber + " and bank ID " +
                 std::to_string(runLabel.bank) +
                 ". Please contact the development team with this message");
 }
@@ -240,7 +240,7 @@ void EnggDiffMultiRunFittingQtWidget::updateRunList(
     const std::vector<RunLabel> &runLabels) {
   m_ui.listWidget_runLabels->clear();
   for (const auto &runLabel : runLabels) {
-    const auto labelStr = QString::number(runLabel.runNumber) + tr("_") +
+    const auto labelStr = QString(runLabel.runNumber.c_str()) + tr("_") +
                           QString::number(runLabel.bank);
     m_ui.listWidget_runLabels->addItem(labelStr);
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
@@ -50,9 +50,8 @@ bool EnggDiffMultiRunFittingWidgetModel::hasFittedPeaksForRun(
 void EnggDiffMultiRunFittingWidgetModel::removeRun(const RunLabel &runLabel) {
   if (!m_focusedRunMap.contains(runLabel)) {
     throw std::runtime_error("Tried to remove non-existent run (run number " +
-                             runLabel.runNumber +
-                             " and bank ID " + std::to_string(runLabel.bank) +
-                             ")");
+                             runLabel.runNumber + " and bank ID " +
+                             std::to_string(runLabel.bank) + ")");
   }
   m_focusedRunMap.remove(runLabel);
   if (m_fittedPeaksMap.contains(runLabel)) {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetModel.cpp
@@ -50,7 +50,7 @@ bool EnggDiffMultiRunFittingWidgetModel::hasFittedPeaksForRun(
 void EnggDiffMultiRunFittingWidgetModel::removeRun(const RunLabel &runLabel) {
   if (!m_focusedRunMap.contains(runLabel)) {
     throw std::runtime_error("Tried to remove non-existent run (run number " +
-                             std::to_string(runLabel.runNumber) +
+                             runLabel.runNumber +
                              " and bank ID " + std::to_string(runLabel.bank) +
                              ")");
   }

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -23,14 +23,14 @@ bool isDigit(const std::string &text) {
 
 std::string
 generateFittedPeaksName(const MantidQt::CustomInterfaces::RunLabel &runLabel) {
-  return runLabel.runNumber + "_" +
-         std::to_string(runLabel.bank) + "_fitted_peaks_external_plot";
+  return runLabel.runNumber + "_" + std::to_string(runLabel.bank) +
+         "_fitted_peaks_external_plot";
 }
 
 std::string
 generateFocusedRunName(const MantidQt::CustomInterfaces::RunLabel &runLabel) {
-  return runLabel.runNumber + "_" +
-         std::to_string(runLabel.bank) + "_external_plot";
+  return runLabel.runNumber + "_" + std::to_string(runLabel.bank) +
+         "_external_plot";
 }
 
 size_t guessBankID(Mantid::API::MatrixWorkspace_const_sptr ws) {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffMultiRunFittingWidgetPresenter.cpp
@@ -23,13 +23,13 @@ bool isDigit(const std::string &text) {
 
 std::string
 generateFittedPeaksName(const MantidQt::CustomInterfaces::RunLabel &runLabel) {
-  return std::to_string(runLabel.runNumber) + "_" +
+  return runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) + "_fitted_peaks_external_plot";
 }
 
 std::string
 generateFocusedRunName(const MantidQt::CustomInterfaces::RunLabel &runLabel) {
-  return std::to_string(runLabel.runNumber) + "_" +
+  return runLabel.runNumber + "_" +
          std::to_string(runLabel.bank) + "_external_plot";
 }
 
@@ -82,7 +82,7 @@ void EnggDiffMultiRunFittingWidgetPresenter::addFittedPeaks(
 
 void EnggDiffMultiRunFittingWidgetPresenter::addFocusedRun(
     const Mantid::API::MatrixWorkspace_sptr ws) {
-  const auto runNumber = ws->getRunNumber();
+  const auto runNumber = std::to_string(ws->getRunNumber());
   const auto bankID = guessBankID(ws);
 
   m_model->addFocusedRun(RunLabel(runNumber, bankID), ws);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -231,6 +231,8 @@ void EnggDiffractionPresenter::updateNewCalib(const std::string &fname) {
  * process.
  *
  * @param fname name of the calibration/GSAS iparm file
+ * @param vanNo output param to hold the vanadium run
+ * @param ceriaNo output param to hold the ceria run
  */
 void EnggDiffractionPresenter::grabCalibParms(const std::string &fname,
                                               std::string &vanNo,
@@ -1663,7 +1665,9 @@ void EnggDiffractionPresenter::focusingFinished() {
  * @param cs user settings for calibration (this does not calibrate but
  * uses calibration input files such as vanadium runs
  *
- * @param runLabel run number and bank ID of the run to focus
+ * @param runLabel run number of the run to focus
+ *
+ * @param bank the Bank ID to focus
  *
  * @param specNos string specifying a list of spectra (for "cropped"
  * focusing or "texture" focusing), only considered if not empty

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1378,7 +1378,10 @@ EnggDiffractionPresenter::outputFocusCroppedFilename(const std::string &runNo) {
       (instrumentPresent != std::string::npos)
           ? runNumber.substr(instrumentPresent + instStr.size())
           : runNumber;
-  return instStr + "_" + runName + "_focused_cropped.nxs";
+  return instStr + "_" +
+         runName.erase(
+             0, std::min(runName.find_first_not_of('0'), runName.size() - 1)) +
+         "_focused_cropped.nxs";
 }
 
 std::vector<std::string> EnggDiffractionPresenter::sumOfFilesLoadVec() {

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -2581,8 +2581,8 @@ std::string EnggDiffractionPresenter::userHDFMultiRunFilename(
   const auto minLabel = std::min_element(begin, end);
   const auto maxLabel = std::max_element(begin, end);
   auto userOutputDir = outFilesUserDir("Runs");
-  userOutputDir.append((minLabel->runNumber) + "_" +
-                       (maxLabel->runNumber) + ".hdf5");
+  userOutputDir.append((minLabel->runNumber) + "_" + (maxLabel->runNumber) +
+                       ".hdf5");
   return userOutputDir.toString();
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -806,8 +806,6 @@ void EnggDiffractionPresenter::parseCalibrateFilename(const std::string &path,
                                 "the expected instrument name: " +
                                 m_currentInst + ".\n\n" + explMsg);
   }
-  const std::string castMsg =
-      "It is not possible to interpret as an integer number ";
 
   instName = parts[0];
 }
@@ -1401,7 +1399,7 @@ std::vector<std::string> EnggDiffractionPresenter::outputFocusTextureFilenames(
       runNumber.substr(runNumber.find(instStr) + instStr.size());
   std::vector<std::string> res;
   res.reserve(bankIDs.size());
-  std::string prefix = instStr + "_" + runNo + "_focused_texture_bank_";
+  std::string prefix = instStr + "_" + runName + "_focused_texture_bank_";
   for (auto bankID : bankIDs) {
     res.emplace_back(prefix + boost::lexical_cast<std::string>(bankID) +
                      ".nxs");

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -2571,7 +2571,7 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) const {
 }
 
 std::string EnggDiffractionPresenter::userHDFRunFilename(
-    const std::string runNumber) const {
+    const std::string &runNumber) const {
   auto userOutputDir = outFilesUserDir("Runs");
   userOutputDir.append(runNumber + ".hdf5");
   return userOutputDir.toString();

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.cpp
@@ -1373,8 +1373,11 @@ std::string
 EnggDiffractionPresenter::outputFocusCroppedFilename(const std::string &runNo) {
   const std::string instStr = m_view->currentInstrument();
   const std::string runNumber = Poco::Path(runNo).getBaseName();
-  const std::string runName =
-      runNumber.substr(runNumber.find(instStr) + instStr.size());
+  const auto instrumentPresent = runNumber.find(instStr);
+  std::string runName =
+      (instrumentPresent != std::string::npos)
+          ? runNumber.substr(instrumentPresent + instStr.size())
+          : runNumber;
   return instStr + "_" + runName + "_focused_cropped.nxs";
 }
 
@@ -1791,8 +1794,8 @@ void EnggDiffractionPresenter::doFocusing(const EnggDiffCalibSettings &cs,
   const bool saveOutputFiles = m_view->saveFocusedOutputFiles();
   if (saveOutputFiles) {
     try {
-      const int runNo =
-          stoi(runLabel.substr(runLabel.rfind(instStr) + instStr.size()));
+      const auto runNo =
+          runLabel.substr(runLabel.rfind(instStr) + instStr.size());
       RunLabel label(runNo, bank);
       saveFocusedXYE(label, outWSName);
       saveGSS(label, outWSName);
@@ -2314,7 +2317,7 @@ EnggDiffractionPresenter::outFileNameFactory(const std::string &inputWorkspace,
                                              const std::string &format) {
   std::string fullFilename;
 
-  const auto runNo = std::to_string(runLabel.runNumber);
+  const auto runNo = runLabel.runNumber;
   const auto bank = std::to_string(runLabel.bank);
 
   // calibration output files
@@ -2564,10 +2567,10 @@ EnggDiffractionPresenter::outFilesUserDir(const std::string &addToDir) const {
   return dir;
 }
 
-std::string
-EnggDiffractionPresenter::userHDFRunFilename(const int runNumber) const {
+std::string EnggDiffractionPresenter::userHDFRunFilename(
+    const std::string runNumber) const {
   auto userOutputDir = outFilesUserDir("Runs");
-  userOutputDir.append(std::to_string(runNumber) + ".hdf5");
+  userOutputDir.append(runNumber + ".hdf5");
   return userOutputDir.toString();
 }
 
@@ -2578,8 +2581,8 @@ std::string EnggDiffractionPresenter::userHDFMultiRunFilename(
   const auto minLabel = std::min_element(begin, end);
   const auto maxLabel = std::max_element(begin, end);
   auto userOutputDir = outFilesUserDir("Runs");
-  userOutputDir.append(std::to_string(minLabel->runNumber) + "_" +
-                       std::to_string(maxLabel->runNumber) + ".hdf5");
+  userOutputDir.append((minLabel->runNumber) + "_" +
+                       (maxLabel->runNumber) + ".hdf5");
   return userOutputDir.toString();
 }
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -120,7 +120,8 @@ private:
   void parseCalibrateFilename(const std::string &path, std::string &instName,
                               std::string &vanNo, std::string &ceriaNo);
 
-  void grabCalibParms(const std::string &fname, std::string &vanNo, std::string &ceriaNo);
+  void grabCalibParms(const std::string &fname, std::string &vanNo,
+                      std::string &ceriaNo);
 
   void updateCalibParmsTable();
 
@@ -189,8 +190,9 @@ private:
                                std::vector<size_t> &bankIDs,
                                std::vector<std::string> &specs);
 
-  void doFocusing(const EnggDiffCalibSettings &cs, const RunLabel &runLabel,
-                  const std::string &specNos, const std::string &dgFile);
+  void doFocusing(const EnggDiffCalibSettings &cs, const std::string &runLabel,
+                  const size_t bank, const std::string &specNos,
+                  const std::string &dgFile);
 
   /// @name Methods related to pre-processing / re-binning
   //@{
@@ -301,7 +303,7 @@ private:
 
   QThread *m_workerThread;
 
-  ///true if the last thing ran was cancelled
+  /// true if the last thing ran was cancelled
   bool m_cancelled;
 
   /// true if the last calibration completed successfully
@@ -318,7 +320,7 @@ private:
 
   /// true if the last focusing completed successfully
   bool m_focusFinishedOK;
-/// error that caused the focus to fail
+  /// error that caused the focus to fail
   std::string m_focusError;
   /// true if the last pre-processing/re-binning completed successfully
   bool m_rebinningFinishedOK;

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -238,7 +238,7 @@ private:
   // returns a directory as a path, creating it if not found, and checking
   // errors
   Poco::Path outFilesUserDir(const std::string &addToDir) const override;
-  std::string userHDFRunFilename(const int runNumber) const override;
+  std::string userHDFRunFilename(const std::string runNumber) const override;
   std::string userHDFMultiRunFilename(
       const std::vector<RunLabel> &runLabels) const override;
   Poco::Path outFilesGeneralDir(const std::string &addComponent);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -98,6 +98,11 @@ protected:
   void processShutDown();
   void processStopFocus();
 
+  std::vector<std::string> outputFocusFilenames(const std::string &runNo,
+                                                const std::vector<bool> &banks);
+
+  std::string outputFocusCroppedFilename(const std::string &runNo);
+
 protected slots:
   void calibrationFinished();
   void focusingFinished();
@@ -174,11 +179,6 @@ private:
                                 const std::string &dgfile);
   void inputChecksBeforeFocus();
   void inputChecksBanks(const std::vector<bool> &banks);
-
-  std::vector<std::string> outputFocusFilenames(const std::string &runNo,
-                                                const std::vector<bool> &banks);
-
-  std::string outputFocusCroppedFilename(const std::string &runNo);
 
   std::vector<std::string> sumOfFilesLoadVec();
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -120,7 +120,7 @@ private:
   void parseCalibrateFilename(const std::string &path, std::string &instName,
                               std::string &vanNo, std::string &ceriaNo);
 
-  void grabCalibParms(const std::string &fname);
+  void grabCalibParms(const std::string &fname, std::string &vanNo, std::string &ceriaNo);
 
   void updateCalibParmsTable();
 
@@ -301,8 +301,14 @@ private:
 
   QThread *m_workerThread;
 
+  ///true if the last thing ran was cancelled
+  bool m_cancelled;
+
   /// true if the last calibration completed successfully
   bool m_calibFinishedOK;
+
+  /// error that caused the calibration to fail
+  std::string m_calibError;
   /// path where the calibration has been produced (par/prm file)
   std::string m_calibFullPath;
 
@@ -312,6 +318,8 @@ private:
 
   /// true if the last focusing completed successfully
   bool m_focusFinishedOK;
+/// error that caused the focus to fail
+  std::string m_focusError;
   /// true if the last pre-processing/re-binning completed successfully
   bool m_rebinningFinishedOK;
 

--- a/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggDiffractionPresenter.h
@@ -238,7 +238,7 @@ private:
   // returns a directory as a path, creating it if not found, and checking
   // errors
   Poco::Path outFilesUserDir(const std::string &addToDir) const override;
-  std::string userHDFRunFilename(const std::string runNumber) const override;
+  std::string userHDFRunFilename(const std::string &runNumber) const override;
   std::string userHDFMultiRunFilename(
       const std::vector<RunLabel> &runLabels) const override;
   Poco::Path outFilesGeneralDir(const std::string &addComponent);

--- a/qt/scientific_interfaces/EnggDiffraction/EnggVanadiumCorrectionsModel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/EnggVanadiumCorrectionsModel.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <Poco/File.h>
+#include <Poco/Path.h>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -32,8 +33,9 @@ const std::string EnggVanadiumCorrectionsModel::VANADIUM_INPUT_WORKSPACE_NAME =
 std::pair<Mantid::API::ITableWorkspace_sptr, Mantid::API::MatrixWorkspace_sptr>
 EnggVanadiumCorrectionsModel::calculateCorrectionWorkspaces(
     const std::string &vanadiumRunNumber) const {
-  const auto vanadiumRunName = generateVanadiumRunName(vanadiumRunNumber);
-  loadMatrixWorkspace(vanadiumRunName, VANADIUM_INPUT_WORKSPACE_NAME);
+  const auto vanadiumWS =
+      loadMatrixWorkspace(vanadiumRunNumber, VANADIUM_INPUT_WORKSPACE_NAME);
+
   auto enggVanadiumCorrections =
       Mantid::API::AlgorithmManager::Instance().create(
           "EnggVanadiumCorrections");
@@ -105,7 +107,7 @@ std::string EnggVanadiumCorrectionsModel::generateCurvesFilename(
   const static std::string filenameSuffix =
       "_precalculated_vanadium_run_bank_curves.nxs";
 
-  const auto normalisedRunName = generateVanadiumRunName(vanadiumRunNumber);
+  const auto normalisedRunName = Poco::Path(vanadiumRunNumber).getBaseName();
   const auto curvesFilename = normalisedRunName + filenameSuffix;
 
   Poco::Path inputDir(m_calibSettings.m_inputDirCalib);
@@ -118,7 +120,7 @@ std::string EnggVanadiumCorrectionsModel::generateIntegratedFilename(
   const static std::string filenameSuffix =
       "_precalculated_vanadium_run_integration.nxs";
 
-  const auto normalisedRunName = generateVanadiumRunName(vanadiumRunNumber);
+  const auto normalisedRunName = Poco::Path(vanadiumRunNumber).getBaseName();
   const auto integratedFilename = normalisedRunName + filenameSuffix;
 
   Poco::Path inputDir(m_calibSettings.m_inputDirCalib);

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
@@ -30,7 +30,8 @@ public:
   virtual Poco::Path outFilesUserDir(const std::string &addToDir) const = 0;
 
   /// Get the name of a HDF file for a given run number to save to
-  virtual std::string userHDFRunFilename(const std::string runNumber) const = 0;
+  virtual std::string
+  userHDFRunFilename(const std::string &runNumber) const = 0;
 
   /// Get the name of a HDF file for a range of runs
   virtual std::string

--- a/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
+++ b/qt/scientific_interfaces/EnggDiffraction/IEnggDiffractionParam.h
@@ -30,7 +30,7 @@ public:
   virtual Poco::Path outFilesUserDir(const std::string &addToDir) const = 0;
 
   /// Get the name of a HDF file for a given run number to save to
-  virtual std::string userHDFRunFilename(const int runNumber) const = 0;
+  virtual std::string userHDFRunFilename(const std::string runNumber) const = 0;
 
   /// Get the name of a HDF file for a range of runs
   virtual std::string

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
@@ -9,7 +9,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-RunLabel::RunLabel(const int _runNumber, const size_t _bank)
+RunLabel::RunLabel(const std::string _runNumber, const size_t _bank)
     : runNumber(_runNumber), bank(_bank) {}
 
 bool operator==(const RunLabel &lhs, const RunLabel &rhs) {

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.cpp
@@ -9,7 +9,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-RunLabel::RunLabel(const std::string _runNumber, const size_t _bank)
+RunLabel::RunLabel(const std::string &_runNumber, const size_t _bank)
     : runNumber(_runNumber), bank(_bank) {}
 
 bool operator==(const RunLabel &lhs, const RunLabel &rhs) {

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -8,7 +8,7 @@
 #define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
 
 #include "DllConfig.h"
-
+#include <string>
 #include <cstddef>
 
 namespace MantidQt {
@@ -18,11 +18,11 @@ namespace CustomInterfaces {
 /// into the ED GUI
 class MANTIDQT_ENGGDIFFRACTION_DLL RunLabel {
 public:
-  RunLabel(const int runNumber, const size_t bank);
+  RunLabel(const std::string runNumber, const size_t bank);
 
   RunLabel() = default;
 
-  int runNumber;
+  std::string runNumber;
   std::size_t bank;
 };
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -8,8 +8,8 @@
 #define MANTIDQT_CUSTOMINTERFACES_ENGGDIFFRUNLABEL_H_
 
 #include "DllConfig.h"
-#include <string>
 #include <cstddef>
+#include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunLabel.h
@@ -18,7 +18,7 @@ namespace CustomInterfaces {
 /// into the ED GUI
 class MANTIDQT_ENGGDIFFRACTION_DLL RunLabel {
 public:
-  RunLabel(const std::string runNumber, const size_t bank);
+  RunLabel(const std::string &runNumber, const size_t bank);
 
   RunLabel() = default;
 

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.h
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.h
@@ -47,11 +47,11 @@ public:
   size_t size() const;
 
 private:
-  std::set<int> getAllRunNumbers() const;
+  std::set<std::string> getAllRunNumbers() const;
 
   void validateBankID(const size_t bank) const;
 
-  std::array<std::unordered_map<int, T>, NumBanks> m_map;
+  std::array<std::unordered_map<std::string, T>, NumBanks> m_map;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
+++ b/qt/scientific_interfaces/EnggDiffraction/RunMap.tpp
@@ -22,8 +22,8 @@ const T &RunMap<NumBanks, T>::get(const RunLabel &runLabel) const {
   validateBankID(runLabel.bank);
   if (!contains(runLabel)) {
     throw std::invalid_argument("Tried to access invalid run number " +
-                                std::to_string(runLabel.runNumber) +
-                                " for bank " + std::to_string(runLabel.bank));
+                                runLabel.runNumber + " for bank " +
+                                std::to_string(runLabel.bank));
   }
   return m_map[runLabel.bank].at(runLabel.runNumber);
 }
@@ -50,8 +50,8 @@ std::vector<RunLabel> RunMap<NumBanks, T>::getRunLabels() const {
 }
 
 template <size_t NumBanks, typename T>
-std::set<int> RunMap<NumBanks, T>::getAllRunNumbers() const {
-  std::set<int> runNumbers;
+std::set<std::string> RunMap<NumBanks, T>::getAllRunNumbers() const {
+  std::set<std::string> runNumbers;
 
   for (const auto &bank : m_map) {
     for (const auto &runLabel : bank) {

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -42,8 +42,7 @@ inline void
 EnggDiffFittingModelAddWSExposed::addWorkspace(const RunLabel &runLabel,
                                                API::MatrixWorkspace_sptr ws) {
   addFocusedWorkspace(runLabel, ws,
-                      runLabel.runNumber + "_" +
-                          std::to_string(runLabel.bank));
+                      runLabel.runNumber + "_" + std::to_string(runLabel.bank));
 }
 
 inline void EnggDiffFittingModelAddWSExposed::addFitParams(
@@ -194,7 +193,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_LABEL));
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(std::to_string(ws->getRunNumber()), FOCUSED_WS_RUN_LABEL.runNumber);
+    TS_ASSERT_EQUALS(std::to_string(ws->getRunNumber()),
+                     FOCUSED_WS_RUN_LABEL.runNumber);
   }
 
   void test_setDifcTzero() {

--- a/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingModelTest.h
@@ -42,7 +42,7 @@ inline void
 EnggDiffFittingModelAddWSExposed::addWorkspace(const RunLabel &runLabel,
                                                API::MatrixWorkspace_sptr ws) {
   addFocusedWorkspace(runLabel, ws,
-                      std::to_string(runLabel.runNumber) + "_" +
+                      runLabel.runNumber + "_" +
                           std::to_string(runLabel.bank));
 }
 
@@ -162,7 +162,7 @@ public:
     API::MatrixWorkspace_sptr ws =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
 
-    const RunLabel runLabel(100, 1);
+    const RunLabel runLabel("100", 1);
     TS_ASSERT_THROWS_NOTHING(model.addWorkspace(runLabel, ws));
     const auto retrievedWS = model.getFocusedWorkspace(runLabel);
 
@@ -173,18 +173,18 @@ public:
   void test_getRunNumbersAndBankIDs() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    addSampleWorkspaceToModel(RunLabel(123, 1), model);
-    addSampleWorkspaceToModel(RunLabel(456, 2), model);
-    addSampleWorkspaceToModel(RunLabel(789, 1), model);
-    addSampleWorkspaceToModel(RunLabel(123, 2), model);
+    addSampleWorkspaceToModel(RunLabel("123", 1), model);
+    addSampleWorkspaceToModel(RunLabel("456", 2), model);
+    addSampleWorkspaceToModel(RunLabel("789", 1), model);
+    addSampleWorkspaceToModel(RunLabel("123", 2), model);
 
     const auto runLabels = model.getRunLabels();
 
     TS_ASSERT_EQUALS(runLabels.size(), 4);
-    TS_ASSERT_EQUALS(runLabels[0], RunLabel(123, 1));
-    TS_ASSERT_EQUALS(runLabels[1], RunLabel(123, 2));
-    TS_ASSERT_EQUALS(runLabels[2], RunLabel(456, 2));
-    TS_ASSERT_EQUALS(runLabels[3], RunLabel(789, 1));
+    TS_ASSERT_EQUALS(runLabels[0], RunLabel("123", 1));
+    TS_ASSERT_EQUALS(runLabels[1], RunLabel("123", 2));
+    TS_ASSERT_EQUALS(runLabels[2], RunLabel("456", 2));
+    TS_ASSERT_EQUALS(runLabels[3], RunLabel("789", 1));
   }
 
   void test_loadWorkspaces() {
@@ -194,7 +194,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(
         ws = model.getFocusedWorkspace(FOCUSED_WS_RUN_LABEL));
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
-    TS_ASSERT_EQUALS(ws->getRunNumber(), FOCUSED_WS_RUN_LABEL.runNumber);
+    TS_ASSERT_EQUALS(std::to_string(ws->getRunNumber()), FOCUSED_WS_RUN_LABEL.runNumber);
   }
 
   void test_setDifcTzero() {
@@ -231,9 +231,9 @@ public:
   void test_getNumFocusedWorkspaces() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    addSampleWorkspaceToModel(RunLabel(123, 1), model);
-    addSampleWorkspaceToModel(RunLabel(456, 2), model);
-    addSampleWorkspaceToModel(RunLabel(789, 1), model);
+    addSampleWorkspaceToModel(RunLabel("123", 1), model);
+    addSampleWorkspaceToModel(RunLabel("456", 2), model);
+    addSampleWorkspaceToModel(RunLabel("789", 1), model);
 
     TS_ASSERT_EQUALS(model.getNumFocusedWorkspaces(), 3);
   }
@@ -284,11 +284,11 @@ public:
   void test_removeRun() {
     auto model = EnggDiffFittingModelAddWSExposed();
 
-    const RunLabel label1(123, 1);
+    const RunLabel label1("123", 1);
     addSampleWorkspaceToModel(label1, model);
-    const RunLabel label2(456, 2);
+    const RunLabel label2("456", 2);
     addSampleWorkspaceToModel(label2, model);
-    const RunLabel label3(789, 1);
+    const RunLabel label3("789", 1);
     addSampleWorkspaceToModel(label3, model);
 
     model.removeRun(label1);
@@ -309,6 +309,6 @@ const std::string EnggDiffFittingModelTest::FOCUSED_WS_FILENAME =
     "ENGINX_277208_focused_bank_2.nxs";
 
 const RunLabel EnggDiffFittingModelTest::FOCUSED_WS_RUN_LABEL =
-    RunLabel(277208, 2);
+    RunLabel("277208", 2);
 
 #endif

--- a/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffFittingPresenterTest.h
@@ -244,7 +244,7 @@ public:
         .Times(1)
         .WillOnce(Return("2.3445,3.3433,4.5664"));
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
         .WillOnce(Return(std::vector<RunLabel>({runLabel})));
@@ -284,7 +284,7 @@ public:
         .WillOnce(Return(",3.5,7.78,r43d"));
     EXPECT_CALL(mockView, setPeakList(testing::_)).Times(1);
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
         .WillOnce(Return(std::vector<RunLabel>({runLabel})));
@@ -614,11 +614,11 @@ public:
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(1)
         .WillOnce(Return(boost::optional<std::string>("123_1")));
-    EXPECT_CALL(*mockModel_ptr, removeRun(RunLabel(123, 1)));
+    EXPECT_CALL(*mockModel_ptr, removeRun(RunLabel("123", 1)));
     EXPECT_CALL(*mockModel_ptr, getRunLabels())
         .Times(1)
         .WillOnce(Return(
-            std::vector<RunLabel>({RunLabel(123, 2), RunLabel(456, 1)})));
+            std::vector<RunLabel>({RunLabel("123", 2), RunLabel("456", 1)})));
     EXPECT_CALL(mockView, updateFittingListWidget(
                               std::vector<std::string>({"123_2", "456_1"})));
 
@@ -638,7 +638,7 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(2)
         .WillRepeatedly(Return(boost::optional<std::string>("123_1")));
@@ -673,7 +673,7 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(1)
         .WillOnce(Return(boost::optional<std::string>("123_1")));
@@ -708,7 +708,7 @@ public:
 
     EnggDiffFittingPresenterNoThread pres(&mockView, std::move(mockModel));
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(mockView, getFittingListWidgetCurrentValue())
         .Times(2)
         .WillRepeatedly(Return(boost::optional<std::string>("123_1")));

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingModelTest.h
@@ -146,7 +146,7 @@ public:
   void test_getRwp() {
     TestEnggDiffGSASFittingModel model;
 
-    const RunLabel valid(123, 1);
+    const RunLabel valid("123", 1);
     const double rwp = 75.5;
     model.addRwpValue(valid, rwp);
 
@@ -155,7 +155,7 @@ public:
     TS_ASSERT(retrievedRwp);
     TS_ASSERT_EQUALS(rwp, *retrievedRwp);
 
-    const RunLabel invalid(456, 2);
+    const RunLabel invalid("456", 2);
     TS_ASSERT_THROWS_NOTHING(retrievedRwp = model.getRwp(invalid));
     TS_ASSERT_EQUALS(retrievedRwp, boost::none);
   }
@@ -163,7 +163,7 @@ public:
   void test_getGamma() {
     TestEnggDiffGSASFittingModel model;
 
-    const RunLabel valid(123, 1);
+    const RunLabel valid("123", 1);
     const double gamma = 75.5;
     model.addGammaValue(valid, gamma);
 
@@ -172,7 +172,7 @@ public:
     TS_ASSERT(retrievedGamma);
     TS_ASSERT_EQUALS(gamma, *retrievedGamma);
 
-    const RunLabel invalid(456, 2);
+    const RunLabel invalid("456", 2);
     TS_ASSERT_THROWS_NOTHING(retrievedGamma = model.getGamma(invalid));
     TS_ASSERT_EQUALS(retrievedGamma, boost::none);
   }
@@ -180,7 +180,7 @@ public:
   void test_getSigma() {
     TestEnggDiffGSASFittingModel model;
 
-    const RunLabel valid(123, 1);
+    const RunLabel valid("123", 1);
     const double sigma = 75.5;
     model.addSigmaValue(valid, sigma);
 
@@ -189,7 +189,7 @@ public:
     TS_ASSERT(retrievedSigma);
     TS_ASSERT_EQUALS(sigma, *retrievedSigma);
 
-    const RunLabel invalid(456, 2);
+    const RunLabel invalid("456", 2);
     TS_ASSERT_THROWS_NOTHING(retrievedSigma = model.getSigma(invalid));
     TS_ASSERT_EQUALS(retrievedSigma, boost::none);
   }
@@ -202,7 +202,7 @@ public:
 
     TestEnggDiffGSASFittingModel model;
 
-    const RunLabel valid(123, 1);
+    const RunLabel valid("123", 1);
     TS_ASSERT_THROWS_NOTHING(model.addLatticeParamTable(valid, table));
 
     // auto retrievedTable = model.getLatticeParams(123, 1);
@@ -223,7 +223,7 @@ public:
     TS_ASSERT_EQUALS(b, expectedB);
     TS_ASSERT_EQUALS(c, expectedC);
 
-    const RunLabel invalid(456, 2);
+    const RunLabel invalid("456", 2);
     TS_ASSERT_THROWS_NOTHING(retrievedTable = model.getLatticeParams(invalid));
     TS_ASSERT_EQUALS(retrievedTable, boost::none);
   }
@@ -233,7 +233,7 @@ public:
     // is used properly. It tests that, given that the algorithm is used
     // properly, results are added to the appropriate maps in the model
     TestEnggDiffGSASFittingModel model;
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     API::MatrixWorkspace_sptr inputWS =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);
@@ -262,7 +262,7 @@ public:
     // is used properly. It tests that, given that the algorithm is used
     // properly, results are added to the appropriate maps in the model
     TestEnggDiffGSASFittingModel model;
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     API::MatrixWorkspace_sptr inputWS =
         API::WorkspaceFactory::Instance().create("Workspace2D", 1, 10, 10);

--- a/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffGSASFittingPresenterTest.h
@@ -73,7 +73,7 @@ public:
 
     const GSASIIRefineFitPeaksParameters params(
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100),
-        RunLabel(123, 1), GSASRefinementMethod::RIETVELD, "Instrument file",
+        RunLabel("123", 1), GSASRefinementMethod::RIETVELD, "Instrument file",
         {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", boost::none, boost::none,
         10000, 40000, true, false);
     setRefinementParamsExpectations(params);
@@ -93,7 +93,7 @@ public:
 
     const GSASIIRefineFitPeaksParameters params(
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100),
-        RunLabel(123, 1), GSASRefinementMethod::PAWLEY, "Instrument file",
+        RunLabel("123", 1), GSASRefinementMethod::PAWLEY, "Instrument file",
         {"Phase1", "Phase2"}, "GSASHOME", "GPX.gpx", 1, 2, 10000, 40000, true,
         false);
     setRefinementParamsExpectations(params);
@@ -110,7 +110,7 @@ public:
 
   void test_selectValidRunFitResultsAvailable() {
     auto presenter = setUpPresenter();
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
@@ -152,7 +152,7 @@ public:
 
   void test_selectRunNoFitResults() {
     auto presenter = setUpPresenter();
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     EXPECT_CALL(*m_mockMultiRunWidgetPtr, getSelectedRunLabel())
         .Times(1)
@@ -199,10 +199,10 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
     const auto latticeParams =
         Mantid::API::WorkspaceFactory::Instance().createTable();
-    const RunLabel runLabel1(123, 1);
+    const RunLabel runLabel1("123", 1);
     const GSASIIRefineFitPeaksOutputProperties refinementResults1(
         1, 2, 3, fittedPeaks, latticeParams, runLabel1);
-    const RunLabel runLabel2(125, 1);
+    const RunLabel runLabel2("125", 1);
     const std::vector<RunLabel> runLabels({runLabel1, runLabel2});
     const GSASIIRefineFitPeaksOutputProperties refinementResults2(
         1, 2, 3, fittedPeaks, latticeParams, runLabel2);
@@ -228,7 +228,7 @@ public:
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100));
     const auto latticeParams =
         Mantid::API::WorkspaceFactory::Instance().createTable();
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     const GSASIIRefineFitPeaksOutputProperties refinementResults(
         1, 2, 3, fittedPeaks, latticeParams, runLabel);
     const Mantid::API::IAlgorithm_sptr alg(nullptr);
@@ -277,12 +277,12 @@ public:
 
     const GSASIIRefineFitPeaksParameters params1(
         WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100),
-        RunLabel(123, 1), GSASRefinementMethod::RIETVELD, "Instrument file",
+        RunLabel("123", 1), GSASRefinementMethod::RIETVELD, "Instrument file",
         {"Phase1", "Phase2"}, "GSASHOME", "GPX_123_1.gpx", boost::none,
         boost::none, 10000, 40000, true, false);
     const GSASIIRefineFitPeaksParameters params2(
         WorkspaceCreationHelper::create2DWorkspaceBinned(2, 200),
-        RunLabel(456, 2), GSASRefinementMethod::RIETVELD, "Instrument file",
+        RunLabel("456", 2), GSASRefinementMethod::RIETVELD, "Instrument file",
         {"Phase1", "Phase2"}, "GSASHOME", "GPX_456_2.gpx", boost::none,
         boost::none, 10000, 40000, true, false);
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetModelTest.h
@@ -22,7 +22,7 @@ public:
 
     Mantid::API::MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     TS_ASSERT_THROWS_NOTHING(model.addFittedPeaks(runLabel, ws));
 
     boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
@@ -35,7 +35,7 @@ public:
     EnggDiffMultiRunFittingWidgetModel model;
     boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
     TS_ASSERT_THROWS_NOTHING(retrievedWS =
-                                 model.getFittedPeaks(RunLabel(123, 1)));
+                                 model.getFittedPeaks(RunLabel("123", 1)));
     TS_ASSERT(!retrievedWS);
   }
 
@@ -44,7 +44,7 @@ public:
 
     Mantid::API::MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     TS_ASSERT_THROWS_NOTHING(model.addFocusedRun(runLabel, ws));
 
     boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
@@ -57,7 +57,7 @@ public:
     EnggDiffMultiRunFittingWidgetModel model;
     boost::optional<Mantid::API::MatrixWorkspace_sptr> retrievedWS(boost::none);
     TS_ASSERT_THROWS_NOTHING(retrievedWS =
-                                 model.getFocusedRun(RunLabel(123, 1)));
+                                 model.getFocusedRun(RunLabel("123", 1)));
     TS_ASSERT(!retrievedWS);
   }
 
@@ -67,9 +67,9 @@ public:
     Mantid::API::MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
 
-    const RunLabel label1(123, 1);
+    const RunLabel label1("123", 1);
     model.addFocusedRun(label1, ws);
-    const RunLabel label2(456, 2);
+    const RunLabel label2("456", 2);
     model.addFocusedRun(label2, ws);
 
     const std::vector<RunLabel> expectedLabels1({label1, label2});
@@ -78,9 +78,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(retrievedLabels = model.getAllWorkspaceLabels());
     TS_ASSERT_EQUALS(expectedLabels1, retrievedLabels);
 
-    const RunLabel label3(456, 1);
+    const RunLabel label3("456", 1);
     model.addFocusedRun(label3, ws);
-    model.addFittedPeaks(RunLabel(123, 2), ws);
+    model.addFittedPeaks(RunLabel("123", 2), ws);
     const std::vector<RunLabel> expectedLabels2 = {label1, label3, label2};
     TS_ASSERT_THROWS_NOTHING(retrievedLabels = model.getAllWorkspaceLabels());
     TS_ASSERT_EQUALS(expectedLabels2, retrievedLabels);
@@ -92,13 +92,13 @@ public:
     Mantid::API::MatrixWorkspace_sptr ws =
         WorkspaceCreationHelper::create2DWorkspaceBinned(4, 4, 0.5);
 
-    const RunLabel label1(123, 1);
+    const RunLabel label1("123", 1);
     model.addFocusedRun(label1, ws);
 
     TS_ASSERT_THROWS_NOTHING(model.removeRun(label1));
     TS_ASSERT(!model.getFocusedRun(label1));
 
-    TS_ASSERT_THROWS_ANYTHING(model.removeRun(RunLabel(456, 2)));
+    TS_ASSERT_THROWS_ANYTHING(model.removeRun(RunLabel("456", 2)));
   }
 };
 

--- a/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffMultiRunFittingWidgetPresenterTest.h
@@ -45,7 +45,7 @@ public:
     auto presenter = setUpPresenter();
     const auto ws = createSampleWorkspace();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockModel, addFittedPeaks(runLabel, ws)).Times(1);
 
     EXPECT_CALL(*m_mockModel, getFocusedRun(runLabel))
@@ -70,7 +70,7 @@ public:
     auto presenter = setUpPresenter();
     const API::MatrixWorkspace_sptr ws = createSampleWorkspace();
     addBankID(ws, 2);
-    const RunLabel runLabel(0, 2);
+    const RunLabel runLabel("0", 2);
 
     const std::vector<RunLabel> workspaceLabels({runLabel});
     EXPECT_CALL(*m_mockModel, getAllWorkspaceLabels())
@@ -87,7 +87,7 @@ public:
     const API::MatrixWorkspace_sptr ws = createSampleWorkspace();
     addBankID(ws, 2);
 
-    const RunLabel runLabel(0, 2);
+    const RunLabel runLabel("0", 2);
     const std::vector<RunLabel> workspaceLabels({runLabel});
     ON_CALL(*m_mockModel, getAllWorkspaceLabels())
         .WillByDefault(Return(workspaceLabels));
@@ -100,7 +100,7 @@ public:
   void test_getFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockModel, getFittedPeaks(runLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
@@ -112,7 +112,7 @@ public:
   void test_getFocusedRun() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockModel, getFocusedRun(runLabel))
         .Times(1)
         .WillOnce(Return(boost::none));
@@ -124,7 +124,7 @@ public:
   void test_selectValidRunWithoutFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -149,7 +149,7 @@ public:
   void test_selectRunInvalid() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -167,7 +167,7 @@ public:
   void test_selectValidRunWithFittedPeaks() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     ON_CALL(*m_mockView, getSelectedRunLabel()).WillByDefault(Return(runLabel));
 
     const auto sampleWorkspace = createSampleWorkspace();
@@ -202,7 +202,7 @@ public:
   void test_plotPeaksStateChangedUpdatesPlot() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -241,7 +241,7 @@ public:
   void test_removeRun() {
     auto presenter = setUpPresenter();
 
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
         .WillOnce(Return(runLabel));
@@ -285,7 +285,7 @@ public:
 
   void test_plotToSeparateWindowValidFocusedRunNoFittedPeaks() {
     auto presenter = setUpPresenter();
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)
@@ -320,7 +320,7 @@ public:
 
   void test_plotToSeparateWindowWithFittedPeaks() {
     auto presenter = setUpPresenter();
-    const RunLabel runLabel(123, 1);
+    const RunLabel runLabel("123", 1);
 
     EXPECT_CALL(*m_mockView, getSelectedRunLabel())
         .Times(1)

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -20,7 +20,8 @@ class MockEnggDiffractionParam : public IEnggDiffractionParam {
 public:
   MOCK_CONST_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
 
-  MOCK_CONST_METHOD1(userHDFRunFilename, std::string(const std::string runNumber));
+  MOCK_CONST_METHOD1(userHDFRunFilename,
+                     std::string(const std::string runNumber));
 
   MOCK_CONST_METHOD1(userHDFMultiRunFilename,
                      std::string(const std::vector<RunLabel> &runLabels));

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -21,7 +21,7 @@ public:
   MOCK_CONST_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
 
   MOCK_CONST_METHOD1(userHDFRunFilename,
-                     std::string(const std::string runNumber));
+                     std::string(const std::string &runNumber));
 
   MOCK_CONST_METHOD1(userHDFMultiRunFilename,
                      std::string(const std::vector<RunLabel> &runLabels));

--- a/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionParamMock.h
@@ -20,7 +20,7 @@ class MockEnggDiffractionParam : public IEnggDiffractionParam {
 public:
   MOCK_CONST_METHOD1(outFilesUserDir, Poco::Path(const std::string &addToDir));
 
-  MOCK_CONST_METHOD1(userHDFRunFilename, std::string(const int runNumber));
+  MOCK_CONST_METHOD1(userHDFRunFilename, std::string(const std::string runNumber));
 
   MOCK_CONST_METHOD1(userHDFMultiRunFilename,
                      std::string(const std::vector<RunLabel> &runLabels));

--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -129,7 +129,7 @@ public:
   // Several of these are indirectly tested through some of the GUI-mock-based
   // tests below but should be tested as isolated methods here at the beginning.
 
-  void xtest_start() {
+  void test_start() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -147,7 +147,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_loadExistingCalibWithWrongName() {
+  void test_loadExistingCalibWithWrongName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -171,7 +171,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_loadExistingCalibWithAcceptableName() {
+  void test_loadExistingCalibWithAcceptableName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // by setting this here, when initialising the presenter, the function will
@@ -205,7 +205,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_calcCalibWithoutRunNumbers() {
+  void test_calcCalibWithoutRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -236,7 +236,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_calcCalibFailsWhenNoCalibDirectory() {
+  void test_calcCalibFailsWhenNoCalibDirectory() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
 
@@ -262,7 +262,7 @@ public:
   }
 
   // this can start the calibration thread, so watch out
-  void xtest_calcCalibWithSettingsMissing() {
+  void test_calcCalibWithSettingsMissing() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test can start a Qt thread that needs signals/slots
@@ -408,7 +408,7 @@ public:
 
   // This would test the cropped calibration with no cerial number
   // which should produce a warning
-  void xtestcalcCroppedCalibWithoutRunNumbers() {
+  void testcalcCroppedCalibWithoutRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -436,7 +436,7 @@ public:
   // this can start the cropped calibration thread, so watch out
   // the test provide gui with missing calib settings
   // which should return a single error
-  void xtestcalcCroppedCalibWithSettingsMissing() {
+  void testcalcCroppedCalibWithSettingsMissing() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test can start a Qt thread that needs signals/slots
@@ -471,7 +471,7 @@ public:
 
   // This should not start the process, tests with an empty spec number which
   // should generate a user warning that spec number is missing
-  void xtestcalcCroppedCalibWithEmptySpec() {
+  void testcalcCroppedCalibWithEmptySpec() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -519,7 +519,7 @@ public:
   // the thread unless you use the mock without thread
   // this will utlise the bank name north and not still carry out the cropped
   // calibration process normal
-  void xtestcalcCroppedCalibWithBankName() {
+  void testcalcCroppedCalibWithBankName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -585,7 +585,7 @@ public:
   // starting the thread unless you use the mock without thread
   // this test case includes all valid settings, run numbers, spectrum no
   // selected & valid spectrum no provided
-  void xtestcalcCroppedCalibWithRunNumbers() {
+  void testcalcCroppedCalibWithRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -694,7 +694,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusWithoutRunNumber() {
+  void testfocusWithoutRunNumber() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -731,7 +731,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusWithRunNumberButWrongBanks() {
+  void testfocusWithRunNumberButWrongBanks() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -766,7 +766,7 @@ public:
   }
 
   // the focusing process starts but the input run number cannot be found
-  void xtestfocusWithNumbersButError() {
+  void testfocusWithNumbersButError() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test starts the focusing process which would start a Qt
@@ -894,7 +894,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusCropped_withoutRunNo() {
+  void testfocusCropped_withoutRunNo() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -934,7 +934,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusCropped_withoutBanks() {
+  void testfocusCropped_withoutBanks() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -974,7 +974,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusCropped_withoutSpectrumNos() {
+  void testfocusCropped_withoutSpectrumNos() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1014,7 +1014,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusTexture_withoutRunNo() {
+  void testfocusTexture_withoutRunNo() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1050,7 +1050,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusTexture_withoutFilename() {
+  void testfocusTexture_withoutFilename() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1086,7 +1086,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestfocusTexture_withInexistentTextureFile() {
+  void testfocusTexture_withInexistentTextureFile() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1122,7 +1122,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestresetFocus() {
+  void testresetFocus() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1139,7 +1139,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestresetFocus_thenFocus() {
+  void testresetFocus_thenFocus() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1175,7 +1175,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestpreproc_event_time_bin_missing_runno() {
+  void testpreproc_event_time_bin_missing_runno() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1196,7 +1196,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestpreproc_event_time_wrong_bin() {
+  void testpreproc_event_time_wrong_bin() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1221,7 +1221,7 @@ public:
   }
 
   // this test does run Load and then Rebin //
-  void xtestpreproc_event_time_ok() {
+  void testpreproc_event_time_ok() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
     // inputs from user
@@ -1253,7 +1253,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtestpreproc_event_multiperiod_missing_runno() {
+  void testpreproc_event_multiperiod_missing_runno() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1274,7 +1274,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_preproc_event_multiperiod_wrong_bin() {
+  void test_preproc_event_multiperiod_wrong_bin() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1302,7 +1302,7 @@ public:
   }
 
   // this test does run Load but then RebinByPulseTimes should fail
-  void xtest_preproc_event_multiperiod_file_wrong_type() {
+  void test_preproc_event_multiperiod_file_wrong_type() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
 
@@ -1331,7 +1331,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_logMsg() {
+  void test_logMsg() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1353,7 +1353,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_RBNumberChange_ok() {
+  void test_RBNumberChange_ok() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1375,7 +1375,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_RBNumberChange_empty() {
+  void test_RBNumberChange_empty() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1397,7 +1397,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_instChange() {
+  void test_instChange() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // by setting this here, when initialising the presenter, the function will
@@ -1427,7 +1427,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void xtest_shutDown() {
+  void test_shutDown() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 

--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -302,7 +302,7 @@ public:
 
   // this test actually starts the calibration process - which implies starting
   // the thread unless you use the mock without thread
-  void xtestcalcCalibWithRunNumbersButError() {
+  void testcalcCalibWithRunNumbersButError() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots

--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -253,8 +253,7 @@ public:
     ON_CALL(mockView, currentCalibSettings())
         .WillByDefault(Return(calibSettings));
 
-    EXPECT_CALL(mockView,
-                userWarning("No calibration directory selected", testing::_));
+    EXPECT_CALL(mockView, userWarning("Calibration Error", testing::_));
 
     pres.notify(IEnggDiffractionPresenter::CalcCalib);
   }
@@ -277,7 +276,7 @@ public:
     // them
     EnggDiffCalibSettings calibSettings;
 
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
 
@@ -318,7 +317,7 @@ public:
     calibSettings.m_pixelCalibFilename =
         instr + "_" + vanNo + "_" + ceriaNo + ".prm";
     calibSettings.m_templateGSAS_PRM = "fake.prm";
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
 
@@ -450,7 +449,7 @@ public:
     EnggDiffCalibSettings calibSettings;
 
     // doesn't get here
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
 
@@ -487,7 +486,7 @@ public:
     calibSettings.m_pixelCalibFilename =
         instr + "_" + vanNo + "_" + ceriaNo + ".prm";
     calibSettings.m_templateGSAS_PRM = "fake.prm";
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
 
@@ -535,7 +534,7 @@ public:
     calibSettings.m_pixelCalibFilename =
         instr + "_" + vanNo + "_" + ceriaNo + ".prm";
     calibSettings.m_templateGSAS_PRM = "fake.prm";
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
     // if it got here it would: .WillRepeatedly(Return(calibSettings));
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
@@ -601,7 +600,7 @@ public:
     calibSettings.m_pixelCalibFilename =
         instr + "_" + vanNo + "_" + ceriaNo + ".prm";
     calibSettings.m_templateGSAS_PRM = "fake.prm";
-    EXPECT_CALL(mockView, currentCalibSettings()).Times(0);
+    EXPECT_CALL(mockView, currentCalibSettings()).Times(1);
     // if it was called it would: .WillRepeatedly(Return(calibSettings));
 
     EXPECT_CALL(mockView, newVanadiumNo()).Times(1).WillOnce(Return(g_vanNo));
@@ -1224,7 +1223,7 @@ public:
     EnggDiffPresenterNoThread pres(&mockView);
     // inputs from user
     EXPECT_CALL(mockView, currentPreprocRunNo())
-        .Times(1)
+        .Times(2)
         .WillRepeatedly(Return(g_rebinRunNo));
 
     EXPECT_CALL(mockView, rebinningTimeBin())
@@ -1232,7 +1231,7 @@ public:
         .WillRepeatedly(Return(0.100000));
 
     // doesn't effectively finish the processing
-    EXPECT_CALL(mockView, showStatus(testing::_)).Times(0);
+    EXPECT_CALL(mockView, showStatus(testing::_)).Times(2);
 
     // A warning complaining about the run number / path Because the
     // real QtView uses MWRunFile::getFilenames, if we give a run
@@ -1241,7 +1240,7 @@ public:
     // returning the run number without the path that would be
     // needed. EnggDiffractionPresenter::isValidRunNumber() will not
     // find the file (when it tries Poco::File(path).exists()).
-    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(1);
+    EXPECT_CALL(mockView, userWarning(testing::_, testing::_)).Times(0);
     EXPECT_CALL(mockView, userError(testing::_, testing::_)).Times(0);
 
     pres.notify(IEnggDiffractionPresenter::RebinTime);

--- a/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
+++ b/qt/scientific_interfaces/test/EnggDiffractionPresenterTest.h
@@ -29,6 +29,9 @@ public:
   EnggDiffPresenterNoThread(IEnggDiffractionView *view)
       : EnggDiffractionPresenter(view) {}
 
+  using EnggDiffractionPresenter::outputFocusCroppedFilename;
+  using EnggDiffractionPresenter::outputFocusFilenames;
+
 private:
   // not async at all
   void startAsyncCalibWorker(const std::string &outFilename,
@@ -126,7 +129,7 @@ public:
   // Several of these are indirectly tested through some of the GUI-mock-based
   // tests below but should be tested as isolated methods here at the beginning.
 
-  void test_start() {
+  void xtest_start() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -144,7 +147,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_loadExistingCalibWithWrongName() {
+  void xtest_loadExistingCalibWithWrongName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -168,7 +171,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_loadExistingCalibWithAcceptableName() {
+  void xtest_loadExistingCalibWithAcceptableName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // by setting this here, when initialising the presenter, the function will
@@ -202,7 +205,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_calcCalibWithoutRunNumbers() {
+  void xtest_calcCalibWithoutRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -233,7 +236,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_calcCalibFailsWhenNoCalibDirectory() {
+  void xtest_calcCalibFailsWhenNoCalibDirectory() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
 
@@ -259,7 +262,7 @@ public:
   }
 
   // this can start the calibration thread, so watch out
-  void test_calcCalibWithSettingsMissing() {
+  void xtest_calcCalibWithSettingsMissing() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test can start a Qt thread that needs signals/slots
@@ -299,7 +302,7 @@ public:
 
   // this test actually starts the calibration process - which implies starting
   // the thread unless you use the mock without thread
-  void test_calcCalibWithRunNumbersButError() {
+  void xtestcalcCalibWithRunNumbersButError() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -405,7 +408,7 @@ public:
 
   // This would test the cropped calibration with no cerial number
   // which should produce a warning
-  void test_calcCroppedCalibWithoutRunNumbers() {
+  void xtestcalcCroppedCalibWithoutRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -433,7 +436,7 @@ public:
   // this can start the cropped calibration thread, so watch out
   // the test provide gui with missing calib settings
   // which should return a single error
-  void test_calcCroppedCalibWithSettingsMissing() {
+  void xtestcalcCroppedCalibWithSettingsMissing() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test can start a Qt thread that needs signals/slots
@@ -468,7 +471,7 @@ public:
 
   // This should not start the process, tests with an empty spec number which
   // should generate a user warning that spec number is missing
-  void test_calcCroppedCalibWithEmptySpec() {
+  void xtestcalcCroppedCalibWithEmptySpec() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -516,7 +519,7 @@ public:
   // the thread unless you use the mock without thread
   // this will utlise the bank name north and not still carry out the cropped
   // calibration process normal
-  void test_calcCroppedCalibWithBankName() {
+  void xtestcalcCroppedCalibWithBankName() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -582,7 +585,7 @@ public:
   // starting the thread unless you use the mock without thread
   // this test case includes all valid settings, run numbers, spectrum no
   // selected & valid spectrum no provided
-  void test_calcCroppedCalibWithRunNumbers() {
+  void xtestcalcCroppedCalibWithRunNumbers() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test would start a Qt thread that needs signals/slots
@@ -691,7 +694,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusWithoutRunNumber() {
+  void xtestfocusWithoutRunNumber() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -728,7 +731,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusWithRunNumberButWrongBanks() {
+  void xtestfocusWithRunNumberButWrongBanks() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -763,7 +766,7 @@ public:
   }
 
   // the focusing process starts but the input run number cannot be found
-  void test_focusWithNumbersButError() {
+  void xtestfocusWithNumbersButError() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // this test starts the focusing process which would start a Qt
@@ -891,7 +894,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusCropped_withoutRunNo() {
+  void xtestfocusCropped_withoutRunNo() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -931,7 +934,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusCropped_withoutBanks() {
+  void xtestfocusCropped_withoutBanks() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -971,7 +974,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusCropped_withoutSpectrumNos() {
+  void xtestfocusCropped_withoutSpectrumNos() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1011,7 +1014,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusTexture_withoutRunNo() {
+  void xtestfocusTexture_withoutRunNo() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1047,7 +1050,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusTexture_withoutFilename() {
+  void xtestfocusTexture_withoutFilename() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1083,7 +1086,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_focusTexture_withInexistentTextureFile() {
+  void xtestfocusTexture_withInexistentTextureFile() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1119,7 +1122,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_resetFocus() {
+  void xtestresetFocus() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1136,7 +1139,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_resetFocus_thenFocus() {
+  void xtestresetFocus_thenFocus() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1172,7 +1175,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_preproc_event_time_bin_missing_runno() {
+  void xtestpreproc_event_time_bin_missing_runno() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1193,7 +1196,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_preproc_event_time_wrong_bin() {
+  void xtestpreproc_event_time_wrong_bin() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1218,7 +1221,7 @@ public:
   }
 
   // this test does run Load and then Rebin //
-  void test_preproc_event_time_ok() {
+  void xtestpreproc_event_time_ok() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
     // inputs from user
@@ -1250,7 +1253,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_preproc_event_multiperiod_missing_runno() {
+  void xtestpreproc_event_multiperiod_missing_runno() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1271,7 +1274,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_preproc_event_multiperiod_wrong_bin() {
+  void xtest_preproc_event_multiperiod_wrong_bin() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1299,7 +1302,7 @@ public:
   }
 
   // this test does run Load but then RebinByPulseTimes should fail
-  void test_preproc_event_multiperiod_file_wrong_type() {
+  void xtest_preproc_event_multiperiod_file_wrong_type() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     EnggDiffPresenterNoThread pres(&mockView);
 
@@ -1328,7 +1331,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_logMsg() {
+  void xtest_logMsg() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1350,7 +1353,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_RBNumberChange_ok() {
+  void xtest_RBNumberChange_ok() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1372,7 +1375,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_RBNumberChange_empty() {
+  void xtest_RBNumberChange_empty() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1394,7 +1397,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_instChange() {
+  void xtest_instChange() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
 
     // by setting this here, when initialising the presenter, the function will
@@ -1424,7 +1427,7 @@ public:
         testing::Mock::VerifyAndClearExpectations(&mockView))
   }
 
-  void test_shutDown() {
+  void xtest_shutDown() {
     testing::NiceMock<MockEnggDiffractionView> mockView;
     MantidQt::CustomInterfaces::EnggDiffractionPresenter pres(&mockView);
 
@@ -1440,6 +1443,46 @@ public:
         "Mock not used as expected. Some EXPECT_CALL conditions were not "
         "satisfied.",
         testing::Mock::VerifyAndClearExpectations(&mockView))
+  }
+
+  void test_Output_Focus_Filename_With_Instrument() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    EnggDiffPresenterNoThread pres(&mockView);
+    std::vector<bool> vec(true, 1);
+    EXPECT_CALL(mockView, currentInstrument())
+        .WillOnce(Return(std::string("INSTRUMENT")));
+    TS_ASSERT_EQUALS(pres.outputFocusFilenames("INSTRUMENT1234", vec)[0],
+                     "INSTRUMENT_1234_focused_bank_1.nxs");
+  }
+
+  void test_Output_Focus_Filename_Without_Instrument() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    EnggDiffPresenterNoThread pres(&mockView);
+    std::vector<bool> vec(true, 1);
+    EXPECT_CALL(mockView, currentInstrument())
+        .WillOnce(Return(std::string("INSTRUMENT")));
+    TS_ASSERT_EQUALS(pres.outputFocusFilenames("004567", vec)[0],
+                     "INSTRUMENT_4567_focused_bank_1.nxs");
+  }
+
+  void test_Output_Focus_Cropped_Filename_With_Instrument() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    EnggDiffPresenterNoThread pres(&mockView);
+    std::vector<bool> vec(true, 1);
+    EXPECT_CALL(mockView, currentInstrument())
+        .WillOnce(Return(std::string("INSTRUMENT")));
+    TS_ASSERT_EQUALS(pres.outputFocusCroppedFilename("INSTRUMENT1234"),
+                     "INSTRUMENT_1234_focused_cropped.nxs");
+  }
+
+  void test_Output_Focus_Cropped_Filename_Without_Instrument() {
+    testing::NiceMock<MockEnggDiffractionView> mockView;
+    EnggDiffPresenterNoThread pres(&mockView);
+    std::vector<bool> vec(true, 1);
+    EXPECT_CALL(mockView, currentInstrument())
+        .WillOnce(Return(std::string("INSTRUMENT")));
+    TS_ASSERT_EQUALS(pres.outputFocusCroppedFilename("004567"),
+                     "INSTRUMENT_4567_focused_cropped.nxs");
   }
 
 private:

--- a/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
+++ b/qt/scientific_interfaces/test/EnggVanadiumCorrectionsModelTest.h
@@ -122,13 +122,11 @@ public:
     TS_ASSERT(correctionWorkspaces.second);
 
     Poco::Path curvesWSPath(m_inputDir.path());
-    curvesWSPath.append(CURRENT_INSTRUMENT +
-                        "00000123_precalculated_vanadium_run_bank_curves.nxs");
+    curvesWSPath.append("123_precalculated_vanadium_run_bank_curves.nxs");
     TS_ASSERT(Poco::File(curvesWSPath).exists());
 
     Poco::Path integWSPath(m_inputDir.path());
-    integWSPath.append(CURRENT_INSTRUMENT +
-                       "00000123_precalculated_vanadium_run_integration.nxs");
+    integWSPath.append("123_precalculated_vanadium_run_integration.nxs");
     TS_ASSERT(Poco::File(integWSPath).exists());
   }
 
@@ -193,13 +191,11 @@ private:
       Mantid::API::ITableWorkspace_sptr integratedWS,
       Mantid::API::MatrixWorkspace_sptr curvesWS) {
     Poco::Path curvesWSPath(m_inputDir.path());
-    curvesWSPath.append(CURRENT_INSTRUMENT +
-                        "00000123_precalculated_vanadium_run_bank_curves.nxs");
+    curvesWSPath.append("123_precalculated_vanadium_run_bank_curves.nxs");
     saveNexus(curvesWSPath.toString(), curvesWS);
 
     Poco::Path integWSPath(m_inputDir.path());
-    integWSPath.append(CURRENT_INSTRUMENT +
-                       "00000123_precalculated_vanadium_run_integration.nxs");
+    integWSPath.append("123_precalculated_vanadium_run_integration.nxs");
     saveNexus(integWSPath.toString(), integratedWS);
   }
 };

--- a/qt/scientific_interfaces/test/RunMapTest.h
+++ b/qt/scientific_interfaces/test/RunMapTest.h
@@ -19,13 +19,13 @@ public:
   void test_addedItemsExistInMap() {
     RunMap<3, std::string> runMap;
 
-    const RunLabel polly(123, 1);
+    const RunLabel polly("123", 1);
     TS_ASSERT_THROWS_NOTHING(runMap.add(polly, "Polly"));
 
-    const RunLabel morphism(456, 2);
+    const RunLabel morphism("456", 2);
     TS_ASSERT_THROWS_NOTHING(runMap.add(morphism, "Morphism"));
 
-    const RunLabel al(789, 4);
+    const RunLabel al("789", 4);
     TS_ASSERT_THROWS(runMap.add(al, "Al"), std::invalid_argument);
 
     TS_ASSERT(runMap.contains(polly));
@@ -36,10 +36,10 @@ public:
   void test_addedItemsAreCorrect() {
     RunMap<3, std::string> runMap;
 
-    const RunLabel polly(123, 1);
+    const RunLabel polly("123", 1);
     runMap.add(polly, "Polly");
 
-    const RunLabel morphism(456, 2);
+    const RunLabel morphism("456", 2);
     runMap.add(morphism, "Morphism");
 
     TS_ASSERT_EQUALS(runMap.get(polly), "Polly");
@@ -49,30 +49,30 @@ public:
   void test_remove() {
     RunMap<3, std::string> runMap;
 
-    const RunLabel polly(123, 1);
+    const RunLabel polly("123", 1);
     runMap.add(polly, "Polly");
     TS_ASSERT(runMap.contains(polly));
 
     TS_ASSERT_THROWS_NOTHING(runMap.remove(polly));
     TS_ASSERT(!runMap.contains(polly));
 
-    const RunLabel invalid(123, 4);
+    const RunLabel invalid("123", 4);
     TS_ASSERT_THROWS(runMap.remove(invalid), std::invalid_argument);
   }
 
   void test_getRunLabels() {
     RunMap<3, std::string> runMap;
 
-    const RunLabel polly(111, 0);
+    const RunLabel polly("111", 0);
     runMap.add(polly, "Polly");
 
-    const RunLabel morphism(222, 1);
+    const RunLabel morphism("222", 1);
     runMap.add(morphism, "Morphism");
 
-    const RunLabel al(333, 2);
+    const RunLabel al("333", 2);
     runMap.add(al, "Al");
 
-    const RunLabel gorithm(444, 0);
+    const RunLabel gorithm("444", 0);
     runMap.add(gorithm, "Gorithm");
 
     const std::vector<RunLabel> runLabels({polly, morphism, al, gorithm});
@@ -90,12 +90,12 @@ public:
     RunMap<3, std::string> runMap;
     TS_ASSERT_EQUALS(runMap.size(), 0);
 
-    runMap.add(RunLabel(111, 0), "Polly");
-    runMap.add(RunLabel(222, 1), "Morphism");
+    runMap.add(RunLabel("111", 0), "Polly");
+    runMap.add(RunLabel("222", 1), "Morphism");
     TS_ASSERT_EQUALS(runMap.size(), 2);
 
-    runMap.add(RunLabel(333, 2), "Al");
-    runMap.add(RunLabel(444, 0), "Gorithm");
+    runMap.add(RunLabel("333", 2), "Al");
+    runMap.add(RunLabel("444", 0), "Gorithm");
     TS_ASSERT_EQUALS(runMap.size(), 4);
   }
 };


### PR DESCRIPTION
**Description of work.**
The engineering gui now correctly loads the file selected via browse, rather than trying to find a valid run number contained in any folder along the path to the selected file.

**To test:**
Interfaces->Diffraction->Engineering
enter 1 as the RB number, ensure the input directories in the settings tab are set, then head to the calibration tab, set the logger level to information,click browse on the vanadium and select the enginx data provided in the systemtests (SystemTest/ENGINX00236516, and 241391), the logger should show that it has found the correct path, do the same on the calibration, then select calibrate, checking the history the correct path should show there, rename one of the files and then try again it should use the newly renamed file, and not got stuck trying to find a number in the folder in question, repeat this with the focus tab and ENGINX_280625_focused_bank_1.

Fixes #25439 



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
