### PR TITLE
Muon Analysis 2 Ensured that fits always display on-top of raw data

### DIFF
--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
@@ -62,7 +62,7 @@ class HomePlotWidgetModel(object):
             return
 
         self.plot_figure = plot(workspaces, spectrum_nums=[specNum], fig=self.plot_figure, overplot=True,
-                                plot_kwargs={'distribution': True})
+                                plot_kwargs={'distribution': True, 'zorder': 4})
 
     def remove_workpace_from_plot(self, workspace_name):
         """


### PR DESCRIPTION
**Description of work.**

In the muon analysis 2 interface when fits were added to a plot with errors they were appearing beneath the original data. This adds a zorder parameter to ensure that they instead appear on top.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because this fixes an issue introduced this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
