### PR TITLE
Add custom sliceviewer toolbar and grid button

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -1,0 +1,66 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2017 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#    This file is part of the mantid workbench.
+#
+#
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from mantidqt.MPLwidgets import NavigationToolbar2QT
+from mantidqt.icons import get_icon
+from qtpy.QtCore import Signal, Qt, QSize
+from qtpy.QtWidgets import QLabel, QSizePolicy
+
+
+class SliceViewerNavigationToolbar(NavigationToolbar2QT):
+
+    gridClicked = Signal()
+
+    toolitems = (
+        ('Home', 'Reset original view', 'mdi.home', 'home', None),
+        ('Pan', 'Pan axes with left mouse, zoom with right', 'mdi.arrow-all', 'pan', False),
+        ('Zoom', 'Zoom to rectangle', 'mdi.magnify-plus-outline', 'zoom', False),
+        (None, None, None, None, None),
+        ('Grid', 'Toggle grid on/off', 'mdi.grid', 'gridClicked', None),
+        ('Save', 'Save the figure', 'mdi.content-save', 'save_figure', None),
+        (None, None, None, None, None),
+        ('Customize', 'Configure plot options', 'mdi.settings', 'edit_parameters', None),
+    )
+
+    def _init_toolbar(self):
+        for text, tooltip_text, fa_icon, callback, checked in self.toolitems:
+            if text is None:
+                self.addSeparator()
+            else:
+                if fa_icon:
+                    a = self.addAction(get_icon(fa_icon),
+                                       text, getattr(self, callback))
+                else:
+                    a = self.addAction(text, getattr(self, callback))
+                self._actions[callback] = a
+                if checked is not None:
+                    a.setCheckable(True)
+                    a.setChecked(checked)
+                if tooltip_text is not None:
+                    a.setToolTip(tooltip_text)
+
+        self.buttons = {}
+
+        # Add the x,y location widget at the right side of the toolbar
+        # The stretch factor is 1 which means any resizing of the toolbar
+        # will resize this label instead of the buttons.
+        if self.coordinates:
+            self.locLabel = QLabel("", self)
+            self.locLabel.setAlignment(Qt.AlignRight | Qt.AlignTop)
+            self.locLabel.setSizePolicy(
+                QSizePolicy(QSizePolicy.Expanding,
+                            QSizePolicy.Ignored))
+            labelAction = self.addWidget(self.locLabel)
+            labelAction.setVisible(True)
+
+        # Adjust icon size or they are too small in PyQt5 by default
+        self.setIconSize(QSize(24, 24))

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -10,7 +10,8 @@
 from __future__ import (absolute_import, division, print_function)
 from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout
 from qtpy.QtCore import Qt
-from mantidqt.MPLwidgets import FigureCanvas, NavigationToolbar2QT as NavigationToolbar
+from mantidqt.MPLwidgets import FigureCanvas
+from .toolbar import SliceViewerNavigationToolbar
 from matplotlib.figure import Figure
 from .dimensionwidget import DimensionWidget
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
@@ -45,7 +46,8 @@ class SliceViewerView(QWidget):
         self.mpl_layout.addWidget(self.colorbar)
 
         # MPL toolbar
-        self.mpl_toolbar = NavigationToolbar(self.canvas, self)
+        self.mpl_toolbar = SliceViewerNavigationToolbar(self.canvas, self)
+        self.mpl_toolbar.gridClicked.connect(self.toggle_grid)
 
         # layout
         self.layout = QVBoxLayout(self)
@@ -90,6 +92,10 @@ class SliceViewerView(QWidget):
         """
         self.im.set_data(data.T)
         self.colorbar.update_clim()
+
+    def toggle_grid(self):
+        self.ax.grid()
+        self.canvas.draw_idle()
 
     def closeEvent(self, event):
         self.deleteLater()


### PR DESCRIPTION
This adds a custom toolbar to sliceviewer, similar to the [workbench plotting toolbar](https://github.com/mantidproject/mantid/blob/master/qt/applications/workbench/workbench/plotting/toolbar.py)

This will now allow adding additional buttons, to open liveviewer, sliceviewer, _etc_ , and makes the styling consistent across the workbench. This also adds a button to toggle the plot grid.

**To test:**

Open the sliceviewer and check that the new toolbar works.


Closes #25604

*This does not require release notes* because part of sliceviewer, will be added later


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
