### PR TITLE
Reflectometry GUI: Add group and row when empty

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
@@ -264,6 +264,15 @@ ReductionJobs twoGroupsWithMixedRowsModel() {
   return reductionJobs;
 }
 
+ReductionJobs emptyReductionJobs() {
+  auto reductionJobs = ReductionJobs();
+  auto group1 = Group("Group1");
+  group1.appendRow(makeRow());
+  reductionJobs.appendGroup(std::move(group1));
+
+  return reductionJobs;
+}
+
 /* Experiment */
 
 std::vector<PerThetaDefaults> makePerThetaDefaults() {

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.h
@@ -59,6 +59,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs anotherGroupWithARowModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithARowModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithTwoRowsModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithMixedRowsModel();
+MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs emptyReductionJobs();
 
 /* Experiment */
 MANTIDQT_ISISREFLECTOMETRY_DLL std::vector<PerThetaDefaults>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -520,9 +520,11 @@ void RunsTablePresenter::notifySelectionChanged() {
 void RunsTablePresenter::applyGroupStylingToRow(
     MantidWidgets::Batch::RowLocation const &location) {
   auto cells = m_view->jobs().cellsAt(location);
-  boost::fill(boost::make_iterator_range(cells.begin() + 1, cells.end()),
-              m_view->jobs().deadCell());
-  m_view->jobs().setCellsAt(location, cells);
+  if (cells.size() > 0) {
+    boost::fill(boost::make_iterator_range(cells.begin() + 1, cells.end()),
+                m_view->jobs().deadCell());
+    m_view->jobs().setCellsAt(location, cells);
+  }
 }
 
 void RunsTablePresenter::notifyRowInserted(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -368,9 +368,15 @@ void RunsTablePresenter::ensureAtLeastOneGroupExists() {
 
   // The model is fine, we just need to update the view. Add a new, proper,
   // group first, then delete the original one
-  appendRowAndGroup();
+  appendEmptyGroupInView();
   removeRowsAndGroupsFromView({location});
+
+  appendRowAndGroup();
   notifyExpandAllRequested();
+
+  // After repairing the view and adding the Row and Group
+  removeGroupsFromModel({0});
+  removeGroupsFromView({0});
 }
 
 void RunsTablePresenter::notifyExpandAllRequested() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -114,8 +114,7 @@ RunsTablePresenter::RunsTablePresenter(
   m_view->subscribe(this);
 
   // Add Group to view and model, add row to this group in view and model.
-  appendRowAndGroup({0});
-  notifyExpandAllRequested();
+  ensureAtLeastOneGroupExists();
 }
 
 void RunsTablePresenter::appendRowAndGroup(std::vector<int> localGroupIndices) {
@@ -354,6 +353,13 @@ void RunsTablePresenter::ensureAtLeastOneGroupExists() {
   // If we have more than one group/row then it's ok
   if (m_model.reductionJobs().groups().size() > 1)
     return;
+
+  if (m_model.reductionJobs().groups().size() == 0) {
+    appendRowAndGroup({0});
+    notifyExpandAllRequested();
+    return;
+  }
+
   auto const &group = m_model.reductionJobs().groups()[0];
   if (group.rows().size() > 0)
     return;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -371,6 +371,8 @@ void RunsTablePresenter::ensureAtLeastOneGroupExists() {
   appendEmptyGroupInView();
   removeRowsAndGroupsFromView({location});
 
+  // Insert a new group (and include an expanded row, for usability) and then
+  // delete the original "bad" group
   appendRowAndGroup();
   notifyExpandAllRequested();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -120,7 +120,8 @@ RunsTablePresenter::RunsTablePresenter(
 void RunsTablePresenter::appendRowAndGroup(std::vector<int> localGroupIndices) {
   if (localGroupIndices.size() == 0) {
     // Calculate
-    localGroupIndices.emplace_back(m_model.reductionJobs().groups().size());
+    localGroupIndices.emplace_back(
+        static_cast<int>(m_model.reductionJobs().groups().size()));
   }
   appendEmptyGroupInModel();
   appendEmptyGroupInView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -119,7 +119,8 @@ RunsTablePresenter::RunsTablePresenter(
 
 void RunsTablePresenter::appendRowAndGroup() {
   // Calculate
-  std::vector<int> localGroupIndices(
+  std::vector<int> localGroupIndices;
+  localGroupIndices.emplace_back(
       static_cast<int>(m_model.reductionJobs().groups().size()));
   appendEmptyGroupInModel();
   appendEmptyGroupInView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -117,12 +117,10 @@ RunsTablePresenter::RunsTablePresenter(
   ensureAtLeastOneGroupExists();
 }
 
-void RunsTablePresenter::appendRowAndGroup(std::vector<int> localGroupIndices) {
-  if (localGroupIndices.size() == 0) {
-    // Calculate
-    localGroupIndices.emplace_back(
-        static_cast<int>(m_model.reductionJobs().groups().size()));
-  }
+void RunsTablePresenter::appendRowAndGroup() {
+  // Calculate
+  std::vector<int> localGroupIndices(
+      static_cast<int>(m_model.reductionJobs().groups().size()));
   appendEmptyGroupInModel();
   appendEmptyGroupInView();
   appendRowsToGroupsInView(localGroupIndices);
@@ -356,7 +354,7 @@ void RunsTablePresenter::ensureAtLeastOneGroupExists() {
     return;
 
   if (m_model.reductionJobs().groups().size() == 0) {
-    appendRowAndGroup({0});
+    appendRowAndGroup();
     notifyExpandAllRequested();
     return;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -112,6 +112,21 @@ RunsTablePresenter::RunsTablePresenter(
     : m_view(view), m_model(instruments, thetaTolerance, std::move(jobs)),
       m_clipboard(), m_jobViewUpdater(m_view->jobs()), m_plotter(plotter) {
   m_view->subscribe(this);
+
+  // Add Group to view and model, add row to this group in view and model.
+  appendRowAndGroup({0});
+  notifyExpandAllRequested();
+}
+
+void RunsTablePresenter::appendRowAndGroup(std::vector<int> localGroupIndices) {
+  if (localGroupIndices.size() == 0) {
+    // Calculate
+    localGroupIndices.emplace_back(m_model.reductionJobs().groups().size());
+  }
+  appendEmptyGroupInModel();
+  appendEmptyGroupInView();
+  appendRowsToGroupsInView(localGroupIndices);
+  appendRowsToGroupsInModel(localGroupIndices);
 }
 
 void RunsTablePresenter::acceptMainPresenter(IRunsPresenter *mainPresenter) {
@@ -353,8 +368,9 @@ void RunsTablePresenter::ensureAtLeastOneGroupExists() {
 
   // The model is fine, we just need to update the view. Add a new, proper,
   // group first, then delete the original one
-  appendEmptyGroupInView();
+  appendRowAndGroup();
   removeRowsAndGroupsFromView({location});
+  notifyExpandAllRequested();
 }
 
 void RunsTablePresenter::notifyExpandAllRequested() {
@@ -721,7 +737,6 @@ void RunsTablePresenter::forAllCellsAt(
 
 void RunsTablePresenter::setRowStylingForItem(
     MantidWidgets::Batch::RowPath const &rowPath, Item const &item) {
-
   switch (item.state()) {
   case State::ITEM_NOT_STARTED: // fall through
   case State::ITEM_STARTING:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -112,6 +112,7 @@ private:
   void appendEmptyGroupInView();
   void insertEmptyGroupInModel(int beforeGroup);
   void insertEmptyGroupInView(int beforeGroup);
+  void appendRowAndGroup(std::vector<int> groupIndices = {});
   void ensureAtLeastOneGroupExists();
   void insertEmptyRowInModel(int groupIndex, int beforeRow);
   std::vector<std::string>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -112,7 +112,7 @@ private:
   void appendEmptyGroupInView();
   void insertEmptyGroupInModel(int beforeGroup);
   void insertEmptyGroupInView(int beforeGroup);
-  void appendRowAndGroup(std::vector<int> groupIndices = {});
+  void appendRowAndGroup();
   void ensureAtLeastOneGroupExists();
   void insertEmptyRowInModel(int groupIndex, int beforeRow);
   std::vector<std::string>

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
@@ -36,23 +36,22 @@ public:
     auto reductionJobs = twoEmptyGroupsModel();
     selectedRowLocationsAre(m_jobs, {location(0)});
 
-    EXPECT_CALL(m_jobs, removeRowAt(location(0)));
-
     auto presenter = makePresenter(m_view, std::move(reductionJobs));
+    EXPECT_CALL(m_jobs, removeRowAt(location(0))).Times(2);
     presenter.notifyDeleteGroupRequested();
 
     verifyAndClearExpectations();
   }
 
   void testUpdatesModelWhenGroupDeletedFromDirectSelection() {
-    selectedRowLocationsAre(m_jobs, {location(0)});
+    selectedRowLocationsAre(m_jobs, {location(1)});
 
-    auto presenter = makePresenter(m_view, twoEmptyGroupsModel());
+    auto presenter = makePresenter(m_view, twoGroupsWithARowModel());
     presenter.notifyDeleteGroupRequested();
 
     auto &groups = jobsFromPresenter(presenter).groups();
     TS_ASSERT_EQUALS(1, groups.size());
-    TS_ASSERT_EQUALS("Test group 2", groups[0].name());
+    TS_ASSERT_EQUALS("Test group 1", groups[0].name());
 
     verifyAndClearExpectations();
   }
@@ -76,7 +75,7 @@ public:
     {
       testing::InSequence s;
       EXPECT_CALL(m_jobs, removeRowAt(location(1)));
-      EXPECT_CALL(m_jobs, removeRowAt(location(0)));
+      EXPECT_CALL(m_jobs, removeRowAt(location(0))).Times(2);
     }
 
     auto presenter = makePresenter(m_view, std::move(reductionJobs));
@@ -104,7 +103,7 @@ public:
     {
       testing::InSequence s;
       EXPECT_CALL(m_jobs, removeRowAt(location(1)));
-      EXPECT_CALL(m_jobs, removeRowAt(location(0)));
+      EXPECT_CALL(m_jobs, removeRowAt(location(0))).Times(2);
     }
 
     auto presenter = makePresenter(m_view, std::move(reductionJobs));
@@ -136,22 +135,20 @@ public:
     verifyAndClearExpectations();
   }
 
-  void testRemoveAllRowsAndGroupsUpdatesModel() {
-    auto presenter = makePresenter(m_view, ReductionJobs());
-    presenter.notifyRemoveAllRowsAndGroupsRequested();
-    auto &groups = jobsFromPresenter(presenter).groups();
-    // Should be left with a single empty group
-    TS_ASSERT_EQUALS(1, groups.size());
-    TS_ASSERT_EQUALS(0, groups[0].rows().size());
-    verifyAndClearExpectations();
-  }
-
   void testRemoveAllRowsAndGroupsPerformedIfProcessingOrAutoreducing() {
     auto presenter = makePresenter(m_view, ReductionJobs());
     EXPECT_CALL(m_mainPresenter, isProcessing()).Times(0);
     EXPECT_CALL(m_mainPresenter, isAutoreducing()).Times(0);
     presenter.notifyRemoveAllRowsAndGroupsRequested();
     verifyAndClearExpectations();
+  }
+
+  void testRemoveAllRowsAndGroupsLeavesAGroupAndRow() {
+    auto presenter = makePresenter(m_view);
+    presenter.notifyRemoveAllRowsAndGroupsRequested();
+    auto &groups = jobsFromPresenter(presenter).groups();
+    TS_ASSERT_EQUALS(1, groups.size());
+    TS_ASSERT_EQUALS(1, groups[0].rows().size());
   }
 };
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
@@ -32,7 +32,7 @@ public:
   }
 
   void testExpandsAllGroupsWhenRequested() {
-    EXPECT_CALL(m_jobs, expandAll());
+    EXPECT_CALL(m_jobs, expandAll()).Times(2);
 
     auto presenter = makePresenter(m_view);
     presenter.notifyExpandAllRequested();

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
@@ -32,20 +32,6 @@ public:
     delete suite;
   }
 
-  void testMergeNothingIntoNothing() {
-    auto presenter = makePresenter(m_view, ReductionJobs());
-    presenter.mergeAdditionalJobs(ReductionJobs());
-    auto &result = jobsFromPresenter(presenter);
-    TS_ASSERT_EQUALS(result, ReductionJobs());
-  }
-
-  void testMergeGroupIntoEmptyTable() {
-    auto presenter = makePresenter(m_view, ReductionJobs());
-    presenter.mergeAdditionalJobs(oneGroupWithARowModel());
-    auto &result = jobsFromPresenter(presenter);
-    TS_ASSERT_EQUALS(result, oneGroupWithARowModel());
-  }
-
   void testMergeEmptyTableDoesNothing() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
     presenter.mergeAdditionalJobs(ReductionJobs());
@@ -77,13 +63,6 @@ public:
   void testMergeInvalidRowDoesNothing() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
     presenter.mergeAdditionalJobs(oneGroupWithAnInvalidRowModel());
-    auto &result = jobsFromPresenter(presenter);
-    TS_ASSERT_EQUALS(result, oneGroupWithARowModel());
-  }
-
-  void testMergeNewRowIntoEmptyGroup() {
-    auto presenter = makePresenter(m_view, oneEmptyGroupModel());
-    presenter.mergeAdditionalJobs(oneGroupWithARowModel());
     auto &result = jobsFromPresenter(presenter);
     TS_ASSERT_EQUALS(result, oneGroupWithARowModel());
   }

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
@@ -20,11 +20,11 @@
 #include <gtest/gtest.h>
 
 using namespace MantidQt::CustomInterfaces;
+using testing::_;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
-using testing::_;
 
 class RunsTablePresenterTest {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
@@ -20,11 +20,11 @@
 #include <gtest/gtest.h>
 
 using namespace MantidQt::CustomInterfaces;
-using testing::_;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
+using testing::_;
 
 class RunsTablePresenterTest {
 public:


### PR DESCRIPTION
THIS IS DEPENDANT ON #26034

**Description of work.**
Whenever the GUI is empty, via startup or deletion of rows and group and row should now be present in the table.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open MantidPlot and Workbench
- Open the ISIS Reflectometry GUI
- Note there is a group and row in the table
- Now delete those rows by highlighting them
- They should be re-added (probably too quick to see)
- They should also come expanded
<!-- Instructions for testing. -->

Re #26025  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
