### PR TITLE
ISIS Pearl Longmode fix

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_PowderPearlTest.py
@@ -135,6 +135,7 @@ class FocusTest(systemtesting.MantidSystemTest):
             config['datasearch.directories'] = self.existing_config
             mantid.mtd.clear()
 
+
 class FocusLongThenShortTest(systemtesting.MantidSystemTest):
 
     focus_results = None

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -28,6 +28,8 @@ Bug Fixes
 
 - HRPD Absorption corrections now correctly takes into account the thickness of the slab.
 
+- Pearl no longer produces an output of NaN when long-mode is changed after focusing.
+
 Engineering Diffraction
 -----------------------
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -89,17 +89,20 @@ class Pearl(AbstractInst):
                                                                        self._inst_settings.tt_mode)
         if run_number_string_key in self._cached_run_details:
             # update spline path of cache
-            if self._inst_settings.long_mode:
-                self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                              [self._inst_settings.tt_mode, "long"])
+
+            add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
+                [self._inst_settings.tt_mode]
+
+            self._cached_run_details[run_number_string_key].update_spline(self._inst_settings, add_spline)
         yield
         # reset instrument settings
         self._inst_settings = copy.deepcopy(self._default_inst_settings)
 
         # reset spline path
-        if self._inst_settings.long_mode:
-            self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                          [self._inst_settings.tt_mode, "long"])
+        add_spline = [self._inst_settings.tt_mode, "long"] if self._inst_settings.long_mode else \
+            [self._inst_settings.tt_mode]
+
+        self._cached_run_details[run_number_string_key].update_spline(self._inst_settings, add_spline)
 
     def _run_create_vanadium(self):
         # Provides a minimal wrapper so if we have tt_mode 'all' we can loop round

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -97,7 +97,7 @@ class Pearl(AbstractInst):
 
         # reset spline path
         self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                          [self._inst_settings.tt_mode])
+                                                                      [self._inst_settings.tt_mode])
 
     def _run_create_vanadium(self):
         # Provides a minimal wrapper so if we have tt_mode 'all' we can loop round

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -40,7 +40,6 @@ class Pearl(AbstractInst):
 
     def create_vanadium(self, **kwargs):
         kwargs["perform_attenuation"] = None  # Hard code this off as we do not need an attenuation file
-        print(kwargs)
         with self._apply_temporary_inst_settings(kwargs, kwargs.get("run_in_cycle")):
             if str(self._inst_settings.tt_mode).lower() == "all":
                 for new_tt_mode in ["tt35", "tt70", "tt88"]:

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -33,15 +33,15 @@ class Pearl(AbstractInst):
         self._cached_run_details = {}
 
     def focus(self, **kwargs):
-        with self._apply_temporary_inst_settings(kwargs):
+        with self._apply_temporary_inst_settings(kwargs, kwargs.get("run_number")):
             return self._focus(run_number_string=self._inst_settings.run_number,
                                do_absorb_corrections=self._inst_settings.absorb_corrections,
                                do_van_normalisation=self._inst_settings.van_norm)
 
     def create_vanadium(self, **kwargs):
         kwargs["perform_attenuation"] = None  # Hard code this off as we do not need an attenuation file
-
-        with self._apply_temporary_inst_settings(kwargs):
+        print(kwargs)
+        with self._apply_temporary_inst_settings(kwargs, kwargs.get("run_in_cycle")):
             if str(self._inst_settings.tt_mode).lower() == "all":
                 for new_tt_mode in ["tt35", "tt70", "tt88"]:
                     self._inst_settings.tt_mode = new_tt_mode
@@ -50,7 +50,7 @@ class Pearl(AbstractInst):
                 self._run_create_vanadium()
 
     def create_cal(self, **kwargs):
-        with self._apply_temporary_inst_settings(kwargs):
+        with self._apply_temporary_inst_settings(kwargs, kwargs.get("run_number")):
             run_details = self._get_run_details(self._inst_settings.run_number)
 
             cross_correlate_params = {"ReferenceSpectra": self._inst_settings.reference_spectra,
@@ -77,7 +77,7 @@ class Pearl(AbstractInst):
         return self._inst_settings.subtract_empty_inst
 
     @contextmanager
-    def _apply_temporary_inst_settings(self, kwargs):
+    def _apply_temporary_inst_settings(self, kwargs, run):
 
         # set temporary settings
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
@@ -85,7 +85,7 @@ class Pearl(AbstractInst):
         self._inst_settings.update_attributes(kwargs=kwargs)
 
         # check that cache exists
-        run_number_string_key = self._generate_run_details_fingerprint(self._inst_settings.run_number,
+        run_number_string_key = self._generate_run_details_fingerprint(run,
                                                                        self._inst_settings.file_extension,
                                                                        self._inst_settings.tt_mode)
         if run_number_string_key in self._cached_run_details:

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -89,15 +89,17 @@ class Pearl(AbstractInst):
                                                                        self._inst_settings.tt_mode)
         if run_number_string_key in self._cached_run_details:
             # update spline path of cache
-            self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                          [self._inst_settings.tt_mode])
+            if self._inst_settings.long_mode:
+                self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
+                                                                              [self._inst_settings.tt_mode, "long"])
         yield
         # reset instrument settings
         self._inst_settings = copy.deepcopy(self._default_inst_settings)
 
         # reset spline path
-        self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
-                                                                      [self._inst_settings.tt_mode])
+        if self._inst_settings.long_mode:
+            self._cached_run_details[run_number_string_key].update_spline(self._inst_settings,
+                                                                          [self._inst_settings.tt_mode, "long"])
 
     def _run_create_vanadium(self):
         # Provides a minimal wrapper so if we have tt_mode 'all' we can loop round

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -94,7 +94,7 @@ def get_run_details(run_number_string, inst_settings, is_vanadium_run):
 
     spline_identifier = [inst_settings.tt_mode]
     if inst_settings.long_mode:
-        spline_identifier.append("_long")
+        spline_identifier.append("long")
 
     return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
                                      is_vanadium_run=is_vanadium_run, splined_name_list=spline_identifier,

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -118,3 +118,22 @@ class _RunDetails(object):
         self.vanadium_absorption_path = vanadium_abs_path
         self.output_suffix = output_suffix
         self.van_paths = van_paths
+
+    def update_spline(self, inst_settings, new_splined_name_list):
+        """Updates the spline path using a new splined name list, this is necessary on instruments where the spline path
+        may change e.g. Pearl due to long-mode
+        :param inst_settings The current Instrument settings
+        :param new_splined_name_list  List of unique properties to generate a splined vanadium name from
+        """
+
+        cal_map_dict = get_cal_mapping_dict(run_number_string=self.output_run_string,
+                                            cal_mapping_path=inst_settings.cal_mapping_path)
+        offset_file_name = common.cal_map_dictionary_key_helper(dictionary=cal_map_dict, key="offset_file_name")
+
+        # Prepend the properties used for creating a van spline so we can fingerprint the file
+        splined_list = new_splined_name_list if new_splined_name_list else []
+        splined_list.append(os.path.basename(offset_file_name))
+
+        splined_van_name = common.generate_splined_name(self.vanadium_run_numbers, splined_list)
+        self.splined_vanadium_file_path = os.path.join(self.van_paths, splined_van_name)
+

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -136,4 +136,3 @@ class _RunDetails(object):
 
         splined_van_name = common.generate_splined_name(self.vanadium_run_numbers, splined_list)
         self.splined_vanadium_file_path = os.path.join(self.van_paths, splined_van_name)
-


### PR DESCRIPTION
**Description of work.**
Fixed ISIS PEARL focus producing NaN as its result if the long mode was changed after focusing
**To test:**
*Requires ISIS Data Search Archive*
Ask me for the calibration files (they're too large to fit on github) and update the paths in the calibration file, enable the data search archive, then run the following scripts
```
from isis_powder import Pearl

config_file_path = r"path/to/config"
Pearl_example = Pearl(config_file=config_file_path,user_name="test")
Pearl_example.create_vanadium(run_in_cycle=101508)
Pearl_example.create_vanadium(run_in_cycle=101508,long_mode=True)
```
once this has run, clear the ADS and run 
```
from isis_powder import Pearl

config_file_path = r"path/to/config"
Pearl_example = Pearl(config_file=config_file_path,user_name="test")
Pearl_example.focus(run_number="101508", focus_mode="trans",long_mode=False)
Pearl_example.focus(run_number="101508", focus_mode="trans",long_mode=True)
```
then plot `PRL101508_tt70_mods1-9` and `PRL101508_tt70_long_mods1-9`
both should properly plot instead of erroring due to NaN



Fixes #25810 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
