### PR TITLE
Upgrade Poco to 1.6.1 on Windows

### DIFF
--- a/Framework/Algorithms/test/CMakeLists.txt
+++ b/Framework/Algorithms/test/CMakeLists.txt
@@ -52,6 +52,10 @@ if(CXXTEST_FOUND)
       ../../TestHelpers/src/ParallelRunner.cpp
       ../../TestHelpers/src/ReflectometryHelper.cpp)
   cxxtest_add_test(AlgorithmsTest ${TEST_FILES})
+  if(WIN32)
+    # On Windows Boost uuid requires the bcrypt library
+    set(BCRYPT bcrypt)
+  endif()
   target_link_libraries(AlgorithmsTest
                         LINK_PRIVATE
                         ${TCMALLOC_LIBRARIES_LINKTIME}
@@ -59,6 +63,7 @@ if(CXXTEST_FOUND)
                         Algorithms
                         DataHandling
                         Nexus
+                        ${BCRYPT}
                         ${GMOCK_LIBRARIES}
                         ${GTEST_LIBRARIES})
   add_dependencies(AlgorithmsTest Crystal CurveFitting)

--- a/Framework/Kernel/inc/MantidKernel/PrecompiledHeader.h
+++ b/Framework/Kernel/inc/MantidKernel/PrecompiledHeader.h
@@ -9,13 +9,6 @@
 
 #include "MantidKernel/System.h"
 
-#if _WIN32
-#define _WIN32_WINNT 0x0510
-#include <winsock2.h> // prevents a conflict caused by windows.h
-                      // trying to include winsock.h
-#include <windows.h>
-#endif
-
 // STL
 #include <crtdefs.h>
 #include <cstddef>

--- a/Framework/Kernel/src/DllOpen.cpp
+++ b/Framework/Kernel/src/DllOpen.cpp
@@ -8,11 +8,10 @@
 #include "MantidKernel/Logger.h"
 
 #if _WIN32
-#define _WIN32_WINNT 0x0510
 #include <windows.h>
 #else
 #include <dlfcn.h>
-#endif /* _WIN32 */
+#endif
 
 #include <boost/algorithm/string/predicate.hpp>
 

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 90f5f288d5413ab0f2349fc65c9bf6aff73727e0 )
+  set ( THIRD_PARTY_GIT_SHA1 66fe3958e5191757fe8809fbf3f9264445893c1f )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -11,7 +11,7 @@ set (SYSTEM_PACKAGE_TARGET RUNTIME)
 add_definitions ( -D_WINDOWS -DMS_VISUAL_STUDIO )
 add_definitions ( -D_USE_MATH_DEFINES -DNOMINMAX )
 add_definitions ( -DGSL_DLL -DJSON_DLL )
-add_definitions ( -DPOCO_NO_UNWINDOWS )
+add_definitions ( -DPOCO_DLL -DPOCO_NO_UNWINDOWS )
 add_definitions ( -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE )
 add_definitions ( -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS )
   # Prevent deprecation errors from std::tr1 in googletest until it is fixed upstream. In MSVC 2017 and later

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/MdViewerWidget.h
@@ -7,15 +7,6 @@
 #ifndef MDVIEWERWIDGET_H_
 #define MDVIEWERWIDGET_H_
 
-#ifdef ERROR
-#undef ERROR
-#endif
-// Moving this to the bottom of the include stack causes a compilation error
-// under Visual Studio.
-// clang-format off
-#include "ui_MdViewerWidget.h"
-// clang-format on
-
 #include "MantidQtWidgets/Common/MdConstants.h"
 #include "MantidQtWidgets/Common/MdSettings.h"
 #include "MantidQtWidgets/Common/VatesViewerInterface.h"
@@ -24,6 +15,7 @@
 #include "MantidVatesSimpleGuiViewWidgets/RebinAlgorithmDialogProvider.h"
 #include "MantidVatesSimpleGuiViewWidgets/RebinnedSourcesManager.h"
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
+#include "ui_MdViewerWidget.h"
 
 #include "vtkSmartPointer.h"
 

--- a/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
+++ b/qt/paraview_ext/VatesSimpleGui/ViewWidgets/inc/MantidVatesSimpleGuiViewWidgets/TimeControlWidget.h
@@ -8,6 +8,12 @@
 #define TIMECONTROLWIDGET_H_
 
 #include "MantidVatesSimpleGuiViewWidgets/WidgetDllOption.h"
+
+// The Windows SDK defines an ERROR macro in um\wingdi.h that conflicts
+// with the definition of a enum value in pqOutputWidget.h
+#if defined(_WIN32) && defined(ERROR)
+#undef ERROR
+#endif
 #include "ui_TimeControlWidget.h"
 
 namespace Mantid {


### PR DESCRIPTION
**Description of work.**

All other platforms have Poco 1.6.x. #25684 requires `RecursiveDirectoryIterator` that appeared in v1.5.

**To test:**

If Windows builds pass then this is good as Poco is linked at a very low level.

*There is no associated issue.*

*This does not require release notes* because **it is a buildconfig change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
