### PR TITLE
Change diagnostic page icon to a stethoscope

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -28,6 +28,7 @@ Improvements
 - When the main save directory is changed, the add runs save directory is also updated. Add runs save directory can be still changed independently of the main save directory.
 - File type buttons are disabled when memory mode is selected to make it clearer that SANS will not save to file.
 - The path to the user file used to reduce the data is now added to the workspace sample logs. This user file path is added to canSAS file metadata.
+- The **diagnostic** page icon has been changed from a question mark to a stethoscope, to distinguish it from the **Help** page icon. The **Export Table** button now has an icon. There have been minor icon changes elsewhere on the interface.
 
 Bug Fixes
 #########

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -289,7 +289,7 @@ class SANSDataProcessorGui(QMainWindow,
         runs_icon = icons.get_icon("mdi.play-circle-outline")
         _ = QListWidgetItem(runs_icon, "Runs", self.tab_choice_list)  # noqa
 
-        settings_icon = icons.get_icon("mdi.settings")
+        settings_icon = icons.get_icon("mdi.settings-outline")
         _ = QListWidgetItem(settings_icon, "Settings", self.tab_choice_list)  # noqa
 
         centre_icon = icons.get_icon("mdi.adjust")
@@ -298,7 +298,7 @@ class SANSDataProcessorGui(QMainWindow,
         add_runs_page_icon = icons.get_icon("mdi.plus-circle-outline")
         _ = QListWidgetItem(add_runs_page_icon, "Sum Runs", self.tab_choice_list)  # noqa
 
-        diagnostic_icon = icons.get_icon("mdi.help-circle-outline")
+        diagnostic_icon = icons.get_icon("mdi.stethoscope")
         _ = QListWidgetItem(diagnostic_icon, "Diagnostic Page", self.tab_choice_list)  # noqa
 
         # Set the 0th row enabled

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -223,8 +223,8 @@ class SANSDataProcessorGui(QMainWindow,
         self.copy_button.setIcon(icons.get_icon("mdi.content-copy"))
         self.cut_button.setIcon(icons.get_icon("mdi.content-cut"))
         self.erase_button.setIcon(icons.get_icon("mdi.eraser"))
-        self.delete_row_button.setIcon(icons.get_icon("mdi.trash-can"))
-        self.insert_row_button.setIcon(icons.get_icon("mdi.table"))
+        self.delete_row_button.setIcon(icons.get_icon("mdi.table-row-remove"))
+        self.insert_row_button.setIcon(icons.get_icon("mdi.table-row-plus-after"))
         self.export_table_button.setIcon(icons.get_icon("mdi.file-export"))
 
         self.paste_button.clicked.connect(self._paste_rows_requested)
@@ -286,16 +286,16 @@ class SANSDataProcessorGui(QMainWindow,
         self.tab_choice_list.currentRowChanged.connect(self.set_current_page)
         self.set_current_page(0)
 
-        runs_icon = icons.get_icon("mdi.play-circle-outline")
+        runs_icon = icons.get_icon("mdi.play")
         _ = QListWidgetItem(runs_icon, "Runs", self.tab_choice_list)  # noqa
 
-        settings_icon = icons.get_icon("mdi.settings-outline")
+        settings_icon = icons.get_icon("mdi.settings")
         _ = QListWidgetItem(settings_icon, "Settings", self.tab_choice_list)  # noqa
 
         centre_icon = icons.get_icon("mdi.adjust")
         _ = QListWidgetItem(centre_icon, "Beam Centre", self.tab_choice_list)  # noqa
 
-        add_runs_page_icon = icons.get_icon("mdi.plus-circle-outline")
+        add_runs_page_icon = icons.get_icon("mdi.plus")
         _ = QListWidgetItem(add_runs_page_icon, "Sum Runs", self.tab_choice_list)  # noqa
 
         diagnostic_icon = icons.get_icon("mdi.stethoscope")


### PR DESCRIPTION
**Description of work.**
The ISIS SANS diagnostic page icon has been changed to a stethoscope, to distinguish it from the Help page icon.
The settings page icon changed from a dark cog to an outline of a cog. This brings it more inline with the surrounding icons, which are predominantly white.

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Look at the tabs on the left hand side of the main gui. There should be a play button, a cog, a circle with a dot, a circle with a plus, and a stethoscope.
3. Do the cog or stethoscope look out of place or ambiguous?

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
