### PR TITLE
GroupWorkspaces allows a Workspace with the same name as the group

### DIFF
--- a/Framework/API/inc/MantidAPI/AnalysisDataService.h
+++ b/Framework/API/inc/MantidAPI/AnalysisDataService.h
@@ -147,7 +147,8 @@ public:
 
 private:
   /// Checks the name is valid, throwing if not
-  void verifyName(const std::string &name);
+  void verifyName(const std::string &name,
+                  const boost::shared_ptr<API::WorkspaceGroup> &workspace);
 
   friend struct Mantid::Kernel::CreateUsingNew<AnalysisDataServiceImpl>;
   /// Constructor

--- a/Framework/API/inc/MantidAPI/WorkspaceGroup.h
+++ b/Framework/API/inc/MantidAPI/WorkspaceGroup.h
@@ -109,6 +109,8 @@ public:
   void remove(const std::string &wsName) {
     AnalysisDataService::Instance().removeFromGroup(this->getName(), wsName);
   }
+  /// Does a workspace exist within the group or any groups within this group
+  bool containsInChildren(const std::string &wsName) const;
   /// Does a workspace exist within the group
   bool contains(const std::string &wsName) const;
   /// Does a workspace exist within the group

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -152,8 +152,8 @@ void AnalysisDataServiceImpl::rename(const std::string &oldName,
   auto oldWorkspace = retrieve(oldName);
   auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(oldWorkspace);
   if (group && group->contains(newName)) {
-    throw std::runtime_error(
-        "Unable to rename group as the new name matches its member's");
+    throw std::invalid_argument(
+        "Unable to rename group as the new name matches its members");
   }
 
   Kernel::DataService<API::Workspace>::rename(oldName, newName);
@@ -391,8 +391,8 @@ void AnalysisDataServiceImpl::verifyName(
   }
 
   if (group && group->contains(name)) {
-    throw std::runtime_error(
-        "Unable to add group as name matches its member's");
+    throw std::invalid_argument(
+        "Unable to add group as name matches its members");
   }
 }
 

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -376,8 +376,12 @@ void AnalysisDataServiceImpl::setIllegalCharacterList(
 /**
  * Checks the name is valid
  * @param name A string containing the name to check. If the name is invalid a
- * std::invalid_argument is thrown
+ * std::invalid_argument or std::runtime_error is thrown
+ * @param group A WorkspaceGroup shared ptr which will be evaluated if it is
+ * valid then it will check it's container for the same name that is passed if
+ * true throws std::runtime_error else nothing.
  */
+
 void AnalysisDataServiceImpl::verifyName(
     const std::string &name,
     const boost::shared_ptr<API::WorkspaceGroup> &group) {

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -151,7 +151,7 @@ void AnalysisDataServiceImpl::rename(const std::string &oldName,
 
   auto oldWorkspace = retrieve(oldName);
   auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(oldWorkspace);
-  if (group && group->contains(newName)) {
+  if (group && group->containsInChildren(newName)) {
     throw std::invalid_argument(
         "Unable to rename group as the new name matches its members");
   }
@@ -390,7 +390,7 @@ void AnalysisDataServiceImpl::verifyName(
     throw std::invalid_argument(error);
   }
 
-  if (group && group->contains(name)) {
+  if (group && group->containsInChildren(name)) {
     throw std::invalid_argument(
         "Unable to add group as name matches its members");
   }

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -113,12 +113,7 @@ void WorkspaceGroup::sortMembersByName() {
  * workspace already exists give a warning.
  */
 void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
-  if (this->getName() != "" && workspace->getName() == this->getName()) {
-    throw std::runtime_error(
-        "A workspace cannot have the same name as it's group");
-  }
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
-  // check it's not there already
   const auto it =
       std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
   if (it == m_workspaces.end()) {

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -113,9 +113,13 @@ void WorkspaceGroup::sortMembersByName() {
  * workspace already exists give a warning.
  */
 void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
+  if (this->getName() != "" && workspace->getName() == this->getName()) {
+    throw std::runtime_error(
+        "A workspace cannot have the same name as it's group");
+  }
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   // check it's not there already
-  auto it = std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
+  const auto it = std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
   if (it == m_workspaces.end()) {
     m_workspaces.push_back(workspace);
   } else {

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -119,7 +119,8 @@ void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
   }
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
   // check it's not there already
-  const auto it = std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
+  const auto it =
+      std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
   if (it == m_workspaces.end()) {
     m_workspaces.push_back(workspace);
   } else {

--- a/Framework/API/src/WorkspaceGroup.cpp
+++ b/Framework/API/src/WorkspaceGroup.cpp
@@ -114,6 +114,10 @@ void WorkspaceGroup::sortMembersByName() {
  */
 void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
   std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+  if (this == workspace.get()) {
+    g_log.warning("Can't add a workspace as a child of itself!\n");
+    return;
+  }
   const auto it =
       std::find(m_workspaces.begin(), m_workspaces.end(), workspace);
   if (it == m_workspaces.end()) {
@@ -121,6 +125,28 @@ void WorkspaceGroup::addWorkspace(const Workspace_sptr &workspace) {
   } else {
     g_log.warning() << "Workspace already exists in a WorkspaceGroup\n";
   }
+}
+
+/**
+ * Does this group or any of it's child groups contain the named workspace?
+ * @param wsName :: A string to compare
+ * @returns True if the name is part of this group, false otherwise
+ */
+bool WorkspaceGroup::containsInChildren(const std::string &wsName) const {
+  std::lock_guard<std::recursive_mutex> _lock(m_mutex);
+  for (const auto &workspace : m_workspaces) {
+    if (workspace->isGroup()) {
+      // Recursive containsInChildren search
+      const auto group = boost::dynamic_pointer_cast<WorkspaceGroup>(workspace);
+      if (group->containsInChildren(wsName)) {
+        return true;
+      }
+    } else {
+      if (workspace->getName() == wsName)
+        return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -503,6 +503,27 @@ public:
     TS_ASSERT(!ads.doesExist("null_workspace"));
   }
 
+  void
+  test_throws_when_adding_a_group_which_contains_a_ws_with_the_same_name() {
+    auto ws1 = addToADS("ws1");
+    auto ws2 = addToADS("ws2");
+    WorkspaceGroup_sptr group(new WorkspaceGroup);
+    group->addWorkspace(ws1);
+    group->addWorkspace(ws2);
+
+    TS_ASSERT_THROWS(ads.add("ws1", group), const std::runtime_error &);
+    TS_ASSERT_THROWS(ads.addOrReplace("ws1", group),
+                     const std::runtime_error &);
+  }
+
+  void test_throws_when_adding_to_a_group_a_workspace_with_the_same_name() {
+    auto ws1 = addToADS("ws1");
+    auto ws2 = addToADS("ws2");
+    auto group = addOrReplaceGroupToADS("ws1", 2);
+
+    TS_ASSERT_THROWS(ads.addToGroup("ws1", "ws1"), const std::runtime_error &);
+  }
+
 private:
   /// If replace=true then usea addOrReplace
   void doAddingOnInvalidNameTests(bool replace) {
@@ -552,6 +573,17 @@ private:
       group->addWorkspace(boost::make_shared<MockWorkspace>());
     }
     ads.add(name, group);
+    return group;
+  }
+
+  /// Add a group with N simple workspaces to the ADS
+  WorkspaceGroup_sptr addOrReplaceGroupToADS(const std::string &name,
+                                             const size_t nitems = 2) {
+    auto group(boost::make_shared<WorkspaceGroup>());
+    for (auto i = 0u; i < nitems; ++i) {
+      group->addWorkspace(boost::make_shared<MockWorkspace>());
+    }
+    ads.addOrReplace(name, group);
     return group;
   }
 

--- a/Framework/API/test/AnalysisDataServiceTest.h
+++ b/Framework/API/test/AnalysisDataServiceTest.h
@@ -511,9 +511,9 @@ public:
     group->addWorkspace(ws1);
     group->addWorkspace(ws2);
 
-    TS_ASSERT_THROWS(ads.add("ws1", group), const std::runtime_error &);
+    TS_ASSERT_THROWS(ads.add("ws1", group), const std::invalid_argument &);
     TS_ASSERT_THROWS(ads.addOrReplace("ws1", group),
-                     const std::runtime_error &);
+                     const std::invalid_argument &);
   }
 
   void test_throws_when_adding_to_a_group_a_workspace_with_the_same_name() {

--- a/Framework/API/test/WorkspaceGroupTest.h
+++ b/Framework/API/test/WorkspaceGroupTest.h
@@ -440,6 +440,49 @@ public:
     TS_ASSERT(wsCastNonConst != nullptr);
     TS_ASSERT_EQUALS(wsCastConst, wsCastNonConst);
   }
+
+  void test_unableToAddAGroupToItself() {
+    WorkspaceGroup_sptr group(new WorkspaceGroup());
+    Workspace_sptr wsInput(new WorkspaceTester());
+    group->addWorkspace(wsInput);
+    group->addWorkspace(group);
+    TS_ASSERT(group->contains(wsInput));
+    TS_ASSERT(!group->contains(group));
+  }
+
+  void test_containsInChildrenFindsChildrenWithGivenName1LayerDown() {
+    WorkspaceGroup_sptr group0(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group0", group0);
+    WorkspaceGroup_sptr group1(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group1", group1);
+    Workspace_sptr wsInput(new WorkspaceTester());
+    AnalysisDataService::Instance().addOrReplace("wsInput", wsInput);
+    group1->addWorkspace(wsInput);
+    group0->addWorkspace(group1);
+
+    TS_ASSERT(group0->containsInChildren("wsInput"));
+  }
+
+  void test_containsInChildrenFindsChildrenWithGivenName4LayersDown() {
+    WorkspaceGroup_sptr group0(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group0", group0);
+    WorkspaceGroup_sptr group1(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group1", group1);
+    WorkspaceGroup_sptr group2(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group2", group2);
+    WorkspaceGroup_sptr group3(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group3", group3);
+    WorkspaceGroup_sptr group4(new WorkspaceGroup());
+    AnalysisDataService::Instance().addOrReplace("group4", group4);
+    Workspace_sptr wsInput(new WorkspaceTester());
+    AnalysisDataService::Instance().addOrReplace("wsInput", wsInput);
+    group4->addWorkspace(wsInput);
+    group3->addWorkspace(group4);
+    group2->addWorkspace(group3);
+    group1->addWorkspace(group2);
+    group0->addWorkspace(group1);
+    TS_ASSERT(group0->containsInChildren("wsInput"));
+  }
 };
 
 #endif /* MANTID_API_WORKSPACEGROUPTEST_H_ */

--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -67,6 +67,16 @@ std::map<std::string, std::string> GroupWorkspaces::validateInputs() {
   const std::vector<std::string> inputWorkspaces =
       getProperty("InputWorkspaces");
   std::string globExpression = getProperty("GlobExpression");
+  std::string outputWorkspace = getProperty("OutputWorkspace");
+
+  // Peform a check that inputworkspaces cannot contain a workspace with the
+  // same name as the group/output workspace
+  for (const auto &ws : inputWorkspaces) {
+    if (ws == outputWorkspace) {
+      results["OutputWorkspace"] = "The Output workspace has the same name as "
+                                   "one of the input workspaces";
+    }
+  }
 
   for (auto it = globExpression.begin(); it < globExpression.end(); ++it) {
     if (*it == '\\') {

--- a/Framework/Algorithms/test/GroupWorkspacesTest.h
+++ b/Framework/Algorithms/test/GroupWorkspacesTest.h
@@ -38,9 +38,9 @@ public:
   }
 
   void testInit() {
+    using Mantid::Algorithms::GroupWorkspaces;
     using Mantid::API::WorkspaceGroup;
     using Mantid::API::WorkspaceProperty;
-    using Mantid::Algorithms::GroupWorkspaces;
 
     GroupWorkspaces alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
@@ -388,6 +388,18 @@ public:
         Mantid::API::AnalysisDataService::Instance().doesExist(groupName));
 
     removeFromADS("", inputs);
+  }
+
+  void test_OutputGroup_cannot_contain_workspaces_from_the_ADS() {
+    std::vector<std::string> inputs{"ws1", "ws2"};
+    addTestMatrixWorkspacesToADS(inputs);
+    Mantid::Algorithms::GroupWorkspaces alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", inputs));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws1"));
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
   }
 
 private:

--- a/Framework/Algorithms/test/GroupWorkspacesTest.h
+++ b/Framework/Algorithms/test/GroupWorkspacesTest.h
@@ -38,9 +38,9 @@ public:
   }
 
   void testInit() {
-    using Mantid::Algorithms::GroupWorkspaces;
     using Mantid::API::WorkspaceGroup;
     using Mantid::API::WorkspaceProperty;
+    using Mantid::Algorithms::GroupWorkspaces;
 
     GroupWorkspaces alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());

--- a/Framework/PythonInterface/plugins/algorithms/RefinePowderDiffProfileSeq.py
+++ b/Framework/PythonInterface/plugins/algorithms/RefinePowderDiffProfileSeq.py
@@ -403,7 +403,7 @@ class SeqRefineProfile(object):
 
         # Group newly generated workspaces and add name to reposiotry
         if self._wsgroupCreated is True:
-            api.GroupWorkspaces(InputWorkspaces="%s, %s, %s, %s" % (outwsname, outprofilewsname, outbraggpeakwsname, self._wsgroupName),
+            api.GroupWorkspaces(InputWorkspaces="%s, %s, %s" % (outwsname, outprofilewsname, outbraggpeakwsname),
                                 OutputWorkspace=self._wsgroupName)
         else:
             wsgroup = AnalysisDataService.retrieve(self._wsgroupName)

--- a/Testing/SystemTests/tests/analysis/WishMasking.py
+++ b/Testing/SystemTests/tests/analysis/WishMasking.py
@@ -58,7 +58,7 @@ class WishMasking(systemtesting.MantidSystemTest):
             os.remove(cal_file_full_path)
 
     def requiredMemoryMB(self):
-        return 2000
+        return 16384
 
     def runTest(self):
         Load(Filename='WISH00016748.raw',OutputWorkspace='wish_ws')


### PR DESCRIPTION
**Description of work.**
The original issue shed light on the fact that GroupWorkspaces the algorithm allows the addition of a workspace with the same name as the group. Which lead to an investigation of the ADS in which it was found that this is "perfectly valid". The current ADS structure assumes this isn't the case. It registered two items with the same name in a "map" representation. So the checks have to be added at input time so extra validation was added to the ADS add, addOrReplace and addToGroup functions to remove this.

**To test:**
If tests pass ADS changes can be assumed.
Run this script to test GroupWorkspaces changes:
```python
dataX = [0, 1, 2, 3, 4, 5] * 4
dataY = [10, 20, 30, 20, 10] + \
        [20, 30, 40, 30, 20] + \
        [30, 40, 50, 40, 30] + \
        [40, 50, 60, 50, 40]
print(dataY)
input_workspace = CreateWorkspace(dataX, dataY, NSpec=4)

input_workspace = GroupWorkspaces(input_workspace)
```

<!-- Instructions for testing. -->

Fixes #24100 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
