### PR TITLE
Muon Analysis: Only display single parameter in results for global parameters

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -77,7 +77,7 @@ class FittingContext(object):
                             global_parameters=None):
         """
         Add a new fit information object based on the raw values.
-        See FitInformation constructor for details are arguments
+        See FitInformation constructor for details are arguments.
         """
         self.add_fit(
             FitInformation(parameter_workspace, fit_function_name,

--- a/scripts/Muon/GUI/Common/contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_context.py
@@ -12,29 +12,41 @@ from Muon.GUI.Common.observer_pattern import Observable
 class FitInformation(object):
     """Data-object encapsulating a single fit"""
 
-    def __init__(self, parameter_workspace, fit_function_name,
-                 input_workspace):
+    def __init__(self,
+                 parameter_workspace,
+                 fit_function_name,
+                 input_workspace,
+                 global_parameters=None):
         """
         :param parameter_workspace: The workspace wrapper
         that contains all of the parameters from the fit
         :param fit_function_name: The name of the function used
         :param input_workspace: The name of the workspace containing
         the original data
+        :param global_parameters: An optional list of parameters
+        that were tied together during the fit
         """
         self.parameter_workspace = parameter_workspace
         self.fit_function_name = fit_function_name
         self.input_workspace = input_workspace
+        self.global_parameters = global_parameters if global_parameters is not None else []
 
     @property
     def parameter_name(self):
         """Returns the name of the parameter workspace"""
         return self.parameter_workspace.workspace_name
 
+    @property
+    def parameters(self):
+        """Returns the dictionary of the fit parameters"""
+        return self.parameter_workspace.workspace.toDict()
+
     def __eq__(self, other):
         """Objects are equal if each member is equal to the other"""
         return self.parameter_workspace == other.parameter_workspace and \
             self.fit_function_name == other.fit_function_name and \
-            self.input_workspace == other.input_workspace
+            self.input_workspace == other.input_workspace and \
+            self.global_parameters == other.global_parameters
 
 
 class FittingContext(object):
@@ -58,15 +70,18 @@ class FittingContext(object):
         """
         return len(self.fit_list)
 
-    def add_fit_from_values(self, parameter_workspace, fit_function_name,
-                            input_workspace):
+    def add_fit_from_values(self,
+                            parameter_workspace,
+                            fit_function_name,
+                            input_workspace,
+                            global_parameters=None):
         """
         Add a new fit information object based on the raw values.
         See FitInformation constructor for details are arguments
         """
         self.add_fit(
             FitInformation(parameter_workspace, fit_function_name,
-                           input_workspace))
+                           input_workspace, global_parameters))
 
     def add_fit(self, fit):
         """

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -68,7 +68,7 @@ class FittingTabModel(object):
 
         return name, directory
 
-    def do_simultaneous_fit(self, parameter_dict):
+    def do_simultaneous_fit(self, parameter_dict, global_parameters):
         fit_group_name = parameter_dict.pop('FitGroupName')
         output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared = \
             self.do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
@@ -150,7 +150,7 @@ class FittingTabModel(object):
             return function_temp.name()
 
     def add_fit_to_context(self, parameter_workspace, function,
-                           input_workspace):
+                           input_workspace, global_parameters=None):
         self.context.fitting_context.add_fit_from_values(
             parameter_workspace, self.function_name,
-            input_workspace)
+            input_workspace, global_parameters)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -88,7 +88,8 @@ class FittingTabModel(object):
                                                                 table_directory)
         self.add_fit_to_context(wrapped_parameter_workspace,
                                 parameter_dict['Function'],
-                                parameter_dict['InputWorkspace'])
+                                parameter_dict['InputWorkspace'],
+                                global_parameters)
 
         return function_object, output_status, output_chi_squared
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -29,19 +29,22 @@ class FittingTabPresenter(object):
         self.automatically_update_fit_name = True
         self.thread_success = True
         self.update_selected_workspace_guess()
-        self.gui_context_observer = GenericObserverWithArgPassing(self.handle_gui_changes_made)
-        self.selected_group_pair_observer = GenericObserver(self.handle_selected_group_pair_changed)
-        self.input_workspace_observer = GenericObserver(self.handle_new_data_loaded)
-        self.disable_tab_observer = GenericObserver(lambda: self.view.setEnabled(False))
-        self.enable_tab_observer = GenericObserver(lambda: self.view.setEnabled(True))
+        self.gui_context_observer = GenericObserverWithArgPassing(
+            self.handle_gui_changes_made)
+        self.selected_group_pair_observer = GenericObserver(
+            self.handle_selected_group_pair_changed)
+        self.input_workspace_observer = GenericObserver(
+            self.handle_new_data_loaded)
+        self.disable_tab_observer = GenericObserver(lambda: self.view.
+                                                    setEnabled(False))
+        self.enable_tab_observer = GenericObserver(lambda: self.view.
+                                                   setEnabled(True))
 
     def handle_select_fit_data_clicked(self):
-        selected_data, dialog_return = WorkspaceSelectorView.get_selected_data(self.context.data_context.current_runs,
-                                                                               self.context.data_context.instrument,
-                                                                               self.selected_data,
-                                                                               self.view.fit_to_raw,
-                                                                               self.context,
-                                                                               self.view)
+        selected_data, dialog_return = WorkspaceSelectorView.get_selected_data(
+            self.context.data_context.current_runs,
+            self.context.data_context.instrument, self.selected_data,
+            self.view.fit_to_raw, self.context, self.view)
 
         if dialog_return:
             self.selected_data = selected_data
@@ -61,10 +64,11 @@ class FittingTabPresenter(object):
 
     def update_selected_workspace_guess(self):
         if not self.manual_selection_made:
-            guess_selection = self.context.get_names_of_workspaces_to_fit(runs='All',
-                                                                          group_and_pair=self.context.group_pair_context.selected,
-                                                                          phasequad=True,
-                                                                          rebin=not self.view.fit_to_raw)
+            guess_selection = self.context.get_names_of_workspaces_to_fit(
+                runs='All',
+                group_and_pair=self.context.group_pair_context.selected,
+                phasequad=True,
+                rebin=not self.view.fit_to_raw)
         else:
             guess_selection = self.selected_data
 
@@ -77,7 +81,8 @@ class FittingTabPresenter(object):
         self.view.end_time = self.end_x[current_index]
 
         if fit_type != self.view.simultaneous_fit:
-            self.view.set_datasets_in_function_browser([self.view.display_workspace])
+            self.view.set_datasets_in_function_browser(
+                [self.view.display_workspace])
         else:
             self.view.function_browser.setCurrentDataset(current_index)
 
@@ -102,14 +107,16 @@ class FittingTabPresenter(object):
         if fit_type == self.view.single_fit:
             self.view.workspace_combo_box_label.setText('Select Workspace')
         else:
-            self.view.workspace_combo_box_label.setText('Display parameters for')
+            self.view.workspace_combo_box_label.setText(
+                'Display parameters for')
 
         self.update_selected_workspace_guess()
 
         if self.view.fit_type == self.view.simultaneous_fit:
             self.view.set_datasets_in_function_browser(self.selected_data)
         else:
-            self.view.set_datasets_in_function_browser([self.selected_data[0]] if self.selected_data else [])
+            self.view.set_datasets_in_function_browser(
+                [self.selected_data[0]] if self.selected_data else [])
 
         self.update_fit_status_information_in_view()
 
@@ -119,18 +126,30 @@ class FittingTabPresenter(object):
         try:
             if fit_type == self.view.single_fit:
                 single_fit_parameters = self.get_parameters_for_single_fit()
-                calculation_function = functools.partial(self.model.do_single_fit, single_fit_parameters)
-                self.calculation_thread = self.create_thread(calculation_function)
+                calculation_function = functools.partial(
+                    self.model.do_single_fit, single_fit_parameters)
+                self.calculation_thread = self.create_thread(
+                    calculation_function)
             elif fit_type == self.view.simultaneous_fit:
-                simultaneous_fit_parameters = self.get_multi_domain_fit_parameters()
-                calculation_function = functools.partial(self.model.do_simultaneous_fit, simultaneous_fit_parameters)
-                self.calculation_thread = self.create_thread(calculation_function)
+                simultaneous_fit_parameters = self.get_multi_domain_fit_parameters(
+                )
+                global_parameters = self.view.get_global_parameters()
+                calculation_function = functools.partial(
+                    self.model.do_simultaneous_fit,
+                    simultaneous_fit_parameters, global_parameters)
+                self.calculation_thread = self.create_thread(
+                    calculation_function)
             elif fit_type == self.view.sequential_fit:
-                sequential_fit_parameters = self.get_multi_domain_fit_parameters()
-                calculation_function = functools.partial(self.model.do_sequential_fit, sequential_fit_parameters)
-                self.calculation_thread = self.create_thread(calculation_function)
+                sequential_fit_parameters = self.get_multi_domain_fit_parameters(
+                )
+                calculation_function = functools.partial(
+                    self.model.do_sequential_fit, sequential_fit_parameters)
+                self.calculation_thread = self.create_thread(
+                    calculation_function)
 
-            self.calculation_thread.threadWrapperSetUp(self.handle_started, self.handle_finished, self.handle_error)
+            self.calculation_thread.threadWrapperSetUp(self.handle_started,
+                                                       self.handle_finished,
+                                                       self.handle_error)
             self.calculation_thread.start()
         except ValueError as error:
             self.view.warning_popup(error)
@@ -184,7 +203,8 @@ class FittingTabPresenter(object):
     def handle_function_structure_changed(self):
         self.clear_fit_information()
         if self.automatically_update_fit_name:
-            self.view.function_name = self.model.get_function_name(self.view.fit_object)
+            self.view.function_name = self.model.get_function_name(
+                self.view.fit_object)
             self.model.function_name = self.view.function_name
 
     def get_parameters_for_single_fit(self):
@@ -206,12 +226,15 @@ class FittingTabPresenter(object):
         return params
 
     def _get_shared_parameters(self):
-        params = {}
-        params['Function'] = self.view.fit_object
-        params['Minimizer'] = self.view.minimizer
-        params['EvaluationType'] = self.view.evaluation_type
-        params['FitGroupName'] = self.view.group_name
-        return params
+        """
+        :return: The set of attributes common to all fit types
+        """
+        return {
+            'Function': self.view.fit_string,
+            'Minimizer': self.view.minimizer,
+            'EvaluationType': self.view.evaluation_type,
+            'FitGroupName': self.view.group_name
+        }
 
     @property
     def selected_data(self):
@@ -226,23 +249,30 @@ class FittingTabPresenter(object):
         self.clear_and_reset_gui_state()
 
     def clear_and_reset_gui_state(self):
-        self._fit_status = [None] * len(self.selected_data) if self.selected_data else [None]
-        self._fit_chi_squared = [0.0] * len(self.selected_data) if self.selected_data else [0.0]
-        self._fit_function = [None] * len(self.selected_data) if self.selected_data else [None]
+        self._fit_status = [None] * len(
+            self.selected_data) if self.selected_data else [None]
+        self._fit_chi_squared = [0.0] * len(
+            self.selected_data) if self.selected_data else [0.0]
+        self._fit_function = [None] * len(
+            self.selected_data) if self.selected_data else [None]
 
         if self.view.fit_type == self.view.simultaneous_fit:
             self.view.set_datasets_in_function_browser(self.selected_data)
         else:
-            self.view.set_datasets_in_function_browser([self.selected_data[0]] if self.selected_data else [])
+            self.view.set_datasets_in_function_browser(
+                [self.selected_data[0]] if self.selected_data else [])
 
         self.reset_start_time_to_first_good_data_value()
         self.view.update_displayed_data_combo_box(self.selected_data)
         self.update_fit_status_information_in_view()
 
     def clear_fit_information(self):
-        self._fit_status = [None] * len(self.selected_data) if self.selected_data else [None]
-        self._fit_chi_squared = [0.0] * len(self.selected_data) if self.selected_data else [0.0]
-        self._fit_function = [None] * len(self.selected_data) if self.selected_data else [None]
+        self._fit_status = [None] * len(
+            self.selected_data) if self.selected_data else [None]
+        self._fit_chi_squared = [0.0] * len(
+            self.selected_data) if self.selected_data else [0.0]
+        self._fit_function = [None] * len(
+            self.selected_data) if self.selected_data else [None]
         self.update_fit_status_information_in_view()
 
     @property
@@ -274,12 +304,15 @@ class FittingTabPresenter(object):
     def reset_start_time_to_first_good_data_value(self):
         self._start_x = [self.retrieve_first_good_data_from_run_name(run_name) for run_name in self.selected_data] if\
             self.selected_data else [0.0]
-        self._end_x = [self.view.end_time] * len(self.selected_data) if self.selected_data else [15.0]
-        self.view.start_time = self.start_x[0] if 0 < len(self.start_x) else 0.0
+        self._end_x = [self.view.end_time] * len(
+            self.selected_data) if self.selected_data else [15.0]
+        self.view.start_time = self.start_x[0] if 0 < len(
+            self.start_x) else 0.0
         self.view.end_time = self.end_x[0] if 0 < len(self.end_x) else 15.0
 
     def update_fit_status_information_in_view(self):
         current_index = self.view.get_index_for_start_end_times()
-        self.view.update_with_fit_outputs(self._fit_function[current_index], self._fit_status[current_index],
+        self.view.update_with_fit_outputs(self._fit_function[current_index],
+                                          self._fit_status[current_index],
                                           self._fit_chi_squared[current_index])
         self.view.update_global_fit_state(self._fit_status)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -230,7 +230,7 @@ class FittingTabPresenter(object):
         :return: The set of attributes common to all fit types
         """
         return {
-            'Function': self.view.fit_string,
+            'Function': self.view.fit_object,
             'Minimizer': self.view.minimizer,
             'EvaluationType': self.view.evaluation_type,
             'FitGroupName': self.view.group_name

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -226,6 +226,9 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
 
         return current_index if current_index != -1 else 0
 
+    def get_global_parameters(self):
+        return self.function_browser.getGlobalParameters()
+
     def setup_fit_options_table(self):
         self.fit_options_table.setRowCount(5)
         self.fit_options_table.setColumnCount(2)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, unicode_literals)
 
 from mantid.api import AnalysisDataService, WorkspaceFactory, WorkspaceGroup
 from mantid.kernel import FloatTimeSeriesProperty
-from mantid.py3compat import iterkeys, string_types
+from mantid.py3compat import string_types
 import numpy as np
 
 from Muon.GUI.Common.observer_pattern import GenericObserver
@@ -18,6 +18,7 @@ from Muon.GUI.Common.observer_pattern import GenericObserver
 DEFAULT_TABLE_NAME = 'ResultsTable'
 ALLOWED_NON_TIME_SERIES_LOGS = ("run_number", "run_start", "run_end", "group",
                                 "period", "sample_temp", "sample_magn_field")
+ERROR_COL_SUFFIX = 'Error'
 # This is not a particularly robust way of ignoring this as it
 # depends on how Fit chooses to output the name of that value
 RESULTS_TABLE_COLUMNS_NO_ERRS = ['Cost function value']
@@ -136,7 +137,10 @@ class ResultsTabModel(object):
         fit_list = self._fit_context.fit_list
         for _, position in results_selection:
             fit = fit_list[position]
-            row_dict = {'workspace_name': fit.parameter_name}
+            fit_parameters = fit.parameters
+            row_dict = {
+                'workspace_name': fit_parameters.parameter_workspace_name
+            }
             # logs first
             if len(log_selection) > 0:
                 workspace = _workspace_for_logs(fit.input_workspace)
@@ -148,13 +152,13 @@ class ResultsTabModel(object):
                         log_value = np.nan
                     row_dict.update({log_name: log_value})
             # fit parameters
-            parameter_dict = fit.parameters
-            for name, value, error in zip(parameter_dict['Name'],
-                                          parameter_dict['Value'],
-                                          parameter_dict['Error']):
-                row_dict.update({name: value})
-                if name not in RESULTS_TABLE_COLUMNS_NO_ERRS:
-                    row_dict.update({name + 'Error': error})
+            for param_name in fit_parameters.names():
+                row_dict.update({param_name: fit_parameters.value(param_name)})
+                if _param_error_should_be_displayed(param_name):
+                    row_dict.update({
+                        _error_column_name(param_name):
+                        fit_parameters.error(param_name)
+                    })
 
             try:
                 results_table.addRow(row_dict)
@@ -182,10 +186,10 @@ class ResultsTabModel(object):
         # assume all fit functions are the same in fit_selection and take
         # the parameter names from the first fit.
         parameters = self._find_parameters_for_table(results_selection)
-        for name in parameters['Name']:
+        for name in parameters.names():
             table.addColumn('float', name)
-            if name not in RESULTS_TABLE_COLUMNS_NO_ERRS:
-                table.addColumn('float', name + 'Error')
+            if _param_error_should_be_displayed(name):
+                table.addColumn('float', _error_column_name(name))
         return table
 
     # Private API
@@ -217,25 +221,7 @@ class ResultsTabModel(object):
         :return: The parameters for the table
         """
         first_fit = self._fit_context.fit_list[results_selection[0][1]]
-        return self._remove_duplicate_globals(first_fit.parameters,
-                                              first_fit.global_parameters)
-
-    def _remove_duplicate_globals(self, parameters, global_parameters):
-        """
-        Remove any duplicate parameters that were marked as global
-        and leave the first one.
-
-        :param parameters: The full list of fitted parameters
-        :param global_parameters: The list of parameters marked global
-        :return: An updated dictionary of parameters with a single
-        parameter/error value for each global
-        """
-        if not global_parameters:
-            return parameters
-
-        # PRUNE HERE
-
-        return parameters
+        return first_fit.parameters
 
 
 # Public helper functions
@@ -273,6 +259,20 @@ def _log_should_be_displayed(log):
     """Returns true if the given log should be included in the display"""
     return isinstance(log, FloatTimeSeriesProperty) or \
         log.name in ALLOWED_NON_TIME_SERIES_LOGS
+
+
+def _param_error_should_be_displayed(param_name):
+    """Returns true if the given parameter's error should included in the display"""
+    return param_name not in RESULTS_TABLE_COLUMNS_NO_ERRS
+
+
+def _error_column_name(name):
+    """
+    Create the name of a column for an error on the named value
+    :param name: The name of a value column
+    :return: A name for the error column
+    """
+    return name + ERROR_COL_SUFFIX
 
 
 def _result_workspace_name(fit):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -49,7 +49,7 @@ class ResultsTabPresenter(QObject):
         try:
             self.model.create_results_table(log_selection, results_selection)
         except Exception as exc:
-            self.view.show_warning("Error creating results table: " + str(exc))
+            self.view.show_warning(str(exc))
 
     def on_function_selection_changed(self):
         """React to the change in function selection"""

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -69,7 +69,10 @@ set ( TEST_PY_FILES_QT5
    FFTModel_test.py
    FFTPresenter_test.py
    fft_presenter_context_interaction_test.py
+   fitting_tab_widget/workspace_selector_dialog_presenter_test.py
    fitting_tab_widget/fitting_tab_presenter_test.py
+   fitting_tab_widget/fitting_tab_model_test.py
+   fitting_context_test.py
    home_grouping_widget_test.py
    home_instrument_widget_test.py
    home_plot_widget_test.py

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -5,14 +5,128 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, unicode_literals)
+
+from collections import OrderedDict
 import unittest
-from mantid.py3compat import mock
-from Muon.GUI.Common.contexts.fitting_context import FittingContext, FitInformation
+
+from mantid.py3compat import iteritems, mock
+
+from Muon.GUI.Common.contexts.fitting_context import FittingContext, FitInformation, FitParameters
+
+
+def create_test_fit_parameters(test_parameters, global_parameters=None):
+    # needs to look like a standard fit table
+    fit_table = [{
+        'Name': name,
+        'Value': value,
+        'Error': error
+    } for name, (value, error) in iteritems(test_parameters)]
+
+    parameter_workspace = mock.MagicMock()
+    parameter_workspace.workspace.__iter__.return_value = fit_table
+    return FitParameters(parameter_workspace, global_parameters)
+
+
+class FitParametersTest(unittest.TestCase):
+    def test_equality_with_no_globals(self):
+        parameter_workspace = mock.MagicMock()
+        fit_params1 = FitParameters(parameter_workspace)
+        fit_params2 = FitParameters(parameter_workspace)
+
+        self.assertEqual(fit_params1, fit_params2)
+
+    def test_inequality_with_no_globals(self):
+        fit_params1 = FitParameters(mock.MagicMock())
+        fit_params2 = FitParameters(mock.MagicMock())
+
+        self.assertNotEqual(fit_params1, fit_params2)
+
+    def test_equality_with_globals(self):
+        parameter_workspace = mock.MagicMock()
+        fit_params1 = FitParameters(parameter_workspace, ['A'])
+        parameter_workspace = parameter_workspace
+        fit_params2 = FitParameters(parameter_workspace, ['A'])
+
+        self.assertEqual(fit_params1, fit_params2)
+
+    def test_inequality_with_globals(self):
+        parameter_workspace = mock.MagicMock()
+        fit_params1 = FitParameters(parameter_workspace, ['A'])
+        fit_params2 = FitParameters(parameter_workspace, ['B'])
+
+        self.assertNotEqual(fit_params1, fit_params2)
+
+    def test_length_returns_all_params_with_no_globals(self):
+        test_parameters = OrderedDict([('Height', (10., 0.4)),
+                                       ('A0', (1, 0.01)),
+                                       ('Cost function', (0.1, 0.))])
+        fit_params = create_test_fit_parameters(test_parameters)
+
+        self.assertEqual(3, len(fit_params))
+
+    def test_length_returns_unique_params_with_globals(self):
+        test_parameters = OrderedDict([('f0.Height', (10., 0.4)),
+                                       ('f0.A0', (1, 0.01)),
+                                       ('f1.Height', (10., 0.4)),
+                                       ('f1.A0', (2, 0.001)),
+                                       ('Cost function', (0.1, 0.))])
+        fit_params = create_test_fit_parameters(test_parameters,
+                                                global_parameters=['Height'])
+
+        self.assertEqual(4, len(fit_params))
+
+    def test_names_value_error_returns_all_expected_values_with_no_globals(
+            self):
+        test_parameters = OrderedDict([('f0.Height', (10., 0.4)),
+                                       ('f0.A0', (1, 0.01)),
+                                       ('Cost function', (0.1, 0.))])
+        fit_params = create_test_fit_parameters(test_parameters)
+
+        self.assertEqual(test_parameters.keys(), fit_params.names())
+        self.assertEqual(3, len(fit_params))
+        for index, name in enumerate(fit_params.names()):
+            self.assertEqual(test_parameters[name][0],
+                             fit_params.value(name),
+                             msg="Mismatch in error for parameter" + name)
+            self.assertEqual(test_parameters[name][1],
+                             fit_params.error(name),
+                             msg="Mismatch in error for parameter" + name)
+
+    def test_names_value_error_returns_all_expected_values_with_globals(self):
+        test_parameters = OrderedDict([
+            ('f0.Height', (10., 0.4)),  # global
+            ('f0.A0', (1, 0.01)),
+            ('f1.Height', (10., 0.4)),  # global
+            ('f1.A0', (2, 0.05)),
+            ('Cost function', (0.1, 0.)),
+        ])
+        global_parameters = ['Height']
+        # Make some parameters that look like a simultaneous fit
+        fit_params = create_test_fit_parameters(test_parameters,
+                                                global_parameters)
+
+        expected_keys = ['f0.Height', 'f0.A0', 'f1.A0', 'Cost function']
+        self.assertEqual(expected_keys, fit_params.names())
+        for index, name in enumerate(fit_params.names()):
+            self.assertEqual(test_parameters[name][0],
+                             fit_params.value(name),
+                             msg="Mismatch in error for parameter" + name)
+            self.assertEqual(test_parameters[name][1],
+                             fit_params.error(name),
+                             msg="Mismatch in error for parameter" + name)
 
 
 class FittingContextTest(unittest.TestCase):
     def setUp(self):
         self.fitting_context = FittingContext()
+
+    def test_context_constructor_accepts_fit_list(self):
+        fit_list = [
+            FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        ]
+        context = FittingContext(fit_list)
+
+        self.assertEqual(fit_list, context.fit_list)
 
     def test_len_gives_length_of_fit_list(self):
         self.assertEqual(0, len(self.fitting_context))
@@ -21,7 +135,8 @@ class FittingContextTest(unittest.TestCase):
         self.assertEqual(1, len(self.fitting_context))
 
     def test_fitinformation_equality_with_no_globals(self):
-        fit_info = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        fit_info = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
+                                  mock.MagicMock())
         self.assertEqual(fit_info, fit_info)
 
     def test_fitinformation_equality_with_globals(self):
@@ -31,14 +146,15 @@ class FittingContextTest(unittest.TestCase):
 
     def test_fitinformation_inequality_with_globals(self):
         fit_info1 = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
-                                  mock.MagicMock(), ['A'])
+                                   mock.MagicMock(), ['A'])
         fit_info2 = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
-                                  mock.MagicMock(), ['B'])
+                                   mock.MagicMock(), ['B'])
         self.assertNotEqual(fit_info1, fit_info2)
 
     def test_items_can_be_added_to_fitting_context(self):
-        fit_information_object = FitInformation(
-            mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        fit_information_object = FitInformation(mock.MagicMock(),
+                                                'MuonGuassOsc',
+                                                mock.MagicMock())
 
         self.fitting_context.add_fit(fit_information_object)
 
@@ -50,14 +166,16 @@ class FittingContextTest(unittest.TestCase):
                                                 mock.MagicMock(),
                                                 mock.MagicMock())
 
-        self.assertEqual([], fit_information_object.global_parameters)
+        self.assertEqual([],
+                         fit_information_object.parameters.global_parameters)
 
     def test_global_parameters_are_captured(self):
         fit_information_object = FitInformation(mock.MagicMock(),
                                                 mock.MagicMock(),
                                                 mock.MagicMock(), ['A'])
 
-        self.assertEqual(['A'], fit_information_object.global_parameters)
+        self.assertEqual(['A'],
+                         fit_information_object.parameters.global_parameters)
 
     def test_fitfunctions_gives_list_of_unique_function_names(self):
         test_fit_function = 'MuonGuassOsc'
@@ -96,48 +214,64 @@ class FittingContextTest(unittest.TestCase):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
-        fit_information_object = FitInformation(
-            parameter_workspace, fit_function_name, input_workspace)
+        fit_information_object = FitInformation(parameter_workspace,
+                                                fit_function_name,
+                                                input_workspace)
 
-        self.fitting_context.add_fit_from_values(
-            parameter_workspace, fit_function_name, input_workspace)
+        self.fitting_context.add_fit_from_values(parameter_workspace,
+                                                 fit_function_name,
+                                                 input_workspace)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
 
-    def test_can_add_fits_with_global_parameters_without_creating_fit_information(self):
+    def test_can_add_fits_with_global_parameters_without_creating_fit_information(
+            self):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
         global_params = ['A']
         fit_information_object = FitInformation(parameter_workspace,
                                                 fit_function_name,
-                                                input_workspace,
-                                                global_params)
+                                                input_workspace, global_params)
 
         self.fitting_context.add_fit_from_values(parameter_workspace,
                                                  fit_function_name,
-                                                 input_workspace, global_params)
+                                                 input_workspace,
+                                                 global_params)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
 
-    def test_can_add_fits_with_global_parameters_without_creating_fit_information(self):
+    def test_can_add_fits_with_global_parameters_without_creating_fit_information(
+            self):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
         global_params = ['A']
         fit_information_object = FitInformation(parameter_workspace,
                                                 fit_function_name,
-                                                input_workspace,
-                                                global_params)
+                                                input_workspace, global_params)
 
         self.fitting_context.add_fit_from_values(parameter_workspace,
                                                  fit_function_name,
-                                                 input_workspace, global_params)
+                                                 input_workspace,
+                                                 global_params)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
+
+    def test_parameters_are_readonly(self):
+        test_parameters = OrderedDict([('Height', (10., 0.4)),
+                                       ('A0', (1, 0.01)),
+                                       ('Cost function', (0.1, 0.))])
+        fit_params = create_test_fit_parameters(test_parameters)
+        fit_info = FitInformation(fit_params._parameter_workspace,
+                                  mock.MagicMock(), mock.MagicMock())
+
+        self.assertRaises(AttributeError, setattr, fit_info, "parameters",
+                          fit_params)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -57,8 +57,8 @@ class FitParametersTest(unittest.TestCase):
         self.assertNotEqual(fit_params1, fit_params2)
 
     def test_length_returns_all_params_with_no_globals(self):
-        test_parameters = OrderedDict([('Height', (10., 0.4)),
-                                       ('A0', (1, 0.01)),
+        test_parameters = OrderedDict([('Height', (10., 0.4)), ('A0', (1,
+                                                                       0.01)),
                                        ('Cost function', (0.1, 0.))])
         fit_params = create_test_fit_parameters(test_parameters)
 
@@ -70,8 +70,8 @@ class FitParametersTest(unittest.TestCase):
                                        ('f1.Height', (10., 0.4)),
                                        ('f1.A0', (2, 0.001)),
                                        ('Cost function', (0.1, 0.))])
-        fit_params = create_test_fit_parameters(test_parameters,
-                                                global_parameters=['Height'])
+        fit_params = create_test_fit_parameters(
+            test_parameters, global_parameters=['Height'])
 
         self.assertEqual(4, len(fit_params))
 
@@ -85,12 +85,62 @@ class FitParametersTest(unittest.TestCase):
         self.assertEqual(list(test_parameters.keys()), fit_params.names())
         self.assertEqual(3, len(fit_params))
         for index, name in enumerate(fit_params.names()):
-            self.assertEqual(test_parameters[name][0],
-                             fit_params.value(name),
-                             msg="Mismatch in error for parameter" + name)
-            self.assertEqual(test_parameters[name][1],
-                             fit_params.error(name),
-                             msg="Mismatch in error for parameter" + name)
+            self.assertEqual(
+                test_parameters[name][0],
+                fit_params.value(name),
+                msg="Mismatch in error for parameter" + name)
+            self.assertEqual(
+                test_parameters[name][1],
+                fit_params.error(name),
+                msg="Mismatch in error for parameter" + name)
+
+    def test_names_return_globals_first_with_simultaneous_prefixes_stripped_for_single_fn(
+            self):
+        # Make some parameters that look like a simultaneous fit of 2 data sets
+        test_parameters = OrderedDict([
+            ('f0.Height', (10., 0.4)),
+            ('f0.A0', (1, 0.01)),  # global
+            ('f0.Sigma', (0.01, 0.0001)),  # global
+            ('f1.Height', (11., 0.5)),
+            ('f1.A0', (1, 0.01)),  # global
+            ('f1.Sigma', (0.01, 0.0001)),  # global
+            ('Cost function', (0.1, 0.)),
+        ])
+        global_parameters = ['A0', 'Sigma']
+        fit_params = create_test_fit_parameters(test_parameters,
+                                                global_parameters)
+
+        expected_keys = [
+            'A0', 'Sigma', 'f0.Height', 'f1.Height', 'Cost function'
+        ]
+        self.assertEqual(expected_keys, fit_params.names())
+
+    def test_names_return_globals_first_with_simultaneous_prefixes_stripped_for_composite_fn(
+            self):
+        # Make some parameters that look like a simultaneous fit of 2 data sets where parameters
+        # could be called the same thing in each function. The values are irrelevant for this test
+        test_parameters = OrderedDict([
+            # data set 0
+            ('f0.f0.A0', (10., 0.4)),
+            ('f0.f0.A1', (10., 0.4)),
+            ('f0.f1.A0', (10., 0.4)),
+            ('f0.f1.A1', (10., 0.4)),
+            # data set 1
+            ('f1.f0.A0', (10., 0.4)),
+            ('f1.f0.A1', (10., 0.4)),
+            ('f1.f1.A0', (10., 0.4)),
+            ('f1.f1.A1', (10., 0.4)),
+            ('Cost function', (0.1, 0.)),
+        ])
+        global_parameters = ['f0.A0']
+        fit_params = create_test_fit_parameters(test_parameters,
+                                                global_parameters)
+
+        expected_keys = [
+            'f0.A0', 'f0.f0.A1', 'f0.f1.A0', 'f0.f1.A1', 'f1.f0.A1',
+            'f1.f1.A0', 'f1.f1.A1', 'Cost function'
+        ]
+        self.assertEqual(expected_keys, fit_params.names())
 
     def test_names_value_error_returns_all_expected_values_with_globals(self):
         test_parameters = OrderedDict([
@@ -105,15 +155,21 @@ class FitParametersTest(unittest.TestCase):
         fit_params = create_test_fit_parameters(test_parameters,
                                                 global_parameters)
 
-        expected_keys = ['f0.Height', 'f0.A0', 'f1.A0', 'Cost function']
+        expected_keys = ['Height', 'f0.A0', 'f1.A0', 'Cost function']
         self.assertEqual(expected_keys, fit_params.names())
         for index, name in enumerate(fit_params.names()):
-            self.assertEqual(test_parameters[name][0],
-                             fit_params.value(name),
-                             msg="Mismatch in error for parameter" + name)
-            self.assertEqual(test_parameters[name][1],
-                             fit_params.error(name),
-                             msg="Mismatch in error for parameter" + name)
+            if name == 'Height':
+                orig_name = 'f0.Height'
+            else:
+                orig_name = name
+            self.assertEqual(
+                test_parameters[orig_name][0],
+                fit_params.value(name),
+                msg="Mismatch in error for parameter" + name)
+            self.assertEqual(
+                test_parameters[orig_name][1],
+                fit_params.error(name),
+                msg="Mismatch in error for parameter" + name)
 
 
 class FittingContextTest(unittest.TestCase):
@@ -152,9 +208,8 @@ class FittingContextTest(unittest.TestCase):
         self.assertNotEqual(fit_info1, fit_info2)
 
     def test_items_can_be_added_to_fitting_context(self):
-        fit_information_object = FitInformation(mock.MagicMock(),
-                                                'MuonGuassOsc',
-                                                mock.MagicMock())
+        fit_information_object = FitInformation(
+            mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
 
         self.fitting_context.add_fit(fit_information_object)
 
@@ -214,13 +269,11 @@ class FittingContextTest(unittest.TestCase):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
-        fit_information_object = FitInformation(parameter_workspace,
-                                                fit_function_name,
-                                                input_workspace)
+        fit_information_object = FitInformation(
+            parameter_workspace, fit_function_name, input_workspace)
 
-        self.fitting_context.add_fit_from_values(parameter_workspace,
-                                                 fit_function_name,
-                                                 input_workspace)
+        self.fitting_context.add_fit_from_values(
+            parameter_workspace, fit_function_name, input_workspace)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
@@ -235,10 +288,9 @@ class FittingContextTest(unittest.TestCase):
                                                 fit_function_name,
                                                 input_workspace, global_params)
 
-        self.fitting_context.add_fit_from_values(parameter_workspace,
-                                                 fit_function_name,
-                                                 input_workspace,
-                                                 global_params)
+        self.fitting_context.add_fit_from_values(
+            parameter_workspace, fit_function_name, input_workspace,
+            global_params)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
@@ -253,17 +305,16 @@ class FittingContextTest(unittest.TestCase):
                                                 fit_function_name,
                                                 input_workspace, global_params)
 
-        self.fitting_context.add_fit_from_values(parameter_workspace,
-                                                 fit_function_name,
-                                                 input_workspace,
-                                                 global_params)
+        self.fitting_context.add_fit_from_values(
+            parameter_workspace, fit_function_name, input_workspace,
+            global_params)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
 
     def test_parameters_are_readonly(self):
-        test_parameters = OrderedDict([('Height', (10., 0.4)),
-                                       ('A0', (1, 0.01)),
+        test_parameters = OrderedDict([('Height', (10., 0.4)), ('A0', (1,
+                                                                       0.01)),
                                        ('Cost function', (0.1, 0.))])
         fit_params = create_test_fit_parameters(test_parameters)
         fit_info = FitInformation(fit_params._parameter_workspace,

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -122,6 +122,22 @@ class FittingContextTest(unittest.TestCase):
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
 
+    def test_can_add_fits_with_global_parameters_without_creating_fit_information(self):
+        parameter_workspace = mock.MagicMock()
+        input_workspace = mock.MagicMock()
+        fit_function_name = 'MuonGuassOsc'
+        global_params = ['A']
+        fit_information_object = FitInformation(parameter_workspace,
+                                                fit_function_name,
+                                                input_workspace,
+                                                global_params)
+
+        self.fitting_context.add_fit_from_values(parameter_workspace,
+                                                 fit_function_name,
+                                                 input_workspace, global_params)
+
+        self.assertEqual(fit_information_object,
+                         self.fitting_context.fit_list[0])
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -20,15 +20,44 @@ class FittingContextTest(unittest.TestCase):
             FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock()))
         self.assertEqual(1, len(self.fitting_context))
 
+    def test_fitinformation_equality_with_no_globals(self):
+        fit_info = FitInformation(mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
+        self.assertEqual(fit_info, fit_info)
+
+    def test_fitinformation_equality_with_globals(self):
+        fit_info = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
+                                  mock.MagicMock(), ['A'])
+        self.assertEqual(fit_info, fit_info)
+
+    def test_fitinformation_inequality_with_globals(self):
+        fit_info1 = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
+                                  mock.MagicMock(), ['A'])
+        fit_info2 = FitInformation(mock.MagicMock(), 'MuonGuassOsc',
+                                  mock.MagicMock(), ['B'])
+        self.assertNotEqual(fit_info1, fit_info2)
+
     def test_items_can_be_added_to_fitting_context(self):
-        fit_information_object = FitInformation(mock.MagicMock(),
-                                                'MuonGuassOsc',
-                                                mock.MagicMock())
+        fit_information_object = FitInformation(
+            mock.MagicMock(), 'MuonGuassOsc', mock.MagicMock())
 
         self.fitting_context.add_fit(fit_information_object)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])
+
+    def test_empty_global_parameters_if_none_specified(self):
+        fit_information_object = FitInformation(mock.MagicMock(),
+                                                mock.MagicMock(),
+                                                mock.MagicMock())
+
+        self.assertEqual([], fit_information_object.global_parameters)
+
+    def test_global_parameters_are_captured(self):
+        fit_information_object = FitInformation(mock.MagicMock(),
+                                                mock.MagicMock(),
+                                                mock.MagicMock(), ['A'])
+
+        self.assertEqual(['A'], fit_information_object.global_parameters)
 
     def test_fitfunctions_gives_list_of_unique_function_names(self):
         test_fit_function = 'MuonGuassOsc'
@@ -67,13 +96,28 @@ class FittingContextTest(unittest.TestCase):
         parameter_workspace = mock.MagicMock()
         input_workspace = mock.MagicMock()
         fit_function_name = 'MuonGuassOsc'
+        fit_information_object = FitInformation(
+            parameter_workspace, fit_function_name, input_workspace)
+
+        self.fitting_context.add_fit_from_values(
+            parameter_workspace, fit_function_name, input_workspace)
+
+        self.assertEqual(fit_information_object,
+                         self.fitting_context.fit_list[0])
+
+    def test_can_add_fits_with_global_parameters_without_creating_fit_information(self):
+        parameter_workspace = mock.MagicMock()
+        input_workspace = mock.MagicMock()
+        fit_function_name = 'MuonGuassOsc'
+        global_params = ['A']
         fit_information_object = FitInformation(parameter_workspace,
                                                 fit_function_name,
-                                                input_workspace)
+                                                input_workspace,
+                                                global_params)
 
         self.fitting_context.add_fit_from_values(parameter_workspace,
                                                  fit_function_name,
-                                                 input_workspace)
+                                                 input_workspace, global_params)
 
         self.assertEqual(fit_information_object,
                          self.fitting_context.fit_list[0])

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -82,7 +82,7 @@ class FitParametersTest(unittest.TestCase):
                                        ('Cost function', (0.1, 0.))])
         fit_params = create_test_fit_parameters(test_parameters)
 
-        self.assertEqual(test_parameters.keys(), fit_params.names())
+        self.assertEqual(list(test_parameters.keys()), fit_params.names())
         self.assertEqual(3, len(fit_params))
         for index, name in enumerate(fit_params.names()):
             self.assertEqual(test_parameters[name][0],

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -111,7 +111,7 @@ class FittingTabModelTest(unittest.TestCase):
             {'Function': mock.ANY, 'InputWorkspace': workspace, 'Minimizer': 'Levenberg-Marquardt',
              'StartX': 0.0, 'EndX': 100.0, 'EvaluationType': 'CentrePoint'})
 
-    def test_do_simultaneous_fit_adds_single_input_workspace_to_fit_context(self):
+    def test_do_simultaneous_fit_adds_single_input_workspace_to_fit_context_with_globals(self):
         trial_function = FunctionFactory.createInitialized('name = Quadratic, A0 = 0, A1 = 0, A2 = 0')
         x_data = range(0, 100)
         y_data = [5 + x * x for x in x_data]
@@ -120,10 +120,12 @@ class FittingTabModelTest(unittest.TestCase):
                           'Minimizer': 'Levenberg-Marquardt',
                           'StartX': [0.0], 'EndX': [100.0], 'EvaluationType': 'CentrePoint',
                           'FitGroupName': 'SimulFit'}
-        self.model.do_simultaneous_fit(parameter_dict, global_parameters=[])
+        global_parameters = ['A0']
+        self.model.do_simultaneous_fit(parameter_dict, global_parameters)
 
         fit_context = self.model.context.fitting_context
         self.assertEqual(1, len(fit_context))
+        self.assertEqual(global_parameters, fit_context.fit_list[0].parameters.global_parameters)
 
     def test_do_simultaneous_fit_adds_multi_input_workspace_to_fit_context(self):
         # create function

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -120,7 +120,7 @@ class FittingTabModelTest(unittest.TestCase):
                           'Minimizer': 'Levenberg-Marquardt',
                           'StartX': [0.0], 'EndX': [100.0], 'EvaluationType': 'CentrePoint',
                           'FitGroupName': 'SimulFit'}
-        self.model.do_simultaneous_fit(parameter_dict)
+        self.model.do_simultaneous_fit(parameter_dict, global_parameters=[])
 
         fit_context = self.model.context.fitting_context
         self.assertEqual(1, len(fit_context))
@@ -138,7 +138,7 @@ class FittingTabModelTest(unittest.TestCase):
                           'Minimizer': 'Levenberg-Marquardt',
                           'StartX': [0.0]*2, 'EndX': [100.0]*2, 'EvaluationType': 'CentrePoint',
                           'FitGroupName': 'SimulFit'}
-        self.model.do_simultaneous_fit(parameter_dict)
+        self.model.do_simultaneous_fit(parameter_dict, global_parameters=[])
 
         fit_context = self.model.context.fitting_context
         self.assertEqual(1, len(fit_context))

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -104,7 +104,7 @@ class FittingTabPresenterTest(GuiTest):
 
         self.assertEqual(self.view.function_browser.getDatasetNames(), ['Input Workspace Name'])
 
-    def test_fit_clicked_with_simultaneous_selected(self):
+    def test_fit_clicked_with_simultaneous_selected_and_no_globals(self):
         self.view.simul_fit_radio.toggle()
         self.presenter.selected_data = ['Input Workspace Name_1', 'Input Workspace Name 2']
         self.view.function_browser.setFunction('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
@@ -114,12 +114,33 @@ class FittingTabPresenterTest(GuiTest):
         self.view.fit_button.clicked.emit(True)
         wait_for_thread(self.presenter.calculation_thread)
 
-        call_args_dict = self.presenter.model.do_simultaneous_fit.call_args[0][0]
+        simultaneous_call_args = self.presenter.model.do_simultaneous_fit.call_args
+        call_args_dict = simultaneous_call_args[0][0]
 
         self.assertEqual(call_args_dict['InputWorkspace'], ['Input Workspace Name_1', 'Input Workspace Name 2'])
         self.assertEqual(call_args_dict['Minimizer'], 'Levenberg-Marquardt')
         self.assertEqual(call_args_dict['StartX'], [0.0, 0.0])
         self.assertEqual(call_args_dict['EndX'], [15.0, 15.0])
+
+        call_args_globals = simultaneous_call_args[0][1]
+        self.assertEqual(call_args_globals, [])
+
+    def test_fit_clicked_with_simultaneous_selected_with_global_parameters(self):
+        self.view.simul_fit_radio.toggle()
+        self.presenter.selected_data = ['Input Workspace Name_1', 'Input Workspace Name 2']
+        self.view.function_browser.setFunction('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
+        self.view.function_browser.setGlobalParameters(['A'])
+        self.presenter.model.do_simultaneous_fit.return_value = (self.view.function_browser.getGlobalFunction(),
+                                                                 'Fit Suceeded', 0.5)
+
+        self.view.fit_button.clicked.emit(True)
+        wait_for_thread(self.presenter.calculation_thread)
+
+        simultaneous_call_args = self.presenter.model.do_simultaneous_fit.call_args
+
+        # above tests output with no globals set
+        call_args_globals = simultaneous_call_args[0][1]
+        self.assertEqual(call_args_globals, ['A'])
 
     def test_when_new_data_is_selected_clear_out_old_fits_and_information(self):
         self.presenter._fit_status = ['success', 'success', 'success']

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -105,6 +105,7 @@ class FittingTabPresenterTest(GuiTest):
         self.assertEqual(self.view.function_browser.getDatasetNames(), ['Input Workspace Name'])
 
     def test_fit_clicked_with_simultaneous_selected_and_no_globals(self):
+        self.presenter.model.get_function_name.return_value = 'GausOsc'
         self.view.simul_fit_radio.toggle()
         self.presenter.selected_data = ['Input Workspace Name_1', 'Input Workspace Name 2']
         self.view.function_browser.setFunction('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
@@ -126,6 +127,7 @@ class FittingTabPresenterTest(GuiTest):
         self.assertEqual(call_args_globals, [])
 
     def test_fit_clicked_with_simultaneous_selected_with_global_parameters(self):
+        self.presenter.model.get_function_name.return_value = 'GausOsc'
         self.view.simul_fit_radio.toggle()
         self.presenter.selected_data = ['Input Workspace Name_1', 'Input Workspace Name 2']
         self.view.function_browser.setFunction('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
@@ -138,7 +140,12 @@ class FittingTabPresenterTest(GuiTest):
 
         simultaneous_call_args = self.presenter.model.do_simultaneous_fit.call_args
 
-        # above tests output with no globals set
+        call_args_dict = simultaneous_call_args[0][0]
+        self.assertEqual(call_args_dict['InputWorkspace'], ['Input Workspace Name_1', 'Input Workspace Name 2'])
+        self.assertEqual(call_args_dict['Minimizer'], 'Levenberg-Marquardt')
+        self.assertEqual(call_args_dict['StartX'], [0.0, 0.0])
+        self.assertEqual(call_args_dict['EndX'], [15.0, 15.0])
+
         call_args_globals = simultaneous_call_args[0][1]
         self.assertEqual(call_args_globals, ['A'])
 

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -5,14 +5,16 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from __future__ import (absolute_import, unicode_literals)
+from __future__ import (absolute_import, print_function, unicode_literals)
 
+from collections import OrderedDict
+from copy import deepcopy
 import itertools
 import unittest
 
 from mantid.api import AnalysisDataService, ITableWorkspace, WorkspaceFactory, WorkspaceGroup
 from mantid.kernel import FloatTimeSeriesProperty, StringPropertyWithValue
-from mantid.py3compat import mock
+from mantid.py3compat import iteritems, mock, string_types
 
 from Muon.GUI.Common.results_tab_widget.results_tab_model import (
     DEFAULT_TABLE_NAME, ALLOWED_NON_TIME_SERIES_LOGS, log_names,
@@ -21,299 +23,6 @@ from Muon.GUI.Common.contexts.fitting_context import FittingContext, FitInformat
 
 # constants
 LOG_NAMES_FUNC = 'Muon.GUI.Common.results_tab_widget.results_tab_model.log_names'
-
-
-class ResultsTabModelTest(unittest.TestCase):
-    def setUp(self):
-        self.parameters = {
-            'Name': ['Height', 'PeakCentre', 'Sigma', 'Cost function value'],
-            'Value': [2309.2, 2.1, 0.04, 30.8],
-            'Error': [16, 0.002, 0.003, 0]
-        }
-        self.logs = ['sample_temp', 'sample_magn_field']
-        fits = create_test_fits_with_logs(('ws1', ), 'func1', self.parameters,
-                                          self.logs)
-        self.fitting_context = FittingContext()
-        for fit in fits:
-            self.fitting_context.add_fit(fit)
-
-        self.model = ResultsTabModel(self.fitting_context)
-
-    def tearDown(self):
-        AnalysisDataService.Instance().clear()
-
-    # ------------------------- success tests ----------------------------
-    def xtest_default_model_has_results_table_name(self):
-        self.assertEqual(self.model.results_table_name(), DEFAULT_TABLE_NAME)
-
-    def xtest_updating_model_results_table_name(self):
-        table_name = 'table_name'
-        self.model.set_results_table_name(table_name)
-        self.assertEqual(self.model.results_table_name(), table_name)
-
-    def xtest_default_model_has_no_selected_function_without_fits(self):
-        model = ResultsTabModel(FittingContext())
-
-        self.assertTrue(model.selected_fit_function() is None)
-
-    def xtest_updating_model_selected_fit_function(self):
-        new_selection = 'func2'
-        self.model.set_selected_fit_function(new_selection)
-        self.assertEqual(self.model.selected_fit_function(), new_selection)
-
-    def xtest_log_names_from_workspace_with_logs(self):
-        fake_ws = create_test_workspace()
-        run = fake_ws.run()
-        # populate with log data
-        time_series_names = ('ts_1', 'ts_2')
-        for name in time_series_names:
-            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
-        single_value_log_names = ('sv_1', 'sv_2')
-        for name in itertools.chain(single_value_log_names,
-                                    ALLOWED_NON_TIME_SERIES_LOGS):
-            run.addProperty(
-                name, StringPropertyWithValue(name, 'test'), replace=True)
-        # verify
-        allowed_logs = log_names(fake_ws.name())
-        for name in itertools.chain(time_series_names,
-                                    ALLOWED_NON_TIME_SERIES_LOGS):
-            self.assertTrue(
-                name in allowed_logs,
-                msg="{} not found in allowed log list".format(name))
-        for name in single_value_log_names:
-            self.assertFalse(
-                name in allowed_logs,
-                msg="{} found in allowed log list".format(name))
-
-    def xtest_log_names_from_workspace_without_logs(self):
-        fake_ws = create_test_workspace()
-        allowed_logs = log_names(fake_ws.name())
-        self.assertEqual(0, len(allowed_logs))
-
-    def xtest_log_names_from_workspacegroup_uses_first_workspace(self):
-        def add_log(workspace, name):
-            run = workspace.run()
-            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
-
-        fake_group = create_test_workspacegroup(size=2)
-        logs = ['log_1', 'log_2']
-        for index, name in enumerate(logs):
-            add_log(fake_group[index], name)
-
-        visible_logs = log_names(fake_group.name())
-        self.assertTrue(
-            logs[0] in visible_logs,
-            msg="{} not found in log list".format(logs[0]))
-        self.assertFalse(
-            logs[1] in visible_logs,
-            msg="{} not found in log list".format(logs[1]))
-
-    def xtest_model_returns_fit_functions_from_context(self):
-        self.assertEqual(['func1'], self.model.fit_functions())
-
-    def xtest_model_returns_no_fit_selection_if_no_fits_present(self):
-        model = ResultsTabModel(FittingContext())
-        self.assertEqual(0, len(model.fit_selection({})))
-
-    def xtest_model_creates_fit_selection_given_zero_existing_state(self):
-        expected_list_state = {'ws1': [0, True, True]}
-
-        self.assertEqual(expected_list_state, self.model.fit_selection({}))
-
-    def xtest_model_creates_fit_selection_given_existing_state(self):
-        more_fits = create_test_fits_with_logs(('ws2', ), 'func1',
-                                               self.parameters, self.logs)
-        for fit in more_fits:
-            self.fitting_context.add_fit(fit)
-
-        orig_list_state = {'ws1': [0, False, True]}
-        expected_list_state = {'ws1': [0, False, True], 'ws2': [1, True, True]}
-        self.assertEqual(expected_list_state,
-                         self.model.fit_selection(orig_list_state))
-
-    def xtest_model_returns_no_log_selection_if_not_fits_present(self):
-        self.fitting_context.fit_list = []
-        self.assertEqual(0, len(self.model.log_selection({})))
-
-    def xtest_model_returns_log_selection_of_first_workspace(self):
-        self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
-            ('ws1', 'ws2'))[0]
-        with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
-            ws1_logs = ('run_number', 'run_start')
-            ws2_logs = ('temp', 'magnetic_field')
-
-            def side_effect(name):
-                return ws1_logs if name == 'ws1' else ws2_logs
-
-            mock_log_names.side_effect = side_effect
-            expected_selection = {
-                'run_number': [0, False, True],
-                'run_start': [1, False, True],
-            }
-
-            self.assertEqual(expected_selection, self.model.log_selection({}))
-
-    def xtest_model_combines_existing_selection(self):
-        self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
-            ('ws1', ))[0]
-        with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
-            mock_log_names.return_value = ('run_number', 'run_start',
-                                           'magnetic_field')
-
-            existing_selection = {
-                'run_number': [0, False, True],
-                'run_start': [1, True, True],
-            }
-            expected_selection = {
-                'run_number': [0, False, True],
-                'run_start': [1, True, True],
-                'magnetic_field': [2, False, True]
-            }
-            self.assertDictEqual(expected_selection,
-                                 self.model.log_selection(existing_selection))
-
-    def xtest_create_results_table_with_no_logs(self):
-        parameters = {
-            'Name': ['Height', 'PeakCentre', 'Sigma', 'Cost function value'],
-            'Value': [2309.2, 2.1, 0.04, 30.8],
-            'Error': [16, 0.002, 0.003, 0]
-        }
-        self.fitting_context.fit_list = create_test_fits(('ws1', ), 'func1',
-                                                         parameters)
-        selected_results = [('ws1', 0)]
-        table = self.model.create_results_table([], selected_results)
-
-        self.assertTrue(isinstance(table, ITableWorkspace))
-        self.assertEqual(8, table.columnCount())
-        self.assertEqual(1, table.rowCount())
-        expected_cols = [
-            'workspace_name', 'Height', 'HeightError', 'PeakCentre',
-            'PeakCentreError', 'Sigma', 'SigmaError', 'Cost function value'
-        ]
-        self.assertEqual(expected_cols, table.getColumnNames())
-        self.assertEqual('ws1_Parameters', table.cell(0, 0))
-        for index, (expected_val, expected_err) in enumerate(
-                zip(parameters['Value'], parameters['Error'])):
-            self.assertAlmostEqual(
-                expected_val, table.cell(0, 2 * index + 1), places=2)
-            if 2 * index + 2 < table.columnCount():
-                self.assertAlmostEqual(
-                    expected_err, table.cell(0, 2 * index + 2), places=2)
-
-        self.assertTrue(
-            self.model.results_table_name() in AnalysisDataService.Instance())
-
-    def xtest_create_results_table_with_logs_selected(self):
-        selected_results = [('ws1', 0)]
-        logs = self.logs
-        table = self.model.create_results_table(logs, selected_results)
-
-        expected_cols = ['workspace_name'] + logs + [
-            'Height', 'HeightError', 'PeakCentre', 'PeakCentreError', 'Sigma',
-            'SigmaError', 'Cost function value'
-        ]
-        expected_row_count = 1
-        workspace_name = 'ws1_Parameters'
-        self._assert_table_matches_expected(table, expected_row_count,
-                                            expected_cols, workspace_name,
-                                            logs, self.parameters)
-
-    def test_create_results_table_with_fit_with_global_parameters(self):
-        logs = []
-        parameters = {
-            'Name': [
-                'f0.Height', 'f0.PeakCentre', 'f0.Sigma', 'f1.Height',
-                'f1.PeakCentre', 'f1.Sigma', 'Cost function value'
-            ],
-            'Value': [2309.2, 2.1, 0.04, 2309.2, 2.5, 0.02, 30.8],
-            'Error': [16, 0.002, 0.003, 0, 0.004, 0.006, 0]
-        }
-        global_parameters = None
-        fits = create_test_fits_with_logs(('simul-1',), 'func1', parameters,
-                                          logs, global_parameters)
-        fitting_context = FittingContext()
-        for fit in fits:
-            fitting_context.add_fit(fit)
-        model = ResultsTabModel(fitting_context)
-
-        selected_results = [('simul-1', 0)]
-        table = model.create_results_table(logs, selected_results)
-        expected_row_count = 1
-        expected_cols = [
-            'workspace_name', 'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
-            'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError',
-            'f1.PeakCentre', 'f1.PeakCentreError', 'f1.Sigma', 'f1.SigmaError',
-            'Cost function value'
-        ]
-        workspace_name = 'simul-1_Parameters'
-        self._assert_table_matches_expected(table, expected_row_count,
-                                            expected_cols, workspace_name,
-                                            logs, parameters)
-
-    # ------------------------- failure tests ----------------------------
-    def xtest_log_names_from_workspace_not_in_ADS_raises_exception(self):
-        self.assertRaises(KeyError, log_names, 'not a workspace in ADS')
-
-    def xtest_create_results_table_raises_error_if_number_params_different(
-            self):
-        parameters = {
-            'Name': ['Height', 'Cost function value'],
-            'Value': [2309.2, 30.8],
-            'Error': [16, 0]
-        }
-        fits = create_test_fits_with_logs(('ws1', ), 'func1', parameters,
-                                          self.logs)
-        self.fitting_context = FittingContext()
-        for fit in fits:
-            self.fitting_context.add_fit(fit)
-
-        parameters = {
-            'Name': ['Height', 'A0', 'Cost function value'],
-            'Value': [2309.2, 0.1, 30.8],
-            'Error': [16, 0.001, 0]
-        }
-        fits = create_test_fits_with_logs(('ws2', ), 'func1', parameters,
-                                          self.logs)
-        for fit in fits:
-            self.fitting_context.add_fit(fit)
-        self.model = ResultsTabModel(self.fitting_context)
-
-        selected_results = [('ws1', 0), ('ws2', 1)]
-        self.assertRaises(RuntimeError, self.model.create_results_table, [],
-                          selected_results)
-
-    def xtest_create_results_table_with_mixed_global_non_global_raises_error(
-            self):
-        self.fail("Implement test!")
-
-    def _assert_table_matches_expected(self, table, expected_row_count,
-                                       expected_cols, workspace_name, logs,
-                                       parameters):
-        self.assertTrue(isinstance(table, ITableWorkspace))
-        self.assertEqual(len(expected_cols), table.columnCount())
-        self.assertEqual(expected_row_count, table.rowCount())
-        self.assertEqual(expected_cols, table.getColumnNames())
-        # first value is workspace name
-        self.assertEqual(workspace_name, table.cell(0, 0))
-        # first check log columns
-        nlogs = len(logs)
-        for index, _ in enumerate(logs):
-            expected_val = 0.5 * (float(index) + float(index + 1))
-            self.assertAlmostEqual(
-                expected_val, table.cell(0, index + 1), places=2)
-        checked_columns = 1 + nlogs
-        for index, (expected_val, expected_err) in enumerate(
-                zip(parameters['Value'], parameters['Error'])):
-            self.assertAlmostEqual(
-                expected_val,
-                table.cell(0, 2 * index + checked_columns),
-                places=2)
-            err_col_idx = 2 * index + checked_columns + 1
-            if err_col_idx < table.columnCount():
-                self.assertAlmostEqual(
-                    expected_err, table.cell(0, err_col_idx), places=2)
-        self.assertTrue(
-            self.model.results_table_name() in AnalysisDataService.Instance())
 
 
 def create_test_workspace(ws_name=None):
@@ -337,30 +46,6 @@ def create_test_workspacegroup(size, group_name=None):
     return group
 
 
-def create_test_fits_with_only_workspace_names(input_workspaces,
-                                               checked_states=None):
-    """
-    Create a minimal list of fits and selection states with only
-    workspace names attached to them.
-    :param input_workspaces: The name of the input workspaces to create
-    :param checked_states: Option set of checked states (list of boolean)
-    :return: A 2-tuple of fits, selection states
-    """
-    fits = []
-    list_state = {}
-    if checked_states is None:
-        checked_states = (True for _ in input_workspaces)
-    enabled = True
-    for index, (name, checked) in enumerate(
-            zip(input_workspaces, checked_states)):
-        fit_info = mock.MagicMock()
-        fit_info.input_workspace = name
-        fits.append(fit_info)
-        list_state[name] = [index, checked, enabled]
-
-    return fits, list_state
-
-
 def create_test_fits(input_workspaces,
                      function_name,
                      parameters,
@@ -373,10 +58,17 @@ def create_test_fits(input_workspaces,
     :param global_parameters: An optional list of tied parameters
     :return: A list of Fits
     """
+    # Convert parameters to fit table-like structure
+    fit_table = [{
+        'Name': name,
+        'Value': value,
+        'Error': error
+    } for name, (value, error) in iteritems(parameters)]
+
     fits = []
     for name in input_workspaces:
         parameter_workspace = mock.NonCallableMagicMock()
-        parameter_workspace.workspace.toDict.return_value = parameters
+        parameter_workspace.workspace.__iter__.return_value = fit_table
         parameter_workspace.workspace_name = name + '_Parameters'
         fits.append(
             FitInformation(parameter_workspace, function_name, name,
@@ -385,11 +77,11 @@ def create_test_fits(input_workspaces,
     return fits
 
 
-def create_test_fits_with_logs(input_workspaces,
-                               function_name,
-                               parameters,
-                               logs,
-                               global_parameters=None):
+def create_test_model(input_workspaces,
+                      function_name,
+                      parameters,
+                      logs=None,
+                      global_parameters=None):
     """
     Create a list of fits with time series logs on the workspaces
     :param input_workspaces: See create_test_fits
@@ -401,6 +93,7 @@ def create_test_fits_with_logs(input_workspaces,
     """
     fits = create_test_fits(input_workspaces, function_name, parameters,
                             global_parameters)
+    logs = logs if logs is not None else []
     for fit, workspace_name in zip(fits, input_workspaces):
         test_ws = create_test_workspace(workspace_name)
         run = test_ws.run()
@@ -413,7 +106,294 @@ def create_test_fits_with_logs(input_workspaces,
 
         fit.input_workspace = workspace_name
 
-    return fits
+    fitting_context = FittingContext()
+    for fit in fits:
+        fitting_context.add_fit(fit)
+    return fitting_context, ResultsTabModel(fitting_context)
+
+
+class ResultsTabModelTest(unittest.TestCase):
+    def setUp(self):
+        self.f0_height = (2309.2, 16)
+        self.f0_centre = (2.1, 0.002)
+        self.f0_sigma = (1.1, 0.001)
+        self.f1_height = (2315.2, 14)
+        self.f1_centre = (2.5, 0.004)
+        self.f1_sigma = (0.9, 0.002)
+        self.cost_function = (30.8, 0)
+        self.parameters = OrderedDict([('f0.Height', self.f0_height),
+                                       ('f0.PeakCentre', self.f0_centre),
+                                       ('f0.Sigma', self.f0_sigma),
+                                       ('f1.Height', self.f1_height),
+                                       ('f1.PeakCentre', self.f1_centre),
+                                       ('f1.Sigma', self.f1_sigma),
+                                       ('Cost function value',
+                                        self.cost_function)])
+
+        self.logs = ['sample_temp', 'sample_magn_field']
+
+    def tearDown(self):
+        AnalysisDataService.Instance().clear()
+
+    # ------------------------- success tests ----------------------------
+    def test_default_model_has_results_table_name(self):
+        model = ResultsTabModel(FittingContext())
+        self.assertEqual(model.results_table_name(), DEFAULT_TABLE_NAME)
+
+    def test_updating_model_results_table_name(self):
+        table_name = 'table_name'
+        model = ResultsTabModel(FittingContext())
+        model.set_results_table_name(table_name)
+
+        self.assertEqual(model.results_table_name(), table_name)
+
+    def test_default_model_has_no_selected_function_without_fits(self):
+        model = ResultsTabModel(FittingContext())
+
+        self.assertTrue(model.selected_fit_function() is None)
+
+    def test_updating_model_selected_fit_function(self):
+        model = ResultsTabModel(FittingContext())
+        new_selection = 'func2'
+        model.set_selected_fit_function(new_selection)
+
+        self.assertEqual(model.selected_fit_function(), new_selection)
+
+    def test_log_names_from_workspace_with_logs(self):
+        fake_ws = create_test_workspace()
+        run = fake_ws.run()
+        # populate with log data
+        time_series_names = ('ts_1', 'ts_2')
+        for name in time_series_names:
+            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
+        single_value_log_names = ('sv_1', 'sv_2')
+        for name in itertools.chain(single_value_log_names,
+                                    ALLOWED_NON_TIME_SERIES_LOGS):
+            run.addProperty(name,
+                            StringPropertyWithValue(name, 'test'),
+                            replace=True)
+        # verify
+        allowed_logs = log_names(fake_ws.name())
+        for name in itertools.chain(time_series_names,
+                                    ALLOWED_NON_TIME_SERIES_LOGS):
+            self.assertTrue(
+                name in allowed_logs,
+                msg="{} not found in allowed log list".format(name))
+        for name in single_value_log_names:
+            self.assertFalse(name in allowed_logs,
+                             msg="{} found in allowed log list".format(name))
+
+    def test_log_names_from_workspace_without_logs(self):
+        fake_ws = create_test_workspace()
+        allowed_logs = log_names(fake_ws.name())
+        self.assertEqual(0, len(allowed_logs))
+
+    def test_log_names_from_workspacegroup_uses_first_workspace(self):
+        def add_log(workspace, name):
+            run = workspace.run()
+            run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
+
+        fake_group = create_test_workspacegroup(size=2)
+        logs = ['log_1', 'log_2']
+        for index, name in enumerate(logs):
+            add_log(fake_group[index], name)
+
+        visible_logs = log_names(fake_group.name())
+        self.assertTrue(logs[0] in visible_logs,
+                        msg="{} not found in log list".format(logs[0]))
+        self.assertFalse(logs[1] in visible_logs,
+                         msg="{} not found in log list".format(logs[1]))
+
+    def test_model_returns_fit_functions_from_context(self):
+        _, model = create_test_model(('ws1', ), 'func1', self.parameters,
+                                     self.logs)
+
+        self.assertEqual(['func1'], model.fit_functions())
+
+    def test_model_returns_no_fit_selection_if_no_fits_present(self):
+        model = ResultsTabModel(FittingContext())
+        self.assertEqual(0, len(model.fit_selection({})))
+
+    def test_model_creates_fit_selection_given_no_existing_state(self):
+        _, model = create_test_model(('ws1', 'ws2'), 'func1', self.parameters,
+                                     self.logs)
+
+        expected_list_state = {'ws1': [0, True, True], 'ws2': [1, True, True]}
+        self.assertDictEqual(expected_list_state, model.fit_selection({}))
+
+    def test_model_creates_fit_selection_given_existing_state(self):
+        _, model = create_test_model(('ws1', 'ws2'), 'func1', self.parameters,
+                                     self.logs)
+
+        orig_list_state = {'ws1': [0, False, True]}
+        expected_list_state = {'ws1': [0, False, True], 'ws2': [1, True, True]}
+        self.assertEqual(expected_list_state,
+                         model.fit_selection(orig_list_state))
+
+    def test_model_returns_no_log_selection_if_no_fits_present(self):
+        model = ResultsTabModel(FittingContext())
+        self.assertEqual(0, len(model.log_selection({})))
+
+    def test_model_returns_log_selection_of_first_workspace(self):
+        _, model = create_test_model(('ws1', 'ws2'), 'func1', self.parameters)
+        with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
+            ws1_logs = ('run_number', 'run_start')
+            ws2_logs = ('temp', 'magnetic_field')
+
+            def side_effect(name):
+                return ws1_logs if name == 'ws1' else ws2_logs
+
+            mock_log_names.side_effect = side_effect
+            expected_selection = {
+                'run_number': [0, False, True],
+                'run_start': [1, False, True],
+            }
+
+            self.assertEqual(expected_selection, model.log_selection({}))
+
+    def test_model_combines_existing_log_selection(self):
+        _, model = create_test_model(('ws1', ), 'func1', self.parameters)
+        with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
+            mock_log_names.return_value = [
+                'run_number', 'run_start', 'magnetic_field'
+            ]
+
+            existing_selection = {
+                'run_number': [0, False, True],
+                'run_start': [1, True, True],
+            }
+            expected_selection = deepcopy(existing_selection)
+            expected_selection.update({
+                'run_number': [0, False, True],
+                'run_start': [1, True, True],
+                'magnetic_field': [2, False, True],
+            })
+
+            self.assertDictEqual(expected_selection,
+                                 model.log_selection(existing_selection))
+
+    def test_create_results_table_with_no_logs_or_global_parameters(self):
+        _, model = create_test_model(('ws1', ), 'func1', self.parameters)
+        logs = []
+        selected_results = [('ws1', 0)]
+        table = model.create_results_table(logs, selected_results)
+
+        expected_cols = [
+            'workspace_name', 'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
+            'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError', 'f1.Height',
+            'f1.HeightError', 'f1.PeakCentre', 'f1.PeakCentreError',
+            'f1.Sigma', 'f1.SigmaError', 'Cost function value'
+        ]
+        expected_content = [
+            ('ws1_Parameters', self.f0_height[0], self.f0_height[1],
+             self.f0_centre[0], self.f0_centre[1], self.f0_sigma[0],
+             self.f0_sigma[1], self.f1_height[0], self.f1_height[1],
+             self.f1_centre[0], self.f1_centre[1], self.f1_sigma[0],
+             self.f1_sigma[1], self.cost_function[0])
+        ]
+        self._assert_table_matches_expected(expected_cols, expected_content,
+                                            table, model.results_table_name())
+
+    def test_create_results_table_with_logs_selected(self):
+        _, model = create_test_model(('ws1', ), 'func1', self.parameters,
+                                     self.logs)
+        selected_results = [('ws1', 0)]
+        table = model.create_results_table(self.logs, selected_results)
+
+        expected_cols = ['workspace_name'] + self.logs + [
+            'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
+            'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError', 'f1.Height',
+            'f1.HeightError', 'f1.PeakCentre', 'f1.PeakCentreError',
+            'f1.Sigma', 'f1.SigmaError', 'Cost function value'
+        ]
+        avg_log_values = 0.5, 1.5
+        expected_content = [
+            ('ws1_Parameters', avg_log_values[0], avg_log_values[1],
+             self.f0_height[0], self.f0_height[1], self.f0_centre[0],
+             self.f0_centre[1], self.f0_sigma[0], self.f0_sigma[1],
+             self.f1_height[0], self.f1_height[1], self.f1_centre[0],
+             self.f1_centre[1], self.f1_sigma[0], self.f1_sigma[1],
+             self.cost_function[0])
+        ]
+        self._assert_table_matches_expected(expected_cols, expected_content,
+                                            table, model.results_table_name())
+
+    def test_create_results_table_with_fit_with_global_parameters(self):
+        logs = []
+        global_parameters = ['Height']
+        _, model = create_test_model(('simul-1', ), 'func1', self.parameters,
+                                     logs, global_parameters)
+        selected_results = [('simul-1', 0)]
+        table = model.create_results_table(logs, selected_results)
+
+        expected_cols = [
+            'workspace_name', 'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
+            'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError', 'f1.PeakCentre',
+            'f1.PeakCentreError', 'f1.Sigma', 'f1.SigmaError',
+            'Cost function value'
+        ]
+        expected_content = [
+            ('simul-1_Parameters', self.f0_height[0], self.f0_height[1],
+             self.f0_centre[0], self.f0_centre[1], self.f0_sigma[0],
+             self.f0_sigma[1], self.f1_centre[0], self.f1_centre[1],
+             self.f1_sigma[0], self.f1_sigma[1], self.cost_function[0])
+        ]
+        self._assert_table_matches_expected(expected_cols, expected_content,
+                                            table, model.results_table_name())
+
+    # ------------------------- failure tests ----------------------------
+    def test_log_names_from_workspace_not_in_ADS_raises_exception(self):
+        self.assertRaises(KeyError, log_names, 'not a workspace in ADS')
+
+    def test_create_results_table_raises_error_if_number_params_different(
+            self):
+        parameters = OrderedDict([('Height', (100, 0.1)),
+                                  ('Cost function value', (1.5, 0))])
+        fits_func1 = create_test_fits(('ws1', ), 'func1', parameters)
+
+        parameters = OrderedDict([('Height', (100, 0.1)), ('A0', (1, 0.001)),
+                                  ('Cost function value', (1.5, 0))])
+        fits_func2 = create_test_fits(('ws2', ), 'func2', parameters)
+        model = ResultsTabModel(FittingContext(fits_func1 + fits_func2))
+
+        selected_results = [('ws1', 0), ('ws2', 1)]
+        self.assertRaises(RuntimeError, model.create_results_table, [],
+                          selected_results)
+
+    def test_create_results_table_with_mixed_global_non_global_raises_error(
+            self):
+        parameters = OrderedDict([('f0.Height', (100, 0.1)),
+                                  ('f1.Height', (90, 0.001)),
+                                  ('Cost function value', (1.5, 0))])
+        fits_func1= create_test_fits(('ws1', ), 'func1', parameters)
+        fits_globals = create_test_fits(('ws2', ), 'func1', parameters,
+                                        global_parameters=['Height'])
+        model = ResultsTabModel(FittingContext(fits_func1 + fits_globals))
+
+        selected_results = [('ws1', 0), ('ws2', 1)]
+        self.assertRaises(RuntimeError, model.create_results_table, [],
+                          selected_results)
+
+    # ---------------------- Private helper functions -------------------------
+
+    def _assert_table_matches_expected(self, expected_cols, expected_content,
+                                       table, table_name):
+        self.assertTrue(isinstance(table, ITableWorkspace))
+        self.assertTrue(table_name in AnalysisDataService.Instance())
+        self.assertEqual(len(expected_cols), table.columnCount())
+        self.assertEqual(len(expected_content), table.rowCount())
+        self.assertEqual(expected_cols, table.getColumnNames())
+
+        for row_index, (expected_row,
+                        actual_row) in enumerate(zip(expected_content, table)):
+            self.assertEqual(len(expected_row), len(actual_row))
+            for col_index, expected in enumerate(expected_row):
+                actual = table.cell(row_index, col_index)
+                if isinstance(expected, string_types):
+                    self.assertEqual(expected, actual)
+                else:
+                    # Fit pushes things back/forth through strings so exact match is not possible
+                    self.assertAlmostEqual(expected, actual, places=3)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -43,25 +43,25 @@ class ResultsTabModelTest(unittest.TestCase):
         AnalysisDataService.Instance().clear()
 
     # ------------------------- success tests ----------------------------
-    def test_default_model_has_results_table_name(self):
+    def xtest_default_model_has_results_table_name(self):
         self.assertEqual(self.model.results_table_name(), DEFAULT_TABLE_NAME)
 
-    def test_updating_model_results_table_name(self):
+    def xtest_updating_model_results_table_name(self):
         table_name = 'table_name'
         self.model.set_results_table_name(table_name)
         self.assertEqual(self.model.results_table_name(), table_name)
 
-    def test_default_model_has_no_selected_function_without_fits(self):
+    def xtest_default_model_has_no_selected_function_without_fits(self):
         model = ResultsTabModel(FittingContext())
 
         self.assertTrue(model.selected_fit_function() is None)
 
-    def test_updating_model_selected_fit_function(self):
+    def xtest_updating_model_selected_fit_function(self):
         new_selection = 'func2'
         self.model.set_selected_fit_function(new_selection)
         self.assertEqual(self.model.selected_fit_function(), new_selection)
 
-    def test_log_names_from_workspace_with_logs(self):
+    def xtest_log_names_from_workspace_with_logs(self):
         fake_ws = create_test_workspace()
         run = fake_ws.run()
         # populate with log data
@@ -71,9 +71,8 @@ class ResultsTabModelTest(unittest.TestCase):
         single_value_log_names = ('sv_1', 'sv_2')
         for name in itertools.chain(single_value_log_names,
                                     ALLOWED_NON_TIME_SERIES_LOGS):
-            run.addProperty(name,
-                            StringPropertyWithValue(name, 'test'),
-                            replace=True)
+            run.addProperty(
+                name, StringPropertyWithValue(name, 'test'), replace=True)
         # verify
         allowed_logs = log_names(fake_ws.name())
         for name in itertools.chain(time_series_names,
@@ -82,15 +81,16 @@ class ResultsTabModelTest(unittest.TestCase):
                 name in allowed_logs,
                 msg="{} not found in allowed log list".format(name))
         for name in single_value_log_names:
-            self.assertFalse(name in allowed_logs,
-                             msg="{} found in allowed log list".format(name))
+            self.assertFalse(
+                name in allowed_logs,
+                msg="{} found in allowed log list".format(name))
 
-    def test_log_names_from_workspace_without_logs(self):
+    def xtest_log_names_from_workspace_without_logs(self):
         fake_ws = create_test_workspace()
         allowed_logs = log_names(fake_ws.name())
         self.assertEqual(0, len(allowed_logs))
 
-    def test_log_names_from_workspacegroup_uses_first_workspace(self):
+    def xtest_log_names_from_workspacegroup_uses_first_workspace(self):
         def add_log(workspace, name):
             run = workspace.run()
             run.addProperty(name, FloatTimeSeriesProperty(name), replace=True)
@@ -101,24 +101,26 @@ class ResultsTabModelTest(unittest.TestCase):
             add_log(fake_group[index], name)
 
         visible_logs = log_names(fake_group.name())
-        self.assertTrue(logs[0] in visible_logs,
-                        msg="{} not found in log list".format(logs[0]))
-        self.assertFalse(logs[1] in visible_logs,
-                         msg="{} not found in log list".format(logs[1]))
+        self.assertTrue(
+            logs[0] in visible_logs,
+            msg="{} not found in log list".format(logs[0]))
+        self.assertFalse(
+            logs[1] in visible_logs,
+            msg="{} not found in log list".format(logs[1]))
 
-    def test_model_returns_fit_functions_from_context(self):
+    def xtest_model_returns_fit_functions_from_context(self):
         self.assertEqual(['func1'], self.model.fit_functions())
 
-    def test_model_returns_no_fit_selection_if_no_fits_present(self):
+    def xtest_model_returns_no_fit_selection_if_no_fits_present(self):
         model = ResultsTabModel(FittingContext())
         self.assertEqual(0, len(model.fit_selection({})))
 
-    def test_model_creates_fit_selection_given_zero_existing_state(self):
+    def xtest_model_creates_fit_selection_given_zero_existing_state(self):
         expected_list_state = {'ws1': [0, True, True]}
 
         self.assertEqual(expected_list_state, self.model.fit_selection({}))
 
-    def test_model_creates_fit_selection_given_existing_state(self):
+    def xtest_model_creates_fit_selection_given_existing_state(self):
         more_fits = create_test_fits_with_logs(('ws2', ), 'func1',
                                                self.parameters, self.logs)
         for fit in more_fits:
@@ -129,11 +131,11 @@ class ResultsTabModelTest(unittest.TestCase):
         self.assertEqual(expected_list_state,
                          self.model.fit_selection(orig_list_state))
 
-    def test_model_returns_no_log_selection_if_not_fits_present(self):
+    def xtest_model_returns_no_log_selection_if_not_fits_present(self):
         self.fitting_context.fit_list = []
         self.assertEqual(0, len(self.model.log_selection({})))
 
-    def test_model_returns_log_selection_of_first_workspace(self):
+    def xtest_model_returns_log_selection_of_first_workspace(self):
         self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
             ('ws1', 'ws2'))[0]
         with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
@@ -151,7 +153,7 @@ class ResultsTabModelTest(unittest.TestCase):
 
             self.assertEqual(expected_selection, self.model.log_selection({}))
 
-    def test_model_combines_existing_selection(self):
+    def xtest_model_combines_existing_selection(self):
         self.fitting_context.fit_list = create_test_fits_with_only_workspace_names(
             ('ws1', ))[0]
         with mock.patch(LOG_NAMES_FUNC) as mock_log_names:
@@ -170,7 +172,7 @@ class ResultsTabModelTest(unittest.TestCase):
             self.assertDictEqual(expected_selection,
                                  self.model.log_selection(existing_selection))
 
-    def test_create_results_table_with_no_logs(self):
+    def xtest_create_results_table_with_no_logs(self):
         parameters = {
             'Name': ['Height', 'PeakCentre', 'Sigma', 'Cost function value'],
             'Value': [2309.2, 2.1, 0.04, 30.8],
@@ -192,63 +194,67 @@ class ResultsTabModelTest(unittest.TestCase):
         self.assertEqual('ws1_Parameters', table.cell(0, 0))
         for index, (expected_val, expected_err) in enumerate(
                 zip(parameters['Value'], parameters['Error'])):
-            self.assertAlmostEqual(expected_val,
-                                   table.cell(0, 2 * index + 1),
-                                   places=2)
+            self.assertAlmostEqual(
+                expected_val, table.cell(0, 2 * index + 1), places=2)
             if 2 * index + 2 < table.columnCount():
-                self.assertAlmostEqual(expected_err,
-                                       table.cell(0, 2 * index + 2),
-                                       places=2)
+                self.assertAlmostEqual(
+                    expected_err, table.cell(0, 2 * index + 2), places=2)
 
         self.assertTrue(
             self.model.results_table_name() in AnalysisDataService.Instance())
 
-    def test_create_results_table_with_logs_selected(self):
+    def xtest_create_results_table_with_logs_selected(self):
         selected_results = [('ws1', 0)]
         logs = self.logs
         table = self.model.create_results_table(logs, selected_results)
-
-        self.assertTrue(isinstance(table, ITableWorkspace))
-        self.assertEqual(10, table.columnCount())
-        self.assertEqual(1, table.rowCount())
 
         expected_cols = ['workspace_name'] + logs + [
             'Height', 'HeightError', 'PeakCentre', 'PeakCentreError', 'Sigma',
             'SigmaError', 'Cost function value'
         ]
-        self.assertEqual(expected_cols, table.getColumnNames())
+        expected_row_count = 1
+        workspace_name = 'ws1_Parameters'
+        self._assert_table_matches_expected(table, expected_row_count,
+                                            expected_cols, workspace_name,
+                                            logs, self.parameters)
 
-        # first value is workspace name
-        self.assertEqual('ws1_Parameters', table.cell(0, 0))
+    def test_create_results_table_with_fit_with_global_parameters(self):
+        logs = []
+        parameters = {
+            'Name': [
+                'f0.Height', 'f0.PeakCentre', 'f0.Sigma', 'f1.Height',
+                'f1.PeakCentre', 'f1.Sigma', 'Cost function value'
+            ],
+            'Value': [2309.2, 2.1, 0.04, 2309.2, 2.5, 0.02, 30.8],
+            'Error': [16, 0.002, 0.003, 0, 0.004, 0.006, 0]
+        }
+        global_parameters = None
+        fits = create_test_fits_with_logs(('simul-1',), 'func1', parameters,
+                                          logs, global_parameters)
+        fitting_context = FittingContext()
+        for fit in fits:
+            fitting_context.add_fit(fit)
+        model = ResultsTabModel(fitting_context)
 
-        # first check log columns
-        nlogs = len(logs)
-        for index, _ in enumerate(logs):
-            expected_val = 0.5 * (float(index) + float(index + 1))
-            self.assertAlmostEqual(expected_val,
-                                   table.cell(0, index + 1),
-                                   places=2)
-        checked_columns = 1 + nlogs
-        parameters = self.parameters
-        for index, (expected_val, expected_err) in enumerate(
-                zip(parameters['Value'], parameters['Error'])):
-            self.assertAlmostEqual(expected_val,
-                                   table.cell(0, 2 * index + checked_columns),
-                                   places=2)
-            err_col_idx = 2 * index + checked_columns + 1
-            if err_col_idx < table.columnCount():
-                self.assertAlmostEqual(expected_err,
-                                       table.cell(0, err_col_idx),
-                                       places=2)
-
-        self.assertTrue(
-            self.model.results_table_name() in AnalysisDataService.Instance())
+        selected_results = [('simul-1', 0)]
+        table = model.create_results_table(logs, selected_results)
+        expected_row_count = 1
+        expected_cols = [
+            'workspace_name', 'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
+            'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError',
+            'f1.PeakCentre', 'f1.PeakCentreError', 'f1.Sigma', 'f1.SigmaError',
+            'Cost function value'
+        ]
+        workspace_name = 'simul-1_Parameters'
+        self._assert_table_matches_expected(table, expected_row_count,
+                                            expected_cols, workspace_name,
+                                            logs, parameters)
 
     # ------------------------- failure tests ----------------------------
-    def test_log_names_from_workspace_not_in_ADS_raises_exception(self):
+    def xtest_log_names_from_workspace_not_in_ADS_raises_exception(self):
         self.assertRaises(KeyError, log_names, 'not a workspace in ADS')
 
-    def test_create_results_table_raises_error_if_number_params_different(
+    def xtest_create_results_table_raises_error_if_number_params_different(
             self):
         parameters = {
             'Name': ['Height', 'Cost function value'],
@@ -273,9 +279,41 @@ class ResultsTabModelTest(unittest.TestCase):
         self.model = ResultsTabModel(self.fitting_context)
 
         selected_results = [('ws1', 0), ('ws2', 1)]
-        self.assertRaises(
-            RuntimeError,
-            self.model.create_results_table, [], selected_results)
+        self.assertRaises(RuntimeError, self.model.create_results_table, [],
+                          selected_results)
+
+    def xtest_create_results_table_with_mixed_global_non_global_raises_error(
+            self):
+        self.fail("Implement test!")
+
+    def _assert_table_matches_expected(self, table, expected_row_count,
+                                       expected_cols, workspace_name, logs,
+                                       parameters):
+        self.assertTrue(isinstance(table, ITableWorkspace))
+        self.assertEqual(len(expected_cols), table.columnCount())
+        self.assertEqual(expected_row_count, table.rowCount())
+        self.assertEqual(expected_cols, table.getColumnNames())
+        # first value is workspace name
+        self.assertEqual(workspace_name, table.cell(0, 0))
+        # first check log columns
+        nlogs = len(logs)
+        for index, _ in enumerate(logs):
+            expected_val = 0.5 * (float(index) + float(index + 1))
+            self.assertAlmostEqual(
+                expected_val, table.cell(0, index + 1), places=2)
+        checked_columns = 1 + nlogs
+        for index, (expected_val, expected_err) in enumerate(
+                zip(parameters['Value'], parameters['Error'])):
+            self.assertAlmostEqual(
+                expected_val,
+                table.cell(0, 2 * index + checked_columns),
+                places=2)
+            err_col_idx = 2 * index + checked_columns + 1
+            if err_col_idx < table.columnCount():
+                self.assertAlmostEqual(
+                    expected_err, table.cell(0, err_col_idx), places=2)
+        self.assertTrue(
+            self.model.results_table_name() in AnalysisDataService.Instance())
 
 
 def create_test_workspace(ws_name=None):
@@ -313,8 +351,8 @@ def create_test_fits_with_only_workspace_names(input_workspaces,
     if checked_states is None:
         checked_states = (True for _ in input_workspaces)
     enabled = True
-    for index, (name,
-                checked) in enumerate(zip(input_workspaces, checked_states)):
+    for index, (name, checked) in enumerate(
+            zip(input_workspaces, checked_states)):
         fit_info = mock.MagicMock()
         fit_info.input_workspace = name
         fits.append(fit_info)
@@ -323,12 +361,16 @@ def create_test_fits_with_only_workspace_names(input_workspaces,
     return fits, list_state
 
 
-def create_test_fits(input_workspaces, function_name, parameters):
+def create_test_fits(input_workspaces,
+                     function_name,
+                     parameters,
+                     global_parameters=None):
     """
     Create a list of fits
     :param input_workspaces: The input workspaces
     :param function_name: The name of the function
     :param parameters: The parameters list
+    :param global_parameters: An optional list of tied parameters
     :return: A list of Fits
     """
     fits = []
@@ -336,22 +378,29 @@ def create_test_fits(input_workspaces, function_name, parameters):
         parameter_workspace = mock.NonCallableMagicMock()
         parameter_workspace.workspace.toDict.return_value = parameters
         parameter_workspace.workspace_name = name + '_Parameters'
-        fits.append(FitInformation(parameter_workspace, function_name, name))
+        fits.append(
+            FitInformation(parameter_workspace, function_name, name,
+                           global_parameters))
 
     return fits
 
 
-def create_test_fits_with_logs(input_workspaces, function_name, parameters,
-                               logs):
+def create_test_fits_with_logs(input_workspaces,
+                               function_name,
+                               parameters,
+                               logs,
+                               global_parameters=None):
     """
     Create a list of fits with time series logs on the workspaces
     :param input_workspaces: See create_test_fits
     :param function_name: See create_test_fits
     :param parameters: See create_test_fits
     :param logs: A list of log names to create
+    :param global_parameters: An optional list of tied parameters
     :return: A list of Fits with workspaces/logs attached
     """
-    fits = create_test_fits(input_workspaces, function_name, parameters)
+    fits = create_test_fits(input_workspaces, function_name, parameters,
+                            global_parameters)
     for fit, workspace_name in zip(fits, input_workspaces):
         test_ws = create_test_workspace(workspace_name)
         run = test_ws.run()

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -327,7 +327,7 @@ class ResultsTabModelTest(unittest.TestCase):
         table = model.create_results_table(logs, selected_results)
 
         expected_cols = [
-            'workspace_name', 'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
+            'workspace_name', 'Height', 'HeightError', 'f0.PeakCentre',
             'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError', 'f1.PeakCentre',
             'f1.PeakCentreError', 'f1.Sigma', 'f1.SigmaError',
             'Cost function value'


### PR DESCRIPTION
**Description of work.**

Updates the fit context and results model in the new Muon analysis GUI to only display a single parameter for those that are tied globally. The tests have been significantly revamped in an aid to make them simpler to follow.

**To test:**

Try out the Muon [acceptance tests](http://developer.mantidproject.org/Testing/MuonInterface/MuonTesting.html#id5) and verify that for global parameters you only see 1 entry in the final results table.

Refs #25825

*This does not require release notes* because **this is a new GUI for this release and is advertised elsewhere.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
