### PR TITLE
Add run numbers to NXcanSAS and canSAS metadata

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/NXcanSASDefinitions.h
@@ -114,6 +114,15 @@ const std::string sasProcessTermCan = "can_trans_run";
 const std::string sasProcessTermUserFile = "user_file";
 const std::string sasProcessUserFileInLogs = "UserFile";
 
+// SASnote
+const std::string sasNoteClassAttr = "SASnote";
+const std::string nxNoteClassAttr = "NXnote";
+const std::string sasNoteGroupName = "sasnote";
+const std::string sasProcessTermSampleTrans = "sample_trans_run";
+const std::string sasProcessTermSampleDirect = "sample_direct_run";
+const std::string sasProcessTermCanScatter = "can_scatter_run";
+const std::string sasProcessTermCanDirect = "can_direct_run";
+
 // SAStransmission_spectrum
 const std::string sasTransmissionSpectrumClassAttr = "SAStransmission_spectrum";
 const std::string nxTransmissionSpectrumClassAttr = "NXdata";

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -245,7 +245,6 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
     } else {
       g_log.debug() << "Didn't find RunNumber log in workspace. Writing "
                        "<Run></Run> to the CANSAS file\n";
-      can_run = "";
     }
     std::string sasProcCanRun = "\n\t\t\t<term name=\"can_trans_run\">";
     sasProcCanRun += can_run;

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -74,6 +74,11 @@ void SaveCanSAS1D2::init() {
           boost::make_shared<API::WorkspaceUnitValidator>("Wavelength")),
       "The transmission workspace of the Can. Optional. If given, will be "
       "saved at TransmissionSpectrum");
+
+  declareProperty("SampleTransmissionRunNumber", "", "The run number for the sample transmission workspace. Optional.");
+  declareProperty("SampleDirectRunNumber", "", "The run number for the sample direct workspace. Optional.");
+  declareProperty("CanScatterRunNumber", "", "The run number for the can scatter workspace. Optional.");
+  declareProperty("CanDirectRunNumber", "", "The run number for the can direct workspace. Optional.");
 }
 
 /// Overwrites Algorithm method
@@ -212,19 +217,44 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   // outFile<<sasProcuserfile;
   sasProcess += sasProcuserfile;
 
+  if (m_trans_ws) {
+    // Add other run numbers
+    // SampleTransmission
+    const auto sample_trans_run = getPropertyValue("SampleTransmissionRunNumber");
+    sasProcess += "\n\t\t\t<term name=\"sample_trans_run\">";
+    sasProcess += sample_trans_run + "</term>";
+
+    // SampleDirect
+    const auto sample_direct_run = getPropertyValue("SampleDirectRunNumber");
+    sasProcess += "\n\t\t\t<term name=\"sample_direct_run\">";
+    sasProcess += sample_direct_run + "</term>";
+  }
+
   // can run number if available
   if (m_transcan_ws) {
+    std::string can_run;
     if (m_transcan_ws->run().hasProperty("run_number")) {
       Kernel::Property *logP = m_transcan_ws->run().getLogData("run_number");
-      auto can_run = logP->value();
-      std::string sasProcCanRun = "\n\t\t\t<term name=\"can_trans_run\">";
-      sasProcCanRun += can_run;
-      sasProcCanRun += "</term>";
-      sasProcess += sasProcCanRun;
+      can_run = logP->value();
     } else {
       g_log.debug() << "Didn't find RunNumber log in workspace. Writing "
                        "<Run></Run> to the CANSAS file\n";
+      can_run = "";
     }
+    std::string sasProcCanRun = "\n\t\t\t<term name=\"can_trans_run\">";
+    sasProcCanRun += can_run;
+    sasProcCanRun += "</term>";
+    sasProcess += sasProcCanRun;
+
+    // CanScatter
+    const auto can_scatter_run = getPropertyValue("CanScatterRunNumber");
+    sasProcess += "\n\t\t\t<term name=\"can_scatter_run\">";
+    sasProcess += can_scatter_run + "</term>";
+
+    // CanDirect
+    const auto can_direct_run = getPropertyValue("CanDirectRunNumber");
+    sasProcess += "\n\t\t\t<term name=\"can_direct_run\">";
+    sasProcess += can_direct_run + "</term>";
   }
 
   // Reduction process note, if available

--- a/Framework/DataHandling/src/SaveCanSAS1D2.cpp
+++ b/Framework/DataHandling/src/SaveCanSAS1D2.cpp
@@ -75,10 +75,15 @@ void SaveCanSAS1D2::init() {
       "The transmission workspace of the Can. Optional. If given, will be "
       "saved at TransmissionSpectrum");
 
-  declareProperty("SampleTransmissionRunNumber", "", "The run number for the sample transmission workspace. Optional.");
-  declareProperty("SampleDirectRunNumber", "", "The run number for the sample direct workspace. Optional.");
-  declareProperty("CanScatterRunNumber", "", "The run number for the can scatter workspace. Optional.");
-  declareProperty("CanDirectRunNumber", "", "The run number for the can direct workspace. Optional.");
+  declareProperty(
+      "SampleTransmissionRunNumber", "",
+      "The run number for the sample transmission workspace. Optional.");
+  declareProperty("SampleDirectRunNumber", "",
+                  "The run number for the sample direct workspace. Optional.");
+  declareProperty("CanScatterRunNumber", "",
+                  "The run number for the can scatter workspace. Optional.");
+  declareProperty("CanDirectRunNumber", "",
+                  "The run number for the can direct workspace. Optional.");
 }
 
 /// Overwrites Algorithm method
@@ -220,7 +225,8 @@ void SaveCanSAS1D2::createSASProcessElement(std::string &sasProcess) {
   if (m_trans_ws) {
     // Add other run numbers
     // SampleTransmission
-    const auto sample_trans_run = getPropertyValue("SampleTransmissionRunNumber");
+    const auto sample_trans_run =
+        getPropertyValue("SampleTransmissionRunNumber");
     sasProcess += "\n\t\t\t<term name=\"sample_trans_run\">";
     sasProcess += sample_trans_run + "</term>";
 

--- a/Framework/DataHandling/src/SaveNXcanSAS.cpp
+++ b/Framework/DataHandling/src/SaveNXcanSAS.cpp
@@ -809,10 +809,15 @@ void SaveNXcanSAS::init() {
       "The transmission workspace of the Can. Optional. If given, will be "
       "saved at TransmissionSpectrum");
 
-  declareProperty("SampleTransmissionRunNumber", "", "The run number for the sample transmission workspace. Optional.");
-  declareProperty("SampleDirectRunNumber", "", "The run number for the sample direct workspace. Optional.");
-  declareProperty("CanScatterRunNumber", "", "The run number for the can scatter workspace. Optional.");
-  declareProperty("CanDirectRunNumber", "", "The run number for the can direct workspace. Optional.");
+  declareProperty(
+      "SampleTransmissionRunNumber", "",
+      "The run number for the sample transmission workspace. Optional.");
+  declareProperty("SampleDirectRunNumber", "",
+                  "The run number for the sample direct workspace. Optional.");
+  declareProperty("CanScatterRunNumber", "",
+                  "The run number for the can scatter workspace. Optional.");
+  declareProperty("CanDirectRunNumber", "",
+                  "The run number for the can direct workspace. Optional.");
 }
 
 std::map<std::string, std::string> SaveNXcanSAS::validateInputs() {

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -41,6 +41,8 @@ struct NXcanSASTestParameters {
     sampleDirectRun = "";
     canScatterRun = "";
     canDirectRun = "";
+    hasCanRuns = false;
+    hasSampleRuns = false;
   }
 
   std::string filename;
@@ -63,10 +65,12 @@ struct NXcanSASTestParameters {
   bool is2dData;
   std::string idf;
   bool isHistogram;
-  std::string sampleTransmissionRun = "";
-  std::string sampleDirectRun = "";
-  std::string canScatterRun = "";
-  std::string canDirectRun = "";
+  std::string sampleTransmissionRun;
+  std::string sampleDirectRun;
+  std::string canScatterRun;
+  std::string canDirectRun;
+  bool hasCanRuns;
+  bool hasSampleRuns;
 };
 
 struct NXcanSASTestTransmissionParameters {

--- a/Framework/DataHandling/test/NXcanSASTestHelper.h
+++ b/Framework/DataHandling/test/NXcanSASTestHelper.h
@@ -37,6 +37,10 @@ struct NXcanSASTestParameters {
     ymax = 12.0;
     is2dData = false;
     isHistogram = false;
+    sampleTransmissionRun = "";
+    sampleDirectRun = "";
+    canScatterRun = "";
+    canDirectRun = "";
   }
 
   std::string filename;
@@ -59,6 +63,10 @@ struct NXcanSASTestParameters {
   bool is2dData;
   std::string idf;
   bool isHistogram;
+  std::string sampleTransmissionRun = "";
+  std::string sampleDirectRun = "";
+  std::string canScatterRun = "";
+  std::string canDirectRun = "";
 };
 
 struct NXcanSASTestTransmissionParameters {

--- a/Framework/DataHandling/test/SaveCanSAS1dTest2.h
+++ b/Framework/DataHandling/test/SaveCanSAS1dTest2.h
@@ -225,6 +225,35 @@ public:
       Poco::File(m_filename).remove();
   }
 
+  void testCanSetAdditionalRunNumbersAsProperties() {
+    // Initialize alg
+    SaveCanSAS1D2 savealg;
+
+    TS_ASSERT_THROWS_NOTHING(savealg.initialize());
+    TS_ASSERT(savealg.isInitialized());
+    savealg.setPropertyValue("InputWorkspace", m_workspace1);
+    savealg.setPropertyValue("Filename", m_filename);
+    savealg.setPropertyValue("DetectorNames", "HAB");
+
+    // Set the additional run number properties
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set SampleTransmissionRunNumber property",
+        savealg.setProperty("SampleTransmissionRunNumber", "5"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set SampleDirectRunNumber property",
+        savealg.setProperty("SampleDirectRunNumber", "6"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set CanScatterRunNumber property",
+        savealg.setProperty("CanScatterRunNumber", "7"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set CanDirectRunNumber property",
+        savealg.setProperty("CanDirectRunNumber", "8"));
+
+    // Execute
+    TS_ASSERT_THROWS_NOTHING(savealg.execute());
+    TS_ASSERT(savealg.isExecuted());
+  }
+
   void testGroup() {
     // do the save, the results of which we'll test
     SaveCanSAS1D2 savealg;

--- a/Framework/DataHandling/test/SaveNXcanSASTest.h
+++ b/Framework/DataHandling/test/SaveNXcanSASTest.h
@@ -62,18 +62,22 @@ public:
 
   void test_that_can_set_run_numbers_as_string_properties() {
     auto saveAlg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(
-       "SaveNXcanSAS");
+        "SaveNXcanSAS");
     saveAlg->setChild(true);
     saveAlg->initialize();
 
-    TSM_ASSERT_THROWS_NOTHING("Should be able to set SampleTransmissionRunNumber property",
-            saveAlg->setProperty("SampleTransmissionRunNumber", "5"));
-    TSM_ASSERT_THROWS_NOTHING("Should be able to set SampleDirectRunNumber property",
-            saveAlg->setProperty("SampleDirectRunNumber", "6"));
-    TSM_ASSERT_THROWS_NOTHING("Should be able to set CanScatterRunNumber property",
-            saveAlg->setProperty("CanScatterRunNumber", "7"));
-    TSM_ASSERT_THROWS_NOTHING("Should be able to set CanDirectRunNumber property",
-            saveAlg->setProperty("CanDirectRunNumber", "8"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set SampleTransmissionRunNumber property",
+        saveAlg->setProperty("SampleTransmissionRunNumber", "5"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set SampleDirectRunNumber property",
+        saveAlg->setProperty("SampleDirectRunNumber", "6"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set CanScatterRunNumber property",
+        saveAlg->setProperty("CanScatterRunNumber", "7"));
+    TSM_ASSERT_THROWS_NOTHING(
+        "Should be able to set CanDirectRunNumber property",
+        saveAlg->setProperty("CanDirectRunNumber", "8"));
   }
 
   void

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSSave.py
@@ -79,6 +79,17 @@ class SANSSave(DataProcessorAlgorithm):
         self.declareProperty("UseZeroErrorFree", True, direction=Direction.Input,
                              doc="This allows the user to artificially inflate zero error values.")
 
+        self.declareProperty("SampleTransmissionRunNumber", "", direction=Direction.Input,
+                             doc="The run number for the Sample Transmission workspace used in "
+                                 "the reduction. Can be blank.")
+        self.declareProperty("SampleDirectRunNumber", "", direction=Direction.Input,
+                             doc="The run number for the Sample Direct workspace used in "
+                                 "the reduction. Can be blank.")
+        self.declareProperty("CanScatterRunNumber", "", direction=Direction.Input,
+                             doc="The run number for the Can Scatter workspace used in the reduction. Can be blank.")
+        self.declareProperty("CanDirectRunNumber", "", direction=Direction.Input,
+                             doc="The run number for the Can Direct workspace used in the reduction. Can be blank.")
+
     def PyExec(self):
         use_zero_error_free = self.getProperty("UseZeroErrorFree").value
         file_formats = self._get_file_formats()
@@ -97,11 +108,17 @@ class SANSSave(DataProcessorAlgorithm):
         transmission_workspaces = {"Transmission": transmission,
                                    "TransmissionCan": transmission_can}
 
+        additional_run_numbers = {"SampleTransmissionRunNumber": self.getProperty("SampleTransmissionRunNumber").value,
+                                  "SampleDirectRunNumber": self.getProperty("SampleDirectRunNumber").value,
+                                  "CanScatterRunNumber": self.getProperty("CanScatterRunNumber").value,
+                                  "CanDirectRunNumber": self.getProperty("CanDirectRunNumber").value}
+
         progress = Progress(self, start=0.0, end=1.0, nreports=len(file_formats) + 1)
         for file_format in file_formats:
             progress_message = "Saving to {0}.".format(SaveType.to_string(file_format.file_format))
             progress.report(progress_message)
-            save_to_file(workspace, file_format, file_name, transmission_workspaces)
+            progress.report(progress_message)
+            save_to_file(workspace, file_format, file_name, transmission_workspaces, additional_run_numbers)
         progress.report("Finished saving workspace to files.")
 
     def validateInputs(self):

--- a/Testing/SystemTests/tests/analysis/SANSSaveTest.py
+++ b/Testing/SystemTests/tests/analysis/SANSSaveTest.py
@@ -63,6 +63,29 @@ class SANSSaveTest(unittest.TestCase):
         if os.path.exists(file_name):
             os.remove(file_name)
 
+    def test_that_run_number_properties_can_be_set(self):
+        # Arrange
+        workspace = SANSSaveTest._get_sample_workspace(with_zero_errors=False, convert_to_numeric_axis=True)
+        file_name = os.path.join(mantid.config.getString('defaultsave.directory'), 'sample_sans_save_file')
+        save_name = "SANSSave"
+        save_options = {"InputWorkspace": workspace,
+                        "Filename": file_name,
+                        "UseZeroErrorFree": False,
+                        "Nexus": False,
+                        "CanSAS": False,
+                        "NXCanSAS": True,
+                        "NistQxy": False,
+                        "RKH": False,
+                        "CSV": False,
+                        "SampleTransmissionRunNumber": "5",
+                        "SampleDirectRunNumber": "6",
+                        "CanScatterRunNumber": "7",
+                        "CanDirectRunNumber": "8"}
+        try:
+            create_unmanaged_algorithm(save_name, **save_options)
+        except RuntimeError:
+            self.fail("Unable to set properties for SANSSave.")
+
     def test_that_workspace_can_be_saved_without_zero_error_free_option(self):
         # Arrange
         workspace = SANSSaveTest._get_sample_workspace(with_zero_errors=False, convert_to_numeric_axis=True)

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -32,6 +32,7 @@ Improvements
 - File type buttons are disabled when memory mode is selected to make it clearer that SANS will not save to file.
 - The path to the user file used to reduce the data is now added to the workspace sample logs. This user file path is added to canSAS file metadata.
 - The **diagnostic** page icon has been changed from a question mark to a stethoscope, to distinguish it from the **Help** page icon. The **Export Table** button now has an icon. There have been minor icon changes elsewhere on the interface.
+- The run numbers for sample transmission, sample direct, can scatter, and can direct workspaces are now added to NXCanSAS and CanSAS files.
 
 Bug Fixes
 #########

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -55,6 +55,7 @@ def get_save_strategy(file_format_bundle, file_name, save_options, transmission_
         file_name = get_file_name(file_format_bundle, file_name, "", ".xml")
         save_name = "SaveCanSAS1D"
         save_options.update(transmission_workspaces)
+        save_options.update(additional_run_numbers)
     elif file_format is SaveType.NXcanSAS:
         file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".h5")
         save_name = "SaveNXcanSAS"

--- a/scripts/SANS/sans/algorithm_detail/save_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/save_workspace.py
@@ -18,7 +18,7 @@ ZERO_ERROR_DEFAULT = 1e6
 file_format_with_append = namedtuple('file_format_with_append', 'file_format, append_file_format_name')
 
 
-def save_to_file(workspace, file_format, file_name, transmission_workspaces):
+def save_to_file(workspace, file_format, file_name, transmission_workspaces, additional_run_numbers):
     """
     Save a workspace to a file.
 
@@ -27,15 +27,16 @@ def save_to_file(workspace, file_format, file_name, transmission_workspaces):
     :param file_name: the file name.
     :param transmission_workspaces: a dict of additional save algorithm inputs
             e.g. Transmission and TransmissionCan for SaveCanSAS1D-v2
+    :param additional_run_numbers: a dict of workspace type to run number. Used in SaveNXCanSAS only.
     :return:
     """
     save_options = {"InputWorkspace": workspace}
-    save_alg = get_save_strategy(file_format, file_name, save_options, transmission_workspaces)
+    save_alg = get_save_strategy(file_format, file_name, save_options, transmission_workspaces, additional_run_numbers)
     save_alg.setRethrows(True)
     save_alg.execute()
 
 
-def get_save_strategy(file_format_bundle, file_name, save_options, transmission_workspaces):
+def get_save_strategy(file_format_bundle, file_name, save_options, transmission_workspaces, additional_run_numbers):
     """
     Provide a save strategy based on the selected file format
 
@@ -43,6 +44,7 @@ def get_save_strategy(file_format_bundle, file_name, save_options, transmission_
     :param file_name: the name of the file
     :param save_options: the save options such as file name and input workspace
     :param transmission_workspaces: a dict of additional inputs for SaveCanSAS algorithm
+    :param additional_run_numbers: a dict of workspace type to run number
     :return: a handle to a save algorithm
     """
     file_format = file_format_bundle.file_format
@@ -57,6 +59,7 @@ def get_save_strategy(file_format_bundle, file_name, save_options, transmission_
         file_name = get_file_name(file_format_bundle, file_name, "_nxcansas", ".h5")
         save_name = "SaveNXcanSAS"
         save_options.update(transmission_workspaces)
+        save_options.update(additional_run_numbers)
     elif file_format is SaveType.NistQxy:
         file_name = get_file_name(file_format_bundle, file_name, "_nistqxy", ".dat")
         save_name = "SaveNISTDAT"
@@ -106,7 +109,7 @@ def remove_zero_errors_from_workspace(workspace):
     :return: A zero-error free workspace
     """
     # Make sure we are dealing with a MatrixWorkspace
-    if not isinstance(workspace, MatrixWorkspace) or isinstance(workspace,EventWorkspace):
+    if not isinstance(workspace, MatrixWorkspace) or isinstance(workspace, EventWorkspace):
         raise ValueError('Cannot remove zero errors from a workspace which is not a MatrixWorkspace.')
 
     # Uncomment the next line and tests fail for checking error values should not be zero, and


### PR DESCRIPTION
**Description of work.**
This PR adds "additional" run numbers to NXcanSAS and CanSAS files. Can transmission and sample scatter are already added to these files, so this PR adds sample direct, sample transmission, can direct, and can scatter.

**Report to:** Steve King ISIS

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Load the attached user and batch file
3. Select an appropriate output directory in Directories Manager
4. In the settings tab (on the left), change reduction mode (at the top) to **front**
5. Back in the runs tab, select file output mode radio button (at the bottom), and select the NXCanSAS and CanSAS output file types
6. Click process all
7. Using your favourite hdf viewing software, open **aa.h5**
8. Navigate to sasEntry/sasProcess/sasNote. The datasets should match up the run numbers in the sans table, excluding sample scatter and can transmission
9. Open up aa.xml and scroll to the bottom. There should be terms containing the run numbers in the sans table, exluding sample scatter and can transmission

Fixes #22813 

**Data:**
[metadata_pr.zip](https://github.com/mantidproject/mantid/files/3325503/metadata_pr.zip)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
