### PR TITLE
add approximate position of beam monitor 4

### DIFF
--- a/Framework/DataHandling/test/GenerateGroupingPowderTest.h
+++ b/Framework/DataHandling/test/GenerateGroupingPowderTest.h
@@ -159,7 +159,7 @@ public:
     auto histogram = m_emptyInstrument->histogram(0);
     MatrixWorkspace_sptr ws =
         create<Workspace2D>(*m_emptyInstrument, 1, histogram);
-    ws->getSpectrum(0).copyInfoFrom(m_emptyInstrument->getSpectrum(7));
+    ws->getSpectrum(0).copyInfoFrom(m_emptyInstrument->getSpectrum(8));
     GenerateGroupingPowder alg;
     alg.setChild(true);
     alg.setRethrows(true);

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -93,16 +93,20 @@ class MaskBTPTest(unittest.TestCase):
         #check whether some pixels are masked when they should
         w=mtd['CNCSMaskBTP']
         detInfo = w.detectorInfo()
-        self.assertTrue(detInfo.isMasked(29699)) #pixel1 (detID 29696)
-        self.assertTrue(detInfo.isMasked(29700)) #pixel2 (detID 29697)
-        self.assertTrue(detInfo.isMasked(29701)) #pixel3 (detID 29698)
-        self.assertFalse(detInfo.isMasked(29702)) #pixel4 (detID 29699)
-        self.assertTrue(detInfo.isMasked(29703)) #pixel5 (detID 29700)
+        detIds = detInfo.detectorIDs()
 
-        self.assertTrue(detInfo.isMasked(1023)) #bank1 (detID 1020)
-        self.assertFalse(detInfo.isMasked(3071)) #bank3, tube 8 (detID 3068)
+        # check for some to be masked
+        for id in (29696, 29697, 29698, #29699,
+                   29700, 1020, 4400):
+            index = int(where(detIds == id)[0][0])
+            self.assertTrue(detInfo.isMasked(index),
+                            msg='detId={}, index={} should not be masked'.format(id, index))
 
-        self.assertTrue(detInfo.isMasked(4403)) #bank5, tube 3 (detID 4400)
+        # check for some to not be masked
+        for id in [3071]:
+            index = int(where(detIds == id)[0][0])
+            self.assertFalse(detInfo.isMasked(index),
+                             msg='detId={}, index={} should not be masked'.format(id, index))
         DeleteWorkspace(w)
 
     def testSEQMaskBTP(self):

--- a/docs/source/algorithms/ConvertSnsRoiFileToMask-v1.rst
+++ b/docs/source/algorithms/ConvertSnsRoiFileToMask-v1.rst
@@ -34,7 +34,7 @@ Usage
     # To test, load data and mask
     ws = Load("CNCS_7860_event.nxs")
     mask_file = inst_name + "_Mask.xml"
-    mask = LoadMask(inst_name, mask_file)
+    mask = LoadMask(inst_name, mask_file, RefWorkspace = ws)
     MaskDetectors(ws, MaskedWorkspace=mask)
 
     # Check to see that only first 2 pixels are not masked

--- a/instrument/CNCS_Definition.xml
+++ b/instrument/CNCS_Definition.xml
@@ -29,6 +29,7 @@
       <location name="monitor1" z="-29.949"/>
       <location name="monitor2" z="-28.706"/>
       <location name="monitor3" z="-1.416"/>
+      <location name="monitor4" z="3.7338"/>
     </component>
   </type>
   <component idlist="detectors" type="detectors">
@@ -714,6 +715,7 @@
     <id val="-1"/>
     <id val="-2"/>
     <id val="-3"/>
+    <id val="-4"/>
   </idlist>
   <!--DETECTOR PARAMETERS-->
   <component-link name="detectors">


### PR DESCRIPTION
**Description of work.**

We have added new hardware to SNS, BL-5, CNCS.  It is beam monitor #4 that is after the sample position.

**To test:**

Make sure it is a valid geometry file.


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
