### PR TITLE
MaskBTP adds property for masking named components

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -203,6 +203,16 @@ class MaskBTPTest(unittest.TestCase):
         self.assertEqual(int(32 * 160), len(masked))
         self.checkConsistentMask(wksp, masked)
 
+    def test_components(self):
+        # this also verifies support for instruments that aren't explicitly in the list
+        wksp = LoadEmptyInstrument(InstrumentName='GEM', OutputWorkspace='GEM')
+        masked = MaskBTP(Workspace=wksp, Components='bank3-east,bank3-west', Tube='1-3')  # zero indexed b/c not supported instrument
+        self.assertEqual(2*3*90, len(masked))
+
+        wksp = LoadEmptyInstrument(InstrumentName='GEM', OutputWorkspace='GEM')
+        masked = MaskBTP(Workspace=wksp, Components='bank3')
+        self.assertEqual(10 * 90, len(masked))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/algorithms/MaskBTP-v1.rst
+++ b/docs/source/algorithms/MaskBTP-v1.rst
@@ -10,27 +10,27 @@
 Description
 -----------
 
-Algorithm to mask detectors in particular banks, tube, or pixels. It
-applies to the following instruments only: ARCS, CNCS, CORELLI, HYSPEC, NOMAD,
-POWGEN, SEQUOIA, SNAP, TOPAZ. For instruments with rectangular position
-sensitive detectors (POWGEN, SNAP, TOPAZ), the tube is corresponding to
-the x coordinate, and pixel to the y coordinate. For example, on SNAP
-Bank="1", Tube="3" corresponds to 'SNAP/East/Column1/bank1/bank1(x=3)',
-and Bank="1", Tube="3", Pixel="5" is 'SNAP/East/Column1/bank1/bank1(x=3)/bank1(3,5)'.
+Algorithm to mask detectors in particular banks, tube, or pixels.
+To use the ``Bank`` argument, the instrument must be one of: ARCS, BIOSANS, CG2 CNCS, CORELLI, EQ-SANS HYSPEC, MANDI, NOMAD, POWGEN, SEQUOIA, SNAP, SXD, TOPAZ, WAND, WISH.
+For instruments with rectangular position sensitive detectors (POWGEN, SNAP, TOPAZ), the tube is corresponding to the x coordinate, and pixel to the y coordinate.
+For example, on SNAP ``Bank="1"``, ``Tube="3"`` corresponds to ``SNAP/East/Column1/bank1/bank1(x=3)``, and ``Bank="1"``, ``Tube="3"``, ``Pixel="5"`` is ``SNAP/East/Column1/bank1/bank1(x=3)/bank1(3,5)``.
 
-If one of Bank, Tube, Pixel entries is left blank, it will apply to all
+If one of ``Bank``, ``Tube``, ``Pixel`` entries is left blank, it will apply to all
 elements of that type. For example:
 
-- MaskBTP(w,Bank = "1") will completely mask all tubes and pixels in bank 1. 
-- MaskBTP(w,Pixel = "1,2") will mask all pixels 1 and 2, in all tubes, in all banks.
+- ``MaskBTP(w,Bank = "1")`` will completely mask all tubes and pixels in bank 1.
+- ``MaskBTP(w,Pixel = "1,2")`` will mask all pixels 1 and 2, in all tubes, in all banks.
 
-The algorithm allows ranged inputs: 
+The algorithm allows ranged inputs:
 
-- Pixel = "1-8,121-128" is equivalent to Pixel = "1,2,3,4,5,6,7,8,121,122,123,124,125,126,127,128"
+- ``Pixel="1-8,121-128"` is equivalent to ``Pixel="1,2,3,4,5,6,7,8,121,122,123,124,125,126,127,128"
+
+Alternatively, the ``Components`` argument can be used to select named components instead of ``Banks``.
+This is can be used for masking entire sub-components of an instrument.
 
 .. Note::
 
-    Either the input workspace or the instrument must be set. 
+    Either the input workspace or the instrument must be set.
     If the workspace is set, the instrument is ignored.
 
 Usage
@@ -72,7 +72,7 @@ Output:
     A pixel Bank 42, detector 42700:  True
     Pixel 1 in Tube 4 in Bank 45, detector 45440:  True
     Pixel 100 in Tube 2 in Bank 45, detector 45283:  True
-    
+
     And one that should not be masked
     Pixel 128 in Tube 8 in Bank 50, detector 51199:  False
 

--- a/docs/source/algorithms/MaskBTP-v1.rst
+++ b/docs/source/algorithms/MaskBTP-v1.rst
@@ -23,7 +23,7 @@ elements of that type. For example:
 
 The algorithm allows ranged inputs:
 
-- ``Pixel="1-8,121-128"` is equivalent to ``Pixel="1,2,3,4,5,6,7,8,121,122,123,124,125,126,127,128"
+- ``Pixel="1-8,121-128"`` is equivalent to ``Pixel="1,2,3,4,5,6,7,8,121,122,123,124,125,126,127,128"``
 
 Alternatively, the ``Components`` argument can be used to select named components instead of ``Banks``.
 This is can be used for masking entire sub-components of an instrument.

--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -12,7 +12,7 @@ SANS Changes
 :ref:`Release 4.1.0 <v4.1.0>`
 
 - New IDF for EQSANS
-- Added support for ``BIOSANS``, ``EQSANS``, and ``GPSANS`` to :ref:`MaskBTP <algm-MaskBTP>`
+- Added support for ``BIOSANS``, ``EQSANS``, and ``GPSANS`` to :ref:`MaskBTP <algm-MaskBTP>`. This includes an additional parameter ``Components`` to mask a particular list of instrument components.
 
 ISIS SANS Interface
 -------------------


### PR DESCRIPTION
This is intended for masking the front or back planes of EQ-SANS, but it
written to work generically. Using this property also makes the
algorithm work with any instrument in this mode.

**To test:**

Try it out on the (in progress) EQ-SANS IDF.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
