### PR TITLE
SliceViewer bug fixes

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -48,7 +48,7 @@ class SliceViewerView(QWidget):
         self.create_axes()
         self.mpl_layout.addWidget(self.canvas)
         self.colorbar = ColorbarWidget(self)
-        self.colorbar.colorbarChanged.connect(self.canvas.draw_idle)
+        self.colorbar.colorbarChanged.connect(self.update_data_clim)
         self.colorbar.colorbarChanged.connect(self.update_line_plot_limits)
         self.mpl_layout.addWidget(self.colorbar)
 
@@ -127,10 +127,14 @@ class SliceViewerView(QWidget):
 
     def clear_line_plots(self):
         try: # clear old plots
-            self.xfig.clear()
-            self.yfig.clear()
+            del self.xfig
+            del self.yfig
         except AttributeError:
             pass
+
+    def update_data_clim(self):
+        self.im.set_clim(self.colorbar.colorbar.get_clim()) # force clim update, needed for RHEL7
+        self.canvas.draw_idle()
 
     def update_line_plot_limits(self):
         if self.line_plots:


### PR DESCRIPTION
`list.clear()` isn't available on python 2, changed to `del`

The imshow limits were not updating when the colorbar changed (only older versions of matplotlib, _i.e._ RHEL7), this forcefully set the limits on the data from the colorbar

**To test:**

Try the step to reproduce in #25900

Fixes #25900 

*This does not require release notes* because only added this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
