### PR TITLE
Add checks to avoid crashing in reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -239,7 +239,8 @@ private:
 
 void updateEventProperties(AlgorithmRuntimeProps &properties,
                            Slicing const &slicing) {
-  boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
+  if (isValid(slicing))
+    boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
 }
 
 boost::optional<double> getDouble(IAlgorithm_sptr algorithm,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -570,7 +570,7 @@ void RunsTablePresenter::notifyCutRowsRequested() {
                           m_view->jobs().selectedSubtreeRoots());
   if (m_clipboard.isInitialized()) {
     removeRowsAndGroupsFromView(selected);
-    removeRowsFromModel(selected);
+    removeRowsAndGroupsFromModel(selected);
     m_view->jobs().clearSelection();
     ensureAtLeastOneGroupExists();
     notifySelectionChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -616,7 +616,7 @@ void RunsTablePresenter::pasteRowsOntoRows(
     auto replacementRows = m_clipboard.createRowsForAllRoots();
     auto replacementRow = replacementRows.begin();
     auto replacementPoint = replacementRoots.cbegin();
-    for (; replacementRow < replacementRows.end(),
+    for (; replacementRow < replacementRows.end() &&
            replacementPoint < replacementRoots.cend();
          ++replacementRow, ++replacementPoint) {
       auto &group = groups[groupOf(*replacementPoint)];

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -562,9 +562,12 @@ void RunsTablePresenter::notifyCutRowsRequested() {
   if (isProcessing() || isAutoreducing())
     return;
 
+  auto selected = m_view->jobs().selectedRowLocations();
+  if (selected.size() < 1)
+    return;
+
   m_clipboard = Clipboard(m_view->jobs().selectedSubtrees(),
                           m_view->jobs().selectedSubtreeRoots());
-  auto selected = m_view->jobs().selectedRowLocations();
   if (m_clipboard.isInitialized()) {
     removeRowsAndGroupsFromView(selected);
     removeRowsFromModel(selected);

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -259,8 +259,15 @@ void JobTreeView::replaceSubtreeAt(RowLocation const &rootToRemove,
                                    Subtree const &toInsert) {
   auto const insertionParent = rootToRemove.parent();
   auto insertionIndex = rootToRemove.rowRelativeToParent();
-  removeRowAt(rootToRemove);
+  // Insert the new row first (to avoid possibility of an empty table, which
+  // will cause problems because it is not allowed and will insert an empty
+  // group which we don't want)
   insertSubtreeAt(insertionParent, insertionIndex, toInsert);
+  // Now find the new index of the root we're replacing and remove it. It is
+  // now the sibling below.
+  auto originalRootIndexToRemove = rowLocation().indexAt(rootToRemove);
+  auto newRootIndexToRemove = below(originalRootIndexToRemove.untyped());
+  removeRowAt(rowLocation().atIndex(fromMainModel(newRootIndexToRemove)));
 }
 
 void JobTreeView::insertSubtreeAt(RowLocation const &parent, int index,


### PR DESCRIPTION
This PR adds a couple of checks to avoid some crashes:
- do not perform a Cut if nothing is selected
- update model correctly when cutting a group with no rows
- do not using slicing if it's invalid

**To test:**

- Open the ISIs Reflectometry interface
- Click the Cut button - nothing should happen
- Add an empty group and select it and Cut. It should not crash
- Add a group with a row with run 13460 and angle 0.5
- Ensure nothing is selected and click Cut. Again nothing should happen.
- On the Event tab, select custom slicing and enter some gibberish text. It will be highlighted red to indicate error. 
- Click Process on the Runs tab. The slicing is ignored

Refs #26025

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
