### PR TITLE
Remove generate notebook checkbox

### DIFF
--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -52,6 +52,11 @@ Bug fixes
 
 - Fixed an error about an unknown property value when starting the live data monitor from the reflectometry interface.
 	
+Removed
+#######
+
+- The ``Generate Notebook`` checkbox has been removed.
+
 Algorithms
 ----------
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.ui
@@ -76,16 +76,6 @@
             </widget>
           </item>
           <item>
-            <widget class="QCheckBox" name="notebookCheckbox">
-              <property name="toolTip">
-                <string>Whether to generate a python notebook when performing a reduction</string>
-              </property>
-              <property name="text">
-                <string>Output Notebook</string>
-              </property>
-            </widget>
-          </item>
-          <item>
             <widget class="QPushButton" name="processButton">
               <property name="toolTip">
                 <string>Begin reducing the data in the table</string>


### PR DESCRIPTION
**Description of work.**

This PR removes the `Generate Notebook` checkbox from the reflectometry GUI. This is not implemented yet in the restructured GUI and is not required for the initial implementation because it was not really in use and does not generate a particularly useful notebook. We may look into a better implementation in the future although requirements need to be discussed.

**To test:**

- Open the `ISIS Reflectometry` GUI.
- Ensure the `Generate Notebook` checkbox does not appear on the Runs tab
- Ensure the GUI functions as normal

Refs #23027

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
