### PR TITLE
MDNorm bug fixes and improvements

### DIFF
--- a/Framework/Kernel/src/UnitLabelTypes.cpp
+++ b/Framework/Kernel/src/UnitLabelTypes.cpp
@@ -37,7 +37,7 @@ const UnitLabel Symbol::Nanometre("nm");
 /// Inverse centimeters
 const UnitLabel Symbol::InverseCM("cm^-1", L"cm\u207b\u00b9", "cm^{-1}");
 /// Reciprocal lattice (dimensionless)
-const UnitLabel Symbol::RLU("r.l.u");
+const UnitLabel Symbol::RLU("r.l.u.");
 
 } // namespace Units
 } // namespace Kernel

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -927,7 +927,6 @@ void MDNorm::calculateNormalization(const std::vector<coord_t> &otherValues,
 
   // Mappings
   const int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
-  detid2index_map fluxDetToIdx;
   detid2index_map solidAngDetToIdx;
   bool haveSA = false;
   API::MatrixWorkspace_const_sptr solidAngleWS =
@@ -937,9 +936,7 @@ void MDNorm::calculateNormalization(const std::vector<coord_t> &otherValues,
     haveSA = true;
     solidAngDetToIdx = solidAngleWS->getDetectorIDToWorkspaceIndexMap();
   }
-  if (m_diffraction) {
-    fluxDetToIdx = integrFlux->getDetectorIDToWorkspaceIndexMap();
-  }
+  const detid2index_map fluxDetToIdx = (m_diffraction) ? integrFlux->getDetectorIDToWorkspaceIndexMap() : detid2index_map();
 
   const size_t vmdDims = (m_diffraction) ? 3 : 4;
   std::vector<std::atomic<signal_t>> signalArray(m_normWS->getNPoints());

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -927,16 +927,19 @@ void MDNorm::calculateNormalization(const std::vector<coord_t> &otherValues,
 
   // Mappings
   const int64_t ndets = static_cast<int64_t>(spectrumInfo.size());
-  detid2index_map solidAngDetToIdx;
   bool haveSA = false;
   API::MatrixWorkspace_const_sptr solidAngleWS =
       getProperty("SolidAngleWorkspace");
   API::MatrixWorkspace_const_sptr integrFlux = getProperty("FluxWorkspace");
   if (solidAngleWS != nullptr) {
     haveSA = true;
-    solidAngDetToIdx = solidAngleWS->getDetectorIDToWorkspaceIndexMap();
   }
-  const detid2index_map fluxDetToIdx = (m_diffraction) ? integrFlux->getDetectorIDToWorkspaceIndexMap() : detid2index_map();
+  const detid2index_map solidAngDetToIdx =
+      (haveSA) ? solidAngleWS->getDetectorIDToWorkspaceIndexMap()
+               : detid2index_map();
+  const detid2index_map fluxDetToIdx =
+      (m_diffraction) ? integrFlux->getDetectorIDToWorkspaceIndexMap()
+                      : detid2index_map();
 
   const size_t vmdDims = (m_diffraction) ? 3 : 4;
   std::vector<std::atomic<signal_t>> signalArray(m_normWS->getNPoints());

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -71,8 +71,8 @@ MDNorm::MDNorm()
     : m_normWS(), m_inputWS(), m_isRLU(false), m_UB(3, 3, true),
       m_W(3, 3, true), m_transformation(), m_hX(), m_kX(), m_lX(), m_eX(),
       m_hIdx(-1), m_kIdx(-1), m_lIdx(-1), m_eIdx(-1), m_numExptInfos(0),
-      m_Ei(0.0), m_diffraction(true), m_accumulate(false),
-      m_dEIntegrated(true), m_samplePos(), m_beamDir(), convention("") {}
+      m_Ei(0.0), m_diffraction(true), m_accumulate(false), m_dEIntegrated(true),
+      m_samplePos(), m_beamDir(), convention("") {}
 
 /// Algorithms name for identification. @see Algorithm::name
 const std::string MDNorm::name() const { return "MDNorm"; }
@@ -793,8 +793,8 @@ MDNorm::binInputWS(std::vector<Geometry::SymmetryOperation> symmetryOps) {
   auto outputMDHWS = boost::dynamic_pointer_cast<MDHistoWorkspace>(outputWS);
   // set MDUnits for Q dimensions
   if (m_isRLU) {
-    Mantid::Geometry::MDFrameArgument argument(Mantid::Geometry::HKL::HKLName,
-                                               Mantid::Kernel::Units::Symbol::RLU);
+    Mantid::Geometry::MDFrameArgument argument(
+        Mantid::Geometry::HKL::HKLName, Mantid::Kernel::Units::Symbol::RLU);
     auto mdFrameFactory = Mantid::Geometry::makeMDFrameFactoryChain();
     Mantid::Geometry::MDFrame_uptr hklFrame = mdFrameFactory->create(argument);
     for (size_t i : qDimensionIndices) {
@@ -974,15 +974,14 @@ for (int64_t i = 0; i < ndets; i++) {
 
   // get the flux spectrum number
   size_t wsIdx = 0;
-  if(m_diffraction) {
-    auto index=fluxDetToIdx.find(detID);
+  if (m_diffraction) {
+    auto index = fluxDetToIdx.find(detID);
     if (index != fluxDetToIdx.end()) {
       wsIdx = index->second;
-    } else { //masked detector in flux, but not in input workspace
+    } else { // masked detector in flux, but not in input workspace
       continue;
     }
   }
-
 
   // Intersections
   this->calculateIntersections(intersections, theta, phi, Qtransform,

--- a/docs/source/algorithms/LoadDNSSCD-v1.rst
+++ b/docs/source/algorithms/LoadDNSSCD-v1.rst
@@ -102,10 +102,10 @@ Usage
 
     Output Workspace Type is:  MDEventWorkspace<MDEvent,4>
     It has 24 events and 4 dimensions:
-    Dimension 0 has name: H, id: H, Range: -15.22 to 15.22 r.l.u
-    Dimension 1 has name: K, id: K, Range: -15.22 to 15.22 r.l.u
-    Dimension 2 has name: L, id: L, Range: -41.95 to 41.95 r.l.u
-    Dimension 3 has name: DeltaE, id: DeltaE, Range: -10.00 to 4.64 r.l.u
+    Dimension 0 has name: H, id: H, Range: -15.22 to 15.22 r.l.u.
+    Dimension 1 has name: K, id: K, Range: -15.22 to 15.22 r.l.u.
+    Dimension 2 has name: L, id: L, Range: -41.95 to 41.95 r.l.u.
+    Dimension 3 has name: DeltaE, id: DeltaE, Range: -10.00 to 4.64 r.l.u.
     TableWorkspace 'huber_ws' has 1 row in the column 'Huber(degrees)'.
     It contains sample rotation angle 79.0 degrees
 

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -39,6 +39,9 @@ Bug Fixes
 
 - GUI now correctly loads the file browsed to instead of looking for a run number in every folder along the path to that file.
 
+- :ref:`MDNorm <algm-MDNorm>` will not crash if the detector is masked in the flux workspace, but not in the input workspace.
+
+
 Single Crystal Diffraction
 --------------------------
 

--- a/docs/source/release/v4.1.0/direct_geometry.rst
+++ b/docs/source/release/v4.1.0/direct_geometry.rst
@@ -42,6 +42,8 @@ Improvements
 Bugfixes
 ########
 
+- :ref:`MDNorm <algm-MDNorm>` now allows completely integrating the energy transfer dimension.
+
 Python
 ------
 


### PR DESCRIPTION
**Description of work.**
The following bugs were fixed
- for diffraction, if the flux workspace has a detector masked that is not masked in the input workspace, `MDNorm` used to segfault
- for inelastic workspace, the `DeltaE` dimension used to be a required dimension to bin
- the output workspaces are now having HKL special coordinate system

**To test:**

<!-- Instructions for testing. -->
Here is the script from Ross that showed the segfault issue
```python
from mantid.simpleapi import *

LoadNexus(Filename='/SNS/users/rwp/SHUG_tutorial/Flux.nxs', OutputWorkspace='Flux')
LoadNexus(Filename='/SNS/users/rwp/SHUG_tutorial/SA.nxs', OutputWorkspace='SA')

# load with mask
ConvertMultipleRunsToSingleCrystalMD(Filename='CORELLI_8600',
                                     SetGoniometer=True,
                                     Axis0='BL9:Mot:Sample:Axis1,0,1,0,1',
                                     MaskFile='/SNS/users/rwp/corelli/ZrO2/IPTS-12310/mask.xml',
                                     OutputWorkspace='md',
                                     FilterByTimeStop=60,
                                     MinValues=[-15,-15,-15],
                                     MaxValues=[15,15,15],
                                     MomentumMin=2.5,
                                     MomentumMax=10.0)

LoadIsawUB('md','/SNS/users/rwp/SHUG_tutorial/ZrO2_300K.mat')

# this runs
MDNorm(InputWorkspace='md',
       SolidAngleWorkspace='SA',
       FluxWorkspace='Flux',
       Dimension0Binning='-8.52,0.04,8.52',
       Dimension1Binning='-8.52,0.04,8.52',
       Dimension2Binning='-8.52,0.04,8.52',
       OutputWorkspace='result',
       OutputDataWorkspace='dataMD',
       OutputNormalizationWorkspace='normMD')

# load without mask
ConvertMultipleRunsToSingleCrystalMD(Filename='CORELLI_8600',
                                     SetGoniometer=True,
                                     Axis0='BL9:Mot:Sample:Axis1,0,1,0,1',
                                     OutputWorkspace='md2',
                                     FilterByTimeStop=60,
                                     MinValues=[-15,-15,-15],
                                     MaxValues=[15,15,15],
                                     MomentumMin=2.5,
                                     MomentumMax=10.0)

LoadIsawUB('md2','/SNS/users/rwp/SHUG_tutorial/ZrO2_300K.mat')

# this segfaults
MDNorm(InputWorkspace='md2',
       SolidAngleWorkspace='SA',
       FluxWorkspace='Flux',
       Dimension0Binning='-8.52,0.04,8.52',
       Dimension1Binning='-8.52,0.04,8.52',
       Dimension2Binning='-8.52,0.04,8.52',
       OutputWorkspace='result2',
       OutputDataWorkspace='dataMD2',
       OutputNormalizationWorkspace='normMD2')
```

For the inelastic integration of energy, use the documentation test, and just completely skip the `DeltaE` dimension.

For the special coordinate system, check that running `print(mtd['result2'].getSpecialCoordinateSystem())` after the first script yields `HKL`

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
