### PR TITLE
Change shortcut to avoid clash on on workbench

### DIFF
--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -33,7 +33,7 @@ The Runs Table
   - Tab/Shift-Tab moves to the next/previous cell
   - Pressing Tab when in the last cell of a row adds a new row and moves to the first cell in it
   - Enter adds a new row/group at the same level
-  - Ctrl-Enter adds a new child row to a group
+  - Ctrl-I inserts a new child row to a group
   - Ctrl-X/Ctrl-C/Ctrl-V perform cut/copy/paste
 
 - Additional highlighting has been added for rows in the table:

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -516,11 +516,14 @@ void JobTreeView::enableFiltering() {
 
 void JobTreeView::keyPressEvent(QKeyEvent *event) {
   switch (event->key()) {
-  case Qt::Key_Return:
-  case Qt::Key_Enter: {
+  case Qt::Key_I:
     if (event->modifiers() & Qt::ControlModifier) {
       appendAndEditAtChildRowRequested();
-    } else if (event->modifiers() & Qt::ShiftModifier) {
+      break;
+    }
+  case Qt::Key_Return:
+  case Qt::Key_Enter: {
+    if (event->modifiers() & Qt::ShiftModifier) {
       editAtRowAboveRequested();
     } else {
       appendAndEditAtRowBelowRequested();


### PR DESCRIPTION
Change the Ctrl-Enter shortcut to Ctrl-I to avoid a clash with running scripts on workbench. This inserts a new child row into the current parent item so `I` makes sense.

**To test:**

- Open the `ISIS Reflectometry` interface
- Add a group to the table and click on it
- Press Ctrl-I to insert a row into the group
- Check that pressing Enter inserts another and shift-enter edits the row above

Refs #23027 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
