### PR TITLE
LoadPSIMuonBin Algorithm Improvements

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
@@ -58,6 +58,12 @@ struct headerData {
   float monHigh[4];
 };
 
+struct temperatureHeaderData {
+  std::vector<std::string> titles;
+  std::string startDateTime;
+  bool delimeterOfTitlesIsBackSlash;
+};
+
 class DLLExport LoadPSIMuonBin
     : public API::IFileLoader<Kernel::FileDescriptor> {
 public:
@@ -81,8 +87,28 @@ private:
   void readInHistograms(Mantid::Kernel::BinaryStreamReader &streamReader);
   void generateUnknownAxis();
 
+  // Temperature file processing
+  void readInTemperatureFile(DataObjects::Workspace2D_sptr &ws);
+  std::string detectTempFile();
+  void processLine(const std::string &line, DataObjects::Workspace2D_sptr &ws);
+  void readInTemperatureFileHeader(const std::string &contents);
+  void processHeaderLine(const std::string &line);
+  void processDateHeaderLine(const std::string &line);
+  void processTitleHeaderLine(const std::string &line);
+
+  // Sample log helper functions
+  Mantid::API::Algorithm_sptr
+  createSampleLogAlgorithm(DataObjects::Workspace2D_sptr &ws);
+  void addToSampleLog(const std::string &logName, const std::string &logText,
+                      DataObjects::Workspace2D_sptr &ws);
+  void addToSampleLog(const std::string &logName, const double &logNumber,
+                      DataObjects::Workspace2D_sptr &ws);
+  void addToSampleLog(const std::string &logName, const int &logNumber,
+                      DataObjects::Workspace2D_sptr &ws);
+
   std::vector<std::vector<double>> m_histograms;
   struct headerData m_header;
+  struct temperatureHeaderData m_tempHeader;
   std::vector<double> m_xAxis;
   std::vector<std::vector<double>> m_eAxis;
 };

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -19,12 +19,25 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/UnitLabelTypes.h"
 
+#include <Poco/Path.h>
+#include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
 #include <fstream>
 #include <map>
 
 namespace Mantid {
 namespace DataHandling {
+
+namespace {
+const std::map<std::string, std::string> months{
+    {"JAN", "01"}, {"FEB", "02"}, {"MAR", "03"}, {"APR", "04"},
+    {"MAY", "05"}, {"JUN", "06"}, {"JUL", "07"}, {"AUG", "08"},
+    {"SEP", "09"}, {"OCT", "10"}, {"NOV", "11"}, {"DEC", "12"}};
+const std::vector<std::string> psiMonths{"JAN", "FEB", "MAR", "APR",
+                                         "MAY", "JUN", "JUL", "AUG",
+                                         "SEP", "OCT", "NOV", "DEC"};
+} // namespace
 
 DECLARE_FILELOADER_ALGORITHM(LoadPSIMuonBin)
 
@@ -41,7 +54,7 @@ const std::string LoadPSIMuonBin::summary() const {
 
 // Algorithm's category for identification. @see Algorithm::category
 const std::string LoadPSIMuonBin::category() const {
-  return "DataHandling\\PSIMuonBin";
+  return "DataHandling\\PSI";
 }
 
 int LoadPSIMuonBin::confidence(Kernel::FileDescriptor &descriptor) const {
@@ -65,16 +78,48 @@ void LoadPSIMuonBin::init() {
                       "Filename", "", Mantid::API::FileProperty::Load, exts),
                   "The name of the Bin file to load");
 
+  const std::vector<std::string> extsTemps{".mon"};
+  declareProperty(
+      Kernel::make_unique<Mantid::API::FileProperty>(
+          "TemperatureFilename", "", Mantid::API::FileProperty::OptionalLoad,
+          extsTemps),
+      "The name of the temperature file to be loaded, this is optional as it "
+      "will be automatically searched for if not provided.");
+
   declareProperty(Kernel::make_unique<
                       Mantid::API::WorkspaceProperty<Mantid::API::Workspace>>(
                       "OutputWorkspace", "", Kernel::Direction::Output),
                   "An output workspace.");
+
+  declareProperty("SearchForTempFile", true,
+                  "If no temp file has been given decide whether the algorithm "
+                  "will search for the temperature file.");
+
+  declareProperty("FirstGoodData", 0.0,
+                  "First good data in the OutputWorkspace's spectra",
+                  Kernel::Direction::Output);
+
+  declareProperty("LastGoodData", 0.0,
+                  "Last good data in the OutputWorkspace's spectra",
+                  Kernel::Direction::Output);
+
+  declareProperty("TimeZero", 0.0, "The TimeZero of the OutputWorkspace",
+                  Kernel::Direction::Output);
+
+  declareProperty("DataDeadTimeTable", 0,
+                  "This property should not be set and is present to work with "
+                  "the Muon GUI preprocessor.",
+                  Kernel::Direction::Output);
+
+  declareProperty("MainFieldDirection", 0,
+                  "The field direction of the magnetic field on the instrument",
+                  Kernel::Direction::Output);
 }
 
 void LoadPSIMuonBin::exec() {
 
   if (sizeof(float) != 4) {
-    // assumpetions made about the binary input won't work but since there is no
+    // assumptions made about the binary input won't work but since there is no
     // way to guarantee floating points are 32 bits on all Operating systems
     // here we are.
     throw std::runtime_error("A float on this machine is not 32 bits");
@@ -112,22 +157,56 @@ void LoadPSIMuonBin::exec() {
     outputWorkspace->mutableX(specNum) = m_xAxis;
     outputWorkspace->mutableY(specNum) = m_histograms[specNum];
     outputWorkspace->mutableE(specNum) = m_eAxis[specNum];
+    outputWorkspace->getSpectrum(specNum).setDetectorID(specNum + 1);
   }
 
   assignOutputWorkspaceParticulars(outputWorkspace);
 
+  // Set up for the Muon PreProcessor
   setProperty("OutputWorkspace", outputWorkspace);
+
+  auto largestBinValue =
+      outputWorkspace->x(0)[outputWorkspace->x(0).size() - 1];
+
+  auto firstGoodDataSpecIndex = static_cast<int>(
+      *std::max_element(m_header.firstGood, m_header.firstGood + 16));
+  if (firstGoodDataSpecIndex > largestBinValue)
+    setProperty("FirstGoodData", outputWorkspace->x(0)[firstGoodDataSpecIndex]);
+  else
+    setProperty("FirstGoodData", firstGoodDataSpecIndex);
+
+  // Since the arrray is all 0s before adding them this can't get min
+  // element so just get first element
+  auto lastGoodDataSpecNum = static_cast<int>(m_header.lastGood[0]);
+  setProperty("LastGoodData", outputWorkspace->x(0)[lastGoodDataSpecNum]);
+
+  double timeZero = 0.0;
+  if (m_header.realT0[0] != 0) {
+    timeZero = m_header.realT0[0];
+  } else {
+    timeZero = static_cast<double>(m_header.integerT0[0]);
+  }
+
+  // If timeZero is bigger than the largest bin assume it refers to a bin's
+  // value
+  if (timeZero > largestBinValue) {
+    setProperty("TimeZero",
+                outputWorkspace->x(0)[static_cast<int>(std::floor(timeZero))]);
+  } else {
+    setProperty("TimeZero", timeZero);
+  }
 }
 
 std::string LoadPSIMuonBin::getFormattedDateTime(std::string date,
                                                  std::string time) {
-  std::map<std::string, std::string> months{
-      {"JAN", "01"}, {"FEB", "02"}, {"MAR", "03"}, {"APR", "04"},
-      {"MAY", "05"}, {"JUN", "06"}, {"JUL", "07"}, {"AUG", "08"},
-      {"SEP", "09"}, {"OCT", "10"}, {"NOV", "11"}, {"DEC", "12"}};
-  return "20" + date.substr(7, 2) + "-" +
-         months.find(date.substr(3, 3))->second + "-" + date.substr(0, 2) +
-         "T" + time;
+  std::string year;
+  if (date.size() == 11) {
+    year = date.substr(7, 4);
+  } else {
+    year = "20" + date.substr(7, 2);
+  }
+  return year + "-" + months.find(date.substr(3, 3))->second + "-" +
+         date.substr(0, 2) + "T" + time;
 }
 
 void LoadPSIMuonBin::readSingleVariables(
@@ -292,9 +371,11 @@ void LoadPSIMuonBin::readInHeader(
 void LoadPSIMuonBin::readInHistograms(
     Mantid::Kernel::BinaryStreamReader &streamReader) {
   // Read in the m_histograms
+  m_histograms.reserve(m_header.numberOfHistograms);
   for (auto histogramIndex = 0; histogramIndex < m_header.numberOfHistograms;
        ++histogramIndex) {
     std::vector<double> nextHistogram;
+    nextHistogram.reserve(m_header.lengthOfHistograms);
     for (auto rowIndex = 0; rowIndex < m_header.lengthOfHistograms;
          ++rowIndex) {
       // Each histogram bit is 1024 bytes below the file start, and 4 bytes
@@ -308,18 +389,16 @@ void LoadPSIMuonBin::readInHistograms(
       streamReader.moveStreamToPosition(streamPosition);
       int32_t nextReadValue;
       streamReader >> nextReadValue;
-      nextHistogram.push_back(nextReadValue);
+      nextHistogram.emplace_back(nextReadValue);
     }
-    m_histograms.push_back(nextHistogram);
+    m_histograms.emplace_back(nextHistogram);
   }
 }
 
 void LoadPSIMuonBin::generateUnknownAxis() {
   // Create a x axis, assumption that m_histograms will all be the same size,
   // and that x will be 1 more in size than y
-  for (auto xIndex = 0;
-       static_cast<unsigned int>(xIndex) < m_histograms[0].size() + 1;
-       ++xIndex) {
+  for (auto xIndex = 0u; xIndex < m_histograms[0].size() + 1; ++xIndex) {
     m_xAxis.push_back(static_cast<double>(xIndex) * m_header.histogramBinWidth);
   }
 
@@ -333,19 +412,56 @@ void LoadPSIMuonBin::generateUnknownAxis() {
   }
 }
 
+Mantid::API::Algorithm_sptr
+LoadPSIMuonBin::createSampleLogAlgorithm(DataObjects::Workspace2D_sptr &ws) {
+  Mantid::API::Algorithm_sptr logAlg = createChildAlgorithm("AddSampleLog");
+  logAlg->setProperty("Workspace", ws);
+  return logAlg;
+}
+
+void LoadPSIMuonBin::addToSampleLog(const std::string &logName,
+                                    const std::string &logText,
+                                    DataObjects::Workspace2D_sptr &ws) {
+  auto alg = createSampleLogAlgorithm(ws);
+  alg->setProperty("LogType", "String");
+  alg->setProperty("LogName", logName);
+  alg->setProperty("LogText", logText);
+  alg->executeAsChildAlg();
+}
+
+void LoadPSIMuonBin::addToSampleLog(const std::string &logName,
+                                    const double &logNumber,
+                                    DataObjects::Workspace2D_sptr &ws) {
+  auto alg = createSampleLogAlgorithm(ws);
+  alg->setProperty("LogType", "Number");
+  alg->setProperty("NumberType", "Double");
+  alg->setProperty("LogName", logName);
+  alg->setProperty("LogText", std::to_string(logNumber));
+  alg->executeAsChildAlg();
+}
+
+void LoadPSIMuonBin::addToSampleLog(const std::string &logName,
+                                    const int &logNumber,
+                                    DataObjects::Workspace2D_sptr &ws) {
+  auto alg = createSampleLogAlgorithm(ws);
+  alg->setProperty("LogType", "Number");
+  alg->setProperty("NumberType", "Int");
+  alg->setProperty("LogName", logName);
+  alg->setProperty("LogText", std::to_string(logNumber));
+  alg->executeAsChildAlg();
+}
+
 void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
     DataObjects::Workspace2D_sptr &outputWorkspace) {
   // Sort some workspace particulars
   outputWorkspace->setTitle(m_header.sample +
                             " - Run:" + std::to_string(m_header.numberOfRuns));
 
-  // Set the detector IDs
-  for (auto i = 0; i < m_header.numberOfHistograms; ++i) {
-    outputWorkspace->getSpectrum(i).setDetectorID(i);
-  }
-
   // Set Run Property goodfrm
-  outputWorkspace->mutableRun().addProperty("goodfrm", 1);
+  outputWorkspace->mutableRun().addProperty(
+      "goodfrm", static_cast<int>(m_header.lengthOfHistograms));
+  outputWorkspace->mutableRun().addProperty(
+      "run_number", static_cast<int>(m_header.numberOfRuns));
 
   // Set axis variables
   outputWorkspace->setYUnit("Counts");
@@ -356,184 +472,303 @@ void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
   outputWorkspace->getAxis(0)->unit() = lblUnit;
 
   // Set Start date and time and end date and time
-  Mantid::Types::Core::DateAndTime start(
-      getFormattedDateTime(m_header.dateStart, m_header.timeStart));
-  Mantid::Types::Core::DateAndTime end(
-      getFormattedDateTime(m_header.dateEnd, m_header.timeEnd));
+  auto startDate = getFormattedDateTime(m_header.dateStart, m_header.timeStart);
+  auto endDate = getFormattedDateTime(m_header.dateEnd, m_header.timeEnd);
+  Mantid::Types::Core::DateAndTime start(startDate);
+  Mantid::Types::Core::DateAndTime end(endDate);
   outputWorkspace->mutableRun().setStartAndEndTime(start, end);
 
-  // Start the log building
-  Mantid::API::Algorithm_sptr logAlg = createChildAlgorithm("AddSampleLog");
-  logAlg->setProperty("Workspace", outputWorkspace);
+  addToSampleLog("run_end", startDate, outputWorkspace);
+  addToSampleLog("run_start", endDate, outputWorkspace);
 
-  // Log the set temperature
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Set Temperature");
-  logAlg->setProperty("LogText", m_header.temp);
-  logAlg->executeAsChildAlg();
+  // Assume unit is at the end of the temperature
+  boost::trim_right(m_header.temp);
+  auto tempUnit = std::string(1, m_header.temp.at(m_header.temp.size() - 1));
+  addToSampleLog("sample_temp_unit", tempUnit, outputWorkspace);
+
+  // When poping the back off the temperature it is meant to remove the unit
+  m_header.temp.pop_back();
+  try {
+    double temperature = std::stod(m_header.temp);
+    addToSampleLog("sample_temp", temperature, outputWorkspace);
+  } catch (std::invalid_argument &) {
+    g_log.warning("The \"sample_temp\" could not be converted to a number for "
+                  "the sample log so has been added as a string");
+    addToSampleLog("sample_temp", m_header.temp, outputWorkspace);
+  }
 
   // Add The other temperatures as log
-  auto sizeOfTemps =
+  constexpr auto sizeOfTemps =
       sizeof(m_header.temperatures) / sizeof(*m_header.temperatures);
   for (auto tempNum = 1u; tempNum < sizeOfTemps + 1; ++tempNum) {
     if (m_header.temperatures[tempNum - 1] != 0) {
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName",
-                          "Actual Temperature" + std::to_string(tempNum));
-      logAlg->setProperty("LogText",
-                          std::to_string(m_header.temperatures[tempNum - 1]));
-      logAlg->executeAsChildAlg();
-
-      // Temperature deviation
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName",
-                          "Temperature Deviation" + std::to_string(tempNum));
-      logAlg->setProperty(
-          "LogText",
-          std::to_string(m_header.temperatureDeviation[tempNum - 1]));
-      logAlg->executeAsChildAlg();
+      addToSampleLog("Spectra " + std::to_string(tempNum) + " Temperature",
+                     m_header.temperatures[tempNum - 1], outputWorkspace);
+      addToSampleLog(
+          "Spectra " + std::to_string(tempNum) + " Temperature Deviation",
+          m_header.temperatureDeviation[tempNum - 1], outputWorkspace);
     }
   }
 
-  // Set the comment
   outputWorkspace->setComment(m_header.comment);
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Comment");
-  logAlg->setProperty("LogText", m_header.comment);
-  logAlg->executeAsChildAlg();
+  addToSampleLog("Comment", m_header.comment, outputWorkspace);
+  addToSampleLog("Length of run",
+                 static_cast<double>(m_histograms[0].size()) *
+                     m_header.histogramBinWidth,
+                 outputWorkspace);
 
-  // Length of run
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Length of Run");
-  logAlg->setProperty(
-      "LogText", std::to_string((static_cast<double>(m_histograms[0].size())) *
-                                m_header.histogramBinWidth) +
-                     "MicroSeconds");
-  logAlg->executeAsChildAlg();
-
-  // Log field
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Field");
-  logAlg->setProperty("LogText", m_header.field);
-  logAlg->executeAsChildAlg();
+  boost::trim_right(m_header.field);
+  auto fieldUnit = std::string(1, m_header.field.at(m_header.field.size() - 1));
+  addToSampleLog("Field Unit", fieldUnit, outputWorkspace);
+  m_header.field.pop_back();
+  try {
+    auto field = std::stod(m_header.field);
+    addToSampleLog("sample_magn_field", field, outputWorkspace);
+  } catch (std::invalid_argument &) {
+    g_log.warning("The \"Field\" could not be converted to a number for "
+                  "the sample log so has been added as a string");
+    addToSampleLog("sample_magn_field", m_header.field, outputWorkspace);
+  }
 
   // get scalar labels and set spectra accordingly
   for (auto i = 0u; i < sizeof(m_header.scalars) / sizeof(*m_header.scalars);
        ++i) {
     if (m_header.labels_scalars[i] != "NONE") {
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName",
-                          "Spectra" + std::to_string(i) + " label and scalar");
-      logAlg->setProperty("LogText", m_header.labels_scalars[i] + " - " +
-                                         std::to_string(m_header.scalars[i]));
-      logAlg->executeAsChildAlg();
+      addToSampleLog("Label Spectra " + std::to_string(i),
+                     m_header.labels_scalars[i], outputWorkspace);
+      addToSampleLog("Scalar Spectra " + std::to_string(i), m_header.scalars[i],
+                     outputWorkspace);
     } else {
       break;
     }
   }
 
-  // Orientation
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Orientation");
-  logAlg->setProperty("LogText", m_header.orientation);
-  logAlg->executeAsChildAlg();
+  addToSampleLog("Orientation", m_header.orientation, outputWorkspace);
 
   // first good and last good
   for (size_t i = 0;
        i < sizeof(m_header.firstGood) / sizeof(*m_header.firstGood); ++i) {
     if (m_header.firstGood[i] != 0) {
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName", "First and Last good for Spectra #" +
-                                         std::to_string(i));
-      logAlg->setProperty("LogText", std::to_string(m_header.firstGood[i]) +
-                                         " - " +
-                                         std::to_string(m_header.lastGood[i]));
-      logAlg->executeAsChildAlg();
+      addToSampleLog("First good spectra " + std::to_string(i),
+                     m_header.firstGood[i], outputWorkspace);
+      addToSampleLog("Last good spectra " + std::to_string(i),
+                     m_header.lastGood[i], outputWorkspace);
     }
   }
 
-  // total events
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Total Number of Events");
-  logAlg->setProperty("LogText", std::to_string(m_header.totalEvents));
-  logAlg->executeAsChildAlg();
-
-  // tdcResolution
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "TDC Resolution");
-  logAlg->setProperty("LogText", std::to_string(m_header.tdcResolution));
-  logAlg->executeAsChildAlg();
-
-  // tdcOverflow
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "TDC Overflow");
-  logAlg->setProperty("LogText", std::to_string(m_header.tdcOverflow));
-  logAlg->executeAsChildAlg();
-
-  // Length of spectra
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Spectra Length");
-  logAlg->setProperty("LogText", std::to_string(m_header.lengthOfHistograms));
-  logAlg->executeAsChildAlg();
-
-  // Number of Spectra
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Number of Spectra");
-  logAlg->setProperty("LogText", std::to_string(m_header.numberOfHistograms));
-  logAlg->executeAsChildAlg();
-
-  // monNumber of events
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Mon number of events");
-  logAlg->setProperty("LogText", std::to_string(m_header.monNumberOfevents));
-  logAlg->executeAsChildAlg();
-
-  // Mon Period
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Mon Period");
-  logAlg->setProperty("LogText", std::to_string(m_header.periodOfMon));
-  logAlg->executeAsChildAlg();
+  addToSampleLog("TDC Resolution", m_header.tdcResolution, outputWorkspace);
+  addToSampleLog("TDC Overflow", m_header.tdcOverflow, outputWorkspace);
+  addToSampleLog("Spectra Length", m_header.lengthOfHistograms,
+                 outputWorkspace);
+  addToSampleLog("Number of Spectra", m_header.numberOfHistograms,
+                 outputWorkspace);
+  addToSampleLog("Mon number of events", m_header.monNumberOfevents,
+                 outputWorkspace);
+  addToSampleLog("Mon Period", m_header.periodOfMon, outputWorkspace);
 
   if (m_header.monLow[0] == 0 && m_header.monHigh[0] == 0) {
-    logAlg->setProperty("LogType", "String");
-    logAlg->setProperty("LogName", "Mon Low");
-    logAlg->setProperty("LogText", "0");
-    logAlg->executeAsChildAlg();
-
-    logAlg->setProperty("LogType", "String");
-    logAlg->setProperty("LogName", "Mon High");
-    logAlg->setProperty("LogText", "0");
-    logAlg->executeAsChildAlg();
+    addToSampleLog("Mon Low", "0", outputWorkspace);
+    addToSampleLog("Mon High", "0", outputWorkspace);
   } else {
     for (auto i = 0u; i < 4; ++i) {
       if (m_header.monLow[i] == 0 || m_header.monHigh[i] == 0)
         break;
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName", "Mon Low" + std::to_string(i));
-      logAlg->setProperty("LogText", std::to_string(m_header.monLow[i]));
-      logAlg->executeAsChildAlg();
-
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName", "Mon High + i");
-      logAlg->setProperty("LogText", std::to_string(m_header.monHigh[i]));
-      logAlg->executeAsChildAlg();
+      addToSampleLog("Mon Low " + std::to_string(i), m_header.monLow[i],
+                     outputWorkspace);
+      addToSampleLog("Mon High" + std::to_string(i), m_header.monHigh[i],
+                     outputWorkspace);
     }
   }
 
-  // Mon Deviation
-  logAlg->setProperty("LogType", "String");
-  logAlg->setProperty("LogName", "Mon Deviation");
-  logAlg->setProperty("LogText", m_header.monDeviation);
-  logAlg->executeAsChildAlg();
+  addToSampleLog("Mon Deviation", m_header.monDeviation, outputWorkspace);
 
   if (m_header.realT0[0] != 0) {
-    for (const float &i : m_header.realT0) {
-      if (i == 0)
+    // 16 is the max size of realT0
+    for (auto i = 0u; i < 16; ++i) {
+      if (m_header.realT0[i] == 0)
         break;
-      logAlg->setProperty("LogType", "String");
-      logAlg->setProperty("LogName", "realT0 + i");
-      logAlg->setProperty("LogText", std::to_string(i));
+      addToSampleLog("realT0 " + std::to_string(i), m_header.realT0[i],
+                     outputWorkspace);
+    }
+  }
+
+  // Read in the temperature file if provided/found
+  try {
+    readInTemperatureFile(outputWorkspace);
+  } catch (std::invalid_argument &e) {
+    g_log.warning("Temperature file could not be loaded: " +
+                  std::string(e.what()));
+  } catch (std::runtime_error &e) {
+    g_log.warning("Temperature file could not be loaded:" +
+                  std::string(e.what()));
+  }
+}
+
+void LoadPSIMuonBin::processTitleHeaderLine(const std::string &line) {
+  bool titlesFound = false;
+  std::string foundTitles = "";
+  for (const auto &charecter : line) {
+    if (charecter == ':') {
+      titlesFound = true;
+      continue;
+    } else if (titlesFound) {
+      foundTitles += charecter;
+    }
+  }
+  boost::trim(foundTitles);
+  if (foundTitles.find("\\") == std::string::npos) {
+    boost::split(m_tempHeader.titles, foundTitles, boost::is_any_of(" "));
+    m_tempHeader.delimeterOfTitlesIsBackSlash = false;
+  } else {
+    boost::split(m_tempHeader.titles, foundTitles, boost::is_any_of("\\"));
+    m_tempHeader.delimeterOfTitlesIsBackSlash = true;
+  }
+} // namespace DataHandling
+
+void LoadPSIMuonBin::processDateHeaderLine(const std::string &line) {
+  // Assume the date is added in the same place as always
+  auto date = line.substr(2, 11);
+  auto _time = line.substr(14, 8);
+  m_tempHeader.startDateTime = getFormattedDateTime(date, _time);
+}
+
+void LoadPSIMuonBin::processHeaderLine(const std::string &line) {
+  if (line.find("Title") != std::string::npos) {
+    // Find sample log titles from the header
+    processTitleHeaderLine(line);
+
+  } else if (std::find(std::begin(psiMonths), std::end(psiMonths),
+                       line.substr(5, 3)) != std::end(psiMonths)) {
+    // If the line contains a Month in the PSI format then assume it conains a
+    // date on the line
+    processDateHeaderLine(line);
+  }
+}
+
+void LoadPSIMuonBin::readInTemperatureFileHeader(const std::string &contents) {
+  const int uselessLines = 6;
+  int lineNo = 0;
+  std::string line = "";
+  for (const auto charecter : contents) {
+    if (charecter == '\n') {
+      if (line[0] == '!' && lineNo > uselessLines) {
+        processHeaderLine(line);
+      } else if (line[0] != '!') {
+        break;
+      }
+      ++lineNo;
+      line = "";
+    } else {
+      line += charecter;
+    }
+  }
+}
+
+void LoadPSIMuonBin::processLine(const std::string &line,
+                                 DataObjects::Workspace2D_sptr &ws) {
+  std::vector<std::string> segments;
+  boost::split(segments, line, boost::is_any_of("\\"));
+
+  const auto recordTime = segments[0];
+  const auto numValues = std::stoi(segments[1]);
+  std::vector<std::string> firstValues;
+  boost::split(firstValues, segments[2], boost::is_any_of(" "));
+  std::vector<std::string> secondValues;
+  boost::split(secondValues, segments[3], boost::is_any_of(" "));
+
+  double secondsInRecordTime =
+      (std::stoi(recordTime.substr(0, 2)) * 60 * 60) + // Hours
+      (std::stoi(recordTime.substr(3, 2)) * 60) +      // Minutes
+      (std::stoi(recordTime.substr(6, 2)));            // Seconds
+  const auto timeLog = (Types::Core::DateAndTime(m_tempHeader.startDateTime) +
+                        secondsInRecordTime)
+                           .toISO8601String();
+
+  Mantid::API::Algorithm_sptr logAlg = createChildAlgorithm("AddTimeSeriesLog");
+  logAlg->setProperty("Workspace", ws);
+  logAlg->setProperty("Time", timeLog);
+  if (!m_tempHeader.delimeterOfTitlesIsBackSlash) {
+    for (auto i = 0; i < numValues; ++i) {
+      logAlg->setProperty("Name", "Temp_" + m_tempHeader.titles[i]);
+      logAlg->setProperty("Type", "double");
+      logAlg->setProperty("Value", firstValues[i]);
       logAlg->executeAsChildAlg();
+    }
+  } else {
+    logAlg->setProperty("Name", "Temp_" + m_tempHeader.titles[0]);
+    logAlg->setProperty("Type", "double");
+    logAlg->setProperty("Value", firstValues[0]);
+    logAlg->executeAsChildAlg();
+
+    logAlg->setProperty("Name", "Temp_" + m_tempHeader.titles[1]);
+    logAlg->setProperty("Type", "double");
+    logAlg->setProperty("Value", secondValues[0]);
+    logAlg->executeAsChildAlg();
+  }
+}
+
+std::string LoadPSIMuonBin::detectTempFile() {
+  const std::string binFileName = getPropertyValue("Filename");
+  const Poco::Path fileDir(Poco::Path(binFileName).parent());
+
+  boost::filesystem::recursive_directory_iterator iter(fileDir.toString());
+  boost::filesystem::recursive_directory_iterator end;
+
+  // Recursively iterate through the directory and sub directories looking for a
+  // temp file. The file has the run number in it's name and .mon as it's
+  while (iter != end) {
+    const std::string filepath = iter->path().string();
+    if (filepath.find(std::to_string(m_header.numberOfRuns)) !=
+            std::string::npos &&
+        filepath.find(".mon") != std::string::npos) {
+      return filepath;
+    }
+
+    boost::system::error_code ec;
+    iter.increment(ec);
+    if (ec) {
+      g_log.warning("When searching for temp file, accessing this file: " +
+                    iter->path().string() +
+                    " caused this error: " + ec.message());
+    }
+  }
+
+  return "";
+}
+
+void LoadPSIMuonBin::readInTemperatureFile(DataObjects::Workspace2D_sptr &ws) {
+  std::string fileName = getPropertyValue("TemperatureFilename");
+  const bool searchForTempFile = getProperty("SearchForTempFile");
+  if (fileName == "" && searchForTempFile) {
+    fileName = detectTempFile();
+  }
+
+  if (fileName == "") {
+    throw std::invalid_argument(
+        "No temperature file could be found/was provided");
+  }
+
+  std::ifstream in(fileName, std::ios::in);
+  std::string contents;
+  in.seekg(0, std::ios::end);
+  contents.resize(in.tellg());
+  in.seekg(0, std::ios::beg);
+  in.read(&contents[0], contents.size());
+  in.close();
+
+  readInTemperatureFileHeader(contents);
+
+  std::string line = "";
+  for (const auto &charecter : contents) {
+    if (charecter == '\n') {
+      if (line[0] == '!') {
+        line = "";
+      } else {
+        processLine(line, ws);
+        line = "";
+      }
+    } else {
+      line += charecter;
     }
   }
 }

--- a/Framework/DataHandling/test/LoadPSIMuonBinTest.h
+++ b/Framework/DataHandling/test/LoadPSIMuonBinTest.h
@@ -69,21 +69,22 @@ public:
     TS_ASSERT(ws);
 
     TS_ASSERT_EQUALS(ws->getTitle(), "BNFSO      - Run:1529");
-    TS_ASSERT_EQUALS(ws->getLog("Field")->value(), "0.000G");
+    TS_ASSERT_EQUALS(ws->getLog("sample_magn_field")->value(), "0");
     TS_ASSERT_EQUALS(
         ws->getComment(),
         "Ba3NbFe3Si2O14, crystal                                       ");
-    TS_ASSERT_EQUALS(ws->getLog("Actual Temperature1")->value(), "4.999610");
-    TS_ASSERT_EQUALS(ws->getLog("Actual Temperature2")->value(), "5.197690");
+    TS_ASSERT_DELTA(std::stod(ws->getLog("Spectra 1 Temperature")->value()),
+                    4.99961, 0.00001)
+    TS_ASSERT_DELTA(std::stod(ws->getLog("Spectra 2 Temperature")->value()),
+                    5.19769, 0.00001)
     TS_ASSERT_EQUALS(ws->getLog("end_time")->value(), "2011-07-04T11:56:24");
     TS_ASSERT_EQUALS(ws->getLog("start_time")->value(), "2011-07-04T10:40:23");
-    TS_ASSERT_EQUALS(ws->getLog("Spectra0 label and scalar")->value(),
-                     "Forw - 14493858");
-    TS_ASSERT_EQUALS(ws->getLog("Spectra3 label and scalar")->value(),
-                     "Rite - 38247601");
-    TS_ASSERT_EQUALS(ws->getLog("Length of Run")->value(),
-                     "10.000000MicroSeconds");
-    TS_ASSERT_EQUALS(ws->getLog("Set Temperature")->value(), "5.000K");
+    TS_ASSERT_EQUALS(ws->getLog("Label Spectra 0")->value(), "Forw");
+    TS_ASSERT_EQUALS(ws->getLog("Scalar Spectra 0")->value(), "14493858");
+    TS_ASSERT_EQUALS(ws->getLog("Label Spectra 3")->value(), "Rite");
+    TS_ASSERT_EQUALS(ws->getLog("Scalar Spectra 3")->value(), "38247601");
+    TS_ASSERT_EQUALS(ws->getLog("Length of Run")->value(), "10");
+    TS_ASSERT_EQUALS(ws->getLog("sample_temp")->value(), "5");
 
     TS_ASSERT_EQUALS(ws->x(0).size(), 10241);
     TS_ASSERT_EQUALS(ws->y(0).size(), 10240);
@@ -131,6 +132,56 @@ public:
     FileDescriptor descriptor1(
         getTestFilePath("pid_offset_vulcan_new.dat.bin"));
     TS_ASSERT_EQUALS(alg.confidence(descriptor1), 0);
+  }
+
+  void test_outputProperties() {
+    LoadPSIMuonBin alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+        "Filename", getTestFilePath("deltat_tdc_dolly_1529.bin")));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    double firstGoodData = std::stod(alg.getPropertyValue("FirstGoodData"));
+    double lastGoodData = std::stod(alg.getPropertyValue("LastGoodData"));
+    double timeZero = std::stod(alg.getPropertyValue("TimeZero"));
+
+    TS_ASSERT_DELTA(firstGoodData, 0.167, 0.001);
+    TS_ASSERT_DELTA(lastGoodData, 9.989, 0.001);
+    TS_ASSERT_DELTA(timeZero, 0.158, 0.001);
+  }
+
+  void test_temperatureFileLoaded() {
+    LoadPSIMuonBin alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty(
+        "Filename", getTestFilePath("deltat_tdc_dolly_1529.bin")));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+
+    MatrixWorkspace_sptr ws;
+    TS_ASSERT_THROWS_NOTHING(
+        ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("ws"));
+    TS_ASSERT(ws);
+
+    // These values rely on run_1529_templs0.mon being found and loaded by
+    // LoadPSIMuonBin
+    TS_ASSERT_EQUALS(ws->getLog("Temp_Heater")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  4.9906")
+    TS_ASSERT_EQUALS(ws->getLog("Temp_Analog")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  5.1805")
+    TS_ASSERT_EQUALS(ws->getLog("Temp_ChannelA")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  4.9921")
+    TS_ASSERT_EQUALS(ws->getLog("Temp_ChannelB")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  5.1804")
+    TS_ASSERT_EQUALS(ws->getLog("Temp_ChannelC")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  314.36")
+    TS_ASSERT_EQUALS(ws->getLog("Temp_ChannelD")->value().substr(0, 28),
+                     "2011-Jul-04 10:40:23  314.46")
   }
 
 private:

--- a/Framework/DataHandling/test/LoadPSIMuonBinTest.h
+++ b/Framework/DataHandling/test/LoadPSIMuonBinTest.h
@@ -35,6 +35,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize())
     TS_ASSERT(alg.isInitialized())
 
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("SearchForTempFile", false));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(
         "Filename", getTestFilePath("deltat_tdc_dolly_1529.bin")));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws"));
@@ -44,6 +45,7 @@ public:
     LoadPSIMuonBin alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("SearchForTempFile", false));
 
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(
         "Filename", getTestFilePath("deltat_tdc_dolly_1529.bin")));
@@ -57,6 +59,7 @@ public:
     LoadPSIMuonBin alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("SearchForTempFile", false));
 
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(
         "Filename", getTestFilePath("deltat_tdc_dolly_1529.bin")));
@@ -106,6 +109,7 @@ public:
     LoadPSIMuonBin alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("SearchForTempFile", false));
 
     TS_ASSERT_THROWS_NOTHING(alg.setProperty(
         "Filename", getTestFilePath("pid_offset_vulcan_new.dat.bin")));

--- a/Testing/Data/UnitTest/PSI/run_1529_templs0.mon.md5
+++ b/Testing/Data/UnitTest/PSI/run_1529_templs0.mon.md5
@@ -1,0 +1,1 @@
+8f9afccc1593bfee52c9f55e380e9d9b

--- a/docs/source/algorithms/LoadPSIMuonBin-v1.rst
+++ b/docs/source/algorithms/LoadPSIMuonBin-v1.rst
@@ -9,23 +9,36 @@
 Description
 -----------
 
-The algorithm LoadPSIMuonBin will read in a .bin file from the PSI
+The algorithm LoadPSIMuonBin will read in a .bin file from the PSI 
 facility, from one of the various machines that use that format.
-The file name can be absolute or relative path and should have the
+The file name can be an absolute or relative path and should have the
 extension .bin. The file should only be loaded if the first two bytes
 are "1N" representing it as the format that this will load.
+
+LoadPSIMuonBin is capable of loading in accompanying temperature files.
+There are two options for achieving this. If a temperature file path 
+is passed to the property `TemperatureFilename` it will attempt to use
+this file. With no file given and temperature file searching is not 
+turned off (on by default), this is done by setting 
+`SearchForTempFile` to False, then it will recursively search for the 
+file in the current directory of the data file, and up to 3 directories
+deeper than the file.
+
+Any temperature data loaded in from a separate file will be available 
+from the resultant workspace's sample logs, as a number series that 
+is plottable.
 
 Errors
 ######
 
-For errors we use the Poisson distribution.
+For errors the Poisson distribution is used.
 
 Child Algorithms used
 #####################
 
 The ChildAlgorithms used by LoadPSIMuonBin are:
 
-* :ref:`algm-AddSampleLog-v1` - It adds to the Sample Log of the workspace
+* :ref:`algm-AddSampleLog-v1` - Adds data to the Sample Log of the workspace
 
 .. categories::
 

--- a/docs/source/algorithms/LoadPSIMuonBin-v1.rst
+++ b/docs/source/algorithms/LoadPSIMuonBin-v1.rst
@@ -16,13 +16,10 @@ extension .bin. The file should only be loaded if the first two bytes
 are "1N" representing it as the format that this will load.
 
 LoadPSIMuonBin is capable of loading in accompanying temperature files.
-There are two options for achieving this. If a temperature file path 
-is passed to the property `TemperatureFilename` it will attempt to use
-this file. With no file given and temperature file searching is not 
-turned off (on by default), this is done by setting 
-`SearchForTempFile` to False, then it will recursively search for the 
-file in the current directory of the data file, and up to 3 directories
-deeper than the file.
+There are two options for achieving this. If no file is provided and 
+the temperature file searching enabled (it is by default), then it 
+will recursively search for the file in the current directory of the
+data file and up to 3 directories deeper than the file.
 
 Any temperature data loaded in from a separate file will be available 
 from the resultant workspace's sample logs, as a number series that 


### PR DESCRIPTION
**Description of work.**
PSI temperature files can now be read-in alongside the workspace loadable files to and added to the sample logs of the created workspace. Alongside these changes, several sample logs are now numeric instead of strings.

**Report to:** Francis Pratt (ISIS)

**To test:**
- Load `deltat_tdc_dolly_1529.bin` from the Unit Test data
- Open the sample logs
- Check the sample logs with the names that start with `Temp_` and make sure that the temperature values against time make a plot, (If none of the number series appear, build the test data).
- Do some testing around with the algorithm looking for files manually and searching for them etc.

<!-- Instructions for testing. -->

Fixes #23070, do not close the issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
