### PR TITLE
Fixing a bug in MaskBTP for SEQUOIA

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -199,6 +199,7 @@ class MaskBTP(mantid.api.PythonAlgorithm):
                 raise ValueError("Out of range index for ARCS instrument bank numbers: {}".format(banknum))
             return '{}{}'.format(label, banknum)
         elif self.instname == 'SEQUOIA':
+            ToB = '' # top/bottom for short packs
             # there are only banks 23-26 in A row
             if self.bankmin[self.instname] <= banknum <= 37:
                 label = 'A'
@@ -208,15 +209,26 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             elif 37 < banknum <= 74:
                 label = 'B'
                 banknum = banknum - 37
-            elif 74 < banknum <= 113:
+            elif 74 < banknum <= 98:
                 label = 'C'
                 banknum = banknum-74
+            elif banknum==99:
+                label, banknum, ToB = 'C', 25, 'T'
+            elif banknum==100:
+                label, banknum, ToB = 'C', 26, 'T'
+            elif banknum==101:
+                label, banknum, ToB = 'C', 25, 'B'
+            elif banknum==102:
+                label, banknum, ToB = 'C', 26, 'B'
+            elif 102 < banknum <= 113:
+                label = 'C'
+                banknum = banknum-76
             elif 113 <banknum <= self.bankmax[self.instname]:
                 label = 'D'
                 banknum = banknum-113
             else:
                 raise ValueError("Out of range index for SEQUOIA instrument bank numbers: {}".format(banknum))
-            return '{}{}'.format(label, banknum)
+            return '{}{}{}'.format(label, banknum, ToB)
         elif self.instname == "WISH":
             return "panel" + "%02d" % banknum
         elif self.instname in ['CG2', 'EQ-SANS', 'REF_M']:

--- a/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskBTP.py
@@ -212,14 +212,13 @@ class MaskBTP(mantid.api.PythonAlgorithm):
             elif 74 < banknum <= 98:
                 label = 'C'
                 banknum = banknum-74
-            elif banknum==99:
-                label, banknum, ToB = 'C', 25, 'T'
-            elif banknum==100:
-                label, banknum, ToB = 'C', 26, 'T'
-            elif banknum==101:
-                label, banknum, ToB = 'C', 25, 'B'
-            elif banknum==102:
-                label, banknum, ToB = 'C', 26, 'B'
+            elif banknum in range(99, 102+1):
+                label = 'C'
+                d = {99: (25, 'T'),
+                     100: (26, 'T'),
+                     101: (25, 'B'),
+                     102: (26, 'B')}
+                banknum, ToB = d[banknum]
             elif 102 < banknum <= 113:
                 label = 'C'
                 banknum = banknum-76

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -113,6 +113,17 @@ class MaskBTPTest(unittest.TestCase):
         MaskBTP(Instrument='SEQUOIA', Bank="27")
         MaskBTP(Instrument='SEQUOIA', Bank="37")
         MaskBTP(Instrument='SEQUOIA', Bank="38")
+        MaskBTP(Instrument='SEQUOIA', Bank="74")
+        MaskBTP(Instrument='SEQUOIA', Bank="75")
+        MaskBTP(Instrument='SEQUOIA', Bank="98")
+        MaskBTP(Instrument='SEQUOIA', Bank="99")
+        MaskBTP(Instrument='SEQUOIA', Bank="100")
+        MaskBTP(Instrument='SEQUOIA', Bank="101")
+        MaskBTP(Instrument='SEQUOIA', Bank="102")
+        MaskBTP(Instrument='SEQUOIA', Bank="103")
+        MaskBTP(Instrument='SEQUOIA', Bank="113")
+        MaskBTP(Instrument='SEQUOIA', Bank="114")
+        MaskBTP(Instrument='SEQUOIA', Bank="150")
         return
 
     def testEdges(self):


### PR DESCRIPTION
It currently does not work for the packs around the short packs.
For example, `MaskBTP(instrument='SEQUOIA', Bank='100')` fails now

**Description of work.**

This bug was recently introduced, probably around https://github.com/mantidproject/mantid/commit/0a3d3e58c5e77d63522a256c83966040ce22e54a#diff-12977ce2773da076066006cfe044baee

SEQ has short packs like "C25T". The logic of getting names like that from the bank number needs to be improved.

Added more tests to make sure they are tested in the future

**To test:**

`MaskBTP(instrument='SEQUOIA', Bank='100')` 

*There is no associated issue.*

*This does not require release notes* 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
