### PR TITLE
Porting Indirect Diffraction interface

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -261,6 +261,8 @@ set(
   ContainerSubtraction.cpp
   CorrectionsTab.cpp
   IndirectCorrections.cpp
+  IndirectDiffractionReduction.cpp
+  IndirectInstrumentConfig.cpp
   IndirectInterface.cpp
   IndirectSettings.cpp
   IndirectSettingsModel.cpp
@@ -278,6 +280,8 @@ set(
   CorrectionsTab.h
   IIndirectSettingsView.h
   IndirectCorrections.h
+  IndirectDiffractionReduction.h
+  IndirectInstrumentConfig.h
   IndirectInterface.h
   IndirectSettings.h
   IndirectSettingsPresenter.h
@@ -294,6 +298,8 @@ set(
   CalculatePaalmanPings.ui
   ContainerSubtraction.ui
   IndirectCorrections.ui
+  IndirectDiffractionReduction.ui
+  IndirectInstrumentConfig.ui
   IndirectInterfaceSettings.ui
   IndirectSettings.ui
 )

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -31,6 +31,7 @@ set(QT5_SRC_FILES
     # todo: move this to the instrument view library when the slice
     # viewer library is removed
     src/InputController.cpp
+    src/InstrumentSelector.cpp
     src/InterfaceManager.cpp
     src/LineEditWithClear.cpp
     src/ListPropertyWidget.cpp
@@ -146,6 +147,7 @@ set(
   inc/MantidQtWidgets/Common/IFunctionView.h
   inc/MantidQtWidgets/Common/HintingLineEdit.h
   inc/MantidQtWidgets/Common/InputController.h
+  inc/MantidQtWidgets/Common/InstrumentSelector.h
   inc/MantidQtWidgets/Common/LineEditWithClear.h
   inc/MantidQtWidgets/Common/ListPropertyWidget.h
   inc/MantidQtWidgets/Common/LocalParameterEditor.h
@@ -217,10 +219,10 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/DropEventHelper.h
     inc/MantidQtWidgets/Common/FileDialogHandler.h
     inc/MantidQtWidgets/Common/FlowLayout.h
+    inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
     inc/MantidQtWidgets/Common/HelpWindow.h
     inc/MantidQtWidgets/Common/Hint.h
     inc/MantidQtWidgets/Common/IFunctionBrowser.h
-    inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
     inc/MantidQtWidgets/Common/IFunctionView.h
     inc/MantidQtWidgets/Common/InterfaceManager.h
     inc/MantidQtWidgets/Common/LogValueFinder.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InstrumentSelector.h
@@ -9,15 +9,11 @@
 
 #include "DllOption.h"
 #include "MantidKernel/ConfigService.h"
+
+#include <Poco/NObserver.h>
 #include <QComboBox>
 #include <QStringList>
 
-#include <Poco/AutoPtr.h>
-#include <Poco/NObserver.h>
-
-//----------------------------------------------------------------
-// Forward declarations
-//----------------------------------------------------------------
 namespace Mantid {
 namespace Kernel {
 class FacilityInfo;

--- a/qt/widgets/common/src/InstrumentSelector.cpp
+++ b/qt/widgets/common/src/InstrumentSelector.cpp
@@ -4,9 +4,6 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-//------------------------------------------------------
-// Includes
-//------------------------------------------------------
 #include "MantidQtWidgets/Common/InstrumentSelector.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
@@ -14,12 +11,6 @@
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/Logger.h"
 
-#include <QMessageBox>
-
-#include <Poco/AutoPtr.h>
-#include <Poco/NObserver.h>
-#include <Poco/Notification.h>
-#include <Poco/NotificationCenter.h>
 #include <set>
 
 namespace {
@@ -29,10 +20,6 @@ Mantid::Kernel::Logger g_log("InstrumentSelector");
 namespace MantidQt {
 namespace MantidWidgets {
 using namespace Mantid::Kernel;
-
-//------------------------------------------------------
-// Public member functions
-//------------------------------------------------------
 
 /**
  * Default constructor


### PR DESCRIPTION
~~MERGE AFTER #25715~~
-----------------------------
**Description of work.**
This PR ports the Indirect Diffraction interface. It is an easy starter interface to port.

**To test:**
Start the Indirect Diffraction interface in both MantidPlot and Workbench and follow this:

1. Interfaces->Indirect->Diffraction
2. Instrument is `OSIRIS` and reflection is `diffspec`
2. Enter the run numbers `137793-137794`
3. Tick manual grouping and enter the number of groups to be `1`.
4. Click Run and there should be no error.
5. Now untick manual grouping
6. Tick vanadium runs and enter `137713-137714`
7. Click Run and wait.

You may see a few warnings in the results log, but these are normal. The external plotting does not work yet and will be added later.

*This does not require release notes* because **the release notes for indirect will be updated when more of their useful interfaces are ported.**

Fixes #25830

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
