### PR TITLE
ISIS SANS code refactor to use constants

### DIFF
--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -834,7 +834,8 @@ def sanitise_instrument_name(instrument_name):
     instrument_name_upper = instrument_name.upper()
     for instrument in SANSInstrument_string_list:
         if re.search(instrument, instrument_name_upper):
-            return instrument_name
+            return instrument
+    return instrument_name
 
 
 def get_facility(instrument):

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -15,7 +15,9 @@ from copy import deepcopy
 import json
 import numpy as np
 from mantid.api import (AlgorithmManager, AnalysisDataService, isSameWorkspaceObject)
-from sans.common.constants import (SANS_FILE_TAG, ALL_PERIODS, SANS2D, LOQ, LARMOR, ZOOM, EMPTY_NAME,
+from sans.common.constant_containers import (SANSInstrument_enum_list, SANSInstrument_string_list,
+                                             SANSInstrument_string_as_key_NoInstrument)
+from sans.common.constants import (SANS_FILE_TAG, ALL_PERIODS, SANS2D, EMPTY_NAME,
                                    REDUCED_CAN_TAG)
 from sans.common.log_tagger import (get_tag, has_tag, set_tag, has_hash, get_hash_value, set_hash)
 from sans.common.enums import (DetectorType, RangeStepType, ReductionDimensionality, OutputParts, ISISReductionMode,
@@ -830,20 +832,13 @@ def sanitise_instrument_name(instrument_name):
     :return: a sanitises instrument name string
     """
     instrument_name_upper = instrument_name.upper()
-    if re.search(LOQ, instrument_name_upper):
-        instrument_name = LOQ
-    elif re.search(SANS2D, instrument_name_upper):
-        instrument_name = SANS2D
-    elif re.search(LARMOR, instrument_name_upper):
-        instrument_name = LARMOR
-    elif re.search(ZOOM, instrument_name_upper):
-        instrument_name = ZOOM
-    return instrument_name
+    for instrument in SANSInstrument_string_list:
+        if re.search(instrument, instrument_name_upper):
+            return instrument_name
 
 
 def get_facility(instrument):
-    if (instrument is SANSInstrument.SANS2D or instrument is SANSInstrument.LOQ or
-        instrument is SANSInstrument.LARMOR or instrument is SANSInstrument.ZOOM):  # noqa
+    if instrument in SANSInstrument_enum_list:
         return SANSFacility.ISIS
     else:
         return SANSFacility.NoFacility
@@ -858,17 +853,10 @@ def instrument_name_correction(instrument_name):
 
 def get_instrument(instrument_name):
     instrument_name = instrument_name.upper()
-    if instrument_name == SANS2D:
-        instrument = SANSInstrument.SANS2D
-    elif instrument_name == LARMOR:
-        instrument = SANSInstrument.LARMOR
-    elif instrument_name == LOQ:
-        instrument = SANSInstrument.LOQ
-    elif instrument_name == ZOOM:
-        instrument = SANSInstrument.ZOOM
-    else:
-        instrument = SANSInstrument.NoInstrument
-    return instrument
+    try:
+        return SANSInstrument_string_as_key_NoInstrument[instrument_name]
+    except KeyError:
+        pass
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -9,6 +9,8 @@ import os
 from qtpy.QtCore import QSettings
 from qtpy.QtWidgets import QFileDialog
 
+from sans.common.constant_containers import (SANSInstrument_enum_as_key, SANSInstrument_string_as_key_NoInstrument,
+                                             SANSInstrument_string_list)
 from sans.common.enums import SANSInstrument, ISISReductionMode, DetectorType
 
 
@@ -103,7 +105,7 @@ def get_reduction_mode_strings_for_gui(instrument=None):
 
 
 def get_instrument_strings_for_gui():
-        return ['SANS2D', 'LOQ', 'LARMOR', 'ZOOM']
+        return SANSInstrument_string_list
 
 
 def get_reduction_selection(instrument):
@@ -134,11 +136,9 @@ def get_string_for_gui_from_reduction_mode(reduction_mode, instrument):
 
 
 def get_string_for_gui_from_instrument(instrument):
-    instrument_selection = {SANSInstrument.SANS2D: 'SANS2D', SANSInstrument.LOQ: 'LOQ', SANSInstrument.LARMOR: 'LARMOR'
-                            , SANSInstrument.ZOOM: 'ZOOM'}
-    if instrument in instrument_selection:
-        return instrument_selection[instrument]
-    else:
+    try:
+        return SANSInstrument_enum_as_key[instrument]
+    except KeyError:
         return None
 
 
@@ -163,17 +163,9 @@ def get_detector_from_gui_selection(gui_selection):
 
 
 def get_instrument_from_gui_selection(gui_selection):
-    if gui_selection == 'LOQ':
-        return SANSInstrument.LOQ
-    elif gui_selection == 'LARMOR':
-        return SANSInstrument.LARMOR
-    elif gui_selection == 'SANS2D':
-        return SANSInstrument.SANS2D
-    elif gui_selection == 'ZOOM':
-        return SANSInstrument.ZOOM
-    elif gui_selection == 'NoInstrument':
-        return SANSInstrument.NoInstrument
-    else:
+    try:
+        return SANSInstrument_string_as_key_NoInstrument[gui_selection]
+    except KeyError:
         raise RuntimeError("Instrument selection is not valid.")
 
 

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -278,16 +278,16 @@ class SANSFunctionsTest(unittest.TestCase):
 
     def test_that_sanitises_instrument_names(self):
         name1 = sanitise_instrument_name("LOQ_trans")
-        self.assertTrue(LOQ == name1)
+        self.assertEqual(name1, LOQ)
 
         name2 = sanitise_instrument_name("sans2d")
-        self.assertTrue(SANS2D == name2)
+        self.assertEqual(name2, SANS2D)
 
         name3 = sanitise_instrument_name("__LArMOR_")
-        self.assertTrue(LARMOR == name3)
+        self.assertEqual(name3, LARMOR)
 
         name4 = sanitise_instrument_name("OThER")
-        self.assertTrue("OThER" == name4)
+        self.assertEqual(name4, "OThER")
 
     def test_that_can_find_can_reduction_if_it_exists(self):
         # Arrange


### PR DESCRIPTION
**Description of work.**
In a previous PR, we added containers of commonly used sans object - e.g. lists of instruments, dicts of instruments as strings to instrument enums. This PR uses the containers in files instead of explicitly typing the container each time

**To test:**
Code review

Fixes #24529 

*This does not require release notes* because **internal code change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
