### PR TITLE
Expose getMaxOrder to python

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -204,8 +204,6 @@ void IndexPeaks::exec() {
         iteration++;
       }
 
-      g_log.notice() << "Maximum Order: " << o_lattice.getMaxOrder() << '\n';
-
       if (o_lattice.getMaxOrder() ==
           0) // If data not modulated, recalculate fractional HKL
       {
@@ -236,6 +234,7 @@ void IndexPeaks::exec() {
           }
         }
       } else {
+        g_log.notice() << "Maximum Order: " << o_lattice.getMaxOrder() << '\n';
         int ModDim = 0;
         int main_indexed = 0;
         int sate_indexed = 0;

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -352,7 +352,7 @@ void export_UnitCell() {
            "convention. This will return a :class:`numpy.ndarray` with shape "
            "``(3,3)``.")
       .def("getMaxOrder", &UnitCell::getMaxOrder, arg("self"),
-           "Returns the number of modulation vectorsell. This will return an "
+           "Returns the number of modulation vectors. This will return an "
            "int.")
       .def("recalculateFromGstar", &recalculateFromGstar,
            (arg("self"), arg("NewGstar")),

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/UnitCell.cpp
@@ -351,6 +351,9 @@ void export_UnitCell() {
            "right-handed coordinate system and using the Busing-Levy "
            "convention. This will return a :class:`numpy.ndarray` with shape "
            "``(3,3)``.")
+      .def("getMaxOrder", &UnitCell::getMaxOrder, arg("self"),
+           "Returns the number of modulation vectorsell. This will return an "
+           "int.")
       .def("recalculateFromGstar", &recalculateFromGstar,
            (arg("self"), arg("NewGstar")),
            "Recalculate the unit cell parameters from a metric tensor. This "

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -82,6 +82,8 @@ Improvements
 
 - :ref:`DeltaPDF3D <algm-DeltaPDF3D>` has a new method for peak removal, KAREN (K-space Algorithmic REconstructioN)
 
+- Maximum order of modulated vectors is now available to python: ws.sample().getOrientedLattice().getMaxOrder()
+
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**
Expose getMaxOrder to python so TOPAZ reduction scripts know if there are satellite peaks. Don't print maxOrder from IndexPeaks for integer peaks only.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
````python
ws=LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-10003/shared/xpwang/2019/TOPAZ_8071_8x8x5_all.integrate', OutputWorkspace='integer')
LoadIsawUB(ws,Filename='/SNS/TOPAZ/IPTS-10003/shared/xpwang/2019/TOPAZ_8071_8x8x5.mat')
IndexPeaks(PeaksWorkspace=ws, RoundHKLs=False)
print "MaxOrder =", ws.sample().getOrientedLattice().getMaxOrder()

ws=LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-10003/shared/xpwang/2019/TOPAZ_8071_8x8x5_sat.integrate', OutputWorkspace='satellite')
IndexPeaks(PeaksWorkspace=ws, RoundHKLs=False)
print "MaxOrder =", ws.sample().getOrientedLattice().getMaxOrder()
````
Fixes #25891 
<!-- alternative
*There is no associated issue.*
-->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
