### PR TITLE
Indirect FQFit Column Heading value is wrong

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
+++ b/Framework/CurveFitting/src/Algorithms/PlotPeakByLogValue.cpp
@@ -188,7 +188,7 @@ void PlotPeakByLogValue::exec() {
   ITableWorkspace_sptr result =
       WorkspaceFactory::Instance().createTable("TableWorkspace");
   if (logName == "SourceName") {
-    result->addColumn("str", "Source name");
+    result->addColumn("str", "SourceName");
     isDataName = true;
   } else if (logName.empty()) {
     auto col = result->addColumn("double", "axis-1");
@@ -261,7 +261,7 @@ void PlotPeakByLogValue::exec() {
       // Find the log value: it is either a log-file value or simply the
       // workspace number
       double logValue = 0;
-      if (logName.empty()) {
+      if (logName.empty() || logName == "axis-1") {
         API::Axis *axis = data.ws->getAxis(1);
         if (dynamic_cast<BinEdgeAxis *>(axis)) {
           double lowerEdge((*axis)(j));

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -398,7 +398,7 @@ void QENSFitSequential::init() {
   declareProperty(
       std::make_unique<FunctionProperty>("Function", Direction::InOut),
       "The fitting function, common for all workspaces in the input.");
-  declareProperty("LogValue", "axis-1",
+  declareProperty("LogName", "axis-1",
                   "Name of the log value to plot the "
                   "parameters against. Default: use spectra "
                   "numbers.");
@@ -660,7 +660,7 @@ std::vector<std::size_t> QENSFitSequential::getDatasetGrouping(
 WorkspaceGroup_sptr QENSFitSequential::processIndirectFitParameters(
     ITableWorkspace_sptr parameterWorkspace,
     const std::vector<std::size_t> &grouping) {
-  std::string const columnX = getProperty("LogValue");
+  std::string const columnX = getProperty("LogName");
   std::string const xAxisUnit = getProperty("ResultXAxisUnit");
   auto pifp =
       createChildAlgorithm("ProcessIndirectFitParameters", 0.91, 0.95, false);
@@ -733,7 +733,7 @@ ITableWorkspace_sptr QENSFitSequential::performFit(const std::string &input,
   plotPeaks->setProperty("Minimizer", getPropertyValue("Minimizer"));
   plotPeaks->setProperty("PassWSIndexToFunction", passWsIndex);
   plotPeaks->setProperty("PeakRadius", getPropertyValue("PeakRadius"));
-  plotPeaks->setProperty("LogValue", getPropertyValue("LogValue"));
+  plotPeaks->setProperty("LogValue", getPropertyValue("LogName"));
   plotPeaks->setProperty("EvaluationType", getPropertyValue("EvaluationType"));
   plotPeaks->setProperty("CostFunction", getPropertyValue("CostFunction"));
   plotPeaks->executeAsChildAlg();

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -398,7 +398,7 @@ void QENSFitSequential::init() {
   declareProperty(
       std::make_unique<FunctionProperty>("Function", Direction::InOut),
       "The fitting function, common for all workspaces in the input.");
-  declareProperty("LogValue", "",
+  declareProperty("LogValue", "axis-1",
                   "Name of the log value to plot the "
                   "parameters against. Default: use spectra "
                   "numbers.");

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -660,12 +660,13 @@ std::vector<std::size_t> QENSFitSequential::getDatasetGrouping(
 WorkspaceGroup_sptr QENSFitSequential::processIndirectFitParameters(
     ITableWorkspace_sptr parameterWorkspace,
     const std::vector<std::size_t> &grouping) {
+  std::string const columnX = getProperty("LogValue");
   std::string const xAxisUnit = getProperty("ResultXAxisUnit");
   auto pifp =
       createChildAlgorithm("ProcessIndirectFitParameters", 0.91, 0.95, false);
   pifp->setAlwaysStoreInADS(false);
   pifp->setProperty("InputWorkspace", parameterWorkspace);
-  pifp->setProperty("ColumnX", "axis-1");
+  pifp->setProperty("ColumnX", columnX);
   pifp->setProperty("XAxisUnit", xAxisUnit);
   pifp->setProperty("ParameterNames", getFitParameterNames());
   pifp->setProperty("IncludeChiSquared", true);

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -247,7 +247,7 @@ public:
 
     std::vector<std::string> tnames = result->getColumnNames();
     TS_ASSERT_EQUALS(tnames.size(), 12);
-    TS_ASSERT_EQUALS(tnames[0], "Source name");
+    TS_ASSERT_EQUALS(tnames[0], "SourceName");
 
     TS_ASSERT_EQUALS(result->String(0, 0), "PlotPeakGroup_0");
     TS_ASSERT_EQUALS(result->String(1, 0), "PlotPeakGroup_1");

--- a/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
+++ b/Framework/WorkflowAlgorithms/src/ProcessIndirectFitParameters.cpp
@@ -278,7 +278,7 @@ void ProcessIndirectFitParameters::init() {
  */
 void ProcessIndirectFitParameters::exec() {
   ITableWorkspace_sptr const inputWs = getProperty("InputWorkspace");
-  std::string const xColumn = getProperty("ColumnX");
+  std::string xColumn = getProperty("ColumnX");
   std::string const xUnit = getProperty("XAxisUnit");
   bool const includeChiSquared = getProperty("IncludeChiSquared");
   std::vector<std::string> parameterNames = getProperty("ParameterNames");

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -317,8 +317,15 @@ void ApplyAbsorptionCorrections::run() {
     geometryType = "_cyl";
   }
 
+  QString correctionType;
+  if (correctionsWsName.contains("PP")) {
+    correctionType = "_PP";
+  } else if (correctionsWsName.contains("MC")) {
+    correctionType = "_MC";
+  }
+
   QString outputWsName = QStrSampleWsName.left(nameCutIndex);
-  outputWsName += geometryType + "_Corrected";
+  outputWsName += geometryType + correctionType + "_Corrected";
 
   // Using container
   if (m_uiForm.ckUseCan->isChecked()) {

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -329,8 +329,8 @@ PrivateFittingData::PrivateFittingData(
     std::vector<std::unique_ptr<IndirectFitData>> &&data)
     : m_data(std::move(data)) {}
 
-PrivateFittingData &PrivateFittingData::
-operator=(PrivateFittingData &&fittingData) {
+PrivateFittingData &
+PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
   m_data = std::move(fittingData.m_data);
   return *this;
 }
@@ -738,6 +738,8 @@ std::string IndirectFittingModel::getResultXAxisUnit() const {
   return "MomentumTransfer";
 }
 
+std::string IndirectFittingModel::getResultLogValue() const { return "axis-1"; }
+
 boost::optional<ResultLocation>
 IndirectFittingModel::getResultLocation(std::size_t index,
                                         std::size_t spectrum) const {
@@ -814,6 +816,7 @@ IAlgorithm_sptr IndirectFittingModel::createSequentialFit(
   fitAlgorithm->setProperty("Input", input);
   fitAlgorithm->setProperty("OutputWorkspace", sequentialFitOutputName());
   fitAlgorithm->setProperty("PassWSIndexToFunction", true);
+  fitAlgorithm->setProperty("LogValue", getResultLogValue());
 
   const auto range = initialFitData->getRange(0);
   fitAlgorithm->setProperty("StartX", range.first);

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -329,8 +329,8 @@ PrivateFittingData::PrivateFittingData(
     std::vector<std::unique_ptr<IndirectFitData>> &&data)
     : m_data(std::move(data)) {}
 
-PrivateFittingData &
-PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
+PrivateFittingData &PrivateFittingData::
+operator=(PrivateFittingData &&fittingData) {
   m_data = std::move(fittingData.m_data);
   return *this;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -329,8 +329,8 @@ PrivateFittingData::PrivateFittingData(
     std::vector<std::unique_ptr<IndirectFitData>> &&data)
     : m_data(std::move(data)) {}
 
-PrivateFittingData &PrivateFittingData::
-operator=(PrivateFittingData &&fittingData) {
+PrivateFittingData &
+PrivateFittingData::operator=(PrivateFittingData &&fittingData) {
   m_data = std::move(fittingData.m_data);
   return *this;
 }
@@ -738,7 +738,7 @@ std::string IndirectFittingModel::getResultXAxisUnit() const {
   return "MomentumTransfer";
 }
 
-std::string IndirectFittingModel::getResultLogValue() const { return "axis-1"; }
+std::string IndirectFittingModel::getResultLogName() const { return "axis-1"; }
 
 boost::optional<ResultLocation>
 IndirectFittingModel::getResultLocation(std::size_t index,
@@ -816,7 +816,7 @@ IAlgorithm_sptr IndirectFittingModel::createSequentialFit(
   fitAlgorithm->setProperty("Input", input);
   fitAlgorithm->setProperty("OutputWorkspace", sequentialFitOutputName());
   fitAlgorithm->setProperty("PassWSIndexToFunction", true);
-  fitAlgorithm->setProperty("LogValue", getResultLogValue());
+  fitAlgorithm->setProperty("LogName", getResultLogName());
 
   const auto range = initialFitData->getRange(0);
   fitAlgorithm->setProperty("StartX", range.first);

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -159,7 +159,7 @@ private:
   createDefaultParameters(std::size_t index) const;
 
   virtual std::string getResultXAxisUnit() const;
-  virtual std::string getResultLogValue() const;
+  virtual std::string getResultLogName() const;
 
   bool isPreviousModelSelected() const;
 

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -159,6 +159,7 @@ private:
   createDefaultParameters(std::size_t index) const;
 
   virtual std::string getResultXAxisUnit() const;
+  virtual std::string getResultLogValue() const;
 
   bool isPreviousModelSelected() const;
 

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -364,7 +364,7 @@ std::string JumpFitModel::singleFitOutputName(std::size_t index,
 
 std::string JumpFitModel::getResultXAxisUnit() const { return ""; }
 
-std::string JumpFitModel::getResultLogValue() const { return "SourceName"; }
+std::string JumpFitModel::getResultLogName() const { return "SourceName"; }
 
 std::string JumpFitModel::constructOutputName() const {
   auto const name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -364,6 +364,8 @@ std::string JumpFitModel::singleFitOutputName(std::size_t index,
 
 std::string JumpFitModel::getResultXAxisUnit() const { return ""; }
 
+std::string JumpFitModel::getResultLogValue() const { return "SourceName"; }
+
 std::string JumpFitModel::constructOutputName() const {
   auto const name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
   auto const position = name.find("_Results");

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -61,7 +61,7 @@ private:
   std::unordered_map<std::string, JumpFitParameters>::const_iterator
   findJumpFitParameters(std::size_t dataIndex) const;
   std::string getResultXAxisUnit() const override;
-  std::string getResultLogValue() const override;
+  std::string getResultLogName() const override;
 
   std::string m_fitType;
   std::unordered_map<std::string, JumpFitParameters> m_jumpParameters;

--- a/qt/scientific_interfaces/Indirect/JumpFitModel.h
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.h
@@ -61,6 +61,7 @@ private:
   std::unordered_map<std::string, JumpFitParameters>::const_iterator
   findJumpFitParameters(std::size_t dataIndex) const;
   std::string getResultXAxisUnit() const override;
+  std::string getResultLogValue() const override;
 
   std::string m_fitType;
   std::unordered_map<std::string, JumpFitParameters> m_jumpParameters;


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the column heading value after an FQFit is `8e+307` instead of being `0`.

No release notes required as this is a minor bug.

**To test:**
1.`Interfaces`->`Indirect`->`Data Analysis`->`FQFit` tab
2. Load data
3. Select `TeixeiraWater` fit type.
4. Click `Run`
5. Open the `iris26176_graphite002_conv_1L_s0_to_17_Result_HWHM_FofQFit_TeixeiraWater` workspace
6. The column heading value should be 0:
![image](https://user-images.githubusercontent.com/40830825/60275094-3f6a9280-98f1-11e9-927d-27eb8a752e06.png)

**Data Files**
[iris26176_graphite002_conv_1L_s0_to_17_Result.zip](https://github.com/mantidproject/mantid/files/3335213/iris26176_graphite002_conv_1L_s0_to_17_Result.zip)

Fixes #26035

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
