### PR TITLE
Throw clear error when invalid periods in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -93,10 +93,15 @@ public:
   int confidence(Kernel::NexusDescriptor &descriptor) const override;
 
   template <typename T>
-  static boost::shared_ptr<BankPulseTimes>
-  runLoadNexusLogs(const std::string &nexusfilename, T localWorkspace,
-                   Algorithm &alg, bool returnpulsetimes, int &nPeriods,
-                   std::unique_ptr<Kernel::TimeSeriesProperty<int>> &periodLog);
+  static boost::shared_ptr<BankPulseTimes> runLoadNexusLogs(
+      const std::string &nexusfilename, T localWorkspace, Algorithm &alg,
+      bool returnpulsetimes, int &nPeriods,
+      std::unique_ptr<const Kernel::TimeSeriesProperty<int>> &periodLog);
+
+  static void checkForCorruptedPeriods(
+      std::unique_ptr<Kernel::TimeSeriesProperty<int>> tempPeriodLog,
+      std::unique_ptr<const Kernel::TimeSeriesProperty<int>> &periodLog,
+      const int &nPeriods, const std::string &nexusfilename);
 
   template <typename T>
   static void loadEntryMetadata(const std::string &nexusfilename, T WS,

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -40,6 +40,17 @@
 namespace Mantid {
 namespace DataHandling {
 
+/** @class InvalidLogPeriods
+ * Custom exception extending std::invalid_argument
+ * Thrown when nperiods does not match period_log
+ * Custom exception so we can re-propagate this error and
+ * handle all other errors.
+ */
+class InvalidLogPeriods : public std::invalid_argument {
+public:
+  InvalidLogPeriods(const std::string &msg) : std::invalid_argument(msg) {}
+};
+
 bool exists(::NeXus::File &file, const std::string &name);
 
 /** @class LoadEventNexus LoadEventNexus.h Nexus/LoadEventNexus.h

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -93,10 +93,10 @@ public:
   int confidence(Kernel::NexusDescriptor &descriptor) const override;
 
   template <typename T>
-  static boost::shared_ptr<BankPulseTimes> runLoadNexusLogs(
-      const std::string &nexusfilename, T localWorkspace, Algorithm &alg,
-      bool returnpulsetimes, int &nPeriods,
-      std::unique_ptr<const Kernel::TimeSeriesProperty<int>> &periodLog);
+  static boost::shared_ptr<BankPulseTimes>
+  runLoadNexusLogs(const std::string &nexusfilename, T localWorkspace,
+                   Algorithm &alg, bool returnpulsetimes, int &nPeriods,
+                   std::unique_ptr<Kernel::TimeSeriesProperty<int>> &periodLog);
 
   template <typename T>
   static void loadEntryMetadata(const std::string &nexusfilename, T WS,

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -636,6 +636,9 @@ boost::shared_ptr<BankPulseTimes> LoadEventNexus::runLoadNexusLogs(
  * change
  * @param periodLog :: unique pointer which will point to period logs once they
  * have been changed
+ * @param nPeriods :: the value in the nperiods log of the run. Number of
+ * expected periods
+ * @param nexusfilename :: the filename of the run to load
  */
 void LoadEventNexus::checkForCorruptedPeriods(
     std::unique_ptr<TimeSeriesProperty<int>> tempPeriodLog,

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -631,7 +631,7 @@ boost::shared_ptr<BankPulseTimes> LoadEventNexus::runLoadNexusLogs(
       localWorkspace->mutableRun().setGoniometer(gm, true);
     } catch (std::runtime_error &) {
     }
-  } catch (const InvalidLogPeriods &e) {
+  } catch (const InvalidLogPeriods &) {
     throw;
   } catch (...) {
     alg.getLogger().error() << "Error while loading Logs from SNS Nexus. Some "

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -632,6 +632,8 @@ boost::shared_ptr<BankPulseTimes> LoadEventNexus::runLoadNexusLogs(
     } catch (std::runtime_error &) {
     }
   } catch (const InvalidLogPeriods &) {
+    // Rethrow so LoadEventNexus fails.
+    // If we don't, Mantid will crash.
     throw;
   } catch (...) {
     alg.getLogger().error() << "Error while loading Logs from SNS Nexus. Some "

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -632,7 +632,7 @@ boost::shared_ptr<BankPulseTimes> LoadEventNexus::runLoadNexusLogs(
     } catch (std::runtime_error &) {
     }
   } catch (const InvalidLogPeriods &e) {
-    throw e;
+    throw;
   } catch (...) {
     alg.getLogger().error() << "Error while loading Logs from SNS Nexus. Some "
                                "sample logs may be missing."

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -580,9 +580,7 @@ boost::shared_ptr<BankPulseTimes> LoadEventNexus::runLoadNexusLogs(
       // cause undescriptive crashes if not caught.
       // We throw here to make it clear
       // that the file is corrupted and must be manually assessed.
-      const auto valuesAsVector = periodLog->valuesAsVector();
-      const auto nPeriodsInLog =
-          *std::max_element(valuesAsVector.begin(), valuesAsVector.end());
+      const auto nPeriodsInLog = periodLog->valuesAsVector().back();
       if (nPeriodsInLog != nPeriods) {
         const auto msg =
             "File " + nexusfilename +

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -508,7 +508,7 @@ void LoadTOFRawNexus::exec() {
 
   int nPeriods = 1; // Unused
   auto periodLog =
-      std::make_unique<const TimeSeriesProperty<int>>("period_log"); // Unused
+      std::make_unique<TimeSeriesProperty<int>>("period_log"); // Unused
   LoadEventNexus::runLoadNexusLogs<MatrixWorkspace_sptr>(
       filename, WS, *this, false, nPeriods, periodLog);
 

--- a/Framework/DataHandling/src/LoadTOFRawNexus.cpp
+++ b/Framework/DataHandling/src/LoadTOFRawNexus.cpp
@@ -508,7 +508,7 @@ void LoadTOFRawNexus::exec() {
 
   int nPeriods = 1; // Unused
   auto periodLog =
-      std::make_unique<TimeSeriesProperty<int>>("period_log"); // Unused
+      std::make_unique<const TimeSeriesProperty<int>>("period_log"); // Unused
   LoadEventNexus::runLoadNexusLogs<MatrixWorkspace_sptr>(
       filename, WS, *this, false, nPeriods, periodLog);
 

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -82,7 +82,6 @@ void ProcessBankData::run() { // override {
 
   // Default pulse time (if none are found)
   Mantid::Types::Core::DateAndTime pulsetime;
-  int periodNumber = 1;
   int periodIndex = 0;
   Mantid::Types::Core::DateAndTime lastpulsetime(0);
 
@@ -134,11 +133,7 @@ void ProcessBankData::run() { // override {
       // Save the pulse time at this index for creating those events
       pulsetime = thisBankPulseTimes->pulseTimes[pulse_i];
       int logPeriodNumber = thisBankPulseTimes->periodNumbers[pulse_i];
-      periodNumber = logPeriodNumber > 0
-                         ? logPeriodNumber
-                         : periodNumber; // Some historic files have recorded
-                                         // their logperiod numbers as zeros!
-      periodIndex = periodNumber - 1;
+      periodIndex = logPeriodNumber - 1;
 
       // Determine if pulse times continue to increase
       if (pulsetime < lastpulsetime)

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -1012,6 +1012,19 @@ public:
     runner.run(run_MPI_load, hdf5Mutex, "SANS2D00022048.nxs");
   }
 
+  void test_load_fails_on_corrupted_run() {
+    // Some ISIS runs can be corrupted by instrument noise,
+    // resulting in incorrect period numbers.
+    // LoadEventNexus should fail in this case.
+    LoadEventNexus loader;
+
+    loader.setChild(true);
+    loader.initialize();
+    loader.setPropertyValue("OutputWorkspace", "dummy");
+    loader.setPropertyValue("Filename", "SANS2D00059115_corrupted.nxs");
+    TS_ASSERT_THROWS(loader.execute(), const InvalidLogPeriods &);
+  }
+
 private:
   std::string wsSpecFilterAndEventMonitors;
 };

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -109,6 +109,9 @@ class DLLExport TimeSeriesProperty : public Property,
 public:
   /// Constructor
   explicit TimeSeriesProperty(const std::string &name);
+  TimeSeriesProperty(const std::string &name,
+                     const std::vector<Types::Core::DateAndTime> &times,
+                     const std::vector<TYPE> &values);
 
   /// Virtual destructor
   ~TimeSeriesProperty() override;

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -33,6 +33,20 @@ TimeSeriesProperty<TYPE>::TimeSeriesProperty(const std::string &name)
     : Property(name, typeid(std::vector<TimeValueUnit<TYPE>>)), m_values(),
       m_size(), m_propSortedFlag(), m_filterApplied() {}
 
+/**
+ * Constructor
+ * @param name :: The name to assign to the property
+ * @param times :: A vector of DateAndTime objects
+ * @param values :: A vector of TYPE
+ */
+template <typename TYPE>
+TimeSeriesProperty<TYPE>::TimeSeriesProperty(
+    const std::string &name, const std::vector<Types::Core::DateAndTime> &times,
+    const std::vector<TYPE> &values)
+    : TimeSeriesProperty(name) {
+  addValues(times, values);
+}
+
 /// Virtual destructor
 template <typename TYPE> TimeSeriesProperty<TYPE>::~TimeSeriesProperty() {}
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -82,6 +82,65 @@ public:
     TS_ASSERT_EQUALS(sProp->isValid(), "");
   }
 
+  void test_Constructor_with_values() {
+    std::vector<DateAndTime> times = {DateAndTime("2019-01-01T00:00:00"),
+                                      DateAndTime("2019-01-01T00:01:00")};
+
+    // Test int TimeSeriesProperty
+    std::vector<int> iValues = {0, 1};
+    auto iPropWithValues =
+        std::make_unique<TimeSeriesProperty<int>>("intProp", times, iValues);
+    TS_ASSERT(!iPropWithValues->name().compare("intProp"));
+    TS_ASSERT(!iPropWithValues->documentation().compare(""));
+    TS_ASSERT(typeid(std::vector<TimeValueUnit<int>>) ==
+              *iPropWithValues->type_info());
+    TS_ASSERT(!iPropWithValues->isDefault());
+
+    auto iPropTimes = iPropWithValues->timesAsVector();
+    TS_ASSERT_EQUALS(iPropTimes[0], DateAndTime("2019-01-01T00:00:00"));
+    TS_ASSERT_EQUALS(iPropTimes[1], DateAndTime("2019-01-01T00:01:00"));
+
+    auto iPropValues = iPropWithValues->valuesAsVector();
+    TS_ASSERT_EQUALS(iPropValues[0], 0);
+    TS_ASSERT_EQUALS(iPropValues[1], 1);
+
+    // Test double TimeSeriesProperty
+    std::vector<double> dValues = {0.1, 1.2};
+    auto dPropWithValues = std::make_unique<TimeSeriesProperty<double>>(
+        "doubleProp", times, dValues);
+    TS_ASSERT(!dPropWithValues->name().compare("doubleProp"));
+    TS_ASSERT(!dPropWithValues->documentation().compare(""));
+    TS_ASSERT(typeid(std::vector<TimeValueUnit<double>>) ==
+              *dPropWithValues->type_info());
+    TS_ASSERT(!dPropWithValues->isDefault());
+
+    auto dPropTimes = dPropWithValues->timesAsVector();
+    TS_ASSERT_EQUALS(dPropTimes[0], DateAndTime("2019-01-01T00:00:00"));
+    TS_ASSERT_EQUALS(dPropTimes[1], DateAndTime("2019-01-01T00:01:00"));
+
+    auto dPropValues = dPropWithValues->valuesAsVector();
+    TS_ASSERT_EQUALS(dPropValues[0], 0.1);
+    TS_ASSERT_EQUALS(dPropValues[1], 1.2);
+
+    // Test string TimeSeriesProperty
+    std::vector<std::string> sValues = {"test", "test2"};
+    auto sPropWithValues = std::make_unique<TimeSeriesProperty<std::string>>(
+        "stringProp", times, sValues);
+    TS_ASSERT(!sPropWithValues->name().compare("stringProp"));
+    TS_ASSERT(!sPropWithValues->documentation().compare(""));
+    TS_ASSERT(typeid(std::vector<TimeValueUnit<std::string>>) ==
+              *sPropWithValues->type_info());
+    TS_ASSERT(!sPropWithValues->isDefault());
+
+    auto sPropTimes = sPropWithValues->timesAsVector();
+    TS_ASSERT_EQUALS(sPropTimes[0], DateAndTime("2019-01-01T00:00:00"));
+    TS_ASSERT_EQUALS(sPropTimes[1], DateAndTime("2019-01-01T00:01:00"));
+
+    auto sPropValues = sPropWithValues->valuesAsVector();
+    TS_ASSERT_EQUALS(sPropValues[0], "test");
+    TS_ASSERT_EQUALS(sPropValues[1], "test2");
+  }
+
   void test_SetValueFromString() {
     TS_ASSERT_THROWS(iProp->setValue("1"),
                      const Exception::NotImplementedError &);

--- a/Testing/Data/UnitTest/SANS2D00059115_corrupted.nxs.md5
+++ b/Testing/Data/UnitTest/SANS2D00059115_corrupted.nxs.md5
@@ -1,0 +1,1 @@
+a1dc69f06d3f3fceab83d049104cc0b5

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -117,7 +117,7 @@ Here are some tables that show it in more detail:
 +------------------------------+-------------------------------------------+-------------------------------------+
 
 Invalid Period Logs Error
-#######################
+#########################
 
 There is an issue specific to ISIS, particularly on long runs, where noise on data collection instruments can change the period
 of the data. This can cause the period associated with certain data points to exceed the total number of periods we expect.

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -116,6 +116,22 @@ Here are some tables that show it in more detail:
 |                              | else sample not loaded                    |                                     |
 +------------------------------+-------------------------------------------+-------------------------------------+
 
+Invalid Period Logs Error
+#######################
+
+There is an issue specific to ISIS, particularly on long runs, where noise on data collection instruments can change the period
+of the data. This can cause the period associated with certain data points to exceed the total number of periods we expect.
+
+LoadEventNeXus compares the total number of periods we expect, which can be found in the **periods/number** attribute of the run,
+and the greatest period number found in **framelog/period_log/value** attribute of the data. If they do not match, an error message
+is raised which explains this problem, and loading of the data will be unsuccessful.
+
+In this case, the data is fundamentally corrupted, so Mantid does not know how to correct this automatically. If you only expect 1 period, there is a script
+in the script repository, *user/TomTitcombe/correct_period_logs.py*, which will change all the periods in **framelog/period_log/value** to 1.
+
+If you expect more than 1 periods, there is currently no solution script available through Mantid. You should contact the Mantid team to discuss
+the problem and possible solutions.
+
 Sample Object
 '''''''''''''
 

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -41,6 +41,7 @@ Improvements
 Bug fixes
 #########
 - :ref:`SetSample <algm-SetSample>` now correctly handles the Sample number density being passed as a string, before the algorithm would execute, but silently ignored the provided number density, the number density is now properly used.
+- Mantid no longer crashed when invalid period logs encountered in `LoadEventNexus <algm-LoadEventNexus>`. A clear error message is displayed which explains the problem.
 
 Removed
 #######


### PR DESCRIPTION
**Description of work.**
Currently, Mantid hard crashes when trying to load runs with invalid period logs using `LoadEventNexus`. The "invalid period logs" are when `nperiods` is different to the number of periods present in `period_log`. 

We throw an error if the logs are different as there is no sensible way to automatically deal with the corrupted runs. This error stops mantid from continuing into a hard crash, and explains to the user what the problem is.

For some historic files, the period number can be 1, but all periods are 0. We have had to check for this case in `LoadEventNexus` as this should not fail the check.
Previously, this case was accounted for in each individual event. Speaking to @martyngigg, we have decided to change the local copy of the logs to contain period 1 instead of 0. This will be more efficient than checking each individual event.

However, the pointer containing the periodLogs object expected a const object. I have decided to create a pointer to a non-const object and then create a pointer to a const object once we have got past the code which would edit the local period logs. This is instead of changing the numerous occurrences of this pointer to non-const just for a small change which will only take place on a small number of historic files. I am not sure about this solution.

**Report to:** Steve King

**To test:**
1. Turn on ISIS archive
2. Using `Load`, load **SANS2D59115**

Mantid should not crash. Check that the error message posted to the logger is clear.

3. Build the docs and read `LoadEventNexus.rst`

*There is no associated issue.*

Release notes updated are: **release/4.1.0/framework.rst**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
