### PR TITLE
Muon analysis qlineedit signal not emmitiing

### DIFF
--- a/scripts/Muon/GUI/Common/home_grouping_widget/home_grouping_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_grouping_widget/home_grouping_widget_view.py
@@ -9,6 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 from qtpy import QtWidgets, QtCore, QtGui
 from Muon.GUI.Common.utilities.run_string_utils import valid_alpha_regex
 from Muon.GUI.Common.message_box import warning
+from Muon.GUI.Common.utilities.run_string_utils import run_string_regex
 
 
 class HomeGroupingWidgetView(QtWidgets.QWidget):
@@ -67,7 +68,7 @@ class HomeGroupingWidgetView(QtWidgets.QWidget):
 
         self.summed_period_edit = QtWidgets.QLineEdit(self)
         self.summed_period_edit.setText("1")
-        reg_ex = QtCore.QRegExp("^[0-9]*([0-9]+[,-]{0,1})*[0-9]+$")
+        reg_ex = QtCore.QRegExp(run_string_regex)
         period_validator = QtGui.QRegExpValidator(reg_ex, self.summed_period_edit)
         self.summed_period_edit.setValidator(period_validator)
 

--- a/scripts/Muon/GUI/Common/utilities/run_string_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/run_string_utils.py
@@ -13,7 +13,7 @@ import re
 
 delimiter = ","
 range_separator = "-"
-run_string_regex = "^[0-9]*([0-9]+\s*[,-]{0,1}\s*)*[0-9]+$"
+run_string_regex = "^[0-9]*([0-9]+\s*[,-]{0,1}\s*)*[0-9]*$"
 max_run_list_size = 100
 valid_float_regex = "^[0-9]+([.][0-9]*)?$"
 valid_name_regex = "^\w+$"
@@ -87,8 +87,11 @@ def run_string_to_list(run_string, max_value = True):
     if not validate_run_string(run_string):
         raise IndexError("{} is not a valid run string".format(run_string))
     run_list = []
+    if run_string.endswith(',') or run_string.endswith('-'):
+        run_string = run_string[:-1]
     if run_string == "":
         return run_list
+
     run_string_list = run_string.split(delimiter)
     for runs in run_string_list:
         split_runs = runs.split(range_separator)

--- a/scripts/test/Muon/utilities/run_string_utils_conversion_test.py
+++ b/scripts/test/Muon/utilities/run_string_utils_conversion_test.py
@@ -59,12 +59,12 @@ class RunStringUtilsStringToListTest(unittest.TestCase):
             self.assertEqual(utils.validate_run_string(valid_string), True)
 
     def test_validate_run_string_returns_false_for_delimiter_typos(self):
-        invalid_strings = [",", ",,,", ",1", "1,", ",1,2,3", "1,2,3,"]
+        invalid_strings = [",,,", ",1", ",1,2,3"]
         for invalid_string in invalid_strings:
             self.assertEqual(utils.validate_run_string(invalid_string), False)
 
     def test_validate_run_string_returns_false_for_range_separator_typos(self):
-        invalid_strings = ["-", "---", "-1", "1-", "-1,2,3", "1,2,3-", "1,-4", "1-,4"]
+        invalid_strings = ["---", "-1", "-1,2,3", "1,-4", "1-,4"]
         for invalid_string in invalid_strings:
             self.assertEqual(utils.validate_run_string(invalid_string), False)
 
@@ -92,14 +92,14 @@ class RunStringUtilsStringToListTest(unittest.TestCase):
             self.assertEqual(run_list, [1, 2, 3, 4, 5])
 
     def test_run_string_to_list_throws_for_incorrectly_placed_range_separator(self):
-        run_strings = ["-1,2,3", "1,2,3-"]
+        run_strings = ["-1,2,3"]
         for run_string in run_strings:
             with self.assertRaises(IndexError) as error:
                 utils.run_string_to_list(run_string)
             self.assertTrue(run_string + " is not a valid run string" in str(error.exception))
 
     def test_run_string_to_list_throws_for_incorrectly_placed_delimiter(self):
-        run_strings = [",1,2,3", "1,2,3,"]
+        run_strings = [",1,2,3"]
         for run_string in run_strings:
             with self.assertRaises(IndexError) as context:
                 utils.run_string_to_list(run_string)
@@ -120,6 +120,11 @@ class RunStringUtilsStringToListTest(unittest.TestCase):
         run_string = '62260-66'
         run_list = [62260, 62261, 62262, 62263, 62264, 62265, 62266]
         self.assertEqual(utils.run_string_to_list(run_string), run_list)
+
+    def test_run_string_allows_trailing_comma(self):
+        run_string = '5,4,3,2,1,'
+        run_list = utils.run_string_to_list(run_string)
+        self.assertEqual(run_list, [1, 2, 3, 4, 5])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

There was an issue with the run entry box in the Muon Analysis 2 interface. This box had a regex attached which would only let you enter a comma separated list of numbers. If you exited the box after having left a trailing comma however qt would let this be entered as it is an intermediate state between valid states but would not send the editing finished signal as the string would then fail the validator check.

This PR relaxes the regular expression validator slightly so that it is not required to end in a number and adds some code for dealing with trailing seperators in the backend.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * Open Muon Analysis 2
  * Change the instrument to EMU
  * Type `19489,` into the load run box and press enter (This data should be in the unit test directory)
  * This should successfully trigger a load event in the GUI.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because this fixes an issue introduced in this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
