### PR TITLE
SetSample calculates density from mass

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ReadMaterial.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ReadMaterial.h
@@ -16,6 +16,7 @@ class Material;
 }
 namespace DataHandling {
 using ValidationErrors = std::map<std::string, std::string>;
+
 /**
     This class contains code for interpreting a material input for
    SetSampleMaterial, validating the parameters before sending them on to
@@ -43,6 +44,10 @@ public:
     double unitCellVolume = EMPTY_DBL();
     /// The sample mass density to set, defaults to EMPTY_DBL()
     double sampleMassDensity = EMPTY_DBL();
+    /// The sample mass to set, defaults to EMPTY_DBL()
+    double sampleMass = EMPTY_DBL();
+    /// The sample volume to set, defaults to EMPTY_DBL()
+    double sampleVolume = EMPTY_DBL();
     /// The coherent scattering cross section to set, defaults to EMPTY_DBL()
     double coherentXSection = EMPTY_DBL();
     /// The incoherent scattering cross section to set, defaults to EMPTY_DBL()

--- a/Framework/DataHandling/src/ReadMaterial.cpp
+++ b/Framework/DataHandling/src/ReadMaterial.cpp
@@ -74,6 +74,14 @@ ReadMaterial::validateInputs(const MaterialParameters &params) {
       result["SampleMassDensity"] =
           "Cannot give SampleMassDensity with SampleNumberDensity set";
     }
+    bool canCalculateMassDensity =
+        ((!isEmpty(params.sampleMass)) && (!isEmpty(params.sampleVolume)));
+    if (canCalculateMassDensity) {
+      result["SampleMassDensity"] =
+          "Cannot give SampleMassDensity with SampleNumberDensity set";
+      result["SampleMassDensity"] =
+          "Cannot give SampleMassDensity with SampleNumberDensity set";
+    }
   }
   return result;
 }
@@ -86,7 +94,15 @@ ReadMaterial::validateInputs(const MaterialParameters &params) {
  */
 void ReadMaterial::setMaterialParameters(const MaterialParameters &params) {
   setMaterial(params.chemicalSymbol, params.atomicNumber, params.massNumber);
-  setNumberDensity(params.sampleMassDensity, params.sampleNumberDensity,
+
+  // calculate the mass density if it wasn't provided
+  double massDensity = params.sampleMassDensity;
+  if (isEmpty(massDensity)) {
+    if (!(isEmpty(params.sampleMass) || isEmpty(params.sampleVolume)))
+      massDensity = params.sampleMass / params.sampleVolume;
+  }
+
+  setNumberDensity(massDensity, params.sampleNumberDensity,
                    params.numberDensityUnit, params.zParameter,
                    params.unitCellVolume);
   setScatteringInfo(params.coherentXSection, params.incoherentXSection,

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -308,7 +308,8 @@ void SetSample::exec() {
       // only add the volume if it isn't already specfied
       if (!materialArgs->existsProperty(VOLUME_ARG)) {
         materialArgs->declareProperty(
-              Kernel::make_unique<PropertyWithValue<double>>(VOLUME_ARG, sampleVolume));
+            Kernel::make_unique<PropertyWithValue<double>>(VOLUME_ARG,
+                                                           sampleVolume));
       }
     }
     runChildAlgorithm("SetSampleMaterial", workspace, *materialArgs);

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -33,9 +33,12 @@ using Geometry::Goniometer;
 using Geometry::ReferenceFrame;
 using Geometry::SampleEnvironment;
 using Kernel::Logger;
+using Kernel::PropertyWithValue;
 using Kernel::V3D;
 
 namespace {
+constexpr double CUBIC_METRE_TO_CM = 100. * 100. * 100.;
+
 /// Private namespace storing property name strings
 namespace PropertyNames {
 /// Input workspace property name
@@ -290,12 +293,24 @@ void SetSample::exec() {
     sampleEnviron = setSampleEnvironment(workspace, environArgs);
   }
 
+  double sampleVolume = 0.;
   if (geometryArgs || sampleEnviron) {
     setSampleShape(workspace, geometryArgs, sampleEnviron);
+    // get the volume back out to use in setting the material
+    sampleVolume = CUBIC_METRE_TO_CM * workspace->sample().getShape().volume();
   }
 
   // Finally the material arguments
   if (materialArgs) {
+    // add the sample volume if it was defined/determined
+    if (sampleVolume > 0.) {
+      const std::string VOLUME_ARG{"SampleVolume"};
+      // only add the volume if it isn't already specfied
+      if (!materialArgs->existsProperty(VOLUME_ARG)) {
+        materialArgs->declareProperty(
+              Kernel::make_unique<PropertyWithValue<double>>(VOLUME_ARG, sampleVolume));
+      }
+    }
     runChildAlgorithm("SetSampleMaterial", workspace, *materialArgs);
   }
 }

--- a/Framework/DataHandling/src/SetSampleMaterial.cpp
+++ b/Framework/DataHandling/src/SetSampleMaterial.cpp
@@ -77,6 +77,14 @@ void SetSampleMaterial::init() {
   declareProperty("SampleMassDensity", EMPTY_DBL(), mustBePositive,
                   "Measured mass density in g/cubic cm of the sample "
                   "to be used to calculate the number density.");
+  declareProperty(
+      "SampleMass", EMPTY_DBL(), mustBePositive,
+      "Measured mass in g of the sample. This is used with the SampleVolume "
+      "to calculate the number density.");
+  declareProperty(
+      "SampleVolume", EMPTY_DBL(), mustBePositive,
+      "Measured volume in gm^3 of the sample. This is used with the SampleMass "
+      "to calculate the number density.");
   const std::vector<std::string> units({"Atoms", "Formula Units"});
   declareProperty("NumberDensityUnit", units.front(),
                   boost::make_shared<StringListValidator>(units),
@@ -94,6 +102,8 @@ void SetSampleMaterial::init() {
   setPropertyGroup("ZParameter", densityGrp);
   setPropertyGroup("UnitCellVolume", densityGrp);
   setPropertyGroup("SampleMassDensity", densityGrp);
+  setPropertyGroup("SampleMass", densityGrp);
+  setPropertyGroup("SampleVolume", densityGrp);
 
   std::string specificValuesGrp("Override Cross Section Values");
   setPropertyGroup("CoherentXSection", specificValuesGrp);
@@ -123,6 +133,8 @@ std::map<std::string, std::string> SetSampleMaterial::validateInputs() {
   params.zParameter = getProperty("ZParameter");
   params.unitCellVolume = getProperty("UnitCellVolume");
   params.sampleMassDensity = getProperty("SampleMassDensity");
+  params.sampleMass = getProperty("SampleMass");
+  params.sampleVolume = getProperty("SampleVolume");
   params.coherentXSection = getProperty("CoherentXSection");
   params.incoherentXSection = getProperty("IncoherentXSection");
   params.attenuationXSection = getProperty("AttenuationXSection");

--- a/Framework/DataHandling/test/ReadMaterialTest.h
+++ b/Framework/DataHandling/test/ReadMaterialTest.h
@@ -336,7 +336,7 @@ public:
 
   void testCalculateDensity() {
     // test getting the number density from the table
-    const ReadMaterial::MaterialParameters tableParams = [this]()->auto {
+    const ReadMaterial::MaterialParameters tableParams = [this]() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.chemicalSymbol = FORMULA;
       return setMaterial;
@@ -352,7 +352,7 @@ public:
     }
 
     // test getting the number density from the mass density
-    const ReadMaterial::MaterialParameters massParams = [this]()->auto {
+    const ReadMaterial::MaterialParameters massParams = [this]() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.chemicalSymbol = FORMULA;
       setMaterial.sampleMassDensity = MASS_DENSITY;
@@ -368,7 +368,7 @@ public:
     }
 
     // test getting the number density from the mass and volume
-    const ReadMaterial::MaterialParameters sampleParams = [this]()->auto {
+    const ReadMaterial::MaterialParameters sampleParams = [this]() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
       setMaterial.chemicalSymbol = FORMULA;
       setMaterial.sampleMass = 5.; // grams
@@ -406,12 +406,12 @@ public:
 
 private:
   // these values are for elemental vanadium
-  const double EMPTY_DOUBLE_VAL{ 8.9884656743115785e+307 };
-  const double PRECISION{ 1e-8 };
-  const double NUMBER_DENSITY{ 0.0722305 };
-  const double MASS_DENSITY{ 6.11 }; // matches the number density
-  const std::string EMPTY{ "" };
-  const std::string FORMULA{ "V" };
+  const double EMPTY_DOUBLE_VAL{8.9884656743115785e+307};
+  const double PRECISION{1e-8};
+  const double NUMBER_DENSITY{0.0722305};
+  const double MASS_DENSITY{6.11}; // matches the number density
+  const std::string EMPTY{""};
+  const std::string FORMULA{"V"};
 
   void compareMaterial(const Material &material, const Material &check) {
     std::vector<Material::FormulaUnit> checkFormula = check.chemicalFormula();

--- a/Framework/DataHandling/test/ReadMaterialTest.h
+++ b/Framework/DataHandling/test/ReadMaterialTest.h
@@ -334,6 +334,57 @@ public:
     compareMaterial(*material, check);
   }
 
+  void testCalculateDensity() {
+    // test getting the number density from the table
+    const ReadMaterial::MaterialParameters tableParams = [this]()->auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.chemicalSymbol = FORMULA;
+      return setMaterial;
+    }
+    ();
+
+    {
+      ReadMaterial reader;
+      reader.setMaterialParameters(tableParams);
+      auto material = reader.buildMaterial();
+
+      TS_ASSERT_DELTA(material->numberDensity(), NUMBER_DENSITY, 1e-7);
+    }
+
+    // test getting the number density from the mass density
+    const ReadMaterial::MaterialParameters massParams = [this]()->auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.chemicalSymbol = FORMULA;
+      setMaterial.sampleMassDensity = MASS_DENSITY;
+      return setMaterial;
+    }
+    ();
+
+    {
+      ReadMaterial reader;
+      reader.setMaterialParameters(massParams);
+      auto material = reader.buildMaterial();
+      TS_ASSERT_DELTA(material->numberDensity(), NUMBER_DENSITY, 1e-7);
+    }
+
+    // test getting the number density from the mass and volume
+    const ReadMaterial::MaterialParameters sampleParams = [this]()->auto {
+      ReadMaterial::MaterialParameters setMaterial;
+      setMaterial.chemicalSymbol = FORMULA;
+      setMaterial.sampleMass = 5.; // grams
+      setMaterial.sampleVolume = setMaterial.sampleMass / MASS_DENSITY;
+      return setMaterial;
+    }
+    ();
+
+    {
+      ReadMaterial reader;
+      reader.setMaterialParameters(sampleParams);
+      auto material = reader.buildMaterial();
+      TS_ASSERT_DELTA(material->numberDensity(), NUMBER_DENSITY, 1e-7);
+    }
+  }
+
   void testNoMaterialFailure() {
     const ReadMaterial::MaterialParameters params = [this]() -> auto {
       ReadMaterial::MaterialParameters setMaterial;
@@ -354,10 +405,13 @@ public:
   }
 
 private:
-  const double EMPTY_DOUBLE_VAL = 8.9884656743115785e+307;
-  const double PRECISION = 1e-8;
-  const std::string EMPTY = "";
-  const std::string FORMULA = "V";
+  // these values are for elemental vanadium
+  const double EMPTY_DOUBLE_VAL{ 8.9884656743115785e+307 };
+  const double PRECISION{ 1e-8 };
+  const double NUMBER_DENSITY{ 0.0722305 };
+  const double MASS_DENSITY{ 6.11 }; // matches the number density
+  const std::string EMPTY{ "" };
+  const std::string FORMULA{ "V" };
 
   void compareMaterial(const Material &material, const Material &check) {
     std::vector<Material::FormulaUnit> checkFormula = check.chemicalFormula();

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -286,7 +286,6 @@ public:
     TS_ASSERT_EQUALS(false, sampleShape.isValid(V3D(0, 0.06, -0.001)));
   }
 
-
   void test_Setting_Geometry_No_Volume() {
     using Mantid::Kernel::V3D;
     auto inputWS = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1);
@@ -488,7 +487,8 @@ private:
     workspace->setInstrument(inst);
   }
 
-  Mantid::Kernel::PropertyManager_sptr createMaterialProps(const double volume = 0.) {
+  Mantid::Kernel::PropertyManager_sptr
+  createMaterialProps(const double volume = 0.) {
     using Mantid::Kernel::PropertyManager;
     using StringProperty = Mantid::Kernel::PropertyWithValue<std::string>;
 
@@ -496,9 +496,10 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<StringProperty>("ChemicalFormula", "V"),
         "");
-    if (volume > 0.)     // <mass> = <standard mass density for vanadium> x <volume>
+    if (volume > 0.) // <mass> = <standard mass density for vanadium> x <volume>
       props->declareProperty(
-          Mantid::Kernel::make_unique<PropertyWithValue<double>>("SampleMass", 6.11 * volume),
+          Mantid::Kernel::make_unique<PropertyWithValue<double>>("SampleMass",
+                                                                 6.11 * volume),
           "");
     return props;
   }

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -29,6 +29,7 @@
 #include <fstream>
 
 using Mantid::DataHandling::SetSample;
+using Mantid::Kernel::PropertyWithValue;
 
 class SetSampleTest : public CxxTest::TestSuite {
 public:
@@ -285,6 +286,38 @@ public:
     TS_ASSERT_EQUALS(false, sampleShape.isValid(V3D(0, 0.06, -0.001)));
   }
 
+
+  void test_Setting_Geometry_No_Volume() {
+    using Mantid::Kernel::V3D;
+    auto inputWS = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1);
+    setTestReferenceFrame(inputWS);
+    // this must match geometry created in createCylinderGeometryProps()
+    constexpr double VOLUME = M_PI * 5. * 5. * 2.; // pi * (r^2) * h
+
+    auto alg = createAlgorithm(inputWS);
+    alg->setProperty("Geometry", createCylinderGeometryProps());
+    alg->setProperty("Material", createMaterialProps(VOLUME));
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+
+    // New shape
+    const auto &sampleShape = inputWS->sample().getShape();
+    TS_ASSERT(sampleShape.hasValidShape());
+    auto tag = dynamic_cast<const Mantid::Geometry::CSGObject &>(sampleShape)
+                   .getShapeXML()
+                   .find("cylinder");
+    TS_ASSERT(tag != std::string::npos);
+
+    TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0, 0.049, 0.019)));
+    TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0, 0.049, 0.001)));
+    TS_ASSERT_EQUALS(false, sampleShape.isValid(V3D(0, 0.06, 0.021)));
+    TS_ASSERT_EQUALS(false, sampleShape.isValid(V3D(0, 0.06, -0.001)));
+
+    const auto &material = inputWS->sample().getMaterial();
+    TS_ASSERT_EQUALS("V", material.name());
+    TS_ASSERT_DELTA(0.0722, material.numberDensity(), 1e-04);
+  }
+
   void test_Setting_Geometry_As_HollowCylinder() {
     using Mantid::Kernel::V3D;
     auto inputWS = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1);
@@ -455,7 +488,7 @@ private:
     workspace->setInstrument(inst);
   }
 
-  Mantid::Kernel::PropertyManager_sptr createMaterialProps() {
+  Mantid::Kernel::PropertyManager_sptr createMaterialProps(const double volume = 0.) {
     using Mantid::Kernel::PropertyManager;
     using StringProperty = Mantid::Kernel::PropertyWithValue<std::string>;
 
@@ -463,6 +496,10 @@ private:
     props->declareProperty(
         Mantid::Kernel::make_unique<StringProperty>("ChemicalFormula", "V"),
         "");
+    if (volume > 0.)     // <mass> = <standard mass density for vanadium> x <volume>
+      props->declareProperty(
+          Mantid::Kernel::make_unique<PropertyWithValue<double>>("SampleMass", 6.11 * volume),
+          "");
     return props;
   }
 

--- a/docs/source/algorithms/SetSample-v1.rst
+++ b/docs/source/algorithms/SetSample-v1.rst
@@ -139,6 +139,19 @@ The following example uses a test file called ``CRYO-01.xml`` in the
              Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
                        'SampleNumberDensity': 0.1})
 
+**Example - Specify height and mass of preset cylinder sample**
+
+.. testcode:: Ex2
+
+   # A fake host workspace, replace this with your real one.
+   ws = CreateSampleWorkspace()
+   # Use geometry from environment but set different height for sample
+   # and calculate density with supplied sample mass
+   SetSample(ws, Environment={'Name': 'CRYO-01', 'Container': '8mm'},
+             Geometry={'Height': 4.0},
+             Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
+                       'SampleMass': 3.0})
+
 **Example - Override complete sample geometry**
 
 .. testcode:: Ex3

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -27,6 +27,7 @@ Improvements
 - :ref:`LoadSampleShape <algm-LoadSampleShape>` now rotates the sample based off of the setting of the goniometer.
 - :ref:`GenerateEventsFilter <algm-GenerateEventsFilter>` is able to accept any `MatrixWorkspace`, as long as it has run objects loaded from `LoadNexusLogs <algm-LoadNexusLogs>`, other than `EventWorkspace`.
 - :ref:`AbsorptionCorrection <algm-AbsorptionCorrection>` has a new property `ScatterFrom` which allows for calculating the correction for the other components (i.e. container and environment)
+- :ref:`SetSample <algm-SetSample>` can calculate the density from the sample mass
 - Prevent an error due to the locale settings which may appear when reading, for instance, the incident energy Ei value from the logs in :ref:`ConvertUnits <algm-ConvertUnits>` and many other algorithms.
 - :code:`indices` and :code:`slicepoint` options have been added to :ref:`mantid.plots <mantid.plots>` to allow selection of which plane to plot from an MDHistoWorkspace. :code:`transpose` has also been added to transpose the axes of any 2D plot.
 - :ref:`Pseudo-Voigt <func-PseudoVoigt>` has been modified to be more in line with FULLPROF and GSAS.  One of its basic parameter, Height, is changed to Intensity.


### PR DESCRIPTION
Since the user often knows the "height in container" and sample mass, add functionality to `SetSample` to allow for specifying these parameters.

**To test:**

The usage example added to the `SetSample` documentation shows off the feature.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
