### PR TITLE
switch to use miniconda3 docker image for systemtests of mantid-framework conda package

### DIFF
--- a/Testing/SystemTests/scripts/install_conda_mantid.sh
+++ b/Testing/SystemTests/scripts/install_conda_mantid.sh
@@ -5,13 +5,13 @@
 # which has cmake and gcc installed
 
 CONDA_PREFIX=/opt/conda
+CONDA_DEFAULT_ENV_PREFIX=${CONDA_PREFIX}
 
 conda config --add channels conda-forge
 conda config --add channels mantid
 conda config --set always_yes true
 
 # checking
-source activate mantid-systemtests
 echo "checking installation environment..."
 pwd
 which conda
@@ -29,7 +29,10 @@ mkdir -p ${CONDA_PREFIX}/conda-bld/linux-64
 cp ${package} ${CONDA_PREFIX}/conda-bld/linux-64
 set -e
 conda index ${CONDA_PREFIX}/conda-bld
-conda install -c ${CONDA_PREFIX}/conda-bld mantid-framework=${VERSION}=${BUILD}
+
+# install
+source activate mantid-systemtests
+conda install -c ${CONDA_DEFAULT_ENV_PREFIX}/conda-bld mantid-framework=${VERSION}=${BUILD}
 
 # post-install check
 echo "post-installation check ..."


### PR DESCRIPTION
**Description of work.**
miniconda2 was used before but recently it becomes not as stable. Recently the jenkins system tests fails as `conda index` command hangs. Switch to miniconda3 and use the base environment to do conda indexing.  See also: [system tests script for conda mantid-framework build run by jenkins](https://github.com/mantidproject/conda-recipes/blob/1369e3/docker/framework/run_docker_jenkinssystemtests_continuumio-mc.sh)

**To test:**

This is tested by https://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-conda/471/

*There is no associated issue.*

*This does not require release notes* because **this is an internal change**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
