### PR TITLE
Added error copying on function cloning

### DIFF
--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -71,8 +71,9 @@ IFunction::~IFunction() { m_attrs.clear(); }
  * Virtual copy constructor
  */
 boost::shared_ptr<IFunction> IFunction::clone() const {
-  auto clonedFunction = FunctionFactory::Instance().createInitialized(this->asString());
-  for (size_t i = 0; i< this->nParams();i++){
+  auto clonedFunction =
+      FunctionFactory::Instance().createInitialized(this->asString());
+  for (size_t i = 0; i < this->nParams(); i++) {
     double error = this->getError(i);
     clonedFunction->setError(i, error);
   }

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -71,7 +71,12 @@ IFunction::~IFunction() { m_attrs.clear(); }
  * Virtual copy constructor
  */
 boost::shared_ptr<IFunction> IFunction::clone() const {
-  return FunctionFactory::Instance().createInitialized(this->asString());
+  auto clonedFunction = FunctionFactory::Instance().createInitialized(this->asString());
+  for (size_t i = 0; i< this->nParams();i++){
+    double error = this->getError(i);
+    clonedFunction->setError(i, error);
+  }
+  return clonedFunction;
 }
 
 /**

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -44,6 +44,7 @@ Improvements
 - :ref:`SetSample <algm-SetSample>` will now look for facility wide sample environments. instrument specific ones will be loaded first.
 - :ref:`SolidAngle <algm-SolidAngle>` is extended to accommodate few options for fast analytical calculation for SANS-type detectors.
 - :ref:`algm-FilterEvents` has a property `InformativeOutputNames` which changes the name of output workspace to include the start and end time of the slice.
+- Updated the clone method of IFunction to copy parameter errors across as well as parameter values.
 
 Instrument Definition Files
 ###########################

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -773,6 +773,7 @@ public:
     %End
 signals:
     void functionStructureChanged();
+    void parameterChanged(const QString &funcIndex, const QString &paramName);
 };
 
 // ---------------------------------

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -361,6 +361,10 @@ class FittingTabPresenter(object):
             self.view.function_name += ',TFAsymmetry'
             self.model.function_name = self.view.function_name
 
+    def handle_function_parameter_changed(self):
+        index = self.view.get_index_for_start_end_times()
+        self._fit_function[index] = self.view.fit_object.clone()
+
     def get_parameters_for_single_fit(self):
         params = self._get_shared_parameters()
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -362,8 +362,11 @@ class FittingTabPresenter(object):
             self.model.function_name = self.view.function_name
 
     def handle_function_parameter_changed(self):
-        index = self.view.get_index_for_start_end_times()
-        self._fit_function[index] = self.view.fit_object.clone()
+        if self.view.fit_type != self.view.simultaneous_fit:
+            index = self.view.get_index_for_start_end_times()
+            self._fit_function[index] = self.view.fit_object.clone()
+        else:
+            self._fit_function = [self.view.fit_object] * len(self.selected_data)
 
     def get_parameters_for_single_fit(self):
         params = self._get_shared_parameters()

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -78,7 +78,9 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
             self.fit_status_chi_squared.setText('Chi squared: {}'.format(output_chi_squared))
             return
 
+        self.function_browser.blockSignals(True)
         self.function_browser.updateMultiDatasetParameters(fit_function)
+        self.function_browser.blockSignals(False)
 
         if output_status == 'success':
             self.fit_status_success_failure.setText('Success')

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -32,3 +32,4 @@ class FittingTabWidget(object):
             self.fitting_tab_presenter.handle_fit_name_changed_by_user)
         context.update_view_from_model_notifier.add_subscriber(self.fitting_tab_presenter.update_view_from_model_observer)
         self.fitting_tab_view.tf_asymmetry_mode_checkbox.stateChanged.connect(self.fitting_tab_presenter.handle_tf_asymmetry_mode_changed)
+        self.fitting_tab_view.function_browser.parameterChanged.connect(self.fitting_tab_presenter.handle_function_parameter_changed)


### PR DESCRIPTION
**Description of work.**

The clone function defined on IFunction was not copying over the errors, this change updates function to correctly copy errors.

The function browser in the new Muon Analysis GUI also did not register when the function parameters were manually updated.

**To test:**

You will need access to the ISIS data archive to test this PR.
  * Change the instrument to MUSR and type 62260-1 in the runs box press enter
  * Go to the fitting tab, add a GausOsc function to the function browser and click fit.
  * Check that the fit browser is updated with errors displayed after parameter values
  * Change the display parameter and check that the parameter values change
  * Manually change a parameter and check the change is preserved when you switch which workspace you are displaying.


<!-- Instructions for testing. -->

Fixes #25958  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this adds functionality to a new interface


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
