### PR TITLE
Adding composite functions to function browser list

### DIFF
--- a/Framework/API/inc/MantidAPI/FunctionFactory.h
+++ b/Framework/API/inc/MantidAPI/FunctionFactory.h
@@ -56,7 +56,7 @@ public:
 
   /// Query available functions based on the template type
   template <typename FunctionType>
-  const std::vector<std::string> &getFunctionNames() const;
+  std::vector<std::string> getFunctionNames() const;
   /// Get function names that can be used by generic fitting GUIs
   std::vector<std::string> getFunctionNamesGUI() const;
   // Unhide the base class version (to satisfy the intel compiler)
@@ -115,7 +115,7 @@ private:
  * @returns A vector of the names of the functions matching the template type
  */
 template <typename FunctionType>
-const std::vector<std::string> &FunctionFactoryImpl::getFunctionNames() const {
+std::vector<std::string> FunctionFactoryImpl::getFunctionNames() const {
   std::lock_guard<std::mutex> _lock(m_mutex);
 
   const std::string soughtType(typeid(FunctionType).name());

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -368,6 +368,7 @@ std::vector<std::string> FunctionFactoryImpl::getFunctionNamesGUI() const {
   allNames.push_back("ProductFunction");
   allNames.push_back("CompositeFunction");
   allNames.push_back("Convolution");
+  std::sort(allNames.begin(), allNames.end());
   std::vector<std::string> names;
   names.reserve(allNames.size());
   auto excludes =

--- a/Framework/API/src/FunctionFactory.cpp
+++ b/Framework/API/src/FunctionFactory.cpp
@@ -364,7 +364,10 @@ void FunctionFactoryImpl::addTie(IFunction_sptr fun,
 }
 
 std::vector<std::string> FunctionFactoryImpl::getFunctionNamesGUI() const {
-  auto &allNames = getFunctionNames<IFunction1D>();
+  auto allNames = getFunctionNames<IFunction1D>();
+  allNames.push_back("ProductFunction");
+  allNames.push_back("CompositeFunction");
+  allNames.push_back("Convolution");
   std::vector<std::string> names;
   names.reserve(allNames.size());
   auto excludes =


### PR DESCRIPTION
**Description of work.**

Currently the composite functions, Product Function, Composite Function and Convolution are missing from the function browser. This PR updates the list of functions passed to the function browser to include them.

**Report to:** Peter


**To test:**
  * Open the fit window, check that Product Function, Composite Function and Convolution appear under general. Try a fit with each of them and check that they work correctly
  * Code review
<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because this fixes an issue introduced this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
