### PR TITLE
Make Sliceviewer work with QT4 again

### DIFF
--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -92,6 +92,7 @@ if(ENABLE_WORKBENCH)
     mantidqt/widgets/samplelogs/test/test_samplelogs_presenter.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
     mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+    mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
     mantidqt/widgets/observers/test/test_ads_observer.py
     mantidqt/widgets/observers/test/test_observing_presenter.py
     mantidqt/widgets/observers/test/test_observing_view.py
@@ -112,7 +113,6 @@ if(ENABLE_WORKBENCH)
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
     mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
-    mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
     mantidqt/widgets/test/test_jupyterconsole.py
     mantidqt/widgets/workspacedisplay/test/test_data_copier.py
     mantidqt/widgets/workspacedisplay/test/test_user_notifier.py

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -33,7 +33,7 @@ class ColorbarWidget(QWidget):
 
         self.cmap = QComboBox()
         self.cmap.addItems(sorted(cm.cmap_d.keys()))
-        self.cmap.currentTextChanged.connect(self.cmap_changed)
+        self.cmap.currentIndexChanged.connect(self.cmap_index_changed)
 
         self.cmin = QLineEdit()
         self.cmin_value = 0
@@ -111,8 +111,11 @@ class ColorbarWidget(QWidget):
         self.cmin_value, self.cmax_value = self.colorbar.get_clim()
         self.update_clim_text()
         self.cmap_changed(cmap)
-        self.cmap.setCurrentText(self.colorbar.get_cmap().name)
+        self.cmap.setCurrentIndex(sorted(cm.cmap_d.keys()).index(self.colorbar.get_cmap().name))
         self.redraw()
+
+    def cmap_index_changed(self):
+        self.cmap_changed(self.cmap.currentText())
 
     def cmap_changed(self, name):
         self.colorbar.set_cmap(name)


### PR DESCRIPTION
This fixes the colorbar in the sliceviewer to work with pyqt4. Also move the view unit test to now include qt4

**To test:**

Try the failing example in #25913

Fixes #25913


*This does not require release notes* because it was only added this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
