### PR TITLE
Fix CMake warning

### DIFF
--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -34,7 +34,7 @@ if ( stdint )
 endif ( stdint )
 
 # Configure a variable to hold the required test timeout value for all tests
-set ( TESTING_TIMEOUT 300 CACHE INTEGER
+set ( TESTING_TIMEOUT 300 CACHE STRING
       "Timeout in seconds for each test (default 300=5minutes)")
 
 ###########################################################################


### PR DESCRIPTION
**Description of work.**

Fixes the following CMake warning
```
CMake Warning (dev) at buildconfig/CMake/CommonSetup.cmake:37 (set):
  implicitly converting 'INTEGER' to 'STRING' type.
Call Stack (most recent call first):
  CMakeLists.txt:89 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

I can't find an `INTEGER` type. `STRING` looks like the closest option. 
https://cmake.org/cmake/help/v3.14/prop_cache/TYPE.html

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

*There is no associated issue.*

*This does not require release notes* because internal build issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
