### PR TITLE
Adding remove if to mantid axes

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -21,7 +21,6 @@ from mantid.kernel import logger
 from mantid.plots import helperfunctions, plotfunctions
 from mantid.plots import plotfunctions3D
 from mantid.plots.scales import PowerScale, SquareScale
-from mantid.api import AnalysisDataService
 from matplotlib import cbook
 from matplotlib.axes import Axes
 from matplotlib.collections import Collection
@@ -90,12 +89,9 @@ class _WorkspaceArtists(object):
         """
         Remove the tracked artists from the given axes
         :param axes: A reference to the axes instance the artists are attached to
-        :returns: Returns a bool specifying whether the class is now empty
         """
         # delete the artists from the axes
         self._remove(axes, self._artists)
-
-        return True
 
     def remove_if(self, axes, predicate):
         """
@@ -130,8 +126,6 @@ class _WorkspaceArtists(object):
 
         if (not axes.is_empty(axes)) and axes.legend_ is not None:
             axes.legend()
-
-
 
     def replace_data(self, workspace):
         """Replace or replot artists based on a new workspace
@@ -311,6 +305,12 @@ class MantidAxes(Axes):
         return self.is_empty(self)
 
     def _remove_artist_info_if(self, artist_info, unary_predicate):
+        """
+        Remove any artists which satisfy the predicate from the artist_info_list
+        :param artist_info: A list of _WorkspaceArtists objects
+        :param unary_predicate: A predicate taking a single matplotlib artist object
+        :return: True if the artist_info is empty, false if artist_info remain
+        """
         is_empty_list = []
         for workspace_artist in artist_info:
             empty = workspace_artist.remove_if(self, unary_predicate)

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -91,6 +91,55 @@ class Plots__init__Test(unittest.TestCase):
         self.assertTrue(line_second_ws in self.ax.lines)
         DeleteWorkspace(second_ws)
 
+    def test_remove_workspace_artist_with_predicate_removes_only_lines_from_specified_workspace_which_return_true(self):
+        line_ws2d_histo_spec_2 = self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)[0]
+        line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
+        self.assertEqual(2, len(self.ax.lines))
+
+        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: spec 2')
+        self.assertEqual(1, len(self.ax.lines))
+        self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
+        self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)
+
+    def test_workspace_artist_object_correctly_removed_if_all_lines_removed(self):
+        line_ws2d_histo_spec_2 = self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)[0]
+        line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
+        self.assertEqual(2, len(self.ax.lines))
+
+        is_empty = self.ax.remove_artists_if(lambda artist: artist.get_label() in ['ws2d_histo: spec 2', 'ws2d_histo: spec 3'])
+        self.assertEqual(0, len(self.ax.lines))
+        self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
+        self.assertTrue(line_ws2d_histo_spec_3 not in self.ax.lines)
+        self.assertEqual(self.ax.tracked_workspaces, {})
+        self.assertTrue(is_empty)
+
+    def test_remove_if_correctly_prunes_workspace_artist_list(self):
+        line_ws2d_histo_spec_2 = self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)[0]
+        line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
+        self.assertEqual(2, len(self.ax.lines))
+
+        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: spec 2')
+        self.assertEqual(1, len(self.ax.lines))
+        self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
+        self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)
+        self.assertEqual(self.ax.tracked_workspaces[self.ws2d_histo.name()][0]._artists, [line_ws2d_histo_spec_3])
+
+    def test_remove_if_correctly_removes_lines_associated_with_multiple_workspaces(self):
+        second_ws = CreateSampleWorkspace()
+        line_ws2d_histo_spec_2 = self.ax.plot(self.ws2d_histo, specNum=2, linewidth=6)[0]
+        line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
+        line_second_ws = self.ax.plot(second_ws, specNum=5)[0]
+        self.assertEqual(3, len(self.ax.lines))
+
+        is_empty = self.ax.remove_artists_if(lambda artist: artist.get_label() in ['ws2d_histo: spec 2', 'second_ws: spec 5'])
+        self.assertEqual(1, len(self.ax.lines))
+        self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
+        self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)
+        self.assertTrue(line_second_ws not in self.ax.lines)
+        self.assertEqual(len(self.ax.tracked_workspaces), 1)
+        self.assertFalse(is_empty)
+        DeleteWorkspace(second_ws)
+
     def test_replace_workspace_data_plot(self):
         plot_data = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30, 10, 20, 30],
                                     DataY=[3, 4, 5, 3, 4, 5],


### PR DESCRIPTION
**Description of work.**
This adds a remove_if method to mantid axes that allows the safe removal of a line from an axes object if a predicate is satisfied. 


**To test:**

 * Careful code review
 * Testing that plotting in workbench still functions as expected

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because this is an internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
