### PR TITLE
changed pearl longmode spline coefficient

### DIFF
--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -31,6 +31,8 @@ Improvements
 
 - The Pearl scripts now automatically disable attenuation on long-mode.
 
+- The Pearl scripts now set now use a spline coefficient of 5 on long-mode due to the increased amount of noise.
+
 Bug Fixes
 #########
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_advanced_config.py
@@ -93,7 +93,7 @@ long_mode_on_params = {
         (20300, 39990)   # Bank 14
     ],
     "monitor_spline_coefficient": 20,
-    "spline_coefficient": 60
+    "spline_coefficient": 5
 }
 
 calibration_params = {


### PR DESCRIPTION
**Description of work.**
changed pearl longmode spline coefficient to 5 from 60, due to the increased noise of longmode
**To test:**
follow the setup from #25816, then run
```
from isis_powder import Pearl

config_file_path = r"path/to/config"
Pearl_example = Pearl(config_file=config_file_path,user_name="test")
Pearl_example.create_vanadium(run_in_cycle=101508,long_mode=True)
Pearl_example.focus(run_number="101508", focus_mode="trans",long_mode=True)
```
this should run without failing.

Fixes #25962 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
