### PR TITLE
Deprecate total_nanoseconds method

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -81,6 +81,13 @@ void export_DateAndTime() {
       .def(self - self);
 }
 
+long time_duration_total_nanoseconds(time_duration &self) {
+  PyErr_Warn(
+      PyExc_DeprecationWarning,
+      ".total_nanoseconds() is deprecated. Use .totalNanoseconds() instead.");
+  return self.total_nanoseconds();
+}
+
 void export_time_duration() {
   class_<time_duration>("time_duration", no_init)
       .def("hours", &time_duration::hours, arg("self"),
@@ -99,7 +106,10 @@ void export_time_duration() {
            arg("self"),
            "Get the total number of microseconds truncating any remaining "
            "digits")
-      .def("total_nanoseconds", &time_duration::total_nanoseconds, arg("self"),
+      .def("total_nanoseconds", &time_duration_total_nanoseconds, arg("self"),
+           "Get the total number of nanoseconds truncating any remaining "
+           "digits")
+      .def("totalNanoseconds", &time_duration::total_nanoseconds, arg("self"),
            "Get the total number of nanoseconds truncating any remaining "
            "digits");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -29,6 +29,13 @@ std::string ISO8601StringPlusSpace(DateAndTime &self) {
   return self.toISO8601String() + " ";
 }
 
+int64_t total_nanoseconds(DateAndTime &self) {
+  PyErr_Warn(
+      PyExc_DeprecationWarning,
+      ".total_nanoseconds() is deprecated. Use .totalNanoseconds() instead.");
+  return self.totalNanoseconds();
+}
+
 void export_DateAndTime() {
   class_<DateAndTime>("DateAndTime", no_init)
       // Constructors
@@ -49,7 +56,7 @@ void export_DateAndTime() {
            make_constructor(Converters::to_dateandtime, default_call_policies(),
                             (arg("other"))),
            "Construct from numpy.datetime64")
-      .def("total_nanoseconds", &DateAndTime::totalNanoseconds, arg("self"),
+      .def("total_nanoseconds", &total_nanoseconds, arg("self"),
            "Since 1990-01-01T00:00")
       .def("totalNanoseconds", &DateAndTime::totalNanoseconds, arg("self"),
            "Since 1990-01-01T00:00")

--- a/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
+++ b/Framework/PythonInterface/plugins/algorithms/MRFilterCrossSections.py
@@ -175,7 +175,7 @@ class MRFilterCrossSections(PythonAlgorithm):
                 change_list.extend(extract_times(time_dict['start'], True, is_veto2=True))
                 change_list.extend(extract_times(time_dict['stop'], False, is_veto2=True))
 
-        start_time = ws_raw.run().startTime().total_nanoseconds()
+        start_time = ws_raw.run().startTime().totalNanoseconds()
 
         change_list = sorted(change_list, key=itemgetter(0))
         split_table_ws = self.create_table(change_list, start_time,

--- a/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
@@ -30,7 +30,7 @@ class DateAndTimeTest(unittest.TestCase):
 
     def test_convert_to_np(self):
         dt = DateAndTime(598471118000000000)
-        dt_np = timedelta64(dt.total_nanoseconds(), 'ns') + datetime64('1990-01-01T00:00')
+        dt_np = timedelta64(dt.totalNanoseconds(), 'ns') + datetime64('1990-01-01T00:00')
 
         # convert both into ISO8601 strings up to the seconds
         dt = str(dt)[:19]

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -49,5 +49,6 @@ Python
 ------
 
 - The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
+- The method `total_nanoseconds` in `DateAndTime` has been deprecated. `totalNanoseconds` should be used instead.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -50,5 +50,6 @@ Python
 
 - The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
 - The method `total_nanoseconds` in `DateAndTime` has been deprecated. `totalNanoseconds` should be used instead.
+- The method `total_nanoseconds` in `time_duration` has been deprecated. `totalNanoseconds` should be used instead.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/scripts/test/SANSUtilityTest.py
+++ b/scripts/test/SANSUtilityTest.py
@@ -379,7 +379,7 @@ class AddOperationTest(unittest.TestCase):
         # Total time difference is TIME1 - (TIME2 + extraShift)
         shift = 0.0
         if isOverlay:
-            shift = time_duration.total_nanoseconds(DateAndTime(time1)- DateAndTime(time2))/1e9 - extra_time_shift
+            shift = time_duration.totalNanoseconds(DateAndTime(time1)- DateAndTime(time2))/1e9 - extra_time_shift
 
         # Check ws1 against output
         # We shift the second workspace onto the first workspace
@@ -539,7 +539,7 @@ class TestOverlayWorkspaces(unittest.TestCase):
         time_difference = overlayWorkspaces._extract_time_difference_in_seconds(event_ws_1, event_ws_2)
 
         # Assert
-        expected_time_difference = time_duration.total_nanoseconds(DateAndTime(start_time_1)- DateAndTime(start_time_2))/1e9
+        expected_time_difference = time_duration.totalNanoseconds(DateAndTime(start_time_1)- DateAndTime(start_time_2))/1e9
         self.assertEqual(time_difference, expected_time_difference)
 
         # Clean up
@@ -564,7 +564,7 @@ class TestOverlayWorkspaces(unittest.TestCase):
         time_difference = overlayWorkspaces._extract_time_difference_in_seconds(event_ws_1, event_ws_2)
 
         # Assert
-        expected_time_difference = time_duration.total_nanoseconds(DateAndTime(start_time_1)- DateAndTime(start_time_2))/1e9
+        expected_time_difference = time_duration.totalNanoseconds(DateAndTime(start_time_1)- DateAndTime(start_time_2))/1e9
         expected_time_difference -= optional_time_shift # Need to subtract as we add the time shift to the subtrahend
         self.assertEqual(time_difference, expected_time_difference)
 


### PR DESCRIPTION
**Description of work.**
It was discovered that the python exposure to `DateAndTime` has two methods, `total_nanoseconds` and `totalNanoseconds`, which both point to `DateAndTime::totalNanoseconds`.

`total_nanoseconds` has been deprecated.

**To test:**
1. Run the following script 
```
ws = Load("SANS2D58080")
time = ws.getRun().getProperty("proton_charge").firstTime()
print(time.totalNanoseconds())
print(time.total_nanoseconds())
```

The first method call should print the time without a deprecation warning.
The second method call should have a deprecation warning

2. Check the codebase for any usages of `total_nanoseconds` on the python exposure of `DateAndTime`

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
