### PR TITLE
Remove warning

### DIFF
--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -33,7 +33,6 @@ using namespace DataObjects;
 
 void FindCenterOfMassPosition2::init() {
   auto wsValidator = boost::make_shared<CompositeValidator>();
-  wsValidator->add<WorkspaceUnitValidator>("Wavelength");
   wsValidator->add<HistogramValidator>();
   declareProperty(make_unique<WorkspaceProperty<>>(
       "InputWorkspace", "", Direction::Input, wsValidator));

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2D.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/Workspace2D.cpp
@@ -148,22 +148,24 @@ public:
 
     std::string instrumentXML = extract<std::string>(state["instrument_xml"]);
     std::string instrumentName = extract<std::string>(state["instrument_name"]);
-    try {
-      auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
-          "LoadInstrument");
-      // Do not put the workspace in the ADS
-      alg->setChild(true);
-      alg->initialize();
-      alg->setPropertyValue("InstrumentName", instrumentName);
-      alg->setPropertyValue("InstrumentXML", instrumentXML);
-      alg->setProperty("Workspace", boost::shared_ptr<Workspace2D>(
-                                        &ws, [](Workspace2D *) {}));
-      alg->setProperty("RewriteSpectraMap",
-                       Mantid::Kernel::OptionalBool(false));
-      alg->execute();
-    } catch (std::exception &exc) {
-      Mantid::Kernel::Logger("Workspace2DPickleSuite").warning()
-          << "Could not load instrument XML: " << exc.what() << "\n";
+    if (!instrumentName.empty() && !instrumentXML.empty()) {
+      try {
+        auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
+            "LoadInstrument");
+        // Do not put the workspace in the ADS
+        alg->setChild(true);
+        alg->initialize();
+        alg->setPropertyValue("InstrumentName", instrumentName);
+        alg->setPropertyValue("InstrumentXML", instrumentXML);
+        alg->setProperty("Workspace", boost::shared_ptr<Workspace2D>(
+                                          &ws, [](Workspace2D *) {}));
+        alg->setProperty("RewriteSpectraMap",
+                         Mantid::Kernel::OptionalBool(false));
+        alg->execute();
+      } catch (std::exception &exc) {
+        Mantid::Kernel::Logger("Workspace2DPickleSuite").warning()
+            << "Could not load instrument XML: " << exc.what() << "\n";
+      }
     }
 
     Mantid::Indexing::IndexInfo indexInfo(spectrumNumbers);


### PR DESCRIPTION
**Description of work.**

1. remove the wavelength restriction for center of mass
2. When running:

```python
from multiprocessing import Pool
p = Pool(4)

def f(suffix):
    dataX = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16]
    dataY = [1,2,3,4,5,6,7,8,9,10,11,12]
    dataE = [1,2,3,4,5,6,7,8,9,10,11,12]
    dX = [1,2,3,4,5,6,7,8,9,10,11,12]
    ws = CreateWorkspace(
        DataX=dataX, DataY=dataY, DataE=dataE, NSpec=4, UnitX="Wavelength",
        Dx=dX, OutputWorkspace="ws_{}".format(suffix))
    return ws.name

p.map(f, [1, 2])
```

There was the warning:
```
Either the InstrumentName or Filename property of LoadInstrument most be specified
Error in execution of algorithm LoadInstrument:
Either the InstrumentName or Filename property of LoadInstrument must be specified to load an instrument in ""
Could not load instrument XML: Either the InstrumentName or Filename property of LoadInstrument must be specified to load an instrument in ""
```

The changes in the code remove that warning.


**To test:**

Tests should pass. The code above does not give a warning anymore.

This does not require release notes because it is an internal change.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
