### PR TITLE
Fix autosaving of group workspaces on the reflectometry GUI

### DIFF
--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -49,6 +49,7 @@ Bug fixes
 #########
 
 - Fixed an error about an unknown property value when starting the live data monitor from the reflectometry interface.
+- Fixed a problem where auto-saving would fail if the output for a row is a group workspace.
 	
 Algorithms
 ----------

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
@@ -8,7 +8,7 @@
 #define MANTID_ISISREFLECTOMETRY_ASCIISAVER_H
 #include "IAsciiSaver.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
-#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/Workspace_fwd.h"
 #include <string>
 #include <vector>
 
@@ -28,7 +28,7 @@ public:
 private:
   Mantid::API::IAlgorithm_sptr
   setUpSaveAlgorithm(std::string const &saveDirectory,
-                     Mantid::API::MatrixWorkspace_sptr workspace,
+                     Mantid::API::Workspace_sptr workspace,
                      std::vector<std::string> const &logParameters,
                      FileFormatOptions const &fileFormat) const;
 
@@ -37,8 +37,11 @@ private:
                                std::string const &name,
                                std::string const &extension) const;
 
-  Mantid::API::MatrixWorkspace_sptr
-  workspace(std::string const &workspaceName) const;
+  Mantid::API::Workspace_sptr workspace(std::string const &workspaceName) const;
+  void save(Mantid::API::Workspace_sptr workspace,
+            std::string const &saveDirectory,
+            std::vector<std::string> const &logParameters,
+            FileFormatOptions const &fileFormat) const;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt


### PR DESCRIPTION
Rows in the reflectometry GUI may have a group workspace as their output. If we enable auto-saving, the save algorithms that are currently used cannot handle group workspaces, so it throws an exception, which is unhandled. This PR fixes the problem by saving all the child workspaces individually.

Note that longer term we will replace the current save algorithms with `SaveReflectometryAscii` which can handle group workspaces so this will no longer be a problem. However that is a bigger job.


**To test:**

- Open the `ISIS Reflectometry` interface
- On the Save ASCII tab, enter a `Save Path` to a location you want to save the files to and tick `Save as ASCII on completion`
- On the Runs tab, add a row to the table with run number `11938` and angle `2.3`
- Click Process
- When processing has finished (the row will turn green) check that the save directory contains 121 files named `IvsQ_binned_11938_1.dat` to `IvsQ_binned_11938_121.dat`

Refs #23027

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
