### PR TITLE
Save Environment Algorithm

### DIFF
--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -561,6 +561,7 @@ set(TEST_FILES
     SaveReflectometryAsciiTest.h
     SaveReflCustomAsciiTest.h
     SaveReflThreeColumnAsciiTest.h
+    SaveSampleEnvironmentAndShapeTest.h
     SaveSESANSTest.h
     SaveSPETest.h
     SaveStlTest.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -561,6 +561,7 @@ set(TEST_FILES
     SaveReflThreeColumnAsciiTest.h
     SaveSESANSTest.h
     SaveSPETest.h
+    SaveStlTest.h
     SaveTBLTest.h
     SaveToSNSHistogramNexusTest.h
     SetBeamTest.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -181,6 +181,7 @@ set(SRC_FILES
     src/SaveReflectometryAscii.cpp
     src/SaveReflCustomAscii.cpp
     src/SaveReflThreeColumnAscii.cpp
+    src/SaveSampleEnvironmentAndShape.cpp
     src/SaveSESANS.cpp
     src/SaveSPE.cpp
     src/SaveStl.cpp
@@ -377,6 +378,7 @@ set(INC_FILES
     inc/MantidDataHandling/SaveReflectometryAscii.h
     inc/MantidDataHandling/SaveReflCustomAscii.h
     inc/MantidDataHandling/SaveReflThreeColumnAscii.h
+    inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
     inc/MantidDataHandling/SaveSESANS.h
     inc/MantidDataHandling/SaveSPE.h
     inc/MantidDataHandling/SaveStl.h

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -183,6 +183,7 @@ set(SRC_FILES
     src/SaveReflThreeColumnAscii.cpp
     src/SaveSESANS.cpp
     src/SaveSPE.cpp
+    src/SaveStl.cpp
     src/SaveTBL.cpp
     src/SaveToSNSHistogramNexus.cpp
     src/SaveVTK.cpp
@@ -378,6 +379,7 @@ set(INC_FILES
     inc/MantidDataHandling/SaveReflThreeColumnAscii.h
     inc/MantidDataHandling/SaveSESANS.h
     inc/MantidDataHandling/SaveSPE.h
+    inc/MantidDataHandling/SaveStl.h
     inc/MantidDataHandling/SaveTBL.h
     inc/MantidDataHandling/SaveToSNSHistogramNexus.h
     inc/MantidDataHandling/SaveVTK.h

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
@@ -22,10 +22,13 @@ namespace DataHandling {
 class DLLExport SaveSampleEnvironmentAndShape : public Mantid::API::Algorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
-  const std::string name() const override { return "SaveSampleEnvironmentAndShape"; }
+  const std::string name() const override {
+    return "SaveSampleEnvironmentAndShape";
+  }
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "The algorithm saves the environment and sample shape from the instrument of a "
+    return "The algorithm saves the environment and sample shape from the "
+           "instrument of a "
            "workspace. ";
   }
 
@@ -43,7 +46,14 @@ public:
 private:
   // Implement abstract Algorithm methods
   void init() override;
-  void exec() override;  
+  void exec() override;
+
+  void addMeshToVector(const Mantid::Geometry::MeshObject &mesh);
+  size_t addMeshToVector(const Mantid::Geometry::MeshObject &mesh,
+                         size_t offset);
+
+  std::vector<Kernel::V3D> m_vertices;
+  std::vector<uint32_t> m_triangle;
 };
 
 } // end namespace DataHandling

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef DATAHANDLING_SAVE_ENVIRONMENT_H_
+#define DATAHANDLING_SAVE_ENVIRONMENT_H_
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidKernel/Matrix.h"
+
+namespace Mantid {
+namespace Geometry {
+class MeshObject;
+}
+namespace DataHandling {
+/**
+ * Save the Shape of the sample and environment into a single binary .stl file
+ */
+
+class DLLExport SaveSampleEnvironmentAndShape : public Mantid::API::Algorithm {
+public:
+  /// Algorithm's name for identification overriding a virtual method
+  const std::string name() const override { return "SaveSampleEnvironmentAndShape"; }
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "The algorithm saves the environment and sample shape from the instrument of a "
+           "workspace. ";
+  }
+
+  /// Algorithm's version for identification overriding a virtual method
+  int version() const override { return 1; }
+  /// Related algorithms
+  const std::vector<std::string> seeAlso() const override {
+    return {"LoadSampleEnvironment", "SetSampleMaterial", "LoadSampleShape"};
+  }
+  /// Algorithm's category for identification overriding a virtual method
+  const std::string category() const override {
+    return "DataHandling\\Instrument";
+  }
+
+private:
+  // Implement abstract Algorithm methods
+  void init() override;
+  void exec() override;  
+};
+
+} // end namespace DataHandling
+} // namespace Mantid
+
+#endif /* DATAHANDLING_SAVE_ENVIRONMENT_H_ */

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
@@ -14,7 +14,7 @@ namespace Mantid {
 namespace Geometry {
 class MeshObject;
 class IObject;
-}
+} // namespace Geometry
 namespace DataHandling {
 /**
  * Save the Shape of the sample and environment into a single binary .stl file
@@ -54,7 +54,8 @@ private:
   std::vector<Kernel::V3D> m_vertices;
   std::vector<uint32_t> m_triangle;
 };
-const Mantid::Geometry::MeshObject &toMeshObject(const Mantid::Geometry::IObject &object);
+const Mantid::Geometry::MeshObject &
+toMeshObject(const Mantid::Geometry::IObject &object);
 } // end namespace DataHandling
 } // namespace Mantid
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSampleEnvironmentAndShape.h
@@ -13,12 +13,12 @@
 namespace Mantid {
 namespace Geometry {
 class MeshObject;
+class IObject;
 }
 namespace DataHandling {
 /**
  * Save the Shape of the sample and environment into a single binary .stl file
  */
-
 class DLLExport SaveSampleEnvironmentAndShape : public Mantid::API::Algorithm {
 public:
   /// Algorithm's name for identification overriding a virtual method
@@ -31,7 +31,6 @@ public:
            "instrument of a "
            "workspace. ";
   }
-
   /// Algorithm's version for identification overriding a virtual method
   int version() const override { return 1; }
   /// Related algorithms
@@ -55,7 +54,7 @@ private:
   std::vector<Kernel::V3D> m_vertices;
   std::vector<uint32_t> m_triangle;
 };
-
+const Mantid::Geometry::MeshObject &toMeshObject(const Mantid::Geometry::IObject &object);
 } // end namespace DataHandling
 } // namespace Mantid
 

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
@@ -17,13 +17,13 @@ class MeshObject;
 }
 namespace DataHandling {
 enum class ScaleUnits;
+/**
+ * Class to contain functionality for writing out STL files for
+ * SaveShapeAndEnvironment. handles actual writing to file, creating the
+ * header, and removing the scale applied when loading.
+ *
+ */
 class DLLExport SaveStl {
-  /**
-   * Class to contain functionality for writing out STL files for
-   * SaveShapeAndEnvironment. handles actual writing to file, creating the
-   * header, and removing the scale applied when loading.
-   *
-   */
 public:
   SaveStl(const std::string &filename, const std::vector<uint32_t> triangle,
           std::vector<Kernel::V3D> vertices, ScaleUnits scaleType)

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
@@ -31,6 +31,7 @@ private:
   const std::vector<uint32_t> m_triangle;
   const std::vector<Kernel::V3D> m_vertices;
   const ScaleUnits m_units;
+  void writeHeader(Kernel::BinaryStreamWriter streamWriter);
   void writeTriangle(Kernel::BinaryStreamWriter streamWriter,
                      uint32_t triangle);
   float removeScale(double value);

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
@@ -18,6 +18,12 @@ class MeshObject;
 namespace DataHandling {
 enum class ScaleUnits;
 class DLLExport SaveStl {
+  /**
+   * Class to contain functionality for writing out STL files for
+   * SaveShapeAndEnvironment. handles actual writing to file, creating the
+   * header, and removing the scale applied when loading.
+   *
+   */
 public:
   SaveStl(const std::string &filename, const std::vector<uint32_t> triangle,
           std::vector<Kernel::V3D> vertices, ScaleUnits scaleType)

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
@@ -16,8 +16,8 @@ namespace Geometry {
 class MeshObject;
 }
 namespace DataHandling {
-enum class ScaleUnits { metres, centimetres, millimetres };
-class SaveStl {
+enum class ScaleUnits;
+class DLLExport SaveStl {
 public:
   SaveStl(const std::string &filename, const std::vector<uint32_t> triangle,
           std::vector<Kernel::V3D> vertices, ScaleUnits scaleType)

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveStl.h
@@ -1,0 +1,41 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_DATAHANDLING_SAVESTL_H_
+#define MANTID_DATAHANDLING_SAVESTL_H_
+
+#include "MantidKernel/BinaryStreamWriter.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/V3D.h"
+
+namespace Mantid {
+namespace Geometry {
+class MeshObject;
+}
+namespace DataHandling {
+enum class ScaleUnits { metres, centimetres, millimetres };
+class SaveStl {
+public:
+  SaveStl(const std::string &filename, const std::vector<uint32_t> triangle,
+          std::vector<Kernel::V3D> vertices, ScaleUnits scaleType)
+      : m_filename(filename), m_triangle(triangle), m_vertices(vertices),
+        m_units(scaleType) {}
+
+  void writeStl();
+
+private:
+  const std::string m_filename;
+  const std::vector<uint32_t> m_triangle;
+  const std::vector<Kernel::V3D> m_vertices;
+  const ScaleUnits m_units;
+  void writeTriangle(Kernel::BinaryStreamWriter streamWriter,
+                     uint32_t triangle);
+  float removeScale(double value);
+};
+
+} // namespace DataHandling
+} // namespace Mantid
+#endif /* MANTID_DATAHANDLING_SAVESTL_H_ */

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -1,0 +1,130 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataHandling/SaveSampleEnvironmentAndShape.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/InstrumentValidator.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Sample.h"
+#include "MantidDataHandling/SaveStl.h"
+#include "MantidGeometry/Instrument/Container.h"
+#include "MantidGeometry/Instrument/SampleEnvironment.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+
+#include <memory>
+namespace Mantid {
+namespace DataHandling {
+enum class ScaleUnits { metres, centimetres, millimetres };
+// Register the algorithm into the algorithm factory
+DECLARE_ALGORITHM(SaveSampleEnvironmentAndShape)
+using namespace Kernel;
+using namespace API;
+using namespace Geometry;
+void SaveSampleEnvironmentAndShape::init() {
+  auto wsValidator = boost::make_shared<InstrumentValidator>();
+
+  // input workspace
+  declareProperty(
+      make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input,
+                                       wsValidator),
+      "The name of the workspace containing the environment to save ");
+
+  // Environment file
+  const std::vector<std::string> extensions{".stl"};
+  declareProperty(
+      make_unique<FileProperty>("Filename", "", FileProperty::Save, extensions),
+      "The path name of the file to save");
+
+  // scale to use for stl
+  declareProperty("Scale", "cm", "The scale of the stl: m, cm, or mm");
+}
+
+void SaveSampleEnvironmentAndShape::exec() {
+  auto filename = getPropertyValue("Filename");
+  MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  try {
+    // track the total number of triangles and vertices
+    size_t numTriangles = 0;
+    size_t numVertices = 0;
+
+    // Get the shape of the sample
+    auto &sampleShape =
+        dynamic_cast<const MeshObject &>(inputWS->sample().getShape());
+    auto environment = inputWS->sample().getEnvironment();
+    auto numElements = environment.nelements();
+    numVertices += sampleShape.numberOfVertices();
+    numTriangles += (sampleShape.numberOfTriangles() * 3);
+
+    // Setup vector to store the pieves of the environment
+    std::vector<const MeshObject *> environmentPieces;
+    environmentPieces.reserve(numElements);
+
+    // get the shape the container of the environment and add it to the vector
+    environmentPieces.emplace_back(dynamic_cast<const MeshObject *>(
+        &environment.getContainer().getShape()));
+    numVertices += environmentPieces[0]->numberOfVertices();
+    numTriangles += (environmentPieces[0]->numberOfTriangles() * 3);
+
+    // get the shapes of the components and add them to the vector
+    for (size_t i = 1; i < numElements;
+         ++i) { // start at 1 because element 0 is container
+      const MeshObject *temp =
+          dynamic_cast<const MeshObject *>(&environment.getComponent(i));
+      numVertices += temp->numberOfVertices();
+      numTriangles += (temp->numberOfTriangles() * 3);
+      environmentPieces.emplace_back(temp);
+    }
+
+    // setup vectors to store all triangles and vertices
+    std::vector<V3D> vertices;
+    std::vector<uint32_t> triangle;
+    vertices.reserve(numVertices);
+    triangle.reserve(numTriangles);
+
+    // get the sample vertices and triangles and add them into the vector
+    auto shapeVertices = sampleShape.getV3Ds();
+    auto shapeTriangles = sampleShape.getTriangles();
+    vertices.insert(std::end(vertices), std::begin(shapeVertices),
+                    std::end(shapeVertices));
+    triangle.insert(std::end(triangle), std::begin(shapeTriangles),
+                    std::end(shapeTriangles));
+
+    // keep track of the current number of vertices added
+    size_t offset = sampleShape.numberOfVertices();
+
+    // go through the environment, adding the triangles and vertices to the
+    // vector
+    for (size_t i = 0; i < environmentPieces.size(); ++i) {
+      std::vector<Kernel::V3D> tempVertices = environmentPieces[i]->getV3Ds();
+      std::vector<uint32_t> tempTriangles =
+          environmentPieces[i]->getTriangles();
+
+      // increase the triangles by the offset, so they refer to the new index of
+      // the vertices
+      std::transform(std::begin(tempTriangles), std::end(tempTriangles),
+                     std::begin(tempTriangles),
+                     [&offset](uint32_t &val) { return val + offset; });
+      vertices.insert(std::end(vertices), std::begin(tempVertices),
+                      std::end(tempVertices));
+      triangle.insert(std::end(triangle), std::begin(tempTriangles),
+                      std::end(tempTriangles));
+
+      // add the newly added vertices to the offset
+      offset += tempVertices.size();
+    }
+
+    // Save out the shape
+    SaveStl writer = SaveStl(filename, triangle, vertices, ScaleUnits::metres);
+    writer.writeStl();
+  } catch (std::bad_cast &) {
+    // if bad_cast is thrown the sample or environment is not a mesh_object, and
+    // therefore cannot be saved as an STL
+    throw std::invalid_argument(
+        "Attempted to Save out non-mesh based Sample Shape");
+  }
+}
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -39,7 +39,7 @@ void SaveSampleEnvironmentAndShape::init() {
       "The path name of the file to save");
 
   // scale to use for stl
-  declareProperty("Scale", "cm", "The scale of the stl: m, cm, or mm");
+  declareProperty("Scale", "m", "The scale of the stl: m, cm, or mm");
 }
 
 void SaveSampleEnvironmentAndShape::exec() {

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -130,6 +130,8 @@ void SaveSampleEnvironmentAndShape::exec() {
         "Attempted to Save out non mesh based Sample or Environment");
   }
 }
+
+// Add a mesh to the vectors
 void SaveSampleEnvironmentAndShape::addMeshToVector(const MeshObject &mesh) {
   auto vertices = mesh.getV3Ds();
   auto triangles = mesh.getTriangles();
@@ -139,6 +141,8 @@ void SaveSampleEnvironmentAndShape::addMeshToVector(const MeshObject &mesh) {
                     std::end(triangles));
 }
 
+// Add a mesh to the vectors, with the addresses changed by the offset, then
+// return the new offset
 size_t SaveSampleEnvironmentAndShape::addMeshToVector(
     const Mantid::Geometry::MeshObject &mesh, size_t offset) {
   auto vertices = mesh.getV3Ds();

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -20,9 +20,11 @@ namespace Mantid {
 namespace DataHandling {
 // Register the algorithm into the algorithm factory
 DECLARE_ALGORITHM(SaveSampleEnvironmentAndShape)
+
 using namespace Kernel;
 using namespace API;
 using namespace Geometry;
+
 void SaveSampleEnvironmentAndShape::init() {
   auto wsValidator = boost::make_shared<InstrumentValidator>();
 
@@ -43,92 +45,81 @@ void SaveSampleEnvironmentAndShape::init() {
 }
 
 void SaveSampleEnvironmentAndShape::exec() {
-
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
-  try {
-    // track the total number of triangles and vertices
-    size_t numTriangles = 0;
-    size_t numVertices = 0;
+  // track the total number of triangles and vertices
+  size_t numTriangles = 0;
+  size_t numVertices = 0;
 
-    // Get the shape of the sample
-    auto &sampleShape =
-        dynamic_cast<const MeshObject &>(inputWS->sample().getShape());
-    if (!sampleShape.hasValidShape()) {
-      throw std::invalid_argument("Sample Shape is not complete");
-    }
-    numVertices += sampleShape.numberOfVertices();
-    numTriangles += (sampleShape.numberOfTriangles() * 3);
-
-    if (inputWS->sample().hasEnvironment()) {
-
-      // get the environment
-      auto environment = inputWS->sample().getEnvironment();
-
-      // Setup vector to store the pieces of the environment
-      std::vector<const MeshObject *> environmentPieces;
-      auto numElements = environment.nelements();
-      environmentPieces.reserve(numElements);
-
-      // get the shape the container of the environment and add it to the vector
-      bool environmentValid = true;
-      environmentPieces.emplace_back(dynamic_cast<const MeshObject *>(
-          &environment.getContainer().getShape()));
-      environmentValid =
-          environmentValid && environmentPieces[0]->hasValidShape();
-      numVertices += environmentPieces[0]->numberOfVertices();
-      numTriangles += (environmentPieces[0]->numberOfTriangles() * 3);
-
-      // get the shapes of the components and add them to the vector
-      for (size_t i = 1; i < numElements;
-           ++i) { // start at 1 because element 0 is container
-        const MeshObject *temp =
-            dynamic_cast<const MeshObject *>(&environment.getComponent(i));
-        numVertices += temp->numberOfVertices();
-        numTriangles += (temp->numberOfTriangles() * 3);
-        environmentValid = environmentValid && temp->hasValidShape();
-        environmentPieces.emplace_back(temp);
-      }
-      if (!environmentValid) {
-        throw std::invalid_argument("Environment Shape is not complete");
-      }
-
-      // setup vectors to store all triangles and vertices
-      m_vertices.reserve(numVertices);
-      m_triangle.reserve(numTriangles);
-
-      // get the sample vertices and triangles and add them into the vector
-      addMeshToVector(sampleShape);
-
-      // keep track of the current number of vertices added
-      size_t offset = sampleShape.numberOfVertices();
-
-      // go through the environment, adding the triangles and vertices to the
-      // vector
-      for (size_t i = 0; i < environmentPieces.size(); ++i) {
-        offset = addMeshToVector(*environmentPieces[i], offset);
-      }
-    } else {
-      // setup vectors to store all triangles and vertices
-      m_vertices.reserve(numVertices);
-      m_triangle.reserve(numTriangles);
-
-      // get the sample vertices and triangles and add them into the vector
-      addMeshToVector(sampleShape);
-    }
-    // get the scale to use
-    auto scale = getPropertyValue("Scale");
-    auto scaleType = getScaleType(scale);
-
-    // Save out the shape
-    auto filename = getPropertyValue("Filename");
-    SaveStl writer = SaveStl(filename, m_triangle, m_vertices, scaleType);
-    writer.writeStl();
-  } catch (std::bad_cast &) {
-    // if bad_cast is thrown the sample or environment is not a mesh_object, and
-    // therefore cannot be saved as an STL
-    throw std::invalid_argument(
-        "Attempted to Save out non mesh based Sample or Environment");
+  // Get the shape of the sample
+  auto &sampleShape = toMeshObject(inputWS->sample().getShape());
+  if (!sampleShape.hasValidShape()) {
+    throw std::invalid_argument("Sample Shape is not complete");
   }
+  numVertices += sampleShape.numberOfVertices();
+  numTriangles += (sampleShape.numberOfTriangles() * 3);
+
+  if (inputWS->sample().hasEnvironment()) {
+    // get the environment
+    auto environment = inputWS->sample().getEnvironment();
+
+    // Setup vector to store the pieces of the environment
+    std::vector<const MeshObject *> environmentPieces;
+    auto numElements = environment.nelements();
+    environmentPieces.reserve(numElements);
+
+    // get the shape the container of the environment and add it to the vector
+    bool environmentValid = true;
+    environmentPieces.emplace_back(
+        &toMeshObject(environment.getContainer().getShape()));
+    environmentValid =
+        environmentValid && environmentPieces[0]->hasValidShape();
+    numVertices += environmentPieces[0]->numberOfVertices();
+    numTriangles += (environmentPieces[0]->numberOfTriangles() * 3);
+
+    // get the shapes of the components and add them to the vector
+    for (size_t i = 1; i < numElements;
+         ++i) { // start at 1 because element 0 is container
+      const MeshObject *temp = &toMeshObject(environment.getComponent(i));
+      numVertices += temp->numberOfVertices();
+      numTriangles += (temp->numberOfTriangles() * 3);
+      environmentValid = environmentValid && temp->hasValidShape();
+      environmentPieces.emplace_back(temp);
+    }
+    if (!environmentValid) {
+      throw std::invalid_argument("Environment Shape is not complete");
+    }
+
+    // setup vectors to store all triangles and vertices
+    m_vertices.reserve(numVertices);
+    m_triangle.reserve(numTriangles);
+
+    // get the sample vertices and triangles and add them into the vector
+    addMeshToVector(sampleShape);
+
+    // keep track of the current number of vertices added
+    size_t offset = sampleShape.numberOfVertices();
+
+    // go through the environment, adding the triangles and vertices to the
+    // vector
+    for (size_t i = 0; i < environmentPieces.size(); ++i) {
+      offset = addMeshToVector(*environmentPieces[i], offset);
+    }
+  } else {
+    // setup vectors to store all triangles and vertices
+    m_vertices.reserve(numVertices);
+    m_triangle.reserve(numTriangles);
+
+    // get the sample vertices and triangles and add them into the vector
+    addMeshToVector(sampleShape);
+  }
+  // get the scale to use
+  auto scale = getPropertyValue("Scale");
+  auto scaleType = getScaleType(scale);
+
+  // Save out the shape
+  auto filename = getPropertyValue("Filename");
+  SaveStl writer = SaveStl(filename, m_triangle, m_vertices, scaleType);
+  writer.writeStl();
 }
 
 // Add a mesh to the vectors
@@ -160,6 +151,18 @@ size_t SaveSampleEnvironmentAndShape::addMeshToVector(
 
   // add the newly added vertices to the offset
   return offset += vertices.size();
+}
+
+const Geometry::MeshObject &toMeshObject(const Geometry::IObject &object) {
+
+  try {
+    return dynamic_cast<const Geometry::MeshObject &>(object);
+  } catch (const std::bad_cast &) {
+    // if bad_cast is thrown the sample or environment is not a mesh_object, and
+    // therefore cannot be saved as an STL
+    throw std::invalid_argument(
+        "Attempted to Save out non mesh based Sample or Environment");
+  }
 }
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -122,7 +122,12 @@ void SaveSampleEnvironmentAndShape::exec() {
   writer.writeStl();
 }
 
-// Add a mesh to the vectors
+/**
+ * Function to add the triangles and vertices of a mesh object into a vector to
+ * allow combining with multiple meshes.
+ *
+ * @param mesh The mesh object to get the triangles and vertices from.
+ */
 void SaveSampleEnvironmentAndShape::addMeshToVector(const MeshObject &mesh) {
   auto vertices = mesh.getV3Ds();
   auto triangles = mesh.getTriangles();
@@ -132,8 +137,16 @@ void SaveSampleEnvironmentAndShape::addMeshToVector(const MeshObject &mesh) {
                     std::end(triangles));
 }
 
-// Add a mesh to the vectors, with the addresses changed by the offset, then
-// return the new offset
+/**
+ * Function to add the triangles and vertices of a mesh object into a vector to
+ * allow combining with multiple meshes, with an offset to take into account
+ * meshes that are already added.
+ *
+ * @param mesh The mesh object to get the triangles and vertices from.
+ * @param offset The value to offset the triangles by.
+ *
+ * @return size_t the new offset value to use if this needs to be used again.
+ */
 size_t SaveSampleEnvironmentAndShape::addMeshToVector(
     const Mantid::Geometry::MeshObject &mesh, size_t offset) {
   auto vertices = mesh.getV3Ds();
@@ -153,6 +166,12 @@ size_t SaveSampleEnvironmentAndShape::addMeshToVector(
   return offset += vertices.size();
 }
 
+/**
+ * Function to convert an IObject to a mesh, and throw if this can't be done.
+ *
+ * @param object The IObject to convert.
+ * @return const Geometry::MeshObject& The converted MeshObject.
+ */
 const Geometry::MeshObject &toMeshObject(const Geometry::IObject &object) {
 
   try {

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -30,15 +30,15 @@ void SaveSampleEnvironmentAndShape::init() {
 
   // input workspace
   declareProperty(
-      make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input,
-                                       wsValidator),
+      std::make_unique<WorkspaceProperty<>>("InputWorkspace", "",
+                                            Direction::Input, wsValidator),
       "The name of the workspace containing the environment to save ");
 
   // Environment file
   const std::vector<std::string> extensions{".stl"};
-  declareProperty(
-      make_unique<FileProperty>("Filename", "", FileProperty::Save, extensions),
-      "The path name of the file to save");
+  declareProperty(std::make_unique<FileProperty>(
+                      "Filename", "", FileProperty::Save, extensions),
+                  "The path name of the file to save");
 
   // scale to use for stl
   declareProperty("Scale", "m", "The scale of the stl: m, cm, or mm");

--- a/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
+++ b/Framework/DataHandling/src/SaveSampleEnvironmentAndShape.cpp
@@ -152,7 +152,7 @@ size_t SaveSampleEnvironmentAndShape::addMeshToVector(
   // the vertices
   std::transform(std::begin(triangles), std::end(triangles),
                  std::begin(triangles),
-                 [&offset](uint32_t &val) { return val + offset; });
+                 [&offset](uint32_t &val) { return val + uint32_t(offset); });
   m_vertices.insert(std::end(m_vertices), std::begin(vertices),
                     std::end(vertices));
   m_triangle.insert(std::end(m_triangle), std::begin(triangles),

--- a/Framework/DataHandling/src/SaveStl.cpp
+++ b/Framework/DataHandling/src/SaveStl.cpp
@@ -16,18 +16,6 @@ namespace Mantid {
 namespace DataHandling {
 enum class ScaleUnits { metres, centimetres, millimetres };
 namespace {
-void writeHeader(Kernel::BinaryStreamWriter streamWriter) {
-  const std::string headerStart =
-      "Binary STL File created using Mantid Environment:";
-  const auto timeString =
-      Types::Core::DateAndTime::getCurrentTime().toFormattedString(
-          "%Y-%b-%dT%H:%M:%S") +
-      ":";
-  // TODO add scale type
-  const size_t emptySize =
-      80 - size_t(headerStart.size() + timeString.size() + 4);
-  streamWriter << headerStart + timeString + std::string(emptySize, ' ');
-}
 
 void writeNumberTriangles(Kernel::BinaryStreamWriter streamWriter,
                           uint32_t numberTrianglesLong) {
@@ -44,6 +32,31 @@ void writeNormal(Kernel::BinaryStreamWriter StreamWriter) {
 }
 
 } // namespace
+
+void SaveStl::writeHeader(Kernel::BinaryStreamWriter streamWriter) {
+  const std::string headerStart =
+      "Binary STL File created using Mantid Environment:";
+  const auto timeString =
+      Types::Core::DateAndTime::getCurrentTime().toFormattedString(
+          "%Y-%b-%dT%H:%M:%S") +
+      ":";
+  std::string unitString;
+  switch (m_units) {
+  case ScaleUnits::centimetres:
+    unitString = "cm:";
+    break;
+  case ScaleUnits::millimetres:
+    unitString = "mm:";
+    break;
+  case ScaleUnits::metres:
+    unitString = "m:";
+    break;
+  }
+  const size_t emptySize = 80 - size_t(headerStart.size() + timeString.size() +
+                                       4 + unitString.size());
+  streamWriter << headerStart + timeString + unitString +
+                      std::string(emptySize, ' ');
+}
 
 void SaveStl::writeStl() {
   if (m_triangle.size() % 3 != 0) {

--- a/Framework/DataHandling/src/SaveStl.cpp
+++ b/Framework/DataHandling/src/SaveStl.cpp
@@ -77,6 +77,7 @@ void SaveStl::writeStl() {
 
     streamWriter << attributeByte;
   }
+  myFile.close();
 }
 
 void SaveStl::writeTriangle(Kernel::BinaryStreamWriter streamWriter,

--- a/Framework/DataHandling/src/SaveStl.cpp
+++ b/Framework/DataHandling/src/SaveStl.cpp
@@ -63,7 +63,6 @@ void SaveStl::writeStl() {
     throw std::runtime_error("Invalid mesh, could not save.");
   }
   std::ofstream myFile(m_filename.c_str(), std::ios::out | std::ios::binary);
-
   const uint32_t numberOfTriangles = uint32_t(m_triangle.size() / 3);
   Kernel::BinaryStreamWriter streamWriter = Kernel::BinaryStreamWriter(myFile);
   writeHeader(streamWriter);

--- a/Framework/DataHandling/src/SaveStl.cpp
+++ b/Framework/DataHandling/src/SaveStl.cpp
@@ -9,13 +9,19 @@
 #include "MantidKernel/DateAndTime.h"
 
 #include <Poco/File.h>
-#include <boost/functional/hash.hpp>
 #include <fstream>
 #include <vector>
 namespace Mantid {
 namespace DataHandling {
 enum class ScaleUnits { metres, centimetres, millimetres };
+
 namespace {
+/**
+ * Class to contain functionality for writing out STL files for
+ * SaveShapeAndEnvironment. handles actual writing to file, creating the header,
+ * and removing the scale applied when loading.
+ *
+ */
 
 void writeNumberTriangles(Kernel::BinaryStreamWriter streamWriter,
                           uint32_t numberTrianglesLong) {

--- a/Framework/DataHandling/src/SaveStl.cpp
+++ b/Framework/DataHandling/src/SaveStl.cpp
@@ -1,0 +1,94 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidDataHandling/SaveStl.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidKernel/DateAndTime.h"
+
+#include <Poco/File.h>
+#include <boost/functional/hash.hpp>
+#include <fstream>
+#include <vector>
+namespace Mantid {
+namespace DataHandling {
+
+namespace {
+void writeHeader(Kernel::BinaryStreamWriter streamWriter) {
+  const std::string header =
+      "Binary STL File created using Mantid Environment:";
+  streamWriter << header;
+  const auto time =
+      Types::Core::DateAndTime::getCurrentTime().toISO8601String() + ":";
+  streamWriter << time;
+  // TODO add scale type
+  const size_t emptySize = 80 - size_t(header.size() + time.size());
+  streamWriter << std::string(emptySize, ' ');
+}
+
+void writeNumberTriangles(Kernel::BinaryStreamWriter streamWriter,
+                          uint32_t numberTrianglesLong) {
+
+  // Write the number of triangles
+  streamWriter << numberTrianglesLong;
+}
+
+void writeNormal(Kernel::BinaryStreamWriter StreamWriter) {
+  float normal = 0;
+  StreamWriter << normal;
+  StreamWriter << normal;
+  StreamWriter << normal;
+}
+
+} // namespace
+
+void SaveStl::writeStl() {
+  std::ofstream myFile(m_filename.c_str(), std::ios::out | std::ios::binary);
+  const uint32_t numberOfTriangles = uint32_t(m_triangle.size() / 3);
+  Kernel::BinaryStreamWriter streamWriter = Kernel::BinaryStreamWriter(myFile);
+  writeHeader(streamWriter);
+  writeNumberTriangles(streamWriter, numberOfTriangles);
+  const uint16_t attributeByte = 0;
+  for (uint32_t i = 0; i < numberOfTriangles; ++i) {
+    // Write out 0, 0, 0 to act as default normal vector
+    writeNormal(streamWriter);
+    // write out vertices of triangle
+    writeTriangle(streamWriter, i * 3);
+
+    streamWriter << attributeByte;
+  }
+}
+
+void SaveStl::writeTriangle(Kernel::BinaryStreamWriter streamWriter,
+                            uint32_t triangle) {
+  // get each vertex
+  for (int i = 0; i < 3; ++i) {
+    uint32_t index = m_triangle[triangle + i];
+    Kernel::V3D vertex = m_vertices[index];
+    float xVal = removeScale(vertex.X());
+    float yVal = removeScale(vertex.Y());
+    float zVal = removeScale(vertex.Z());
+    streamWriter << xVal;
+    streamWriter << yVal;
+    streamWriter << zVal;
+  }
+}
+
+float SaveStl::removeScale(double value) {
+  switch (m_units) {
+  case ScaleUnits::centimetres:
+    value = value * 100;
+    break;
+  case ScaleUnits::millimetres:
+    value = value * 1000;
+    break;
+  case ScaleUnits::metres:
+    break;
+  }
+  return float(value);
+}
+
+} // namespace DataHandling
+} // namespace Mantid

--- a/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
+++ b/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
@@ -1,0 +1,183 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidAPI/Sample.h"
+#include "MantidDataHandling/SaveSampleEnvironmentAndShape.h"
+#include "MantidGeometry/Instrument/Container.h"
+#include "MantidGeometry/Instrument/SampleEnvironment.h"
+#include "MantidGeometry/Objects/IObject.h"
+#include "MantidGeometry/Objects/MeshObject.h"
+#include "MantidKernel/V3D.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid;
+using namespace Mantid::API;
+using namespace Mantid::DataHandling;
+using namespace Mantid::Geometry;
+
+class SaveSampleEnvironmentAndShapeTest : public CxxTest::TestSuite {
+public:
+  static std::unique_ptr<SaveSampleEnvironmentAndShapeTest> createSuite() {
+    return std::make_unique<SaveSampleEnvironmentAndShapeTest>();
+  }
+  static void
+  destroySuite(std::unique_ptr<SaveSampleEnvironmentAndShapeTest> suite) {
+    suite.reset(nullptr);
+  }
+
+  void testInit() {
+
+    SaveSampleEnvironmentAndShape alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize());
+    TS_ASSERT(alg.isInitialized());
+    auto props = alg.getProperties();
+    TSM_ASSERT_EQUALS("should be 3 properties here", 3,
+                      (size_t)(alg.getProperties().size()));
+  }
+
+  void testSimpleShape() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto mesh1 = createCube();
+    ws->mutableSample().setShape(mesh1);
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+  }
+
+  void testWithEnvironment() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto mesh1 = createCube();
+    ws->mutableSample().setShape(mesh1);
+
+    auto mesh2 = createCube();
+    mesh2->translate(Kernel::V3D{10, 10, 10});
+    auto can = boost::make_shared<Container>(mesh2);
+    auto environment = std::make_unique<SampleEnvironment>("name", can);
+    ws->mutableSample().setEnvironment(std::move(environment));
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+  }
+
+  void testComplexEnvironment() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto mesh1 = createCube();
+    ws->mutableSample().setShape(mesh1);
+
+    auto mesh2 = createCube();
+    mesh2->translate(Kernel::V3D{10, 10, 10});
+    auto can = boost::make_shared<Container>(mesh2);
+    auto environment = std::make_unique<SampleEnvironment>("name", can);
+    auto mesh3 = createCube();
+    mesh3->translate(Kernel::V3D{-10, -10, -10});
+    environment->add(mesh3);
+    ws->mutableSample().setEnvironment(std::move(environment));
+
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+  }
+
+  void testFailNoShape() {
+    SaveSampleEnvironmentAndShape alg;
+    setup(alg);
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument &);
+  }
+
+  void testFailNotMesh() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto container = boost::make_shared<Container>();
+    ws->mutableSample().setShape(container);
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument &);
+  }
+
+  void testFailIncompleteSample() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const std::vector<uint32_t> v1;
+    const std::vector<Kernel::V3D> v2;
+    const auto mesh =
+        boost::make_shared<MeshObject>(v1, v2, Kernel::Material());
+    ws->mutableSample().setShape(mesh);
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument &);
+  }
+
+  void testFailIncompleteEnvironmentCan() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto mesh1 = createCube();
+    ws->mutableSample().setShape(mesh1);
+
+    const std::vector<uint32_t> v1;
+    const std::vector<Kernel::V3D> v2;
+    const auto mesh2 =
+        boost::make_shared<MeshObject>(v1, v2, Kernel::Material());
+    auto can = boost::make_shared<Container>(mesh2);
+    auto environment = std::make_unique<SampleEnvironment>("name", can);
+    ws->mutableSample().setEnvironment(std::move(environment));
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument &);
+  }
+
+  void testFailIncompleteEnvironmentComponent() {
+    SaveSampleEnvironmentAndShape alg;
+    auto ws = setup(alg);
+
+    const auto mesh1 = createCube();
+    ws->mutableSample().setShape(mesh1);
+
+    auto mesh2 = createCube();
+    const std::vector<uint32_t> v1;
+    const std::vector<Kernel::V3D> v2;
+    auto can = boost::make_shared<Container>(mesh2);
+    auto environment = std::make_unique<SampleEnvironment>("can", can);
+    auto mesh3 = boost::make_shared<MeshObject>(v1, v2, Kernel::Material());
+    environment->add(mesh3);
+    ws->mutableSample().setEnvironment(std::move(environment));
+
+    TS_ASSERT_THROWS(alg.execute(), std::invalid_argument &);
+  }
+
+  // setup algorithm properties
+  MatrixWorkspace_sptr setup(SaveSampleEnvironmentAndShape &alg) {
+
+    const int nvectors(2), nbins(10);
+    MatrixWorkspace_sptr inputWS =
+        WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(nvectors,
+                                                                     nbins);
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", inputWS);
+    alg.setPropertyValue("Filename", "TempFile");
+    return inputWS;
+  }
+
+  // create a cube mesh object
+  boost::shared_ptr<MeshObject> createCube() {
+    const std::vector<uint32_t> faces{0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5,
+                                      2, 5, 4, 6, 1, 3, 6, 5, 1, 4, 5, 6,
+                                      7, 3, 0, 0, 4, 7, 7, 6, 3, 4, 6, 7};
+    const std::vector<Mantid::Kernel::V3D> vertices{
+        Mantid::Kernel::V3D(-5, -5, -15), Mantid::Kernel::V3D(5, 5, -15),
+        Mantid::Kernel::V3D(5, -5, -15),  Mantid::Kernel::V3D(-5, 5, -15),
+        Mantid::Kernel::V3D(5, -5, 15),   Mantid::Kernel::V3D(5, 5, 15),
+        Mantid::Kernel::V3D(-5, 5, 15),   Mantid::Kernel::V3D(-5, -5, 15)};
+    auto cube = boost::make_shared<MeshObject>(faces, vertices,
+                                               Mantid::Kernel::Material());
+    return cube;
+  }
+};

--- a/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
+++ b/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
@@ -185,7 +185,7 @@ public:
     LoadBinaryStl loader = LoadBinaryStl(m_OutputFile, ScaleUnits::metres);
     TS_ASSERT(loader.isBinarySTL(m_OutputFile))
     auto shape = loader.readStl();
-    return shape;
+    return boost::shared_ptr<MeshObject>(shape.release());
   }
 
   void assertVectorsMatch(const MeshObject &mesh1, const MeshObject &mesh2) {

--- a/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
+++ b/Framework/DataHandling/test/SaveSampleEnvironmentAndShapeTest.h
@@ -16,6 +16,7 @@
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 #include <Poco/File.h>
+#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid;
@@ -256,5 +257,5 @@ public:
     return cube;
   }
 
-  const std::string m_OutputFile = "SaveSampleTest.stl";
+  const std::string m_OutputFile = Poco::Path::current() + "SaveSampleTest.stl";
 };

--- a/Framework/DataHandling/test/SaveStlTest.h
+++ b/Framework/DataHandling/test/SaveStlTest.h
@@ -1,0 +1,82 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef SAVE_STL_TEST_H_
+#define SAVE_STL_TEST_H_
+#include "MantidDataHandling//SaveStl.h"
+#include "MantidDataHandling/LoadBinaryStl.h"
+#include "MantidKernel/V3D.h"
+
+#include <Poco/File.h>
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::DataHandling;
+using namespace Mantid::Kernel;
+
+class SaveStlTest : public CxxTest::TestSuite {
+public:
+  static SaveStlTest *createSuite() { return new SaveStlTest(); }
+  static void destroySuite(SaveStlTest *suite) { delete suite; }
+
+  void test_saves_valid_stl() {
+    std::string path =
+        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+    std::vector<uint32_t> triangle{1, 0, 3, 1, 4, 0, 1, 3, 6, 3, 0, 7,
+                                   3, 7, 6, 6, 0, 2, 4, 7, 0, 6, 7, 4,
+                                   5, 2, 1, 1, 3, 5, 5, 4, 2, 6, 4, 5};
+    std::vector<V3D> vertices{
+        V3D(5, 5, -15), V3D(-5, -5, -15), V3D(-5, 5, -15), V3D(5, -5, -15),
+        V3D(-5, 5, 15), V3D(-5, -5, 15),  V3D(5, -5, 15),  V3D(5, 5, 15)};
+    auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
+    writer.writeStl();
+    auto reader = LoadBinaryStl(path, ScaleUnits::metres);
+    TS_ASSERT(Poco::File(path).exists());
+    TS_ASSERT(reader.isBinarySTL(path));
+    Poco::File(path).remove();
+  }
+
+  void test_saves_shape_correctly() {
+    std::string path =
+        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+    std::vector<uint32_t> triangle{0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5,
+                                   2, 5, 4, 6, 1, 3, 6, 5, 1, 4, 5, 6,
+                                   7, 3, 0, 0, 4, 7, 7, 6, 3, 4, 6, 7};
+    std::vector<V3D> vertices{V3D(-5, -5, -15), V3D(5, 5, -15), V3D(5, -5, -15),
+                              V3D(-5, 5, -15),  V3D(5, -5, 15), V3D(5, 5, 15),
+                              V3D(-5, 5, 15),   V3D(-5, -5, 15)};
+    std::vector<double> compareVertices{-5,  -5, -15, 5,   5,  -15, 5,  -5,
+                                        -15, -5, 5,   -15, 5,  -5,  15, 5,
+                                        5,   15, -5,  5,   15, -5,  -5, 15};
+    auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
+    writer.writeStl();
+    auto reader = LoadBinaryStl("/home/sjenkins/Work/Build-1/ExternalData/"
+                                "Testing/Data/UnitTest/cubeBin.stl",
+                                ScaleUnits::metres);
+    TS_ASSERT(Poco::File(path).exists());
+    TS_ASSERT(reader.isBinarySTL(path));
+    auto shape = reader.readStl();
+    auto loadedTriangles = shape->getTriangles();
+    auto loadedVertices = shape->getVertices();
+    TS_ASSERT_EQUALS(loadedTriangles, triangle);
+    TS_ASSERT_EQUALS(loadedVertices, compareVertices);
+    Poco::File(path).remove();
+  }
+
+  void test_fails_invalid_shape(){
+    std::string path =
+        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+    std::vector<uint32_t> triangle{0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5,
+                                   2, 5, 4, 6, 1, 3, 6, 5, 1, 4, 5, 6,
+                                   7, 3, 0, 0, 4, 7, 7, 6, 3, 4, };
+    std::vector<V3D> vertices{V3D(-5, -5, -15), V3D(5, 5, -15), V3D(5, -5, -15),
+                              V3D(-5, 5, -15),  V3D(5, -5, 15), V3D(5, 5, 15),
+                              V3D(-5, 5, 15),   V3D(-5, -5, 15)};
+    auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
+    TS_ASSERT_THROWS(writer.writeStl(),std::runtime_error);
+    TS_ASSERT(!Poco::File(path).exists());
+  }
+};
+#endif /*SAVE_STL_TEST_H_*/

--- a/Framework/DataHandling/test/SaveStlTest.h
+++ b/Framework/DataHandling/test/SaveStlTest.h
@@ -65,17 +65,18 @@ public:
     Poco::File(path).remove();
   }
 
-  void test_fails_invalid_shape(){
+  void test_fails_invalid_shape() {
     std::string path =
         "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
-    std::vector<uint32_t> triangle{0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5,
-                                   2, 5, 4, 6, 1, 3, 6, 5, 1, 4, 5, 6,
-                                   7, 3, 0, 0, 4, 7, 7, 6, 3, 4, };
+    std::vector<uint32_t> triangle{
+        0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5, 2, 5, 4, 6, 1,
+        3, 6, 5, 1, 4, 5, 6, 7, 3, 0, 0, 4, 7, 7, 6, 3, 4,
+    };
     std::vector<V3D> vertices{V3D(-5, -5, -15), V3D(5, 5, -15), V3D(5, -5, -15),
                               V3D(-5, 5, -15),  V3D(5, -5, 15), V3D(5, 5, 15),
                               V3D(-5, 5, 15),   V3D(-5, -5, 15)};
     auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
-    TS_ASSERT_THROWS(writer.writeStl(),std::runtime_error);
+    TS_ASSERT_THROWS(writer.writeStl(), std::runtime_error);
     TS_ASSERT(!Poco::File(path).exists());
   }
 };

--- a/Framework/DataHandling/test/SaveStlTest.h
+++ b/Framework/DataHandling/test/SaveStlTest.h
@@ -6,24 +6,33 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #ifndef SAVE_STL_TEST_H_
 #define SAVE_STL_TEST_H_
+#include "MantidAPI/FileFinder.h"
 #include "MantidDataHandling//SaveStl.h"
 #include "MantidDataHandling/LoadBinaryStl.h"
 #include "MantidKernel/V3D.h"
 
 #include <Poco/File.h>
+#include <Poco/Path.h>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::DataHandling;
 using namespace Mantid::Kernel;
+using namespace Mantid::API;
 
 class SaveStlTest : public CxxTest::TestSuite {
 public:
   static SaveStlTest *createSuite() { return new SaveStlTest(); }
   static void destroySuite(SaveStlTest *suite) { delete suite; }
 
+  SaveStlTest() {
+    auto end = cubePath.rfind("cubeBin.stl");
+    path = cubePath;
+    path.resize(end);
+    path = path + "SaveStlTest.stl";
+  }
+
   void test_saves_valid_stl() {
-    std::string path =
-        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+
     std::vector<uint32_t> triangle{1, 0, 3, 1, 4, 0, 1, 3, 6, 3, 0, 7,
                                    3, 7, 6, 6, 0, 2, 4, 7, 0, 6, 7, 4,
                                    5, 2, 1, 1, 3, 5, 5, 4, 2, 6, 4, 5};
@@ -39,8 +48,7 @@ public:
   }
 
   void test_saves_shape_correctly() {
-    std::string path =
-        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+
     std::vector<uint32_t> triangle{0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5,
                                    2, 5, 4, 6, 1, 3, 6, 5, 1, 4, 5, 6,
                                    7, 3, 0, 0, 4, 7, 7, 6, 3, 4, 6, 7};
@@ -52,9 +60,7 @@ public:
                                         5,   15, -5,  5,   15, -5,  -5, 15};
     auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
     writer.writeStl();
-    auto reader = LoadBinaryStl("/home/sjenkins/Work/Build-1/ExternalData/"
-                                "Testing/Data/UnitTest/cubeBin.stl",
-                                ScaleUnits::metres);
+    auto reader = LoadBinaryStl(cubePath, ScaleUnits::metres);
     TS_ASSERT(Poco::File(path).exists());
     TS_ASSERT(reader.isBinarySTL(path));
     auto shape = reader.readStl();
@@ -66,8 +72,7 @@ public:
   }
 
   void test_fails_invalid_shape() {
-    std::string path =
-        "/home/sjenkins/Documents/SampleCorrections/SaveStlTest.stl";
+
     std::vector<uint32_t> triangle{
         0, 1, 2, 0, 3, 1, 0, 2, 4, 2, 1, 5, 2, 5, 4, 6, 1,
         3, 6, 5, 1, 4, 5, 6, 7, 3, 0, 0, 4, 7, 7, 6, 3, 4,
@@ -79,5 +84,9 @@ public:
     TS_ASSERT_THROWS(writer.writeStl(), std::runtime_error);
     TS_ASSERT(!Poco::File(path).exists());
   }
+
+  const std::string cubePath =
+      FileFinder::Instance().getFullPath("cubeBin.stl");
+  std::string path;
 };
 #endif /*SAVE_STL_TEST_H_*/

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -36,9 +36,7 @@ public:
 
   void setSampleShape(const std::string &sampleShapeXML);
 
-  const IObject& getShape() const {
-    return *m_shape;
-  }
+  const IObject &getShape() const { return *m_shape; }
 
   bool isValid(const Kernel::V3D &p) const override {
     return m_shape->isValid(p);

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -36,6 +36,10 @@ public:
 
   void setSampleShape(const std::string &sampleShapeXML);
 
+  const IObject& getShape() const {
+    return *m_shape;
+  }
+
   bool isValid(const Kernel::V3D &p) const override {
     return m_shape->isValid(p);
   }

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -134,6 +134,7 @@ public:
   /// Read access to mesh object for rendering
   size_t numberOfVertices() const;
   std::vector<double> getVertices() const;
+  const std::vector<Kernel::V3D> &getV3Ds() const;
   size_t numberOfTriangles() const;
   std::vector<uint32_t> getTriangles() const;
 

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -500,9 +500,7 @@ std::vector<uint32_t> MeshObject::getTriangles() const { return m_triangles; }
 /**
  * get number of points
  */
-size_t MeshObject::numberOfVertices() const {
-  return m_vertices.size();
-}
+size_t MeshObject::numberOfVertices() const { return m_vertices.size(); }
 
 /**
  * get vertices
@@ -511,10 +509,10 @@ std::vector<double> MeshObject::getVertices() const {
   return MeshObjectCommon::getVertices(m_vertices);
 }
 
-/** 
+/**
  * get vertices in V3D form
  */
- const std::vector<Kernel::V3D> &MeshObject::getV3Ds() const {
+const std::vector<Kernel::V3D> &MeshObject::getV3Ds() const {
   return m_vertices;
 }
 

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -501,7 +501,7 @@ std::vector<uint32_t> MeshObject::getTriangles() const { return m_triangles; }
  * get number of points
  */
 size_t MeshObject::numberOfVertices() const {
-  return static_cast<int>(m_vertices.size());
+  return m_vertices.size();
 }
 
 /**
@@ -509,6 +509,13 @@ size_t MeshObject::numberOfVertices() const {
  */
 std::vector<double> MeshObject::getVertices() const {
   return MeshObjectCommon::getVertices(m_vertices);
+}
+
+/** 
+ * get vertices in V3D form
+ */
+ const std::vector<Kernel::V3D> &MeshObject::getV3Ds() const {
+  return m_vertices;
 }
 
 detail::ShapeInfo::GeometryShape MeshObject::shape() const {

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -322,6 +322,7 @@ set(TEST_FILES
     BinFinderTest.h
     BinaryFileTest.h
     BinaryStreamReaderTest.h
+    BinaryStreamWriterTest.h
     BoseEinsteinDistributionTest.h
     BoundedValidatorTest.h
     CPUTimerTest.h

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SRC_FILES
     src/Atom.cpp
     src/BinFinder.cpp
     src/BinaryStreamReader.cpp
+    src/BinaryStreamWriter.cpp
     src/CPUTimer.cpp
     src/CatalogInfo.cpp
     src/ChecksumHelper.cpp
@@ -149,6 +150,7 @@ set(INC_FILES
     inc/MantidKernel/BinFinder.h
     inc/MantidKernel/BinaryFile.h
     inc/MantidKernel/BinaryStreamReader.h
+    inc/MantidKernel/BinaryStreamWriter.h
     inc/MantidKernel/BoundedValidator.h
     inc/MantidKernel/CPUTimer.h
     inc/MantidKernel/Cache.h

--- a/Framework/Kernel/inc/MantidKernel/BinaryStreamReader.h
+++ b/Framework/Kernel/inc/MantidKernel/BinaryStreamReader.h
@@ -45,6 +45,7 @@ public:
   BinaryStreamReader &operator>>(float &value);
   BinaryStreamReader &operator>>(double &value);
   BinaryStreamReader &operator>>(std::string &value);
+  BinaryStreamReader &operator>>(uint16_t &value);
   BinaryStreamReader &operator>>(uint32_t &value);
   /// @}
 

--- a/Framework/Kernel/inc/MantidKernel/BinaryStreamWriter.h
+++ b/Framework/Kernel/inc/MantidKernel/BinaryStreamWriter.h
@@ -1,0 +1,89 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_KERNEL_BINARYSTREAMWRITER_H_
+#define MANTID_KERNEL_BINARYSTREAMWRITER_H_
+//------------------------------------------------------------------------------
+// Includes
+//------------------------------------------------------------------------------
+#include "MantidKernel/DllConfig.h"
+
+#include <cstdint>
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace Mantid {
+namespace Kernel {
+
+// Forward declarations
+template <typename T> class Matrix;
+
+/**
+ * Assists with writing a binary file by providing standard overloads for the
+ * ostream operators (<<) to given types (and vectors of those types). It
+ * only allows for writing fixed-width integer types to avoid cross-platform
+ * differences on the sizes of various types.
+ *
+ *
+ */
+class MANTID_KERNEL_DLL BinaryStreamWriter {
+public:
+  /// Define the ordering of 2D structures in the file
+  enum class MatrixOrdering { RowMajor, ColumnMajor };
+
+  BinaryStreamWriter(std::ostream &ofstrm);
+
+  ///@name Single-value stream operators
+  /// @{
+  BinaryStreamWriter &operator<<(const int16_t &value);
+  BinaryStreamWriter &operator<<(const int32_t &value);
+  BinaryStreamWriter &operator<<(const int64_t &value);
+  BinaryStreamWriter &operator<<(const float &value);
+  BinaryStreamWriter &operator<<(const double &value);
+  BinaryStreamWriter &operator<<(const std::string &value);
+  BinaryStreamWriter &operator<<(const uint16_t &value);
+  BinaryStreamWriter &operator<<(const uint32_t &value);
+  /// @}
+
+  ///@name 1D methods
+  /// @{
+  BinaryStreamWriter &write(const std::vector<int16_t> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<int32_t> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<int64_t> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<float> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<double> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::string &value, const size_t length);
+  /// @}
+
+  ///@name 2D methods
+  /// @{
+  BinaryStreamWriter &write(const std::vector<std::string> &value,
+                           const std::vector<int32_t> &shape,
+                           MatrixOrdering order);
+  BinaryStreamWriter &write(const Kernel::Matrix<float> &value,
+                           const std::vector<int32_t> &shape,
+                           MatrixOrdering order);
+  BinaryStreamWriter &write(const Kernel::Matrix<double> &value,
+                           const std::vector<int32_t> &shape,
+                           MatrixOrdering order);
+  /// @}
+
+
+
+private:
+  /// Reference to the stream being written to
+  std::ostream &m_ofstrm;
+  /// The default size in bytes of the type used to encode the length
+  /// of a string in the file. Used by operator<<(std::string&). Use largest
+  /// fixed-width unsigned integer as sizeof(size_t) varies
+  uint64_t m_strLengthSize;
+};
+
+} // namespace Kernel
+} // namespace Mantid
+
+#endif /* MANTID_KERNEL_BINARYSTREAMWRITER_H_ */

--- a/Framework/Kernel/inc/MantidKernel/BinaryStreamWriter.h
+++ b/Framework/Kernel/inc/MantidKernel/BinaryStreamWriter.h
@@ -51,28 +51,31 @@ public:
 
   ///@name 1D methods
   /// @{
-  BinaryStreamWriter &write(const std::vector<int16_t> &value, const size_t nvals);
-  BinaryStreamWriter &write(const std::vector<int32_t> &value, const size_t nvals);
-  BinaryStreamWriter &write(const std::vector<int64_t> &value, const size_t nvals);
-  BinaryStreamWriter &write(const std::vector<float> &value, const size_t nvals);
-  BinaryStreamWriter &write(const std::vector<double> &value, const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<int16_t> &value,
+                            const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<int32_t> &value,
+                            const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<int64_t> &value,
+                            const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<float> &value,
+                            const size_t nvals);
+  BinaryStreamWriter &write(const std::vector<double> &value,
+                            const size_t nvals);
   BinaryStreamWriter &write(const std::string &value, const size_t length);
   /// @}
 
   ///@name 2D methods
   /// @{
   BinaryStreamWriter &write(const std::vector<std::string> &value,
-                           const std::vector<int32_t> &shape,
-                           MatrixOrdering order);
+                            const std::vector<int32_t> &shape,
+                            MatrixOrdering order);
   BinaryStreamWriter &write(const Kernel::Matrix<float> &value,
-                           const std::vector<int32_t> &shape,
-                           MatrixOrdering order);
+                            const std::vector<int32_t> &shape,
+                            MatrixOrdering order);
   BinaryStreamWriter &write(const Kernel::Matrix<double> &value,
-                           const std::vector<int32_t> &shape,
-                           MatrixOrdering order);
+                            const std::vector<int32_t> &shape,
+                            MatrixOrdering order);
   /// @}
-
-
 
 private:
   /// Reference to the stream being written to

--- a/Framework/Kernel/src/BinaryStreamReader.cpp
+++ b/Framework/Kernel/src/BinaryStreamReader.cpp
@@ -172,6 +172,16 @@ BinaryStreamReader &BinaryStreamReader::operator>>(std::string &value) {
 }
 
 /**
+ * Read a uint16_t from the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamReader object
+ */
+BinaryStreamReader &BinaryStreamReader::operator>>(uint16_t &value) {
+  readFromStream(m_istrm, value);
+  return *this;
+}
+
+/**
  * Read a uint32_t from the stream
  * @param value The value is stored in the given stream
  * @return A reference to the BinaryStreamReader object

--- a/Framework/Kernel/src/BinaryStreamWriter.cpp
+++ b/Framework/Kernel/src/BinaryStreamWriter.cpp
@@ -1,0 +1,230 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+//------------------------------------------------------------------------------
+// Includes
+//------------------------------------------------------------------------------
+#include "MantidKernel/BinaryStreamWriter.h"
+#include "MantidKernel/Matrix.h"
+
+#include <cassert>
+#include <fstream>
+#include <stdexcept>
+
+namespace Mantid {
+namespace Kernel {
+
+//------------------------------------------------------------------------------
+// Anonymous functions
+//------------------------------------------------------------------------------
+namespace {
+
+/**
+ * write a value to the stream based on the template type
+ * @param stream The open stream on which to perform the write
+ * @param value An object of type T to fill with the value from the file
+ */
+template <typename T>
+inline void writeToStream(std::ostream &stream, const T &value) {
+  stream.write(reinterpret_cast<const char *>(&value), sizeof(T));
+}
+
+/**
+ * Overload to write an array of values to the stream based on the template
+ * type for the element of the array.
+ * @param stream The open stream on which to perform the write
+ * @param value An object of type std::vector<T> to fill with the value from
+ * the file
+ * @param nvals The number of values to write
+ */
+template <typename T>
+inline void writeToStream(std::ostream &stream, const std::vector<T> &value,
+                           size_t nvals) {
+  stream.write(reinterpret_cast<const char *>(value.data()), nvals * sizeof(T));
+}
+} // namespace
+
+//------------------------------------------------------------------------------
+// Public members
+//------------------------------------------------------------------------------
+
+/**
+ * Constructor taking the stream to write.
+ * @param ofstrm An open stream from which data will be write. The object does
+ * not take ownership of the stream. The caller is responsible for closing
+ * it.
+ */
+BinaryStreamWriter::BinaryStreamWriter(std::ostream &ofstrm)
+    : m_ofstrm(ofstrm), m_strLengthSize(static_cast<uint64_t>(sizeof(int32_t))) {
+  if (!ofstrm) {
+    throw std::runtime_error(
+        "BinaryStreamWriter: Output stream is in a bad state. Cannot continue.");
+  }
+}
+
+/**
+ * write a int16_t to the stream
+ * @param value the value is stored in the given stream
+ * @return BinaryStreamWriter&
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const int16_t &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a int32_t to the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const int32_t &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a int64_t to the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const int64_t &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a float (4-bytes) to the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const float &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a double (8-bytes) to the stream
+ * @param value The value is stored in this object
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const double &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a string of characters from given object. This method assumes that
+ * the stream currently points at a type specifying the length followed directly
+ * by the string itself.
+ * @param value The string value is stored in the given object. It is resized
+ * to the appropriate length
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const std::string &value) {
+  // First write the size.
+  decltype(m_strLengthSize) length(value.length());
+  m_ofstrm.write(reinterpret_cast<char *>(&length), m_strLengthSize);
+  // Now the value
+  m_ofstrm.write(const_cast<char *>(value.data()), static_cast<size_t>(length));
+  return *this;
+}
+
+/**
+ * write a uint16_t to the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const uint16_t &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write a uint32_t to the stream
+ * @param value The value is stored in the given stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::operator<<(const uint32_t &value) {
+  writeToStream(m_ofstrm, value);
+  return *this;
+}
+
+/**
+ * write an array of int16_t from the given vector.
+ * @param value The array to fille. Its size is increased if necessary
+ * @param nvals The number values to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int16_t> &value,
+                                             const size_t nvals) {
+  writeToStream(m_ofstrm, value, nvals);
+  return *this;
+}
+
+/**
+ * write an array of int32_t from the given vector.
+ * @param value The array to fill. Its size is increased if necessary
+ * @param nvals The number values to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int32_t> &value,
+                                             const size_t nvals) {
+  writeToStream(m_ofstrm, value, nvals);
+  return *this;
+}
+
+/**
+ * write an array of int64_t from the given vector.
+ * @param value The array to fill. Its size is increased if necessary
+ * @param nvals The number values to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int64_t> &value,
+                                             const size_t nvals) {
+  writeToStream(m_ofstrm, value, nvals);
+  return *this;
+}
+
+/**
+ * write an array of float balues from the given vector.
+ * @param value The array to fill. Its size is increased if necessary
+ * @param nvals The number values to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<float> &value,
+                                             const size_t nvals) {
+  writeToStream(m_ofstrm, value, nvals);
+  return *this;
+}
+
+/**
+ * write an array of double values from the given vector.
+ * @param value The array to fill. Its size is increased if necessary
+ * @param nvals The number values to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<double> &value,
+                                             const size_t nvals) {
+  writeToStream(m_ofstrm, value, nvals);
+  return *this;
+}
+
+/**
+ * write a series of characters from a string object.
+ * @param value The string to fill. Its size is increased if necessary
+ * @param length The number characters to attempt to write to the stream
+ * @return A reference to the BinaryStreamWriter object
+ */
+BinaryStreamWriter &BinaryStreamWriter::write(const std::string &value,
+                                             const size_t length) {
+  m_ofstrm.write(const_cast<char *>(value.data()), length);
+  return *this;
+}
+
+
+
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/src/BinaryStreamWriter.cpp
+++ b/Framework/Kernel/src/BinaryStreamWriter.cpp
@@ -42,7 +42,7 @@ inline void writeToStream(std::ostream &stream, const T &value) {
  */
 template <typename T>
 inline void writeToStream(std::ostream &stream, const std::vector<T> &value,
-                           size_t nvals) {
+                          size_t nvals) {
   stream.write(reinterpret_cast<const char *>(value.data()), nvals * sizeof(T));
 }
 } // namespace
@@ -58,10 +58,11 @@ inline void writeToStream(std::ostream &stream, const std::vector<T> &value,
  * it.
  */
 BinaryStreamWriter::BinaryStreamWriter(std::ostream &ofstrm)
-    : m_ofstrm(ofstrm), m_strLengthSize(static_cast<uint64_t>(sizeof(int32_t))) {
+    : m_ofstrm(ofstrm),
+      m_strLengthSize(static_cast<uint64_t>(sizeof(int32_t))) {
   if (!ofstrm) {
-    throw std::runtime_error(
-        "BinaryStreamWriter: Output stream is in a bad state. Cannot continue.");
+    throw std::runtime_error("BinaryStreamWriter: Output stream is in a bad "
+                             "state. Cannot continue.");
   }
 }
 
@@ -159,7 +160,7 @@ BinaryStreamWriter &BinaryStreamWriter::operator<<(const uint32_t &value) {
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int16_t> &value,
-                                             const size_t nvals) {
+                                              const size_t nvals) {
   writeToStream(m_ofstrm, value, nvals);
   return *this;
 }
@@ -171,7 +172,7 @@ BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int16_t> &value,
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int32_t> &value,
-                                             const size_t nvals) {
+                                              const size_t nvals) {
   writeToStream(m_ofstrm, value, nvals);
   return *this;
 }
@@ -183,7 +184,7 @@ BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int32_t> &value,
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int64_t> &value,
-                                             const size_t nvals) {
+                                              const size_t nvals) {
   writeToStream(m_ofstrm, value, nvals);
   return *this;
 }
@@ -195,7 +196,7 @@ BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<int64_t> &value,
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<float> &value,
-                                             const size_t nvals) {
+                                              const size_t nvals) {
   writeToStream(m_ofstrm, value, nvals);
   return *this;
 }
@@ -207,7 +208,7 @@ BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<float> &value,
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<double> &value,
-                                             const size_t nvals) {
+                                              const size_t nvals) {
   writeToStream(m_ofstrm, value, nvals);
   return *this;
 }
@@ -219,12 +220,10 @@ BinaryStreamWriter &BinaryStreamWriter::write(const std::vector<double> &value,
  * @return A reference to the BinaryStreamWriter object
  */
 BinaryStreamWriter &BinaryStreamWriter::write(const std::string &value,
-                                             const size_t length) {
+                                              const size_t length) {
   m_ofstrm.write(const_cast<char *>(value.data()), length);
   return *this;
 }
-
-
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/src/BinaryStreamWriter.cpp
+++ b/Framework/Kernel/src/BinaryStreamWriter.cpp
@@ -60,7 +60,7 @@ inline void writeToStream(std::ostream &stream, const std::vector<T> &value,
 BinaryStreamWriter::BinaryStreamWriter(std::ostream &ofstrm)
     : m_ofstrm(ofstrm),
       m_strLengthSize(static_cast<uint64_t>(sizeof(int32_t))) {
-  if (!ofstrm) {
+  if (ofstrm.fail()) {
     throw std::runtime_error("BinaryStreamWriter: Output stream is in a bad "
                              "state. Cannot continue.");
   }

--- a/Framework/Kernel/test/BinaryStreamWriterTest.h
+++ b/Framework/Kernel/test/BinaryStreamWriterTest.h
@@ -55,6 +55,14 @@ public:
     doWriteSingleValueTest<int64_t>(200);
   }
 
+  void test_Write_uint16_t_Gives_Correct_Value() {
+    doWriteSingleValueTest<uint16_t>(111);
+  }
+
+  void test_Write_uint32_t_Gives_Correct_Value() {
+    doWriteSingleValueTest<uint32_t>(231);
+  }
+
   void test_Write_float_Gives_Correct_Value() {
     doWriteSingleValueTest<float>(787.0f);
   }
@@ -102,11 +110,8 @@ private:
     BinaryStreamWriter writer(m_bytes);
     BinaryStreamReader reader(m_bytes);
     T readVal;
-    auto place1 =m_bytes.tellg();
     writer << value;
-    auto place= m_bytes.tellg();
     reader >> readVal;
-    auto place2= m_bytes.tellg();
     TS_ASSERT_EQUALS(readVal, value);
   }
 

--- a/Framework/Kernel/test/BinaryStreamWriterTest.h
+++ b/Framework/Kernel/test/BinaryStreamWriterTest.h
@@ -1,0 +1,131 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_KERNEL_BINARYSTREAMWRITERTEST_H_
+#define MANTID_KERNEL_BINARYSTREAMWRITERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <cxxtest/ValueTraits.h>
+
+#include "MantidKernel/BinaryStreamReader.h"
+#include "MantidKernel/BinaryStreamWriter.h"
+#include "MantidKernel/Matrix.h"
+
+#include <sstream>
+
+using Mantid::Kernel::BinaryStreamReader;
+using Mantid::Kernel::BinaryStreamWriter;
+using Mantid::Kernel::Matrix;
+
+class BinaryStreamWriterTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static BinaryStreamWriterTest *createSuite() {
+    return new BinaryStreamWriterTest();
+  }
+  static void destroySuite(BinaryStreamWriterTest *suite) { delete suite; }
+
+  BinaryStreamWriterTest() : CxxTest::TestSuite(), m_bytes() {}
+
+
+  //----------------------------------------------------------------------------
+  // Successes cases
+  //----------------------------------------------------------------------------
+
+  // single values
+  void test_Constructor_With_Good_Stream_Does_Not_Touch_Stream() {
+    BinaryStreamReader reader(m_bytes);
+    TS_ASSERT_EQUALS(std::ios_base::beg, m_bytes.tellg());
+  }
+
+  void test_Write_int16_t_Gives_Correct_Value() {
+    doWriteSingleValueTest<int16_t>(6);
+  }
+
+  void test_Write_int32_t_Gives_Correct_Value() {
+    doWriteSingleValueTest<int32_t>(580);
+  }
+
+  void test_Write_int64_t_Gives_Correct_Value() {
+    ;
+    doWriteSingleValueTest<int64_t>(200);
+  }
+
+  void test_Write_float_Gives_Correct_Value() {
+    doWriteSingleValueTest<float>(787.0f);
+  }
+
+  void test_Write_double_Gives_Correct_Value() {
+    doWriteSingleValueTest<double>(2.0);
+  }
+
+  void test_Write_String_Gives_Expected_String() {
+    doWriteSingleValueTest<std::string>("mantid");
+  }
+
+  // vectors of values
+  void test_Write_Vector_int16_t() {
+    const size_t nvals(3);
+    std::vector<int16_t> expectedValue{2, 0, 4};
+    doWriteArrayValueTest(nvals, expectedValue);
+  }
+
+  void test_Write_Vector_int32_t() {
+    const size_t nvals(3);
+    std::vector<int32_t> expectedValue{2, 4, 6};
+    doWriteArrayValueTest(nvals, expectedValue);
+  }
+
+  void test_Write_Vector_int64_t() {
+    std::vector<int64_t> expectedValue{200, 400, 600, 900};
+    doWriteArrayValueTest(expectedValue.size(), expectedValue);
+  }
+
+  void test_Write_Vector_float() {
+    std::vector<float> expectedValue{0.0f, 5.0f, 10.0f};
+    doWriteArrayValueTest(expectedValue.size(), expectedValue);
+  }
+
+  void test_Write_Vector_double() {
+    std::vector<double> expectedValue{10.0, 15.0, 20.0, 25.0};
+    doWriteArrayValueTest(expectedValue.size(), expectedValue);
+  }
+
+
+  
+private:
+  template <typename T> void doWriteSingleValueTest(T value) {
+    BinaryStreamWriter writer(m_bytes);
+    BinaryStreamReader reader(m_bytes);
+    T readVal;
+    auto place1 =m_bytes.tellg();
+    writer << value;
+    auto place= m_bytes.tellg();
+    reader >> readVal;
+    auto place2= m_bytes.tellg();
+    TS_ASSERT_EQUALS(readVal, value);
+  }
+
+  template <typename T> void doWriteArrayValueTest(const size_t nvals,
+                            const std::vector<T> &values) {
+    BinaryStreamWriter writer(m_bytes);
+    BinaryStreamReader reader(m_bytes);
+    std::vector<T> readValues;
+    writer.write(values, nvals);
+    reader.read(readValues, nvals);
+    TS_ASSERT_EQUALS(readValues, values);
+    TS_ASSERT_EQUALS(nvals, values.size());
+  }
+
+  void resetStreamToStart() {
+    m_bytes.clear();
+    m_bytes.seekg(std::ios_base::beg);
+  }
+
+  std::stringstream m_bytes;
+};
+#endif

--- a/Framework/Kernel/test/BinaryStreamWriterTest.h
+++ b/Framework/Kernel/test/BinaryStreamWriterTest.h
@@ -31,7 +31,6 @@ public:
 
   BinaryStreamWriterTest() : CxxTest::TestSuite(), m_bytes() {}
 
-
   //----------------------------------------------------------------------------
   // Successes cases
   //----------------------------------------------------------------------------
@@ -103,8 +102,6 @@ public:
     doWriteArrayValueTest(expectedValue.size(), expectedValue);
   }
 
-
-  
 private:
   template <typename T> void doWriteSingleValueTest(T value) {
     BinaryStreamWriter writer(m_bytes);
@@ -115,8 +112,8 @@ private:
     TS_ASSERT_EQUALS(readVal, value);
   }
 
-  template <typename T> void doWriteArrayValueTest(const size_t nvals,
-                            const std::vector<T> &values) {
+  template <typename T>
+  void doWriteArrayValueTest(const size_t nvals, const std::vector<T> &values) {
     BinaryStreamWriter writer(m_bytes);
     BinaryStreamReader reader(m_bytes);
     std::vector<T> readValues;

--- a/docs/source/algorithms/SaveSampleEnvironmentAndShape-v1.rst
+++ b/docs/source/algorithms/SaveSampleEnvironmentAndShape-v1.rst
@@ -1,0 +1,24 @@
+﻿.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Saves out the sample and environment on a workspace as a binary .stl file, the sample shape and environment must have been set using :ref:`LoadSampleShape <algm-LoadSampleShape>` and :ref:`LoadSampleEnvironment <algm-LoadSampleEnvironment>`, as this algorithm only supports shapes stored as a mesh. 
+
+The output is of the following type:
+
+* ``*.stl`` stereolithography `https://en.wikipedia.org/wiki/STL_(file_format) <https://en.wikipedia.org/wiki/STL_(file_format)>`_
+  This is a file format consisting of a list of faces specified by their vertex coordinates.
+  The file will be in Binary format, the Header will contain information about when the file was created, and the normals and attribute code are unset. 
+  The vertices are in the standard order (counter clockwise when viewed from the outside).
+
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -12,6 +12,10 @@ Diffraction Changes
 Powder Diffraction
 ------------------
 
+New Algorithms
+##############
+- New algorithm :ref:`SaveSampleEnvironmentAndShape <algm-SaveSampleEnvironmentAndShape>` to save out a sample shape and environment as a single STL file, this can be used to save out pieces with a set rotation or scale, or to assemble multiple stl files into one for viewing purposes.
+
 Improvements
 ############
 


### PR DESCRIPTION
**Description of work.**
Added algorithm `SaveSampleEnvironmentAndShape` to save out a binary .stl file containing the mesh of the entire shape of the environment and sample as a single mesh.
**To test:**
use .stl files in `ExternalData/Testing/Data/UnitTest/` along with `LoadSampleShape` and `LoadSampleEnvironment` to construct a sample (it must at least have a sample shape) then run `SaveSampleEnvironmentAndShape`, the .stl file created should be loadable in mantid using `LoadSampleShape` and should be able to be loaded in https://www.viewstl.com/. 

Attempting to save a non mesh based sample, e.g. one created using `CreateSampleShape` should fail.

The new tests should pass.

Fixes #25722

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
