### PR TITLE
Runs table not cleared on autoprocess

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -622,8 +622,10 @@ void RunsTablePresenter::notifyRowOutputsChanged() {
     auto groupPath = MantidWidgets::Batch::RowPath{groupIndex};
     int rowIndex = 0;
     for (auto &row : group.rows()) {
-      auto rowPath = MantidWidgets::Batch::RowPath{groupIndex, rowIndex};
-      m_jobViewUpdater.rowModified(groupOf(rowPath), rowOf(rowPath), *row);
+      if (row) {
+        auto rowPath = MantidWidgets::Batch::RowPath{groupIndex, rowIndex};
+        m_jobViewUpdater.rowModified(groupOf(rowPath), rowOf(rowPath), *row);
+      }
       ++rowIndex;
     }
     ++groupIndex;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -499,9 +499,6 @@ void RunsTablePresenter::notifyRemoveRowsRequested(
 }
 
 void RunsTablePresenter::notifyRemoveAllRowsAndGroupsRequested() {
-  if (isProcessing() || isAutoreducing())
-    return;
-
   removeAllRowsAndGroupsFromModel();
   removeAllRowsAndGroupsFromView();
   ensureAtLeastOneGroupExists();

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
@@ -128,6 +128,31 @@ public:
     presenter.notifyDeleteGroupRequested();
     verifyAndClearExpectations();
   }
+
+  void testRemoveAllRowsAndGroupsUpdatesView() {
+    auto presenter = makePresenter(m_view, ReductionJobs());
+    EXPECT_CALL(m_jobs, removeAllRows()).Times(1);
+    presenter.notifyRemoveAllRowsAndGroupsRequested();
+    verifyAndClearExpectations();
+  }
+
+  void testRemoveAllRowsAndGroupsUpdatesModel() {
+    auto presenter = makePresenter(m_view, ReductionJobs());
+    presenter.notifyRemoveAllRowsAndGroupsRequested();
+    auto &groups = jobsFromPresenter(presenter).groups();
+    // Should be left with a single empty group
+    TS_ASSERT_EQUALS(1, groups.size());
+    TS_ASSERT_EQUALS(0, groups[0].rows().size());
+    verifyAndClearExpectations();
+  }
+
+  void testRemoveAllRowsAndGroupsPerformedIfProcessingOrAutoreducing() {
+    auto presenter = makePresenter(m_view, ReductionJobs());
+    EXPECT_CALL(m_mainPresenter, isProcessing()).Times(0);
+    EXPECT_CALL(m_mainPresenter, isAutoreducing()).Times(0);
+    presenter.notifyRemoveAllRowsAndGroupsRequested();
+    verifyAndClearExpectations();
+  }
 };
 
 #endif // MANTID_CUSTOMINTERFACES_REFLRUNSTABLEPRESENTERGROUPDELETETEST_H_


### PR DESCRIPTION
Fix a bug where the runs table was not being cleared when starting a new autoprocess search.

**To test:**

This should be tested by someone at ISIS.

- Open the `ISIS Reflectometry` GUI
- Add a group containing a row to the table
- Set the instrument to INTER and enter investigation id `1120015`
- Click `Autoprocess`
- Click Yes when prompted about losing changes and log in to the catalog
- Check that the row/group you entered is cleared and the table is populated with the runs for the investigation. Note that there will be an empty group left at the top - this is another known issue.

Refs #23027

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
