### PR TITLE
Adding results tab to new Muon Analysis Interface

### DIFF
--- a/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/inc/MantidPythonInterface/kernel/PropertyWithValueExporter.h
@@ -46,7 +46,8 @@ struct PropertyWithValueExporter {
     using namespace Mantid::Kernel;
 
     class_<PropertyWithValue<HeldType>, bases<Property>, boost::noncopyable>(
-        pythonClassName, no_init)
+        pythonClassName,
+        init<std::string, HeldType>((arg("self"), arg("name"), arg("value"))))
         .add_property("value",
                       make_function(&PropertyWithValue<HeldType>::operator(),
                                     return_value_policy<ValueReturnPolicy>()))

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -67,8 +67,8 @@ class RunTest(unittest.TestCase):
         self.assertEquals(self._expt_ws.run().get('not_a_log', 5.), 5.)
 
     def test_run_getPropertyAsSingleValue_with_number(self):
-        nspectra = self._expt_ws.run().getPropertyAsSingleValue('nspectra')
-        self.assertEquals(nspectra, float(self._nspec))
+        charge = self._expt_ws.run().getPropertyAsSingleValue('gd_prtn_chrg')
+        self.assertAlmostEqual(10.05, charge)
 
     def test_add_property_with_known_type_succeeds(self):
         run = self._expt_ws.run()

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -11,18 +11,24 @@ from testhelpers import run_algorithm
 from mantid.geometry import Goniometer
 from mantid.kernel import DateAndTime
 
+
 class RunTest(unittest.TestCase):
 
     _expt_ws = None
-    _nspec=1
+    _nspec = 1
 
     def setUp(self):
         if self.__class__._expt_ws is None:
-            alg = run_algorithm('CreateWorkspace', DataX=[1,2,3,4,5], DataY=[1,2,3,4,5],NSpec=self._nspec, child=True)
+            alg = run_algorithm('CreateWorkspace',
+                                DataX=[1, 2, 3, 4, 5],
+                                DataY=[1, 2, 3, 4, 5],
+                                NSpec=self._nspec,
+                                child=True)
             ws = alg.getProperty("OutputWorkspace").value
             ws.run().addProperty("gd_prtn_chrg", 10.05, True)
             ws.run().addProperty("nspectra", self._nspec, True)
-            ws.run().setStartAndEndTime(DateAndTime("2008-12-18T17:58:38"), DateAndTime("2008-12-18T17:59:40"))
+            ws.run().setStartAndEndTime(DateAndTime("2008-12-18T17:58:38"),
+                                        DateAndTime("2008-12-18T17:59:40"))
             self.__class__._expt_ws = ws
 
     def test_get_goniometer(self):
@@ -49,7 +55,8 @@ class RunTest(unittest.TestCase):
         def do_spectra_check(nspectra):
             self.assertEquals(type(nspectra.value), int)
             self.assertEquals(nspectra.value, self._nspec)
-            self.assertRaises(RuntimeError, self._expt_ws.run().getProperty, 'not_a_log')
+            self.assertRaises(RuntimeError,
+                              self._expt_ws.run().getProperty, 'not_a_log')
 
         do_spectra_check(self._expt_ws.run().getProperty('nspectra'))
         do_spectra_check(self._expt_ws.run()['nspectra'])
@@ -58,6 +65,10 @@ class RunTest(unittest.TestCase):
         # get returns the default if key does not exist, or None if no default
         self.assertEquals(self._expt_ws.run().get('not_a_log'), None)
         self.assertEquals(self._expt_ws.run().get('not_a_log', 5.), 5.)
+
+    def test_run_getPropertyAsSingleValue_with_number(self):
+        nspectra = self._expt_ws.run().getPropertyAsSingleValue('nspectra')
+        self.assertEquals(nspectra, float(self._nspec))
 
     def test_add_property_with_known_type_succeeds(self):
         run = self._expt_ws.run()
@@ -100,7 +111,9 @@ class RunTest(unittest.TestCase):
 
         runstart = run.startTime()
         runstartstr = str(runstart)
-        self.assertEquals(runstartstr, "2008-12-18T17:58:38 ") # The space at the end is to get around an IPython bug (#8351)
+        self.assertEquals(
+            runstartstr, "2008-12-18T17:58:38 "
+        )  # The space at the end is to get around an IPython bug (#8351)
         self.assertTrue(isinstance(runstart, DateAndTime))
 
     def test_endtime(self):
@@ -110,8 +123,11 @@ class RunTest(unittest.TestCase):
 
         runend = run.endTime()
         runendstr = str(runend)
-        self.assertEquals(runendstr, "2008-12-18T17:59:40 ") # The space at the end is to get around an IPython bug (#8351)
+        self.assertEquals(
+            runendstr, "2008-12-18T17:59:40 "
+        )  # The space at the end is to get around an IPython bug (#8351)
         self.assertTrue(isinstance(runend, DateAndTime))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyWithValueTest.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 from mantid.api import AlgorithmManager, MatrixWorkspace
+from mantid.kernel import Property, StringPropertyWithValue
 from testhelpers import create_algorithm, run_algorithm
 import numpy as np
 import sys
@@ -27,6 +28,12 @@ class PropertyWithValueTest(unittest.TestCase):
         if self._mask_dets is None:
             self.__class__._mask_dets = create_algorithm("MaskDetectors")
             self.__class__._mask_dets.initialize()
+
+    def test_construction_by_name(self):
+        prop = StringPropertyWithValue("testprop", "default")
+        self.assertTrue(isinstance(prop, Property))
+        self.assertEqual(prop.name, "testprop")
+        self.assertEqual(prop.value, "default")
 
     def test_value_setting_as_string_gives_expected_value_for_correct_type(self):
         prop = self.__class__._integration.getProperty("RangeLower")

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -4,54 +4,85 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division)
+
 from Muon.GUI.Common.observer_pattern import Observable
 
 
-class FittingNotifier(Observable):
-    def __init__(self, outer):
-        Observable.__init__(self)
-        self.outer = outer  # handle to containing class
-
-    def notify_subscribers(self, *args, **kwargs):
-        Observable.notify_subscribers(self, *args, **kwargs)
-
-
 class FitInformation(object):
-    def __init__(self, parameter_workspace, fit_function_name, input_workspace):
+    """Data-object encapsulating a single fit"""
+
+    def __init__(self, parameter_workspace, fit_function_name,
+                 input_workspace):
+        """
+        :param parameter_workspace: The workspace wrapper
+        that contains all of the parameters from the fit
+        :param fit_function_name: The name of the function used
+        :param input_workspace: The name of the workspace containing
+        the original data
+        """
         self.parameter_workspace = parameter_workspace
         self.fit_function_name = fit_function_name
         self.input_workspace = input_workspace
 
     @property
     def parameter_name(self):
+        """Returns the name of the parameter workspace"""
         return self.parameter_workspace.workspace_name
 
     def __eq__(self, other):
-        return self.parameter_workspace == other.parameter_workspace\
-               and self.fit_function_name == other.fit_function_name\
-               and self.input_workspace == other.input_workspace
+        """Objects are equal if each member is equal to the other"""
+        return self.parameter_workspace == other.parameter_workspace and \
+               self.fit_function_name == other.fit_function_name and \
+               self.input_workspace == other.input_workspace
 
 
 class FittingContext(object):
+    """Context specific to fitting.
+
+    It holds details are any fits performed including:
+       - input workspaces
+       - parameters
+       - function names
+    """
+
     def __init__(self):
         self.fit_list = []
-        self.new_fit_notifier = FittingNotifier(self)
+        # Register callbacks with this object to observe when new fits
+        # are added
+        self.new_fit_notifier = Observable()
+
+    def add_fit_from_values(self, parameter_workspace, fit_function_name,
+                            input_workspace):
+        """
+        Add a new fit information object based on the raw values.
+        See FitInformation constructor for details are arguments
+        """
+        self.add_fit(
+            FitInformation(parameter_workspace, fit_function_name,
+                           input_workspace))
 
     def add_fit(self, fit):
+        """
+        Add a new fit to the context. Subscribers are notified of the update.
+        :param fit: A new FitInformation object
+        """
         self.fit_list.append(fit)
         self.new_fit_notifier.notify_subscribers()
 
-    def add_fit_from_values(self, parameter_workspace, fit_function_name, input_workspace):
-        fit_information = FitInformation(parameter_workspace, fit_function_name, input_workspace)
-        self.add_fit(fit_information)
-
-    def get_list_of_fits_for_a_given_fit_function(self, fit_function_name):
-        return [fit for fit in self.fit_list if fit.fit_function_name == fit_function_name]
-
-    def get_list_of_fit_functions(self):
+    def fit_function_names(self):
+        """
+        :return: a list of unique function names used in the fit
+        """
         return list(set([fit.fit_function_name for fit in self.fit_list]))
 
-    def get_fit_object_from_parameter_name(self, parameter_name):
-        for fit in self.fit_list:
-            if fit.parameter_name == parameter_name:
-                return fit
+    def find_fits_for_function(self, fit_function_name):
+        """
+        Find the functoins in the list whose function name matches
+        :param fit_function_name: The name of the function
+        :return: A list of any matching fits
+        """
+        return [
+            fit for fit in self.fit_list
+            if fit.fit_function_name == fit_function_name
+        ]

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -50,3 +50,8 @@ class FittingContext(object):
 
     def get_list_of_fit_functions(self):
         return list(set([fit.fit_function_name for fit in self.fit_list]))
+
+    def get_fit_object_from_parameter_name(self, parameter_name):
+        for fit in self.fit_list:
+            if fit.parameter_name == parameter_name:
+                return fit

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -33,8 +33,8 @@ class FitInformation(object):
     def __eq__(self, other):
         """Objects are equal if each member is equal to the other"""
         return self.parameter_workspace == other.parameter_workspace and \
-               self.fit_function_name == other.fit_function_name and \
-               self.input_workspace == other.input_workspace
+            self.fit_function_name == other.fit_function_name and \
+            self.input_workspace == other.input_workspace
 
 
 class FittingContext(object):
@@ -51,6 +51,12 @@ class FittingContext(object):
         # Register callbacks with this object to observe when new fits
         # are added
         self.new_fit_notifier = Observable()
+
+    def __len__(self):
+        """
+        :return: The number of fits in the list
+        """
+        return len(self.fit_list)
 
     def add_fit_from_values(self, parameter_workspace, fit_function_name,
                             input_workspace):

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -1,0 +1,52 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.observer_pattern import Observable
+
+
+class FittingNotifier(Observable):
+    def __init__(self, outer):
+        Observable.__init__(self)
+        self.outer = outer  # handle to containing class
+
+    def notify_subscribers(self, *args, **kwargs):
+        Observable.notify_subscribers(self, *args, **kwargs)
+
+
+class FitInformation(object):
+    def __init__(self, parameter_workspace, fit_function_name, input_workspace):
+        self.parameter_workspace = parameter_workspace
+        self.fit_function_name = fit_function_name
+        self.input_workspace = input_workspace
+
+    @property
+    def parameter_name(self):
+        return self.parameter_workspace.workspace_name
+
+    def __eq__(self, other):
+        return self.parameter_workspace == other.parameter_workspace\
+               and self.fit_function_name == other.fit_function_name\
+               and self.input_workspace == other.input_workspace
+
+
+class FittingContext(object):
+    def __init__(self):
+        self.fit_list = []
+        self.new_fit_notifier = FittingNotifier(self)
+
+    def add_fit(self, fit):
+        self.fit_list.append(fit)
+        self.new_fit_notifier.notify_subscribers()
+
+    def add_fit_from_values(self, parameter_workspace, fit_function_name, input_workspace):
+        fit_information = FitInformation(parameter_workspace, fit_function_name, input_workspace)
+        self.add_fit(fit_information)
+
+    def get_list_of_fits_for_a_given_fit_function(self, fit_function_name):
+        return [fit for fit in self.fit_list if fit.fit_function_name == fit_function_name]
+
+    def get_list_of_fit_functions(self):
+        return list(set([fit.fit_function_name for fit in self.fit_list]))

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -78,7 +78,7 @@ class FittingContext(object):
 
     def find_fits_for_function(self, fit_function_name):
         """
-        Find the functoins in the list whose function name matches
+        Find the fits in the list whose function name matches
         :param fit_function_name: The name of the function
         :return: A list of any matching fits
         """

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -13,6 +13,7 @@ from Muon.GUI.Common.calculate_pair_and_group import calculate_group_data, calcu
 from Muon.GUI.Common.contexts.muon_data_context import MuonDataContext
 from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContext
 from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
+from Muon.GUI.Common.contexts.fitting_context import FittingContext
 from Muon.GUI.Common.contexts.phase_table_context import PhaseTableContext
 from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string, run_string_to_list
 import Muon.GUI.Common.ADSHandler.workspace_naming as wsName
@@ -21,11 +22,13 @@ from Muon.GUI.Common.contexts.muon_data_context import get_default_grouping
 
 class MuonContext(object):
     def __init__(self, muon_data_context=MuonDataContext(), muon_gui_context=MuonGuiContext(),
-                 muon_group_context=MuonGroupPairContext(), base_directory='Muon Data', muon_phase_context= PhaseTableContext()):
+                 muon_group_context=MuonGroupPairContext(), base_directory='Muon Data', muon_phase_context= PhaseTableContext(),
+                 fitting_context=FittingContext()):
         self._data_context = muon_data_context
         self._gui_context = muon_gui_context
         self._group_pair_context = muon_group_context
         self._phase_context = muon_phase_context
+        self.fitting_context = fitting_context
         self.base_directory = base_directory
 
         self.gui_context.update({'DeadTimeSource': 'None', 'LastGoodDataFromFile': True, 'selected_group_pair': ''})

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -13,80 +13,106 @@ from mantid.api import FunctionFactory
 
 
 class FittingTabModel(object):
-    def __init__(self):
-        pass
+    def __init__(self, context):
+        self.context = context
 
     def do_single_fit(self, parameter_dict):
         output_workspace, fitting_parameters_table, function_string, output_status, output_chi_squared =\
             self.do_single_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
 
-        workspace_name, directory = self.create_fitted_workspace_name(parameter_dict['InputWorkspace'],
-                                                                      parameter_dict['Function'])
-        table_name, directory = self.create_parameter_table_name(parameter_dict['InputWorkspace'],
-                                                                 parameter_dict['Function'])
+        workspace_name, directory = self.create_fitted_workspace_name(
+            parameter_dict['InputWorkspace'], parameter_dict['Function'])
+        table_name, directory = self.create_parameter_table_name(
+            parameter_dict['InputWorkspace'], parameter_dict['Function'])
 
         self.add_workspace_to_ADS(output_workspace, workspace_name, directory)
-        self.add_workspace_to_ADS(fitting_parameters_table, table_name, directory)
+        wrapped_parameter_workspace = self.add_workspace_to_ADS(
+            fitting_parameters_table, table_name, directory)
+        self.add_fit_to_context(wrapped_parameter_workspace,
+                                parameter_dict['Function'],
+                                parameter_dict['InputWorkspace'])
 
         return function_string, output_status, output_chi_squared
 
-    def do_single_fit_and_return_workspace_parameters_and_fit_function(self, parameters_dict):
+    def do_single_fit_and_return_workspace_parameters_and_fit_function(
+            self, parameters_dict):
         alg = mantid.AlgorithmManager.create("Fit")
         return run_Fit(parameters_dict, alg)
 
     def add_workspace_to_ADS(self, workspace, name, directory):
         workspace_wrapper = MuonWorkspaceWrapper(workspace, directory + name)
         workspace_wrapper.show()
+        return workspace_wrapper
 
-    def create_fitted_workspace_name(self, input_workspace_name, function_name):
+    def create_fitted_workspace_name(self, input_workspace_name,
+                                     function_name):
         directory = get_fit_workspace_base_directory()
-        name = input_workspace_name + '; Fitted; ' + self.get_function_name(function_name)
+        name = input_workspace_name + '; Fitted; ' + self.get_function_name(
+            function_name)
 
         return name, directory
 
-    def create_multi_domain_fitted_workspace_name(self, input_workspace, function):
+    def create_multi_domain_fitted_workspace_name(self, input_workspace,
+                                                  function):
         directory = get_fit_workspace_base_directory()
-        name = input_workspace + '+ ...; Fitted; ' + self.get_function_name(function)
+        name = input_workspace + '+ ...; Fitted; ' + self.get_function_name(
+            function)
 
         return name, directory
 
     def create_parameter_table_name(self, input_workspace_name, function_name):
         directory = get_fit_workspace_base_directory()
-        name = input_workspace_name + '; Fitted Parameters; ' + self.get_function_name(function_name)
+        name = input_workspace_name + '; Fitted Parameters; ' + self.get_function_name(
+            function_name)
         return name, directory
 
     def do_simultaneous_fit(self, parameter_dict):
         output_workspace, fitting_parameters_table, function_string, output_status, output_chi_squared =\
             self.do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
 
-        workspace_name, directory = self.create_multi_domain_fitted_workspace_name(parameter_dict['InputWorkspace'][0],
-                                                                                   parameter_dict['Function'])
-        table_name, directory = self.create_parameter_table_name(parameter_dict['InputWorkspace'][0] + '+ ...',
+        workspace_name, directory = self.create_multi_domain_fitted_workspace_name(
+            parameter_dict['InputWorkspace'][0], parameter_dict['Function'])
+        table_name, directory = self.create_parameter_table_name(
+            parameter_dict['InputWorkspace'][0] + '+ ...',
                                                                  parameter_dict['Function'])
 
         self.add_workspace_to_ADS(output_workspace, workspace_name, directory)
         if len(parameter_dict['InputWorkspace']) > 1:
-            self.rename_members_of_fitted_workspace_group(output_workspace, parameter_dict['InputWorkspace'], parameter_dict['Function'])
-        self.add_workspace_to_ADS(fitting_parameters_table, table_name, directory)
+            self.rename_members_of_fitted_workspace_group(
+                output_workspace, parameter_dict['InputWorkspace'],
+                parameter_dict['Function'])
+        wrapped_parameter_workspace = self.add_workspace_to_ADS(
+            fitting_parameters_table, table_name, directory)
+        self.add_fit_to_context(wrapped_parameter_workspace,
+                                parameter_dict['Function'],
+                                parameter_dict['InputWorkspace'])
 
         return function_string, output_status, output_chi_squared
 
-    def do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(self, parameters_dict):
+
+    def do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(
+            self, parameters_dict):
         alg = mantid.AlgorithmManager.create("Fit")
         return run_simultaneous_Fit(parameters_dict, alg)
 
-    def rename_members_of_fitted_workspace_group(self, group_workspace, inputworkspace_list, function):
+    def rename_members_of_fitted_workspace_group(self, group_workspace,
+                                                 inputworkspace_list,
+                                                 function):
         for index, workspace_name in enumerate(group_workspace.getNames()):
-            new_name, _ = self.create_fitted_workspace_name(inputworkspace_list[index], function)
+            new_name, _ = self.create_fitted_workspace_name(
+                inputworkspace_list[index], function)
             new_name += '; Simultaneous'
-            RenameWorkspace(InputWorkspace=workspace_name, OutputWorkspace=new_name)
+            RenameWorkspace(InputWorkspace=workspace_name,
+                            OutputWorkspace=new_name)
 
     def do_sequential_fit(self, parameter_dict):
         function_string_list = []
         output_status_list = []
         output_chi_squared_list = []
         function_string = parameter_dict['Function']
-        for input_workspace, startX, endX in zip(parameter_dict['InputWorkspace'], parameter_dict['StartX'], parameter_dict['EndX']):
+        for input_workspace, startX, endX in zip(
+                parameter_dict['InputWorkspace'], parameter_dict['StartX'],
+                parameter_dict['EndX']):
             sub_parameter_dict = parameter_dict.copy()
             sub_parameter_dict['InputWorkspace'] = input_workspace
             sub_parameter_dict['StartX'] = startX
@@ -107,3 +133,9 @@ class FittingTabModel(object):
             return function.getFunction(0).name()
         else:
             return function.name()
+
+    def add_fit_to_context(self, parameter_workspace, function,
+                           input_workspace):
+        self.context.fitting_context.add_fit_from_values(
+            parameter_workspace, self.get_function_name(function),
+            input_workspace)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -74,7 +74,7 @@ class FittingTabModel(object):
             parameter_dict['InputWorkspace'][0], parameter_dict['Function'])
         table_name, directory = self.create_parameter_table_name(
             parameter_dict['InputWorkspace'][0] + '+ ...',
-                                                                 parameter_dict['Function'])
+            parameter_dict['Function'])
 
         self.add_workspace_to_ADS(output_workspace, workspace_name, directory)
         if len(parameter_dict['InputWorkspace']) > 1:
@@ -88,7 +88,6 @@ class FittingTabModel(object):
                                 parameter_dict['InputWorkspace'])
 
         return function_string, output_status, output_chi_squared
-
 
     def do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
@@ -119,9 +118,11 @@ class FittingTabModel(object):
             sub_parameter_dict['EndX'] = endX
             sub_parameter_dict['Function'] = function_string
 
-            function_string, output_status, output_chi_squared = self.do_single_fit(sub_parameter_dict)
+            function_string, output_status, output_chi_squared = self.do_single_fit(
+                sub_parameter_dict)
             # This is required so that a new function object is created that is not overwritten in subsequent iterations
-            new_function = FunctionFactory.createInitialized(str(function_string))
+            new_function = FunctionFactory.createInitialized(
+                str(function_string))
             function_string_list.append(new_function)
             output_status_list.append(output_status)
             output_chi_squared_list.append(output_chi_squared)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -12,7 +12,7 @@ from Muon.GUI.Common.fitting_tab_widget.fitting_tab_model import FittingTabModel
 class FittingTabWidget(object):
     def __init__(self, context, parent):
         self.fitting_tab_view = FittingTabView(parent)
-        self.fitting_tab_model = FittingTabModel()
+        self.fitting_tab_model = FittingTabModel(context)
 
         self.fitting_tab_presenter = FittingTabPresenter(self.fitting_tab_view, self.fitting_tab_model, context)
 

--- a/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
@@ -30,12 +30,16 @@ class ListSelectorPresenter(object):
         self.filter_list = []
         self.show_only_selected = False
 
-        self.view.set_filter_line_edit_changed_action(self.handle_filter_changed)
-        self.view.set_item_selection_changed_action(self.handle_selection_changed)
+        self.view.set_filter_line_edit_changed_action(
+            self.handle_filter_changed)
+        self.view.set_item_selection_changed_action(
+            self.handle_selection_changed)
         self.view.set_filter_type_combo_changed_action(self.set_filter_type)
-        self.view.set_select_all_checkbox_action(self.handle_select_all_checkbox_changed)
+        self.view.set_select_all_checkbox_action(
+            self.handle_select_all_checkbox_changed)
         self.view.set_row_moved_checkbox_action(self.handle_row_moved)
-        self.view.set_show_selected_checkbox_changed(self.handle_show_selected_checked)
+        self.view.set_show_selected_checkbox_changed(
+            self.handle_show_selected_checked)
 
     def update_view_from_model(self):
         filtered_list = self.get_filtered_list()
@@ -43,9 +47,12 @@ class ListSelectorPresenter(object):
         self.view.clearItems()
         self.view.addItems(filtered_list)
 
-        number_selected = len([item for item in filtered_list if item[view_item_selected]])
-        number_of_selected_displayed = len([item for item in self.model.values() if item[model_selected]])
-        self.view.update_number_of_selected_label(number_selected, number_of_selected_displayed)
+        number_selected = len(
+            [item for item in filtered_list if item[view_item_selected]])
+        number_of_selected_displayed = len(
+            [item for item in self.model.values() if item[model_selected]])
+        self.view.update_number_of_selected_label(
+            number_selected, number_of_selected_displayed)
 
     def handle_filter_changed(self, filter_string):
         self.filter_string = filter_string
@@ -61,8 +68,23 @@ class ListSelectorPresenter(object):
         self.update_view_from_model()
 
     def get_selected_items(self):
-        selected_items = [name for name in self.model if self.model[name][model_selected]]
-        selected_items.sort(key=lambda selected_item: self.model[selected_item][model_position])
+        selected_items = [
+            name for name in self.model if self.model[name][model_selected]
+        ]
+        selected_items.sort(key=lambda selected_item: self.model[selected_item]
+                            [model_position])
+        return selected_items
+
+    def get_selected_items_and_positions(self):
+        """
+        :return: A list of 2-tuples containing the (name, list position)
+        of each selected item. They are ordered by the position
+        """
+        selected_items = [(name, self.model[name][model_position])
+                          for name in self.model
+                          if self.model[name][model_selected]]
+        selected_items.sort(key=lambda selected_item: self.model[selected_item[0]]
+                            [model_position])
         return selected_items
 
     def set_filter_type(self):
@@ -75,16 +97,22 @@ class ListSelectorPresenter(object):
         if insertion_index >= len(filtered_list):
             new_position = len(filtered_list)
         else:
-            name_of_row_to_insert_before = self.get_filtered_list()[insertion_index][view_item_name]
-            new_position = self.model[name_of_row_to_insert_before][model_position]
+            name_of_row_to_insert_before = self.get_filtered_list(
+            )[insertion_index][view_item_name]
+            new_position = self.model[name_of_row_to_insert_before][
+                model_position]
 
-        names_of_rows_moved = [self.get_filtered_list()[index][view_item_name] for index in rows_moved]
+        names_of_rows_moved = [
+            self.get_filtered_list()[index][view_item_name]
+            for index in rows_moved
+        ]
 
         for index, row in enumerate(names_of_rows_moved):
             old_position = self.model[row][model_position] + index
             new_position_temp = new_position + index
             for name in self.model:
-                if new_position_temp <= self.model[name][model_position] < old_position:
+                if new_position_temp <= self.model[name][
+                        model_position] < old_position:
                     self.model[name][model_position] += 1
                 self.model[row][model_position] = new_position_temp
 
@@ -100,20 +128,28 @@ class ListSelectorPresenter(object):
 
     def get_filtered_list(self):
         if self.show_only_selected:
-            filtered_list = [[name, vals[model_selected], vals[model_enabled]] for (name, vals) in self.model.items() if
-                             vals[model_selected]]
-            filtered_list.sort(key=lambda item: self.model[item[view_item_name]][model_position])
+            filtered_list = [[name, vals[model_selected], vals[model_enabled]]
+                             for (name, vals) in self.model.items()
+                             if vals[model_selected]]
+            filtered_list.sort(key=lambda item: self.model[item[view_item_name]
+                                                           ][model_position])
             return filtered_list
 
         if self.filter_type == 'Include':
-            filtered_list = [[name, vals[model_selected], vals[model_enabled]] for (name, vals) in self.model.items() if
-                             self.filter_string in name]
+            filtered_list = [[name, vals[model_selected], vals[model_enabled]]
+                             for (name, vals) in self.model.items()
+                             if self.filter_string in name]
         else:
-            filtered_list = [[name, vals[model_selected], vals[model_enabled]] for (name, vals) in self.model.items() if
-                             self.filter_string not in name]
+            filtered_list = [[name, vals[model_selected], vals[model_enabled]]
+                             for (name, vals) in self.model.items()
+                             if self.filter_string not in name]
 
-        filtered_list.sort(key=lambda item: self.model[item[view_item_name]][model_position])
-        filtered_list = [item for item in filtered_list if item[view_item_name] not in self.filter_list]
+        filtered_list.sort(
+            key=lambda item: self.model[item[view_item_name]][model_position])
+        filtered_list = [
+            item for item in filtered_list
+            if item[view_item_name] not in self.filter_list
+        ]
 
         return filtered_list
 

--- a/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
@@ -4,6 +4,8 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, unicode_literals)
+
 model_position = 0
 model_selected = 1
 model_enabled = 2
@@ -15,6 +17,12 @@ view_item_enabled = 2
 
 class ListSelectorPresenter(object):
     def __init__(self, view, model):
+        """
+        Initialize with a view and model reference
+        :param view: A reference to a view to control
+        :param model: A reference to a dictionary to act as a model. The following structure is expected:
+        {'name': [index_position, ticked, enabled]}
+        """
         self.view = view
         self.model = model
         self.filter_string = ''

--- a/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
@@ -112,3 +112,7 @@ class ListSelectorPresenter(object):
     def update_filter_list(self, filter_list):
         self.filter_list = filter_list
         self.update_view_from_model()
+
+    def update_model(self, new_model):
+        self.model = new_model
+        self.update_view_from_model()

--- a/scripts/Muon/GUI/Common/observer_pattern.py
+++ b/scripts/Muon/GUI/Common/observer_pattern.py
@@ -54,11 +54,25 @@ class Observable(object):
 
 
 class GenericObserver(Observer):
+    """
+    General purpose observer wrapping a Python callable.
+    """
     def __init__(self, callback):
-        Observer.__init__(self)
+        """
+        Initialize the observer
+        :param callback: A Python callable called when update() is called. It
+        should take no arguments
+        """
+        super(GenericObserver, self).__init__()
         self.callback = callback
 
     def update(self, observable, arg):
+        """
+        Called to notify the observer that something has happened. This implementation
+        just calls the registered callback
+        :param observable: A reference to the observable object (unused)
+        :param arg: Argument delivered from the Observable (unused)
+        """
         self.callback()
 
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -133,7 +133,6 @@ class ResultsTabModel(object):
         """
         results_table = self._create_empty_results_table(
             log_selection, results_selection)
-
         fit_list = self._fit_context.fit_list
         for _, position in results_selection:
             fit = fit_list[position]
@@ -157,7 +156,12 @@ class ResultsTabModel(object):
                 if name not in RESULTS_TABLE_COLUMNS_NO_ERRS:
                     row_dict.update({name + 'Error': error})
 
-            results_table.addRow(row_dict)
+            try:
+                results_table.addRow(row_dict)
+            except ValueError:
+                msg = "Incompatible fits for results table:\n"
+                msg += " fit 1 and {} have a different parameters".format(position + 1)
+                raise RuntimeError(msg)
 
         AnalysisDataService.Instance().addOrReplace(self.results_table_name(),
                                                     results_table)
@@ -228,6 +232,7 @@ def log_names(workspace_name):
     return [log.name for log in all_logs if _log_should_be_displayed(log)]
 
 
+# Private helper functions
 def _workspace_for_logs(name_or_names):
     """Return the workspace handle to be used to access the logs.
     We assume workspace_name is a string or a list of strings

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -7,13 +7,16 @@
 #  This file is part of the mantid workbench.
 from __future__ import (absolute_import, division, unicode_literals)
 
-from mantid.api import AnalysisDataService
+from mantid.api import AnalysisDataService, WorkspaceFactory
 from mantid.kernel import FloatTimeSeriesProperty
 
 # Constants
 DEFAULT_TABLE_NAME = 'ResultsTable'
 ALLOWED_NON_TIME_SERIES_LOGS = ("run_number", "run_start", "run_end", "group",
                                 "period", "sample_temp", "sample_magn_field")
+# This is not a particularly robust way of ignoring this as it
+# depends on how Fit chooses to output the name of that value
+RESULTS_TABLE_COLUMNS_NO_ERRS = ['Cost function value']
 
 
 class ResultsTabModel(object):
@@ -27,8 +30,9 @@ class ResultsTabModel(object):
         :param fitting_context: A FitContext detailing the outputs from the
         fitting
         """
-        self._results_table_name = DEFAULT_TABLE_NAME
         self._fit_context = fitting_context
+        self._results_table_name = DEFAULT_TABLE_NAME
+        self._selected_fit_function = None
 
     def results_table_name(self):
         """Return the current name of the results table"""
@@ -40,6 +44,17 @@ class ResultsTabModel(object):
         :param name: A new name for the table
         """
         self._results_table_name = name
+
+    def selected_fit_function(self):
+        """Return the name of the selected fit function"""
+        return self._selected_fit_function
+
+    def set_selected_fit_function(self, name):
+        """Set the name of the selected fit_function
+
+        :param name: The name of the selected function
+        """
+        self._selected_fit_function = name
 
     def fit_functions(self):
         """
@@ -91,6 +106,73 @@ class ResultsTabModel(object):
 
         return selection
 
+    # Ideally log_selection and model_selection would be part of this model but the ListSelectorPresenter
+    # contains the model and it's not yet trivial to share that
+    def create_results_table(self, log_selection, results_selection):
+        """Create a TableWorkspace with the fit results and logs combined. The format is
+        a single row per workspace with columns:
+          |workspace_name|selected_log_1|selected_log_2|...|param1_|param1_err|param2|param2_err|...|
+        Any time-series log values are averaged.
+        The workspace is added to the ADS with the name given by results_table_name
+
+        :param log_selection: The current selection of logs as a list
+        It is assumed this is ordered as it should be displayed. It can be empty.
+        :param results_selection: The current selection of result workspaces as a list of 2-tuple
+        [(workspace, fit_position),...]
+        It is assumed this is not empty and ordered as it should be displayed.
+        """
+        results_table = self._create_empty_results_table(
+            log_selection, results_selection)
+
+        fit_list = self._fit_context.fit_list
+        for workspace, position in results_selection:
+            fit = fit_list[position]
+            parameter_dict = fit.parameter_workspace.workspace.toDict()
+            row_dict = {'workspace_name': fit.parameter_name}
+            for name, value, error in zip(parameter_dict['Name'],
+                                          parameter_dict['Value'],
+                                          parameter_dict['Error']):
+                row_dict.update({name: value})
+                if name not in RESULTS_TABLE_COLUMNS_NO_ERRS:
+                    row_dict.update({name + 'Error': error})
+
+            results_table.addRow(row_dict)
+
+        AnalysisDataService.Instance().addOrReplace(self.results_table_name(),
+                                                    results_table)
+        return results_table
+
+    def _create_empty_results_table(self, log_selection, results_selection):
+        """
+        Create an empty table workspace to store the results.
+        :param log_selection: See create_results_table
+        :param results_selection: See create_results_table
+        :return: A new TableWorkspace
+        """
+        table = WorkspaceFactory.Instance().createTable()
+        table.addColumn('str', 'workspace_name')
+        for log_name in log_selection:
+            table.addColumn('float', log_name)
+        # assume all fit functions are the same in fit_selection and take
+        # the parameter names from the first fit.
+        parameters = self._first_fit_parameters(results_selection)
+        for name in parameters['Name']:
+            table.addColumn('float', name)
+            if name not in RESULTS_TABLE_COLUMNS_NO_ERRS:
+                table.addColumn('float', name + 'Error')
+        return table
+
+    # Private API
+    def _first_fit_parameters(self, results_selection):
+        """
+        Return the first fit in the selected list.
+
+        :param results_selection: The list of selected results
+        :return: The parameters of the first fit
+        """
+        first_fit = self._fit_context.fit_list[results_selection[0][1]]
+        return first_fit.parameter_workspace.workspace.toDict()
+
 
 # Public helper functions
 def log_names(workspace_name):
@@ -101,9 +183,9 @@ def log_names(workspace_name):
     :return: A list of sample log names
     :raises KeyError: if the workspace does not exist in the ADS
     """
-    all_logs = AnalysisDataService.retrieve(
-        workspace_name).run().getLogData()
+    all_logs = AnalysisDataService.retrieve(workspace_name).run().getLogData()
     return [log.name for log in all_logs if _log_should_be_displayed(log)]
+
 
 # Private helper functions
 def _log_should_be_displayed(log):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -59,14 +59,25 @@ class ResultsTabModel(object):
         """
         return self._fit_context.fit_function_names()
 
-    def fit_input_workspaces(self):
+    def fit_selection(self, existing_selection):
         """
-        :return: The list of workspace names of the original data used as input to the fits
+        Combine the existing selection state of workspaces with the workspace names
+        of fits stored here. New workspaces are always checked for inclusion.
+        :param existing_selection: A dict defining any current selection model. The
+        format matches that of the ListSelectorPresenter class' model.
+        :return: The workspaces that have had fits performed on them along with their selection status. The
+        format matches that of the ListSelectorPresenter class' model.
         """
-        return {
-            fit.input_workspace: [index, True, True]
-            for index, fit in enumerate(self._fit_context.fit_list)
-        }
+        selection = {}
+        for index, fit in enumerate(self._fit_context.fit_list):
+            name = fit.input_workspace
+            if name in existing_selection:
+                checked = existing_selection[name][1]
+            else:
+                checked = True
+            selection[name] = [index, checked, True]
+
+        return selection
 
 
 def _log_should_be_displayed(log):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -1,0 +1,69 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+from __future__ import (absolute_import, division, unicode_literals)
+
+from mantid.api import AnalysisDataService
+from mantid.kernel import FloatTimeSeriesProperty
+
+# Constants
+DEFAULT_TABLE_NAME = 'ResultsTable'
+ALLOWED_NON_TIME_SERIES_LOGS = ("run_number", "run_start", "run_end", "group",
+                                "period", "sample_temp", "sample_magn_field")
+
+
+class ResultsTabModel(object):
+    """Captures the data and operations
+    for the results tab"""
+
+    def __init__(self, fitting_context):
+        """
+        Construct a model around the given FitContext object
+
+        :param fitting_context: A FitContext detailing the outputs from the
+        fitting
+        """
+        self._results_table_name = DEFAULT_TABLE_NAME
+        self._context = fitting_context
+
+    @property
+    def results_table_name(self):
+        """Return the current name of the results table"""
+        return self._results_table_name
+
+    @results_table_name.setter
+    def results_table_name(self, name):
+        """Set the name of the output table
+
+        :param name: A new name for the table
+        """
+        self._results_table_name = name
+
+    def set_results_table_name(self, name):
+        """Set the name of the output table
+
+        :param name: A new name for the table
+        """
+        self._results_table_name = name
+
+    def log_names(self, workspace_name):
+        """
+        Return a list of log names from the given workspace.
+
+        :param workspace: A string name of a workspace in the ADS
+        :return: A list of sample log names
+        :raises KeyError: if the workspace does not exist in the ADS
+        """
+        all_logs = AnalysisDataService.retrieve(
+            workspace_name).run().getLogData()
+        return [log.name for log in all_logs if _log_should_be_displayed(log)]
+
+
+def _log_should_be_displayed(log):
+    """Returns true if the given log should be included in the display"""
+    return isinstance(log, FloatTimeSeriesProperty) or \
+           log.name in ALLOWED_NON_TIME_SERIES_LOGS

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -30,18 +30,9 @@ class ResultsTabModel(object):
         self._results_table_name = DEFAULT_TABLE_NAME
         self._context = fitting_context
 
-    @property
     def results_table_name(self):
         """Return the current name of the results table"""
         return self._results_table_name
-
-    @results_table_name.setter
-    def results_table_name(self, name):
-        """Set the name of the output table
-
-        :param name: A new name for the table
-        """
-        self._results_table_name = name
 
     def set_results_table_name(self, name):
         """Set the name of the output table

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -28,7 +28,7 @@ class ResultsTabModel(object):
         fitting
         """
         self._results_table_name = DEFAULT_TABLE_NAME
-        self._context = fitting_context
+        self._fit_context = fitting_context
 
     def results_table_name(self):
         """Return the current name of the results table"""
@@ -52,6 +52,21 @@ class ResultsTabModel(object):
         all_logs = AnalysisDataService.retrieve(
             workspace_name).run().getLogData()
         return [log.name for log in all_logs if _log_should_be_displayed(log)]
+
+    def fit_functions(self):
+        """
+        :return: The list of fit functions known to have been fitted
+        """
+        return self._fit_context.fit_function_names()
+
+    def fit_input_workspaces(self):
+        """
+        :return: The list of workspace names of the original data used as input to the fits
+        """
+        return {
+            fit.input_workspace: [index, True, True]
+            for index, fit in enumerate(self._fit_context.fit_list)
+        }
 
 
 def _log_should_be_displayed(log):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -46,7 +46,10 @@ class ResultsTabPresenter(QObject):
         if not results_selection:
             return
         log_selection = self.view.selected_log_values()
-        self.model.create_results_table(log_selection, results_selection)
+        try:
+            self.model.create_results_table(log_selection, results_selection)
+        except Exception as exc:
+            self.view.show_warning("Error creating results table: " + str(exc))
 
     def on_function_selection_changed(self):
         """React to the change in function selection"""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -1,0 +1,43 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.observer_pattern import GenericObserver
+
+
+class ResultsTabPresenter(object):
+    def __init__(self, context, view):
+        self.view = view
+        self.context = context
+
+        self.new_fit_performed_observer = GenericObserver(self.handle_new_fit_performed)
+
+    def get_selected_fit_list(self):
+        return []
+
+    def get_selected_logs_list(self):
+        return []
+
+    def get_tuple_of_logname_log_value_pairs(self, selected_workspace_list):
+        return ('run_number', '22275')
+
+    def get_performed_fits_by_fit_function(self, fit_function_name):
+        return self.context.fitting_context.get_list_of_fits_for_a_given_fit_function(fit_function_name)
+
+    def get_list_of_fit_functions_used(self):
+        return self.context.fitting_context.get_list_of_fit_functions()
+
+    def handle_new_fit_performed(self):
+        fit_function_list = self.get_list_of_fit_functions_used()
+        self.view.update_fit_function_list(fit_function_list)
+
+    def handle_fit_function_changed(self):
+        currently_selected_workspaces = self.view.get_selected_fit_list()
+        updated_fit_list = self.get_performed_fits_by_fit_function(self.view.fit_function)
+
+        new_model_dictionary = {item.parameter_name: [index, item.parameter_name in currently_selected_workspaces, True]
+                                for index, item in enumerate(updated_fit_list)}
+
+        self.view.update_fit_selector_model(new_model_dictionary)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -15,7 +15,8 @@ class ResultsTabPresenter(object):
     def __init__(self, view, model):
         self.view = view
         self.model = model
-        self.new_fit_performed_observer = GenericObserver(self.on_new_fit_performed)
+        self.new_fit_performed_observer = GenericObserver(
+            self.on_new_fit_performed)
 
         self._init_view()
 
@@ -27,14 +28,17 @@ class ResultsTabPresenter(object):
     def on_new_fit_performed(self):
         """React to a new fit created in the fitting tab"""
         self.view.set_fit_function_names(self.model.fit_functions())
-        self.view.set_fit_result_workspaces(self.model.fit_input_workspaces())
+        self.view.set_fit_result_workspaces(
+            self.model.fit_selection(
+                existing_selection=self.view.fit_result_workspaces()))
         self.view.set_output_results_button_enabled(True)
 
     # private api
     def _init_view(self):
         """Perform any setup for the view that is related to the model"""
         self.view.set_results_table_name(self.model.results_table_name())
-        self.view.results_name_edited.connect(self.on_results_table_name_edited)
+        self.view.results_name_edited.connect(
+            self.on_results_table_name_edited)
         self.view.set_output_results_button_enabled(False)
 
     # def get_performed_fits_by_fit_function(self, fit_function_name):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -6,13 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division)
 
+from qtpy.QtCore import QMetaObject, QObject, Slot
+
 from Muon.GUI.Common.observer_pattern import GenericObserver
 
 
-class ResultsTabPresenter(object):
+# Ordinarily this does not need to be a QObject but it is required to use some QMetaObject.invokeMethod
+# magic. See on_new_fit_performed() for more details
+class ResultsTabPresenter(QObject):
     """Controller for the results tab"""
 
     def __init__(self, view, model):
+        super(ResultsTabPresenter, self).__init__()
         self.view = view
         self.model = model
         self.new_fit_performed_observer = GenericObserver(
@@ -27,11 +32,13 @@ class ResultsTabPresenter(object):
 
     def on_new_fit_performed(self):
         """React to a new fit created in the fitting tab"""
-        self.view.set_fit_function_names(self.model.fit_functions())
-
-        self._update_fit_results_view()
-        self._update_logs_view()
-        self.view.set_output_results_button_enabled(True)
+        # It's possible that this call can come in on a thread that
+        # is different to the one that the view lives on.
+        # In order to update the GUI we use invokeMethod with the assumption
+        # that 'self' lives on the same thread as the view and Qt forces
+        # the call to the chose method to be done on the thread the
+        # view lives on. This avoids errors from painting on non-gui threads.
+        QMetaObject.invokeMethod(self, "_on_new_fit_performed_impl")
 
     def on_output_results_request(self):
         """React to the output results table request"""
@@ -57,6 +64,14 @@ class ResultsTabPresenter(object):
         self.view.function_selection_changed.connect(
             self.on_function_selection_changed)
         self.view.set_output_results_button_enabled(False)
+
+    @Slot()
+    def _on_new_fit_performed_impl(self):
+        """Use as part of an invokeMethod call to call across threads"""
+        self.view.set_fit_function_names(self.model.fit_functions())
+        self._update_fit_results_view()
+        self._update_logs_view()
+        self.view.set_output_results_button_enabled(True)
 
     def _update_fit_results_view(self):
         """Update the view of results workspaces based on the current model"""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -31,6 +31,9 @@ class ResultsTabPresenter(object):
         self.view.set_fit_result_workspaces(
             self.model.fit_selection(
                 existing_selection=self.view.fit_result_workspaces()))
+        self.view.set_log_values(
+            self.model.log_selection(
+                existing_selection=self.view.log_values()))
         self.view.set_output_results_button_enabled(True)
 
     # private api

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -1,93 +1,88 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-from Muon.GUI.Common.observer_pattern import GenericObserver
-from mantid.api import AnalysisDataService
-from mantid.kernel import StringPropertyWithValue, FloatTimeSeriesProperty
-special_case_log_names = ["run_number", "run_start", "run_end", "group", "period", "sample_temp", "sample_magn_field"]
-from mantid.simpleapi import CreateEmptyTableWorkspace
+from __future__ import (absolute_import, division)
 
 
 class ResultsTabPresenter(object):
-    def __init__(self, context, view):
+    """Controller for the results tab"""
+
+    def __init__(self, view, model):
         self.view = view
-        self.context = context
+        self.model = model
+        self._init_view()
 
-        self.new_fit_performed_observer = GenericObserver(self.handle_new_fit_performed)
+    # callbacks
+    def on_results_table_name_edited(self):
+        """React to the results table name being edited"""
+        self.model.set_results_table_name(self.view.results_table_name())
 
-    def get_selected_fit_list(self):
-        return []
+    def on_new_fit_performed(self):
+        """React to a new fit created in the fitting tab"""
+        pass
 
-    def get_selected_logs_list(self):
-        return []
+    # private api
+    def _init_view(self):
+        """Perform any setup for the view that is related to the model"""
+        self.view.set_results_table_name(self.model.results_table_name())
+        self.view.results_name_edited.connect(self.on_results_table_name_edited)
+        self.view.set_output_results_button_enabled(False)
 
-    def get_log_names_from_workspace(self, workspace_name):
-        log_names = []
-        log_data = list(AnalysisDataService.retrieve(workspace_name).run().getLogData())
-
-        for log in log_data:
-            if type(log) == FloatTimeSeriesProperty:
-                log_names.append(log.name)
-            elif log.name in special_case_log_names:
-                log_names.append(log.name)
-
-        return log_names
-
-    def get_performed_fits_by_fit_function(self, fit_function_name):
-        return self.context.fitting_context.get_list_of_fits_for_a_given_fit_function(fit_function_name)
-
-    def get_list_of_fit_functions_used(self):
-        return self.context.fitting_context.get_list_of_fit_functions()
-
-    def handle_new_fit_performed(self):
-        fit_function_list = self.get_list_of_fit_functions_used()
-        self.view.update_fit_function_list(fit_function_list)
-
-    def handle_fit_function_changed(self):
-        currently_selected_workspaces = self.view.get_selected_fit_list()
-        updated_fit_list = self.get_performed_fits_by_fit_function(self.view.fit_function)
-
-        new_model_dictionary = {item.parameter_name: [index, item.parameter_name in currently_selected_workspaces, True]
-                                for index, item in enumerate(updated_fit_list)}
-
-        self.view.update_fit_selector_model(new_model_dictionary)
-        self.update_logs_list(updated_fit_list)
-
-    def handle_create_results_table_button_clicked(self):
-        selected_fits = [self.context.fitting_context.get_fit_object_from_parameter_name(item)
-                         for item in self.view.get_selected_fit_list()]
-        selected_logs = self.view.get_selected_logs_list()
-        table_workspace = CreateEmptyTableWorkspace(OutputWorkspace=str(self.view.results_table_line_edit.text()))
-
-        table_workspace.addColumn('str', 'workspace_name')
-        first_parameter_dict = selected_fits[0].parameter_workspace.workspace.toDict()
-        # for log_name in selected_logs:
-        #     table_workspace.addColumn('float', log_name)
-
-        for name in first_parameter_dict['Name']:
-            table_workspace.addColumn('float', name)
-            table_workspace.addColumn('float', name + 'Error')
-
-        for fit in selected_fits:
-            parameter_dict = fit.parameter_workspace.workspace.toDict()
-            row_dict = {'workspace_name': fit.parameter_name}
-            for name, value, error in zip(parameter_dict['Name'], parameter_dict['Value'], parameter_dict['Error']):
-                row_dict.update({name: value, name + 'Error': error})
-
-            table_workspace.addRow(row_dict)
-
-    def update_logs_list(self, updated_fit_list):
-        if not updated_fit_list:
-            return
-
-        currently_selected_logs = self.view.get_selected_logs_list()
-        input_workspace_name = updated_fit_list[0].input_workspace
-
-        log_names_list = self.get_log_names_from_workspace(input_workspace_name)
-
-        new_model_dict = {log_name: [index, log_name in currently_selected_logs, True] for index, log_name in enumerate(log_names_list)}
-
-        self.view.update_log_selector_model(new_model_dict)
+    # def get_performed_fits_by_fit_function(self, fit_function_name):
+    #     return self.context.fitting_context.get_list_of_fits_for_a_given_fit_function(fit_function_name)
+    #
+    # def get_list_of_fit_functions_used(self):
+    #     return self.context.fitting_context.get_list_of_fit_functions()
+    #
+    # def handle_new_fit_performed(self):
+    #     fit_function_list = self.get_list_of_fit_functions_used()
+    #     self.view.update_fit_function_list(fit_function_list)
+    #
+    # def handle_fit_function_changed(self):
+    #     currently_selected_workspaces = self.view.get_selected_fit_list()
+    #     updated_fit_list = self.get_performed_fits_by_fit_function(self.view.fit_function)
+    #
+    #     new_model_dictionary = {item.parameter_name: [index, item.parameter_name in currently_selected_workspaces, True]
+    #                             for index, item in enumerate(updated_fit_list)}
+    #
+    #     self.view.update_fit_selector_model(new_model_dictionary)
+    #     self.update_logs_list(updated_fit_list)
+    #
+    # def handle_create_results_table_button_clicked(self):
+    #     selected_fits = [self.context.fitting_context.get_fit_object_from_parameter_name(item)
+    #                      for item in self.view.get_selected_fit_list()]
+    #     selected_logs = self.view.get_selected_logs_list()
+    #     table_workspace = CreateEmptyTableWorkspace(OutputWorkspace=str(self.view.results_table_line_edit.text()))
+    #
+    #     table_workspace.addColumn('str', 'workspace_name')
+    #     first_parameter_dict = selected_fits[0].parameter_workspace.workspace.toDict()
+    #     # for log_name in selected_logs:
+    #     #     table_workspace.addColumn('float', log_name)
+    #
+    #     for name in first_parameter_dict['Name']:
+    #         table_workspace.addColumn('float', name)
+    #         table_workspace.addColumn('float', name + 'Error')
+    #
+    #     for fit in selected_fits:
+    #         parameter_dict = fit.parameter_workspace.workspace.toDict()
+    #         row_dict = {'workspace_name': fit.parameter_name}
+    #         for name, value, error in zip(parameter_dict['Name'], parameter_dict['Value'], parameter_dict['Error']):
+    #             row_dict.update({name: value, name + 'Error': error})
+    #
+    #         table_workspace.addRow(row_dict)
+    #
+    # def update_logs_list(self, updated_fit_list):
+    #     if not updated_fit_list:
+    #         return
+    #
+    #     currently_selected_logs = self.view.get_selected_logs_list()
+    #     input_workspace_name = updated_fit_list[0].input_workspace
+    #
+    #     log_names_list = self.get_log_names_from_workspace(input_workspace_name)
+    #
+    #     new_model_dict = {log_name: [index, log_name in currently_selected_logs, True] for index, log_name in enumerate(log_names_list)}
+    #
+    #     self.view.update_log_selector_model(new_model_dict)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division)
 
+from Muon.GUI.Common.observer_pattern import GenericObserver
+
 
 class ResultsTabPresenter(object):
     """Controller for the results tab"""
@@ -13,6 +15,8 @@ class ResultsTabPresenter(object):
     def __init__(self, view, model):
         self.view = view
         self.model = model
+        self.new_fit_performed_observer = GenericObserver(self.on_new_fit_performed)
+
         self._init_view()
 
     # callbacks
@@ -22,7 +26,9 @@ class ResultsTabPresenter(object):
 
     def on_new_fit_performed(self):
         """React to a new fit created in the fitting tab"""
-        pass
+        self.view.set_fit_function_names(self.model.fit_functions())
+        self.view.set_fit_result_workspaces(self.model.fit_input_workspaces())
+        self.view.set_output_results_button_enabled(True)
 
     # private api
     def _init_view(self):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -28,12 +28,9 @@ class ResultsTabPresenter(object):
     def on_new_fit_performed(self):
         """React to a new fit created in the fitting tab"""
         self.view.set_fit_function_names(self.model.fit_functions())
-        self.view.set_fit_result_workspaces(
-            self.model.fit_selection(
-                existing_selection=self.view.fit_result_workspaces()))
-        self.view.set_log_values(
-            self.model.log_selection(
-                existing_selection=self.view.log_values()))
+
+        self._update_fit_results_view()
+        self._update_logs_view()
         self.view.set_output_results_button_enabled(True)
 
     def on_output_results_request(self):
@@ -44,6 +41,11 @@ class ResultsTabPresenter(object):
         log_selection = self.view.selected_log_values()
         self.model.create_results_table(log_selection, results_selection)
 
+    def on_function_selection_changed(self):
+        """React to the change in function selection"""
+        self.model.set_selected_fit_function(self.view.selected_fit_function())
+        self._update_fit_results_view()
+
     # private api
     def _init_view(self):
         """Perform any setup for the view that is related to the model"""
@@ -52,15 +54,18 @@ class ResultsTabPresenter(object):
             self.on_results_table_name_edited)
         self.view.output_results_requested.connect(
             self.on_output_results_request)
+        self.view.function_selection_changed.connect(
+            self.on_function_selection_changed)
         self.view.set_output_results_button_enabled(False)
 
-    # def handle_fit_function_changed(self):
-    #     currently_selected_workspaces = self.view.get_selected_fit_list()
-    #     updated_fit_list = self.get_performed_fits_by_fit_function(self.view.fit_function)
-    #
-    #     new_model_dictionary = {item.parameter_name: [index, item.parameter_name in currently_selected_workspaces, True]
-    #                             for index, item in enumerate(updated_fit_list)}
-    #
-    #     self.view.update_fit_selector_model(new_model_dictionary)
-    #     self.update_logs_list(updated_fit_list)
-    #
+    def _update_fit_results_view(self):
+        """Update the view of results workspaces based on the current model"""
+        self.view.set_fit_result_workspaces(
+            self.model.fit_selection(
+                existing_selection=self.view.fit_result_workspaces()))
+
+    def _update_logs_view(self):
+        """Update the view of logs based on the current model"""
+        self.view.set_log_values(
+            self.model.log_selection(
+                existing_selection=self.view.log_values()))

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -36,24 +36,24 @@ class ResultsTabPresenter(object):
                 existing_selection=self.view.log_values()))
         self.view.set_output_results_button_enabled(True)
 
+    def on_output_results_request(self):
+        """React to the output results table request"""
+        results_selection = self.view.selected_result_workspaces()
+        if not results_selection:
+            return
+        log_selection = self.view.selected_log_values()
+        self.model.create_results_table(log_selection, results_selection)
+
     # private api
     def _init_view(self):
         """Perform any setup for the view that is related to the model"""
         self.view.set_results_table_name(self.model.results_table_name())
         self.view.results_name_edited.connect(
             self.on_results_table_name_edited)
+        self.view.output_results_requested.connect(
+            self.on_output_results_request)
         self.view.set_output_results_button_enabled(False)
 
-    # def get_performed_fits_by_fit_function(self, fit_function_name):
-    #     return self.context.fitting_context.get_list_of_fits_for_a_given_fit_function(fit_function_name)
-    #
-    # def get_list_of_fit_functions_used(self):
-    #     return self.context.fitting_context.get_list_of_fit_functions()
-    #
-    # def handle_new_fit_performed(self):
-    #     fit_function_list = self.get_list_of_fit_functions_used()
-    #     self.view.update_fit_function_list(fit_function_list)
-    #
     # def handle_fit_function_changed(self):
     #     currently_selected_workspaces = self.view.get_selected_fit_list()
     #     updated_fit_list = self.get_performed_fits_by_fit_function(self.view.fit_function)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -5,6 +5,10 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.Common.observer_pattern import GenericObserver
+from mantid.api import AnalysisDataService
+from mantid.kernel import StringPropertyWithValue, FloatTimeSeriesProperty
+special_case_log_names = ["run_number", "run_start", "run_end", "group", "period", "sample_temp", "sample_magn_field"]
+from mantid.simpleapi import CreateEmptyTableWorkspace
 
 
 class ResultsTabPresenter(object):
@@ -20,8 +24,17 @@ class ResultsTabPresenter(object):
     def get_selected_logs_list(self):
         return []
 
-    def get_tuple_of_logname_log_value_pairs(self, selected_workspace_list):
-        return ('run_number', '22275')
+    def get_log_names_from_workspace(self, workspace_name):
+        log_names = []
+        log_data = list(AnalysisDataService.retrieve(workspace_name).run().getLogData())
+
+        for log in log_data:
+            if type(log) == FloatTimeSeriesProperty:
+                log_names.append(log.name)
+            elif log.name in special_case_log_names:
+                log_names.append(log.name)
+
+        return log_names
 
     def get_performed_fits_by_fit_function(self, fit_function_name):
         return self.context.fitting_context.get_list_of_fits_for_a_given_fit_function(fit_function_name)
@@ -41,3 +54,40 @@ class ResultsTabPresenter(object):
                                 for index, item in enumerate(updated_fit_list)}
 
         self.view.update_fit_selector_model(new_model_dictionary)
+        self.update_logs_list(updated_fit_list)
+
+    def handle_create_results_table_button_clicked(self):
+        selected_fits = [self.context.fitting_context.get_fit_object_from_parameter_name(item)
+                         for item in self.view.get_selected_fit_list()]
+        selected_logs = self.view.get_selected_logs_list()
+        table_workspace = CreateEmptyTableWorkspace(OutputWorkspace=str(self.view.results_table_line_edit.text()))
+
+        table_workspace.addColumn('str', 'workspace_name')
+        first_parameter_dict = selected_fits[0].parameter_workspace.workspace.toDict()
+        # for log_name in selected_logs:
+        #     table_workspace.addColumn('float', log_name)
+
+        for name in first_parameter_dict['Name']:
+            table_workspace.addColumn('float', name)
+            table_workspace.addColumn('float', name + 'Error')
+
+        for fit in selected_fits:
+            parameter_dict = fit.parameter_workspace.workspace.toDict()
+            row_dict = {'workspace_name': fit.parameter_name}
+            for name, value, error in zip(parameter_dict['Name'], parameter_dict['Value'], parameter_dict['Error']):
+                row_dict.update({name: value, name + 'Error': error})
+
+            table_workspace.addRow(row_dict)
+
+    def update_logs_list(self, updated_fit_list):
+        if not updated_fit_list:
+            return
+
+        currently_selected_logs = self.view.get_selected_logs_list()
+        input_workspace_name = updated_fit_list[0].input_workspace
+
+        log_names_list = self.get_log_names_from_workspace(input_workspace_name)
+
+        new_model_dict = {log_name: [index, log_name in currently_selected_logs, True] for index, log_name in enumerate(log_names_list)}
+
+        self.view.update_log_selector_model(new_model_dict)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -64,38 +64,3 @@ class ResultsTabPresenter(object):
     #     self.view.update_fit_selector_model(new_model_dictionary)
     #     self.update_logs_list(updated_fit_list)
     #
-    # def handle_create_results_table_button_clicked(self):
-    #     selected_fits = [self.context.fitting_context.get_fit_object_from_parameter_name(item)
-    #                      for item in self.view.get_selected_fit_list()]
-    #     selected_logs = self.view.get_selected_logs_list()
-    #     table_workspace = CreateEmptyTableWorkspace(OutputWorkspace=str(self.view.results_table_line_edit.text()))
-    #
-    #     table_workspace.addColumn('str', 'workspace_name')
-    #     first_parameter_dict = selected_fits[0].parameter_workspace.workspace.toDict()
-    #     # for log_name in selected_logs:
-    #     #     table_workspace.addColumn('float', log_name)
-    #
-    #     for name in first_parameter_dict['Name']:
-    #         table_workspace.addColumn('float', name)
-    #         table_workspace.addColumn('float', name + 'Error')
-    #
-    #     for fit in selected_fits:
-    #         parameter_dict = fit.parameter_workspace.workspace.toDict()
-    #         row_dict = {'workspace_name': fit.parameter_name}
-    #         for name, value, error in zip(parameter_dict['Name'], parameter_dict['Value'], parameter_dict['Error']):
-    #             row_dict.update({name: value, name + 'Error': error})
-    #
-    #         table_workspace.addRow(row_dict)
-    #
-    # def update_logs_list(self, updated_fit_list):
-    #     if not updated_fit_list:
-    #         return
-    #
-    #     currently_selected_logs = self.view.get_selected_logs_list()
-    #     input_workspace_name = updated_fit_list[0].input_workspace
-    #
-    #     log_names_list = self.get_log_names_from_workspace(input_workspace_name)
-    #
-    #     new_model_dict = {log_name: [index, log_name in currently_selected_logs, True] for index, log_name in enumerate(log_names_list)}
-    #
-    #     self.view.update_log_selector_model(new_model_dict)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -7,7 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from mantidqt.utils.qt import load_ui
-from qtpy import QtCore, QtWidgets
+from qtpy import PYQT4, QtCore, QtWidgets
 
 from Muon.GUI.Common.list_selector.list_selector_presenter import ListSelectorPresenter
 from Muon.GUI.Common.list_selector.list_selector_view import ListSelectorView
@@ -63,7 +63,11 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         function_selector.clear()
         function_selector.addItems(names)
         if original_selection in names:
-            function_selector.setCurrentText(original_selection)
+            if PYQT4:
+                function_selector.setCurrentIndex(
+                    function_selector.findText(original_selection))
+            else:
+                function_selector.setCurrentText(original_selection)
         function_selector.blockSignals(False)
 
     def selected_result_workspaces(self):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -11,6 +11,7 @@ from qtpy import PYQT4, QtCore, QtWidgets
 
 from Muon.GUI.Common.list_selector.list_selector_presenter import ListSelectorPresenter
 from Muon.GUI.Common.list_selector.list_selector_view import ListSelectorView
+from Muon.GUI.Common.message_box import warning
 
 # Constants
 FIT_SELECTOR_COL0_WIDTH = 600
@@ -114,6 +115,13 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         state for the workspace list selector
         """
         self.log_selector_presenter.update_model(logs_list_state)
+
+    def show_warning(self, msg):
+        """
+        Display a warning on that something went wrong
+        :param msg: The message to include
+        """
+        warning(msg, self)
 
     # Private methods
     def _init_layout(self):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -50,6 +50,22 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         """
         self.results_name_editor.setText(name)
 
+    def set_fit_function_names(self, names):
+        """Set a new list of function names for the function selector.
+
+        :param names: A list of strings specifying function names used in known fits
+        """
+        self.fit_function_selector.clear()
+        self.fit_function_selector.addItems(names)
+
+    def set_fit_result_workspaces(self, workspace_list_state):
+        """Set the map of workspaces
+
+        :param workspace_list_state: Dictionary containing the updated
+        state for the workspace list selector
+        """
+        self.fit_selector_presenter.update_model(workspace_list_state)
+
     def selected_fit_function(self):
         """Return the text of the selected item in the function
         selection box"""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -62,7 +62,7 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         function_selector.blockSignals(True)
         function_selector.clear()
         function_selector.addItems(names)
-        if original_selection:
+        if original_selection in names:
             function_selector.setCurrentText(original_selection)
         function_selector.blockSignals(False)
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -134,31 +134,6 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.output_results_table_btn.clicked.connect(
             self.output_results_requested)
 
-    # def update_fit_function_list(self, fit_function_list):
-    #     name = self.fit_function_combo.currentText()
-    #     self.fit_function_combo.clear()
-    #
-    #     self.fit_function_combo.addItems(fit_function_list)
-    #
-    #     index = self.fit_function_combo.findText(name)
-    #
-    #     if index != -1:
-    #         self.fit_function_combo.setCurrentIndex(index)
-    #     else:
-    #         self.fit_function_combo.setCurrentIndex(0)
-    #
-    # def update_fit_selector_model(self, new_model_dictionary):
-    #     self.fit_selector_presenter.update_model(new_model_dictionary)
-    #
-    # def update_log_selector_model(self, new_model_dictionary):
-    #     self.log_selector_presenter.update_model(new_model_dictionary)
-    #
-    # def get_selected_fit_list(self):
-    #     return self.fit_selector_presenter.get_selected_items()
-    #
-    # def get_selected_logs_list(self):
-    #     return self.log_selector_presenter.get_selected_items()
-
 
 # Private helper functions
 def _create_empty_list_selector(parent, col_zero_width):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -58,6 +58,12 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.fit_function_selector.clear()
         self.fit_function_selector.addItems(names)
 
+    def fit_result_workspaces(self):
+        """
+        :return: The current state of the workspace list selector
+        """
+        return self.fit_selector_presenter.model
+
     def set_fit_result_workspaces(self, workspace_list_state):
         """Set the map of workspaces
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -52,5 +52,11 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
     def update_fit_selector_model(self, new_model_dictionary):
         self.fit_selector_presenter.update_model(new_model_dictionary)
 
+    def update_log_selector_model(self, new_model_dictionary):
+        self.log_selector_presenter.update_model(new_model_dictionary)
+
     def get_selected_fit_list(self):
         return self.fit_selector_presenter.get_selected_items()
+
+    def get_selected_logs_list(self):
+        return self.log_selector_presenter.get_selected_items()

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -77,6 +77,20 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         selection box"""
         return self.fit_function_selector.currentText()
 
+    def log_values(self):
+        """
+        :return: The current state of the log list selector
+        """
+        return self.log_selector_presenter.model
+
+    def set_log_values(self, logs_list_state):
+        """Set the map of log values and selected status
+
+        :param logs_list_state: Dictionary containing the updated
+        state for the workspace list selector
+        """
+        self.log_selector_presenter.update_model(logs_list_state)
+
     # Private methods
     def _init_layout(self):
         """Setup the layout of the view"""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -26,6 +26,7 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
     # Public signals
     function_selection_changed = QtCore.Signal()
     results_name_edited = QtCore.Signal()
+    output_results_requested = QtCore.Signal()
 
     def __init__(self, parent=None):
         super(ResultsTabView, self).__init__(parent)
@@ -58,6 +59,12 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.fit_function_selector.clear()
         self.fit_function_selector.addItems(names)
 
+    def selected_result_workspaces(self):
+        """
+        :return: The list of selected workspaces and their positions in the list
+        """
+        return self.fit_selector_presenter.get_selected_items_and_positions()
+
     def fit_result_workspaces(self):
         """
         :return: The current state of the workspace list selector
@@ -76,6 +83,12 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         """Return the text of the selected item in the function
         selection box"""
         return self.fit_function_selector.currentText()
+
+    def selected_log_values(self):
+        """
+        :return: A list of selected log values and their positions in the list
+        """
+        return self.log_selector_presenter.get_selected_items()
 
     def log_values(self):
         """
@@ -111,6 +124,8 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
             self.function_selection_changed)
         self.results_name_editor.editingFinished.connect(
             self.results_name_edited)
+        self.output_results_table_btn.clicked.connect(
+            self.output_results_requested)
 
     # def update_fit_function_list(self, fit_function_list):
     #     name = self.fit_function_combo.currentText()

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -52,12 +52,19 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.results_name_editor.setText(name)
 
     def set_fit_function_names(self, names):
-        """Set a new list of function names for the function selector.
+        """Set a new list of function names for the function selector. This blocks
+        signals from the widget during the update
 
         :param names: A list of strings specifying function names used in known fits
         """
-        self.fit_function_selector.clear()
-        self.fit_function_selector.addItems(names)
+        function_selector = self.fit_function_selector
+        original_selection = function_selector.currentText()
+        function_selector.blockSignals(True)
+        function_selector.clear()
+        function_selector.addItems(names)
+        if original_selection:
+            function_selector.setCurrentText(original_selection)
+        function_selector.blockSignals(False)
 
     def selected_result_workspaces(self):
         """

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -1,0 +1,56 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, print_function)
+
+from qtpy import QtWidgets
+from mantidqt.utils.qt import load_ui
+from Muon.GUI.Common.list_selector.list_selector_presenter import ListSelectorPresenter
+from Muon.GUI.Common.list_selector.list_selector_view import ListSelectorView
+
+ui_fitting_tab, _ = load_ui(__file__, "results_tab_view.ui")
+
+
+class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
+    def __init__(self, parent=None):
+        super(ResultsTabView, self).__init__(parent)
+        self.setupUi(self)
+
+        self.log_selector_widget = ListSelectorView(self)
+        self.fit_selector_widget = ListSelectorView(self)
+
+        self.log_value_layout.addWidget(self.log_selector_widget, 0, 1, 4, 1)
+        self.log_value_layout.setContentsMargins(0, 0, 0, 0)
+        self.fit_layout.addWidget(self.fit_selector_widget, 0, 1, 4, 1)
+        self.fit_layout.setContentsMargins(0, 0, 0, 0)
+        self.log_selector_widget.item_table_widget.setColumnWidth(0, 600)
+        self.fit_selector_widget.item_table_widget.setColumnWidth(0, 600)
+
+        self.log_selector_presenter = ListSelectorPresenter(self.log_selector_widget, {})
+        self.fit_selector_presenter = ListSelectorPresenter(self.fit_selector_widget, {})
+
+    def update_fit_function_list(self, fit_function_list):
+        name = self.fit_function_combo.currentText()
+        self.fit_function_combo.clear()
+
+        self.fit_function_combo.addItems(fit_function_list)
+
+        index = self.fit_function_combo.findText(name)
+
+        if index != -1:
+            self.fit_function_combo.setCurrentIndex(index)
+        else:
+            self.fit_function_combo.setCurrentIndex(0)
+
+    @property
+    def fit_function(self):
+        return self.fit_function_combo.currentText()
+
+    def update_fit_selector_model(self, new_model_dictionary):
+        self.fit_selector_presenter.update_model(new_model_dictionary)
+
+    def get_selected_fit_list(self):
+        return self.fit_selector_presenter.get_selected_items()

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
@@ -14,32 +14,25 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0" colspan="6">
-    <layout class="QGridLayout" name="log_value_layout">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Fit function Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="6">
+    <layout class="QGridLayout" name="fit_layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetFixedSize</enum>
      </property>
     </layout>
-   </item>
-   <item row="3" column="4" colspan="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>196</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="5" column="3" colspan="2">
-    <widget class="QPushButton" name="output_results_table_button">
-     <property name="text">
-      <string>Output Results</string>
-     </property>
-    </widget>
    </item>
    <item row="5" column="5">
     <spacer name="horizontalSpacer_3">
@@ -54,36 +47,33 @@
      </property>
     </spacer>
    </item>
-   <item row="4" column="0" colspan="6">
-    <layout class="QGridLayout" name="fit_layout">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetFixedSize</enum>
-     </property>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
+   <item row="3" column="1" colspan="3">
+    <widget class="QComboBox" name="fit_function_selector">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Fit Selection</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="5" column="3" colspan="2">
+    <widget class="QPushButton" name="output_results_table_btn">
+     <property name="text">
+      <string>Output Results</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="results_name_editor">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Fit function Selection</string>
+      <string/>
      </property>
     </widget>
    </item>
@@ -100,29 +90,6 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QLineEdit" name="results_table_line_edit">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>ResultsTable</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="3">
-    <widget class="QComboBox" name="fit_function_combo">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
-   </item>
    <item row="5" column="0" colspan="2">
     <widget class="QLabel" name="label_4">
      <property name="text">
@@ -130,18 +97,42 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Fit Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="4" colspan="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="0" colspan="6">
+    <layout class="QGridLayout" name="log_value_layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+    </layout>
+   </item>
   </layout>
-  <zorder>gridLayoutWidget</zorder>
-  <zorder>gridLayoutWidget_2</zorder>
-  <zorder>fit_function_combo</zorder>
+  <zorder>fit_function_selector</zorder>
   <zorder>label</zorder>
   <zorder>label_2</zorder>
   <zorder>label_3</zorder>
-  <zorder>label_3</zorder>
   <zorder>horizontalSpacer</zorder>
-  <zorder>output_results_table_button</zorder>
+  <zorder>output_results_table_btn</zorder>
   <zorder>horizontalSpacer_3</zorder>
-  <zorder>results_table_line_edit</zorder>
+  <zorder>results_name_editor</zorder>
   <zorder>label_4</zorder>
  </widget>
  <resources/>

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
@@ -23,7 +23,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Fit function Selection</string>
+      <string>Function Name:</string>
      </property>
     </widget>
    </item>
@@ -86,7 +86,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Log Values Selection</string>
+      <string>Log Values</string>
      </property>
     </widget>
    </item>
@@ -106,7 +106,7 @@
       </sizepolicy>
      </property>
      <property name="text">
-      <string>Fit Selection</string>
+      <string>Fit Results</string>
      </property>
     </widget>
    </item>
@@ -114,6 +114,12 @@
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
      </property>
     </spacer>
    </item>

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
@@ -7,28 +7,55 @@
     <x>0</x>
     <y>0</y>
     <width>569</width>
-    <height>523</height>
+    <height>528</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="1" column="0" colspan="6">
+    <layout class="QGridLayout" name="log_value_layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
      </property>
+    </layout>
+   </item>
+   <item row="3" column="4" colspan="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>196</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="5" column="3" colspan="2">
+    <widget class="QPushButton" name="output_results_table_button">
      <property name="text">
-      <string>Log Values Selection</string>
+      <string>Output Results</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="3">
-    <layout class="QGridLayout" name="log_value_layout">
+   <item row="5" column="5">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>134</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0" colspan="6">
+    <layout class="QGridLayout" name="fit_layout">
      <property name="sizeConstraint">
       <enum>QLayout::SetFixedSize</enum>
      </property>
@@ -60,28 +87,48 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QComboBox" name="fit_function_combo"/>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Log Values Selection</string>
+     </property>
+    </widget>
    </item>
-   <item row="3" column="2">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="5" column="2">
+    <widget class="QLineEdit" name="results_table_line_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>316</width>
-       <height>20</height>
-      </size>
+     <property name="text">
+      <string>ResultsTable</string>
      </property>
-    </spacer>
+    </widget>
    </item>
-   <item row="4" column="0" colspan="3">
-    <layout class="QGridLayout" name="fit_layout">
-     <property name="sizeConstraint">
-      <enum>QLayout::SetFixedSize</enum>
+   <item row="3" column="1" colspan="3">
+    <widget class="QComboBox" name="fit_function_combo">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-    </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Table Name</string>
+     </property>
+    </widget>
    </item>
   </layout>
   <zorder>gridLayoutWidget</zorder>
@@ -92,6 +139,10 @@
   <zorder>label_3</zorder>
   <zorder>label_3</zorder>
   <zorder>horizontalSpacer</zorder>
+  <zorder>output_results_table_button</zorder>
+  <zorder>horizontalSpacer_3</zorder>
+  <zorder>results_table_line_edit</zorder>
+  <zorder>label_4</zorder>
  </widget>
  <resources/>
  <connections/>

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>569</width>
+    <height>523</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Log Values Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <layout class="QGridLayout" name="log_value_layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Fit Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Fit function Selection</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QComboBox" name="fit_function_combo"/>
+   </item>
+   <item row="3" column="2">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>316</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <layout class="QGridLayout" name="fit_layout">
+     <property name="sizeConstraint">
+      <enum>QLayout::SetFixedSize</enum>
+     </property>
+    </layout>
+   </item>
+  </layout>
+  <zorder>gridLayoutWidget</zorder>
+  <zorder>gridLayoutWidget_2</zorder>
+  <zorder>fit_function_combo</zorder>
+  <zorder>label</zorder>
+  <zorder>label_2</zorder>
+  <zorder>label_3</zorder>
+  <zorder>label_3</zorder>
+  <zorder>horizontalSpacer</zorder>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
@@ -15,3 +15,4 @@ class ResultsTabWidget(object):
         self.results_tab_presenter = ResultsTabPresenter(context, self.results_tab_view)
 
         self.results_tab_view.fit_function_combo.currentIndexChanged.connect(self.results_tab_presenter.handle_fit_function_changed)
+        self.results_tab_view.output_results_table_button.clicked.connect(self.results_tab_presenter.handle_create_results_table_button_clicked)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
@@ -1,18 +1,16 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from Muon.GUI.Common.results_tab_widget.results_tab_presenter import ResultsTabPresenter
 from Muon.GUI.Common.results_tab_widget.results_tab_view import ResultsTabView
+from Muon.GUI.Common.results_tab_widget.results_tab_model import ResultsTabModel
 
 
 class ResultsTabWidget(object):
     def __init__(self, context, parent):
         self.results_tab_view = ResultsTabView(parent=parent)
-
-        self.results_tab_presenter = ResultsTabPresenter(context, self.results_tab_view)
-
-        self.results_tab_view.fit_function_combo.currentIndexChanged.connect(self.results_tab_presenter.handle_fit_function_changed)
-        self.results_tab_view.output_results_table_button.clicked.connect(self.results_tab_presenter.handle_create_results_table_button_clicked)
+        self.results_tab_presenter = ResultsTabPresenter(
+            self.results_tab_view, ResultsTabModel(context))

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
@@ -1,0 +1,17 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.results_tab_widget.results_tab_presenter import ResultsTabPresenter
+from Muon.GUI.Common.results_tab_widget.results_tab_view import ResultsTabView
+
+
+class ResultsTabWidget(object):
+    def __init__(self, context, parent):
+        self.results_tab_view = ResultsTabView(parent=parent)
+
+        self.results_tab_presenter = ResultsTabPresenter(context, self.results_tab_view)
+
+        self.results_tab_view.fit_function_combo.currentIndexChanged.connect(self.results_tab_presenter.handle_fit_function_changed)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_widget.py
@@ -4,13 +4,22 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division)
+
 from Muon.GUI.Common.results_tab_widget.results_tab_presenter import ResultsTabPresenter
 from Muon.GUI.Common.results_tab_widget.results_tab_view import ResultsTabView
 from Muon.GUI.Common.results_tab_widget.results_tab_model import ResultsTabModel
 
 
 class ResultsTabWidget(object):
-    def __init__(self, context, parent):
+    """Factory object to wire together components of the results tab"""
+
+    def __init__(self, fit_context, parent):
+        """
+        Initialize the widget.
+        :param fit_context: A reference to the a FitContext object used to store fit results
+        :param parent: A parent widget for the view
+        """
         self.results_tab_view = ResultsTabView(parent=parent)
         self.results_tab_presenter = ResultsTabPresenter(
-            self.results_tab_view, ResultsTabModel(context))
+            self.results_tab_view, ResultsTabModel(fit_context))

--- a/scripts/Muon/GUI/Common/test_helpers/context_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/context_setup.py
@@ -4,6 +4,7 @@ from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContex
 from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.contexts.phase_table_context import PhaseTableContext
+from Muon.GUI.Common.contexts.fitting_context import FittingContext
 from mantid.py3compat import mock
 
 
@@ -14,8 +15,10 @@ def setup_context_for_tests(parent_object):
     parent_object.gui_context = MuonGuiContext()
     parent_object.group_context = MuonGroupPairContext(parent_object.data_context.check_group_contains_valid_detectors)
     parent_object.phase_table_context = PhaseTableContext()
+    parent_object.fitting_context = FittingContext()
     parent_object.context = MuonContext(muon_data_context=parent_object.data_context, muon_group_context=parent_object.group_context,
-                                        muon_gui_context=parent_object.gui_context, muon_phase_context=parent_object.phase_table_context)
+                                        muon_gui_context=parent_object.gui_context, muon_phase_context=parent_object.phase_table_context,
+                                        fitting_context=parent_object.fitting_context)
 
 
 def setup_context():
@@ -25,7 +28,9 @@ def setup_context():
     gui_context = MuonGuiContext()
     group_context = MuonGroupPairContext(data_context.check_group_contains_valid_detectors)
     phase_table_context = PhaseTableContext()
+    fitting_context = FittingContext()
     return MuonContext(muon_data_context=data_context,
                        muon_group_context=group_context,
                        muon_gui_context=gui_context,
-                       muon_phase_context=phase_table_context)
+                       muon_phase_context=phase_table_context,
+                       fitting_context=fitting_context)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -16,6 +16,7 @@ from Muon.GUI.Common.contexts.muon_context import MuonContext
 from Muon.GUI.Common.contexts.muon_data_context import MuonDataContext
 from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContext
 from Muon.GUI.Common.contexts.phase_table_context import PhaseTableContext
+from Muon.GUI.Common.contexts.fitting_context import FittingContext
 from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
 from Muon.GUI.Common.dock.dockable_tabs import DetachableTabWidget
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget import GroupingTabWidget
@@ -25,6 +26,7 @@ from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
 from Muon.GUI.MuonAnalysis.load_widget.load_widget import LoadWidget
 from Muon.GUI.Common.phase_table_widget.phase_table_widget import PhaseTabWidget
+from Muon.GUI.Common.results_tab_widget.results_tab_widget import ResultsTabWidget
 
 SUPPORTED_FACILITIES = ["ISIS", "SmuS"]
 
@@ -65,9 +67,11 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.gui_context = MuonGuiContext()
         self.group_pair_context = MuonGroupPairContext(self.data_context.check_group_contains_valid_detectors)
         self.phase_context = PhaseTableContext()
+        self.fitting_context = FittingContext()
 
         self.context = MuonContext(muon_data_context=self.data_context, muon_gui_context=self.gui_context,
-                                   muon_group_context=self.group_pair_context, muon_phase_context=self.phase_context)
+                                   muon_group_context=self.group_pair_context, muon_phase_context=self.phase_context,
+                                   fitting_context=self.fitting_context)
 
         # construct all the widgets.
         self.load_widget = LoadWidget(self.loaded_data, self.context, self)
@@ -75,6 +79,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.home_tab = HomeTabWidget(self.context, self)
         self.phase_tab = PhaseTabWidget(self.context, self)
         self.fitting_tab = FittingTabWidget(self.context, self)
+        self.results_tab = ResultsTabWidget(self.context, self)
 
         self.setup_tabs()
         self.help_widget = HelpWidget("Muon Analysis 2")
@@ -112,6 +117,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.setup_phase_table_changed_notifier()
 
+        self.setup_fitting_notifier()
+
         self.context.data_context.message_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.message_observer)
 
     def setup_tabs(self):
@@ -124,6 +131,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.addTabWithOrder(self.grouping_tab_widget.group_tab_view, 'Grouping')
         self.tabs.addTabWithOrder(self.phase_tab.phase_table_view, 'Phase Table')
         self.tabs.addTabWithOrder(self.fitting_tab.fitting_tab_view, 'Fitting')
+        self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
 
     def setup_load_observers(self):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
@@ -215,6 +223,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
     def setup_phase_table_changed_notifier(self):
         pass
+
+    def setup_fitting_notifier(self):
+        self.fitting_context.new_fit_notifier.add_subscriber(self.results_tab.results_tab_presenter.new_fit_performed_observer)
 
     def closeEvent(self, event):
         self.tabs.closeEvent(event)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -40,7 +40,7 @@ def check_facility():
     if current_facility not in SUPPORTED_FACILITIES:
         raise AttributeError(
             "Your facility {} is not supported by MuonAnalysis 2.0, so you"
-                             "will not be able to load any files. \n \n"
+            "will not be able to load any files. \n \n"
             "Supported facilities are :" + "\n - ".join(SUPPORTED_FACILITIES))
 
 

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -38,16 +38,17 @@ def check_facility():
     """
     current_facility = ConfigServiceImpl.Instance().getFacility().name()
     if current_facility not in SUPPORTED_FACILITIES:
-        raise AttributeError("Your facility {} is not supported by MuonAnalysis 2.0, so you"
+        raise AttributeError(
+            "Your facility {} is not supported by MuonAnalysis 2.0, so you"
                              "will not be able to load any files. \n \n"
-                             "Supported facilities are :"
-                             + "\n - ".join(SUPPORTED_FACILITIES))
+            "Supported facilities are :" + "\n - ".join(SUPPORTED_FACILITIES))
 
 
 class MuonAnalysisGui(QtWidgets.QMainWindow):
     """
     The Muon Analaysis 2.0 interface.
     """
+
     @staticmethod
     def warning_popup(message):
         message_box.warning(str(message))
@@ -65,12 +66,15 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.loaded_data = MuonLoadData()
         self.data_context = MuonDataContext(self.loaded_data)
         self.gui_context = MuonGuiContext()
-        self.group_pair_context = MuonGroupPairContext(self.data_context.check_group_contains_valid_detectors)
+        self.group_pair_context = MuonGroupPairContext(
+            self.data_context.check_group_contains_valid_detectors)
         self.phase_context = PhaseTableContext()
         self.fitting_context = FittingContext()
 
-        self.context = MuonContext(muon_data_context=self.data_context, muon_gui_context=self.gui_context,
-                                   muon_group_context=self.group_pair_context, muon_phase_context=self.phase_context,
+        self.context = MuonContext(muon_data_context=self.data_context,
+                                   muon_gui_context=self.gui_context,
+                                   muon_group_context=self.group_pair_context,
+                                   muon_phase_context=self.phase_context,
                                    fitting_context=self.fitting_context)
 
         # construct all the widgets.
@@ -79,7 +83,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.home_tab = HomeTabWidget(self.context, self)
         self.phase_tab = PhaseTabWidget(self.context, self)
         self.fitting_tab = FittingTabWidget(self.context, self)
-        self.results_tab = ResultsTabWidget(self.context, self)
+        self.results_tab = ResultsTabWidget(self.context.fitting_context, self)
 
         self.setup_tabs()
         self.help_widget = HelpWidget("Muon Analysis 2")
@@ -119,7 +123,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.setup_fitting_notifier()
 
-        self.context.data_context.message_notifier.add_subscriber(self.grouping_tab_widget.group_tab_presenter.message_observer)
+        self.context.data_context.message_notifier.add_subscriber(
+            self.grouping_tab_widget.group_tab_presenter.message_observer)
 
     def setup_tabs(self):
         """
@@ -128,8 +133,10 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         """
         self.tabs = DetachableTabWidget(self)
         self.tabs.addTabWithOrder(self.home_tab.home_tab_view, 'Home')
-        self.tabs.addTabWithOrder(self.grouping_tab_widget.group_tab_view, 'Grouping')
-        self.tabs.addTabWithOrder(self.phase_tab.phase_table_view, 'Phase Table')
+        self.tabs.addTabWithOrder(self.grouping_tab_widget.group_tab_view,
+                                  'Grouping')
+        self.tabs.addTabWithOrder(self.phase_tab.phase_table_view,
+                                  'Phase Table')
         self.tabs.addTabWithOrder(self.fitting_tab.fitting_tab_view, 'Fitting')
         self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
 
@@ -140,13 +147,16 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.load_widget.load_widget.loadNotifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.loadObserver)
 
-        self.load_widget.load_widget.loadNotifier.add_subscriber(self.phase_tab.phase_table_presenter.run_change_observer)
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.phase_tab.phase_table_presenter.run_change_observer)
 
-        self.load_widget.load_widget.loadNotifier.add_subscriber(self.fitting_tab.fitting_tab_presenter.run_changed_observer)
+        self.load_widget.load_widget.loadNotifier.add_subscriber(
+            self.fitting_tab.fitting_tab_presenter.run_changed_observer)
 
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
-            self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)
+            self.grouping_tab_widget.group_tab_presenter.gui_variables_observer
+        )
 
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.gui_context_observer)
@@ -225,7 +235,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         pass
 
     def setup_fitting_notifier(self):
-        self.fitting_context.new_fit_notifier.add_subscriber(self.results_tab.results_tab_presenter.new_fit_performed_observer)
+        """Connect fitting and results tabs to inform of new fits"""
+        self.fitting_context.new_fit_notifier.add_subscriber(
+            self.results_tab.results_tab_presenter.new_fit_performed_observer)
 
     def closeEvent(self, event):
         self.tabs.closeEvent(event)

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -47,6 +47,7 @@ set ( TEST_PY_FILES
    muon_group_pair_context_test.py
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
+   results_tab_widget/results_tab_model_test.py
    results_tab_widget/results_tab_presenter_test.py
    transformWidget_test.py
    utilities/muon_group_test.py

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -96,6 +96,7 @@ set ( TEST_PY_FILES_QT5
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
    results_tab_widget/results_tab_presenter_test.py
+   results_tab_widget/results_tab_model_test.py
    help_widget_presenter_test.py
 )
 

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -7,6 +7,7 @@ set ( TEST_PY_FILES
    fitting_tab_widget/workspace_selector_dialog_presenter_test.py
    fitting_tab_widget/fitting_tab_presenter_test.py
    fitting_tab_widget/fitting_tab_model_test.py
+   fitting_context_test.py
    home_grouping_widget_test.py
    home_instrument_widget_test.py
    home_plot_widget_test.py
@@ -46,6 +47,7 @@ set ( TEST_PY_FILES
    muon_group_pair_context_test.py
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
+   results_tab_widget/results_tab_presenter_test.py
    transformWidget_test.py
    utilities/muon_group_test.py
    utilities/muon_pair_test.py
@@ -92,6 +94,7 @@ set ( TEST_PY_FILES_QT5
    max_ent_presenter_load_interaction_test.py
    PeriodicTableModel_test.py
    PeriodicTablePresenter_test.py
+   results_tab_widget/results_tab_presenter_test.py
    help_widget_presenter_test.py
 )
 

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -1,0 +1,47 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mantid.py3compat import mock
+from Muon.GUI.Common.contexts.fitting_context import FittingContext, FitInformation
+
+
+class FittingContextTest(unittest.TestCase):
+    def setUp(self):
+        self.fitting_context = FittingContext()
+
+    def test_items_can_be_added_to_fitting_context(self):
+        fit_information_object = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+
+        self.fitting_context.add_fit(fit_information_object)
+
+        self.assertEqual(fit_information_object, self.fitting_context.fit_list[0])
+
+    def test_can_retrieve_a_list_of_fit_objects_based_on_fit_function_name(self):
+        fit_information_object_0 = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        fit_information_object_1 = FitInformation(mock.MagicMock(), 'MuonOsc', mock.MagicMock())
+        fit_information_object_2 = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        self.fitting_context.add_fit(fit_information_object_0)
+        self.fitting_context.add_fit(fit_information_object_1)
+        self.fitting_context.add_fit(fit_information_object_2)
+
+        result = self.fitting_context.get_list_of_fits_for_a_given_fit_function('MuonGuassOsc')
+
+        self.assertEqual([fit_information_object_0, fit_information_object_2], result)
+
+    def test_can_add_fits_without_first_creating_fit_information_objects(self):
+        parameter_workspace = mock.MagicMock()
+        input_workspace = mock.MagicMock()
+        fit_function_name = 'MuonGuassOsc'
+        fit_information_object = FitInformation(parameter_workspace, fit_function_name, input_workspace)
+
+        self.fitting_context.add_fit_from_values(parameter_workspace, fit_function_name, input_workspace)
+
+        self.assertEqual(fit_information_object, self.fitting_context.fit_list[0])
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -20,6 +20,16 @@ class FittingContextTest(unittest.TestCase):
 
         self.assertEqual(fit_information_object, self.fitting_context.fit_list[0])
 
+    def test_fitfunctions_gives_list_of_unique_function_names(self):
+        test_fit_function = 'MuonGuassOsc'
+        self.fitting_context.add_fit_from_values(mock.MagicMock(), test_fit_function, mock.MagicMock())
+        self.fitting_context.add_fit_from_values(mock.MagicMock(), test_fit_function, mock.MagicMock())
+
+        fit_functions = self.fitting_context.fit_function_names()
+
+        self.assertEqual(len(fit_functions), 1)
+        self.assertEqual(test_fit_function, fit_functions[0])
+
     def test_can_retrieve_a_list_of_fit_objects_based_on_fit_function_name(self):
         fit_information_object_0 = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
         fit_information_object_1 = FitInformation(mock.MagicMock(), 'MuonOsc', mock.MagicMock())
@@ -28,7 +38,7 @@ class FittingContextTest(unittest.TestCase):
         self.fitting_context.add_fit(fit_information_object_1)
         self.fitting_context.add_fit(fit_information_object_2)
 
-        result = self.fitting_context.get_list_of_fits_for_a_given_fit_function('MuonGuassOsc')
+        result = self.fitting_context.find_fits_for_function('MuonGuassOsc')
 
         self.assertEqual([fit_information_object_0, fit_information_object_2], result)
 

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -4,6 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, unicode_literals)
 import unittest
 from mantid.py3compat import mock
 from Muon.GUI.Common.contexts.fitting_context import FittingContext, FitInformation
@@ -18,16 +19,6 @@ class FittingContextTest(unittest.TestCase):
         self.fitting_context.add_fit(
             FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock()))
         self.assertEqual(1, len(self.fitting_context))
-
-    def test_items_can_be_added_to_fitting_context(self):
-        fit_information_object = FitInformation(mock.MagicMock(),
-                                                'MuonGuassOsc',
-                                                mock.MagicMock())
-
-        self.fitting_context.add_fit(fit_information_object)
-
-        self.assertEqual(fit_information_object,
-                         self.fitting_context.fit_list[0])
 
     def test_items_can_be_added_to_fitting_context(self):
         fit_information_object = FitInformation(mock.MagicMock(),

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -13,6 +13,22 @@ class FittingContextTest(unittest.TestCase):
     def setUp(self):
         self.fitting_context = FittingContext()
 
+    def test_len_gives_length_of_fit_list(self):
+        self.assertEqual(0, len(self.fitting_context))
+        self.fitting_context.add_fit(
+            FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock()))
+        self.assertEqual(1, len(self.fitting_context))
+
+    def test_items_can_be_added_to_fitting_context(self):
+        fit_information_object = FitInformation(mock.MagicMock(),
+                                                'MuonGuassOsc',
+                                                mock.MagicMock())
+
+        self.fitting_context.add_fit(fit_information_object)
+
+        self.assertEqual(fit_information_object,
+                         self.fitting_context.fit_list[0])
+
     def test_items_can_be_added_to_fitting_context(self):
         fit_information_object = FitInformation(mock.MagicMock(),
                                                 'MuonGuassOsc',

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -14,43 +14,62 @@ class FittingContextTest(unittest.TestCase):
         self.fitting_context = FittingContext()
 
     def test_items_can_be_added_to_fitting_context(self):
-        fit_information_object = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        fit_information_object = FitInformation(mock.MagicMock(),
+                                                'MuonGuassOsc',
+                                                mock.MagicMock())
 
         self.fitting_context.add_fit(fit_information_object)
 
-        self.assertEqual(fit_information_object, self.fitting_context.fit_list[0])
+        self.assertEqual(fit_information_object,
+                         self.fitting_context.fit_list[0])
 
     def test_fitfunctions_gives_list_of_unique_function_names(self):
         test_fit_function = 'MuonGuassOsc'
-        self.fitting_context.add_fit_from_values(mock.MagicMock(), test_fit_function, mock.MagicMock())
-        self.fitting_context.add_fit_from_values(mock.MagicMock(), test_fit_function, mock.MagicMock())
+        self.fitting_context.add_fit_from_values(mock.MagicMock(),
+                                                 test_fit_function,
+                                                 mock.MagicMock())
+        self.fitting_context.add_fit_from_values(mock.MagicMock(),
+                                                 test_fit_function,
+                                                 mock.MagicMock())
 
         fit_functions = self.fitting_context.fit_function_names()
 
         self.assertEqual(len(fit_functions), 1)
         self.assertEqual(test_fit_function, fit_functions[0])
 
-    def test_can_retrieve_a_list_of_fit_objects_based_on_fit_function_name(self):
-        fit_information_object_0 = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
-        fit_information_object_1 = FitInformation(mock.MagicMock(), 'MuonOsc', mock.MagicMock())
-        fit_information_object_2 = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+    def test_can_retrieve_a_list_of_fit_objects_based_on_fit_function_name(
+            self):
+        fit_information_object_0 = FitInformation(mock.MagicMock(),
+                                                  'MuonGuassOsc',
+                                                  mock.MagicMock())
+        fit_information_object_1 = FitInformation(mock.MagicMock(), 'MuonOsc',
+                                                  mock.MagicMock())
+        fit_information_object_2 = FitInformation(mock.MagicMock(),
+                                                  'MuonGuassOsc',
+                                                  mock.MagicMock())
         self.fitting_context.add_fit(fit_information_object_0)
         self.fitting_context.add_fit(fit_information_object_1)
         self.fitting_context.add_fit(fit_information_object_2)
 
         result = self.fitting_context.find_fits_for_function('MuonGuassOsc')
 
-        self.assertEqual([fit_information_object_0, fit_information_object_2], result)
+        self.assertEqual([fit_information_object_0, fit_information_object_2],
+                         result)
 
     def test_can_add_fits_without_first_creating_fit_information_objects(self):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
-        fit_information_object = FitInformation(parameter_workspace, fit_function_name, input_workspace)
+        fit_information_object = FitInformation(parameter_workspace,
+                                                fit_function_name,
+                                                input_workspace)
 
-        self.fitting_context.add_fit_from_values(parameter_workspace, fit_function_name, input_workspace)
+        self.fitting_context.add_fit_from_values(parameter_workspace,
+                                                 fit_function_name,
+                                                 input_workspace)
 
-        self.assertEqual(fit_information_object, self.fitting_context.fit_list[0])
+        self.assertEqual(fit_information_object,
+                         self.fitting_context.fit_list[0])
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -1,5 +1,6 @@
 import unittest
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_model import FittingTabModel
+from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from mantid.api import FunctionFactory, AnalysisDataService
 from mantid.simpleapi import CreateWorkspace
 from mantid.py3compat import mock
@@ -7,7 +8,7 @@ from mantid.py3compat import mock
 
 class FittingTabModelTest(unittest.TestCase):
     def setUp(self):
-        self.model = FittingTabModel()
+        self.model = FittingTabModel(setup_context())
 
     def test_convert_function_string_into_dict(self):
         trial_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -96,6 +96,5 @@ class FittingTabModelTest(unittest.TestCase):
                           'StartX': 0.0, 'EndX': 100.0, 'EvaluationType': 'CentrePoint'})
 
 
-
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -1,3 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest

--- a/scripts/test/Muon/list_selector/list_selector_presenter_test.py
+++ b/scripts/test/Muon/list_selector/list_selector_presenter_test.py
@@ -14,31 +14,41 @@ from mantid.py3compat import mock
 class TestListSelectorPresenter(GuiTest):
     def setUp(self):
         self.view = mock.MagicMock()
-        self.model = {'property_one': [2, True, True], 'property_two': [1, False, False]}
+        self.model = {
+            'property_one': [2, True, True],
+            'property_two': [1, False, False]
+        }
         self.presenter = ListSelectorPresenter(self.view, self.model)
 
     def test_presenter_initialised_with_correct_variables(self):
         self.assertEqual(self.presenter.model, self.model)
         self.assertEqual(self.presenter.view, self.view)
 
-    def test_get_filtered_list_returns_correctly_filtered_list_in_correct_order(self):
+    def test_get_filtered_list_returns_correctly_filtered_list_in_correct_order(
+            self):
         self.presenter.filter_string = 'one'
         self.model.update({'test_one': [0, False, False]})
 
         filtered_list = self.presenter.get_filtered_list()
 
-        self.assertEqual(filtered_list, [['test_one', False, False], ['property_one', True, True]])
+        self.assertEqual(
+            filtered_list,
+            [['test_one', False, False], ['property_one', True, True]])
 
-    def test_handle_filter_changed_creates_filtered_model_and_updates_view_accordingly(self):
+    def test_handle_filter_changed_creates_filtered_model_and_updates_view_accordingly(
+            self):
         self.presenter.handle_filter_changed('one')
 
-        self.view.addItems.assert_called_once_with([['property_one', True, True]])
+        self.view.addItems.assert_called_once_with(
+            [['property_one', True, True]])
 
-    def test_handle_filter_changed_creates_filtered_model_and_updates_view_accordingly_for_no_filter(self):
+    def test_handle_filter_changed_creates_filtered_model_and_updates_view_accordingly_for_no_filter(
+            self):
 
         self.presenter.handle_filter_changed('')
 
-        self.view.addItems.assert_called_once_with([['property_two', False, False], ['property_one', True, True]])
+        self.view.addItems.assert_called_once_with(
+            [['property_two', False, False], ['property_one', True, True]])
 
     def test_handle_selction_changed_updates_model_accordingly(self):
         self.presenter.handle_selection_changed('property_two', True)
@@ -47,6 +57,11 @@ class TestListSelectorPresenter(GuiTest):
 
     def test_get_selected_items_returns_items_names_of_selected_items(self):
         self.assertEqual(self.presenter.get_selected_items(), ['property_one'])
+
+    def test_get_selected_items_and_positions_returns_names_of_selected_items(
+            self):
+        self.assertEqual(self.presenter.get_selected_items_and_positions(),
+                         [('property_one', 2)])
 
     def test_set_filter_type_changes_filter_type_and_updated_view(self):
         self.view.filter_type_combo_box.currentText.return_value = 'Exclude'
@@ -57,12 +72,15 @@ class TestListSelectorPresenter(GuiTest):
 
         self.view.addItems.assert_called_with([['property_two', False, False]])
 
-    def test_select_all_presenter_checkbox_changed_updates_current_filter_list_to_match_itself(self):
+    def test_select_all_presenter_checkbox_changed_updates_current_filter_list_to_match_itself(
+            self):
         self.presenter.handle_select_all_checkbox_changed(True)
 
-        self.view.addItems.assert_called_with([['property_two', True, False], ['property_one', True, True]])
+        self.view.addItems.assert_called_with([['property_two', True, False],
+                                               ['property_one', True, True]])
 
-    def test_that_adding_to_the_filter_list_applies_additional_filter_on_items(self):
+    def test_that_adding_to_the_filter_list_applies_additional_filter_on_items(
+            self):
         self.presenter.update_filter_list(['property_two'])
 
         self.view.addItems.assert_called_with([['property_one', True, True]])

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -93,9 +93,7 @@ class ResultsTabModelTest(unittest.TestCase):
     def test_log_names_from_workspacegroup_uses_first_workspace(self):
         def add_log(workspace, name):
             run = workspace.run()
-            run.addProperty(name,
-                            FloatTimeSeriesProperty(name),
-                            replace=True)
+            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
 
         fake_group = create_test_workspacegroup(size=2)
         logs = ['log_1', 'log_2']
@@ -249,6 +247,35 @@ class ResultsTabModelTest(unittest.TestCase):
     # ------------------------- failure tests ----------------------------
     def test_log_names_from_workspace_not_in_ADS_raises_exception(self):
         self.assertRaises(KeyError, log_names, 'not a workspace in ADS')
+
+    def test_create_results_table_raises_error_if_number_params_different(
+            self):
+        parameters = {
+            'Name': ['Height', 'Cost function value'],
+            'Value': [2309.2, 30.8],
+            'Error': [16, 0]
+        }
+        fits = create_test_fits_with_logs(('ws1', ), 'func1', parameters,
+                                          self.logs)
+        self.fitting_context = FittingContext()
+        for fit in fits:
+            self.fitting_context.add_fit(fit)
+
+        parameters = {
+            'Name': ['Height', 'A0', 'Cost function value'],
+            'Value': [2309.2, 0.1, 30.8],
+            'Error': [16, 0.001, 0]
+        }
+        fits = create_test_fits_with_logs(('ws2', ), 'func1', parameters,
+                                          self.logs)
+        for fit in fits:
+            self.fitting_context.add_fit(fit)
+        self.model = ResultsTabModel(self.fitting_context)
+
+        selected_results = [('ws1', 0), ('ws2', 1)]
+        self.assertRaises(
+            RuntimeError,
+            self.model.create_results_table, [], selected_results)
 
 
 def create_test_workspace(ws_name=None):

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -1,0 +1,80 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+from __future__ import (absolute_import, unicode_literals)
+
+import itertools
+import unittest
+
+from mantid.api import AnalysisDataService, WorkspaceFactory
+from mantid.kernel import FloatTimeSeriesProperty, StringPropertyWithValue
+
+from Muon.GUI.Common.results_tab_widget.results_tab_model import (
+    DEFAULT_TABLE_NAME, ALLOWED_NON_TIME_SERIES_LOGS, ResultsTabModel)
+
+
+class ResultsTabModelTest(unittest.TestCase):
+    def tearDown(self):
+        AnalysisDataService.Instance().clear()
+
+    # ------------------------- success tests ----------------------------
+    def test_default_model_has_results_table_name(self):
+        model = ResultsTabModel()
+        self.assertEqual(model.results_table_name, DEFAULT_TABLE_NAME)
+
+    def test_updating_model_results_table_name(self):
+        model = ResultsTabModel()
+        table_name = 'table_name'
+        model.results_table_name = table_name
+        self.assertEqual(model.results_table_name, table_name)
+
+    def test_log_names_from_workspace_with_logs(self):
+        fake_ws = create_test_workspace(add_logs=True)
+        run = fake_ws.run()
+        # populate with log data
+        time_series_names = ('ts_1', 'ts_2')
+        for name in time_series_names:
+            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
+        single_value_log_names = ('sv_1', 'sv_2')
+        for name in itertools.chain(single_value_log_names,
+                                    ALLOWED_NON_TIME_SERIES_LOGS):
+            run.addProperty(name,
+                            StringPropertyWithValue(name, 'test'),
+                            replace=True)
+        # verify
+        model = ResultsTabModel()
+        allowed_logs = model.log_names(fake_ws.name())
+        for name in itertools.chain(time_series_names,
+                                    ALLOWED_NON_TIME_SERIES_LOGS):
+            self.assertTrue(
+                name in allowed_logs,
+                msg="{} not found in allowed log list".format(name))
+        for name in single_value_log_names:
+            self.assertFalse(name in allowed_logs,
+                             msg="{} found in allowed log list".format(name))
+
+    def test_log_names_from_workspace_without_logs(self):
+        fake_ws = create_test_workspace()
+        model = ResultsTabModel()
+        allowed_logs = model.log_names(fake_ws.name())
+        self.assertEqual(0, len(allowed_logs))
+
+    # ------------------------- failure tests ----------------------------
+    def test_log_names_from_workspace_not_in_ADS_raises_exception(self):
+        model = ResultsTabModel()
+        self.assertRaises(KeyError, model.log_names, 'not a workspace in ADS')
+
+
+def create_test_workspace():
+    fake_ws = WorkspaceFactory.create('Workspace2D', 1, 1, 1)
+    ws_name = 'results_tab_model_test_log_names_fake_ws'
+    AnalysisDataService.Instance().addOrReplace(ws_name, fake_ws)
+    return fake_ws
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -135,24 +135,24 @@ class ResultsTabModelTest(unittest.TestCase):
 
             self.assertEqual(expected_selection, self.model.log_selection({}))
 
-    # def test_model_combines_existing_selection(self):
-    #     self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
-    #         ('ws1', ))[0]
-    #     with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
-    #         mock_log_names.return_value = ('run_number', 'run_start',
-    #                                        'magnetic_field')
-    #
-    #         existing_selection = {
-    #             'run_number': [0, False, True],
-    #             'run_start': [1, True, True]
-    #         }
-    #         expected_selection = {
-    #             'run_number': [0, False, True],
-    #             'run_start': [1, True, True],
-    #             'magnetic_field': [2, True, True]
-    #         }
-    #         self.assertEqual(expected_selection,
-    #                          self.model.log_selection(existing_selection))
+    def test_model_combines_existing_selection(self):
+        self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
+            ('ws1', ))[0]
+        with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
+            mock_log_names.return_value = ('run_number', 'run_start',
+                                           'magnetic_field')
+
+            existing_selection = {
+                'run_number': [0, False, True],
+                'run_start': [1, True, True],
+            }
+            expected_selection = {
+                'run_number': [0, False, True],
+                'run_start': [1, True, True],
+                'magnetic_field': [2, False, True]
+            }
+            self.assertDictEqual(expected_selection,
+                                 self.model.log_selection(existing_selection))
 
     def test_create_results_table_with_no_logs(self):
         parameters = {

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -49,6 +49,25 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_model.set_results_table_name.assert_called_once_with(
             new_name)
 
+    def test_adding_new_fit_populates_tables(self):
+        test_functions = ['func1', 'func2']
+        expected_ws_list_state = {
+            name: [index, True, True]
+            for index, name in enumerate(('ws1', 'ws2'))
+        }
+        self.mock_model.fit_functions.return_value = test_functions
+        self.mock_model.fit_input_workspaces.return_value = expected_ws_list_state
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        # previous test verifies this is correct on construction
+        self.mock_view.set_output_results_button_enabled.reset_mock()
+
+        presenter.on_new_fit_performed()
+
+        self.mock_model.fit_functions.assert_called_once_with()
+        self.mock_view.set_fit_function_names.assert_called_once_with(test_functions)
+        self.mock_view.set_fit_result_workspaces.assert_called_once_with(expected_ws_list_state)
+        self.mock_view.set_output_results_button_enabled.assert_called_once_with(True)
+
     # def test_changing_function_name(self):
     #     # new_name = 'edited_name'
     #     # self.mock_view.results_table_name.return_value = new_name

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -83,6 +83,34 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_view.set_output_results_button_enabled.assert_called_once_with(
             True)
 
+    def test_adding_new_fit_updates_log_values(self):
+        existing_selection = {
+            'run_number': [0, False, True],
+            'run_start': [1, True, True]
+        }
+        self.mock_view.log_values.return_value = existing_selection
+        final_selection = {
+            'run_number': [0, False, True],
+            'run_start': [1, True, True],
+            'magnetic_field': [2, True, True]
+        }
+        self.mock_model.log_selection.return_value = final_selection
+
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        # previous test verifies this is correct on construction
+        self.mock_view.set_output_results_button_enabled.reset_mock()
+        presenter.on_new_fit_performed()
+
+        self.mock_view.log_values.assert_called_once_with()
+        self.mock_model.log_selection.assert_called_once_with(
+            existing_selection)
+        final_selection = {
+            'run_number': [0, False, True],
+            'run_start': [1, True, True],
+            'magnetic_field': [2, True, True]
+        }
+        self.mock_view.set_log_values.assert_called_once_with(final_selection)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -1,0 +1,36 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mantid.py3compat import mock
+from mantidqt.utils.qt.testing import GuiTest
+from Muon.GUI.Common.results_tab_widget.results_tab_widget import ResultsTabWidget
+from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from mantid.api import FunctionFactory
+
+
+def retrieve_combobox_info(combo_box):
+    output_list = []
+    for i in range(combo_box.count()):
+        output_list.append(str(combo_box.itemText(i)))
+
+    return output_list
+
+
+class ResultsTabPresenterTest(GuiTest):
+    def setUp(self):
+        self.context = setup_context()
+        self.results_tab_widget = ResultsTabWidget(self.context, None)
+        self.view = self.results_tab_widget.results_tab_view
+        self.presenter = self.results_tab_widget.results_tab_presenter
+
+    def test_that_widget_initialises_correctly(self):
+        self.assertEqual(self.presenter.get_selected_fit_list(), [])
+        self.assertEqual(self.presenter.get_selected_logs_list(), [])
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -87,7 +87,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
         self.mock_model.fit_functions.assert_called_once_with()
         self.mock_model.fit_selection.assert_called_once_with(
-            orig_ws_list_state)
+            existing_selection=orig_ws_list_state)
         self.mock_view.set_fit_function_names.assert_called_once_with(
             test_functions)
         self.mock_view.fit_result_workspaces.assert_called_once_with()
@@ -116,7 +116,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
         self.mock_view.log_values.assert_called_once_with()
         self.mock_model.log_selection.assert_called_once_with(
-            existing_selection)
+            existing_selection=existing_selection)
         final_selection = {
             'run_number': [0, False, True],
             'run_start': [1, True, True],

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -33,6 +33,8 @@ class ResultsTabPresenterTest(unittest.TestCase):
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
         self.mock_view.set_results_table_name.assert_called_once_with(
             'default_table')
+        self.mock_view.function_selection_changed.connect.assert_called_once_with(
+            presenter.on_function_selection_changed)
         self.mock_view.results_name_edited.connect.assert_called_once_with(
             presenter.on_results_table_name_edited)
         self.mock_view.output_results_requested.connect.assert_called_once_with(
@@ -48,6 +50,16 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
         self.mock_view.results_table_name.assert_called_once_with()
         self.mock_model.set_results_table_name.assert_called_once_with(
+            new_name)
+
+    def test_changing_function_selection(self):
+        new_name = 'func 2'
+        self.mock_view.selected_fit_function.return_value = new_name
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter.on_function_selection_changed()
+
+        self.mock_view.selected_fit_function.assert_called_once_with()
+        self.mock_model.set_selected_fit_function.assert_called_once_with(
             new_name)
 
     def test_adding_new_fit_to_existing_fits_preserves_current_selections(


### PR DESCRIPTION
**Description of work.**

Adds the results tab to the new Python-based Muon GUI.

**To test:**

To enable to interface you need to edit the `mantidqt.interfaces` property in the properties file and add `Muon/Muon_Analysis_2.py` to the list.

1. Switching to the results tab first without any fits should show the "Ouptut Results" button as disabled.
2. Perform a fit in the fitting tab and see that the results have appeared in the results tab with the expected log values and workspaces values in the lists.
   1. The output results tab should be enabled clicking it produces a table of the results.
   2. Select different log values and confirm they appear in the output table
3. Switch back to the fitting tab, select a new workspace and new fitting function and run a fit
   1. The function selection box should now have 2 functions in it
   2. Selecting a new function should show the appropriate fit results in the list
   3. Try more fits and select/deselect different results and confirm the output table looks correct. 

Fixes #25762

*This does not require release notes* because **the whole GUI is not yet production ready.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
