### PR TITLE
Statistics without fractional HKL peaks

### DIFF
--- a/Framework/Crystal/src/SortHKL.cpp
+++ b/Framework/Crystal/src/SortHKL.cpp
@@ -119,7 +119,7 @@ void SortHKL::exec() {
   std::vector<Peak> peaks = getNonZeroPeaks(inputPeaks);
 
   if (peaks.empty()) {
-    g_log.error() << "Number of peaks should not be 0 for SortHKL.\n";
+    g_log.warning() << "Number of peaks should not be 0 for SortHKL.\n";
     return;
   }
 
@@ -205,11 +205,6 @@ void SortHKL::exec() {
           UniqE[i] = intensityStatistics.median - intensities[i];
         g_log.debug() << zScores[i] << "  ";
       }
-      for (size_t i = zScores.size(); i < 20; ++i) {
-        UniqX[i] = wavelengths[zScores.size() - 1];
-        UniqY[i] = intensities[zScores.size() - 1];
-        UniqE[i] = 0.0;
-      }
       g_log.debug() << "\n";
     }
   }
@@ -266,6 +261,7 @@ SortHKL::getNonZeroPeaks(const std::vector<Peak> &inputPeaks) const {
                       std::back_inserter(peaks), [](const Peak &peak) {
                         return peak.getIntensity() <= 0.0 ||
                                peak.getSigmaIntensity() <= 0.0 ||
+                               peak.getIntMNP() != V3D(0, 0, 0) ||
                                peak.getHKL() == V3D(0, 0, 0);
                       });
 

--- a/Framework/Geometry/src/Crystal/BasicHKLFilters.cpp
+++ b/Framework/Geometry/src/Crystal/BasicHKLFilters.cpp
@@ -48,7 +48,7 @@ void HKLFilterDRange::checkProperDRangeValues() {
     throw std::range_error("dMax cannot be <= 0.");
   }
 
-  if (m_dmax <= m_dmin) {
+  if (m_dmax < m_dmin) {
     throw std::range_error("dMax cannot be smaller than dMin.");
   }
 }

--- a/docs/source/algorithms/StatisticsOfPeaksWorkspace-v1.rst
+++ b/docs/source/algorithms/StatisticsOfPeaksWorkspace-v1.rst
@@ -19,6 +19,9 @@ the peaks are assigned to their respective unique reflection so that each theore
 reflection may have :math:`n` observations (:math:`n` can be zero). The number of unique reflections
 which have at least one observation can be labeled :math:`N_{unique}`.
 
+Currently the satellite peaks are removed so only peaks with :math:`m=n=p=0` are used in the statistics.
+In the future, this algorithm will also calculate statistics for these peaks.
+
 The intensities of peaks in each reflection are checked for outliers, which are removed. Outliers
 in this context are peaks with an intensity that deviates more than :math:`3\sigma_{hkl}` from the
 mean of the reflection, where :math:`\sigma_{hkl}` is the standard deviation of the peak intensities.

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -66,7 +66,6 @@ Bug Fixes
 
 - :ref:`StatisticsOfPeaksWorkspace <algm-StatisticsOfPeaksWorkspace>` now only calculates statistics for integer HKL (not satellite peaks) instead of combining. Statistics for satellite peaks will be added later.
 
-
 Imaging
 -------
 

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -61,6 +61,11 @@ Improvements
 
 - :ref:`DeltaPDF3D <algm-DeltaPDF3D>` has a new method for peak removal, KAREN (K-space Algorithmic REconstructioN)
 
+Bug Fixes
+#########
+
+- :ref:`StatisticsOfPeaksWorkspace <algm-StatisticsOfPeaksWorkspace>` now only calculates statistics for integer HKL (not satellite peaks) instead of combining. Statistics for satellite peaks will be added later.
+
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**
Do not use fractional HKL peaks in statistics
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** Shiyun Jin
-->

**To test:**
````python
mod=LoadIsawPeaks(Filename='Modulated.peaks')
FindUBUsingIndexedPeaks(PeaksWorkspace=mod)
numPeaks = mod.getNumberPeaks()

for i in range(numPeaks):
    p = mod.getPeak(i)
    p.setIntensity(100)
    p.setSigmaIntensity(10)
    
StatisticsOfPeaksWorkspace(InputWorkspace='mod', OutputWorkspace='out')
````


Fixes #25711
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
