### PR TITLE
Add all results for simultaneous fit to Muon fit model

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -84,11 +84,11 @@ class FittingTabModel(object):
             self.rename_members_of_fitted_workspace_group(output_workspace, parameter_dict['InputWorkspace'],
                                                           parameter_dict['Function'],
                                                           fit_group_name)
-            wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name,
-                                                                    table_directory)
-            self.add_fit_to_context(wrapped_parameter_workspace,
-                                    parameter_dict['Function'],
-                                    parameter_dict['InputWorkspace'])
+        wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name,
+                                                                table_directory)
+        self.add_fit_to_context(wrapped_parameter_workspace,
+                                parameter_dict['Function'],
+                                parameter_dict['InputWorkspace'])
 
         return function_object, output_status, output_chi_squared
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -111,6 +111,38 @@ class FittingTabModelTest(unittest.TestCase):
             {'Function': mock.ANY, 'InputWorkspace': workspace, 'Minimizer': 'Levenberg-Marquardt',
              'StartX': 0.0, 'EndX': 100.0, 'EvaluationType': 'CentrePoint'})
 
+    def test_do_simultaneous_fit_adds_single_input_workspace_to_fit_context(self):
+        trial_function = FunctionFactory.createInitialized('name = Quadratic, A0 = 0, A1 = 0, A2 = 0')
+        x_data = range(0, 100)
+        y_data = [5 + x * x for x in x_data]
+        workspace = CreateWorkspace(x_data, y_data)
+        parameter_dict = {'Function': trial_function, 'InputWorkspace': [workspace.name()],
+                          'Minimizer': 'Levenberg-Marquardt',
+                          'StartX': [0.0], 'EndX': [100.0], 'EvaluationType': 'CentrePoint',
+                          'FitGroupName': 'SimulFit'}
+        self.model.do_simultaneous_fit(parameter_dict)
+
+        fit_context = self.model.context.fitting_context
+        self.assertEqual(1, len(fit_context))
+
+    def test_do_simultaneous_fit_adds_multi_input_workspace_to_fit_context(self):
+        # create function
+        single_func = ';name=FlatBackground,$domains=i,A0=0'
+        multi_func = 'composite=MultiDomainFunction,NumDeriv=1' + single_func + single_func +";"
+        trial_function = FunctionFactory.createInitialized(multi_func)
+        x_data = range(0, 100)
+        y_data = [5 + x * x for x in x_data]
+        workspace1 = CreateWorkspace(x_data, y_data)
+        workspace2 = CreateWorkspace(x_data, y_data)
+        parameter_dict = {'Function': trial_function, 'InputWorkspace': [workspace1.name(), workspace2.name()],
+                          'Minimizer': 'Levenberg-Marquardt',
+                          'StartX': [0.0]*2, 'EndX': [100.0]*2, 'EvaluationType': 'CentrePoint',
+                          'FitGroupName': 'SimulFit'}
+        self.model.do_simultaneous_fit(parameter_dict)
+
+        fit_context = self.model.context.fitting_context
+        self.assertEqual(1, len(fit_context))
+
     def test_get_function_name_returns_correctly_for_composite_functions(self):
         function_string = 'name=FlatBackground,A0=22.5129;name=Polynomial,n=0,A0=-22.5221;name=ExpDecayOsc,A=-0.172352,Lambda=0.111109,Frequency=-0.280031,Phi=-3.03983'
         function_object = FunctionFactory.createInitialized(function_string)


### PR DESCRIPTION
**Description of work.**

Fixes a bug in master for the new Muon GUI that resulted from a bad merge-conflict resolution where only fits with > 1 workspaces were added to the fitting context.

**To test:**

Do a simultaneous fit with a single input workspace and the result should appear in the output context.

*This does not require release notes* because **the GUI is new this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
