### PR TITLE
Fix raw data not being shown

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -179,6 +179,7 @@ class GroupingTabPresenter(object):
 
     def handle_new_data_loaded(self):
         if self._model.is_data_loaded():
+            self._model._context.show_raw_data()
             self.grouping_table_widget.update_view_from_model()
             self.pairing_table_widget.update_view_from_model()
             self.update_description_text()


### PR DESCRIPTION
**Description of work.**
A recent change meant that the raw data was not added to the ADS in the Muon Analysis GUI this reverses this change.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Load some data and check the raw data appears in the ADS.
<!-- Instructions for testing. -->


*There is no associated issue.*


*This does not require release notes* because this is undoing a recently introduced bug.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
