### PR TITLE
Reflectometry GUI: Help button segfault

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -19,9 +19,12 @@ IMainWindowPresenter is the interface defining the functions that the main
 window presenter needs to implement. This interface is used by tab presenters to
 request information from other tabs.
 */
-class IMainWindowPresenter : public MainWindowSubscriber {
+class IMainWindowPresenter {
 public:
   virtual bool isProcessing() const = 0;
+  virtual void notifyHelpPressed() = 0;
+  virtual void notifyNewBatchRequested() = 0;
+  virtual void notifyCloseBatchRequested(int batchIndex) = 0;
   virtual ~IMainWindowPresenter() = default;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
@@ -21,17 +21,8 @@ window view needs to implement. It is empty and not necessary at the moment, but
 can be used in the future if widgets common to all tabs are added, for instance,
 the help button.
 */
-class MainWindowSubscriber {
-public:
-  virtual void notifyHelpPressed(){};
-  virtual void notifyNewBatchRequested(){};
-  virtual void notifyCloseBatchRequested(int){};
-  virtual ~MainWindowSubscriber() = default;
-};
-
 class IMainWindowView {
 public:
-  virtual void subscribe(MainWindowSubscriber *notifyee) = 0;
   virtual IBatchView *newBatch() = 0;
   virtual void removeBatch(int index) = 0;
   virtual std::vector<IBatchView *> batches() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -23,7 +23,6 @@ namespace CustomInterfaces {
 MainWindowPresenter::MainWindowPresenter(
     IMainWindowView *view, BatchPresenterFactory batchPresenterFactory)
     : m_view(view), m_batchPresenterFactory(std::move(batchPresenterFactory)) {
-  view->subscribe(this);
   for (auto *batchView : m_view->batches())
     m_batchPresenters.emplace_back(m_batchPresenterFactory.make(batchView));
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -29,8 +29,7 @@ int getDefaultInstrumentIndex(std::vector<std::string> &instruments) {
 
 DECLARE_SUBWINDOW(MainWindowView)
 
-MainWindowView::MainWindowView(QWidget *parent)
-    : UserSubWindow(parent), m_notifyee(nullptr) {}
+MainWindowView::MainWindowView(QWidget *parent) : UserSubWindow(parent) {}
 
 IBatchView *MainWindowView::newBatch() {
   auto index = m_ui.mainTabs->count();
@@ -101,14 +100,10 @@ void MainWindowView::onTabCloseRequested(int tabIndex) {
 }
 
 void MainWindowView::onNewBatchRequested(bool) {
-  m_notifyee->notifyNewBatchRequested();
+  m_presenter.get().notifyNewBatchRequested();
 }
 
-void MainWindowView::subscribe(MainWindowSubscriber *notifyee) {
-  m_notifyee = notifyee;
-}
-
-void MainWindowView::helpPressed() { m_notifyee->notifyHelpPressed(); }
+void MainWindowView::helpPressed() { m_presenter.get().notifyHelpPressed(); }
 
 /**
 Runs python code

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.h
@@ -32,7 +32,6 @@ class MainWindowView : public MantidQt::API::UserSubWindow,
   Q_OBJECT
 public:
   explicit MainWindowView(QWidget *parent = nullptr);
-  void subscribe(MainWindowSubscriber *notifyee) override;
 
   static std::string name() { return "ISIS Reflectometry"; }
   static QString categoryInfo() { return "Reflectometry"; }
@@ -62,7 +61,6 @@ private:
   void initLayout() override;
   /// Interface definition with widgets for the main interface window
   Ui::MainWindowWidget m_ui;
-  MainWindowSubscriber *m_notifyee;
   /// The presenter handling this view
   boost::optional<MainWindowPresenter> m_presenter;
   std::vector<IBatchView *> m_batchViews;


### PR DESCRIPTION
**Description of work.**
Previously it was segfaulting when the help button is clicked.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open MantidPlot and Workbench
Open the ISIS Reflectometry GUI
Click the help button
A help window should open

<!-- Instructions for testing. -->

Fixes #23027

NO RELEASE NOTES AS THIS IS A BUG FIX IN UNRELEASED SOFTWARE

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
