### PR TITLE
Fix matplotlib backend warning when running system tests

### DIFF
--- a/qt/python/mantidqt/gui_helper.py
+++ b/qt/python/mantidqt/gui_helper.py
@@ -18,6 +18,8 @@ def set_matplotlib_backend():
     This will set the backend if it hasn't been already. It also returns
     the name of the backend to be the name to be used for importing the
     correct matplotlib widgets.'''
+    if 'MPLBACKEND' in os.environ:
+        return
     backend = matplotlib.get_backend()
     if backend.startswith('module://'):
         if backend.endswith('qt4agg'):

--- a/qt/python/mantidqt/gui_helper.py
+++ b/qt/python/mantidqt/gui_helper.py
@@ -18,9 +18,9 @@ def set_matplotlib_backend():
     This will set the backend if it hasn't been already. It also returns
     the name of the backend to be the name to be used for importing the
     correct matplotlib widgets.'''
-    if 'MPLBACKEND' in os.environ:
-        return
     backend = matplotlib.get_backend()
+    if 'MPLBACKEND' in os.environ:
+        return backend
     if backend.startswith('module://'):
         if backend.endswith('qt4agg'):
             backend = 'Qt4Agg'

--- a/qt/python/mantidqt/gui_helper.py
+++ b/qt/python/mantidqt/gui_helper.py
@@ -19,8 +19,6 @@ def set_matplotlib_backend():
     the name of the backend to be the name to be used for importing the
     correct matplotlib widgets.'''
     backend = matplotlib.get_backend()
-    if 'MPLBACKEND' in os.environ:
-        return backend
     if backend.startswith('module://'):
         if backend.endswith('qt4agg'):
             backend = 'Qt4Agg'

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -26,10 +26,11 @@ PyChop2.showGUI()
 from __future__ import (absolute_import, division, print_function)
 import warnings
 from .Instruments import Instrument as PyChop2  # noqa: F401
-# If the system doesn't have matplotlib, don't import the GUI.
-try:
-    from .PyChopGui import show as showGUI
-except ImportError:
-    def showGUI():
-        warnings.warn("PyChop GUI disabled: Cannot import Matplotlib.", RuntimeWarning)
-        return None
+
+# # If the system doesn't have matplotlib, don't import the GUI.
+# try:
+#     from .PyChopGui import show as showGUI
+# except ImportError:
+#     def showGUI():
+#         warnings.warn("PyChop GUI disabled: Cannot import Matplotlib.", RuntimeWarning)
+#         return None

--- a/scripts/PyChop/__init__.py
+++ b/scripts/PyChop/__init__.py
@@ -24,13 +24,4 @@ PyChop2.showGUI()
 """
 
 from __future__ import (absolute_import, division, print_function)
-import warnings
 from .Instruments import Instrument as PyChop2  # noqa: F401
-
-# # If the system doesn't have matplotlib, don't import the GUI.
-# try:
-#     from .PyChopGui import show as showGUI
-# except ImportError:
-#     def showGUI():
-#         warnings.warn("PyChop GUI disabled: Cannot import Matplotlib.", RuntimeWarning)
-#         return None


### PR DESCRIPTION
**Description of work.**
An import in a PyChop __init__ file was causing the matplotlib backend to be set.
The matplotlib backend is then set again when running system tests, which produces a warning.

Working with @martyngigg, we've commented out the import which was causing the issue

**To test:**
Run a system test. Before the test starts, you should see no matplotlib backend warnings.
Fixes #25884

*This does not require release notes* because **Internal change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
