### PR TITLE
Switched to doing show data in one place

### DIFF
--- a/Framework/Muon/src/MuonGroupingCounts.cpp
+++ b/Framework/Muon/src/MuonGroupingCounts.cpp
@@ -40,7 +40,7 @@ MatrixWorkspace_sptr groupDetectors(MatrixWorkspace_sptr workspace,
   if (wsIndices.size() != detectorIDs.size()) {
     std::string errorMsg =
         str(boost::format("The number of detectors"
-                          "requested does not equalthe number of detectors "
+                          " requested does not equal the number of detectors "
                           "provided %1% != %2% ") %
             wsIndices.size() % detectorIDs.size());
     throw std::invalid_argument(errorMsg);

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -182,6 +182,7 @@ class GroupingTabPresenter(object):
             self.grouping_table_widget.update_view_from_model()
             self.pairing_table_widget.update_view_from_model()
             self.update_description_text()
+            self.handle_update_all_clicked()
         else:
             self.on_clear_requested()
 

--- a/scripts/Muon/GUI/Common/home_tab/home_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/home_tab/home_tab_presenter.py
@@ -78,7 +78,6 @@ class HomeTabPresenter(object):
 
         def update(self, observable, arg):
             self.outer.update_all_widgets()
-            # self.outer.show_all_data()
 
     class GroupingObserver(Observer):
 

--- a/scripts/Muon/GUI/Common/home_tab/home_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/home_tab/home_tab_presenter.py
@@ -44,10 +44,6 @@ class HomeTabPresenter(object):
     def show(self):
         self._view.show()
 
-    def show_all_data(self):
-        if self._model.is_data_loaded():
-            self._model.show_all_data()
-
     def update_all_widgets(self):
         """
         Update all widgets from the context.
@@ -82,7 +78,7 @@ class HomeTabPresenter(object):
 
         def update(self, observable, arg):
             self.outer.update_all_widgets()
-            self.outer.show_all_data()
+            # self.outer.show_all_data()
 
     class GroupingObserver(Observer):
 

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -82,33 +82,15 @@ set ( TEST_PY_FILES_QT5
    loading_tab/loadwidget_presenter_multiple_file_test.py
    loading_tab/loadwidget_presenter_failure_test.py
    phase_table_widget/phase_table_presenter_test.py
-   phase_table_widget/phase_table_context_test.py
-   frequency_domain_context_test.py
    grouping_tab/grouping_table_presenter_test.py
    grouping_tab/pairing_table_presenter_test.py
    grouping_tab/grouping_tab_presenter_test.py
    grouping_tab/pairing_table_group_selector_test.py
    grouping_tab/pairing_table_alpha_test.py
-   MaxEntModel_test.py
    MaxEntPresenter_test.py
    max_ent_presenter_load_interaction_test.py
-   muon_context_test.py
-   muon_data_context_test.py
-   muon_gui_context_test.py
-   muon_group_pair_context_test.py
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
-   transformWidget_test.py
-   utilities/muon_group_test.py
-   utilities/muon_pair_test.py
-   utilities/load_utils_test.py
-   utilities/thread_model_test.py
-   utilities/muon_workspace_wrapper_test.py
-   utilities/muon_workspace_wrapper_directory_test.py
-   utilities/muon_load_data_test.py
-   utilities/muon_file_utils_test.py
-   utilities/run_string_utils_operator_test.py
-   utilities/run_string_utils_conversion_test.py
    help_widget_presenter_test.py
 )
 

--- a/scripts/test/Muon/transformWidget_test.py
+++ b/scripts/test/Muon/transformWidget_test.py
@@ -7,8 +7,8 @@
 import unittest
 
 from mantid.py3compat import mock
+from mantidqt.utils.qt.testing import GuiTest
 
-from Muon.GUI.Common.test_helpers import mock_widget
 from Muon.GUI.Common.utilities import load_utils
 from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_presenter
 from Muon.GUI.FrequencyDomainAnalysis.FFT.fft_widget import FFTWidget
@@ -19,30 +19,29 @@ from Muon.GUI.FrequencyDomainAnalysis.Transform import transform_widget
 from Muon.GUI.FrequencyDomainAnalysis.TransformSelection import transform_selection_view
 
 
-class TransformTest(unittest.TestCase):
+class TransformTest(GuiTest):
     def setUp(self):
-        self._qapp = mock_widget.mockQapp()
-        self.load=  mock.create_autospec( load_utils.LoadUtils,spec_set=True)
-        self.fft=   mock.create_autospec( fft_presenter.FFTPresenter,spec_Set=True)
-        self.maxent=mock.create_autospec( maxent_presenter.MaxEntPresenter,spec_set=True)
+        self.load = mock.create_autospec(load_utils.LoadUtils, spec_set=True)
+        self.fft = mock.create_autospec(fft_presenter.FFTPresenter, spec_Set=True)
+        self.maxent = mock.create_autospec(maxent_presenter.MaxEntPresenter, spec_set=True)
 
         # create widget
-        self.widget=transform_widget.TransformWidget(self.load, FFTWidget, MaxEntWidget)
+        self.widget = transform_widget.TransformWidget(self.load, FFTWidget, MaxEntWidget)
         # create the view
-        self.view=mock.create_autospec(transform_view.TransformView,spec_set=False)
-        self.view.getView=mock.Mock()
-        self.view.getMethods=mock.Mock(return_value=["FFT","MaxEnt"])
-        self.view.hideAll=mock.Mock()
-        self.view.showMethod=mock.Mock()
-        self.view.selection=mock.create_autospec(transform_selection_view.TransformSelectionView,spec_set=True)
-        self.view.selection.changeMethodSignal=mock.Mock()
+        self.view = mock.create_autospec(transform_view.TransformView, spec_set=False)
+        self.view.getView = mock.Mock()
+        self.view.getMethods = mock.Mock(return_value=["FFT", "MaxEnt"])
+        self.view.hideAll = mock.Mock()
+        self.view.showMethod = mock.Mock()
+        self.view.selection = mock.create_autospec(transform_selection_view.TransformSelectionView, spec_set=True)
+        self.view.selection.changeMethodSignal = mock.Mock()
         # set the mocked view to the widget
-        self.widget.mockWidget(self.view)  
+        self.widget.mockWidget(self.view)
 
     def test_changeDisplay(self):
         self.widget.updateDisplay(1)
-        assert(self.view.hideAll.call_count==1)
-        self.assertEquals(self.view.showMethod.call_count,1)
+        assert (self.view.hideAll.call_count == 1)
+        self.assertEquals(self.view.showMethod.call_count, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

This fixes an issue where-by the Muon GUI could crash when runs with different IDF's were loaded concurrently. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Open the new Muon Analysis GUI, switch to the EMU instrument  and load run 90,000. Then try and load the run 812. You should get a succession of error boxes rather than a hard crash.

<!-- Instructions for testing. -->

Fixes #25779 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
