### PR TITLE
Update cmake format with our custom functions

### DIFF
--- a/.cmake-format.json
+++ b/.cmake-format.json
@@ -1,25 +1,104 @@
 {
   "line_width": 80,
   "tab_size": 2,
-  "max_subargs_per_line": 3,
+  "max_subargs_per_line": 1,
   "separate_ctrl_name_with_space": false,
   "separate_fn_name_with_space": false,
-  "dangle_parens": false,
+  "dangle_parens": true,
   "bullet_char": "*",
   "enum_char": ".",
   "line_ending": "unix",
   "command_case": "lower",
   "keyword_case": "unchanged",
   "additional_commands": {
-    "foo": {
-      "flags": [
-        "BAR",
-        "BAZ"
-      ],
+    "mtd_add_qt_library": {
       "kwargs": {
-        "HEADERS": "*",
-        "SOURCES": "*",
-        "DEPENDS": "*"
+        "TARGET_NAME": 1,
+        "QT_VERSION": 1,
+        "SRC": "+",
+        "QT4_SRC": "+",
+        "QT5_SRC": "+",
+        "MOC": "+",
+        "NOMOC": "+",
+        "UI": "+",
+        "RES": "+",
+        "DEFS": "+",
+        "INCLUDE_DIRS": "+",
+        "SYSTEM_INCLUDE_DIRS": "+",
+        "LINK_LIBS": "+",
+        "QT4_LINK_LIBS": "+",
+        "QT5_LINK_LIBS": "+",
+        "MTD_QT_LINK_LIBS": "+",
+        "OUTPUT_DIR_BASE": 1,
+        "OUTPUT_SUBDIR": 1,
+        "INSTALL_DIR": "+",
+        "INSTALL_DIR_BASE": "+",
+        "OSX_INSTALL_RPATH": "+",
+        "LINUX_INSTALL_RPATH": "+"
+      },
+      "flags": [
+        "NO_SUFFIX",
+        "EXCLUDE_FROM_ALL"
+      ]
+    },
+    "mtd_add_qt_executable": {
+      "kwargs": {
+        "TARGET_NAME": 1,
+        "QT_VERSION": 1,
+        "SRC": "+",
+        "QT4_SRC": "+",
+        "QT5_SRC": "+",
+        "MOC": "+",
+        "NOMOC": "+",
+        "UI": "+",
+        "RES": "+",
+        "DEFS": "+",
+        "INCLUDE_DIRS": "+",
+        "SYSTEM_INCLUDE_DIRS": "+",
+        "LINK_LIBS": "+",
+        "QT4_LINK_LIBS": "+",
+        "QT5_LINK_LIBS": "+",
+        "MTD_QT_LINK_LIBS": "+",
+        "OUTPUT_DIR_BASE": 1,
+        "OUTPUT_SUBDIR": 1,
+        "INSTALL_DIR": "+",
+        "INSTALL_DIR_BASE": "+",
+        "OSX_INSTALL_RPATH": "+",
+        "LINUX_INSTALL_RPATH": "+"
+      },
+      "flags": [
+        "NO_SUFFIX",
+        "EXCLUDE_FROM_ALL"
+      ]
+    },
+    "mtd_add_qt_test_executable": {
+      "kwargs": {
+        "TEST_NAME": 1,
+        "QT_VERSION": 1,
+        "SRC": "+",
+        "INCLUDE_DIRS": "+",
+        "TEST_HELPER_SRCS": "+",
+        "LINK_LIBS": "+",
+        "QT4_LINK_LIBS": "+",
+        "QT5_LINK_LIBS": "+",
+        "MTD_QT_LINK_LIBS": "+",
+        "PARENT_DEPENDENCIES": "+"
+      }
+    },
+    "mtd_add_sip_module": {
+      "kwargs": {
+        "MODULE_NAME": 1,
+        "TARGET_NAME": 1,
+        "MODULE_OUTPUT_DIR": 1,
+        "PYQT_VERSION": 1,
+        "FOLDER": 1,
+        "SIP_SRCS": "+",
+        "HEADER_DEPS": "+",
+        "INCLUDE_DIRS": "+",
+        "LINK_LIBS": "+",
+        "INSTALL_DIRS": "+",
+        "OSX_INSTALL_RPATH": "+",
+        "LINUX_INSTALL_RPATH": "+"
       }
     }
   },


### PR DESCRIPTION
**Description of work.**

Update the cmake-format config to understand our custom functions. This produces better formatting rather than aligning all arguments on the same column

Compare the old version:
```
mtd_add_qt_library(TARGET_NAME
                   MantidScientificInterfacesIndirect
                   QT_VERSION
                   5
                   SRC
                   ${SRC_FILES}
                   MOC
                   ${MOC_FILES}
                   NOMOC
                   ${INC_FILES}
                   UI
                   ${UI_FILES}
                   RES
                   ${RES_FILES}
                   DEFS
                   IN_MANTIDQT_INDIRECT
                   PRECOMPILED
                   PrecompiledHeader.h
                   INCLUDE_DIRS
                   ${CMAKE_CURRENT_SOURCE_DIR}
                   LINK_LIBS
                   ${TCMALLOC_LIBRARIES_LINKTIME}
                   ${CORE_MANTIDLIBS}
                   PythonInterfaceCore
                   ${POCO_LIBRARIES}
                   ${Boost_LIBRARIES}
                   ${PYTHON_LIBRARIES}
                   Qt5::Xml
                   MTD_QT_LINK_LIBS
                   MantidQtIcons
                   MantidQtWidgetsCommon
                   MantidQtWidgetsPlotting
                   MantidQtWidgetsMplCpp
                   INSTALL_DIR_BASE
                   ${PLUGINS_DIR}
                   OSX_INSTALL_RPATH
                   @loader_path/../../Contents/MacOS
                   @loader_path/../../plugins/qt5
                   LINUX_INSTALL_RPATH
                   "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/")
```
with
```
mtd_add_qt_library(
  TARGET_NAME MantidScientificInterfacesIndirect
  QT_VERSION 5
  SRC ${SRC_FILES}
  MOC ${MOC_FILES}
  NOMOC ${INC_FILES}
  UI ${UI_FILES}
  RES ${RES_FILES}
  DEFS
    IN_MANTIDQT_INDIRECT
    PRECOMPILED
    PrecompiledHeader.h
  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
  LINK_LIBS
    ${TCMALLOC_LIBRARIES_LINKTIME}
    ${CORE_MANTIDLIBS}
    PythonInterfaceCore
    ${POCO_LIBRARIES}
    ${Boost_LIBRARIES}
    ${PYTHON_LIBRARIES}
    Qt5::Xml
  MTD_QT_LINK_LIBS
    MantidQtIcons
    MantidQtWidgetsCommon
    MantidQtWidgetsPlotting
    MantidQtWidgetsMplCpp
  INSTALL_DIR_BASE ${PLUGINS_DIR}
  OSX_INSTALL_RPATH
    @loader_path/../../Contents/MacOS
    @loader_path/../../plugins/qt5
  LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
)
```
**To test:**

Code review.

*This does not require release notes* because **it is a developer change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
