### PR TITLE
ISIS Powder Pearl Long-mode attenuation

### DIFF
--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -25,6 +25,8 @@ Improvements
 
 - :ref:`LoadSampleEnvironment <algm-LoadSampleEnvironment>` now correctly takes into account scale for translation. Rotation is now applied before translation to reduce confusion.
 
+- The Pearl scripts now automatically disable attenuation on long-mode.
+
 Bug Fixes
 #########
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -78,7 +78,7 @@ class Pearl(AbstractInst):
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):
 
-        # set temporary settings, Check has to occur before updating attributes, 
+        # set temporary settings, Check has to occur before updating attributes,
         # otherwise it would assumed the longmode vars are cached.
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
             self._inst_settings.update_attributes(kwargs=kwargs)

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -80,8 +80,10 @@ class Pearl(AbstractInst):
 
         # set temporary settings
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
+            self._inst_settings.update_attributes(kwargs=kwargs)
             self._switch_long_mode_inst_settings(kwargs.get("long_mode"))
-        self._inst_settings.update_attributes(kwargs=kwargs)
+        else:
+            self._inst_settings.update_attributes(kwargs=kwargs)
 
         # check that cache exists
         run_number_string_key = self._generate_run_details_fingerprint(run,
@@ -206,3 +208,5 @@ class Pearl(AbstractInst):
 
     def _switch_long_mode_inst_settings(self, long_mode_on):
         self._inst_settings.update_attributes(advanced_config=pearl_advanced_config.get_long_mode_dict(long_mode_on))
+        if long_mode_on:
+            setattr(self._inst_settings, "perform_atten", False)

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -78,7 +78,8 @@ class Pearl(AbstractInst):
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):
 
-        # set temporary settings, has to be run this way round, removing update_attributes from the if statement fails.
+        # set temporary settings, Check has to occur before updating attributes, 
+        # otherwise it would assumed the longmode vars are cached.
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
             self._inst_settings.update_attributes(kwargs=kwargs)
             self._switch_long_mode_inst_settings(kwargs.get("long_mode"))

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -79,11 +79,9 @@ class Pearl(AbstractInst):
     def _apply_temporary_inst_settings(self, kwargs, run):
 
         # set temporary settings
+        self._inst_settings.update_attributes(kwargs=kwargs)
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
-            self._inst_settings.update_attributes(kwargs=kwargs)
             self._switch_long_mode_inst_settings(kwargs.get("long_mode"))
-        else:
-            self._inst_settings.update_attributes(kwargs=kwargs)
 
         # check that cache exists
         run_number_string_key = self._generate_run_details_fingerprint(run,

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -79,9 +79,11 @@ class Pearl(AbstractInst):
     def _apply_temporary_inst_settings(self, kwargs, run):
 
         # set temporary settings
-        self._inst_settings.update_attributes(kwargs=kwargs)
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
+            self._inst_settings.update_attributes(kwargs=kwargs)
             self._switch_long_mode_inst_settings(kwargs.get("long_mode"))
+        else:
+            self._inst_settings.update_attributes(kwargs=kwargs)
 
         # check that cache exists
         run_number_string_key = self._generate_run_details_fingerprint(run,

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -78,7 +78,7 @@ class Pearl(AbstractInst):
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):
 
-        # set temporary settings
+        # set temporary settings, has to be run this way round, removing update_attributes from the if statement fails.
         if not self._inst_settings.long_mode == bool(kwargs.get("long_mode")):
             self._inst_settings.update_attributes(kwargs=kwargs)
             self._switch_long_mode_inst_settings(kwargs.get("long_mode"))


### PR DESCRIPTION
~~**DO NOT MERGE UNTIL #25816 IS MERGED**~~
**Description of work.**
Changed Pearl script to automatically set perform_attenuation to false if set to long-mode, as the pearl attenuation files do not cover long-mode

**To test:**
Follow the setup from #25816, then change the `perform_attenuation: False` within the config to `perform_attenuation: True` and run the following script
```
from isis_powder import Pearl

config_file_path = r"/path/to/pearl_shared_config.yaml"
Pearl_example = Pearl(config_file=config_file_path,user_name="test")
Pearl_example.create_vanadium(run_in_cycle=101508,long_mode=True)
Pearl_example.focus(run_number="101508", focus_mode="trans",long_mode=True)
```
it should finish fine,
then replace `long_mode=true` with false, it should fail due to not being able to find attenuation files.

Fixes #25811 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
