### PR TITLE
Add lots of links between docs

### DIFF
--- a/docs/source/api/python/mantid/api/SpectrumInfo.rst
+++ b/docs/source/api/python/mantid/api/SpectrumInfo.rst
@@ -4,30 +4,30 @@
 
 This is a python binding to the C++ class Mantid::API::SpectrumInfo.
 
-Most of the information concerning ``SpectrumInfo`` can be found in the `Instrument Access Layers <https://github.com/mantidproject/mantid/blob/9e3d799d40fda4a5ca08887e8c47f41c3316da91/docs/source/concepts/InstrumentAccessLayers.rst>`_ document.
+Most of the information concerning :py:obj:`~mantid.api.SpectrumInfo` can be found in the :ref:`Instrument Access Layers <InstrumentAccessLayers>` document.
 
 --------
 Purpose
 --------
-The purpose of the ``SpectrumInfo`` object is to allow the user to access information about the spectra being used in an experiment. The ``SpectrumInfo`` object can be used to access information such as the number of spectra, the absolute position of a spectrum as well as the distance from the sample to the source. There are many other methods available as well.
+The purpose of the :py:obj:`~mantid.api.SpectrumInfo` object is to allow the user to access information about the spectra being used in an experiment. The :py:obj:`~mantid.api.SpectrumInfo` object can be used to access information such as the number of spectra, the absolute position of a spectrum as well as the distance from the sample to the source. There are many other methods available as well.
 
 A spectrum corresponds to (a group of) one or more detectors. However if no instrument/beamline has been set then the number of detectors will be zero. An example test case details this below.
 
-Many users may need more information about the spectra in an experiment so that they can have a better understanding of the beamline they are using. This information is easy and fast to access via ``SpectrumInfo``.
+Many users may need more information about the spectra in an experiment so that they can have a better understanding of the beamline they are using. This information is easy and fast to access via :py:obj:`~mantid.api.SpectrumInfo`.
 
-``SpectrumInfo`` is one of three objects that the user can gain access to from a workspace object.
+:py:obj:`~mantid.api.SpectrumInfo` is one of three objects that the user can gain access to from a workspace object.
 The other two are:
 
-* ``DetectorInfo``
-* ``ComponentInfo``
+* :py:obj:`~mantid.geometry.ComponentInfo`
+* :py:obj:`~mantid.geometry.DetectorInfo`
 
 ------
 Usage
 ------
 
 **Example 1 - Creating a SpectrumInfo Object:**
-This example shows how to obtain a ``SpectrumInfo`` object from a workspace object.
-The return value is a ``SpectrumInfo`` object.
+This example shows how to obtain a :py:obj:`~mantid.api.SpectrumInfo` object from a workspace object.
+The return value is a :py:obj:`~mantid.api.SpectrumInfo` object.
 
 .. testcode:: CreateSpectrumInfoObject
 

--- a/docs/source/api/python/mantid/geometry/ComponentInfo.rst
+++ b/docs/source/api/python/mantid/geometry/ComponentInfo.rst
@@ -4,36 +4,36 @@
 
 This is a python binding to the C++ class Mantid::Geometry::ComponentInfo.
 
-Most of the information concerning ``ComponentInfo`` can be found in the `Instrument Access Layers <https://github.com/mantidproject/mantid/blob/9e3d799d40fda4a5ca08887e8c47f41c3316da91/docs/source/concepts/InstrumentAccessLayers.rst>`_ document.
+Most of the information concerning :py:obj:`~mantid.geometry.ComponentInfo` can be found in the :ref:`Instrument Access Layers <InstrumentAccessLayers>` document.
 
 --------
 Purpose
 --------
-The purpose of the ``ComponentInfo`` object is to allow the user to access geometric information about the components which are part of a beamline. A component is any physical item or group of items that is registered for the purpose of data reduction. The ``ComponentInfo`` object can be used to access information such as the total number of components in the beamline, the absolute position of a component as well as the absolute rotation of a component. ``ComponentInfo`` provides tree like access to the beamline including all the detectors.
+The purpose of the :py:obj:`~mantid.geometry.ComponentInfo` object is to allow the user to access geometric information about the components which are part of a beamline. A component is any physical item or group of items that is registered for the purpose of data reduction. The :py:obj:`~mantid.geometry.ComponentInfo` object can be used to access information such as the total number of components in the beamline, the absolute position of a component as well as the absolute rotation of a component. :py:obj:`~mantid.geometry.ComponentInfo` provides tree like access to the beamline including all the detectors.
 
 Many users may need this extra information so that they can have a better understanding of the beamline they are using and the components that make up the beamline - e.g. detectors, banks, choppers. This extra information is easy and fast to access.
 
-ComponentInfo is one of three objects that the user can gain access to from a workspace.
+:py:obj:`~mantid.geometry.ComponentInfo` is one of three objects that the user can gain access to from a workspace.
 The other two are:
 
- * ``SpectrumInfo``
- * ``DetectorInfo``
+ * :py:obj:`~mantid.api.SpectrumInfo`
+ * :py:obj:`~mantid.geometry.DetectorInfo`
 
 ---------
 Indexing
 ---------
-The ``ComponentInfo`` object is accessed by an index going from 0 to N-1 where N is the number of components.
-The component index for a detector is EQUAL to the detector index. In other words, a detector with a detector index of 5 when working with a ``DetectorInfo`` object and will have a component index of 5 when working with a ``ComponentInfo`` object.
+The :py:obj:`~mantid.geometry.ComponentInfo` object is accessed by an index going from 0 to N-1 where N is the number of components.
+The component index for a detector is EQUAL to the detector index. In other words, a detector with a detector index of 5 when working with a ``DetectorInfo`` object and will have a component index of 5 when working with a :py:obj:`~mantid.geometry.ComponentInfo` object.
 
-Another way to think about this is that the first 0 to n-1 components referenced in ``ComponentInfo`` are detectors, where n is the total number of detectors.
+Another way to think about this is that the first 0 to n-1 components referenced in :py:obj:`~mantid.geometry.ComponentInfo` are detectors, where n is the total number of detectors.
 
 -------
 Usage
 -------
 
 **Example 1 - Creating a ComponentInfo Object:**
-This example shows how to obtain a ``ComponentInfo`` object from a workspace object.
-The return value is a ``ComponentInfo`` object.
+This example shows how to obtain a :py:obj:`~mantid.geometry.ComponentInfo` object from a workspace object.
+The return value is a :py:obj:`~mantid.geometry.ComponentInfo` object.
 
 .. testcode:: CreateComponentInfoObject
 

--- a/docs/source/api/python/mantid/geometry/DetectorInfo.rst
+++ b/docs/source/api/python/mantid/geometry/DetectorInfo.rst
@@ -4,25 +4,25 @@
 
 This is a python binding to the C++ class Mantid::Geometry::DetectorInfo.
 
-Most of the information concerning ``DetectorInfo`` can be found in the `Instrument Access Layers <https://github.com/mantidproject/mantid/blob/9e3d799d40fda4a5ca08887e8c47f41c3316da91/docs/source/concepts/InstrumentAccessLayers.rst>`_ document.
+Most of the information concerning :py:obj:`~mantid.geometry.DetectorInfo` can be found in the :ref:`Instrument Access Layers <InstrumentAccessLayers>` document.
 
 --------
 Purpose
 --------
-The purpose of the ``DetectorInfo`` object is to allow the user to access information about the detector(s) being used in an experiment. The ``DetectorInfo`` object can be used to access geometric information such as the number of detectors in the beamline, the absolute position of a detector as well as the absolute rotation of a detector.
+The purpose of the :py:obj:`~mantid.geometry.DetectorInfo` object is to allow the user to access information about the detector(s) being used in an experiment. The :py:obj:`~mantid.geometry.DetectorInfo` object can be used to access geometric information such as the number of detectors in the beamline, the absolute position of a detector as well as the absolute rotation of a detector.
 
 Many users may need this extra information so that they can have a better understanding of the beamline they are using. This information is easy and fast to access. Some information like mask flags can be modified directly.
 
-The ``DetectorInfo`` object is one of three objects that the user can gain access to from a workspace.
+The :py:obj:`~mantid.geometry.DetectorInfo` object is one of three objects that the user can gain access to from a workspace.
 The other two are:
 
- * SpectrumInfo
- * ComponentInfo
+* :py:obj:`~mantid.api.SpectrumInfo`
+* :py:obj:`~mantid.geometry.ComponentInfo`
 
 ---------
 Indexing
 ---------
-The ``DetectorInfo`` object is accessed by an index going from 0 to N-1, where N is the number of detectors.
+The :py:obj:`~mantid.geometry.DetectorInfo` object is accessed by an index going from 0 to N-1, where N is the number of detectors.
 It is important to note that the detector index is NOT the detector ID. A detector index is a way of addressing and enumerating detectors in the beamline.
 A detector index can be found from a detector ID using ``indexOf``.
 
@@ -31,8 +31,8 @@ Usage
 -------
 
 **Example 1 - Creating a DetectorInfo Object:**
-This example shows how to obtain a ``DetectorInfo`` object from a workspace object.
-The return value is a ``DetectorInfo`` object.
+This example shows how to obtain a :py:obj:`~mantid.geometry.DetectorInfo` object from a workspace object.
+The return value is a :py:obj:`~mantid.geometry.DetectorInfo` object.
 
 .. testcode:: CreateDetectorInfoObject
 
@@ -111,4 +111,3 @@ Output:
     :members:
     :undoc-members:
     :inherited-members:
-

--- a/docs/source/concepts/ComponentInfo.rst
+++ b/docs/source/concepts/ComponentInfo.rst
@@ -1,7 +1,7 @@
 .. _ComponentInfo:
 
 =============
-ComponentInfo 
+ComponentInfo
 =============
 
 .. contents::
@@ -9,21 +9,21 @@ ComponentInfo
 
 Introduction
 ------------
-``ComponentInfo`` provides faster and simpler access to instrument/beamline geometry as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``ComponentInfo`` and :ref:`DetectorInfo` are designed as full replacements to :ref:`Instrument`. 
+:py:obj:`~mantid.geometry.ComponentInfo` provides faster and simpler access to instrument/beamline geometry as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. :py:obj:`~mantid.geometry.ComponentInfo` and :ref:`DetectorInfo` are designed as full replacements to :ref:`Instrument`.
 
-:ref:`Instrument Access Layers <InstrumentAccessLayers>` provides details on how `DetectorInfo` interacts with other geometry access layers.
+:ref:`Instrument Access Layers <InstrumentAccessLayers>` provides details on how :py:obj:`~mantid.geometry.DetectorInfo` interacts with other geometry access layers.
 
 Python Interface
 ----------------
 
-Examples of using ``ComponentInfo`` in python
+Examples of using :py:obj:`~mantid.geometry.ComponentInfo` in python
 
 **Print indices of detectors in "bank1" that are masked**
 
-.. testcode:: show_masked_detectors_in_bank 
+.. testcode:: show_masked_detectors_in_bank
 
    from mantid.simpleapi import CreateSampleWorkspace
-   
+
    ws = CreateSampleWorkspace()
    comp_info = ws.componentInfo()
    det_info = ws.detectorInfo()

--- a/docs/source/concepts/DetectorInfo.rst
+++ b/docs/source/concepts/DetectorInfo.rst
@@ -9,22 +9,22 @@ DetectorInfo
 
 Introduction
 ------------
-``DetectorInfo`` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. ``DetectorInfo`` and :ref:`ComponentInfo` are designed as full replacements to :ref:`Instrument`. 
+:py:obj:`~mantid.geometry.DetectorInfo` provides faster and simpler access to instrument/beamline detector geometry and metadata as required by Mantid :ref:`Algorithms <Algorithm>` than was possible using :ref:`Instrument`. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` are designed as full replacements to :ref:`Instrument`.
 
-:ref:`Instrument Access Layers <InstrumentAccessLayers>` provides details on how `DetectorInfo` interacts with other geometry access layers.
+:ref:`Instrument Access Layers <InstrumentAccessLayers>` provides details on how :py:obj:`~mantid.geometry.DetectorInfo` interacts with other geometry access layers.
 
 Python Interface
 ----------------
 
-Example of using ``DetectorInfo`` in python
+Example of using :py:obj:`~mantid.geometry.DetectorInfo` in python
 
 **Mask detectors at some distance from the source**
 
 
-.. testcode:: mask_detectors 
+.. testcode:: mask_detectors
 
    from mantid.simpleapi import CreateSampleWorkspace
-   
+
    # Test workspace with instrument
    ws = CreateSampleWorkspace()
    det_info = ws.detectorInfo();
@@ -38,7 +38,7 @@ Example of using ``DetectorInfo`` in python
 Output:
 
 .. testoutput:: mask_detectors
-  
+
    masked 200 detectors
-  
+
 .. categories:: Concepts

--- a/docs/source/concepts/InstrumentAccessLayers.rst
+++ b/docs/source/concepts/InstrumentAccessLayers.rst
@@ -10,32 +10,32 @@ Instrument Access via SpectrumInfo, DetectorInfo, ComponentInfo
 Introduction
 ------------
 
-There are three layers to access instrument information, ``SpectrumInfo``, ``DetectorInfo``, and ``ComponentInfo``, which are introduced to Mantid as part of Instrument 2.0. These classes  store all commonly accessed information about spectra and detectors, components, and the relationships between them. Masking, monitor flags, L1, L2, 2-theta and position are stored as part of ``DetectorInfo``. In addition, ``ComponentInfo`` provides the API to tree and shape related operations historically performed by ``Instrument`` type. 
+There are three layers to access instrument information, :py:obj:`~mantid.api.SpectrumInfo`, :py:obj:`~mantid.geometry.DetectorInfo`, and :py:obj:`~mantid.geometry.DetectorInfo`, which are introduced to Mantid as part of Instrument 2.0. These classes  store all commonly accessed information about spectra and detectors, components, and the relationships between them. Masking, monitor flags, L1, L2, 2-theta and position are stored as part of :py:obj:`~mantid.geometry.DetectorInfo`. In addition, :py:obj:`~mantid.geometry.ComponentInfo` provides the API to tree and shape related operations historically performed by :ref:`Instrument` type.
 
-A spectrum corresponds to (a group of) one or more detectors. Most algorithms work with spectra and thus ``SpectrumInfo`` would be used. Some algorithms work on a lower level (with individual detectors) and thus ``DetectorInfo`` would be used.
+A spectrum corresponds to (a group of) one or more detectors. Most algorithms work with spectra and thus :py:obj:`~mantid.api.SpectrumInfo` would be used. Some algorithms work on a lower level (with individual detectors) and thus :py:obj:`~mantid.geometry.DetectorInfo` would be used.
 
-The legacy ``Instrument`` largely consists of ``Detectors`` and ``Components`` - all detectors are also components. ``DetectorInfo`` and ``ComponentInfo`` are the respective replacements for these. ``ComponentInfo`` introduces a **component index** for access, and ``DetectorInfo`` introduces a **detector index**, these will be discussed further below. ``DetectorInfo`` and ``ComponentInfo`` share in-memory data. The difference between the two is best thought about in terms of their interfaces. The interface for ``DetectorInfo`` is designed for working with detectors, and the interface for ``ComponentInfo`` is designed for working with generic components.
+The legacy :ref:`Instrument` largely consists of ``Detectors`` and ``Components`` - all detectors are also components. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` are the respective replacements for these. :py:obj:`~mantid.geometry.ComponentInfo` introduces a **component index** for access, and :py:obj:`~mantid.geometry:DetectorInfo` introduces a **detector index**, these will be discussed further below. :py:obj:`~mantid.geometry.DetectorInfo` and :py:obj:`~mantid.geometry.ComponentInfo` share in-memory data. The difference between the two is best thought about in terms of their interfaces. The interface for :py:obj:`~mantid.geometry.DetectorInfo` is designed for working with detectors, and the interface for :py:obj:`~mantid.geometry.ComponentInfo` is designed for working with generic components.
 
-In many cases direct access to legacy ``Instrument`` can be removed by using these layers. This will also help in moving to using indexes for enumeration, and only working with IDs for user-facing input.
+In many cases direct access to legacy :ref:`Instrument` can be removed by using these layers. This will also help in moving to using indexes for enumeration, and only working with IDs for user-facing input.
 
 Current Status
 ##############
 
-``SpectrumInfo``, ``DetectorInfo`` and ``ComponentInfo``  are largely complete, with a diminishing number of cases where any legacy direct ``Instrument`` access is still necessary. However, using the new interfaces everywhere now will help with the eventual complete rollout of Instrument 2.0. 
+``SpectrumInfo``, ``DetectorInfo`` and ``ComponentInfo``  are largely complete, with a diminishing number of cases where any legacy direct ``Instrument`` access is still necessary. However, using the new interfaces everywhere now will help with the eventual complete rollout of Instrument 2.0.
 
 SpectrumInfo
 ____________
 
-``SpectrumInfo`` can be obtained from a call to ``MatrixWorkspace::spectrumInfo()``. The wrapper class holds a reference to a ``DetectorInfo`` object and calls through to this for access to information on masking, monitor flags etc.
+``SpectrumInfo`` can be obtained from a call to :py:obj:`mantid.api.MatrixWorkspace.spectrumInfo()`. The wrapper class holds a reference to a ``DetectorInfo`` object and calls through to this for access to information on masking, monitor flags etc.
 
 DetectorInfo
 ____________
 
-``DetectorInfo`` can be obtained from a call to ``ExperimentInfo::detectorInfo()`` (usually this method would be called on ``MatrixWorkspace``). The wrapper class holds a reference to the parametrised instrument for retrieving the relevant information.
+``DetectorInfo`` can be obtained from a call to :py:obj:`mantid.api.ExperimentInfo.detectorInfo()` (usually this method would be called on ``MatrixWorkspace``). The wrapper class holds a reference to the parametrised instrument for retrieving the relevant information.
 
-There is also a near-complete implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The wrapper ``DetectorInfo`` class (which you get from ``ExperimentInfo::detectorInfo()``) holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
+There is also a near-complete implementation of the "real" ``DetectorInfo`` class, in the ``Beamline`` namespace. The wrapper ``DetectorInfo`` class (which you get from :py:obj:`~mantid.api.ExperimentInfo.detectorInfo()`) holds a reference to the real class. This does not affect the rollout, where the wrapper class should still be used in all cases.
 
-``ExperimentInfo`` now also provides a method ``mutableDetectorInfo()`` so that non-const access to the DetectorInfo is possible for purposes of writing detector related information such as positions or rotations. 
+``ExperimentInfo`` now also provides a method ``mutableDetectorInfo()`` so that non-const access to the DetectorInfo is possible for purposes of writing detector related information such as positions or rotations.
 
 The python interface to ``DetectorInfo`` has matured, and includes widespread immutable access via iterators. The iterators can also be used to set masking flags.
 
@@ -91,7 +91,7 @@ The following methods are useful helpers on ``ComponentInfo`` that allow the ext
 
 **Indexing**
 
-The ``ComponentInfo`` object is accessed by an index going from 0 to the number of components (including the instrument iteself). **The component index for a detector is EQUAL to the detector index**, this is an important point to understand. In other words, a detector with a Detector Index of 5, for the purposes of working with a ``DetectorInfo`` and  will have a Component Index of 5, when working with a ``ComponentInfo``. Explained in yet another way: The first 0 - n components referenced in the ``ComponentInfo`` are detectors, where n is the total number of detectors. This guarantee can be leveraged to provide speedups, as some of the examples will show.  
+The ``ComponentInfo`` object is accessed by an index going from 0 to the number of components (including the instrument iteself). **The component index for a detector is EQUAL to the detector index**, this is an important point to understand. In other words, a detector with a Detector Index of 5, for the purposes of working with a ``DetectorInfo`` and  will have a Component Index of 5, when working with a ``ComponentInfo``. Explained in yet another way: The first 0 - n components referenced in the ``ComponentInfo`` are detectors, where n is the total number of detectors. This guarantee can be leveraged to provide speedups, as some of the examples will show.
 
 A ``ComponentID`` for compatibility with older code, and be extracted from ``ComponentInfo::componentID(componentIndex)``, but such calls should be avoided where possible.
 
@@ -145,10 +145,10 @@ Detector Indices are the same as the corresponding Component Indices. Note that 
 
   const auto &componentInfo = ws->componentInfo();
   const auto &detectorInfo = ws->componentInfo();
-  
+
   std::vector<double> solidAnglesForDetectors(detectorInfo.size(), -1.0);
   for (size_t i = 0; i < componentInfo.size(); ++i) {
-    if(componentInfo.isDetector(i) && !detectorInfo.isMasked(i)) 
+    if(componentInfo.isDetector(i) && !detectorInfo.isMasked(i))
      solidAnglesForDetectors[i] = componentInfo.solidAngle(i, observer);
     }
   }
@@ -165,7 +165,7 @@ Detector Indices are the same as the corresponding Component Indices. Note that 
 
   const auto &componentInfo = ws->componentInfo();
   auto bankComponents = componentInfo.componentsInSubtree(bank0Index);
-  auot bankDetectors = componentInfo.detectorsInSubtree(bank0Index);
+  auto bankDetectors = componentInfo.detectorsInSubtree(bank0Index);
 
 Mutable ComponentInfo
 _____________________
@@ -184,7 +184,7 @@ ___________
 * Get the ``ComponentInfo`` object as a const-ref and use ``const auto &componentInfo = ws->componentInfo();``, do not get a non-const reference unless you really do need to modify the object, and ensure that the ``&`` is always included to prevent accidental copies.
 * ``ComponentInfo`` is widely forward declared. Ensure that you import - ``#include "MantidGeometry/Instrument/ComponentInfo.h"``
 * As explained above, a detector index is the same thing as a component index. No translation necessary. The fact that the first 0-n component indexes are for detectors is a feature that can be leveraged.
-* A bank always has a higher component index than any of its nested components. The root is the highest component index of all. This feature can be leveraged. Consider reverse iterating through component indexes when performing operations that involve higher-level components. 
+* A bank always has a higher component index than any of its nested components. The root is the highest component index of all. This feature can be leveraged. Consider reverse iterating through component indexes when performing operations that involve higher-level components.
 
 Dealing with problems
 ---------------------


### PR DESCRIPTION
`ComponentInfo`, `DetectorInfo`, and `SpectrumInfo` referred to each other by name by not with proper links. This adds in lots of links. More can be done, but this helps.

**To test:**

Build the docs and see that you can more easily navigate between them.

*There is no associated issue.*


*This does not require release notes* because it is only adding links between documentation.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
