### PR TITLE
Move EQSANSTOFStructureTest system test

### DIFF
--- a/Testing/SystemTests/tests/analysis/EQSANSTOFStructureTest.py
+++ b/Testing/SystemTests/tests/analysis/EQSANSTOFStructureTest.py
@@ -6,22 +6,22 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #pylint: disable=no-init,attribute-defined-outside-init
 
-import stresstesting
-from mantid.simpleapi import Load, EQSANSTOFStructure
+import systemtesting
+from mantid.simpleapi import Load, EQSANSTofStructure
 
-class EQSANSTOFSTructureTest(stresstesting.MantidStressTest):
 
+class EQSANSTOFSTructureTest(systemtesting.MantidSystemTest):
     alg_out = None
+    in_file = 'EQSANS_92353_event_eqsanstofstr_in.nxs'
+    ref_file = 'EQSANS_92353_event_eqsanstofstr_out.nxs'
 
     def requiredFiles(self):
-        return ['EQSANS_92353_event_eqsanstofstr_in.nxs',
-                'EQSANS_92353_event_eqsanstofstr_out.nxs']
+        return [self.in_file, self.ref_file]
 
     def runTest(self):
-        in_file = 'EQSANS_92353_event_eqsanstofstr_in.nxs'
-        Load(Filename='EQSANS_92353_event_eqsanstofstr_in.nxs',
+        Load(Filename=self.in_file,
              OutputWorkspace='change_tof_structure')
-        self.alg_out = EQSANSTOFStructure(InputWorkspace='change_tof_structure',
+        self.alg_out = EQSANSTofStructure(InputWorkspace='change_tof_structure',
                                           LowTOFCut=500,
                                           HighTOFCut=2000)
 
@@ -38,5 +38,4 @@ class EQSANSTOFSTructureTest(stresstesting.MantidStressTest):
                          'Incorrect WavelengthMinFrame2')
         self.assertDelta(self.alg_out.WavelengthMaxFrame2, 12.9809, 0.0001,
                          'Incorrect TofOffset')
-        return 'change_tof_structure',\
-               'EQSANS_92353_event_eqsanstofstr_out.nxs'
+        return 'change_tof_structure', self.ref_file


### PR DESCRIPTION
After it was merged into master, it was discovered that `EQSANSTOFStructureTest` wasn't actually being discovered by the test framework. Additionally, it was not inheriting from the right classes. Both of these are fixed and the test should be run correctly now.

**To test:**

See that the RHEL7 build actually ran the test.

This is a follow-on to #25894.

*There is no associated issue.*

*This does not require release notes* because it is activating a system test.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
