### PR TITLE
Reflectometry GUI: Change defaults for Instrument Settings

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
@@ -34,6 +34,11 @@ bool OptionDefaults::getBoolOrFalse(std::string const &propertyName,
   return getValueOrDefault<bool>(propertyName, parameterName, false);
 }
 
+bool OptionDefaults::getBoolOrTrue(std::string const &propertyName,
+                                   std::string const &parameterName) const {
+  return getValueOrDefault<bool>(propertyName, parameterName, true);
+}
+
 std::string
 OptionDefaults::getStringOrDefault(std::string const &propertyName,
                                    std::string const &parameterName,

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -38,6 +38,8 @@ public:
                          std::string const &parameterName) const;
   bool getBoolOrFalse(std::string const &propertyName,
                       std::string const &parameterName) const;
+  bool getBoolOrTrue(std::string const &propertyName,
+                     std::string const &parameterName) const;
   std::string getStringOrDefault(std::string const &propertyName,
                                  std::string const &parameterName,
                                  std::string const &defaultValue) const;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
@@ -30,8 +30,8 @@ getInstrumentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   if (monitorIndex < 0)
     throw std::invalid_argument("Monitor index cannot be negative");
 
-  auto integrate = defaults.getBoolOrFalse("NormalizeByIntegratedMonitors",
-                                           "NormalizeByIntegratedMonitors");
+  auto integrate = defaults.getBoolOrTrue("NormalizeByIntegratedMonitors",
+                                          "NormalizeByIntegratedMonitors");
   auto backgroundRange =
       RangeInLambda(defaults.getDoubleOrZero("MonitorBackgroundWavelengthMin",
                                              "MonitorBackgroundMin"),
@@ -54,7 +54,7 @@ getInstrumentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   auto detectorCorrectionString = defaults.getStringOrDefault(
       "DetectorCorrectionType", "DetectorCorrectionType", "VerticalShift");
   auto detectorCorrections = DetectorCorrections(
-      defaults.getBoolOrFalse("CorrectDetectors", "CorrectDetectors"),
+      defaults.getBoolOrTrue("CorrectDetectors", "CorrectDetectors"),
       detectorCorrectionTypeFromString(detectorCorrectionString));
 
   return Instrument(std::move(wavelengthRange), std::move(monitorCorrections),


### PR DESCRIPTION
**Description of work.**
Change what the new Reflectometry GUI will have as the default for NormalizeByIntegratedMonitors and CorrectDetectors, to True from False.

**To test:**
- Open Workbench or MantidPlot
- Open Reflectometry->ISIS Reflectometry
- Switch to tab Instrument Settings
- NormalizeByIntegratedMonitors and CorrectDetectors should have ticked checkboxes

<!-- Instructions for testing. -->

Fixes #23027

*This does not require release notes* because it fixes an issue with unreleased software

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
