### PR TITLE
BASISPowderReduction and BASISReduction: option to keep temporary workspaces

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/BASISPowderDiffraction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISPowderDiffraction.py
@@ -30,6 +30,7 @@ from mantid.kernel import (FloatArrayProperty, Direction, EnabledWhenProperty,
                            PropertyCriterion, StringListValidator, logger)
 temp_prefix = '_tp_'  # marks a workspace as temporary
 
+
 class VDAS(Enum):
     """Specifices the version of the Data Acquisition System (DAS)"""
     v1900_2018 = 0  # Up to Dec 31 2018
@@ -299,7 +300,6 @@ class BASISPowderDiffraction(DataProcessorAlgorithm):
         self.declareProperty('RemoveTemp', True, direction=Direction.Input,
                              doc='Remove temporary workspaces and files')
         self.setPropertyGroup('RemoveTemp', titleAddionalOutput)
-
 
     def PyExec(self):
         # Facility and database configuration

--- a/Framework/PythonInterface/plugins/algorithms/BASISPowderDiffraction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISPowderDiffraction.py
@@ -297,9 +297,9 @@ class BASISPowderDiffraction(DataProcessorAlgorithm):
         # Aditional output properties
         #
         titleAddionalOutput = 'Additional Output'
-        self.declareProperty('RemoveTemp', True, direction=Direction.Input,
+        self.declareProperty('RemoveTemporaryWorkspaces', True, direction=Direction.Input,
                              doc='Remove temporary workspaces and files')
-        self.setPropertyGroup('RemoveTemp', titleAddionalOutput)
+        self.setPropertyGroup('RemoveTemporaryWorkspaces', titleAddionalOutput)
 
     def PyExec(self):
         # Facility and database configuration
@@ -316,7 +316,7 @@ class BASISPowderDiffraction(DataProcessorAlgorithm):
         #
         # implement with ContextDecorator after python2 is deprecated)
         #
-        remove_temp = self.getProperty('RemoveTemp').value
+        remove_temp = self.getProperty('RemoveTemporaryWorkspaces').value
         with pyexec_setup(remove_temp, config_new_options) as self._temps:
             #
             # Load the mask to a temporary workspace

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -24,9 +24,7 @@ from mantid.kernel import (IntArrayProperty, StringListValidator,
                            Direction, PropertyCriterion)
 from mantid import config as mantid_config
 from os.path import join as pjoin
-
-# name prefix marking a workspace for deletion after algorithm completion
-temporary_workspace_marker = '_t_'
+temp_prefix = '_ti_'  # marks a workspace as temporary
 
 
 def unique_workspace_name(n=3, prefix='', suffix=''):
@@ -60,7 +58,7 @@ def unique_workspace_name(n=3, prefix='', suffix=''):
 
 def tws(marker=''):
     r"""
-    String starting with the temporary workspace marker
+    String starting with the temp_prefix
     and guaranteed not to collide
     with the name of any existing Mantid workspace
     in the analysis data service
@@ -74,8 +72,7 @@ def tws(marker=''):
     -------
     str
     """
-    return unique_workspace_name(prefix=temporary_workspace_marker,
-                                 suffix='_'+marker)
+    return unique_workspace_name(prefix=temp_prefix, suffix='_'+marker)
 
 
 @contextmanager
@@ -90,6 +87,8 @@ def pyexec_setup(remove_temp, new_options):
 
     Parameters
     ----------
+    remove_temp: bool
+        Determine wether to remove the temporary workspaces
     new_options: dict
         Dictionary of mantid configuration options to be modified.
 
@@ -121,8 +120,7 @@ def pyexec_setup(remove_temp, new_options):
             os.remove(file_name)
         to_be_removed = set()
         for name in AnalysisDataService.getObjectNames():
-            twml = len(temporary_workspace_marker)
-            if name[0: twml] == temporary_workspace_marker:
+            if temp_prefix in name:
                 to_be_removed.add(name)
         for workspace in temps.workspaces:
             if isinstance(workspace, str) and AnalysisDataService.doesExist(workspace):
@@ -189,7 +187,6 @@ class BASISReduction(PythonAlgorithm):
         self._normalizeToFirst = False
         self._as_json = None
         self._temps = None  # hold names of temporary workspaces and files
-        self.remove_temp = None  # set to true to keep temporary workspaces
 
         # properties related to the sample
         self._samWs = None  # name of the sample events file
@@ -366,8 +363,8 @@ the first two hours"""
         #
         # implement with ContextDecorator after python2 is deprecated)
         #
-        self.remove_temp = self.getProperty('RemoveTemp').value
-        with pyexec_setup(self.remove_temp, config_new_options) as self._temps:
+        remove_temp = self.getProperty('RemoveTemp').value
+        with pyexec_setup(remove_temp, config_new_options) as self._temps:
             self._PyExec()
 
     def _PyExec(self):

--- a/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/BASISReduction.py
@@ -350,9 +350,9 @@ the first two hours"""
                              direction=Direction.Input,
                              doc='Output S(Q) and S(theta) powder diffraction')
         self.setPropertyGroup('OutputPowderSpectrum', titleAddionalOutput)
-        self.declareProperty('RemoveTemp', True, direction=Direction.Input,
+        self.declareProperty('RemoveTemporaryWorkspaces', True, direction=Direction.Input,
                              doc='Remove temporary workspaces and files')
-        self.setPropertyGroup('RemoveTemp', titleAddionalOutput)
+        self.setPropertyGroup('RemoveTemporaryWorkspaces', titleAddionalOutput)
 
     # pylint: disable=too-many-branches
     def PyExec(self):
@@ -363,7 +363,7 @@ the first two hours"""
         #
         # implement with ContextDecorator after python2 is deprecated)
         #
-        remove_temp = self.getProperty('RemoveTemp').value
+        remove_temp = self.getProperty('RemoveTemporaryWorkspaces').value
         with pyexec_setup(remove_temp, config_new_options) as self._temps:
             self._PyExec()
 

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -17,6 +17,7 @@ Improvements
 
 - The Polaris scripts can now detect the chopper mode if none is provided using the frequency block logs.
 - :ref:`SNSPowderReduction <algm-SNSPowderReduction>` has a new property, ``OffsetData``, which adds a constant to the data at the very end of the reduction
+- :ref:`BASISPowderDiffraction <algm-BASISPowderDiffraction>` has a new property, ``RemoveTemp``, which allows the user to inspect temporary workspaces is left unchecked.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**
- [x] Added property `RemoveTemp`
- [x] Updated [release notes](https://github.com/mantidproject/mantid/blob/6c01253b490305dd004ede2e41a6c154b97abba6/docs/source/release/v4.1.0/diffraction.rst#improvements)
- [x] Test for reviewer

**To test:**

Simply run the following reduction:

```
BASISPowderDiffraction(RunNumbers='93895', OutputWorkspace='powder', RemoveTemp=False)
```

and verify that the temporary workspaces (begin with <b>_tp_</b>) do not dissappear once the reduction has finished.

Fixes #25733

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
