### PR TITLE
Fix sliceviewer for matrix workspace

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -25,6 +25,7 @@ class SliceViewer(object):
             self.update_plot_data = self.update_plot_data_MDE
         else:
             self.new_plot = self.new_plot_matrix
+            self.update_plot_data = self.update_plot_data_matrix
 
         self.view = view if view else SliceViewerView(self, self.model.get_dimensions_info(), parent)
 
@@ -47,3 +48,7 @@ class SliceViewer(object):
         self.view.update_plot_data(self.model.get_data(slicepoint=self.view.dimensions.get_slicepoint(),
                                                        bin_params=self.view.dimensions.get_bin_params(),
                                                        transpose=self.view.dimensions.transpose))
+
+    def update_plot_data_matrix(self):
+        # should never be called, since this workspace type is only 2D the plot dimensions never change
+        pass


### PR DESCRIPTION
After  #25666 was merged in plotting MatrixWorkspaces in sliceviewer stopped working with the following error:
```
/home/rwp/mantid/qt/python/mantidqt/widgets/sliceviewer/view.py in __init__(self, presenter, dims_info, parent)
     31         self.dimensions = DimensionWidget(dims_info, parent=self)
     32         self.dimensions.dimensionsChanged.connect(self.presenter.new_plot)
---> 33         self.dimensions.valueChanged.connect(self.presenter.update_plot_data)
     34 
     35         # MPL figure + colorbar

AttributeError: 'SliceViewer' object has no attribute 'update_plot_data'
```
This fixes that

**To test:**
Try opening a MatrixWorkspace in sliceviewer

*This does not require release notes* because it was only added this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
