### PR TITLE
Clangformat now includes .tcc files

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction1D.tcc
+++ b/Framework/API/inc/MantidAPI/IFunction1D.tcc
@@ -63,7 +63,7 @@ void IFunction1D::calcNumericalDerivative1D(Jacobian *jacobian,
     }
   }
 }
-}
-}
+} // namespace API
+} // namespace Mantid
 
 #endif // MANTID_API_IFUNCTION1D_TCC

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBin.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBin.tcc
@@ -21,5 +21,5 @@ TMDE(MDBin)::MDBin() : m_signal(0), m_errorSquared(0) {
     m_max[d] = +std::numeric_limits<coord_t>::max();
 }
 
-} // namespace Mantid
 } // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBox.tcc
@@ -74,8 +74,8 @@ TMDE(MDBox)::MDBox(API::BoxController *const splitter, const uint32_t depth,
  */
 TMDE(MDBox)::MDBox(
     API::BoxController_sptr &splitter, const uint32_t depth,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
-        extentsVector,
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector,
     const size_t nBoxEvents, const size_t boxID)
     : MDBoxBase<MDE, nd>(splitter.get(), depth, boxID, extentsVector),
       m_Saveable(nullptr), m_bIsMasked(false) {
@@ -92,14 +92,13 @@ TMDE(MDBox)::MDBox(
  */
 TMDE(MDBox)::MDBox(
     API::BoxController *const splitter, const uint32_t depth,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
-        extentsVector,
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector,
     const size_t nBoxEvents, const size_t boxID)
     : MDBoxBase<MDE, nd>(splitter, depth, boxID, extentsVector),
       m_Saveable(nullptr), m_bIsMasked(false) {
   initMDBox(nBoxEvents);
 }
-
 
 /**
  * contructor for explicit creation of MDGridBox with known
@@ -111,11 +110,13 @@ TMDE(MDBox)::MDBox(
  * @param end :: iterator before ened (not included)
  */
 template <typename MDE, size_t nd>
-MDBox<MDE, nd>::MDBox(Mantid::API::BoxController *const bc, const uint32_t depth,
-      const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
-      &extentsVector, EventIterator begin, EventIterator end) :
-      MDBoxBase<MDE, nd>(bc, depth, 0, extentsVector), m_Saveable(nullptr),
-      m_bIsMasked(false)  {
+MDBox<MDE, nd>::MDBox(
+    Mantid::API::BoxController *const bc, const uint32_t depth,
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector,
+    EventIterator begin, EventIterator end)
+    : MDBoxBase<MDE, nd>(bc, depth, 0, extentsVector), m_Saveable(nullptr),
+      m_bIsMasked(false) {
   data = std::vector<MDE>(begin, end);
   MDBoxBase<MDE, nd>::calcCaches(data.begin(), data.end());
   if (this->m_BoxController->isFileBacked())
@@ -230,8 +231,9 @@ TMDE(void MDBox)::getBoxes(
  * @param cond :: condition to check
  *(leaves on the tree)
  */
-TMDE(void MDBox)::getBoxes(std::vector<API::IMDNode *>& outBoxes, const std::function<bool(API::IMDNode *)> &cond) {
-  if(cond(this))
+TMDE(void MDBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
+                           const std::function<bool(API::IMDNode *)> &cond) {
+  if (cond(this))
     outBoxes.emplace_back(this);
 }
 
@@ -240,7 +242,7 @@ TMDE(void MDBox)::getBoxes(std::vector<API::IMDNode *>& outBoxes, const std::fun
  * in memory, or on disk or partially on memory and partially on disk
  * for partially loaded object substantially relies on correct settings of
  * wasSaved and isLoaded switches of iSaveable object
-*/
+ */
 TMDE(uint64_t MDBox)::getNPoints() const {
   if (!m_Saveable)
     return data.size();
@@ -322,11 +324,11 @@ TMDE(void MDBox)::releaseEvents() {
 
 /** The method to convert events in a box into a table of
  * coordinates/signal/errors casted into coord_t type
-  *   Used to save events from plain binary file
-  *   @returns coordTable -- vector of events parameters in the form signal,
+ *   Used to save events from plain binary file
+ *   @returns coordTable -- vector of events parameters in the form signal,
  * error, [detID,rinId], eventsCoordinates....
-  *   @return nColumns    -- number of parameters for each event
-  */
+ *   @return nColumns    -- number of parameters for each event
+ */
 TMDE(void MDBox)::getEventsData(std::vector<coord_t> &coordTable,
                                 size_t &nColumns) const {
   double signal, errorSq;
@@ -593,11 +595,10 @@ TMDE(void MDBox)::generalBin(
  * @param[out] errorSquared :: set to the integrated squared error.
  * @param innerRadiusSquared :: radius^2 above which to integrate
  */
-TMDE(void MDBox)::integrateSphere(Mantid::API::CoordTransform &radiusTransform,
-                                  const coord_t radiusSquared, signal_t &signal,
-                                  signal_t &errorSquared,
-                                  const coord_t innerRadiusSquared,
-                                  const bool useOnePercentBackgroundCorrection) const {
+TMDE(void MDBox)::integrateSphere(
+    Mantid::API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+    signal_t &signal, signal_t &errorSquared, const coord_t innerRadiusSquared,
+    const bool useOnePercentBackgroundCorrection) const {
   // If the box is cached to disk, you need to retrieve it
   const std::vector<MDE> &events = this->getConstEvents();
   if (innerRadiusSquared == 0.0) {
@@ -630,8 +631,10 @@ TMDE(void MDBox)::integrateSphere(Mantid::API::CoordTransform &radiusTransform,
               });
 
     // Remove top 1% of background
-    const size_t endIndex = useOnePercentBackgroundCorrection ?
-        static_cast<size_t>(0.99 * static_cast<double>(vals.size())) : vals.size();
+    const size_t endIndex =
+        useOnePercentBackgroundCorrection
+            ? static_cast<size_t>(0.99 * static_cast<double>(vals.size()))
+            : vals.size();
 
     for (size_t k = 0; k < endIndex; k++) {
       signal += vals[k].first;
@@ -766,9 +769,9 @@ TMDE(void MDBox)::unmask() { m_bIsMasked = false; }
 //------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 /** Create and Add several events. No bounds checking is made!
-  *
-  *@return number of events rejected (0 as nothing is rejected here)
-  */
+ *
+ *@return number of events rejected (0 as nothing is rejected here)
+ */
 TMDE(size_t MDBox)::buildAndAddEvents(const std::vector<signal_t> &sigErrSq,
                                       const std::vector<coord_t> &Coord,
                                       const std::vector<uint16_t> &runIndex,
@@ -858,13 +861,13 @@ TMDE(size_t MDBox)::addEvents(const std::vector<MDE> &events) {
 }
 
 /**Make this box file-backed
-* @param fileLocation -- the starting position of this box data are/should be
-* located in the direct access file
-* @param fileSize     -- the size this box data occupy in the file (in the units
-* of the number of events)
-* @param markSaved    -- set to true if the data indeed are physically there and
-* one can indeed read then from there
-*/
+ * @param fileLocation -- the starting position of this box data are/should be
+ * located in the direct access file
+ * @param fileSize     -- the size this box data occupy in the file (in the
+ * units of the number of events)
+ * @param markSaved    -- set to true if the data indeed are physically there
+ * and one can indeed read then from there
+ */
 TMDE(void MDBox)::setFileBacked(const uint64_t fileLocation,
                                 const size_t fileSize, const bool markSaved) {
   if (!m_Saveable)
@@ -880,12 +883,12 @@ TMDE(void MDBox)::setFileBacked() {
 }
 
 /**Save the box data to specific disk position using the class, responsible for
-  *the file IO.
-  *
-  *@param FileSaver -- the pointer to the class, responsible for File IO
-  *operations
-  *@param position  -- the position of the data within the class.
-*/
+ *the file IO.
+ *
+ *@param FileSaver -- the pointer to the class, responsible for File IO
+ *operations
+ *@param position  -- the position of the data within the class.
+ */
 TMDE(void MDBox)::saveAt(API::IBoxControllerIO *const FileSaver,
                          uint64_t position) const {
   if (data.empty())
@@ -924,14 +927,14 @@ TMDE(void MDBox)::reserveMemoryForLoad(uint64_t size) {
 }
 
 /**Load the box data of specified size from the disk location provided using the
-*class, respoinsible for the file IO and append them to exisiting events
+ *class, respoinsible for the file IO and append them to exisiting events
  * Clear events vector first if overwriting the exisitng events is necessary.
  *
-* @param FileSaver    -- the pointer to the class, responsible for file IO
-* @param filePosition -- the place in the direct access file, where necessary
-*data are located
-* @param nEvents      -- number of events reqested to load
-*/
+ * @param FileSaver    -- the pointer to the class, responsible for file IO
+ * @param filePosition -- the place in the direct access file, where necessary
+ *data are located
+ * @param nEvents      -- number of events reqested to load
+ */
 TMDE(void MDBox)::loadAndAddFrom(API::IBoxControllerIO *const FileSaver,
                                  uint64_t filePosition, size_t nEvents) {
   if (nEvents == 0)
@@ -961,7 +964,7 @@ TMDE(void MDBox)::loadAndAddFrom(API::IBoxControllerIO *const FileSaver,
  * not entirely fool-proof, as if the data is actually loaded is controlled by
  *isLoaded switch in ISaveable
  * and this switch has to be set up correctly
-*/
+ */
 TMDE(void MDBox)::clearFileBacked(bool loadDiskBackedData) {
   if (m_Saveable) {
     if (loadDiskBackedData)

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxBase.tcc
@@ -6,9 +6,9 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataObjects/MDBoxBase.h"
 #include "MantidDataObjects/MDEvent.h"
-#include "MantidKernel/make_unique.h"
 #include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
+#include "MantidKernel/make_unique.h"
 #include <boost/make_shared.hpp>
 #include <limits>
 
@@ -37,8 +37,8 @@ TMDE(MDBoxBase)::MDBoxBase(Mantid::API::BoxController *const boxController,
 TMDE(MDBoxBase)::MDBoxBase(
     Mantid::API::BoxController *const boxController, const uint32_t depth,
     const size_t boxID,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
-        extentsVector)
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector)
     : m_signal(0.0), m_errorSquared(0.0), m_totalWeight(0.0),
       m_BoxController(boxController), m_inverseVolume(UNDEF_COORDT),
       m_depth(depth), m_parent(nullptr), m_fileID(boxID) {
@@ -140,7 +140,8 @@ TMDE(std::vector<Mantid::Kernel::VMD> MDBoxBase)::getVertexes() const {
  * @param[out] numVertices :: returns the number of vertices in the array.
  * @return the bare array. This should be deleted by the caller!
  * */
-TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(size_t &numVertices) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(
+    size_t &numVertices) const {
   // How many vertices does one box have? 2^nd, or bitwise shift left 1 by nd
   // bits
   numVertices = 1 << nd;
@@ -189,9 +190,9 @@ TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(size_t &numVertices
  *caller!
  * @throw if outDimensions == 0
  * */
-TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(size_t &numVertices,
-                                           const size_t outDimensions,
-                                           const bool *maskDim) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxBase)::getVertexesArray(
+    size_t &numVertices, const size_t outDimensions,
+    const bool *maskDim) const {
   if (outDimensions == 0)
     throw std::invalid_argument(
         "MDBoxBase::getVertexesArray(): Must have > 0 output dimensions.");
@@ -283,5 +284,5 @@ TMDE(size_t MDBoxBase)::addEventsUnsafe(const std::vector<MDE> &events) {
   return 0;
 }
 
-} // namespace Mantid
 } // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDBoxIterator.tcc
@@ -4,10 +4,10 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
-#include "MantidKernel/System.h"
 #include "MantidDataObjects/MDBoxBase.h"
 #include "MantidDataObjects/MDBoxIterator.h"
+#include "MantidGeometry/MDGeometry/MDImplicitFunction.h"
+#include "MantidKernel/System.h"
 
 namespace Mantid {
 namespace DataObjects {
@@ -264,13 +264,14 @@ TMDE(signal_t MDBoxIterator)::getSignal() const {
 TMDE(signal_t MDBoxIterator)::getError() const { return m_current->getError(); }
 
 /// Return a list of vertexes defining the volume pointed to
-TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(size_t &numVertices) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(
+    size_t &numVertices) const {
   return m_current->getVertexesArray(numVertices);
 }
 
-TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(size_t &numVertices,
-                                               const size_t outDimensions,
-                                               const bool *maskDim) const {
+TMDE(std::unique_ptr<coord_t[]> MDBoxIterator)::getVertexesArray(
+    size_t &numVertices, const size_t outDimensions,
+    const bool *maskDim) const {
   return m_current->getVertexesArray(numVertices, outDimensions, maskDim);
 }
 
@@ -350,5 +351,5 @@ TMDE(bool MDBoxIterator)::isWithinBounds(size_t) const {
   throw std::runtime_error("MDBoxIterator does not implement isWithinBounds");
 }
 
-} // namespace Mantid
 } // namespace DataObjects
+} // namespace Mantid

--- a/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
+++ b/Framework/DataObjects/inc/MantidDataObjects/MDGridBox.tcc
@@ -4,21 +4,21 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidKernel/Task.h"
-#include "MantidKernel/Utils.h"
-#include "MantidKernel/FunctionTask.h"
-#include "MantidKernel/Timer.h"
-#include "MantidKernel/ThreadPool.h"
-#include "MantidKernel/ThreadScheduler.h"
-#include "MantidKernel/ThreadSchedulerMutexes.h"
-#include "MantidKernel/WarningSuppressions.h"
 #include "MantidDataObjects/MDBox.h"
 #include "MantidDataObjects/MDEvent.h"
 #include "MantidDataObjects/MDGridBox.h"
+#include "MantidKernel/FunctionTask.h"
+#include "MantidKernel/Strings.h"
+#include "MantidKernel/Task.h"
+#include "MantidKernel/ThreadPool.h"
+#include "MantidKernel/ThreadScheduler.h"
+#include "MantidKernel/ThreadSchedulerMutexes.h"
+#include "MantidKernel/Timer.h"
+#include "MantidKernel/Utils.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include <boost/math/special_functions/round.hpp>
 #include <boost/optional.hpp>
 #include <ostream>
-#include "MantidKernel/Strings.h"
 
 // These pragmas ignores the warning in the ctor where "d<nd-1" for nd=1.
 // This is okay (though would be better if it were for only that function
@@ -42,8 +42,8 @@ namespace DataObjects {
  */
 TMDE(MDGridBox)::MDGridBox(
     API::BoxController *const bc, const uint32_t depth,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
-        extentsVector)
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector)
     : MDBoxBase<MDE, nd>(bc, depth, UNDEF_SIZET, extentsVector), numBoxes(0),
       m_Children(), diagonalSquared(0.f), nPoints(0) {
   initGridBox();
@@ -51,14 +51,14 @@ TMDE(MDGridBox)::MDGridBox(
 
 /** convenience Constructor, taking the shared pointer and extracting const
  * pointer from it
-  * @param bc :: shared pointer to the BoxController, owned by workspace
-  * @param depth :: recursive split depth
-  * @param extentsVector :: size of the box
-*/
+ * @param bc :: shared pointer to the BoxController, owned by workspace
+ * @param depth :: recursive split depth
+ * @param extentsVector :: size of the box
+ */
 TMDE(MDGridBox)::MDGridBox(
     boost::shared_ptr<API::BoxController> &bc, const uint32_t depth,
-    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>> &
-        extentsVector)
+    const std::vector<Mantid::Geometry::MDDimensionExtents<coord_t>>
+        &extentsVector)
     : MDBoxBase<MDE, nd>(bc.get(), depth, UNDEF_SIZET, extentsVector),
       numBoxes(0), m_Children(), diagonalSquared(0.f), nPoints(0) {
   initGridBox();
@@ -112,7 +112,7 @@ TMDE(MDGridBox)::MDGridBox(MDBox<MDE, nd> *box)
   // load missing events from HDD in file based ws if there are some.
   const std::vector<MDE> &events = box->getConstEvents();
   // just add event to the existing internal box
-  for (const auto & evnt : events)
+  for (const auto &evnt : events)
     addEvent(evnt);
 
   // Copy the cached numbers from the incoming box. This is quick - don't need
@@ -146,8 +146,8 @@ void MDGridBox<MDE, nd>::fillBoxShell(const size_t tot,
   for (size_t i = 0; i < tot; i++) {
     // Create the box
     // (Increase the depth of this box to one more than the parent (this))
-    auto splitBox = new MDBox<MDE, nd>(
-        this->m_BoxController, this->m_depth + 1, UNDEF_SIZET, size_t(ID0 + i));
+    auto splitBox = new MDBox<MDE, nd>(this->m_BoxController, this->m_depth + 1,
+                                       UNDEF_SIZET, size_t(ID0 + i));
     // This MDGridBox is the parent of the new child.
     splitBox->setParent(this);
 
@@ -164,9 +164,8 @@ void MDGridBox<MDE, nd>::fillBoxShell(const size_t tot,
 
     // Increment the indices, rolling back as needed
     indices[0]++;
-    for (
-        size_t d = 0; d < nd - 1;
-        d++) // This is not run if nd=1; that's okay, you can ignore the warning
+    for (size_t d = 0; d < nd - 1; d++) // This is not run if nd=1; that's okay,
+                                        // you can ignore the warning
     {
       if (indices[d] >= split[d]) {
         indices[d] = 0;
@@ -402,7 +401,6 @@ TMDE(void MDGridBox)::calculateGridCaches() {
   this->m_errorSquared = 0;
   this->m_totalWeight = 0;
 
-
   for (MDBoxBase<MDE, nd> *ibox : m_Children) {
 
     // does nothing for MDBox
@@ -440,7 +438,7 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
     outBoxes.push_back(this);
 
   if (this->getDepth() < maxDepth) {
-    for(API::IMDNode * child: m_Children){
+    for (API::IMDNode *child : m_Children) {
       // Recursively go deeper, if needed
       child->getBoxes(outBoxes, maxDepth, leafOnly);
     }
@@ -649,10 +647,12 @@ TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *> &outBoxes,
  * @param cond :: condition to check
  *(leaves on the tree)
  */
-TMDE(void MDGridBox)::getBoxes(std::vector<API::IMDNode *>& outBoxes, const std::function<bool(API::IMDNode *)> &cond) {
-  if(cond(this))
+TMDE(void MDGridBox)::getBoxes(
+    std::vector<API::IMDNode *> &outBoxes,
+    const std::function<bool(API::IMDNode *)> &cond) {
+  if (cond(this))
     outBoxes.emplace_back(this);
-  for(API::IMDNode * child: m_Children){
+  for (API::IMDNode *child : m_Children) {
     child->getBoxes(outBoxes, cond);
   }
 }
@@ -1130,12 +1130,10 @@ TMDE(void MDGridBox)::centerpointBin(MDBin<MDE, nd> &bin,
  * @param errorSquared [out] :: set to the integrated squared error.
  * @param innerRadiusSquared :: radius^2 above which to integrate
  */
-TMDE(void MDGridBox)::integrateSphere(API::CoordTransform &radiusTransform,
-                                      const coord_t radiusSquared,
-                                      signal_t &signal,
-                                      signal_t &errorSquared, 
-                                      const coord_t innerRadiusSquared,
-                                      const bool useOnePercentBackgroundCorrection) const {
+TMDE(void MDGridBox)::integrateSphere(
+    API::CoordTransform &radiusTransform, const coord_t radiusSquared,
+    signal_t &signal, signal_t &errorSquared, const coord_t innerRadiusSquared,
+    const bool useOnePercentBackgroundCorrection) const {
   // We start by looking at the vertices at every corner of every box contained,
   // to see which boxes are partially contained/fully contained.
 
@@ -1263,7 +1261,7 @@ TMDE(void MDGridBox)::integrateSphere(API::CoordTransform &radiusTransform,
       coord_t out[nd];
       radiusTransform.apply(boxCenter, out);
 
-      if (out[0] < diagonalSquared * 0.72 + radiusSquared || 
+      if (out[0] < diagonalSquared * 0.72 + radiusSquared ||
           out[0] < diagonalSquared * 0.72 + innerRadiusSquared) {
         // If the center is closer than the size of the box, then it MIGHT be
         // touching.
@@ -1280,8 +1278,9 @@ TMDE(void MDGridBox)::integrateSphere(API::CoordTransform &radiusTransform,
     // We couldn't rule out that the box might be partially contained.
     if (partialBox) {
       // Use the detailed integration method.
-      box->integrateSphere(radiusTransform, radiusSquared, signal,
-                           errorSquared, innerRadiusSquared, useOnePercentBackgroundCorrection);
+      box->integrateSphere(radiusTransform, radiusSquared, signal, errorSquared,
+                           innerRadiusSquared,
+                           useOnePercentBackgroundCorrection);
       //        std::cout << ".signal=" << signal << "\n";
       numPartiallyContained++;
     }
@@ -1504,9 +1503,8 @@ TMDE(void MDGridBox)::integrateCylinder(
       radiusTransform.apply(boxCenter, out);
       if ((nd >= 1) &&
           out[0] < std::sqrt(diagonalSquared * 0.72 + radius * radius) &&
-          (nd >= 2 &&
-           std::fabs(out[1]) <
-               std::sqrt(diagonalSquared * 0.72 + 0.25 * length * length))) {
+          (nd >= 2 && std::fabs(out[1]) < std::sqrt(diagonalSquared * 0.72 +
+                                                    0.25 * length * length))) {
         // If the center is closer than the size of the box, then it MIGHT be
         // touching.
         // (We multiply by 0.72 (about sqrt(2)) to look for half the diagonal).
@@ -1726,11 +1724,11 @@ TMDE(inline size_t MDGridBox)::addEventUnsafe(const MDE &event) {
 }
 
 /**Sets particular child MDgridBox at the index, specified by the input
-*parameters
-*@param index     -- the position of the new child in the list of GridBox
-*children
-*@param newChild  -- the pointer to the new child grid box
-*/
+ *parameters
+ *@param index     -- the position of the new child in the list of GridBox
+ *children
+ *@param newChild  -- the pointer to the new child grid box
+ */
 TMDE(inline void MDGridBox)::setChild(size_t index,
                                       MDGridBox<MDE, nd> *newChild) {
   // Delete the old box  (supposetly ungridded);
@@ -1764,7 +1762,7 @@ TMDE(void MDGridBox)::setFileBacked() {
  * not entirely fool-proof, as if the data is actually loaded is controlled by
  *isLoaded switch in ISaveable
  * and this switch has to be set up correctly
-*/
+ */
 
 TMDE(void MDGridBox)::clearFileBacked(bool loadDiskBackedData) {
   auto it = m_Children.begin();

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.tcc
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/IKafkaStreamDecoder.tcc
@@ -95,7 +95,7 @@ void IKafkaStreamDecoder::loadInstrument(const std::string &name,
     alg->execute();
   } catch (std::exception &exc) {
     logger.warning() << "Error loading instrument '" << name
-                    << "': " << exc.what() << "\n";
+                     << "': " << exc.what() << "\n";
   }
 }
 } // namespace LiveData

--- a/buildconfig/Jenkins/clangformat
+++ b/buildconfig/Jenkins/clangformat
@@ -15,8 +15,12 @@ else
 fi
 
 # git needs to have a minimal coniguration for git commit to work
-git config user.name mantid-builder
-git config user.email "mantid-buildserver@mantidproject.org"
+if [ "$(git config user.name)" == "" ]; then
+  git config user.name mantid-builder
+fi
+if [ "$(git config user.email)" == "" ]; then
+  git config user.email "mantid-buildserver@mantidproject.org"
+fi
 
 # sources to format
 sources=`find Framework MantidPlot qt \( -name '*.cpp' -o -name '*.h' \)`

--- a/buildconfig/Jenkins/clangformat
+++ b/buildconfig/Jenkins/clangformat
@@ -23,7 +23,7 @@ if [ "$(git config user.email)" == "" ]; then
 fi
 
 # sources to format
-sources=`find Framework MantidPlot qt \( -name '*.cpp' -o -name '*.h' \)`
+sources=`find Framework MantidPlot qt \( -name '*.cpp' -o -name '*.h' -o -name '*.tcc' \)`
 sha=`git rev-parse --short HEAD`
 
 # format


### PR DESCRIPTION
**Description of work.**

Updates the `clangformat` script to also include `.tcc` files and formats the current set of them.

**To test:**

Code review and builds should pass.

*There is no associated issue.*

*This does not require release notes* because **this is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
