### PR TITLE
Fix ICat Login for new Reflectometry GUI on Workbench

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.cpp
@@ -37,10 +37,9 @@ void removeResultsWithoutFilenameExtension(ITableWorkspace_sptr results) {
 }
 } // unnamed namespace
 
-CatalogSearcher::CatalogSearcher(IPythonRunner *pythonRunner, IRunsView *view)
-    : m_pythonRunner(pythonRunner), m_view(view), m_notifyee(nullptr),
-      m_searchText(), m_instrument(), m_searchType(SearchType::NONE),
-      m_searchInProgress(false) {
+CatalogSearcher::CatalogSearcher(IRunsView *view)
+    : m_view(view), m_notifyee(nullptr), m_searchText(), m_instrument(),
+      m_searchType(SearchType::NONE), m_searchInProgress(false) {
   m_view->subscribeSearch(this);
 }
 
@@ -151,9 +150,6 @@ void execLoginDialog(const IAlgorithm_sptr &alg) {
  * @returns : true if login succeeded
  */
 void CatalogSearcher::logInToCatalog() {
-  if (hasActiveSession())
-    return;
-
   IAlgorithm_sptr alg = AlgorithmManager::Instance().create("CatalogLogin");
   alg->initialize();
   alg->setProperty("KeepSessionAlive", true);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
@@ -26,7 +26,7 @@ class CatalogSearcher : public ISearcher,
                         public RunsViewSearchSubscriber,
                         public Mantid::API::AlgorithmObserver {
 public:
-  CatalogSearcher(IRunsView *m_view);
+  explicit CatalogSearcher(IRunsView *m_view);
   ~CatalogSearcher() override{};
 
   // ISearcher overrides

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
@@ -10,6 +10,7 @@
 #include "GUI/Common/IPythonRunner.h"
 #include "GUI/Runs/IRunsView.h"
 #include "ISearcher.h"
+#include "MantidAPI/AlgorithmObserver.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 
 namespace MantidQt {
@@ -22,7 +23,9 @@ class IMainWindowView;
 CatalogSearcher implements ISearcher to provide ICAT search
 functionality.
 */
-class CatalogSearcher : public ISearcher, public RunsViewSearchSubscriber {
+class CatalogSearcher : public ISearcher,
+                        public RunsViewSearchSubscriber,
+                        public Mantid::API::AlgorithmObserver {
 public:
   CatalogSearcher(IPythonRunner *pythonRunner, IRunsView *m_view);
   ~CatalogSearcher() override{};
@@ -46,6 +49,9 @@ public:
   // RunsViewSearchSubscriber overrides
   void notifySearchComplete() override;
 
+protected:
+  void finishHandle(const Mantid::API::IAlgorithm *alg) override;
+
 private:
   IPythonRunner *m_pythonRunner;
   IRunsView *m_view;
@@ -56,10 +62,11 @@ private:
   bool m_searchInProgress;
 
   bool hasActiveSession() const;
-  bool logInToCatalog();
+  void logInToCatalog();
   std::string activeSessionId() const;
   Mantid::API::IAlgorithm_sptr createSearchAlgorithm(const std::string &text);
   ISearchModel &results() const;
+  void searchAsync();
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogSearcher.h
@@ -7,7 +7,6 @@
 #ifndef MANTID_ISISREFLECTOMETRY_CATALOGSEARCHER_H
 #define MANTID_ISISREFLECTOMETRY_CATALOGSEARCHER_H
 
-#include "GUI/Common/IPythonRunner.h"
 #include "GUI/Runs/IRunsView.h"
 #include "ISearcher.h"
 #include "MantidAPI/AlgorithmObserver.h"
@@ -27,7 +26,7 @@ class CatalogSearcher : public ISearcher,
                         public RunsViewSearchSubscriber,
                         public Mantid::API::AlgorithmObserver {
 public:
-  CatalogSearcher(IPythonRunner *pythonRunner, IRunsView *m_view);
+  CatalogSearcher(IRunsView *m_view);
   ~CatalogSearcher() override{};
 
   // ISearcher overrides
@@ -53,7 +52,6 @@ protected:
   void finishHandle(const Mantid::API::IAlgorithm *alg) override;
 
 private:
-  IPythonRunner *m_pythonRunner;
   IRunsView *m_view;
   SearcherSubscriber *m_notifyee;
   std::string m_searchText;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -51,7 +51,6 @@ namespace CustomInterfaces {
  * @param defaultInstrumentIndex The index of the instrument to have selected by
  * default.
  * @param messageHandler :: A handler to pass messages to the user
- * @param pythonRunner :: [input] Interface for running python code
  */
 RunsPresenter::RunsPresenter(
     IRunsView *mainView, ProgressableView *progressableView,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -57,13 +57,11 @@ RunsPresenter::RunsPresenter(
     IRunsView *mainView, ProgressableView *progressableView,
     const RunsTablePresenterFactory &makeRunsTablePresenter,
     double thetaTolerance, std::vector<std::string> const &instruments,
-    int defaultInstrumentIndex, IMessageHandler *messageHandler,
-    IPythonRunner *pythonRunner)
+    int defaultInstrumentIndex, IMessageHandler *messageHandler)
     : m_runNotifier(std::make_unique<CatalogRunNotifier>(mainView)),
-      m_searcher(std::make_unique<CatalogSearcher>(pythonRunner, mainView)),
-      m_view(mainView), m_progressView(progressableView),
-      m_mainPresenter(nullptr), m_messageHandler(messageHandler),
-      m_instruments(instruments),
+      m_searcher(std::make_unique<CatalogSearcher>(mainView)), m_view(mainView),
+      m_progressView(progressableView), m_mainPresenter(nullptr),
+      m_messageHandler(messageHandler), m_instruments(instruments),
       m_defaultInstrumentIndex(defaultInstrumentIndex),
       m_thetaTolerance(thetaTolerance) {
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -59,8 +59,7 @@ public:
                 const RunsTablePresenterFactory &makeRunsTablePresenter,
                 double thetaTolerance,
                 std::vector<std::string> const &instruments,
-                int defaultInstrumentIndex, IMessageHandler *messageHandler,
-                IPythonRunner *pythonRunner);
+                int defaultInstrumentIndex, IMessageHandler *messageHandler);
   RunsPresenter(RunsPresenter const &) = delete;
   ~RunsPresenter() override;
   RunsPresenter const &operator=(RunsPresenter const &) = delete;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
@@ -33,8 +33,7 @@ public:
   std::unique_ptr<IRunsPresenter> make(IRunsView *view) {
     return std::make_unique<RunsPresenter>(
         view, view, m_runsTablePresenterFactory, m_thetaTolerance,
-        m_instruments, m_defaultInstrumentIndex, m_messageHandler,
-        m_pythonRunner);
+        m_instruments, m_defaultInstrumentIndex, m_messageHandler);
   }
 
 private:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -456,11 +456,10 @@ private:
                         double thetaTolerance,
                         std::vector<std::string> const &instruments,
                         int defaultInstrumentIndex,
-                        IMessageHandler *messageHandler,
-                        IPythonRunner *pythonRunner)
+                        IMessageHandler *messageHandler)
         : RunsPresenter(mainView, progressView, makeRunsTablePresenter,
                         thetaTolerance, instruments, defaultInstrumentIndex,
-                        messageHandler, pythonRunner) {}
+                        messageHandler) {}
   };
 
   RunsPresenterFriend makePresenter() {
@@ -475,8 +474,7 @@ private:
         m_instruments, m_thetaTolerance, std::move(plotter));
     auto presenter = RunsPresenterFriend(
         &m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
-        m_instruments, defaultInstrumentIndex, &m_messageHandler,
-        m_pythonRunner);
+        m_instruments, defaultInstrumentIndex, &m_messageHandler);
 
     presenter.acceptMainPresenter(&m_mainPresenter);
     presenter.m_tablePresenter.reset(new NiceMock<MockRunsTablePresenter>());


### PR DESCRIPTION
**Description of work.**
Previously searching without logging in for ICat on the workbench would cause a segfault. This is no longer the case, I changed the basic behaviour of the login format, to accommodate logging in pre-search with the added bonus of it remembering your username.

**To test:**
- Open Workbench
- Open new GUI (ISIS Reflectometry)
- Select INTER and enter search number: 1120015
- Hit search and login
- The search results should now appear

<!-- Instructions for testing. -->

Fixes #25970. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it is an in-progress feature that has release notes.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
