### PR TITLE
FunctionBrowser add/remove function bug.

### DIFF
--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -110,6 +110,7 @@ void MultiDomainFunctionModel::addFunction(const QString &prefix,
                                " is not composite.");
     }
   }
+  m_function->checkFunction();
   updateGlobals();
 }
 
@@ -133,11 +134,9 @@ void MultiDomainFunctionModel::removeFunction(const QString &functionIndex) {
     cf->removeFunction(index);
     if (cf->nFunctions() == 1 && prefix.isEmpty()) {
       m_function->replaceFunction(i, cf->getFunction(0));
-      m_function->checkFunction();
-    } else {
-      cf->checkFunction();
     }
   }
+  m_function->checkFunction();
   updateGlobals();
 }
 

--- a/qt/widgets/common/test/FunctionModelTest.h
+++ b/qt/widgets/common/test/FunctionModelTest.h
@@ -9,6 +9,7 @@
 #define MANTIDWIDGETS_FUNCTIONMODELTEST_H_
 
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidQtWidgets/Common/FunctionModel.h"
 #include <cxxtest/TestSuite.h>
@@ -50,8 +51,8 @@ public:
     model.setCurrentDomainIndex(1);
     TS_ASSERT_EQUALS(model.currentDomainIndex(), 1);
     TS_ASSERT_THROWS_EQUALS(model.setCurrentDomainIndex(2),
-                            std::runtime_error & e, std::string(e.what()),
-                            "Domain index is out of range: 2 out of 2");
+      std::runtime_error & e, std::string(e.what()),
+      "Domain index is out of range: 2 out of 2");
     {
       auto fun = model.getCurrentFunction();
       TS_ASSERT_EQUALS(fun->name(), "LinearBackground");
@@ -71,8 +72,8 @@ public:
       TS_ASSERT_EQUALS(fun->getParameter("A1"), 2.0);
     }
     TS_ASSERT_THROWS_EQUALS(model.getSingleFunction(2), std::runtime_error & e,
-                            std::string(e.what()),
-                            "Domain index is out of range: 2 out of 2");
+      std::string(e.what()),
+      "Domain index is out of range: 2 out of 2");
     {
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->name(), "MultiDomainFunction");
@@ -114,6 +115,126 @@ public:
     model.clear();
     model.setNumberDomains(1);
     TS_ASSERT_EQUALS(model.getNumberDomains(), 1);
+  }
+
+  void test_add_function_top_level() {
+    MultiDomainFunctionModel model;
+    {
+      model.addFunction("", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 2);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+    }
+    {
+      model.addFunction("", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 4);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+    }
+    {
+      model.addFunction("", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 6);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+      TS_ASSERT_EQUALS(fun->getParameter(4), 7.0);
+      TS_ASSERT_EQUALS(fun->getParameter(5), 8.0);
+    }
+  }
+
+  void test_add_function_nested() {
+    MultiDomainFunctionModel model;
+    model.addFunction("", "name=LinearBackground,A0=1,A1=2;(composite=CompositeFunction)");
+    {
+      model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 4);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+    }
+    {
+      model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;"
+        "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8)");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 6);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+      TS_ASSERT_EQUALS(fun->getParameter(4), 7.0);
+      TS_ASSERT_EQUALS(fun->getParameter(5), 8.0);
+    }
+    {
+      model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;"
+        "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8;name=LinearBackground,A0=9,A1=10)");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 8);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+      TS_ASSERT_EQUALS(fun->getParameter(4), 7.0);
+      TS_ASSERT_EQUALS(fun->getParameter(5), 8.0);
+      TS_ASSERT_EQUALS(fun->getParameter(6), 9.0);
+      TS_ASSERT_EQUALS(fun->getParameter(7), 10.0);
+    }
+  }
+
+  void test_remove_function() {
+    MultiDomainFunctionModel model;
+    model.addFunction("", "name=LinearBackground,A0=1,A1=2;name=LinearBackground,A0=1,A1=2;name=LinearBackground,A0=1,A1=2");
+    {
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 6);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+      TS_ASSERT_EQUALS(fun->getParameter(4), 7.0);
+      TS_ASSERT_EQUALS(fun->getParameter(5), 8.0);
+    }
+    {
+      model.removeFunction("f1.");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 4);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+      TS_ASSERT_EQUALS(fun->getParameter(2), 5.0);
+      TS_ASSERT_EQUALS(fun->getParameter(3), 6.0);
+    }
+    {
+      model.removeFunction("f1.");
+      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4");
+      model.updateMultiDatasetParameters(*testFun);
+      auto fun = model.getFitFunction();
+      TS_ASSERT_EQUALS(fun->nParams(), 2);
+      TS_ASSERT_EQUALS(fun->getParameter(0), 3.0);
+      TS_ASSERT_EQUALS(fun->getParameter(1), 4.0);
+    }
   }
 };
 

--- a/qt/widgets/common/test/FunctionModelTest.h
+++ b/qt/widgets/common/test/FunctionModelTest.h
@@ -51,8 +51,8 @@ public:
     model.setCurrentDomainIndex(1);
     TS_ASSERT_EQUALS(model.currentDomainIndex(), 1);
     TS_ASSERT_THROWS_EQUALS(model.setCurrentDomainIndex(2),
-      std::runtime_error & e, std::string(e.what()),
-      "Domain index is out of range: 2 out of 2");
+                            std::runtime_error & e, std::string(e.what()),
+                            "Domain index is out of range: 2 out of 2");
     {
       auto fun = model.getCurrentFunction();
       TS_ASSERT_EQUALS(fun->name(), "LinearBackground");
@@ -72,8 +72,8 @@ public:
       TS_ASSERT_EQUALS(fun->getParameter("A1"), 2.0);
     }
     TS_ASSERT_THROWS_EQUALS(model.getSingleFunction(2), std::runtime_error & e,
-      std::string(e.what()),
-      "Domain index is out of range: 2 out of 2");
+                            std::string(e.what()),
+                            "Domain index is out of range: 2 out of 2");
     {
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->name(), "MultiDomainFunction");
@@ -121,7 +121,8 @@ public:
     MultiDomainFunctionModel model;
     {
       model.addFunction("", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 2);
@@ -130,7 +131,8 @@ public:
     }
     {
       model.addFunction("", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 4);
@@ -141,7 +143,9 @@ public:
     }
     {
       model.addFunction("", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;"
+          "name=LinearBackground,A0=7,A1=8");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 6);
@@ -156,10 +160,12 @@ public:
 
   void test_add_function_nested() {
     MultiDomainFunctionModel model;
-    model.addFunction("", "name=LinearBackground,A0=1,A1=2;(composite=CompositeFunction)");
+    model.addFunction(
+        "", "name=LinearBackground,A0=1,A1=2;(composite=CompositeFunction)");
     {
       model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 4);
@@ -170,8 +176,9 @@ public:
     }
     {
       model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;"
-        "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8)");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;"
+          "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8)");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 6);
@@ -184,8 +191,10 @@ public:
     }
     {
       model.addFunction("f1.", "name=LinearBackground,A0=1,A1=2");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;"
-        "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8;name=LinearBackground,A0=9,A1=10)");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;"
+          "(name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8;"
+          "name=LinearBackground,A0=9,A1=10)");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 8);
@@ -202,9 +211,13 @@ public:
 
   void test_remove_function() {
     MultiDomainFunctionModel model;
-    model.addFunction("", "name=LinearBackground,A0=1,A1=2;name=LinearBackground,A0=1,A1=2;name=LinearBackground,A0=1,A1=2");
+    model.addFunction("", "name=LinearBackground,A0=1,A1=2;name="
+                          "LinearBackground,A0=1,A1=2;name=LinearBackground,A0="
+                          "1,A1=2");
     {
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;name=LinearBackground,A0=7,A1=8");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6;"
+          "name=LinearBackground,A0=7,A1=8");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 6);
@@ -217,7 +230,8 @@ public:
     }
     {
       model.removeFunction("f1.");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4;name=LinearBackground,A0=5,A1=6");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 4);
@@ -228,7 +242,8 @@ public:
     }
     {
       model.removeFunction("f1.");
-      auto testFun = FunctionFactory::Instance().createInitialized("name=LinearBackground,A0=3,A1=4");
+      auto testFun = FunctionFactory::Instance().createInitialized(
+          "name=LinearBackground,A0=3,A1=4");
       model.updateMultiDatasetParameters(*testFun);
       auto fun = model.getFitFunction();
       TS_ASSERT_EQUALS(fun->nParams(), 2);


### PR DESCRIPTION
**Description of work.**
Added more `checkFunction()` calls after function edits.


**To test:**

* Open the Multi dataset fitting interface.
* Add a spectrum
* Add three or more functions.
* Run fit. there should be no crashes.
* Remove one or more functions.
* Run fit. there should be no crashes.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
