### PR TITLE
Minor ISIS SANS gui changes

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -221,16 +221,17 @@ class SANSDataProcessorGui(QMainWindow,
         self.erase_button.setIcon(icons.get_icon("mdi.eraser"))
         self.delete_row_button.setIcon(icons.get_icon("mdi.trash-can"))
         self.insert_row_button.setIcon(icons.get_icon("mdi.table"))
+        self.export_table_button.setIcon(icons.get_icon("mdi.file-export"))
 
         self.paste_button.clicked.connect(self._paste_rows_requested)
         self.copy_button.clicked.connect(self._copy_rows_requested)
         self.erase_button.clicked.connect(self._erase_rows)
         self.cut_button.clicked.connect(self._cut_rows)
-
         self.delete_row_button.clicked.connect(self._remove_rows_requested_from_button)
         self.insert_row_button.clicked.connect(self._on_insert_button_pressed)
-        self.save_other_pushButton.clicked.connect(self._on_save_other_button_pressed)
+        self.export_table_button.clicked.connect(self._export_table_clicked)
 
+        self.save_other_pushButton.clicked.connect(self._on_save_other_button_pressed)
         self.save_can_checkBox.clicked.connect(self._on_save_can_clicked)
         self.reduction_dimensionality_1D.toggled.connect(self._on_reduction_dimensionality_changed)
 
@@ -316,8 +317,6 @@ class SANSDataProcessorGui(QMainWindow,
         self.process_all_button.clicked.connect(self._process_all_clicked)
 
         self.load_button.clicked.connect(self._load_clicked)
-
-        self.export_table_button.clicked.connect(self._export_table_clicked)
 
         self.help_button.clicked.connect(self._on_help_button_clicked)
 

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -157,7 +157,7 @@ QGroupBox::title {
               <item row="0" column="6">
                <widget class="QPushButton" name="manage_directories_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add directories to search for data, set your output directory, and manage data archvie searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add directories to search for data, set your output directory, and manage data archive searching.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Manage Directories</string>
@@ -198,7 +198,7 @@ QGroupBox::title {
               <item row="1" column="6">
                <widget class="QPushButton" name="user_file_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;a href=&quot;https://www.mantidproject.org/SANS_User_File_Commands&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Load User File</string>
@@ -234,7 +234,7 @@ QGroupBox::title {
               <item row="2" column="6">
                <widget class="QPushButton" name="batch_button">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Load Batch File</string>
@@ -359,12 +359,25 @@ QGroupBox::title {
                </widget>
               </item>
               <item>
-               <widget class="QPushButton" name="export_table_button">
+               <widget class="Line" name="line_7">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="export_table_button">
                 <property name="toolTip">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export the current table as a csv file. This can then be re-loaded at a later date.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
-                 <string>Export Table</string>
+                 <string>...</string>
+                </property>
+                <property name="iconSize">
+                 <size>
+                  <width>24</width>
+                  <height>24</height>
+                 </size>
                 </property>
                </widget>
               </item>
@@ -616,6 +629,9 @@ QGroupBox::title {
               </item>
               <item row="1" column="3">
                <widget class="QPushButton" name="save_other_pushButton">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save a workspace as a CanSAS, NxCanSAS, or RKH file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="text">
                  <string>Save Other</string>
                 </property>

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -109,7 +109,7 @@ QGroupBox::title {
               <item row="2" column="1">
                <widget class="QLabel" name="batch_label">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Batch File:</string>
@@ -143,7 +143,7 @@ QGroupBox::title {
               <item row="1" column="4">
                <widget class="QLineEdit" name="user_file_line_edit">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;a href=&quot;https://www.mantidproject.org/SANS_User_File_Commands&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -174,7 +174,7 @@ QGroupBox::title {
               <item row="2" column="4">
                <widget class="QLineEdit" name="batch_line_edit">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;a href=&quot;https://www.mantidproject.org/SANS_batch_file_format&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify a batch file to load. For the batch file format see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_batch_file_format&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -218,7 +218,7 @@ QGroupBox::title {
               <item row="1" column="1">
                <widget class="QLabel" name="user_file_label">
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;a href=&quot;https://www.mantidproject.org/SANS_User_File_Commands&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;here&lt;/span&gt;&lt;/a&gt;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify the user file (aka mask file) which is used to provide the bulk of the reduction settings. For a list of user file commands see &lt;span style=&quot; font-weight:600;&quot;&gt;https://www.mantidproject.org/SANS_User_File_Commands&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
**Description of work.**
This PR makes a couple of minor changes to the ISIS SANS gui:
1. The `Export Table` button has had its text replaced with a Materials Design icon
2. Links in tooltips, which are impossible to click, have been removed

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. On the row of buttons above the table, check that the rightmost is **Export Table** (see the tooltip to confirm). This button saves the contents of the table as a csv file: does the icon make sense for this feature?
3. Hover your mouse over the `Load User file` and `Load Batch File` buttons in the top right hand corner; Check that none of the text appears as a link. Instead, the urls have been explicitly written in the toolip

Fixes #25472 

*This does not require release notes* because **minor cosmetic changes not requested by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
