### PR TITLE
Adding tf asymmetry mode to Muon Analysis 2

### DIFF
--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -230,13 +230,12 @@ void CalculateMuonAsymmetry::exec() {
 std::vector<double> CalculateMuonAsymmetry::getNormConstants(
     const std::vector<std::string> wsNames) {
   std::vector<double> norms;
-
   double startX = getProperty("StartX");
   double endX = getProperty("EndX");
   int maxIterations = getProperty("MaxIterations");
   auto minimizer = getProperty("Minimizer");
-  API::IAlgorithm_sptr fit =
-      API::AlgorithmManager::Instance().createUnmanaged("Fit");
+  API::IAlgorithm_sptr fit = createChildAlgorithm("Fit");
+
   fit->initialize();
 
   API::IFunction_sptr function = getProperty("InputFunction");
@@ -246,6 +245,8 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(
   fit->setProperty("MaxIterations", maxIterations);
 
   fit->setPropertyValue("Minimizer", minimizer);
+
+  fit->setProperty("CreateOutput", true);
 
   std::string output = getPropertyValue("OutputFitWorkspace");
 
@@ -274,6 +275,54 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(
   setProperty("ChiSquared", chi2);
   API::IFunction_sptr tmp = fit->getProperty("Function");
   setProperty("OutputFunction", tmp);
+
+  API::ITableWorkspace_sptr parameterTable = fit->getProperty("OutputParameters");
+  API::Workspace_sptr outputWorkspace;
+  if(wsNames.size() > 1) {
+    API::WorkspaceGroup_sptr outputWorkspaceGroup = fit->getProperty("OutputWorkspace");
+    outputWorkspace = outputWorkspaceGroup;
+    }
+  else {
+  API::MatrixWorkspace_sptr outputWorkspaceMatrix = fit->getProperty("OutputWorkspace");
+  outputWorkspace = outputWorkspaceMatrix;
+  }
+
+  API::ITableWorkspace_sptr outputNormalisedCovarianceMatrix = fit->getProperty("OutputNormalisedCovarianceMatrix");
+
+  declareProperty(
+        std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
+            "OutputParameters", "", Kernel::Direction::Output),
+        "The name of the TableWorkspace in which to store the "
+        "final fit parameters");
+  setPropertyValue("OutputParameters",
+                     output + "_Parameters");
+
+  declareProperty(
+        std::make_unique<API::WorkspaceProperty<API::Workspace>>(
+            "OutputWorkspace", "", Kernel::Direction::Output),
+        "The name of the matrix in which to store the "
+        "final fit results");
+  if (outputWorkspace->isGroup()){
+  setPropertyValue("OutputWorkspace",
+                     output + "_Workspaces");
+                     } else {
+                     setPropertyValue("OutputWorkspace",
+                     output + "_Workspace");
+                     }
+
+  declareProperty(
+        std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
+            "OutputNormalisedCovarianceMatrix", "", Kernel::Direction::Output),
+        "The name of the TableWorkspace in which to store the final covariance "
+        "matrix");
+  setPropertyValue("OutputNormalisedCovarianceMatrix",
+                     output + "_NormalisedCovarianceMatrix");
+
+
+  setProperty("OutputParameters", parameterTable);
+  setProperty("OutputWorkspace", outputWorkspace);
+  setProperty("OutputNormalisedCovarianceMatrix", outputNormalisedCovarianceMatrix);
+
   try {
     if (wsNames.size() == 1) {
       // N(1+g) + exp

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -276,52 +276,51 @@ std::vector<double> CalculateMuonAsymmetry::getNormConstants(
   API::IFunction_sptr tmp = fit->getProperty("Function");
   setProperty("OutputFunction", tmp);
 
-  API::ITableWorkspace_sptr parameterTable = fit->getProperty("OutputParameters");
+  API::ITableWorkspace_sptr parameterTable =
+      fit->getProperty("OutputParameters");
   API::Workspace_sptr outputWorkspace;
-  if(wsNames.size() > 1) {
-    API::WorkspaceGroup_sptr outputWorkspaceGroup = fit->getProperty("OutputWorkspace");
+  if (wsNames.size() > 1) {
+    API::WorkspaceGroup_sptr outputWorkspaceGroup =
+        fit->getProperty("OutputWorkspace");
     outputWorkspace = outputWorkspaceGroup;
-    }
-  else {
-  API::MatrixWorkspace_sptr outputWorkspaceMatrix = fit->getProperty("OutputWorkspace");
-  outputWorkspace = outputWorkspaceMatrix;
+  } else {
+    API::MatrixWorkspace_sptr outputWorkspaceMatrix =
+        fit->getProperty("OutputWorkspace");
+    outputWorkspace = outputWorkspaceMatrix;
   }
 
-  API::ITableWorkspace_sptr outputNormalisedCovarianceMatrix = fit->getProperty("OutputNormalisedCovarianceMatrix");
+  API::ITableWorkspace_sptr outputNormalisedCovarianceMatrix =
+      fit->getProperty("OutputNormalisedCovarianceMatrix");
 
   declareProperty(
-        std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
-            "OutputParameters", "", Kernel::Direction::Output),
-        "The name of the TableWorkspace in which to store the "
-        "final fit parameters");
-  setPropertyValue("OutputParameters",
-                     output + "_Parameters");
+      std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
+          "OutputParameters", "", Kernel::Direction::Output),
+      "The name of the TableWorkspace in which to store the "
+      "final fit parameters");
+  setPropertyValue("OutputParameters", output + "_Parameters");
+
+  declareProperty(std::make_unique<API::WorkspaceProperty<API::Workspace>>(
+                      "OutputWorkspace", "", Kernel::Direction::Output),
+                  "The name of the matrix in which to store the "
+                  "final fit results");
+  if (outputWorkspace->isGroup()) {
+    setPropertyValue("OutputWorkspace", output + "_Workspaces");
+  } else {
+    setPropertyValue("OutputWorkspace", output + "_Workspace");
+  }
 
   declareProperty(
-        std::make_unique<API::WorkspaceProperty<API::Workspace>>(
-            "OutputWorkspace", "", Kernel::Direction::Output),
-        "The name of the matrix in which to store the "
-        "final fit results");
-  if (outputWorkspace->isGroup()){
-  setPropertyValue("OutputWorkspace",
-                     output + "_Workspaces");
-                     } else {
-                     setPropertyValue("OutputWorkspace",
-                     output + "_Workspace");
-                     }
-
-  declareProperty(
-        std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
-            "OutputNormalisedCovarianceMatrix", "", Kernel::Direction::Output),
-        "The name of the TableWorkspace in which to store the final covariance "
-        "matrix");
+      std::make_unique<API::WorkspaceProperty<API::ITableWorkspace>>(
+          "OutputNormalisedCovarianceMatrix", "", Kernel::Direction::Output),
+      "The name of the TableWorkspace in which to store the final covariance "
+      "matrix");
   setPropertyValue("OutputNormalisedCovarianceMatrix",
-                     output + "_NormalisedCovarianceMatrix");
-
+                   output + "_NormalisedCovarianceMatrix");
 
   setProperty("OutputParameters", parameterTable);
   setProperty("OutputWorkspace", outputWorkspace);
-  setProperty("OutputNormalisedCovarianceMatrix", outputNormalisedCovarianceMatrix);
+  setProperty("OutputNormalisedCovarianceMatrix",
+              outputNormalisedCovarianceMatrix);
 
   try {
     if (wsNames.size() == 1) {

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -249,6 +249,7 @@ QStringList FunctionMultiDomainPresenter::getGlobalParameters() const {
 void FunctionMultiDomainPresenter::setGlobalParameters(
     const QStringList &globals) {
   m_model->setGlobalParameters(globals);
+  m_view->setGlobalParameters(m_model->getGlobalParameters());
 }
 
 QStringList FunctionMultiDomainPresenter::getLocalParameters() const {

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -45,6 +45,21 @@ def get_group_asymmetry_name(context, group_name, run, rebin):
     return name
 
 
+def get_group_asymmetry_unnorm_name(context, group_name, run, rebin):
+    if context.data_context.is_multi_period():
+        name = '__' + context.data_context._base_run_name(run) + "; Group; " + group_name + \
+            "; Asymmetry; Periods; " + context.gui_context.period_string(run) + ";"
+    else:
+        name = '__' + context.data_context._base_run_name(run) + "; Group; " + group_name + "; Asymmetry;"
+
+    if rebin:
+        name += ' Rebin;'
+
+    name += '_unnorm' + context.workspace_suffix
+
+    return name
+
+
 def get_pair_data_workspace_name(context, pair_name, run, rebin):
     if context.data_context.is_multi_period():
         name = context.data_context._base_run_name(run) + "; Pair Asym; " + pair_name + "; Periods; " \

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -46,18 +46,7 @@ def get_group_asymmetry_name(context, group_name, run, rebin):
 
 
 def get_group_asymmetry_unnorm_name(context, group_name, run, rebin):
-    if context.data_context.is_multi_period():
-        name = '__' + context.data_context._base_run_name(run) + "; Group; " + group_name + \
-            "; Asymmetry; Periods; " + context.gui_context.period_string(run) + ";"
-    else:
-        name = '__' + context.data_context._base_run_name(run) + "; Group; " + group_name + "; Asymmetry;"
-
-    if rebin:
-        name += ' Rebin;'
-
-    name += '_unnorm' + context.workspace_suffix
-
-    return name
+    return '__' + get_group_asymmetry_name(context, group_name, run, rebin) + '_unnorm'
 
 
 def get_pair_data_workspace_name(context, pair_name, run, rebin):

--- a/scripts/Muon/GUI/Common/calculate_pair_and_group.py
+++ b/scripts/Muon/GUI/Common/calculate_pair_and_group.py
@@ -35,9 +35,9 @@ def estimate_group_asymmetry_data(context, group_name, run, rebin):
 
     params = _get_MuonGroupingAsymmetry_parameters(context, group_name, run)
     params["InputWorkspace"] = processed_data
-    group_asymmetry = algorithm_utils.run_MuonGroupingAsymmetry(params)
+    group_asymmetry, group_asymmetry_unnorm = algorithm_utils.run_MuonGroupingAsymmetry(params)
 
-    return group_asymmetry
+    return group_asymmetry, group_asymmetry_unnorm
 
 
 def _run_pre_processing(context, run, rebin):

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -79,7 +79,7 @@ class MuonContext(object):
                 if self._do_rebin():
                     name = get_group_data_workspace_name(self, group_name, run_as_string, rebin=True)
                     asym_name = get_group_asymmetry_name(self, group_name, run_as_string, rebin=True)
-                    asym_name_unnorm = get_group_asymmetry_unnorm_name(self, group_name, run_as_string, rebin=False)
+                    asym_name_unnorm = get_group_asymmetry_unnorm_name(self, group_name, run_as_string, rebin=True)
 
                     self.group_pair_context[group_name].show_rebin(run, directory + name, directory + asym_name, asym_name_unnorm)
 

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -225,3 +225,12 @@ class MuonGroupPairContext(object):
     def remove_workspace_by_name(self, workspace_name):
         for item in self.groups + self.pairs:
             item.remove_workspace_by_name(workspace_name)
+
+    def get_unormalisised_workspace_list(self, workspace_list):
+        return [self.find_unormalised_workspace(workspace) for workspace in workspace_list]
+
+    def find_unormalised_workspace(self, workspace):
+        for group in self.groups:
+            unnormalised_workspace = group.find_unormalised(workspace)
+            if unnormalised_workspace:
+                return unnormalised_workspace

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -10,7 +10,7 @@ from Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_simultaneous_
 import mantid
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_fit_workspace_directory
-from mantid.simpleapi import RenameWorkspace, CopyLogs
+from mantid.simpleapi import RenameWorkspace, ConvertFitFunctionForMuonTFAsymmetry, CopyLogs
 
 
 class FittingTabModel(object):
@@ -71,6 +71,8 @@ class FittingTabModel(object):
         return name, directory
 
     def do_simultaneous_fit(self, parameter_dict, global_parameters):
+        import pydevd
+        pydevd.settrace('localhost', port=5544, stdoutToServer=True, stderrToServer=True)
         fit_group_name = parameter_dict.pop('FitGroupName')
         output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared = \
             self.do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
@@ -86,6 +88,9 @@ class FittingTabModel(object):
             workspace_name = self.rename_members_of_fitted_workspace_group(output_workspace, parameter_dict['InputWorkspace'],
                                                                            parameter_dict['Function'],
                                                                            fit_group_name)
+        else:
+            workspace_name = [workspace_name]
+
         wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name,
                                                                 table_directory)
         self.add_fit_to_context(wrapped_parameter_workspace,
@@ -172,3 +177,6 @@ class FittingTabModel(object):
         self.context.fitting_context.add_fit_from_values(
             parameter_workspace, self.function_name,
             input_workspace, output_workspace_name, global_parameters)
+
+    def calculate_tf_function(self, algorithm_parameters):
+        return ConvertFitFunctionForMuonTFAsymmetry(StoreInADS=False, **algorithm_parameters)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, unicode_literals)
 
-from Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_simultaneous_Fit
+from Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_simultaneous_Fit, run_CalculateMuonAsymmetry
 import mantid
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_fit_workspace_directory
@@ -44,6 +44,72 @@ class FittingTabModel(object):
         CopyLogs(InputWorkspace=parameters_dict['InputWorkspace'], OutputWorkspace=output_workspace, StoreInADS=False)
         return output_workspace, output_parameters, function_object, output_status, output_chi
 
+    def do_single_tf_fit(self, parameter_dict, output_workspace_group):
+        import pydevd
+        pydevd.settrace('localhost', port=5544, stdoutToServer=True, stderrToServer=True)
+        alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
+        function_object, output_status, output_chi_squared = run_CalculateMuonAsymmetry(parameter_dict, alg)
+
+        fitting_parameters_table = mantid.api.AnalysisDataService.retrieve(
+            parameter_dict['OutputFitWorkspace'] + '_Parameters')
+        mantid.api.AnalysisDataService.remove(parameter_dict['OutputFitWorkspace'] + '_NormalisedCovarianceMatrix')
+
+        output_workspace = mantid.api.AnalysisDataService.retrieve(
+            parameter_dict['OutputFitWorkspace'] + '_Workspace')
+
+        workspace_name, workspace_directory = self.create_fitted_workspace_name(parameter_dict['ReNormalizedWorkspaceList'],
+                                                                                parameter_dict['InputFunction'],
+                                                                                output_workspace_group)
+        table_name, table_directory = self.create_parameter_table_name(parameter_dict['ReNormalizedWorkspaceList'],
+                                                                       parameter_dict['InputFunction'], output_workspace_group)
+
+        self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
+        wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name, table_directory)
+        self.add_fit_to_context(wrapped_parameter_workspace,
+                                parameter_dict['InputFunction'],
+                                parameter_dict['ReNormalizedWorkspaceList'], [workspace_name])
+
+        return function_object.clone(), output_status, output_chi_squared
+
+    def do_simultaneous_tf_fit(self, parameter_dict, global_parameters, fit_group_name):
+        alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
+        function_object, output_status, output_chi_squared= run_CalculateMuonAsymmetry(parameter_dict, alg)
+
+        fitting_parameters_table = mantid.api.AnalysisDataService.retrieve(parameter_dict['OutputFitWorkspace'] + '_Parameters')
+        mantid.api.AnalysisDataService.remove(parameter_dict['OutputFitWorkspace'] + '_NormalisedCovarianceMatrix')
+
+        if len(parameter_dict['ReNormalizedWorkspaceList']) > 1:
+            output_workspace = mantid.api.AnalysisDataService.retrieve(
+                parameter_dict['OutputFitWorkspace'] + '_Workspaces')
+        else:
+            output_workspace = mantid.api.AnalysisDataService.retrieve(
+                parameter_dict['OutputFitWorkspace'] + '_Workspace')
+
+        workspace_name, workspace_directory = self.create_multi_domain_fitted_workspace_name(
+            parameter_dict['ReNormalizedWorkspaceList'][0],
+            parameter_dict['InputFunction'], fit_group_name)
+        table_name, table_directory = self.create_parameter_table_name(parameter_dict['ReNormalizedWorkspaceList'][0] + '+ ...',
+                                                                       parameter_dict['InputFunction'], fit_group_name)
+
+        self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
+        if len(parameter_dict['ReNormalizedWorkspaceList']) > 1:
+            workspace_name = self.rename_members_of_fitted_workspace_group(output_workspace,
+                                                                           parameter_dict['ReNormalizedWorkspaceList'],
+                                                                           parameter_dict['InputFunction'],
+                                                                           fit_group_name)
+        else:
+            workspace_name = [workspace_name]
+
+        wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name,
+                                                                table_directory)
+        self.add_fit_to_context(wrapped_parameter_workspace,
+                                parameter_dict['InputFunction'],
+                                parameter_dict['ReNormalizedWorkspaceList'],
+                                workspace_name,
+                                global_parameters)
+
+        return function_object, output_status, output_chi_squared
+
     def add_workspace_to_ADS(self, workspace, name, directory):
         workspace_wrapper = MuonWorkspaceWrapper(workspace, directory + name)
         workspace_wrapper.show()
@@ -71,8 +137,6 @@ class FittingTabModel(object):
         return name, directory
 
     def do_simultaneous_fit(self, parameter_dict, global_parameters):
-        import pydevd
-        pydevd.settrace('localhost', port=5544, stdoutToServer=True, stderrToServer=True)
         fit_group_name = parameter_dict.pop('FitGroupName')
         output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared = \
             self.do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
@@ -142,6 +206,28 @@ class FittingTabModel(object):
             sub_parameter_dict['Function'] = function_object
 
             function_object, output_status, output_chi_squared = self.do_single_fit(sub_parameter_dict)
+            # This is required so that a new function object is created that is not overwritten in subsequent iterations
+            new_function = function_object.clone()
+            function_object_list.append(new_function)
+
+            output_status_list.append(output_status)
+            output_chi_squared_list.append(output_chi_squared)
+
+        return function_object_list, output_status_list, output_chi_squared_list
+
+    def do_sequential_tf_fit(self, parameter_dict, output_workspace_group):
+        function_object_list = []
+        output_status_list = []
+        output_chi_squared_list = []
+        function_object = parameter_dict['InputFunction']
+        for input_workspace, un_normalised_workspace in zip(parameter_dict['ReNormalizedWorkspaceList'],
+                                                            parameter_dict['UnNormalizedWorkspaceList']):
+            sub_parameter_dict = parameter_dict.copy()
+            sub_parameter_dict['ReNormalizedWorkspaceList'] = input_workspace
+            sub_parameter_dict['UnNormalizedWorkspaceList'] = un_normalised_workspace
+            sub_parameter_dict['InputFunction'] = function_object
+
+            function_object, output_status, output_chi_squared = self.do_single_tf_fit(sub_parameter_dict, output_workspace_group)
             # This is required so that a new function object is created that is not overwritten in subsequent iterations
             new_function = function_object.clone()
             function_object_list.append(new_function)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -182,7 +182,7 @@ class FittingTabPresenter(object):
                 self.calculation_thread = self.create_thread(
                     calculation_function)
             elif fit_type == self.view.sequential_fit:
-                sequential_fit_parameters = self.get_multi_domain_tf_fit_parameters()
+                sequential_fit_parameters = self.get_sequential_tf_fit_parameters()
                 calculation_function = functools.partial(
                     self.model.do_sequential_tf_fit, sequential_fit_parameters, self.view.group_name)
                 self.calculation_thread = self.create_thread(
@@ -228,6 +228,27 @@ class FittingTabPresenter(object):
                    'EndX': self.end_x[self.view.get_index_for_start_end_times()],
                    'Minimizer': self.view.minimizer
                }
+
+    def get_sequential_tf_fit_parameters(self):
+        fit_group_name = self.model.get_function_name(self.view.fit_object)
+        workspace_name_list = []
+        for workspace in self.selected_data:
+            workspace_name, workspace_directory = self.model.create_multi_domain_fitted_workspace_name(
+                workspace,
+                self.view.fit_object,
+                fit_group_name)
+            workspace_name_list.append(workspace_name)
+
+        return {
+            'InputFunction': self.view.fit_object,
+            'ReNormalizedWorkspaceList': self.selected_data,
+            'UnNormalizedWorkspaceList': self.context.group_pair_context.get_unormalisised_workspace_list(
+                self.selected_data),
+            'OutputFitWorkspace': workspace_name_list,
+            'StartX': self.start_x[self.view.get_index_for_start_end_times()],
+            'EndX': self.end_x[self.view.get_index_for_start_end_times()],
+            'Minimizer': self.view.minimizer
+        }
 
     def handle_started(self):
         self.view.setEnabled(False)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -233,7 +233,7 @@ class FittingTabPresenter(object):
         fit_group_name = self.model.get_function_name(self.view.fit_object)
         workspace_name_list = []
         for workspace in self.selected_data:
-            workspace_name, workspace_directory = self.model.create_multi_domain_fitted_workspace_name(
+            workspace_name, workspace_directory = self.model.create_fitted_workspace_name(
                 workspace,
                 self.view.fit_object,
                 fit_group_name)
@@ -332,10 +332,13 @@ class FittingTabPresenter(object):
             return
 
         self._tf_asymmetry_mode = self.view.tf_asymmetry_mode
+        global_parameters = self.view.get_global_parameters()
         if self._tf_asymmetry_mode:
             self.view.select_workspaces_to_fit_button.setEnabled(False)
+            new_global_parameters = [str('f0.f1.f1.' + item) for item in global_parameters]
         else:
             self.view.select_workspaces_to_fit_button.setEnabled(True)
+            new_global_parameters = [item[9:] for item in global_parameters]
 
         if self.view.fit_type != self.view.simultaneous_fit:
             for index, fit_function in enumerate(self._fit_function):
@@ -350,8 +353,13 @@ class FittingTabPresenter(object):
         self.view.function_browser.blockSignals(True)
         self.view.function_browser.clear()
         self.view.function_browser.setFunction(str(self._fit_function[self.view.get_index_for_start_end_times()]))
+        self.view.function_browser.setGlobalParameters(new_global_parameters)
         self.view.function_browser.blockSignals(False)
         self.update_fit_status_information_in_view()
+        self.handle_display_workspace_changed()
+        if self.automatically_update_fit_name:
+            self.view.function_name += ',TFAsymmetry'
+            self.model.function_name = self.view.function_name
 
     def get_parameters_for_single_fit(self):
         params = self._get_shared_parameters()
@@ -468,6 +476,7 @@ class FittingTabPresenter(object):
             self.selected_data = [item for item in self.selected_data if item != workspace_removed]
         else:
             self.selected_data = []
+
     def check_workspaces_are_tf_asymmetry_compliant(self, workspace_list):
         non_compliant_workspaces = [item for item in workspace_list if 'Group' not in item]
         return False if non_compliant_workspaces else True

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -255,9 +255,9 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.fit_to_raw_data_checkbox = table_utils.addCheckBoxWidgetToTable(
             self.fit_options_table, True, 3)
 
-        table_utils.setRowName(self.fit_options_table, 4, "Evaluate Function As")
-        self.evaluation_combo = table_utils.addComboToTable(self.fit_options_table, 4, ['CentrePoint', 'Histogram'])
-
-        table_utils.setRowName(self.fit_options_table, 5, "TF Asymmetry Mode")
+        table_utils.setRowName(self.fit_options_table, 4, "TF Asymmetry Mode")
         self.tf_asymmetry_mode_checkbox = table_utils.addCheckBoxWidgetToTable(
-            self.fit_options_table, False, 5)
+            self.fit_options_table, False, 4)
+
+        table_utils.setRowName(self.fit_options_table, 5, "Evaluate Function As")
+        self.evaluation_combo = table_utils.addComboToTable(self.fit_options_table, 5, ['CentrePoint', 'Histogram'])

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -194,6 +194,15 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         self.fit_to_raw_data_checkbox.setCheckState(state)
 
     @property
+    def tf_asymmetry_mode(self):
+        return self.tf_asymmetry_mode_checkbox.isChecked()
+
+    @tf_asymmetry_mode.setter
+    def tf_asymmetry_mode(self, value):
+        state = QtCore.Qt.Checked if value else QtCore.Qt.Unchecked
+        self.tf_asymmetry_mode_checkbox.setCheckState(state)
+
+    @property
     def group_name(self):
         return str(self.ads_group_name_textbox.text())
 
@@ -218,19 +227,11 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
         current_index = self.parameter_display_combo.currentIndex()
         return current_index if current_index != -1 else 0
 
-    def get_index_for_fit_specification(self):
-        if self.fit_type == self.sequential_fit:
-            current_index = self.parameter_display_combo.currentIndex()
-        else:
-            current_index = 0
-
-        return current_index if current_index != -1 else 0
-
     def get_global_parameters(self):
         return self.function_browser.getGlobalParameters()
 
     def setup_fit_options_table(self):
-        self.fit_options_table.setRowCount(5)
+        self.fit_options_table.setRowCount(6)
         self.fit_options_table.setColumnCount(2)
         self.fit_options_table.setColumnWidth(0, 300)
         self.fit_options_table.setColumnWidth(1, 300)
@@ -256,3 +257,7 @@ class FittingTabView(QtWidgets.QWidget, ui_fitting_tab):
 
         table_utils.setRowName(self.fit_options_table, 4, "Evaluate Function As")
         self.evaluation_combo = table_utils.addComboToTable(self.fit_options_table, 4, ['CentrePoint', 'Histogram'])
+
+        table_utils.setRowName(self.fit_options_table, 5, "TF Asymmetry Mode")
+        self.tf_asymmetry_mode_checkbox = table_utils.addCheckBoxWidgetToTable(
+            self.fit_options_table, False, 5)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -30,5 +30,5 @@ class FittingTabWidget(object):
             self.fitting_tab_presenter.handle_function_structure_changed)
         self.fitting_tab_view.function_name_line_edit.textChanged.connect(
             self.fitting_tab_presenter.handle_fit_name_changed_by_user)
-
         context.update_view_from_model_notifier.add_subscriber(self.fitting_tab_presenter.update_view_from_model_observer)
+        self.fitting_tab_view.tf_asymmetry_mode_checkbox.stateChanged.connect(self.fitting_tab_presenter.handle_tf_asymmetry_mode_changed)

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -30,6 +30,8 @@ class MuonGroup(object):
         self._asymmetry_estimate = {}
         self._counts_workspace_rebin = {}
         self._asymmetry_estimate_rebin = {}
+        self._asymmetry_estimate_unormalised = {}
+        self._asymmetry_estimate_rebin_unormalised = {}
 
     @property
     def workspace(self):
@@ -73,21 +75,27 @@ class MuonGroup(object):
         else:
             raise ValueError("detectors must be a list of ints.")
 
-    def show_raw(self, run, name, asym_name):
+    def show_raw(self, run, name, asym_name, asym_name_unnorm):
         str(run) not in self._counts_workspace or self._counts_workspace[str(run)].show(name)
         str(run) not in self._asymmetry_estimate or self._asymmetry_estimate[str(run)].show(asym_name)
+        str(run) not in self._asymmetry_estimate_unormalised or\
+            self._asymmetry_estimate_unormalised[str(run)].show(asym_name_unnorm)
 
-    def show_rebin(self, run, name, asym_name):
+    def show_rebin(self, run, name, asym_name, asym_name_unnorm):
         str(run) not in self._counts_workspace_rebin or self._counts_workspace_rebin[str(run)].show(name)
         str(run) not in self._asymmetry_estimate_rebin or self._asymmetry_estimate_rebin[str(run)].show(asym_name)
+        str(run) not in self._asymmetry_estimate_rebin_unormalised or \
+            self._asymmetry_estimate_rebin_unormalised[str(run)].show(asym_name_unnorm)
 
-    def update_workspaces(self, run, counts_workspace, asymmetry_workspace, rebin):
+    def update_workspaces(self, run, counts_workspace, asymmetry_workspace, asymmetry_workspace_unnorm, rebin):
         if rebin:
             self._counts_workspace_rebin.update({str(run): MuonWorkspaceWrapper(counts_workspace)})
             self._asymmetry_estimate_rebin.update({str(run): MuonWorkspaceWrapper(asymmetry_workspace)})
+            self._asymmetry_estimate_rebin_unormalised.update({str(run): MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
         else:
             self._counts_workspace.update({str(run): MuonWorkspaceWrapper(counts_workspace)})
             self._asymmetry_estimate.update({str(run): MuonWorkspaceWrapper(asymmetry_workspace)})
+            self._asymmetry_estimate_unormalised.update({str(run): MuonWorkspaceWrapper(asymmetry_workspace_unnorm)})
 
     def update_counts_workspace(self, counts_workspace, run):
         self._counts_workspace.update({run: MuonWorkspaceWrapper(counts_workspace)})
@@ -154,3 +162,12 @@ class MuonGroup(object):
         _remove_workspace_from_dict_by_name(workspace_name, self._asymmetry_estimate)
         _remove_workspace_from_dict_by_name(workspace_name, self._counts_workspace_rebin)
         _remove_workspace_from_dict_by_name(workspace_name, self._asymmetry_estimate_rebin)
+
+    def find_unormalised(self, workspace):
+        for key, value in self._asymmetry_estimate.items():
+            if value.workspace_name == workspace:
+                return self._asymmetry_estimate_unormalised[key].workspace_name
+
+        for key, value in self._asymmetry_estimate_rebin.items():
+            if value.workspace_name == workspace:
+                return self._asymmetry_estimate_rebin_unormalised[key].workspace_name

--- a/scripts/Muon/GUI/Common/test_helpers/general_test_helpers.py
+++ b/scripts/Muon/GUI/Common/test_helpers/general_test_helpers.py
@@ -20,12 +20,18 @@ def create_group_populated_by_two_workspace():
         group = MuonGroup(group_name="group1")
         counts_workspace_22222 = CreateWorkspace([0], [0])
         asymmetry_workspace_22222 = CreateWorkspace([0], [0])
-        group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, False)
-        group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222')
+        asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
+
+        group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222,
+                                False)
+        group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222', 'asymmetry_name_22222_unnorm')
         counts_workspace_33333 = CreateWorkspace([0], [0])
         asymmetry_workspace_33333 = CreateWorkspace([0], [0])
-        group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, False)
-        group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333')
+        asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
+
+        group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333,
+                                False)
+        group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333', 'asymmetry_name_33333_unnorm')
 
         return group
 
@@ -34,12 +40,18 @@ def create_group_populated_by_two_rebinned_workspaces():
     group = MuonGroup(group_name="group1")
     counts_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, True)
-    group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin')
+    asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
+
+    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222,
+                            True)
+    group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, True)
-    group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin')
+    asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
+
+    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333,
+                            True)
+    group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin', 'asymmetry_name_33333_unnorm')
 
     return group
 
@@ -48,20 +60,31 @@ def create_group_populated_by_two_binned_and_two_unbinned_workspaces():
     group = MuonGroup(group_name="group1")
     counts_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, False)
-    group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222')
+    asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
+    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222
+                            , False)
+    group.show_raw([22222], 'counts_name_22222', 'asymmetry_name_22222', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, False)
-    group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333')
+    asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
+
+    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333,
+                            False)
+    group.show_raw([33333], 'counts_name_33333', 'asymmetry_name_33333', 'asymmetry_name_33333_unnorm')
 
     counts_workspace_22222 = CreateWorkspace([0], [0])
     asymmetry_workspace_22222 = CreateWorkspace([0], [0])
-    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, True)
-    group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin')
+    asymmetry_workspace_unnorm_22222 = CreateWorkspace([0], [0])
+
+    group.update_workspaces([22222], counts_workspace_22222, asymmetry_workspace_22222, asymmetry_workspace_unnorm_22222,
+                            True)
+    group.show_rebin([22222], 'counts_name_22222_rebin', 'asymmetry_name_22222_rebin', 'asymmetry_name_22222_unnorm')
     counts_workspace_33333 = CreateWorkspace([0], [0])
     asymmetry_workspace_33333 = CreateWorkspace([0], [0])
-    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, True)
-    group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin')
+    asymmetry_workspace_unnorm_33333 = CreateWorkspace([0], [0])
+
+    group.update_workspaces([33333], counts_workspace_33333, asymmetry_workspace_33333, asymmetry_workspace_unnorm_33333,
+                            True)
+    group.show_rebin([33333], 'counts_name_33333_rebin', 'asymmetry_name_33333_rebin', 'asymmetry_name_22222_unnorm')
 
     return group

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -71,7 +71,7 @@ def run_MuonGroupingAsymmetry(parameter_dict):
     alg.setProperty("OutputWorkspace", "__notUsed")
     alg.setProperties(parameter_dict)
     alg.execute()
-    return alg.getProperty("OutputWorkspace").value
+    return alg.getProperty("OutputWorkspace").value, alg.getProperty("OutputUnNormWorkspace").value
 
 
 def run_CalMuonDetectorPhases(parameter_dict, alg):
@@ -165,6 +165,16 @@ def run_simultaneous_Fit(parameters_dict, alg):
 
     return alg.getProperty('OutputWorkspace').value, alg.getProperty('OutputParameters').value, alg.getProperty('Function').value,\
         alg.getProperty('OutputStatus').value, alg.getProperty('OutputChi2overDoF').value
+
+
+def run_CalculateMuonAsymmetry(parameters_dict, alg):
+    alg.initialize()
+    alg.setAlwaysStoreInADS(False)
+    alg.setRethrows(True)
+    alg.setProperties(parameters_dict)
+    alg.execute()
+    return alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
+           alg.getProperty('ChiSquared').value
 
 
 def run_AppendSpectra(ws1, ws2):

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -174,8 +174,8 @@ def run_CalculateMuonAsymmetry(parameters_dict, alg):
     alg.setProperties(parameters_dict)
     alg.execute()
     return alg.getProperty('OutputWorkspace').value, alg.getProperty('OutputParameters').value,\
-           alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
-           alg.getProperty('ChiSquared').value
+        alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
+        alg.getProperty('ChiSquared').value
 
 
 def run_AppendSpectra(ws1, ws2):

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -173,7 +173,8 @@ def run_CalculateMuonAsymmetry(parameters_dict, alg):
     alg.setRethrows(True)
     alg.setProperties(parameters_dict)
     alg.execute()
-    return alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
+    return alg.getProperty('OutputWorkspace').value, alg.getProperty('OutputParameters').value,\
+           alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
            alg.getProperty('ChiSquared').value
 
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -18,6 +18,7 @@ EXAMPLE_TF_ASYMMETRY_FUNCTION = '(composite=ProductFunction,NumDeriv=false;name=
                                 '(name=FlatBackground,A0=1,ties=(A0=1);name=ExpDecayOsc,A=0.2,Lambda=0.2,Frequency=0.1,Phi=0))' \
                                 ';name=ExpDecayMuon,A=0,Lambda=-2.19698,ties=(A=0,Lambda=-2.19698)'
 
+
 def retrieve_combobox_info(combo_box):
     output_list = []
     for i in range(combo_box.count()):
@@ -86,9 +87,11 @@ class FittingTabPresenterTest(GuiTest):
 
         self.presenter.model.do_single_fit.assert_called_once_with(
             {'Function': mock.ANY, 'InputWorkspace': 'Input Workspace Name',
-             'Minimizer': 'Levenberg-Marquardt', 'StartX': 0.0, 'EndX': 15.0, 'EvaluationType': 'CentrePoint', 'FitGroupName': 'Fitting Results'})
+             'Minimizer': 'Levenberg-Marquardt', 'StartX': 0.0, 'EndX': 15.0, 'EvaluationType': 'CentrePoint',
+             'FitGroupName': 'Fitting Results'})
 
-        self.assertEqual(str(self.presenter.model.do_single_fit.call_args[0][0]['Function']), 'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
+        self.assertEqual(str(self.presenter.model.do_single_fit.call_args[0][0]['Function']),
+                         'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
 
     def test_get_parameters_for_single_fit_returns_correctly(self):
         self.presenter.selected_data = ['Input Workspace Name']
@@ -208,7 +211,8 @@ class FittingTabPresenterTest(GuiTest):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
                               'MUSR22725; Group; fwd; Asymmetry']
         self.presenter.selected_data = new_workspace_list
-        self.presenter.context.get_names_of_workspaces_to_fit = mock.MagicMock(return_value=['MUSR22725; Group; top; Asymmetry'])
+        self.presenter.context.get_names_of_workspaces_to_fit = mock.MagicMock(
+            return_value=['MUSR22725; Group; top; Asymmetry'])
 
         self.view.simul_fit_radio.toggle()
 
@@ -303,7 +307,8 @@ class FittingTabPresenterTest(GuiTest):
 
         self.view.parameter_display_combo.setCurrentIndex(1)
 
-        self.assertEqual(self.view.function_browser.getFitFunctionString(), 'name=GausOsc,A=0.6,Sigma=0.6,Frequency=0.6,Phi=0')
+        self.assertEqual(self.view.function_browser.getFitFunctionString(),
+                         'name=GausOsc,A=0.6,Sigma=0.6,Frequency=0.6,Phi=0')
         self.assertEqual(self.view.fit_status_success_failure.text(), 'Failure: failure with message')
 
     def test_get_first_good_data_for_workspace_retrieves_correct_first_good_data(self):
@@ -377,7 +382,6 @@ class FittingTabPresenterTest(GuiTest):
         self.assertEqual(result, {'InputFunction': fit_function, 'WorkspaceList': new_workspace_list,
                                   'Mode': 'Extract'})
 
-
     def test_handle_asymmetry_mode_changed_reverts_changed_and_shows_error_if_non_pair_selected(self):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
                               'MUSR22725; Pair; fwd; Long']
@@ -387,7 +391,8 @@ class FittingTabPresenterTest(GuiTest):
 
         self.view.tf_asymmetry_mode = True
 
-        self.view.warning_popup.assert_called_once_with('Can only fit groups in tf asymmetry mode and need a function defined')
+        self.view.warning_popup.assert_called_once_with(
+            'Can only fit groups in tf asymmetry mode and need a function defined')
 
     def test_handle_asymmetry_mode_correctly_updates_function_for_a_single_fit(self):
         new_workspace_list = ['MUSR22725; Group; top; Asymmetry']
@@ -414,7 +419,7 @@ class FittingTabPresenterTest(GuiTest):
 
         self.view.tf_asymmetry_mode = True
 
-        self.assertEqual([str(item) for item in self.presenter._fit_function], [str(fit_function_2)]*3)
+        self.assertEqual([str(item) for item in self.presenter._fit_function], [str(fit_function_2)] * 3)
         self.assertEqual(str(self.view.fit_object), str(fit_function_2))
 
     def test_handle_asymmetry_mode_correctly_updates_function_for_sumultaneous_fit(self):
@@ -446,10 +451,43 @@ class FittingTabPresenterTest(GuiTest):
 
         self.view.tf_asymmetry_mode = False
 
-        self.assertEqual([str(item) for item in self.presenter._fit_function], ['name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0',
-                                                                                'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0',
-                                                                                'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0'])
+        self.assertEqual([str(item) for item in self.presenter._fit_function],
+                         ['name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0',
+                          'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0',
+                          'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0'])
         self.assertEqual(str(self.view.fit_object), 'name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
+
+    # def test_handle_fit_with_tf_asymmetry_mode_calls_CalculateMuonAsymmetry(self):
+    #     self.view.sequential_fit_radio.toggle()
+    #     new_workspace_list = ['MUSR22725; Group; top; Asymmetry']
+    #     fit_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
+    #     fit_function_2 = FunctionFactory.createInitialized(EXAMPLE_TF_ASYMMETRY_FUNCTION)
+    #     self.view.function_browser.setFunction(str(fit_function))
+    #     self.presenter.selected_data = new_workspace_list
+    #     self.presenter.model.calculate_tf_function.return_value = fit_function_2
+    #     self.view.tf_asymmetry_mode = True
+    #
+    #     self.presenter.handle_fit_clicked()
+
+    def test_get_parameters_for_tf_single_fit_calculation(self):
+        self.context.group_pair_context.get_unormalisised_workspace_list = mock.MagicMock(return_value=
+                                                                                          [
+                                                                                              '__MUSR22725; Group; top; Asymmetry_unnorm',
+                                                                                              '__MUSR22725; Group; bottom; Asymmetry_unnorm',
+                                                                                              '__MUSR22725; Group; fwd; Asymmetry_unnorm'])
+
+        result = self.presenter.get_parameters_for_tf_single_fit_calculation()
+
+        self.assertEqual(result, {'EndX': 15.0,
+                                  'InputFunction': None,
+                                  'Minimizer': None,
+                                  'OutputFitWorkspace': 'OutputFitWorkspace',
+                                  'ReNormalizedWorkspaceList': [],
+                                  'StartX': 0.0,
+                                  'UnNormalizedWorkspaceList': ['__MUSR22725; Group; top; Asymmetry_unnorm',
+                                                                '__MUSR22725; Group; bottom; Asymmetry_unnorm',
+                                                                '__MUSR22725; Group; fwd; Asymmetry_unnorm']}
+                         )
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -487,8 +487,8 @@ class FittingTabPresenterTest(GuiTest):
         self.presenter.handle_fit_clicked()
         wait_for_thread(self.presenter.calculation_thread)
 
-        self.presenter.model.do_sequential_tf_fit.assert_called_once()
-        self.presenter.handle_finished.assert_called_once()
+        self.assertEqual(self.presenter.model.do_sequential_tf_fit.call_count, 1)
+        self.assertEqual(self.presenter.handle_finished.call_count, 1)
 
     def test_get_parameters_for_tf_single_fit_calculation(self):
         self.presenter.model.create_fitted_workspace_name.return_value = ('workspace', 'workspace directory')

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -7,15 +7,11 @@
 import sys
 import unittest
 
-from mantid.api import AnalysisDataService
-from mantid.api import FileFinder
+from mantid.api import AnalysisDataService, FileFinder
+from mantid import ConfigService
 from mantid.dataobjects import Workspace2D
 from mantid.simpleapi import CreateWorkspace
-from Muon.GUI.Common.contexts.muon_context import MuonContext
-from Muon.GUI.Common.contexts.muon_data_context import MuonDataContext
-from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContext
-from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
-from Muon.GUI.Common.muon_load_data import MuonLoadData
+from collections import Counter
 from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
@@ -24,6 +20,7 @@ from Muon.GUI.Common.test_helpers.context_setup import setup_context
 class MuonContextTest(unittest.TestCase):
     def setUp(self):
         AnalysisDataService.clear()
+        ConfigService['MantidOptions.InvisibleWorkspaces'] = 'True'
         self.filepath = FileFinder.findRuns('EMU00019489.nxs')[0]
 
         self.load_result, self.run_number, self.filename, psi_data = load_workspace_from_filename(self.filepath)
@@ -44,6 +41,9 @@ class MuonContextTest(unittest.TestCase):
         self.group_pair_context.reset_group_and_pairs_to_default(self.load_result['OutputWorkspace'][0]._workspace,
                                                                  'EMU', '')
 
+    def tearDown(self):
+        ConfigService['MantidOptions.InvisibleWorkspaces'] = 'False'
+
     def populate_ADS(self):
         self.context.calculate_all_groups()
         self.context.show_all_groups()
@@ -58,7 +58,8 @@ class MuonContextTest(unittest.TestCase):
         self.assertEqual(self.group_pair_context.pair_names, ['long'])
 
     def test_calculate_group_calculates_group_for_given_run(self):
-        counts_workspace, asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_group('fwd', run=[19489])
+        counts_workspace, asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_group('fwd',
+                                                                                                          run=[19489])
 
         self.assertEqual(type(counts_workspace), Workspace2D)
         self.assertEqual(type(asymmetry_workspace), Workspace2D)
@@ -72,11 +73,12 @@ class MuonContextTest(unittest.TestCase):
     def test_show_all_groups_calculates_and_shows_all_groups(self):
         self.context.show_all_groups()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(),
-        ['__EMU19489; Group; bwd; Asymmetry; MA_unnorm', '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
-                   'EMU19489 Groups MA', 'EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                   'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; fwd; Asymmetry; MA',
-                   'EMU19489; Group; fwd; Counts; MA', 'Muon Data'])
+        self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
+                          Counter(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
+                                   '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
+                                   'EMU19489 Groups MA', 'EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                   'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; fwd; Asymmetry; MA',
+                                   'EMU19489; Group; fwd; Counts; MA', 'Muon Data']))
 
     def test_that_show_all_calculates_and_shows_all_groups_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -84,21 +86,23 @@ class MuonContextTest(unittest.TestCase):
 
         self.context.show_all_groups()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
-                           '__EMU19489; Group; bwd; Asymmetry; Rebin; MA_unnorm',
-                           '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
-                           '__EMU19489; Group; fwd; Asymmetry; Rebin; MA_unnorm', 'EMU19489 Groups MA', 'EMU19489 MA',
-                           'EMU19489; Group; bwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; Rebin; MA',
-                           'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; bwd; Counts; Rebin; MA',
-                           'EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; fwd; Asymmetry; Rebin; MA',
-                           'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA', 'Muon Data'])
+        self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
+                          Counter(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
+                                   '__EMU19489; Group; bwd; Asymmetry; Rebin; MA_unnorm',
+                                   '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
+                                   '__EMU19489; Group; fwd; Asymmetry; Rebin; MA_unnorm', 'EMU19489 Groups MA',
+                                   'EMU19489 MA',
+                                   'EMU19489; Group; bwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; Rebin; MA',
+                                   'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; bwd; Counts; Rebin; MA',
+                                   'EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; fwd; Asymmetry; Rebin; MA',
+                                   'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA',
+                                   'Muon Data']))
 
     def test_show_all_pairs_calculates_and_shows_all_pairs(self):
         self.context.show_all_pairs()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'Muon Data'])
+        self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
+                          Counter(['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'Muon Data']))
 
     def test_that_show_all_calculates_and_shows_all_pairs_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -106,9 +110,9 @@ class MuonContextTest(unittest.TestCase):
 
         self.context.show_all_pairs()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA',
-                           'EMU19489; Pair Asym; long; Rebin; MA', 'Muon Data'])
+        self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
+                          Counter(['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA',
+                                   'EMU19489; Pair Asym; long; Rebin; MA', 'Muon Data']))
 
     def test_update_current_data_sets_current_run_in_data_context(self):
         self.context.update_current_data()
@@ -124,8 +128,8 @@ class MuonContextTest(unittest.TestCase):
     def test_show_raw_data_puts_raw_data_into_the_ADS(self):
         self.context.show_raw_data()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['EMU19489 MA', 'EMU19489 Raw Data MA', 'EMU19489_raw_data MA', 'Muon Data'])
+        self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
+                          Counter(['EMU19489 MA', 'EMU19489 Raw Data MA', 'EMU19489_raw_data MA', 'Muon Data']))
 
     def test_that_first_good_data_returns_correctly_when_from_file_chosen_option(self):
         self.gui_context.update({'FirstGoodDataFromFile': True})
@@ -166,8 +170,9 @@ class MuonContextTest(unittest.TestCase):
         self.populate_ADS()
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long', True)
 
-        self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                                          'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
+        self.assertEqual(Counter(workspace_list),
+                         Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                  'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489']))
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
         self.populate_ADS()
@@ -179,16 +184,18 @@ class MuonContextTest(unittest.TestCase):
         self.populate_ADS()
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long, random, wrong', True)
 
-        self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                                          'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
+        self.assertEqual(Counter(workspace_list),
+                         Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                  'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489']))
 
     def test_get_workspaces_names_copes_with_non_existent_runs(self):
         self.populate_ADS()
 
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489, 22222', 'fwd, bwd, long', True)
 
-        self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                                          'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
+        self.assertEqual(Counter(workspace_list),
+                         Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                  'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489']))
 
     def test_that_run_ranged_correctly_parsed(self):
         self.populate_ADS()
@@ -196,8 +203,9 @@ class MuonContextTest(unittest.TestCase):
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489-95', 'fwd, bwd, long',
                                                                      True)
 
-        self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                                          'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
+        self.assertEqual(Counter(workspace_list),
+                         Counter(['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                  'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489']))
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -50,17 +50,19 @@ class MuonContextTest(unittest.TestCase):
         self.context.calculate_all_pairs()
         self.context.show_all_pairs()
         workspace = CreateWorkspace([0], [0], StoreInADS=False)
-        self.context.phase_context.add_phase_quad(MuonWorkspaceWrapper(workspace, 'EMU19489; PhaseQuad; PhaseTable EMU19489'))
+        self.context.phase_context.add_phase_quad(
+            MuonWorkspaceWrapper(workspace, 'EMU19489; PhaseQuad; PhaseTable EMU19489'))
 
     def test_reset_groups_and_pairs_to_default(self):
         self.assertEqual(self.group_pair_context.group_names, ['fwd', 'bwd'])
         self.assertEqual(self.group_pair_context.pair_names, ['long'])
 
     def test_calculate_group_calculates_group_for_given_run(self):
-        counts_workspace, asymmetry_workspace = self.context.calculate_group('fwd', run=[19489])
+        counts_workspace, asymmetry_workspace, group_asymmetry_unormalised = self.context.calculate_group('fwd', run=[19489])
 
         self.assertEqual(type(counts_workspace), Workspace2D)
-        self.assertEqual(type(counts_workspace), Workspace2D)
+        self.assertEqual(type(asymmetry_workspace), Workspace2D)
+        self.assertEqual(type(group_asymmetry_unormalised), Workspace2D)
 
     def test_calculate_pair_calculates_pair_for_given_run(self):
         pair_asymmetry = self.context.calculate_pair('long', run=[19489])
@@ -70,9 +72,11 @@ class MuonContextTest(unittest.TestCase):
     def test_show_all_groups_calculates_and_shows_all_groups(self):
         self.context.show_all_groups()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(), ['EMU19489 Groups MA', 'EMU19489 MA','EMU19489; Group; bwd; Asymmetry; MA',
-                                                                 'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; fwd; Asymmetry; MA',
-                                                                 'EMU19489; Group; fwd; Counts; MA', 'Muon Data'])
+        self.assertEquals(AnalysisDataService.getObjectNames(),
+        ['__EMU19489; Group; bwd; Asymmetry; MA_unnorm', '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
+                   'EMU19489 Groups MA', 'EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                   'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; fwd; Asymmetry; MA',
+                   'EMU19489; Group; fwd; Counts; MA', 'Muon Data'])
 
     def test_that_show_all_calculates_and_shows_all_groups_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -81,7 +85,11 @@ class MuonContextTest(unittest.TestCase):
         self.context.show_all_groups()
 
         self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['EMU19489 Groups MA','EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; Rebin; MA',
+                          ['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
+                           '__EMU19489; Group; bwd; Asymmetry; Rebin; MA_unnorm',
+                           '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
+                           '__EMU19489; Group; fwd; Asymmetry; Rebin; MA_unnorm', 'EMU19489 Groups MA', 'EMU19489 MA',
+                           'EMU19489; Group; bwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; Rebin; MA',
                            'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; bwd; Counts; Rebin; MA',
                            'EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; fwd; Asymmetry; Rebin; MA',
                            'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA', 'Muon Data'])
@@ -89,7 +97,8 @@ class MuonContextTest(unittest.TestCase):
     def test_show_all_pairs_calculates_and_shows_all_pairs(self):
         self.context.show_all_pairs()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(), ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'Muon Data'])
+        self.assertEquals(AnalysisDataService.getObjectNames(),
+                          ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'Muon Data'])
 
     def test_that_show_all_calculates_and_shows_all_pairs_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -98,7 +107,8 @@ class MuonContextTest(unittest.TestCase):
         self.context.show_all_pairs()
 
         self.assertEquals(AnalysisDataService.getObjectNames(),
-                          ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'EMU19489; Pair Asym; long; Rebin; MA', 'Muon Data'])
+                          ['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA',
+                           'EMU19489; Pair Asym; long; Rebin; MA', 'Muon Data'])
 
     def test_update_current_data_sets_current_run_in_data_context(self):
         self.context.update_current_data()
@@ -114,7 +124,8 @@ class MuonContextTest(unittest.TestCase):
     def test_show_raw_data_puts_raw_data_into_the_ADS(self):
         self.context.show_raw_data()
 
-        self.assertEquals(AnalysisDataService.getObjectNames(), ['EMU19489 MA', 'EMU19489 Raw Data MA', 'EMU19489_raw_data MA', 'Muon Data'])
+        self.assertEquals(AnalysisDataService.getObjectNames(),
+                          ['EMU19489 MA', 'EMU19489 Raw Data MA', 'EMU19489_raw_data MA', 'Muon Data'])
 
     def test_that_first_good_data_returns_correctly_when_from_file_chosen_option(self):
         self.gui_context.update({'FirstGoodDataFromFile': True})
@@ -156,7 +167,7 @@ class MuonContextTest(unittest.TestCase):
         workspace_list = self.context.get_names_of_workspaces_to_fit('19489', 'fwd, bwd, long', True)
 
         self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
-                                          'EMU19489; Pair Asym; long; MA','EMU19489; PhaseQuad; PhaseTable EMU19489'])
+                                          'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
 
     def test_get_workspace_names_returns_nothing_if_no_parameters_passed(self):
         self.populate_ADS()
@@ -187,6 +198,7 @@ class MuonContextTest(unittest.TestCase):
 
         self.assertEqual(workspace_list, ['EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; MA',
                                           'EMU19489; Pair Asym; long; MA', 'EMU19489; PhaseQuad; PhaseTable EMU19489'])
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**

This adds TF asymmetry mode to the new Muon analysis GUI. It also updates the CalculateMuonAsymmetry algorithm slightly so that what the algorithm puts into the ADS can be controlled. 

**To test:**
  * In the new muon analysis gui try some tf asymmetry mode workflows and check that they work as expected.
  * Run the script from the issue and check it still produces the same results and the workspaces put into the ADS have the same names as previously.

<!-- Instructions for testing. -->

Fixes #25763  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is a change to a new GUI.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
