### PR TITLE
TFAsymm bug in muon analysis

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -22,3 +22,8 @@ Improvements
 
 * Phase table and phase Quad options from frequency domain transform tab moved to phase calculations tab.
 
+Bug Fixes
+#########
+
+* Muon Analysis no longer crashes when `TF Asymmetry` mode is activated. 
+

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -1244,8 +1244,8 @@ void MuonFitPropertyBrowser::ConvertFitFunctionForMuonTFAsymmetry(
       }
     } // single fit
     else {
-      FitPropertyBrowser::clear();
-      FitPropertyBrowser::addFunction(func->asString());
+      m_functionBrowser->clear();
+      m_functionBrowser->setFunction(func);
     }
 
     updateTFPlot();


### PR DESCRIPTION
**Description of work.**
There was a bug in the muon analysis GUI that caused Mantid to crash. This PR fixes it. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open muon analysis
Set instrument to `MUSR`
Load run `62260`
Go to the settings tab and make sure multiple fitting is not selected
Go to the data analysis tab
Add a `GaussOsc` function
Click the `TFASymm` checkbox in the settings table
Mantid use to crash here
<!-- Instructions for testing. -->

Fixes #25677. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
In release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
