### PR TITLE
Change output names for sliced input workspaces

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -114,8 +114,8 @@ private:
                            std::vector<std::string> &IvsQBinnedGroup,
                            std::vector<std::string> &IvsQGroup);
   ReflectometryReductionOneAuto2::WorkspaceNames
-  getOutputNamesForGroups(std::string inputName, std::string runNumber,
-                          size_t wsGroupNumber);
+  getOutputNamesForGroups(const std::string &inputName, const std::string &runNumber,
+                          const size_t wsGroupNumber);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -113,6 +113,9 @@ private:
                            std::vector<std::string> &IvsLamGroup,
                            std::vector<std::string> &IvsQBinnedGroup,
                            std::vector<std::string> &IvsQGroup);
+  ReflectometryReductionOneAuto2::WorkspaceNames
+  getOutputNamesForGroups(std::string inputName, std::string runNumber,
+                          size_t wsGroupNumber);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto2.h
@@ -114,7 +114,8 @@ private:
                            std::vector<std::string> &IvsQBinnedGroup,
                            std::vector<std::string> &IvsQGroup);
   ReflectometryReductionOneAuto2::WorkspaceNames
-  getOutputNamesForGroups(const std::string &inputName, const std::string &runNumber,
+  getOutputNamesForGroups(const std::string &inputName,
+                          const std::string &runNumber,
                           const size_t wsGroupNumber);
 };
 

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -1010,9 +1010,9 @@ bool ReflectometryReductionOneAuto2::processGroups() {
  * format otherwise they are numbered according to the wsGroupNumber
  */
 ReflectometryReductionOneAuto2::WorkspaceNames
-ReflectometryReductionOneAuto2::getOutputNamesForGroups(const std::string &inputName,
-                                                        const std::string &runNumber,
-                                                        const size_t wsGroupNumber) {
+ReflectometryReductionOneAuto2::getOutputNamesForGroups(
+    const std::string &inputName, const std::string &runNumber,
+    const size_t wsGroupNumber) {
   auto const output = getOutputWorkspaceNames();
   std::string informativeName = "TOF" + runNumber + "_";
 

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -897,16 +897,18 @@ bool ReflectometryReductionOneAuto2::processGroups() {
   }
 
   std::vector<std::string> IvsQBinnedGroup, IvsQGroup, IvsLamGroup;
+  std::string runNumber = getRunNumberForWorkspaceGroup(group);
 
   // Execute algorithm over each group member
   for (size_t i = 0; i < group->size(); ++i) {
+    auto inputName = group->getItem(i)->getName();
+    auto outputNames = getOutputNamesForGroups(inputName, runNumber, i);
 
-    const std::string IvsQName = output.iVsQ + "_" + std::to_string(i + 1);
-    const std::string IvsQBinnedName =
-        output.iVsQBinned + "_" + std::to_string(i + 1);
-    const std::string IvsLamName = output.iVsLam + "_" + std::to_string(i + 1);
+    const std::string IvsQName = outputNames.iVsQ;
+    const std::string IvsQBinnedName = outputNames.iVsQBinned;
+    const std::string IvsLamName = outputNames.iVsLam;
 
-    alg->setProperty("InputWorkspace", group->getItem(i)->getName());
+    alg->setProperty("InputWorkspace", inputName);
     alg->setProperty("Debug", true);
     alg->setProperty("OutputWorkspace", IvsQName);
     alg->setProperty("OutputWorkspaceBinned", IvsQBinnedName);
@@ -973,9 +975,11 @@ bool ReflectometryReductionOneAuto2::processGroups() {
 
   auto outputIvsLamNames = workspaceNamesInGroup(output.iVsLam);
   for (size_t i = 0; i < outputIvsLamNames.size(); ++i) {
-    const std::string IvsQName = output.iVsQ + "_" + std::to_string(i + 1);
-    const std::string IvsQBinnedName =
-        output.iVsQBinned + "_" + std::to_string(i + 1);
+    auto inputName = group->getItem(i)->getName();
+    auto outputNames = getOutputNamesForGroups(inputName, runNumber, i);
+
+    const std::string IvsQName = outputNames.iVsQ;
+    const std::string IvsQBinnedName = outputNames.iVsQBinned;
     const std::string IvsLamName = outputIvsLamNames[i];
 
     // Find the spectrum processing instructions for ws index 0
@@ -998,6 +1002,40 @@ bool ReflectometryReductionOneAuto2::processGroups() {
   setOutputWorkspaces(output, IvsLamGroup, IvsQBinnedGroup, IvsQGroup);
 
   return true;
+}
+
+/** Get the output workspace names for a workspace in a group.
+ * If an input workspace has been passed with the format
+ * TOF_<runNumber>_<otherInfo> then the output workspaces will be of the same
+ * format otherwise they are numbered according to the wsGroupNumber
+ */
+ReflectometryReductionOneAuto2::WorkspaceNames
+ReflectometryReductionOneAuto2::getOutputNamesForGroups(std::string inputName,
+                                                        std::string runNumber,
+                                                        size_t wsGroupNumber) {
+  auto const output = getOutputWorkspaceNames();
+  std::string informativeName = "TOF" + runNumber + "_";
+  bool informativeInput = false;
+  if (equal(informativeName.begin(), informativeName.end(),
+            inputName.begin())) {
+    informativeInput = true;
+  }
+
+  WorkspaceNames outputNames;
+  if (informativeInput) {
+    auto informativeTest = inputName.substr(informativeName.length());
+    outputNames.iVsQ = output.iVsQ + "_" + informativeTest;
+    outputNames.iVsQBinned = output.iVsQBinned + "_" + informativeTest;
+    outputNames.iVsLam = output.iVsLam + "_" + informativeTest;
+  } else {
+    outputNames.iVsQ = output.iVsQ + "_" + std::to_string(wsGroupNumber + 1);
+    outputNames.iVsQBinned =
+        output.iVsQBinned + "_" + std::to_string(wsGroupNumber + 1);
+    outputNames.iVsLam =
+        output.iVsLam + "_" + std::to_string(wsGroupNumber + 1);
+  }
+
+  return outputNames;
 }
 
 /** Construct a polarization efficiencies workspace based on values of input

--- a/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOneAuto2.cpp
@@ -1010,19 +1010,15 @@ bool ReflectometryReductionOneAuto2::processGroups() {
  * format otherwise they are numbered according to the wsGroupNumber
  */
 ReflectometryReductionOneAuto2::WorkspaceNames
-ReflectometryReductionOneAuto2::getOutputNamesForGroups(std::string inputName,
-                                                        std::string runNumber,
-                                                        size_t wsGroupNumber) {
+ReflectometryReductionOneAuto2::getOutputNamesForGroups(const std::string &inputName,
+                                                        const std::string &runNumber,
+                                                        const size_t wsGroupNumber) {
   auto const output = getOutputWorkspaceNames();
   std::string informativeName = "TOF" + runNumber + "_";
-  bool informativeInput = false;
-  if (equal(informativeName.begin(), informativeName.end(),
-            inputName.begin())) {
-    informativeInput = true;
-  }
 
   WorkspaceNames outputNames;
-  if (informativeInput) {
+  if (equal(informativeName.begin(), informativeName.end(),
+            inputName.begin())) {
     auto informativeTest = inputName.substr(informativeName.length());
     outputNames.iVsQ = output.iVsQ + "_" + informativeTest;
     outputNames.iVsQBinned = output.iVsQBinned + "_" + informativeTest;

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -50,18 +50,20 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
             'TimeInterval' : 210
         }
         self._expected_dummy_time_sliced_outputs = [
-            'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
-            'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
-            'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
-            'IvsQ_binned_38415_3', 'TOF_38415', 'TOF_38415_monitors',
-            'TOF_38415_sliced', 'TOF_38415_sliced_0_1200', 'TOF_38415_sliced_1200_2400',
-            'TOF_38415_sliced_2400_3600', 'TOF']
+            'IvsQ_38415', 'IvsQ_38415_sliced_0_1200', 'IvsQ_38415_TOF_38415_sliced_1200_2400',
+            'IvsQ_38415__2400_3600', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_1200',
+            'IvsQ_binned_38415_TOF_38415_sliced_1200_2400', 'IvsLam_38415',
+            'IvsLam_38415_sliced_0_1200', 'IvsLam_38415_TOF_38415_sliced_1200_2400',
+            'IvsLam_38415__2400_3600', 'IvsQ_binned_38415__2400_3600', 'TOF_38415',
+            'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415_sliced_0_1200',
+            'TOF_38415_sliced_1200_2400', 'TOF_38415_sliced_2400_3600', 'TOF']
         
         self._expected_real_time_sliced_outputs = [
-            'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
-            'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
-            'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
-            'IvsQ_binned_38415_3', 'TOF_38415', 'TOF_38415_monitors',
+            'IvsQ_38415', 'IvsQ_38415_sliced_0_210', 'IvsQ_38415_sliced_210_420',
+            'IvsQ_38415_sliced_420_610', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_210',
+            'IvsQ_binned_38415_sliced_210_420',  'IvsLam_38415', 'IvsLam_38415_sliced_0_210',
+            'IvsLam_38415_sliced_210_420', 'IvsLam_38415_sliced_420_610',
+            'IvsQ_binned_38415_sliced_420_610', 'TOF_38415', 'TOF_38415_monitors',
             'TOF_38415_sliced', 'TOF_38415_sliced_0_210', 'TOF_38415_sliced_210_420',
             'TOF_38415_sliced_420_610', 'TOF']
 
@@ -196,7 +198,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '13460'
         args['FirstTransmissionRunList'] = '13463'
         args['SecondTransmissionRunList'] = '13464'
-        # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
+        # Expect IvsQ outputs from the reduction, and intermediate LAM outputs from
         # creating the stitched transmission run
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
                    'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
@@ -321,10 +323,11 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args.update(self._default_slice_options_dummy_run)
         args['InputRunList'] = '38415'
         outputs = [
-             'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
-             'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
-             'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
-             'IvsQ_binned_38415_3', '38415', '38415_monitors',
+             'IvsQ_38415', 'IvsQ_38415_sliced_0_1200', 'IvsQ_38415_sliced_1200_2400',
+             'IvsQ_38415_sliced_2400_3600', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_1200',
+             'IvsQ_binned_38415_sliced_1200_2400', 'IvsLam_38415', 'IvsLam_38415_sliced_0_1200',
+             'IvsLam_38415_sliced_1200_2400', 'IvsLam_38415_sliced_2400_3600',
+             'IvsQ_binned_38415_sliced_2400_3600', '38415', '38415_monitors',
              '38415_sliced', '38415_sliced_0_1200', '38415_sliced_1200_2400',
              '38415_sliced_2400_3600', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
@@ -369,8 +372,9 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args = self._default_options
         args['InputRunList'] = '38415'
         args['SliceWorkspace'] = True
-        outputs = ['IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1',
-                   'IvsLam_38415', 'IvsLam_38415_1', 'TOF_38415', 'TOF_38415_monitors',
+        outputs = ['IvsQ_38415', 'IvsQ_38415_sliced_0_4200', 'IvsQ_binned_38415',
+                   'IvsQ_binned_38415_sliced_0_4200', 'IvsLam_38415',
+                   'IvsLam_38415_sliced_0_4200', 'TOF_38415', 'TOF_38415_monitors',
                    'TOF_38415_sliced', 'TOF_38415_sliced_0_4200', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
@@ -395,13 +399,15 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['SliceWorkspace'] = True
         args['LogName'] = 'proton_charge'
         args['LogValueInterval'] = 60
-        outputs = ['IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
-                   'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
-                   'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
-                   'IvsQ_binned_38415_3', 'TOF', 'TOF_38415', 'TOF_38415_monitors',
-                   'TOF_38415_sliced', 'TOF_38415_sliced_Log.proton_charge.From.-30.To.30.Value-change-direction:both',
-                   'TOF_38415_sliced_Log.proton_charge.From.30.To.90.Value-change-direction:both',
-                   'TOF_38415_sliced_Log.proton_charge.From.90.To.150.Value-change-direction:both']
+        slice1 = '_sliced_Log.proton_charge.From.-30.To.30.Value-change-direction:both'
+        slice2 = '_sliced_Log.proton_charge.From.30.To.90.Value-change-direction:both'
+        slice3 = '_sliced_Log.proton_charge.From.90.To.150.Value-change-direction:both'
+        outputs = ['IvsQ_38415', 'IvsQ_38415'+slice1, 'IvsQ_38415'+slice2, 'IvsQ_38415'+slice3,
+                   'IvsQ_binned_38415', 'IvsQ_binned_38415'+slice1,'IvsQ_binned_38415'+slice2,
+                   'IvsQ_binned_38415'+slice3, 'IvsLam_38415', 'IvsLam_38415'+slice1,
+                   'IvsLam_38415'+slice2, 'IvsLam_38415'+slice3, 'TOF', 'TOF_38415',
+                   'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415'+slice1,
+                   'TOF_38415'+slice2, 'TOF_38415'+slice3]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
@@ -413,9 +419,11 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '38415'
         args['SliceWorkspace'] = True
         args['LogName'] = 'proton_charge'
-        outputs = ['IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1',
-                   'IvsLam_38415', 'IvsLam_38415_1', 'TOF', 'TOF_38415', 'TOF_38415_monitors',
-                   'TOF_38415_sliced', 'TOF_38415_sliced_Log.proton_charge.From.0.To.100.Value-change-direction:both']
+        sliceName = '_sliced_Log.proton_charge.From.0.To.100.Value-change-direction:both'
+        outputs = ['IvsQ_38415', 'IvsQ_38415'+sliceName, 'IvsQ_binned_38415',
+                   'IvsQ_binned_38415'+sliceName, 'IvsLam_38415', 'IvsLam_38415'+sliceName,
+                   'TOF', 'TOF_38415', 'TOF_38415_monitors', 'TOF_38415_sliced',
+                   'TOF_38415'+sliceName]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
         self._check_history(mtd['IvsQ_binned_38415_1'], history, False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -50,11 +50,11 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
             'TimeInterval' : 210
         }
         self._expected_dummy_time_sliced_outputs = [
-            'IvsQ_38415', 'IvsQ_38415_sliced_0_1200', 'IvsQ_38415_TOF_38415_sliced_1200_2400',
-            'IvsQ_38415__2400_3600', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_1200',
-            'IvsQ_binned_38415_TOF_38415_sliced_1200_2400', 'IvsLam_38415',
-            'IvsLam_38415_sliced_0_1200', 'IvsLam_38415_TOF_38415_sliced_1200_2400',
-            'IvsLam_38415__2400_3600', 'IvsQ_binned_38415__2400_3600', 'TOF_38415',
+            'IvsQ_38415', 'IvsQ_38415_sliced_0_1200', 'IvsQ_38415_sliced_1200_2400',
+            'IvsQ_38415_sliced_2400_3600', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_1200',
+            'IvsQ_binned_38415_sliced_1200_2400', 'IvsLam_38415',
+            'IvsLam_38415_sliced_0_1200', 'IvsLam_38415_sliced_1200_2400',
+            'IvsLam_38415_sliced_2400_3600', 'IvsQ_binned_38415_sliced_2400_3600', 'TOF_38415',
             'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415_sliced_0_1200',
             'TOF_38415_sliced_1200_2400', 'TOF_38415_sliced_2400_3600', 'TOF']
         
@@ -315,7 +315,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # might be something we want to change in the underlying algorithms at some point
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_1200'], history, False)
 
     def test_slicing_uses_run_in_ADS_with_no_prefix(self):
         self._create_event_workspace(38415)
@@ -323,12 +323,11 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args.update(self._default_slice_options_dummy_run)
         args['InputRunList'] = '38415'
         outputs = [
-             'IvsQ_38415', 'IvsQ_38415_sliced_0_1200', 'IvsQ_38415_sliced_1200_2400',
-             'IvsQ_38415_sliced_2400_3600', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_1200',
-             'IvsQ_binned_38415_sliced_1200_2400', 'IvsLam_38415', 'IvsLam_38415_sliced_0_1200',
-             'IvsLam_38415_sliced_1200_2400', 'IvsLam_38415_sliced_2400_3600',
-             'IvsQ_binned_38415_sliced_2400_3600', '38415', '38415_monitors',
-             '38415_sliced', '38415_sliced_0_1200', '38415_sliced_1200_2400',
+             'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3',
+             'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2',
+             'IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3',
+             'IvsQ_binned_38415_3', '38415', '38415_monitors', '38415_sliced',
+             '38415_sliced_0_1200', '38415_sliced_1200_2400',
              '38415_sliced_2400_3600', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
@@ -343,7 +342,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
 
     def test_slicing_reloads_input_run_if_workspace_is_incorrect_type(self):
         self._create_workspace(38415, 'TOF_')
@@ -354,7 +353,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
 
     def test_slicing_loads_input_run_if_monitor_ws_not_in_ADS(self):
         self._create_event_workspace(38415, 'TOF_', False)
@@ -365,7 +364,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
 
     def test_slicing_with_no_interval_returns_single_slice(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -378,7 +377,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_38415_sliced', 'TOF_38415_sliced_0_4200', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_4200'], history, False)
 
     def test_slicing_by_number_of_slices(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -390,7 +389,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415_sliced_0_1200'], history, False)
 
     def test_slicing_by_log_value(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -411,7 +410,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415'+slice1], history, False)
 
     def test_slicing_by_log_value_with_no_interval_returns_single_slice(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -426,7 +425,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_38415'+sliceName]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(mtd['IvsQ_binned_38415'+sliceName], history, False)
 
     def test_with_input_workspace_group(self):
         self._create_workspace_group(12345, 2, 'TOF_')

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -109,7 +109,7 @@ Output:
 
 .. testoutput:: ExSliceRun
 
-   Workspaces in the ADS after reduction: ['IvsLam_38415', 'IvsLam_38415_1', 'IvsLam_38415_2', 'IvsLam_38415_3', 'IvsQ_38415', 'IvsQ_38415_1', 'IvsQ_38415_2', 'IvsQ_38415_3', 'IvsQ_binned_38415', 'IvsQ_binned_38415_1', 'IvsQ_binned_38415_2', 'IvsQ_binned_38415_3', 'TOF', 'TOF_38415', 'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415_sliced_0_210', 'TOF_38415_sliced_210_420', 'TOF_38415_sliced_420_610']
+   Workspaces in the ADS after reduction: ['IvsLam_38415', 'IvsLam_38415_sliced_0_210', 'IvsLam_38415_sliced_210_420', 'IvsLam_38415_sliced_420_610', 'IvsQ_38415', 'IvsQ_38415_sliced_0_210', 'IvsQ_38415_sliced_210_420', 'IvsQ_38415_sliced_420_610', 'IvsQ_binned_38415', 'IvsQ_binned_38415_sliced_0_210', 'IvsQ_binned_38415_sliced_210_420', 'IvsQ_binned_38415_sliced_420_610', 'TOF', 'TOF_38415', 'TOF_38415_monitors', 'TOF_38415_sliced', 'TOF_38415_sliced_0_210', 'TOF_38415_sliced_210_420', 'TOF_38415_sliced_420_610']
 
 .. seealso :: Algorithm :ref:`algm-ReflectometrySliceEventWorkspace`, :ref:`algm-ReflectometryReductionOneAuto` and the ``ISIS Reflectometry`` interface.
 

--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -24,6 +24,7 @@ Improvements
 ############
 
 - The output workspaces of :ref:`algm-ReflectometrySliceEventWorkspace` now have names which describe the slice.
+- In ref:`ReflectometryISISLoadAndPreprocess` all output workspaces have names which give information about the slice.
 - An additional method to calculate background has been added to :ref:`algm-ReflectometryBackgroundSubtraction`.
 - In ref:`ReflectometryISISLoadAndPreprocess` the TOF workspaces are now grouped together.
 


### PR DESCRIPTION
**Description of work.**
This PR changes the output workspace names to be more informative for sliced workspaces in `ReflectometryReductionOneAuto`.  This will in turn change the output names of `ReflectometryISISLoadAndProcess ` when slicing is done.

Since no information about the input workspace is known other than its name this has been done by pattern matching on the input and if it is of the format `TOF_<run_number>_<some_text>` then it returns a name of a matching format.

**To test:**
The following script should produce 3 groups: `IvsLam_38415`,  `IvsQ_38415` and  `IvsQBinned_38415`. The workspaces inside should be of the format `<groupName>_sliced_<startTime>_<endTime>`. These should match up with the workspaces in `TOF_38415_sliced`.
```
LoadEventNexus(Filename='INTER38415',OutputWorkspace='TOF_38415',LoadMonitors=True)
input_ws = mtd['TOF_38415']
monitor_ws= mtd['TOF_38415_monitors']

TOF_38415_sliced = ReflectometrySliceEventWorkspace(InputWorkspace=input_ws, MonitorWorkspace=monitor_ws, TimeInterval=305)                                    
ReflectometryReductionOneAuto(TOF_38415_sliced)
```

This script should produce the same 3 groups. The workspaces inside should be of the format `<groupName>_1`, `<groupName>_2` and `<groupName>_3`.
```
LoadEventNexus(Filename='INTER38415',OutputWorkspace='TOF_38415',LoadMonitors=True)
input_ws = mtd['TOF_38415']
monitor_ws= mtd['TOF_38415_monitors']

sliced = ReflectometrySliceEventWorkspace(InputWorkspace=input_ws, MonitorWorkspace=monitor_ws, TimeInterval=305)
ReflectometryReductionOneAuto(sliced)
```

Fixes #26007 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
