### PR TITLE
Exclude a new directory that exists when using VSCode on Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,8 +164,9 @@ Desktop.ini
 # PyCharm IDE
 .idea/
 
-# VSCode cache
+# VSCode
 .vscode/
+XDG_CACHE_HOME/
 # The file that contains metadata for VSCode Workspace
 *.code-workspace
 


### PR DESCRIPTION
**Description of work.**
Due to a recent update to VSCode either an extension or the base VSCode creates a new Folder in the repository. This folder is not needed in the repo, so it has been added to the .gitignore. I believe this only effects Ubuntu/Linux users of VSCode.

**To test:**
- Create a folder called XDG_CACHE_HOME in your local repo
- Check that the folder is not staged when either using a GUI or `git add *`

<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because it is a developer change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
