### PR TITLE
Add SANSSolidAngle

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -271,6 +271,7 @@ set(SRC_FILES
     src/RunCombinationHelpers/RunCombinationHelper.cpp
     src/RunCombinationHelpers/SampleLogsBehaviour.cpp
     src/SANSCollimationLengthEstimator.cpp
+    src/SANSSolidAngle.cpp
     src/SampleCorrections/DetectorGridDefinition.cpp
     src/SampleCorrections/MCAbsorptionStrategy.cpp
     src/SampleCorrections/MCInteractionVolume.cpp
@@ -614,6 +615,7 @@ set(INC_FILES
     inc/MantidAlgorithms/RunCombinationHelpers/RunCombinationHelper.h
     inc/MantidAlgorithms/RunCombinationHelpers/SampleLogsBehaviour.h
     inc/MantidAlgorithms/SANSCollimationLengthEstimator.h
+    inc/MantidAlgorithms/SANSSolidAngle.h
     inc/MantidAlgorithms/SampleCorrections/DetectorGridDefinition.h
     inc/MantidAlgorithms/SampleCorrections/IBeamProfile.h
     inc/MantidAlgorithms/SampleCorrections/MCAbsorptionStrategy.h
@@ -957,6 +959,7 @@ set(TEST_FILES
     RunCombinationHelperTest.h
     SampleLogsBehaviourTest.h
     SANSCollimationLengthEstimatorTest.h
+    SANSSolidAngleTest.h
     SassenaFFTTest.h
     ScaleTest.h
     ScaleXTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
@@ -1,0 +1,82 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#ifndef MANTID_ALGORITHMS_SANSSOLIDANGLE_H_
+#define MANTID_ALGORITHMS_SANSSOLIDANGLE_H_
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
+
+namespace Mantid {
+namespace Algorithms {
+/**
+
+    Performs a solid angle correction on a 2D SANS data set to correct
+    for the absence of curvature of the detector.
+
+    Note: one could use SolidAngle to perform this calculation. Solid Angle
+    returns the solid angle of each detector pixel. The correction is then
+    given by:
+      Omega(theta) = Omega(0) cos^3(theta)
+      where Omega is the solid angle.
+    This approach requires more un-necessary calculations so we simply apply the
+   cos^3(theta).
+
+    Brulet et al, J. Appl. Cryst. (2007) 40, 165-177.
+    See equation 22.
+
+    Required Properties:
+    <UL>
+    <LI> InputWorkspace    - The data in units of wavelength. </LI>
+    <LI> OutputWorkspace   - The workspace in which to store the result
+   histogram. </LI>
+    </UL>
+
+    File change history is stored at: <https://github.com/mantidproject/mantid>
+    Code Documentation is available at: <http://doxygen.mantidproject.org>
+*/
+class DLLExport SANSSolidAngle : public API::Algorithm {
+public:
+  /// Algorithm's name
+  const std::string name() const override { return "SANSSolidAngle"; }
+  /// Summary of algorithms purpose
+  const std::string summary() const override {
+    return "Performs solid angle correction on SANS 2D data.";
+  }
+  /// Algorithm's version
+  int version() const override { return (1); }
+  const std::vector<std::string> seeAlso() const override {
+    return {"SANSBeamFluxCorrection"};
+  }
+  /// Algorithm's category for identification
+  const std::string category() const override {
+    return "Workflow\\SANS\\UsesPropertyManager;"
+           "CorrectionFunctions\\InstrumentCorrections";
+  }
+
+private:
+  /// Initialisation code
+  void init() override;
+  /// Execution code
+  void exec() override;
+  void execEvent();
+
+  double getYTubeAngle(const API::SpectrumInfo &spectrumInfo, size_t index);
+  double calculateSolidAngle(int, const API::SpectrumInfo &,
+                             const Geometry::ComponentInfo &,
+                             const double PixelSizeX, const double PixelSizeY);
+};
+
+} // namespace Algorithms
+} // namespace Mantid
+
+#endif /*MANTID_ALGORITHMS_SANSSOLIDANGLE_H_*/

--- a/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
@@ -68,12 +68,6 @@ private:
   void init() override;
   /// Execution code
   void exec() override;
-  void execEvent();
-
-  double getYTubeAngle(const API::SpectrumInfo &spectrumInfo, size_t index);
-  double calculateSolidAngle(int, const API::SpectrumInfo &,
-                             const Geometry::ComponentInfo &,
-                             const double PixelSizeX, const double PixelSizeY);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SANSSolidAngle.h
@@ -20,19 +20,8 @@ namespace Mantid {
 namespace Algorithms {
 /**
 
-    Performs a solid angle correction on a 2D SANS data set to correct
-    for the absence of curvature of the detector.
-
-    Note: one could use SolidAngle to perform this calculation. Solid Angle
-    returns the solid angle of each detector pixel. The correction is then
-    given by:
-      Omega(theta) = Omega(0) cos^3(theta)
-      where Omega is the solid angle.
-    This approach requires more un-necessary calculations so we simply apply the
-   cos^3(theta).
-
-    Brulet et al, J. Appl. Cryst. (2007) 40, 165-177.
-    See equation 22.
+    Computes the solid angle for each detector pixel according to the type
+    of detector.
 
     Required Properties:
     <UL>
@@ -50,7 +39,7 @@ public:
   const std::string name() const override { return "SANSSolidAngle"; }
   /// Summary of algorithms purpose
   const std::string summary() const override {
-    return "Performs solid angle correction on SANS 2D data.";
+    return "Compute solid angle for a SANS detector.";
   }
   /// Algorithm's version
   int version() const override { return (1); }

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -58,10 +58,10 @@ void SANSSolidAngle::init() {
                   "Wing: cos^3(alpha);");
 }
 
-/*
+/**
  * Returns the angle between the sample-to-pixel vector and its
  * projection on the X-Z plane.
- * */
+ */
 double getYTubeAngle(const SpectrumInfo &spectrumInfo, size_t index) {
   const V3D samplePos = spectrumInfo.samplePosition();
 
@@ -77,6 +77,9 @@ double getYTubeAngle(const SpectrumInfo &spectrumInfo, size_t index) {
   return sampleDetVec.angle(inPlane);
 }
 
+/**
+ *Returns correct angular function for the specified type
+ */
 std::function<double(int64_t)>
 getAngularFunction(const SpectrumInfo &spectrumInfo, const std::string &type) {
   if (type == "Normal") {
@@ -101,9 +104,8 @@ getAngularFunction(const SpectrumInfo &spectrumInfo, const std::string &type) {
 }
 
 /**
- * Compute the solid angle
- * */
-
+ * Compute the solid angle using the correct angular function
+ */
 class CalculateSolidAngle {
 public:
   CalculateSolidAngle(const double pixelArea, const SpectrumInfo &spectrumInfo,
@@ -161,20 +163,17 @@ void SANSSolidAngle::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS, *inputWS))
   for (int64_t i = 0; i < numberOfSpectra; ++i) {
     PARALLEL_START_INTERUPT_REGION
-
     if (spectrumInfo.hasDetectors(i) && !spectrumInfo.isMonitor(i)) {
       // Copy over the spectrum number & detector IDs
       outputWS->getSpectrum(i).copyInfoFrom(inputWS->getSpectrum(i));
       outputWS->mutableX(i) = inputWS->x(i);
-      double solidAngle = calculateSolidAngle(i);
-      outputWS->mutableY(i) = solidAngle;
+      outputWS->mutableY(i) = calculateSolidAngle(i);
       outputWS->mutableE(i) = 0.;
     } else {
       outputWS->mutableX(i) = 0.;
       outputWS->mutableY(i) = 0.;
       outputWS->mutableE(i) = 0.;
     }
-
     prog.report();
     PARALLEL_END_INTERUPT_REGION
   } // loop over spectra

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -110,7 +110,7 @@ class CalculateSolidAngle {
 public:
   CalculateSolidAngle(const double pixelArea, const SpectrumInfo &spectrumInfo,
                       const ComponentInfo &componentInfo,
-                      std::function<double(int64_t)> f)
+                      std::function<double(int64_t)> &&f)
       : m_pixelArea(pixelArea), m_spectrumInfo(spectrumInfo),
         m_componentInfo(componentInfo), m_f(std::move(f)) {}
   double operator()(int64_t histogramIndex) const {
@@ -155,7 +155,7 @@ void SANSSolidAngle::exec() {
   const std::string type = getProperty("Type");
   auto angularFunction = getAngularFunction(spectrumInfo, type);
   const CalculateSolidAngle calculateSolidAngle(
-      pixelSizeX * pixelSizeY, spectrumInfo, componentInfo, angularFunction);
+      pixelSizeX * pixelSizeY, spectrumInfo, componentInfo, std::move(angularFunction));
 
   Progress prog(this, 0.0, 1.0, numberOfSpectra);
 

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -34,7 +34,7 @@ DECLARE_ALGORITHM(SANSSolidAngle)
 
 void SANSSolidAngle::init() {
 
-  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+  declareProperty(std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
                       "InputWorkspace", "", Direction::Input,
                       boost::make_shared<InstrumentValidator>()),
                   "This workspace is used to identify the instrument to use "
@@ -44,7 +44,7 @@ void SANSSolidAngle::init() {
                   "not provided one solid angle will be created for each "
                   "spectra in the input\n"
                   "workspace");
-  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+  declareProperty(std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
                       "OutputWorkspace", "", Direction::Output),
                   "The name of the workspace to be created as the output of "
                   "the algorithm.  A workspace of this name will be created "

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -154,8 +154,9 @@ void SANSSolidAngle::exec() {
 
   const std::string type = getProperty("Type");
   auto angularFunction = getAngularFunction(spectrumInfo, type);
-  const CalculateSolidAngle calculateSolidAngle(
-      pixelSizeX * pixelSizeY, spectrumInfo, componentInfo, std::move(angularFunction));
+  const CalculateSolidAngle calculateSolidAngle(pixelSizeX * pixelSizeY,
+                                                spectrumInfo, componentInfo,
+                                                std::move(angularFunction));
 
   Progress prog(this, 0.0, 1.0, numberOfSpectra);
 

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -1,0 +1,169 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/SANSSolidAngle.h"
+#include "MantidAPI/AlgorithmProperty.h"
+#include "MantidAPI/HistogramValidator.h"
+#include "MantidAPI/InstrumentValidator.h"
+#include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
+#include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/EventList.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidKernel/CompositeValidator.h"
+#include "MantidKernel/ListValidator.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/PropertyManager.h"
+#include "MantidKernel/PropertyManagerDataService.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+using namespace Kernel;
+using namespace API;
+using namespace Geometry;
+using namespace DataObjects;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(SANSSolidAngle)
+
+void SANSSolidAngle::init() {
+
+  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+                      "InputWorkspace", "", Direction::Input,
+                      boost::make_shared<InstrumentValidator>()),
+                  "This workspace is used to identify the instrument to use "
+                  "and also which\n"
+                  "spectra to create a solid angle for. If the Max and Min "
+                  "spectra values are\n"
+                  "not provided one solid angle will be created for each "
+                  "spectra in the input\n"
+                  "workspace");
+  declareProperty(make_unique<WorkspaceProperty<API::MatrixWorkspace>>(
+                      "OutputWorkspace", "", Direction::Output),
+                  "The name of the workspace to be created as the output of "
+                  "the algorithm.  A workspace of this name will be created "
+                  "and stored in the Analysis Data Service.");
+
+  std::vector<std::string> exp_options{"Normal", "Tube", "Wing"};
+  declareProperty("Type", "Normal",
+                  boost::make_shared<StringListValidator>(exp_options),
+                  "Select the method to calculate the Solid Angle.\n"
+                  "Normal: cos^3(theta); Tube: cons(alpha)*cos^3(theta); "
+                  "Wing: cos^3(alpha);");
+}
+
+void SANSSolidAngle::exec() {
+
+  // Get the workspaces
+  API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  const int numberOfSpectra = static_cast<int>(inputWS->getNumberHistograms());
+  API::MatrixWorkspace_sptr outputWS =
+      WorkspaceFactory::Instance().create(inputWS, numberOfSpectra, 2, 1);
+  // The result of this will be a distribution
+  outputWS->setDistribution(true);
+  outputWS->setYUnit("");
+  outputWS->setYUnitLabel("Steradian");
+  setProperty("OutputWorkspace", outputWS);
+
+  const auto &spectrumInfo = inputWS->spectrumInfo();
+  const auto &componentInfo = inputWS->componentInfo();
+  const double pixelSizeX =
+      inputWS->getInstrument()->getNumberParameter("x-pixel-size")[0];
+  const double pixelSizeY =
+      inputWS->getInstrument()->getNumberParameter("y-pixel-size")[0];
+
+  g_log.debug() << "Pixel sizes (mm) X=" << pixelSizeX << " Y=" << pixelSizeY
+                << '\n';
+
+  Progress prog(this, 0.0, 1.0, numberOfSpectra);
+
+  // Loop over the histograms (detector spectra)
+  PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS, *inputWS))
+  for (int i = 0; i < numberOfSpectra; ++i) {
+    PARALLEL_START_INTERUPT_REGION
+
+    if (spectrumInfo.hasDetectors(i) && !spectrumInfo.isMonitor(i)) {
+      // Copy over the spectrum number & detector IDs
+      outputWS->getSpectrum(i).copyInfoFrom(inputWS->getSpectrum(i));
+
+      double solidAngle = calculateSolidAngle(i, spectrumInfo, componentInfo,
+                                              pixelSizeX, pixelSizeY);
+
+      outputWS->mutableX(i)[0] = inputWS->x(i).front();
+      outputWS->mutableX(i)[1] = inputWS->x(i).back();
+      outputWS->mutableY(i)[0] = solidAngle;
+      outputWS->mutableE(i)[0] = 0;
+    } else {
+      outputWS->mutableX(i) = 0;
+      outputWS->mutableY(i) = 0;
+      outputWS->mutableE(i) = 0;
+    }
+
+    prog.report();
+    PARALLEL_END_INTERUPT_REGION
+  } // loop over spectra
+  PARALLEL_CHECK_INTERUPT_REGION
+}
+
+/*
+ * Returns the angle between the sample-to-pixel vector and its
+ * projection on the X-Z plane.
+ * */
+double SANSSolidAngle::getYTubeAngle(const SpectrumInfo &spectrumInfo,
+                                     size_t index) {
+  const V3D samplePos = spectrumInfo.samplePosition();
+
+  // Get the vector from the sample position to the detector pixel
+  V3D sampleDetVec = spectrumInfo.position(index) - samplePos;
+
+  // Get the projection of that vector on the X-Z plane
+  V3D inPlane = V3D(sampleDetVec);
+  inPlane.setY(0.0);
+
+  // This is the angle between the sample-to-detector vector
+  // and its project on the X-Z plane.
+  return sampleDetVec.angle(inPlane);
+}
+
+/**
+ * Compute the solid angle
+ * */
+double SANSSolidAngle::calculateSolidAngle(int histogramIndex,
+                                           const SpectrumInfo &spectrumInfo,
+                                           const ComponentInfo &componentInfo,
+                                           const double pixelSizeX,
+                                           const double pixelSizeY) {
+
+  const std::string type = getProperty("Type");
+  double pixelSizeXScaled =
+      pixelSizeX * componentInfo.scaleFactor(histogramIndex)[0];
+  double pixelSizeYScaled =
+      pixelSizeY * componentInfo.scaleFactor(histogramIndex)[1];
+  double pixelArea = pixelSizeXScaled * pixelSizeYScaled;
+  double distance = spectrumInfo.l2(histogramIndex) * 1e3; // mm
+
+  double angularTerm = 0;
+  if (type == "Normal") {
+    double cosTheta = cos(spectrumInfo.twoTheta(histogramIndex));
+    angularTerm = cosTheta * cosTheta * cosTheta;
+  } else if (type == "Tube") {
+    double cosTheta = cos(spectrumInfo.twoTheta(histogramIndex));
+    double cosAlpha = cos(getYTubeAngle(spectrumInfo, histogramIndex));
+    angularTerm = cosTheta * cosTheta * cosAlpha;
+  } else if (type == "Wing") {
+    double cosAlpha = cos(getYTubeAngle(spectrumInfo, histogramIndex));
+    angularTerm = cosAlpha * cosAlpha * cosAlpha;
+  } else {
+    throw std::runtime_error("Invalid type of correction");
+  }
+  return (pixelArea * angularTerm) / (distance * distance);
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/SANSSolidAngle.cpp
+++ b/Framework/Algorithms/src/SANSSolidAngle.cpp
@@ -54,7 +54,7 @@ void SANSSolidAngle::init() {
   declareProperty("Type", "Normal",
                   boost::make_shared<StringListValidator>(exp_options),
                   "Select the method to calculate the Solid Angle.\n"
-                  "Normal: cos^3(theta); Tube: cons(alpha)*cos^3(theta); "
+                  "Normal: cos^3(theta); Tube: cos(alpha)*cos^3(theta); "
                   "Wing: cos^3(alpha);");
 }
 

--- a/Framework/Algorithms/test/SANSSolidAngleTest.h
+++ b/Framework/Algorithms/test/SANSSolidAngleTest.h
@@ -1,0 +1,89 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#ifndef SANSSOLIDANGLETEST_H_
+#define SANSSOLIDANGLETEST_H_
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
+#include "MantidAlgorithms/SANSSolidAngle.h"
+#include "MantidDataHandling/LoadSpice2D.h"
+#include "MantidDataHandling/MoveInstrumentComponent.h"
+#include "MantidKernel/Unit.h"
+
+#include "MantidDataHandling/LoadEmptyInstrument.h"
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+
+class SANSSolidAngleTest : public CxxTest::TestSuite {
+public:
+  void testName() { TS_ASSERT_EQUALS(correction.name(), "SANSSolidAngle") }
+
+  void testVersion() { TS_ASSERT_EQUALS(correction.version(), 1) }
+
+  void testInit() {
+    TS_ASSERT_THROWS_NOTHING(correction.initialize())
+    TS_ASSERT(correction.isInitialized())
+  }
+
+  void testExec() {
+
+    const std::string wsInputName("empty_instrument_ws");
+    const std::string instrument("eqsans");
+
+    // Load empty instrument
+    Mantid::DataHandling::LoadEmptyInstrument loader;
+    loader.initialize();
+    loader.setPropertyValue("InstrumentName", instrument);
+    loader.setPropertyValue("OutputWorkspace", wsInputName);
+    loader.execute();
+    // Move the detector 5m away from the sample
+    Mantid::DataHandling::MoveInstrumentComponent moveInstrumentComponent;
+    moveInstrumentComponent.initialize();
+    moveInstrumentComponent.setPropertyValue("Workspace", wsInputName);
+    moveInstrumentComponent.setPropertyValue("ComponentName", "detector1");
+    moveInstrumentComponent.setPropertyValue("RelativePosition", "0");
+    moveInstrumentComponent.setPropertyValue("Z", "5");
+    moveInstrumentComponent.execute();
+
+    // Solid Angle correction
+    const std::string wsOutputName("instrument_solid_angle_ws");
+    if (!correction.isInitialized())
+      correction.initialize();
+    TS_ASSERT_THROWS_NOTHING(
+        correction.setPropertyValue("InputWorkspace", wsInputName))
+    TS_ASSERT_THROWS_NOTHING(
+        correction.setPropertyValue("OutputWorkspace", wsOutputName))
+    TS_ASSERT_THROWS_NOTHING(correction.execute())
+    TS_ASSERT(correction.isExecuted())
+
+    Mantid::API::MatrixWorkspace_sptr wsOutput;
+    TS_ASSERT_THROWS_NOTHING(
+        wsOutput = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
+            Mantid::API::AnalysisDataService::Instance().retrieve(
+                wsOutputName)))
+
+    // Let's do some validation
+    TS_ASSERT_EQUALS(wsOutput->getNumberHistograms(), 49153)
+    //// SA is bigger in the center: 8.99095e-07 vs 9.4172e-07
+    double correctionEdge = wsOutput->dataY(48896)[0];
+    double correctionCenter = wsOutput->dataY(25984)[0];
+    TS_ASSERT(correctionCenter > correctionEdge);
+
+    Mantid::API::AnalysisDataService::Instance().remove(wsInputName);
+    Mantid::API::AnalysisDataService::Instance().remove(wsOutputName);
+  }
+
+private:
+  Mantid::Algorithms::SANSSolidAngle correction;
+  std::string inputWS;
+};
+
+#endif /*SANSSOLIDANGLETEST_H_*/

--- a/docs/source/algorithms/SANSSolidAngle-v1.rst
+++ b/docs/source/algorithms/SANSSolidAngle-v1.rst
@@ -1,0 +1,29 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Performs a solid angle calculation on all detector pixels.
+
+Depending on the option selected, the solid angle is calculated as follows:
+
+**Normal**
+
+.. math:: I'(x,y)=\frac{I(x,y)}{\cos^3(2\theta)}
+
+**Tube**
+
+.. math:: I'(x,y)=\frac{I(x,y)}{\cos^2(2\theta)\cos(\alpha)}
+
+**Wing**
+
+.. math:: I'(x,y)=\frac{I(x,y)}{\cos^3(\alpha)}
+
+where :math:`\alpha` is the angle between the sample-to-pixel vector and its projection on the X-Z plane.

--- a/docs/source/algorithms/SANSSolidAngle-v1.rst
+++ b/docs/source/algorithms/SANSSolidAngle-v1.rst
@@ -10,7 +10,7 @@
 Description
 -----------
 
-Performs a solid angle calculation on all detector pixels.
+Computes the solid angle for all detector pixels.
 
 Depending on the option selected, the solid angle is calculated as follows:
 

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -12,6 +12,8 @@ SANS Changes
 :ref:`Release 4.1.0 <v4.1.0>`
 
 - New IDF for EQSANS
+- New algorithm :ref:`SANSSolidAngle <algm-SANSSolidAngle>`
+
 
 ISIS SANS Interface
 -------------------


### PR DESCRIPTION
**Description of work.**

Create a Solid Angle calculation for SANS. Note: contrary to the existing algorithm, this does not perform a correction, but only a calculation.

It uses a formula depending on the detector (as described in the ORNL SANS specs document). I cross checked with he default mantid solid angle correction and the results are different.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
<!-- Instructions for testing. -->

Tests should pass. 

 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
