### PR TITLE
Add axes aligned lineplots to sliceviewer

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -52,3 +52,7 @@ class SliceViewer(object):
     def update_plot_data_matrix(self):
         # should never be called, since this workspace type is only 2D the plot dimensions never change
         pass
+
+    def line_plots(self):
+        self.view.create_axes()
+        self.new_plot()

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import QLabel, QSizePolicy
 class SliceViewerNavigationToolbar(NavigationToolbar2QT):
 
     gridClicked = Signal()
+    linePlotsClicked = Signal(bool)
 
     toolitems = (
         ('Home', 'Reset original view', 'mdi.home', 'home', None),
@@ -26,6 +27,7 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
         ('Zoom', 'Zoom to rectangle', 'mdi.magnify-plus-outline', 'zoom', False),
         (None, None, None, None, None),
         ('Grid', 'Toggle grid on/off', 'mdi.grid', 'gridClicked', None),
+        ('LinePlots', 'Toggle lineplots on/off', 'mdi.chart-bell-curve', 'linePlotsClicked', False),
         ('Save', 'Save the figure', 'mdi.content-save', 'save_figure', None),
         (None, None, None, None, None),
         ('Customize', 'Configure plot options', 'mdi.settings', 'edit_parameters', None),

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -13,9 +13,12 @@ from qtpy.QtCore import Qt
 from mantidqt.MPLwidgets import FigureCanvas
 from .toolbar import SliceViewerNavigationToolbar
 from matplotlib.figure import Figure
+from matplotlib import gridspec
 from .dimensionwidget import DimensionWidget
 from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
 from mantidqt.plotting.functions import use_imshow
+from matplotlib.transforms import Bbox, BboxTransform
+import numpy as np
 
 
 class SliceViewerView(QWidget):
@@ -28,6 +31,8 @@ class SliceViewerView(QWidget):
         self.setWindowFlags(Qt.Window)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
+        self.line_plots = False
+
         # Dimension widget
         self.dimensions = DimensionWidget(dims_info, parent=self)
         self.dimensions.dimensionsChanged.connect(self.presenter.new_plot)
@@ -39,15 +44,18 @@ class SliceViewerView(QWidget):
         self.fig.set_facecolor(self.palette().window().color().getRgbF())
         self.fig.set_tight_layout(True)
         self.canvas = FigureCanvas(self.fig)
-        self.ax = self.fig.add_subplot(111, projection='mantid')
+        self.canvas.mpl_connect('motion_notify_event', self.mouse_move)
+        self.create_axes()
         self.mpl_layout.addWidget(self.canvas)
         self.colorbar = ColorbarWidget(self)
         self.colorbar.colorbarChanged.connect(self.canvas.draw_idle)
+        self.colorbar.colorbarChanged.connect(self.update_line_plot_limits)
         self.mpl_layout.addWidget(self.colorbar)
 
         # MPL toolbar
         self.mpl_toolbar = SliceViewerNavigationToolbar(self.canvas, self)
         self.mpl_toolbar.gridClicked.connect(self.toggle_grid)
+        self.mpl_toolbar.linePlotsClicked.connect(self.line_plots_toggle)
 
         # layout
         self.layout = QVBoxLayout(self)
@@ -56,6 +64,24 @@ class SliceViewerView(QWidget):
         self.layout.addLayout(self.mpl_layout, stretch=1)
 
         self.show()
+
+    def create_axes(self):
+        self.fig.clf()
+        if self.line_plots:
+            gs = gridspec.GridSpec(2, 2,
+                                   width_ratios=[1, 4],
+                                   height_ratios=[4, 1],
+                                   wspace=0.0, hspace=0.0)
+            self.ax = self.fig.add_subplot(gs[1], projection='mantid')
+            self.ax.xaxis.set_visible(False)
+            self.ax.yaxis.set_visible(False)
+            self.axx=self.fig.add_subplot(gs[3], sharex=self.ax)
+            self.axx.yaxis.tick_right()
+            self.axy=self.fig.add_subplot(gs[0], sharey=self.ax)
+            self.axy.xaxis.tick_top()
+        else:
+            self.ax = self.fig.add_subplot(111, projection='mantid')
+        self.canvas.draw_idle()
 
     def plot_MDH(self, ws, **kwargs):
         """
@@ -84,6 +110,7 @@ class SliceViewerView(QWidget):
         self.colorbar.set_mappable(self.im)
         self.colorbar.update_clim()
         self.mpl_toolbar.update() # clear nav stack
+        self.clear_line_plots()
         self.canvas.draw_idle()
 
     def update_plot_data(self, data):
@@ -93,9 +120,66 @@ class SliceViewerView(QWidget):
         self.im.set_data(data.T)
         self.colorbar.update_clim()
 
+    def line_plots_toggle(self, state):
+        self.line_plots = state
+        self.clear_line_plots()
+        self.presenter.line_plots()
+
+    def clear_line_plots(self):
+        try: # clear old plots
+            self.xfig.clear()
+            self.yfig.clear()
+        except AttributeError:
+            pass
+
+    def update_line_plot_limits(self):
+        if self.line_plots:
+            self.axx.set_ylim(self.colorbar.cmin_value, self.colorbar.cmax_value)
+            self.axy.set_xlim(self.colorbar.cmin_value, self.colorbar.cmax_value)
+
     def toggle_grid(self):
         self.ax.grid()
         self.canvas.draw_idle()
+
+    def mouse_move(self, event):
+        if event.inaxes == self.ax:
+            if self.line_plots:
+                self.update_line_plots(event.xdata, event.ydata)
+
+    def plot_x_line(self, x, y):
+        try:
+            self.xfig[0].set_data(x, y)
+        except (AttributeError, IndexError):
+            self.axx.clear()
+            self.xfig = self.axx.plot(x, y)
+            self.axx.set_xlabel(self.ax.get_xlabel())
+            self.update_line_plot_limits()
+        self.canvas.draw_idle()
+
+    def plot_y_line(self, x, y):
+        try:
+            self.yfig[0].set_data(y, x)
+        except (AttributeError, IndexError):
+            self.axy.clear()
+            self.yfig = self.axy.plot(y, x)
+            self.axy.set_ylabel(self.ax.get_ylabel())
+            self.update_line_plot_limits()
+        self.canvas.draw_idle()
+
+    def update_line_plots(self, x, y):
+        xmin, xmax, ymin, ymax = self.im.get_extent()
+        arr = self.im.get_array()
+        data_extent = Bbox([[ymin, xmin], [ymax, xmax]])
+        array_extent = Bbox([[0, 0], arr.shape[:2]])
+        trans = BboxTransform(boxin=data_extent, boxout=array_extent)
+        point = trans.transform_point([y, x])
+        if any(np.isnan(point)):
+            return
+        i, j = point.astype(int)
+        if 0 <= i < arr.shape[0]:
+            self.plot_x_line(np.linspace(xmin, xmax, arr.shape[1]), arr[i,:])
+        if 0 <= j < arr.shape[1]:
+            self.plot_y_line(np.linspace(ymin, ymax, arr.shape[0]), arr[:,j])
 
     def closeEvent(self, event):
         self.deleteLater()


### PR DESCRIPTION
Adds an axes aligned 1D plot at mouse location, should work for all workspace types, press button on toolbar to turn on and off.

Should look like
![sliceviewer_lineplots](https://user-images.githubusercontent.com/5595210/57777141-1dc19d00-76ef-11e9-8a2b-ce67d95f2549.png)



**To test:**
Open update different workspaces in sliceviewer and check that the lineplots work as expected.


Closes #25688

*This does not require release notes* because as it's all part of the new sliceviewer work

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
