### PR TITLE
Indirect Diffraction - Prevent out of range spectra

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -30,11 +30,18 @@ def contains_non_ascending_range(strings, delimiter):
     return False
 
 
-def find_minimum_non_zero_y(workspace):
-    y_minimum = min(filter(lambda x: x > 0, workspace.readY(0)))
-    for idx in range(1, workspace.getNumberHistograms()):
-        y_spec_min = min(filter(lambda x: x > 0, workspace.readY(idx)))
-        y_minimum = y_spec_min if y_spec_min < y_minimum else y_minimum
+def find_minimum_non_zero_y_in_spectrum(y_minimum, spectrum):
+    positive_y = filter(lambda x: x > 0, spectrum)
+    y_spec_min = min(positive_y) if len(positive_y) > 0 else None
+    if y_spec_min and (y_minimum is None or y_spec_min < y_minimum):
+        return y_spec_min
+    return y_minimum
+
+
+def find_minimum_non_zero_y_in_workspace(workspace):
+    y_minimum = None
+    for idx in range(0, workspace.getNumberHistograms()):
+        y_minimum = find_minimum_non_zero_y_in_spectrum(y_minimum, workspace.readY(idx))
     return y_minimum
 
 
@@ -266,7 +273,7 @@ class ISISIndirectDiffractionReduction(DataProcessorAlgorithm):
                                          WorkspaceToMatch=ws_name,
                                          OutputWorkspace=van_ws_name)
 
-                    replacement_value = 0.1*find_minimum_non_zero_y(van_ws)
+                    replacement_value = 0.1*find_minimum_non_zero_y_in_workspace(van_ws)
                     logger.information('Replacing zeros in {0} with {1}.'.format(van_ws_name, replacement_value))
                     ReplaceSpecialValues(InputWorkspace=van_ws_name,
                                          SmallNumberThreshold=0.0000001,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReduction.py
@@ -31,7 +31,7 @@ def contains_non_ascending_range(strings, delimiter):
 
 
 def find_minimum_non_zero_y_in_spectrum(y_minimum, spectrum):
-    positive_y = filter(lambda x: x > 0, spectrum)
+    positive_y = list(filter(lambda x: x > 0, spectrum))
     y_spec_min = min(positive_y) if len(positive_y) > 0 else None
     if y_spec_min and (y_minimum is None or y_spec_min < y_minimum):
         return y_spec_min

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -92,6 +92,14 @@ Bug Fixes
 - Fixed an unexpected error when opening the Data Reduction interface with an unrelated facility selected.
 
 
+Diffraction Interface
+----------------------
+
+Bug Fixes
+#########
+- Fixed a bug which allowed an out-of-range Spectra Min and Spectra Max.
+
+
 Indirect Settings Interface
 ---------------------------
 

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -12,6 +12,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/MultiFileNameParser.h"
+#include "MantidQtWidgets/Common/SignalBlocker.h"
 
 using namespace Mantid::API;
 using namespace Mantid::Geometry;
@@ -59,6 +60,11 @@ void IndirectDiffractionReduction::initLayout() {
           this,
           SLOT(instrumentSelected(const QString &, const QString &,
                                   const QString &)));
+
+  connect(m_uiForm.spSpecMin, SIGNAL(valueChanged(int)), this,
+          SLOT(validateSpectrumMin(int)));
+  connect(m_uiForm.spSpecMax, SIGNAL(valueChanged(int)), this,
+          SLOT(validateSpectrumMax(int)));
 
   // Update run button based on state of raw files field
   connectRunButtonValidation(m_uiForm.rfSampleFiles);
@@ -642,6 +648,11 @@ void IndirectDiffractionReduction::instrumentSelected(
   double specMin = instrument->getNumberParameter("spectra-min")[0];
   double specMax = instrument->getNumberParameter("spectra-max")[0];
 
+  m_uiForm.spSpecMin->setMinimum(static_cast<int>(specMin));
+  m_uiForm.spSpecMin->setMaximum(static_cast<int>(specMax));
+  m_uiForm.spSpecMax->setMinimum(static_cast<int>(specMin));
+  m_uiForm.spSpecMax->setMaximum(static_cast<int>(specMax));
+
   m_uiForm.spSpecMin->setValue(static_cast<int>(specMin));
   m_uiForm.spSpecMax->setValue(static_cast<int>(specMax));
 
@@ -703,6 +714,22 @@ void IndirectDiffractionReduction::instrumentSelected(
     m_uiForm.spSpecMin->setEnabled(true);
     m_uiForm.spSpecMax->setEnabled(true);
   }
+}
+
+void IndirectDiffractionReduction::validateSpectrumMin(int value) {
+  MantidQt::API::SignalBlocker blocker(m_uiForm.spSpecMin);
+
+  auto const spectraMax = m_uiForm.spSpecMax->value();
+  if (value > spectraMax)
+    m_uiForm.spSpecMin->setValue(spectraMax);
+}
+
+void IndirectDiffractionReduction::validateSpectrumMax(int value) {
+  MantidQt::API::SignalBlocker blocker(m_uiForm.spSpecMax);
+
+  auto const spectraMin = m_uiForm.spSpecMin->value();
+  if (value < spectraMin)
+    m_uiForm.spSpecMax->setValue(spectraMin);
 }
 
 std::string IndirectDiffractionReduction::documentationPage() const {

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.h
@@ -41,6 +41,8 @@ public slots:
   void manualGroupingToggled(int state);
   void algorithmComplete(bool error);
   void deleteGroupingWorkspace();
+  void validateSpectrumMin(int value);
+  void validateSpectrumMax(int value);
 
 private:
   std::string documentationPage() const override;

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -106,9 +106,13 @@ void cloneWorkspace(std::string const &workspaceName,
 
 bool isTechniqueDirect(MatrixWorkspace_const_sptr sampleWorkspace,
                        MatrixWorkspace_const_sptr resWorkspace) {
-  auto const logValue1 = sampleWorkspace->getLog("deltaE-mode")->value();
-  auto const logValue2 = resWorkspace->getLog("deltaE-mode")->value();
-  return (logValue1 == "Direct") && (logValue2 == "Direct");
+  try {
+    auto const logValue1 = sampleWorkspace->getLog("deltaE-mode")->value();
+    auto const logValue2 = resWorkspace->getLog("deltaE-mode")->value();
+    return (logValue1 == "Direct") && (logValue2 == "Direct");
+  } catch (std::exception const &) {
+    return false;
+  }
 }
 
 void cropWorkspace(std::string const &name, std::string const &newName,

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -104,6 +104,13 @@ void cloneWorkspace(std::string const &workspaceName,
   cloner->execute();
 }
 
+bool isTechniqueDirect(MatrixWorkspace_const_sptr sampleWorkspace,
+                       MatrixWorkspace_const_sptr resWorkspace) {
+  auto const logValue1 = sampleWorkspace->getLog("deltaE-mode")->value();
+  auto const logValue2 = resWorkspace->getLog("deltaE-mode")->value();
+  return (logValue1 == "Direct") && (logValue2 == "Direct");
+}
+
 void cropWorkspace(std::string const &name, std::string const &newName,
                    double const &cropValue) {
   auto croper = AlgorithmManager::Instance().create("CropWorkspace");
@@ -428,12 +435,15 @@ bool Iqt::validate() {
     auto const resWorkspace = getADSMatrixWorkspace(resolutionName);
 
     addErrorMessage(uiv, checkInstrumentsMatch(sampleWorkspace, resWorkspace));
-    addErrorMessage(
-        uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "analyser"));
-    addErrorMessage(
-        uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "reflection"));
     addErrorMessage(uiv,
                     validateNumberOfHistograms(sampleWorkspace, resWorkspace));
+
+    if (!isTechniqueDirect(sampleWorkspace, resWorkspace)) {
+      addErrorMessage(
+          uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "analyser"));
+      addErrorMessage(uiv, checkParametersMatch(sampleWorkspace, resWorkspace,
+                                                "reflection"));
+    }
   }
 
   auto const message = uiv.generateErrorMessage();

--- a/scripts/Inelastic/IndirectReductionCommon.py
+++ b/scripts/Inelastic/IndirectReductionCommon.py
@@ -276,10 +276,14 @@ def crop_workspaces(workspace_names, spec_min, spec_max, extract_monitors=True, 
         # Crop to the detectors required
         workspace = mtd[workspace_name]
 
-        CropWorkspace(InputWorkspace=workspace_name,
-                      OutputWorkspace=workspace_name,
-                      StartWorkspaceIndex=workspace.getIndexFromSpectrumNumber(int(spec_min)),
-                      EndWorkspaceIndex=workspace.getIndexFromSpectrumNumber(int(spec_max)))
+        try:
+            CropWorkspace(InputWorkspace=workspace_name,
+                          OutputWorkspace=workspace_name,
+                          StartWorkspaceIndex=workspace.getIndexFromSpectrumNumber(int(spec_min)),
+                          EndWorkspaceIndex=workspace.getIndexFromSpectrumNumber(int(spec_max)))
+        except RuntimeError:
+            raise RuntimeError('The spectra min {0} or spectra max {1} could not be found in workspace {2}.'
+                               .format(str(spec_min), str(spec_max), workspace_name))
 
 
 # -------------------------------------------------------------------------------
@@ -484,7 +488,6 @@ def unwrap_monitor(workspace_name):
         elif unwrap == 'BaseOnTimeRegime':
             mon_time = mtd[monitor_workspace_name].readX(0)[0]
             det_time = mtd[workspace_name].readX(0)[0]
-            logger.notice(str(mon_time) + " " + str(det_time))
             should_unwrap = mon_time == det_time
         else:
             should_unwrap = False


### PR DESCRIPTION
**Description of work.**
This PR prevents an out-of-range `Spectra Min` or `Spectra Max` being selected on the Indirect Diffraction interface.

**To test:**
1. `Interfaces`->`Indirect`->`Diffraction`
2. Select `OSIRIS`
3. The maximum and minimum that `Spectra Min` and `Spectra Max` can be should be 3 and 962.
4. `Spectra Min` shouldn't be allowed to be higher than `Spectra Max`

Fixes #25844

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
