### PR TITLE
Bugfix for missing ISIS SANS batch file column

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -32,3 +32,4 @@ Bug Fixes
 - Exporting table as a batch file is fixed for Mantid Workbench.
 - The warning message raised when you have supplied a transmission run without a direct run has been suppressed when data is still being input. The warning will still be raised if you load or process the data.
 - The algorithm :ref:`Load <algm-Load>` can now load NXcanSAS files.
+- A bug in which the final column in a batch file was sometimes ignored if empty, and therefore impossible to load, has been fixed.

--- a/scripts/SANS/sans/command_interface/batch_csv_file_parser.py
+++ b/scripts/SANS/sans/command_interface/batch_csv_file_parser.py
@@ -24,7 +24,7 @@ class BatchCsvParser(object):
     batch_file_keywords_which_are_dropped = {"background_sans": None,
                                              "background_trans": None,
                                              "background_direct_beam": None,
-                                             "":None}
+                                             "": None}
 
     data_keys = {BatchReductionEntry.SampleScatter: BatchReductionEntry.SampleScatterPeriod,
                  BatchReductionEntry.SampleTransmission: BatchReductionEntry.SampleTransmissionPeriod,
@@ -71,6 +71,10 @@ class BatchCsvParser(object):
     def _parse_row(self, row, row_number):
         # Clean all elements of the row
         row = list(map(str.strip, row))
+
+        # If the reader has ignored the final empty row, we add it back here
+        if len(row) == 15 and row[-1] in self.batch_file_keywords.keys():
+            row.append("")
 
         # Go sequentially through the row with a stride of two. The user can either leave entries away, or he can leave
         # them blank, ie ... , sample_direct_beam, , can_sans, XXXXX, ...  or even ..., , ,...

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -1303,9 +1303,9 @@ class RunTabPresenter(object):
         :return: Nothing
         """
         for row in rows:
-                table_row = self._table_model.get_table_entry(row).to_batch_list()
-                batch_file_row = self._create_batch_entry_from_row(table_row)
-                filewriter.writerow(batch_file_row)
+            table_row = self._table_model.get_table_entry(row).to_batch_list()
+            batch_file_row = self._create_batch_entry_from_row(table_row)
+            filewriter.writerow(batch_file_row)
 
     @staticmethod
     def _create_batch_entry_from_row(row):

--- a/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
+++ b/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
@@ -186,6 +186,24 @@ class BatchCsvParserTest(unittest.TestCase):
 
         BatchCsvParserTest._remove_csv(batch_file_path)
 
+    def test_can_parse_file_with_empty_final_column(self):
+        """There was a bug where certain batch files with an empty final column (no user file provided)
+        would not be treated as a column and therefore the batch file would be read as having only 15
+        rows.
+        We now add an empty final row in the parser if there are 15 rows and the last row provided is
+        a batch file key"""
+        batch_file_row = ["sample_sans", "1", "sample_trans", "", "sample_direct_beam", "",
+                          "can_sans", "", "can_trans", "", "can_direct_beam", "", "output_as", "", "user_file"]
+
+        content = "# MANTID_BATCH_FILE add more text here\n" + ",".join(batch_file_row)
+        batch_file_path = BatchCsvParserTest._save_to_csv(content)
+        parser = BatchCsvParser(batch_file_path)
+
+        try:
+            parser._parse_row(batch_file_row, 0)
+        except RuntimeError as e:
+            self.fail("An error should not have been raised. Error raised was: {}".format(str(e)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
There is a bug in the ISIS SANS batch files in which the final column is sometimes dropped by the reader if it is empty. This makes it impossible to load the files into the gui as there is an odd number of columns.

This PR makes a check in the csv parser for batch file rows with 15 columns (all columns minus the dropped one) and appends an empty column in order for the batch file parser to read it.

**Report to:** Najet SANS2D

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Click `Load Batch File` and select the attached file. This should populate the table
[Batch_2.zip](https://github.com/mantidproject/mantid/files/3165583/Batch_2.zip)

Fixes #25694 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
