### PR TITLE
Expose indexOf to python

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -101,7 +101,7 @@ public:
   const std::vector<detid_t> &detectorIDs() const;
   /// Returns the index of the detector with the given detector ID.
   /// This will throw an out of range exception if the detector does not exist.
-  size_t indexOf(const detid_t id) const { return m_detIDToIndex->at(id); }
+  size_t indexOf(const detid_t id) const;
 
   size_t scanCount() const;
   const std::vector<

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -317,6 +317,17 @@ const std::vector<detid_t> &DetectorInfo::detectorIDs() const {
   return *m_detectorIDs;
 }
 
+std::size_t DetectorInfo::indexOf(const detid_t id) const {
+  try {
+    return m_detIDToIndex->at(id);
+  } catch (const std::out_of_range &) {
+    // customize the error message
+    std::stringstream msg;
+    msg << "Failed to find detector with id=" << id;
+    throw std::out_of_range(msg.str());
+  }
+}
+
 /// Returns the scan count of the detector with given detector index.
 size_t DetectorInfo::scanCount() const { return m_detectorInfo->scanCount(); }
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
@@ -77,6 +77,9 @@ void export_DetectorInfo() {
            "Returns the size of the DetectorInfo, i.e., the number of "
            "detectors in the instrument.")
 
+      .def("indexOf", &DetectorInfo::indexOf, (arg("self"), arg("detId")),
+           "Returns the index of the detector with the given id.")
+
       .def("isMonitor", isMonitor, (arg("self"), arg("index")),
            "Returns True if the detector is a monitor.")
 

--- a/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
@@ -42,6 +42,16 @@ class DetectorInfoTest(unittest.TestCase):
         info = self._ws.detectorInfo()
         self.assertEqual(info.size(), 2)
 
+    def test_indexOf(self):
+        """ Check if detector is a monitor """
+        info = self._ws.detectorInfo()
+        print(str(info.detectorIDs()))
+        self.assertEqual(info.indexOf(1), 0)
+        self.assertEqual(info.indexOf(2), 1)
+
+        with self.assertRaises(IndexError):
+            info.indexOf(3)
+
     def test_isMonitor(self):
         """ Check if detector is a monitor """
         info = self._ws.detectorInfo()
@@ -87,7 +97,7 @@ class DetectorInfoTest(unittest.TestCase):
     	workspace = CreateWorkspace(DataX=dataX, DataY=dataY)
     	info = workspace.detectorInfo()
     	self.assertEqual(info.size(), 0)
-    
+
     def test_detectorIds(self):
         info = self._ws.detectorInfo()
         ids = info.detectorIDs()
@@ -121,7 +131,7 @@ class DetectorInfoTest(unittest.TestCase):
         l1_calc = sample_pos.distance(source_pos)
         det_info = self._ws.detectorInfo()
         self.assertEqual(det_info.l1(), l1_calc)
-        
+
     """
     ---------------
     Iteration
@@ -130,7 +140,7 @@ class DetectorInfoTest(unittest.TestCase):
 
     def test_basic_iteration(self):
         info = self._ws.detectorInfo()
-        expected_iterations = len(info) 
+        expected_iterations = len(info)
         actual_iterations = len(list(iter(info)))
         self.assertEqual(expected_iterations, actual_iterations)
         it = iter(info)
@@ -142,13 +152,13 @@ class DetectorInfoTest(unittest.TestCase):
         # check no monitors in instrument
         for item in info:
             self.assertFalse(item.isMonitor)
-            
+
     def test_iterator_for_masked(self):
         info = self._ws.detectorInfo()
-        # nothing should be masked 
+        # nothing should be masked
         for item in info:
             self.assertFalse(item.isMasked)
-    
+
     def test_iterator_for_masked(self):
         info = self._ws.detectorInfo()
         it = iter(info)

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -73,6 +73,7 @@ New
 - The ``mantid.plots`` module now registers a ``power`` and ``square`` scale type to be used with ``set_xscale`` and ``set_xscale`` functions.
 - In :class:`mantid.kernel.DateAndTime`, the method :py:meth:`~mantid.kernel.DateAndTime.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.DateAndTime.totalNanoseconds` should be used instead.
 - In :class:`mantid.kernel.time_duration`, The method :py:meth:`~mantid.kernel.time_duration.total_nanoseconds` has been deprecated, :py:meth:`~mantid.kernel.time_duration.totalNanoseconds` should be used instead.
+- :py:obj:`mantid.geometry.DetectorInfo.indexOf` has been exposed to python
 
 Bugfixes
 ########


### PR DESCRIPTION
The user docs suggested using a function that isn't exposed to python `DetectorInfo::indexOf`. This exposes it and makes the exception thrown significantly clearer.

**To test:**

Try running it with a variety of detector ids.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
