### PR TITLE
Add support for step size in IntArrayProperty

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyHelper.h
@@ -195,12 +195,14 @@ inline void appendValue(const std::string &strvalue, std::vector<T> &value) {
   }
 
   if (step == static_cast<T>(0))
-    throw std::runtime_error("Step size must be non-zero");
+    throw std::logic_error("Step size must be non-zero");
 
   // convert the input string into boundaries and run through a list
   const auto start = boost::lexical_cast<T>(strvalue.substr(0, pos));
   const auto stop = boost::lexical_cast<T>(strvalue.substr(pos + 1, numChar));
   if (start <= stop) {
+    if (start + step < start)
+      throw std::logic_error("Step size is negative with increasing limits");
     for (auto i = start; i <= stop;) {
       value.push_back(i);
       // done inside the loop because gcc7 doesn't like i+=step for short
@@ -208,6 +210,8 @@ inline void appendValue(const std::string &strvalue, std::vector<T> &value) {
       i = static_cast<T>(i + step);
     }
   } else {
+    if (start + step >= start)
+      throw std::logic_error("Step size is positive with decreasing limits");
     for (auto i = start; i >= stop;) {
       value.push_back(i);
       // done inside the loop because gcc7 doesn't like i+=step for short

--- a/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Framework/Kernel/test/ArrayPropertyTest.h
@@ -122,6 +122,14 @@ public:
     TS_ASSERT_EQUALS(i7.operator()()[1], 3);
     TS_ASSERT_EQUALS(i7.operator()()[2], 1);
 
+    // bad step size
+    TS_ASSERT_THROWS(ArrayProperty<int> i8("i", "1:5:0"),
+                     const std::logic_error &);
+    TS_ASSERT_THROWS(ArrayProperty<int> i9("i", "1:5:-2"),
+                     const std::logic_error &);
+    TS_ASSERT_THROWS(ArrayProperty<int> i10("i", "5:1"),
+                     const std::logic_error &);
+
     ArrayProperty<unsigned int> u1("i", "0:2,5");
     TS_ASSERT_EQUALS(u1.operator()()[0], 0);
     TS_ASSERT_EQUALS(u1.operator()()[1], 1);

--- a/Framework/Kernel/test/ArrayPropertyTest.h
+++ b/Framework/Kernel/test/ArrayPropertyTest.h
@@ -85,8 +85,7 @@ public:
   }
 
   void testConstructorByString() {
-    const std::string &i_stringValue = "1,2,3";
-    ArrayProperty<int> i("i", i_stringValue);
+    ArrayProperty<int> i("i", "1,2,3");
     TS_ASSERT_EQUALS(i.operator()()[0], 1);
     TS_ASSERT_EQUALS(i.operator()()[1], 2);
     TS_ASSERT_EQUALS(i.operator()()[2], 3);
@@ -98,33 +97,43 @@ public:
     TS_ASSERT_EQUALS(i2.operator()()[1], 0);
     TS_ASSERT_EQUALS(i2.operator()()[2], 1);
 
-    ArrayProperty<int> i4("i", "-1:1");
-    TS_ASSERT_EQUALS(i4.operator()()[0], -1);
-    TS_ASSERT_EQUALS(i4.operator()()[1], 0);
-    TS_ASSERT_EQUALS(i4.operator()()[2], 1);
+    ArrayProperty<int> i3("i", "-1:1");
+    TS_ASSERT_EQUALS(i3.operator()()[0], -1);
+    TS_ASSERT_EQUALS(i3.operator()()[1], 0);
+    TS_ASSERT_EQUALS(i3.operator()()[2], 1);
 
-    ArrayProperty<int> i5("i", "-3--1");
+    ArrayProperty<int> i4("i", "-3--1");
+    TS_ASSERT_EQUALS(i4.operator()()[0], -3);
+    TS_ASSERT_EQUALS(i4.operator()()[1], -2);
+    TS_ASSERT_EQUALS(i4.operator()()[2], -1);
+
+    ArrayProperty<int> i5("i", "-3:-1");
     TS_ASSERT_EQUALS(i5.operator()()[0], -3);
     TS_ASSERT_EQUALS(i5.operator()()[1], -2);
     TS_ASSERT_EQUALS(i5.operator()()[2], -1);
 
-    ArrayProperty<int> i7("i", "-3:-1");
-    TS_ASSERT_EQUALS(i7.operator()()[0], -3);
-    TS_ASSERT_EQUALS(i7.operator()()[1], -2);
-    TS_ASSERT_EQUALS(i7.operator()()[2], -1);
+    ArrayProperty<int> i6("i", "-3:0:2");
+    TS_ASSERT_EQUALS(i6.operator()()[0], -3);
+    TS_ASSERT_EQUALS(i6.operator()()[1], -1);
 
-    ArrayProperty<unsigned int> i3("i", "0:2,5");
-    TS_ASSERT_EQUALS(i3.operator()()[0], 0);
-    TS_ASSERT_EQUALS(i3.operator()()[1], 1);
-    TS_ASSERT_EQUALS(i3.operator()()[2], 2);
-    TS_ASSERT_EQUALS(i3.operator()()[3], 5);
+    // negative step size
+    ArrayProperty<int> i7("i", "5:1:-2");
+    TS_ASSERT_EQUALS(i7.operator()()[0], 5);
+    TS_ASSERT_EQUALS(i7.operator()()[1], 3);
+    TS_ASSERT_EQUALS(i7.operator()()[2], 1);
 
-    ArrayProperty<unsigned int> i6("i", "5,0-2,5");
-    TS_ASSERT_EQUALS(i6.operator()()[0], 5);
-    TS_ASSERT_EQUALS(i6.operator()()[1], 0);
-    TS_ASSERT_EQUALS(i6.operator()()[2], 1);
-    TS_ASSERT_EQUALS(i6.operator()()[3], 2);
-    TS_ASSERT_EQUALS(i6.operator()()[4], 5);
+    ArrayProperty<unsigned int> u1("i", "0:2,5");
+    TS_ASSERT_EQUALS(u1.operator()()[0], 0);
+    TS_ASSERT_EQUALS(u1.operator()()[1], 1);
+    TS_ASSERT_EQUALS(u1.operator()()[2], 2);
+    TS_ASSERT_EQUALS(u1.operator()()[3], 5);
+
+    ArrayProperty<unsigned int> u2("i", "5,0-2,5");
+    TS_ASSERT_EQUALS(u2.operator()()[0], 5);
+    TS_ASSERT_EQUALS(u2.operator()()[1], 0);
+    TS_ASSERT_EQUALS(u2.operator()()[2], 1);
+    TS_ASSERT_EQUALS(u2.operator()()[3], 2);
+    TS_ASSERT_EQUALS(u2.operator()()[4], 5);
 
     ArrayProperty<double> d("d", "7.77,8.88,9.99");
     TS_ASSERT_EQUALS(d.operator()()[0], 7.77)

--- a/docs/source/api/python/mantid/api/MultipleFileProperty.rst
+++ b/docs/source/api/python/mantid/api/MultipleFileProperty.rst
@@ -13,7 +13,7 @@ to load (and optionally sum together) into Mantid.
 
 This functionality is offered via the ``Filename`` property of
 :ref:`algm-Load`, and so is available by calling the algorithm or by
-using the LoadDialog window in the usual way.
+using the LoadDialog window in the usual way. :class:`~mantid.kernel.IntArrayProperty` accepts similar syntax for specifying ranges.
 
 Syntax
 ======

--- a/docs/source/api/python/mantid/kernel/IntArrayProperty.rst
+++ b/docs/source/api/python/mantid/kernel/IntArrayProperty.rst
@@ -4,12 +4,26 @@
 
 This is a Python binding to the C++ class Mantid::Kernel::ArrayProperty.
 
+Much of the syntax of this property is identical to :class:`mantid.api.MultipleFileProperty`.
+
++---------------------+-----------------------------+--------------------------------------------------+---------------+----------------+
+| Name                | Usage                       | Description                                      | Example Input | Example Result |
++=====================+=============================+==================================================+===============+================+
+| Range               | ``<start>-<stop>``          | Used to specify a range of values                | ``1-4``       | 1,2,3,4        |
++---------------------+-----------------------------+--------------------------------------------------+---------------+----------------+
+| Range               | ``<start>:<stop>``          | Used to specify a range of values                | ``1:4``       | 1,2,3,4        |
++---------------------+-----------------------------+--------------------------------------------------+---------------+----------------+
+| Stepped Range       | ``<start>:<stop>:<step>``   | Used to specify a ``stepped`` range of values    | ``1:5:2``     | 1,3,5          |
++---------------------+-----------------------------+--------------------------------------------------+---------------+----------------+
+| List                | ``<item1>,<item2>``         | Used to list values, can be combined with ranges | ``1,3-5``     | 1,3,4,5        |
++---------------------+-----------------------------+--------------------------------------------------+---------------+----------------+
+
+
 *bases:* :py:obj:`mantid.kernel.VectorLongPropertyWithValue`
 
 .. module:`mantid.kernel`
 
-.. autoclass:: mantid.kernel.IntArrayProperty 
+.. autoclass:: mantid.kernel.IntArrayProperty
     :members:
     :undoc-members:
     :inherited-members:
-

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -12,6 +12,8 @@ Framework Changes
 Concepts
 --------
 
+- :class:`mantid.kernel.IntArrayProperty` now supports specifying step sizes
+
 Algorithms
 ----------
 
@@ -34,11 +36,11 @@ Improvements
 - :ref:`Pseudo-Voigt <func-PseudoVoigt>` has been modified to be more in line with FULLPROF and GSAS.  One of its basic parameter, Height, is changed to Intensity.
 - 10x performance improvement in calls to ``Mantid::PhysicalConstants::getAtom``.
 - ARCS, CNCS, HYSPEC, NOMAD, POWGEN, SEQUOIA, SNAP, and VULCAN have had the axis that signed two-theta is calculated against changed from ``+y`` to ``+x``
-- :ref: `SetSample <algm-SetSample>` will now look for facility wide sample environments. instrument specific ones will be loaded first.
+- :ref:`SetSample <algm-SetSample>` will now look for facility wide sample environments. instrument specific ones will be loaded first.
 
 Bug fixes
 #########
-- :ref: `SetSample <algm-SetSample>` now correctly handles the Sample number density being passed as a string, before the algorithm would execute, but silently ignored the provided number density, the number density is now properly used.
+- :ref:`SetSample <algm-SetSample>` now correctly handles the Sample number density being passed as a string, before the algorithm would execute, but silently ignored the provided number density, the number density is now properly used.
 
 Removed
 #######
@@ -53,7 +55,7 @@ Python
 ------
 
 - The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
-- The method `total_nanoseconds` in `DateAndTime` has been deprecated. `totalNanoseconds` should be used instead.
-- The method `total_nanoseconds` in `time_duration` has been deprecated. `totalNanoseconds` should be used instead.
+- In :class:`mantid.kernel.DateAndTime`, the method :py:meth:`~mantid.kernel.DateAndTime.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.DateAndTime.totalNanoseconds` should be used instead.
+- In :class:`mantid.kernel.time_duration`, The method :py:meth:`~mantid.kernel.time_duration.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.time_duration.totalNanoseconds` should be used instead.
 
 :ref:`Release 4.1.0 <v4.1.0>`


### PR DESCRIPTION
This appears to be a common use case of `IntArrayProperty` that is often
handled by using a string array property and parsing it manually.

**To test:**

I've been using `LoadGSS` to create a reasonably small workspace that I can pass onto `SavePlot1D`. `SpectraList` is an `IntArrayProperty`.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
