### PR TITLE
Fix TypeError in Calibration

### DIFF
--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -54,8 +54,16 @@ Data Objects
 Python
 ------
 
+New
+###
+
 - The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
 - In :class:`mantid.kernel.DateAndTime`, the method :py:meth:`~mantid.kernel.DateAndTime.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.DateAndTime.totalNanoseconds` should be used instead.
 - In :class:`mantid.kernel.time_duration`, The method :py:meth:`~mantid.kernel.time_duration.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.time_duration.totalNanoseconds` should be used instead.
+
+Bugfixes
+########
+
+- The TypeError raised when calibrating tubes has been fixed.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/scripts/Calibration/tube_calib.py
+++ b/scripts/Calibration/tube_calib.py
@@ -103,7 +103,7 @@ def fit_edges(fit_par, index, ws, output_ws):
     # get values around the expected center
     all_values = ws.dataY(0)
     right_limit = len(all_values)
-    values = all_values[max(centre - margin, 0):min(centre + margin, len(all_values))]
+    values = all_values[max(int(centre - margin), 0):min(int(centre + margin), len(all_values))]
 
     # identify if the edge is a sloping edge or descent edge
     descent_mode = values[0] > values[-1]
@@ -130,8 +130,8 @@ def fit_gaussian(fit_par, index, ws, output_ws):
 
     right_limit = len(all_values)
 
-    min_index = max(centre - int(margin), 0)
-    max_index = min(centre + int(margin), right_limit)
+    min_index = max(int(centre - margin), 0)
+    max_index = min(int(centre + margin), right_limit)
     values = all_values[min_index:max_index]
 
     # find the peak position


### PR DESCRIPTION
**Description of work.**
Between Mantid 3.13 and 4.0, Windows version of NumPy was changed. From NumPy 1.12, array indices are no longer silently converted to an integer, so attempting to index with a float (e.g. `my_array[1.0:2.0])` will now raise an error.

This was causing failures in `tube_calib.py`. The solution is to explicitly convert the peak positions to an integer before using them as indices.

Tests which could have caught this issue will be introduced in a later PR

**Report to:** Rob Dalgliesh

**To test:**
Code review

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
