### PR TITLE
Trap errors with invalid facility/instrument names in Workbench settings 

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -42,15 +42,23 @@ class GeneralSettings(object):
 
     def setup_facilities_group(self):
         facilities = ConfigService.getFacilityNames()
+        if not facilities:
+            return
         self.view.facility.addItems(facilities)
 
-        default_facility = ConfigService.getFacility().name()
+        try:
+            default_facility = ConfigService.getFacility().name()
+        except RuntimeError:
+            default_facility = facilities[0]
         self.view.facility.setCurrentIndex(self.view.facility.findText(default_facility))
         self.action_facility_changed(default_facility)
         self.view.facility.currentTextChanged.connect(self.action_facility_changed)
 
-        default_instrument = ConfigService.getInstrument().name()
-        self.view.instrument.setCurrentIndex(self.view.instrument.findText(default_instrument))
+        try:
+            default_instrument = ConfigService.getInstrument().name()
+            self.view.instrument.setCurrentIndex(self.view.instrument.findText(default_instrument))
+        except RuntimeError:
+            default_instrument = self.view.instrument.itemText(0)
         self.action_instrument_changed(default_instrument)
         self.view.instrument.currentTextChanged.connect(self.action_instrument_changed)
 


### PR DESCRIPTION
**Description of work.**

Traps errors if a user has set an invalid `default.instrument` or `default.facility` key in the config service that could prevent the settings GUI from popping up.

**To test:**

See instructions in the issue to try and reproduce the problem.

Fixes #25947 

*This does not require release notes* because **the settings GUI was released this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
