### PR TITLE
Fix adding rows bug when erasing rows

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -43,3 +43,4 @@ Bug Fixes
 - You can now process in **memory** mode with no file type buttons selected. A warning box will open if you process with no file types while in **file** or **both** mode, and processing will not continue.
 - A bug in which the final column in a batch file was sometimes ignored if empty, and therefore impossible to load, has been fixed.
 - The differences between non-compatibility and compatibility modes has been minimised. Compatibility mode can now be turned off in the settings tab. When off, workspaces stay as EventWorkspaces until the penultimate stage of **SANSReductionCore**. Bin masking is not performed until workspace has been converted to a histogram.
+- A bug in which a row was added if the only row is the table was erased, has been fixed.

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -791,10 +791,12 @@ class RunTabPresenter(object):
         Make all selected rows empty.
         """
         selected_rows = self._view.get_selected_rows()
-        empty_row = self._table_model.create_empty_row()
-        for row in selected_rows:
-            empty_row = TableModel.create_empty_row()
-            self._table_model.replace_table_entries([row], [empty_row])
+        if len(selected_rows) == 1 and self._table_model.get_number_of_rows() == 1:
+            self._table_model.replace_table_entries(selected_rows, [])
+        else:
+            for row in selected_rows:
+                empty_row = self._table_model.create_empty_row()
+                self._table_model.replace_table_entries([row], [empty_row])
 
     def on_rows_removed(self, rows):
         """

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -740,6 +740,25 @@ class RunTabPresenterTest(unittest.TestCase):
         empty_row.id = 4
         self.assertEqual(presenter._table_model.get_table_entry(2).__dict__, empty_row.__dict__)
 
+    def test_on_erase_rows_does_not_add_rows_when_table_contains_one_row(self):
+        """
+        A bug caused erase rows to add a row to a table containing only 1 row.
+        Check that this is fixed
+        """
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        view = mock.MagicMock()
+        view.get_selected_rows = mock.MagicMock(return_value=[0])
+        presenter.set_view(view)
+
+        test_row = ['SANS2D00022024', '', 'SANS2D00022048', '', 'SANS2D00022048', '', '', '', '', '', '', '',
+                    'test_file', '', '1.0', '', '', '', '']
+
+        presenter.on_row_inserted(0, test_row)
+        presenter.on_erase_rows()
+
+        self.assertEqual(presenter._table_model.get_number_of_rows(), 1)
+        self.assertEqual(presenter._table_model.get_table_entry(0).to_list(), ['']*19)
+
     def test_on_erase_rows_updates_view(self):
         presenter = RunTabPresenter(SANSFacility.ISIS)
         view = mock.MagicMock()


### PR DESCRIPTION
**Description of work.**
A bug in the SANS gui caused an extra row to be added to the table if the only row in the table was erased. This has been fixed

**To test:**
1. Interfaces -> SANS -> ISIS SANS
2. Click on the cell in the table in the "Output name" column and type something
3. With the cell highlighted, click the erase button. There should still be only one row in the table, and it should be empty
4. Play around a bit with multiple rows, highlighting random rows and erasing them. Only highlighted rows should be erased, and the number of rows in the table should remain constant when erase is clicked.

Fixes #25930 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
