### PR TITLE
Fix crashing on opening interfaces in Workbench

### DIFF
--- a/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/scripts/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -49,19 +49,20 @@ from HFIR_4Circle_Reduction.hfctables import MatrixTable
 from mantid.kernel import Logger
 from qtpy.QtWidgets import (QButtonGroup, QFileDialog, QMessageBox, QMainWindow, QInputDialog)  # noqa
 from qtpy.QtCore import (QSettings)  # noqa
-from qtpy import QtCore  # noqa
+from qtpy import PYQT4  # noqa
 try:
     from mantidqt.utils.qt import load_ui
 except ImportError:
     Logger("HFIR_4Circle_Reduction").information('Using legacy ui importer')
     from mantidplot import load_ui
 from qtpy.QtWidgets import (QVBoxLayout)
-try:
-    from mantidqtpython import MantidQt
-except ImportError as e:
-    NO_SCROLL = True
-else:
-    NO_SCROLL = False
+SCROLL_AVAILABLE = False
+if PYQT4:
+    try:
+        from mantidqtpython import MantidQt
+        SCROLL_AVAILABLE = True
+    except ImportError as e:
+        SCROLL_AVAILABLE = False
 if six.PY3:
     unicode = str
 
@@ -105,7 +106,7 @@ class MainWindow(QMainWindow):
         self._general_1d_plot_window = None
 
         # Make UI scrollable
-        if NO_SCROLL is False:
+        if SCROLL_AVAILABLE:
             self._scrollbars = MantidQt.API.WidgetScrollbarDecorator(self)
             self._scrollbars.setEnabled(True)  # Must follow after setupUi(self)!
 

--- a/scripts/Interface/reduction_gui/widgets/inelastic/dgs_sample_setup.py
+++ b/scripts/Interface/reduction_gui/widgets/inelastic/dgs_sample_setup.py
@@ -11,6 +11,7 @@ from qtpy.QtGui import (QDoubleValidator, QIntValidator)  # noqa
 from functools import partial
 from reduction_gui.widgets.base_widget import BaseWidget
 from reduction_gui.reduction.inelastic.dgs_sample_data_setup_script import SampleSetupScript
+from qtpy import PYQT4  # noqa
 import reduction_gui.widgets.util as util
 import os
 try:
@@ -21,12 +22,14 @@ except ImportError:
     from mantidplot import load_ui
 
 IS_IN_MANTIDPLOT = False
-try:
-    import mantidqtpython
-    from mantid.kernel import config
-    IS_IN_MANTIDPLOT = True
-except:
-    pass
+
+if PYQT4:
+    try:
+        import mantidqtpython
+        from mantid.kernel import config
+        IS_IN_MANTIDPLOT = True
+    except:
+        pass
 
 
 class SampleSetupWidget(BaseWidget):

--- a/scripts/Muon/GUI/Common/help_widget/help_widget_view.py
+++ b/scripts/Muon/GUI/Common/help_widget/help_widget_view.py
@@ -3,23 +3,8 @@ from __future__ import (absolute_import, division, print_function)
 from qtpy import QtWidgets
 import Muon.GUI.Common.message_box as message_box
 from qtpy import PYQT4
-
-# determine whether the interface is opened from within Mantid or not
-# (outside of Mantid we cannot use the "Manage user directories" functionality)
-STANDALONE_EXEC = True
-try:
-    from mantidqtpython import MantidQt
-except:
-    STANDALONE_EXEC = False
-
-if PYQT4:
-    IN_MANTIDPLOT = False
-    try:
-        from pymantidplot import proxies
-        IN_MANTIDPLOT = True
-    except ImportError:
-        # We are not in MantidPlot e.g. testing
-        pass
+from mantidqt.widgets.manageuserdirectories import ManageUserDirectories
+from mantidqt.interfacemanager import InterfaceManager
 
 
 class HelpWidgetView(QtWidgets.QWidget):
@@ -69,12 +54,7 @@ class HelpWidgetView(QtWidgets.QWidget):
         self.help_button.clicked.connect(slot)
 
     def show_directory_manager(self):
-        if STANDALONE_EXEC:
-            MantidQt.API.ManageUserDirectories.openUserDirsDialog(self)
-        else:
-            self.warning_popup(
-                "Cannot open user directories dailog outside MantidPlot.")
+        ManageUserDirectories.openUserDirsDialog(self)
 
     def _on_help_button_clicked(self):
-        if PYQT4:
-            proxies.showCustomInterfaceHelp('Frequency Domain Analysis')
+        InterfaceManager().showCustomInterfaceHelp('Frequency Domain Analysis')

--- a/scripts/Muon/GUI/Common/help_widget/help_widget_view.py
+++ b/scripts/Muon/GUI/Common/help_widget/help_widget_view.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 from qtpy import QtWidgets
 import Muon.GUI.Common.message_box as message_box
-from qtpy import PYQT4
 from mantidqt.widgets.manageuserdirectories import ManageUserDirectories
 from mantidqt.interfacemanager import InterfaceManager
 

--- a/scripts/test/Muon/help_widget_presenter_test.py
+++ b/scripts/test/Muon/help_widget_presenter_test.py
@@ -24,11 +24,11 @@ class HelpWidgetPresenterTest(unittest.TestCase):
     def tearDown(self):
         self.view = None
 
-    @mock.patch('Muon.GUI.Common.help_widget.help_widget_view.MantidQt')
-    def test_that_manage_directories_button_clicked_opens_directory_manager(self, mantidqt_mock):
+    @mock.patch('Muon.GUI.Common.help_widget.help_widget_view.ManageUserDirectories')
+    def test_that_manage_directories_button_clicked_opens_directory_manager(self, mock_ManageUserDirectories):
         self.view.manage_user_dir_button.clicked.emit(True)
 
-        mantidqt_mock.API.ManageUserDirectories.openUserDirsDialog.assert_called_once_with(self.view)
+        mock_ManageUserDirectories.openUserDirsDialog.assert_called_once_with(self.view)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Removes, or makes Qt4 only, the `mantidqtpython` import attempts. Doing so pulls in Qt4 libraries and seems to cause a crash when running on the Workbench.

Not 100% sure what exposed this issue, but the crashes are happening now.

**To test:**
- Open Workbench
- From `Interfaces` open:
  - `Diffraction` > `HFIR`
  - `Diffraction` > `Powder`
  - `Direct` > `DGS Reduction`
  - `SANS` > `ORNL SANS`

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
