### PR TITLE
Re-enable ISIS SANS help button

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -541,7 +541,7 @@ class SANSDataProcessorGui(QMainWindow,
         if PYQT4:
             proxies.showCustomInterfaceHelp('ISIS SANS v2')
         else:
-            InterfaceManager().showHelpPage('qthelp://org.sphinx.mantidproject.4.0/doc/'
+            InterfaceManager().showHelpPage('qthelp://org.sphinx.mantidproject/doc/'
                                             'interfaces/ISIS%20SANS%20v2.html')
 
     def _on_output_mode_clicked(self):

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -20,6 +20,7 @@ from six import with_metaclass
 from reduction_gui.reduction.scripter import execute_script
 from mantid.kernel import (Logger)
 from mantidqt import icons
+from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets import jobtreeview, manageuserdirectories
 from sans.common.enums import (BinningType, ReductionDimensionality, OutputMode, SaveType, SANSInstrument,
@@ -539,6 +540,9 @@ class SANSDataProcessorGui(QMainWindow,
     def _on_help_button_clicked(self):
         if PYQT4:
             proxies.showCustomInterfaceHelp('ISIS SANS v2')
+        else:
+            InterfaceManager().showHelpPage('qthelp://org.sphinx.mantidproject.4.0/doc/'
+                                            'interfaces/ISIS%20SANS%20v2.html')
 
     def _on_output_mode_clicked(self):
         """This method is called when an output mode is clicked on the gui"""


### PR DESCRIPTION
**Description of work.**
When the ISIS SANS gui was ported to workbench, the help window was not available.
Workbench has a working help button, and now ISIS SANS does also.

**To test:**
1. Open workbench
2. Interfaces -> SANS -> ISIS SANS
3. At the bottom left hand corner, click the `?`
4. A help window page should open to the ISIS SANS documentation

*There is no associated issue.*

*This does not require release notes* because **minor fix to something not noticed by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
