### PR TITLE
ISIS Pearl crop to avoid noise in long-mode

### DIFF
--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -33,6 +33,8 @@ Improvements
 
 - The Pearl scripts now set now use a spline coefficient of 5 on long-mode due to the increased amount of noise.
 
+- The Pearl scripts now crop to a dspacing of 8 on long-mode to avoid negative values caused by noise after this point.
+
 Bug Fixes
 #########
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_advanced_config.py
@@ -74,23 +74,23 @@ long_mode_on_params = {
     "monitor_integration_range": (6, 10),
     # raw_data_tof_cropping needs to be have smaller/larger values than the bank TOF cropping values or
     # you will get data that divides to 0 or inf
-    "raw_data_tof_cropping": (20280, 39995),
-    "vanadium_tof_cropping": (20295, 39993),
+    "raw_data_tof_cropping": (20280, 39000),
+    "vanadium_tof_cropping": (20295, 39000),
     "focused_cropping_values": [
-        (20300, 39990),  # Bank 1
-        (20300, 39990),  # Bank 2
-        (20300, 39990),  # Bank 3
-        (20300, 39990),  # Bank 4
-        (20300, 39990),  # Bank 5
-        (20300, 39990),  # Bank 6
-        (20300, 39990),  # Bank 7
-        (20300, 39990),  # Bank 8
-        (20300, 39990),  # Bank 9
-        (20300, 39990),  # Bank 10
-        (20300, 39990),  # Bank 11
-        (20300, 39990),  # Bank 12
-        (20300, 39990),  # Bank 13
-        (20300, 39990)   # Bank 14
+        (20300, 38830),  # Bank 1
+        (20300, 38830),  # Bank 2
+        (20300, 38830),  # Bank 3
+        (20300, 38830),  # Bank 4
+        (20300, 38830),  # Bank 5
+        (20300, 38830),  # Bank 6
+        (20300, 38830),  # Bank 7
+        (20300, 38830),  # Bank 8
+        (20300, 38830),  # Bank 9
+        (20300, 38830),  # Bank 10
+        (20300, 38830),  # Bank 11
+        (20300, 38830),  # Bank 12
+        (20300, 38830),  # Bank 13
+        (20300, 38830)   # Bank 14
     ],
     "monitor_spline_coefficient": 20,
     "spline_coefficient": 5


### PR DESCRIPTION
**Description of work.**
changed the cropping values of pearl long-mode to avoid the noisy data after a d-spacing of 8, as it could contain negative values.
**To test:**
follow the setup from #25816, then run
```
from isis_powder import Pearl

config_file_path = r"path/to/config"
Pearl_example = Pearl(config_file=config_file_path,user_name="test")
Pearl_example.create_vanadium(run_in_cycle=101508,long_mode=True)
Pearl_example.focus(run_number="101508", focus_mode="trans",long_mode=True)
```
once this has finished plot any of `PEARL101508_101515_tt70_long-Results-D-Grp` the x axis should reach from 4 to 8 in dspacing.

Fixes #25963 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
