### PR TITLE
Convert bytes to string before updating SANS gui model

### DIFF
--- a/Framework/PythonInterface/mantid/py3compat/__init__.py
+++ b/Framework/PythonInterface/mantid/py3compat/__init__.py
@@ -67,6 +67,28 @@ else:
 # -----------------------------------------------------------------------------
 # Strings
 # -----------------------------------------------------------------------------
+if not hasattr(six, "ensure_str"):
+    # Ubuntu 16.04, Windows, and OSX Mantid builds have a version of six which
+    # doesn't include ensure_str
+    # ensure_str was added in six 1.12.0
+    def ensure_str(s, encoding='utf-8', errors='strict'):
+        """Coerce *s* to `str`.
+        For Python 2:
+          - `unicode` -> encoded to `str`
+          - `str` -> `str`
+        For Python 3:
+          - `str` -> `str`
+          - `bytes` -> decoded to `str`
+        """
+        if not isinstance(s, (text_type, binary_type)):
+            raise TypeError("not expecting type '%s'" % type(s))
+        if PY2 and isinstance(s, text_type):
+            s = s.encode(encoding, errors)
+        elif PY3 and isinstance(s, binary_type):
+            s = s.decode(encoding, errors)
+        return s
+
+
 def is_text_string(obj):
     """Return True if `obj` is a text string, False if it is anything else,
     like binary data (Python 3) or QString (Python 2, PyQt API #1)"""

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -1010,3 +1010,24 @@ def get_bank_for_spectrum_number(spectrum_number, instrument):
         if 36873 <= spectrum_number <= 73736:
             detector = DetectorType.HAB
     return detector
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Utility functions - functions to perform non-SANS specific operations
+# ----------------------------------------------------------------------------------------------------------------------
+def check_for_bytes(value, encoding="utf-8"):
+    """
+    A function to decode a bytes class into a string. In Python3, behaviour of str and bytes classes diverged.
+    There are cases when data intended to be a string can be passed around as bytes, due to legacy Python2 code.
+    While we will try to correctly encode/decode data as we begin to handle it, there may be missed cases.
+    This function should be used to confirm that we have a string when we expect a string.
+    :param value: the variable to convert to a string. This may be *str* or *bytes*. Raises TypeError if other type.
+    :param encoding: optional str. Denotes the encoding of the data.
+    :return: value, now of type *str*
+    """
+    if isinstance(value, str):
+        return value
+    elif isinstance(value, bytes):
+        return value.decode(encoding)
+    else:
+        raise TypeError("{} is type {}, not str or bytes.".format(value, type(value)))

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -1010,24 +1010,3 @@ def get_bank_for_spectrum_number(spectrum_number, instrument):
         if 36873 <= spectrum_number <= 73736:
             detector = DetectorType.HAB
     return detector
-
-
-# ----------------------------------------------------------------------------------------------------------------------
-# Utility functions - functions to perform non-SANS specific operations
-# ----------------------------------------------------------------------------------------------------------------------
-def check_for_bytes(value, encoding="utf-8"):
-    """
-    A function to decode a bytes class into a string. In Python3, behaviour of str and bytes classes diverged.
-    There are cases when data intended to be a string can be passed around as bytes, due to legacy Python2 code.
-    While we will try to correctly encode/decode data as we begin to handle it, there may be missed cases.
-    This function should be used to confirm that we have a string when we expect a string.
-    :param value: the variable to convert to a string. This may be *str* or *bytes*. Raises TypeError if other type.
-    :param encoding: optional str. Denotes the encoding of the data.
-    :return: value, now of type *str*
-    """
-    if isinstance(value, str):
-        return value
-    elif isinstance(value, bytes):
-        return value.decode(encoding)
-    else:
-        raise TypeError("{} is type {}, not str or bytes.".format(value, type(value)))

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -18,6 +18,7 @@ from sans.user_file.settings_tags import (OtherId, DetectorId, LimitsId, SetId, 
                                           q_rebin_values, fit_general, mask_angle_entry, range_entry, position_entry)
 from sans.common.enums import (ReductionDimensionality, ISISReductionMode, RangeStepType, SaveType,
                                DetectorType, DataType, FitType, SANSInstrument)
+from sans.common.general_functions import check_for_bytes
 
 
 class StateGuiModel(object):
@@ -888,7 +889,7 @@ class StateGuiModel(object):
 
     @q_1d_rebin_string.setter
     def q_1d_rebin_string(self, value):
-        self._set_q_1d_limits(rebin_string=value)
+        self._set_q_1d_limits(rebin_string=check_for_bytes(value))
 
     @property
     def q_xy_max(self):

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -12,13 +12,13 @@ are not available in the model associated with the data table.
 
 from __future__ import (absolute_import, division, print_function)
 
+from mantid.py3compat import ensure_str
 from sans.user_file.settings_tags import (OtherId, DetectorId, LimitsId, SetId, SampleId, MonId, TransId, GravityId,
                                           QResolutionId, FitId, MaskId, event_binning_string_values, set_scales_entry,
                                           monitor_spectrum, simple_range, monitor_file, det_fit_range,
                                           q_rebin_values, fit_general, mask_angle_entry, range_entry, position_entry)
 from sans.common.enums import (ReductionDimensionality, ISISReductionMode, RangeStepType, SaveType,
                                DetectorType, DataType, FitType, SANSInstrument)
-from sans.common.general_functions import check_for_bytes
 
 
 class StateGuiModel(object):
@@ -889,7 +889,7 @@ class StateGuiModel(object):
 
     @q_1d_rebin_string.setter
     def q_1d_rebin_string(self, value):
-        self._set_q_1d_limits(rebin_string=check_for_bytes(value))
+        self._set_q_1d_limits(rebin_string=ensure_str(value))
 
     @property
     def q_xy_max(self):

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -13,7 +13,8 @@ from sans.common.general_functions import (quaternion_to_angle_and_axis, create_
                                            get_reduced_can_workspace_from_ads, write_hash_into_reduced_can_workspace,
                                            convert_instrument_and_detector_type_to_bank_name,
                                            convert_bank_name_to_detector_type_isis,
-                                           get_facility, parse_diagnostic_settings, get_transmission_output_name, get_output_name)
+                                           get_facility, parse_diagnostic_settings, get_transmission_output_name,
+                                           get_output_name, check_for_bytes)
 from sans.common.constants import (SANS2D, LOQ, LARMOR)
 from sans.common.enums import (ISISReductionMode, ReductionDimensionality, OutputParts,
                                SANSInstrument, DetectorType, SANSFacility, DataType)
@@ -539,6 +540,24 @@ class SANSFunctionsTest(unittest.TestCase):
 
         self.assertEqual(output_name, '12345rear_1D_12.0_34.0Phi12.0_56.0_t4.57_T12.37')
         self.assertEqual(group_output_name, '12345rear_1DPhi12.0_56.0')
+
+    def test_that_check_for_bytes_can_convert_bytes_to_str(self):
+        value_as_str = "value"
+        actual_value_as_str = check_for_bytes(value_as_str)
+        self.assertEqual(type(actual_value_as_str), str)
+        self.assertEqual(actual_value_as_str, value_as_str)
+
+        # These tests will pass on Python2 regardless of the function working
+        # as b"value" == "value"
+        value_as_bytes = b"value"
+        actual_value_as_bytes = check_for_bytes(value_as_bytes)
+        self.assertEqual(type(actual_value_as_bytes), str)
+        self.assertEqual(actual_value_as_bytes, value_as_str)
+
+        # Test that raises on other types
+        self.assertRaises(TypeError, check_for_bytes, True)
+        self.assertRaises(TypeError, check_for_bytes, 5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -14,7 +14,7 @@ from sans.common.general_functions import (quaternion_to_angle_and_axis, create_
                                            convert_instrument_and_detector_type_to_bank_name,
                                            convert_bank_name_to_detector_type_isis,
                                            get_facility, parse_diagnostic_settings, get_transmission_output_name,
-                                           get_output_name, check_for_bytes)
+                                           get_output_name)
 from sans.common.constants import (SANS2D, LOQ, LARMOR)
 from sans.common.enums import (ISISReductionMode, ReductionDimensionality, OutputParts,
                                SANSInstrument, DetectorType, SANSFacility, DataType)
@@ -540,23 +540,6 @@ class SANSFunctionsTest(unittest.TestCase):
 
         self.assertEqual(output_name, '12345rear_1D_12.0_34.0Phi12.0_56.0_t4.57_T12.37')
         self.assertEqual(group_output_name, '12345rear_1DPhi12.0_56.0')
-
-    def test_that_check_for_bytes_can_convert_bytes_to_str(self):
-        value_as_str = "value"
-        actual_value_as_str = check_for_bytes(value_as_str)
-        self.assertEqual(type(actual_value_as_str), str)
-        self.assertEqual(actual_value_as_str, value_as_str)
-
-        # These tests will pass on Python2 regardless of the function working
-        # as b"value" == "value"
-        value_as_bytes = b"value"
-        actual_value_as_bytes = check_for_bytes(value_as_bytes)
-        self.assertEqual(type(actual_value_as_bytes), str)
-        self.assertEqual(actual_value_as_bytes, value_as_str)
-
-        # Test that raises on other types
-        self.assertRaises(TypeError, check_for_bytes, True)
-        self.assertRaises(TypeError, check_for_bytes, 5)
 
 
 if __name__ == '__main__':

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -448,6 +448,14 @@ class StateGuiModelTest(unittest.TestCase):
         self.assertEqual(state_gui_model.r_cut, 45.)
         self.assertEqual(state_gui_model.w_cut, 890.)
 
+    def test_that_q_1d_rebin_string_as_bytes_is_converted_to_string(self):
+        state_gui_model = StateGuiModel({"test": [1]})
+        state_gui_model.q_1d_rebin_string = b"test"
+
+        q_1d_rebin_string = state_gui_model.q_1d_rebin_string
+        self.assertEqual(type(q_1d_rebin_string), str)
+        self.assertEqual(q_1d_rebin_string, "test")
+
     # ------------------------------------------------------------------------------------------------------------------
     # Gravity
     # ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work.**
ISIS SANS reduction cannot be carried out in a python3 build because a parameter set on the gui model is type bytes, when it is expected to be string e.g. it is b"value", not "value".

This PR quickly converts the value to a string from bytes.

**To test:**
1. Get a python3 build of Mantid
2. Interfaces -> SANS -> ISIS SANS
3. Load the attached user file and batch file. There should be no errors

Fixes #25705

*This does not require release notes* because **mantid users don't use python3**

**Data:**
[SANS2DprData.zip](https://github.com/mantidproject/mantid/files/3177167/SANS2DprData.zip)

**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
