### PR TITLE
Add power and square axis scaling to mantid.plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/plots/CMakeLists.txt
@@ -3,6 +3,7 @@ set(PY_FILES
     helperfunctions.py
     plotfunctions.py
     plotfunctions3D.py
+    scales.py
     utility.py)
 
 add_subdirectory(modest_image)

--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -20,6 +20,7 @@ from collections import Iterable
 from mantid.kernel import logger
 from mantid.plots import helperfunctions, plotfunctions
 from mantid.plots import plotfunctions3D
+from mantid.plots.scales import PowerScale, SquareScale
 from matplotlib import cbook
 from matplotlib.axes import Axes
 from matplotlib.collections import Collection
@@ -29,6 +30,7 @@ from matplotlib.image import AxesImage
 from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
 from matplotlib.projections import register_projection
+from matplotlib.scale import register_scale
 from matplotlib.table import Table
 
 try:
@@ -953,3 +955,5 @@ class MantidAxes3D(Axes3D):
 
 register_projection(MantidAxes)
 register_projection(MantidAxes3D)
+register_scale(PowerScale)
+register_scale(SquareScale)

--- a/Framework/PythonInterface/mantid/plots/scales.py
+++ b/Framework/PythonInterface/mantid/plots/scales.py
@@ -1,0 +1,144 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid package
+"""
+Defines a set of custom axis scales
+"""
+from __future__ import (absolute_import, division, unicode_literals)
+
+from matplotlib.scale import ScaleBase
+from matplotlib.ticker import (AutoLocator, NullFormatter,
+                               NullLocator, ScalarFormatter)
+from matplotlib.transforms import Transform
+import numpy as np
+
+
+class PowerScale(ScaleBase):
+    """Scales the data using a power-law scaling: x^gamma
+    """
+    # Name required by register_scale. Use this is set_*scale
+    # commands
+    name = 'power'
+
+    def __init__(self, _, **kwargs):
+        """
+        Any keyword arguments passed to ``set_xscale`` and
+        ``set_yscale`` will be passed along to the scale's
+        constructor.
+
+        gamma: The power used to scale the data.
+        """
+        super(PowerScale, self).__init__()
+        gamma = kwargs.pop("gamma", None)
+        if gamma is None:
+            raise ValueError("power scale must specify gamma value")
+        self._gamma = float(gamma)
+
+    def get_transform(self):
+        """
+        Return a PowerTransform that does the actual scaling
+        """
+        return PowerScale.PowerTransform(self._gamma)
+
+    def set_default_locators_and_formatters(self, axis):
+        """
+        Set the locators and formatters to automatic and scalar
+        """
+        axis.set_major_locator(AutoLocator())
+        axis.set_major_formatter(ScalarFormatter())
+        axis.set_minor_locator(NullLocator())
+        axis.set_minor_formatter(NullFormatter())
+
+    def limit_range_for_scale(self, vmin, vmax, minpos):
+        """
+        Limit the domain to positive values for even or fractional
+        indices
+        """
+        if not self._gamma.is_integer() or self._gamma % 2 == 0:
+            if not np.isfinite(minpos):
+                minpos = 1e-300  # This value should rarely if ever
+                                 # end up with a visible effect.
+
+            return (minpos if vmin <= 0 else vmin,
+                    minpos if vmax <= 0 else vmax)
+        else:
+            return vmin, vmax
+
+    class PowerTransform(Transform):
+        # There are two value members that must be defined.
+        # ``input_dims`` and ``output_dims`` specify number of input
+        # dimensions and output dimensions to the transformation.
+        # These are used by the transformation framework to do some
+        # error checking and prevent incompatible transformations from
+        # being connected together.  When defining transforms for a
+        # scale, which are, by definition, separable and have only one
+        # dimension, these members should always be set to 1.
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+        has_inverse = True
+
+        def __init__(self, gamma):
+            super(PowerScale.PowerTransform, self).__init__()
+            self._gamma = gamma
+
+        def transform_non_affine(self, a):
+            """Apply the transform to the given data array
+            """
+            with np.errstate(divide="ignore", invalid="ignore"):
+                out = np.power(a, self._gamma)
+            if not self._gamma.is_integer():
+                # negative numbers to power of fractions are undefined
+                # clip them to 0
+                out[a <= 0] = 0
+            return out
+
+        def inverted(self):
+            """
+            Return the type responsible for inverting the transform
+            """
+            return PowerScale.InvertedPowerTransform(self._gamma)
+
+    class InvertedPowerTransform(Transform):
+        input_dims = 1
+        output_dims = 1
+        is_separable = True
+        has_inverse = True
+
+        def __init__(self, gamma):
+            super(PowerScale.InvertedPowerTransform, self).__init__()
+            self._gamma = gamma
+
+        def transform_non_affine(self, a):
+            if not self._gamma.is_integer() or self._gamma % 2 == 0:
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    out = np.power(a, 1. / self._gamma)
+                # clip negative values to 0
+                out[a <= 0] = 0
+            else:
+                # negative numbers to power of non-integers are undefined and np.power
+                # returns nan. In the case of where we have a fractional power with
+                # an odd denominator then we can write the power as
+                #     (-a)^(1/b) = (-1)^1(a^(1/b)) = -1*a^(1/b)
+                negative_indices = (a < 0.)
+                out = np.negative(a, where=negative_indices)
+                out = np.power(out, 1. / self._gamma)
+                out = np.negative(out, where=negative_indices)
+
+            return out
+
+        def inverted(self):
+            return PowerScale.PowerTransform(self._gamma)
+
+
+class SquareScale(PowerScale):
+    # Convenience type for square scaling
+    name = 'square'
+
+    def __init__(self, axis, **kwargs):
+        kwargs['gamma'] = 2
+        super(SquareScale, self).__init__(axis, **kwargs)

--- a/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
@@ -1,0 +1,67 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid package
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, print_function)
+
+import unittest
+
+from matplotlib.scale import scale_factory
+from mantid.plots.scales import PowerScale, SquareScale
+import numpy as np
+
+
+class ScalesTest(unittest.TestCase):
+
+    def test_power_scale_registered_in_factory(self):
+        self.assertTrue(isinstance(scale_factory('power', axis=None, gamma=3),
+                                   PowerScale))
+
+    def test_power_transform(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(0, 10, 1)
+        transform = scale.get_transform()
+        np.testing.assert_almost_equal(np.power(x, gamma),
+                                       transform.transform_non_affine(x))
+
+    def test_power_inverse_transform(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(0, 10, 1)
+        inv_transform = scale.get_transform().inverted()
+        np.testing.assert_almost_equal(np.power(x, 1./gamma),
+                                       inv_transform.transform_non_affine(x))
+
+
+    def test_square_scale_registered_in_factory(self):
+        self.assertTrue(isinstance(scale_factory('square', axis=None),
+                                   SquareScale))
+
+    def test_square_transform(self):
+        scale = SquareScale(None)
+        x = np.linspace(0, 10, 1)
+        transform = scale.get_transform()
+        np.testing.assert_almost_equal(np.power(x, 2),
+                                       transform.transform_non_affine(x))
+
+
+    def test_square_inverse_transform(self):
+        scale = SquareScale(None)
+        x = np.linspace(0, 10, 1)
+        inv_transform = scale.get_transform().inverted()
+        np.testing.assert_almost_equal(np.sqrt(x),
+                                       inv_transform.transform_non_affine(x))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -42,4 +42,6 @@ Data Objects
 Python
 ------
 
+- The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
+
 :ref:`Release 4.1.0 <v4.1.0>`


### PR DESCRIPTION
**Description of work.**

Adds a `PowerScale` and `SquareScale` to the known `matplotlib` scale types for `set_xscale` and `set_yscale`. Some interfaces use squared-axis scaling but it seemed sensible to implement a general power and then a specific square case.

The scale is registered in `mantid.plots` so is available wherever `MantidAxes` is available.

**To test:**

This can be used standalone without MantidPlot or Workbench. The following shows a quadratic curve mapped to a square and power scale (exponent=2) such that it produces a straight line.

```python
import mantid.plots
import numpy as np
import matplotlib.pyplot as plt

fig, axes = plt.subplots(1, 3)

x = np.arange(-5, 6, 1.)
s = np.power(x, 2)

titles = ('Linear X Scale', 'Square X Scale', 'Power 2 X Scale')
for ax in axes:
    ax.plot(x, s, '-', lw=2)
    ax.set_xlabel('X')
    ax.set_ylabel('X^2')
    ax.grid(True)

# 0 is linear
axes[0].set_title('Linear X Scale')
# 1 is square
axes[1].set_title('Square X Scale')
axes[1].set_xscale('square')
# 2 is power
axes[2].set_title('Power gamma=2 X Scale')
axes[2].set_xscale('power', gamma=2)

plt.show()
```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
