### PR TITLE
Option to turn off plot autoscaling in Workbench

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -463,6 +463,8 @@ class MantidAxes(Axes):
         if helperfunctions.validate_args(*args):
             logger.debug('using plotfunctions')
 
+            autoscale_on_update = kwargs.pop("autoscale_on_update", True)
+
             def _data_update(artists, workspace, new_kwargs=None):
                 # It's only possible to plot 1 line at a time from a workspace
                 if new_kwargs:
@@ -473,7 +475,8 @@ class MantidAxes(Axes):
                                                            kwargs)
                 artists[0].set_data(x, y)
                 self.relim()
-                self.autoscale()
+                if autoscale_on_update:
+                    self.autoscale()
                 return artists
 
             workspace = args[0]
@@ -481,9 +484,16 @@ class MantidAxes(Axes):
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(
                 workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or workspace.isDistribution()
-            return self.track_workspace_artist(
+
+            if self.lines:
+                self.set_autoscaley_on(autoscale_on_update)
+
+            artist = self.track_workspace_artist(
                 workspace, plotfunctions.plot(self, *args, **kwargs),
                 _data_update, spec_num, is_normalized)
+
+            self.set_autoscaley_on(True)
+            return artist
         else:
             return Axes.plot(self, *args, **kwargs)
 
@@ -535,7 +545,16 @@ class MantidAxes(Axes):
         if helperfunctions.validate_args(*args):
             logger.debug('using plotfunctions')
 
+            autoscale_on_update = kwargs.pop("autoscale_on_update", True)
+
             def _data_update(artists, workspace, new_kwargs=None):
+                if self.lines:
+                    # If we have at least one line, set autoscaling
+                    # based on autoscale_on_update flag.
+                    # If we have no lines currently, we want to autoscale
+                    # regardless
+                    self.set_autoscaley_on(autoscale_on_update)
+
                 # errorbar with workspaces can only return a single container
                 container_orig = artists[0]
                 # It is not possible to simply reset the error bars so
@@ -562,16 +581,23 @@ class MantidAxes(Axes):
                     artist_new.update_from(artist_orig)
                 # ax.relim does not support collections...
                 self._update_line_limits(container_new[0])
-                self.autoscale()
+                self.set_autoscaley_on(True)
                 return container_new
 
             workspace = args[0]
             spec_num = self._get_spec_number(workspace, kwargs)
             is_normalized, kwargs = get_normalize_by_bin_width(workspace, self,
                                                                **kwargs)
-            return self.track_workspace_artist(
+
+            if self.lines:
+                self.set_autoscaley_on(autoscale_on_update)
+
+            artist = self.track_workspace_artist(
                 workspace, plotfunctions.errorbar(self, *args, **kwargs),
                 _data_update, spec_num, is_normalized)
+
+            self.set_autoscaley_on(True)
+            return artist
         else:
             return Axes.errorbar(self, *args, **kwargs)
 

--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -485,7 +485,11 @@ class MantidAxes(Axes):
                 workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or workspace.isDistribution()
 
+            # If we are making the first plot on an axes object
+            # i.e. self.lines is empty, axes has default ylim values.
+            # Therefore we need to autoscale regardless of autoscale_on_update.
             if self.lines:
+                # Otherwise set autoscale to autoscale_on_update.
                 self.set_autoscaley_on(autoscale_on_update)
 
             artist = self.track_workspace_artist(
@@ -549,10 +553,6 @@ class MantidAxes(Axes):
 
             def _data_update(artists, workspace, new_kwargs=None):
                 if self.lines:
-                    # If we have at least one line, set autoscaling
-                    # based on autoscale_on_update flag.
-                    # If we have no lines currently, we want to autoscale
-                    # regardless
                     self.set_autoscaley_on(autoscale_on_update)
 
                 # errorbar with workspaces can only return a single container

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -284,6 +284,75 @@ class Plots__init__Test(unittest.TestCase):
             [False, False, False])
         self.assertEqual(0, mock_logger.call_count)
 
+    def test_that_autoscaling_can_be_turned_off_when_data_changes(self):
+        """We should be able to plot a workspace without having it
+        autoscale if the workspace changes
+        """
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20],
+                             OutputWorkspace="ws")
+        self.ax.plot(ws, autoscale_on_update=False)
+        CreateWorkspace(DataX=[10, 20],
+                        DataY=[10, 5000],
+                        OutputWorkspace="ws")
+        self.assertLess(self.ax.get_ylim()[1], 5000)
+
+    def test_that_autoscaling_can_be_turned_off_when_plotting_multiple_workspaces(self):
+        """We should be able to plot a new workspace without having the plot scale to it"""
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20])
+        self.ax.plot(ws)
+        ws2 = CreateWorkspace(DataX=[10, 20],
+                              DataY=[10, 5000])
+        self.ax.plot(ws2, autoscale_on_update=False)
+        self.assertLess(self.ax.get_ylim()[1], 5000)
+
+    def test_that_plot_autoscales_by_default(self):
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20],
+                             OutputWorkspace="ws")
+        self.ax.plot(ws)
+        ws2 = CreateWorkspace(DataX=[10, 20],
+                              DataY=[10, 5000],
+                              OutputWorkspace="ws2")
+        self.ax.plot(ws2)
+        self.assertGreaterEqual(self.ax.get_ylim()[1], 5000)
+
+    def test_that_errorbar_autoscales_by_default(self):
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20],
+                             DataE=[1, 1],
+                             OutputWorkspace="ws")
+        self.ax.errorbar(ws)
+        ws2 = CreateWorkspace(DataX=[10, 20],
+                              DataY=[10, 5000],
+                              DataE=[1, 1],
+                              OutputWorkspace="ws2")
+        self.ax.errorbar(ws2)
+        self.assertGreaterEqual(self.ax.get_ylim()[1], 5000)
+
+    def test_that_errorbar_autoscaling_can_be_turned_off_when_plotting_multiple_workspaces(self):
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20])
+        self.ax.errorbar(ws)
+        ws2 = CreateWorkspace(DataX=[10, 20],
+                              DataY=[10, 5000])
+        self.ax.errorbar(ws2, autoscale_on_update=False)
+        self.assertLess(self.ax.get_ylim()[1], 5000)
+
+    def test_that_errorbar_autoscaling_can_be_turned_off(self):
+        ws = CreateWorkspace(DataX=[10, 20],
+                             DataY=[10, 20],
+                             DataE=[1, 2],
+                             OutputWorkspace="ws")
+        self.ax.errorbar(ws)
+        ws2 = CreateWorkspace(DataX=[10, 20],
+                              DataY=[10, 5000],
+                              DataE=[1, 1],
+                              OutputWorkspace="ws2")
+        self.ax.errorbar(ws2, autoscale_on_update=False)
+        self.assertLess(self.ax.get_ylim()[1], 5000)
+
     def _run_check_axes_distribution_consistency(self, normalization_states):
         mock_tracked_workspaces = {
             'ws': [Mock(is_normalized=normalization_states[0]),


### PR DESCRIPTION
**Description of work.**
This PR adds a kwarg, `autoscale_on_update`, to `plot` and `errorbar` in MantidAxes which determines if a plot autoscales or not.

If `autoscale_on_update` is False, a plot should not autoscale:
1. If another workspace is added to the same plot
2. The data in a workspace already being plot is updated

**To test:**
1. Open workbench
2. Plot two workspaces, with data in different ranges, on the same plot without providing `autoscale_on_update` kwarg. The plot should scale to the largest spectrum
3. Plot two workspaces on the same plot with `autoscale_on_update=False`. The plot should be scaled to the first workspace you plotted
4. Do steps 2 and 3, but with `ax.errorbar`, not `ax.plot`
5. Plot a workspace, and then create a new workspace of the same name, but with different data. The plot should autoscale
6. Do step 5, but plot with `autoscale_on_update=False`. The plot should not autoscale to the new data
7. Do steps 5 and 6, but with `ax.errorbar`

Fixes #25971 

*This does not require release notes* because **Internal functionality change. Not intentionally exposed to users yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
