### PR TITLE
Fix workbench plotting options in reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -43,8 +43,8 @@ void Plotter::reflectometryPlot(
 #else
   // Workbench Plotting
   QHash<QString, QVariant> ax_properties;
-  // ax_properties[QString("yscale")] = QVariant("log");
-  // ax_properties[QString("xscale")] = QVariant("log");
+  ax_properties[QString("yscale")] = QVariant("log");
+  ax_properties[QString("xscale")] = QVariant("log");
 
   // plot(workspaces, spectrum_nums, wksp_indices, fig, plot_kwargs,
   // ax_properties, windows_title, errors, overplot)
@@ -56,7 +56,7 @@ void Plotter::reflectometryPlot(
   const bool plotErrorBars = true;
   std::vector<int> wksp_indices = {0};
   plot(workspaces, boost::none, wksp_indices, boost::none, boost::none,
-       ax_properties, window_title, plotErrorBars, true);
+       ax_properties, window_title, plotErrorBars, false);
 #endif
 }
 

--- a/qt/widgets/common/src/Python/QHashToDict.cpp
+++ b/qt/widgets/common/src/Python/QHashToDict.cpp
@@ -13,6 +13,9 @@ namespace Common {
 namespace Python {
 
 Python::Dict qHashToDict(const KwArgs &hash) {
+  auto mod = PyImport_ImportModule("qtpy.QtCore");
+  Py_DECREF(mod);
+
   auto d = Python::Dict();
 
   auto it = hash.constBegin();


### PR DESCRIPTION
When plotting from the reflectometry GUI in workbench, use log-log axes and do not overplot

**To test:**

- Test in workbench
- Open the `IsIS Reflectometry` interface
- Add a group with two rows to the table and enter runs 13460 and 13461 with angles 0.5 and 2.3
- Click process
- Select the group and click the plot-rows button. Check that a plot window opens with log-log axes
- Click the plot-group button. Check that a new plot window opens also with log-log axes.

Refs #26025

*This does not require release notes* because **it re-implements existing functionality from MantidPlot**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
