### PR TITLE
Option to save default layout workbench

### DIFF
--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -18,6 +18,7 @@ Improvements
 - Mantid's offline help is now available in Workbench.
 - A colorfill plot of a workspace with logarithmic bins is plotted on a log scale.
 - You can now toggle the normalization of plots in Workbench from the plot's context menu
+- You can now set a default user layout from the view menu that will be loaded on startup.
 
 Bugfixes
 ########

--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -18,7 +18,8 @@ Improvements
 - Mantid's offline help is now available in Workbench.
 - A colorfill plot of a workspace with logarithmic bins is plotted on a log scale.
 - You can now toggle the normalization of plots in Workbench from the plot's context menu
-- You can now set a default user layout from the view menu that will be loaded on startup.
+- You can now save, load and delete custom layouts from the settings menu with quick access to user layout in the view
+  menu.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -427,12 +427,13 @@ class MainWindow(QMainWindow):
 
     def save_layout_settings(self):
         """Save the current layout to configuration"""
-        CONF.set("Layout/Layout", self.saveState())
+        CONF.set("MainWindow/UserLayout", self.saveState())
 
     def load_layout_settings(self):
-        """Load a layout for the child widgets from the user config, if no user default exists load the default"""
+        """Load a layout for the child widgets from the user config, 
+        if no user default exists load the default"""
         try:
-            self.restoreState(CONF.get("Layout/Layout"))
+            self.restoreState(CONF.get("MainWindow/UserLayout"))
         except KeyError:
             self.setup_default_layouts()  # If user layout not found load default
 

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -297,6 +297,7 @@ class MainWindow(QMainWindow):
                                   action_save_project, action_save_project_as,
                                   None, action_settings, None,
                                   action_manage_directories, None, action_quit]
+
         # view menu
         action_restore_default = create_action(
             self, "Restore Default Layout",
@@ -430,6 +431,10 @@ class MainWindow(QMainWindow):
         layout_options = []
         for item in layout_keys:
             layout_options.append(self.create_load_layout_action(item, layout_dict[item]))
+        layout_options.append(None)
+        action_settings = create_action(
+            self, "Settings", on_triggered=self.open_settings_layout_window)
+        layout_options.append(action_settings)
 
         add_actions(self.view_menu_layouts, layout_options)
 
@@ -574,6 +579,11 @@ class MainWindow(QMainWindow):
 
     def open_settings_window(self):
         settings = SettingsPresenter(self)
+        settings.show()
+
+    def open_settings_layout_window(self):
+        settings = SettingsPresenter(self)
+        settings.general_settings.focus_layout_box()
         settings.show()
 
     def config_updated(self):

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -236,11 +236,10 @@ class MainWindow(QMainWindow):
         self.interface_manager = InterfaceManager()
 
         # uses default configuration as necessary
-        self.readSettings(CONF)
-        self.config_updated()
-
         self.setup_default_layouts()
         self.create_actions()
+        self.readSettings(CONF)
+        self.config_updated()
 
     def post_mantid_init(self):
         """Run any setup that requires mantid

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -303,7 +303,7 @@ class MainWindow(QMainWindow):
             on_triggered=self.setup_default_layouts,
             shortcut="Shift+F10", shortcut_context=Qt.ApplicationShortcut)
         action_save_user_layout = create_action(
-            self, "Set Custom Layout",
+            self, "Save Custom Layout",
             on_triggered=self.save_layout_settings,
             shortcut_context=Qt.ApplicationShortcut)
         action_load_user_layout = create_action(

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -311,8 +311,8 @@ class MainWindow(QMainWindow):
             on_triggered=self.load_layout_settings,
             shortcut="Shift+F11", shortcut_context=Qt.ApplicationShortcut)
 
-        self.view_menu_actions = [action_restore_default, action_save_user_layout, action_load_user_layout, None] \
-                                 + self.create_widget_actions()
+        self.view_menu_actions = [action_restore_default, action_save_user_layout, action_load_user_layout,
+                                  None] + self.create_widget_actions()
 
         # help menu
         action_mantid_help = create_action(
@@ -436,11 +436,6 @@ class MainWindow(QMainWindow):
         except KeyError:
             self.setup_default_layouts()  # If user layout not found load default
 
-    def setup_layout(self):
-        """Assume this is a first run of the application and set layouts
-        accordingly"""
-        self.load_layout_settings()
-
     def prep_window_for_reset(self):
         """Function to reset all dock widgets to a state where they can be
         ordered by setup_default_layout"""
@@ -509,8 +504,8 @@ class MainWindow(QMainWindow):
                     row[0].dockwidget.show()
                     row[0].dockwidget.raise_()
 
-
     # ----------------------- Events ---------------------------------
+    
     def closeEvent(self, event):
         # Check whether or not to save project
         if not self.project.saved:

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -238,7 +238,7 @@ class MainWindow(QMainWindow):
         self.readSettings(CONF)
         self.config_updated()
 
-        self.setup_layout()
+        self.load_layout_settings()
         self.create_actions()
 
     def post_mantid_init(self):
@@ -309,7 +309,7 @@ class MainWindow(QMainWindow):
         action_load_user_layout = create_action(
             self, "Restore Custom Layout",
             on_triggered=self.load_layout_settings,
-            shortcut="Shift+F12", shortcut_context=Qt.ApplicationShortcut)
+            shortcut="Shift+F11", shortcut_context=Qt.ApplicationShortcut)
 
         self.view_menu_actions = [action_restore_default, action_save_user_layout, action_load_user_layout, None] \
                                  + self.create_widget_actions()
@@ -425,10 +425,21 @@ class MainWindow(QMainWindow):
 
     # ----------------------- Layout ---------------------------------
 
+    def save_layout_settings(self):
+        """Save the current layout to configuration"""
+        CONF.set("Layout/Layout", self.saveState())
+
+    def load_layout_settings(self):
+        """Load a layout for the child widgets from the user config, if no user default exists load the default"""
+        try:
+            self.restoreState(CONF.get("Layout/Layout"))
+        except KeyError:
+            self.setup_default_layouts()  # If user layout not found load default
+
     def setup_layout(self):
         """Assume this is a first run of the application and set layouts
         accordingly"""
-        self.setup_default_layouts()
+        self.load_layout_settings()
 
     def prep_window_for_reset(self):
         """Function to reset all dock widgets to a state where they can be
@@ -498,16 +509,6 @@ class MainWindow(QMainWindow):
                     row[0].dockwidget.show()
                     row[0].dockwidget.raise_()
 
-    def save_layout_settings(self):
-        """Save the current layout to configuration"""
-        CONF.set("Layout/Layout", self.saveState())
-
-    def load_layout_settings(self):
-        """Load a layout for the child widgets from a file"""
-        try:
-            self.restoreState(CONF.get("Layout/Layout"))
-        except KeyError:
-            self.setup_default_layouts()  # If user layout not found load default
 
     # ----------------------- Events ---------------------------------
     def closeEvent(self, event):

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -430,7 +430,7 @@ class MainWindow(QMainWindow):
         CONF.set("MainWindow/UserLayout", self.saveState())
 
     def load_layout_settings(self):
-        """Load a layout for the child widgets from the user config, 
+        """Load a layout for the child widgets from the user config,
         if no user default exists load the default"""
         try:
             self.restoreState(CONF.get("MainWindow/UserLayout"))

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -426,7 +426,7 @@ class MainWindow(QMainWindow):
             layout_dict = CONF.get("MainWindow/user_layouts")
         except KeyError:
             layout_dict = {}
-        layout_keys = layout_dict.keys()
+        layout_keys = list(layout_dict.keys())
         layout_keys.sort()
         layout_options = []
         for item in layout_keys:

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -426,8 +426,7 @@ class MainWindow(QMainWindow):
             layout_dict = CONF.get("MainWindow/user_layouts")
         except KeyError:
             layout_dict = {}
-        layout_keys = list(layout_dict.keys())
-        layout_keys.sort()
+        layout_keys = sorted(layout_dict.keys())
         layout_options = []
         for item in layout_keys:
             layout_options.append(self.create_load_layout_action(item, layout_dict[item]))
@@ -583,8 +582,8 @@ class MainWindow(QMainWindow):
 
     def open_settings_layout_window(self):
         settings = SettingsPresenter(self)
-        settings.general_settings.focus_layout_box()
         settings.show()
+        settings.general_settings.focus_layout_box()
 
     def config_updated(self):
         """

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -505,7 +505,6 @@ class MainWindow(QMainWindow):
                     row[0].dockwidget.raise_()
 
     # ----------------------- Events ---------------------------------
-    
     def closeEvent(self, event):
         # Check whether or not to save project
         if not self.project.saved:

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -30,6 +30,7 @@ class GeneralSettings(object):
     PR_RECOVERY_ENABLED = "projectRecovery.enabled"
     PROMPT_SAVE_EDITOR_MODIFIED = 'project/prompt_save_editor_modified'
     PROMPT_SAVE_ON_CLOSE = 'project/prompt_save_on_close'
+    USER_LAYOUT = "MainWindow/user_layouts"
 
     def __init__(self, parent, view=None):
         self.view = view if view else GeneralSettingsView(parent, self)
@@ -132,34 +133,34 @@ class GeneralSettings(object):
 
     def get_layout_dict(self):
         try:
-            layout_list = CONF.get("MainWindow/user_layouts")
+            layout_list = CONF.get(self.USER_LAYOUT)
         except KeyError:
             layout_list = {}
         return layout_list
 
     def save_layout(self):
         filename = self.view.new_layout_name.text()
-        layout_dict = self.get_layout_dict()
-        layout_dict[filename] = self.parent.saveState()
-        if filename == "":
-            pass
-        else:
-            CONF.set("MainWindow/user_layouts", layout_dict)
-        self.view.new_layout_name.clear()
-        self.fill_layout_display()
-        self.parent.populate_layout_menu()
+        if filename != "":
+            layout_dict = self.get_layout_dict()
+            layout_dict[filename] = self.parent.saveState()
+            CONF.set(self.USER_LAYOUT, layout_dict)
+            self.view.new_layout_name.clear()
+            self.fill_layout_display()
+            self.parent.populate_layout_menu()
 
     def load_layout(self):
-        items = self.view.layout_display.currentItem()
-        if hasattr(items, "test"):
-            layout = self.view.layout_display.currentItem().text()
+        item = self.view.layout_display.currentItem()
+        if hasattr(item, "text"):
+            layout = item.text()
             layout_dict = self.get_layout_dict()
             self.parent.restoreState(layout_dict[layout])
 
     def delete_layout(self):
-        layout = self.view.layout_display.currentItem().text()
-        layout_dict = self.get_layout_dict()
-        layout_dict.pop(layout, None)
-        CONF.set("MainWindow/user_layouts", layout_dict)
-        self.fill_layout_display()
-        self.parent.populate_layout_menu()
+        item = self.view.layout_display.currentItem()
+        if hasattr(item, "text"):
+            layout = item.text()
+            layout_dict = self.get_layout_dict()
+            layout_dict.pop(layout, None)
+            CONF.set(self.USER_LAYOUT, layout_dict)
+            self.fill_layout_display()
+            self.parent.populate_layout_menu()

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -150,9 +150,11 @@ class GeneralSettings(object):
         self.parent.populate_layout_menu()
 
     def load_layout(self):
-        layout = self.view.layout_display.currentItem().text()
-        layout_dict = self.get_layout_dict()
-        self.parent.restoreState(layout_dict[layout])
+        items = self.view.layout_display.currentItem()
+        if hasattr(items, "test"):
+            layout = self.view.layout_display.currentItem().text()
+            layout_dict = self.get_layout_dict()
+            self.parent.restoreState(layout_dict[layout])
 
     def delete_layout(self):
         layout = self.view.layout_display.currentItem().text()

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -164,3 +164,7 @@ class GeneralSettings(object):
             CONF.set(self.USER_LAYOUT, layout_dict)
             self.fill_layout_display()
             self.parent.populate_layout_menu()
+
+    def focus_layout_box(self):
+        self.view.scrollArea.ensureWidgetVisible(self.view.new_layout_name)
+        self.view.new_layout_name.setFocus()

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -125,7 +125,7 @@ class GeneralSettings(object):
     def fill_layout_display(self):
         self.view.layout_display.clear()
         layout_dict = self.get_layout_dict()
-        layout_list = layout_dict.keys()
+        layout_list = list(layout_dict.keys())
         layout_list.sort()
         for item in layout_list:
             self.view.layout_display.addItem(item)

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -165,5 +165,6 @@ class GeneralSettings(object):
             self.parent.populate_layout_menu()
 
     def focus_layout_box(self):
-        self.view.scrollArea.ensureWidgetVisible(self.view.new_layout_name)
+        # scroll the settings to the layout box. High yMargin ensures the box is always at the top of the window.
+        self.view.scrollArea.ensureWidgetVisible(self.view.new_layout_name, yMargin=1000)
         self.view.new_layout_name.setFocus()

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -126,8 +126,7 @@ class GeneralSettings(object):
     def fill_layout_display(self):
         self.view.layout_display.clear()
         layout_dict = self.get_layout_dict()
-        layout_list = list(layout_dict.keys())
-        layout_list.sort()
+        layout_list = sorted(layout_dict.keys())
         for item in layout_list:
             self.view.layout_display.addItem(item)
 

--- a/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>493</width>
-    <height>380</height>
+    <width>580</width>
+    <height>479</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,9 +44,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>481</width>
-        <height>337</height>
+        <y>-121</y>
+        <width>547</width>
+        <height>595</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -301,6 +301,42 @@
                </widget>
               </item>
              </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_4">
+           <property name="title">
+            <string>Layouts</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="2" column="0" colspan="2">
+             <widget class="QPushButton" name="load_layout">
+              <property name="text">
+               <string>Load Layout</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="4">
+             <widget class="QListWidget" name="layout_display"/>
+            </item>
+            <item row="2" column="2" colspan="2">
+             <widget class="QPushButton" name="delete_layout">
+              <property name="text">
+               <string>Delete Layout</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="3">
+             <widget class="QPushButton" name="save_layout">
+              <property name="text">
+               <string>Save Layout</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="3">
+             <widget class="QLineEdit" name="new_layout_name"/>
             </item>
            </layout>
           </widget>

--- a/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
@@ -44,7 +44,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-121</y>
+        <y>-127</y>
         <width>547</width>
         <height>595</height>
        </rect>
@@ -335,8 +335,15 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="3">
+            <item row="3" column="1" colspan="2">
              <widget class="QLineEdit" name="new_layout_name"/>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Layout Name:</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>

--- a/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
@@ -44,7 +44,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-91</y>
+        <y>-36</y>
         <width>547</width>
         <height>595</height>
        </rect>
@@ -311,27 +311,10 @@
             <string>Layouts</string>
            </property>
            <layout class="QGridLayout" name="gridLayout">
-            <item row="2" column="0" colspan="2">
-             <widget class="QPushButton" name="load_layout">
-              <property name="text">
-               <string>Load Layout</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0" colspan="4">
-             <widget class="QListWidget" name="layout_display"/>
-            </item>
             <item row="2" column="2" colspan="2">
              <widget class="QPushButton" name="delete_layout">
               <property name="text">
                <string>Delete Layout</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="3">
-             <widget class="QPushButton" name="save_layout">
-              <property name="text">
-               <string>Save Layout</string>
               </property>
              </widget>
             </item>
@@ -342,6 +325,23 @@
              <widget class="QLabel" name="label">
               <property name="text">
                <string>Layout Name:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0" colspan="4">
+             <widget class="QListWidget" name="layout_display"/>
+            </item>
+            <item row="3" column="3">
+             <widget class="QPushButton" name="save_layout">
+              <property name="text">
+               <string>Save Layout</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QPushButton" name="load_layout">
+              <property name="text">
+               <string>Load Layout</string>
               </property>
              </widget>
             </item>

--- a/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
@@ -44,7 +44,7 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-127</y>
+        <y>-91</y>
         <width>547</width>
         <height>595</height>
        </rect>
@@ -306,7 +306,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QGroupBox" name="groupBox_4">
+          <widget class="QGroupBox" name="layout_box">
            <property name="title">
             <string>Layouts</string>
            </property>

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -292,8 +292,3 @@ class GeneralSettingsTest(GuiTest):
         mock_CONF.get.assert_has_calls(calls)
         mock_CONF.set.assert_called_once_with(presenter.USER_LAYOUT, {})
         mock_parent.populate_layout_menu.assert_called_once_with()
-
-
-
-
-

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -200,7 +200,7 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_fill_layout_display(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup CONF.get returns dictionary
         test_dict = {'a': 1, 'b': 2, 'c': 3}
         mock_CONF.get.return_value = test_dict
@@ -214,7 +214,7 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_get_layout_dict(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup CONF.get returns dictionary
         test_dict = {'a': 1}
         mock_CONF.get.return_value = test_dict
@@ -223,7 +223,7 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_get_layout_dict_key_error(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup CONF.get to return KeyError
         mock_CONF.get.side_effect = KeyError()
 
@@ -231,15 +231,14 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_save_layout(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup parent
         mock_parent = Mock()
         mock_parent.saveState.return_value = "value"
         presenter.parent = mock_parent
         # setup CONF.get returns dictionary
         test_dict = {'a': 1}
-        mock_CONF.get = Mock()
-        mock_CONF.get.return_value = test_dict
+        mock_CONF.get = Mock(return_value=test_dict)
         # setup mock commands
         presenter.view.new_layout_name.text = Mock(return_value='key')
         presenter.view.new_layout_name.clear = Mock()
@@ -253,7 +252,7 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_load_layout(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup parent
         mock_parent = Mock()
         presenter.parent = mock_parent
@@ -263,8 +262,7 @@ class GeneralSettingsTest(GuiTest):
         presenter.view.layout_display.currentItem = Mock(return_value=list_item)
         # setup CONF.get returns dictionary
         test_dict = {'a': 1}
-        mock_CONF.get = Mock()
-        mock_CONF.get.return_value = test_dict
+        mock_CONF.get = Mock(return_value=test_dict)
 
         presenter.load_layout()
 
@@ -273,7 +271,7 @@ class GeneralSettingsTest(GuiTest):
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_delete_layout(self, mock_CONF):
-        presenter = GeneralSettings(None)
+        presenter = GeneralSettings(None, view=Mock())
         # setup parent
         mock_parent = Mock()
         presenter.parent = mock_parent
@@ -283,8 +281,7 @@ class GeneralSettingsTest(GuiTest):
         presenter.view.layout_display.currentItem = Mock(return_value=list_item)
         # setup CONF.get returns dictionary
         test_dict = {'a': 1}
-        mock_CONF.get = Mock()
-        mock_CONF.get.return_value = test_dict
+        mock_CONF.get = Mock(return_value=test_dict)
 
         presenter.delete_layout()
 

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench
 from __future__ import absolute_import, unicode_literals
 
-from mantid.py3compat.mock import call, patch
+from mantid.py3compat.mock import call, patch, Mock
 from mantidqt.utils.qt.testing import GuiTest
 from mantidqt.utils.testing.strict_mock import StrictMock
 from workbench.widgets.settings.general.presenter import GeneralSettings
@@ -197,3 +197,103 @@ class GeneralSettingsTest(GuiTest):
 
         presenter.action_show_invisible_workspaces(False)
         mock_ConfigService.setString.assert_called_once_with(GeneralSettings.SHOW_INVISIBLE_WORKSPACES, "False")
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_fill_layout_display(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup CONF.get returns dictionary
+        test_dict = {'a': 1, 'b': 2, 'c': 3}
+        mock_CONF.get.return_value = test_dict
+        # setup mock commands
+        presenter.view.layout_display.addItem = Mock()
+
+        presenter.fill_layout_display()
+
+        calls = [call('a'), call('b'),  call('c')]
+        presenter.view.layout_display.addItem.assert_has_calls(calls)
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_get_layout_dict(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup CONF.get returns dictionary
+        test_dict = {'a': 1}
+        mock_CONF.get.return_value = test_dict
+
+        self.assertEquals(test_dict, presenter.get_layout_dict())
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_get_layout_dict_key_error(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup CONF.get to return KeyError
+        mock_CONF.get.side_effect = KeyError()
+
+        self.assertEquals({}, presenter.get_layout_dict())
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_save_layout(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup parent
+        mock_parent = Mock()
+        mock_parent.saveState.return_value = "value"
+        presenter.parent = mock_parent
+        # setup CONF.get returns dictionary
+        test_dict = {'a': 1}
+        mock_CONF.get = Mock()
+        mock_CONF.get.return_value = test_dict
+        # setup mock commands
+        presenter.view.new_layout_name.text = Mock(return_value='key')
+        presenter.view.new_layout_name.clear = Mock()
+
+        presenter.save_layout()
+
+        calls = [call(presenter.USER_LAYOUT), call(presenter.USER_LAYOUT)]
+        mock_CONF.get.assert_has_calls(calls)
+        mock_parent.saveState.assert_called_once_with()
+        mock_parent.populate_layout_menu.assert_called_once_with()
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_load_layout(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup parent
+        mock_parent = Mock()
+        presenter.parent = mock_parent
+        # setup item selection
+        list_item = Mock()
+        list_item.text.return_value = 'a'
+        presenter.view.layout_display.currentItem = Mock(return_value=list_item)
+        # setup CONF.get returns dictionary
+        test_dict = {'a': 1}
+        mock_CONF.get = Mock()
+        mock_CONF.get.return_value = test_dict
+
+        presenter.load_layout()
+
+        mock_CONF.get.assert_called_once_with(presenter.USER_LAYOUT)
+        mock_parent.restoreState.assert_called_once_with(test_dict['a'])
+
+    @patch(WORKBENCH_CONF_CLASSPATH)
+    def test_delete_layout(self, mock_CONF):
+        presenter = GeneralSettings(None)
+        # setup parent
+        mock_parent = Mock()
+        presenter.parent = mock_parent
+        # setup item selection
+        list_item = Mock()
+        list_item.text.return_value = 'a'
+        presenter.view.layout_display.currentItem = Mock(return_value=list_item)
+        # setup CONF.get returns dictionary
+        test_dict = {'a': 1}
+        mock_CONF.get = Mock()
+        mock_CONF.get.return_value = test_dict
+
+        presenter.delete_layout()
+
+        calls = [call(presenter.USER_LAYOUT), call(presenter.USER_LAYOUT)]
+        mock_CONF.get.assert_has_calls(calls)
+        mock_CONF.set.assert_called_once_with(presenter.USER_LAYOUT, {})
+        mock_parent.populate_layout_menu.assert_called_once_with()
+
+
+
+
+


### PR DESCRIPTION
**Description of work.**
I have implemented an option to save the current layout of the workbench widgets.
On startup workbench will load widgets in the state they were when last closed.
Layout can be reset to any user to using option under view.

**To test:**
1. Open Workbench.
1. Change widget dock layout.
1. ``View --> User Layouts --> Settings``
1. Save your layout.
1. Test that the layout you just saved is accessable in the settings lesection box.
1. Check that your saved layout is listed under ``View --> User Layouts``
1. ``View --> Restore default layout``
1. Test that the option to restore your layout works from the settings menu and from ``View --> User Layouts --> [your layout name]``.
1. Change widget dock layout.
1. Restart Workbench.
1. Check that the the Workbench layout restores the last layout state.
1. Check that your layout is still available.
1. Delete your layout from the settings menu
1. Check that the layout is removed from the settings selection box and ``View --> User Layouts``.

Fixes #25515.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
