### PR TITLE
Disable multiple autoprocessing processes

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -9,6 +9,7 @@
 #include "GUI/Event/IEventPresenter.h"
 #include "GUI/Experiment/IExperimentPresenter.h"
 #include "GUI/Instrument/IInstrumentPresenter.h"
+#include "GUI/MainWindow/IMainWindowPresenter.h"
 #include "GUI/Runs/IRunsPresenter.h"
 #include "GUI/Save/ISavePresenter.h"
 #include "IBatchView.h"
@@ -71,6 +72,13 @@ BatchPresenter::BatchPresenter(
   observePostDelete();
   observeRename();
   observeADSClear();
+}
+
+/** Accept a main presenter
+ * @param mainPresenter :: [input] A main presenter
+ */
+void BatchPresenter::acceptMainPresenter(IMainWindowPresenter *mainPresenter) {
+  m_mainPresenter = mainPresenter;
 }
 
 bool BatchPresenter::requestClose() const { return true; }
@@ -218,6 +226,7 @@ void BatchPresenter::autoreductionResumed() {
   m_runsPresenter->autoreductionResumed();
 
   m_runsPresenter->notifyRowStateChanged();
+  m_mainPresenter->notifyAutoreductionResumed();
 }
 
 void BatchPresenter::pauseAutoreduction() {
@@ -236,11 +245,21 @@ void BatchPresenter::autoreductionPaused() {
   m_experimentPresenter->autoreductionPaused();
   m_instrumentPresenter->autoreductionPaused();
   m_runsPresenter->autoreductionPaused();
+
+  m_mainPresenter->notifyAutoreductionResumed();
 }
 
 void BatchPresenter::autoreductionCompleted() {
   m_runsPresenter->autoreductionCompleted();
   m_runsPresenter->notifyRowStateChanged();
+}
+
+void BatchPresenter::anyBatchAutoreductionResumed() {
+  m_runsPresenter->anyBatchAutoreductionResumed();
+}
+
+void BatchPresenter::anyBatchAutoreductionPaused() {
+  m_runsPresenter->anyBatchAutoreductionPaused();
 }
 
 void BatchPresenter::instrumentChanged(const std::string &instrumentName) {
@@ -306,6 +325,15 @@ bool BatchPresenter::isProcessing() const {
    */
 bool BatchPresenter::isAutoreducing() const {
   return m_jobRunner->isAutoreducing();
+}
+
+/**
+   Checks whether or not autoprocessing is currently running in this batch
+   * i.e. whether we are polling for new runs
+   * @return : Bool on whether data is being processed
+   */
+bool BatchPresenter::isAnyBatchAutoreducing() const {
+  return m_mainPresenter->isAnyBatchAutoreducing();
 }
 
 /** Get the percent of jobs that have been completed out of the current

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -54,6 +54,7 @@ public:
                             std::string const &message) override;
 
   // IBatchPresenter overrides
+  void acceptMainPresenter(IMainWindowPresenter *mainPresenter) override;
   void notifyReductionPaused() override;
   void notifyReductionResumed() override;
   void notifyAutoreductionResumed() override;
@@ -62,12 +63,15 @@ public:
   void notifyInstrumentChanged(const std::string &instName) override;
   void notifyRestoreDefaultsRequested() override;
   void notifySettingsChanged() override;
+  void anyBatchAutoreductionResumed() override;
+  void anyBatchAutoreductionPaused() override;
   bool hasPerAngleOptions() const override;
   MantidWidgets::DataProcessor::OptionsQMap
   getOptionsForAngle(const double angle) const override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;
+  bool isAnyBatchAutoreducing() const override;
   Mantid::Geometry::Instrument_const_sptr instrument() const override;
   int percentComplete() const override;
   AlgorithmRuntimeProps rowProcessingProperties() const override;
@@ -95,6 +99,7 @@ private:
   void settingsChanged();
 
   IBatchView *m_view;
+  IMainWindowPresenter *m_mainPresenter;
   std::unique_ptr<IRunsPresenter> m_runsPresenter;
   std::unique_ptr<IEventPresenter> m_eventPresenter;
   std::unique_ptr<IExperimentPresenter> m_experimentPresenter;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -17,6 +17,8 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+class IMainWindowPresenter;
+
 /** @class IBatchPresenter
 
 IBatchPresenter is the interface defining the functions that the main
@@ -28,6 +30,8 @@ public:
   /// Destructor
   virtual ~IBatchPresenter() = default;
 
+  virtual void acceptMainPresenter(IMainWindowPresenter *mainPresenter) = 0;
+
   virtual void notifyReductionPaused() = 0;
   virtual void notifyReductionResumed() = 0;
   virtual void notifyAutoreductionResumed() = 0;
@@ -36,6 +40,8 @@ public:
   virtual void notifyInstrumentChanged(const std::string &instName) = 0;
   virtual void notifyRestoreDefaultsRequested() = 0;
   virtual void notifySettingsChanged() = 0;
+  virtual void anyBatchAutoreductionResumed() = 0;
+  virtual void anyBatchAutoreductionPaused() = 0;
 
   /// Transmission runs for a specific run angle
   virtual MantidWidgets::DataProcessor::OptionsQMap
@@ -45,6 +51,7 @@ public:
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;
   virtual bool isAutoreducing() const = 0;
+  virtual bool isAnyBatchAutoreducing() const = 0;
   virtual bool requestClose() const = 0;
   virtual int percentComplete() const = 0;
   virtual AlgorithmRuntimeProps rowProcessingProperties() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -21,7 +21,10 @@ request information from other tabs.
 */
 class IMainWindowPresenter {
 public:
-  virtual bool isProcessing() const = 0;
+  virtual bool isAnyBatchProcessing() const = 0;
+  virtual bool isAnyBatchAutoreducing() const = 0;
+  virtual void notifyAutoreductionResumed() = 0;
+  virtual void notifyAutoreductionPaused() = 0;
   virtual ~IMainWindowPresenter() = default;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -25,12 +25,12 @@ MainWindowPresenter::MainWindowPresenter(
     : m_view(view), m_batchPresenterFactory(std::move(batchPresenterFactory)) {
   view->subscribe(this);
   for (auto *batchView : m_view->batches())
-    m_batchPresenters.emplace_back(m_batchPresenterFactory.make(batchView));
+    addNewBatch(batchView);
 }
 
 void MainWindowPresenter::notifyNewBatchRequested() {
   auto *newBatchView = m_view->newBatch();
-  m_batchPresenters.emplace_back(m_batchPresenterFactory.make(newBatchView));
+  addNewBatch(newBatchView);
 }
 
 void MainWindowPresenter::notifyCloseBatchRequested(int batchIndex) {
@@ -40,17 +40,44 @@ void MainWindowPresenter::notifyCloseBatchRequested(int batchIndex) {
   }
 }
 
-/**
-   Used by the view to tell the presenter something has changed
-*/
+void MainWindowPresenter::notifyAutoreductionResumed() {
+  for (auto batchPresenter : m_batchPresenters) {
+    batchPresenter->anyBatchAutoreductionResumed();
+  }
+}
+
+void MainWindowPresenter::notifyAutoreductionPaused() {
+  for (auto batchPresenter : m_batchPresenters) {
+    batchPresenter->anyBatchAutoreductionResumed();
+  }
+}
+
 void MainWindowPresenter::notifyHelpPressed() { showHelp(); }
 
-bool MainWindowPresenter::isProcessing() const {
+bool MainWindowPresenter::isAnyBatchProcessing() const {
   for (auto batchPresenter : m_batchPresenters) {
     if (batchPresenter->isProcessing())
       return true;
   }
   return false;
+}
+
+bool MainWindowPresenter::isAnyBatchAutoreducing() const {
+  for (auto batchPresenter : m_batchPresenters) {
+    if (batchPresenter->isAutoreducing())
+      return true;
+  }
+  return false;
+}
+
+void MainWindowPresenter::addNewBatch(IBatchView *batchView) {
+  m_batchPresenters.emplace_back(m_batchPresenterFactory.make(batchView));
+  m_batchPresenters.back()->acceptMainPresenter(this);
+  // Ensure autoreduce button is enabled/disabled correctly for the new batch
+  if (isAnyBatchAutoreducing())
+    m_batchPresenters.back()->anyBatchAutoreductionResumed();
+  else
+    m_batchPresenters.back()->anyBatchAutoreductionPaused();
 }
 
 void MainWindowPresenter::showHelp() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -18,6 +18,8 @@ namespace CustomInterfaces {
 
 /** Constructor
  * @param view :: [input] The view we are managing
+ * @param messageHandler :: Interface to a class that displays messages to
+ * the user
  * @param batchPresenterFactory :: [input] A factory to create the batches
  * we will manage
  */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -17,6 +17,7 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 class IMainWindowView;
+class IMessageHandler;
 
 /** @class MainWindowPresenter
 
@@ -28,7 +29,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL MainWindowPresenter
       public IMainWindowPresenter {
 public:
   /// Constructor
-  MainWindowPresenter(IMainWindowView *view,
+  MainWindowPresenter(IMainWindowView *view, IMessageHandler *messageHandler,
                       BatchPresenterFactory batchPresenterFactory);
 
   // IMainWindowPresenter overrides
@@ -47,6 +48,7 @@ private:
   void addNewBatch(IBatchView *batchView);
 
   IMainWindowView *m_view;
+  IMessageHandler *m_messageHandler;
   BatchPresenterFactory m_batchPresenterFactory;
   std::vector<std::shared_ptr<IBatchPresenter>> m_batchPresenters;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -32,7 +32,10 @@ public:
                       BatchPresenterFactory batchPresenterFactory);
 
   // IMainWindowPresenter overrides
-  bool isProcessing() const override;
+  bool isAnyBatchProcessing() const override;
+  bool isAnyBatchAutoreducing() const override;
+  void notifyAutoreductionResumed() override;
+  void notifyAutoreductionPaused() override;
 
   // MainWindowSubscriber overrides
   void notifyHelpPressed() override;
@@ -41,6 +44,8 @@ public:
 
 private:
   void showHelp();
+  void addNewBatch(IBatchView *batchView);
+
   IMainWindowView *m_view;
   BatchPresenterFactory m_batchPresenterFactory;
   std::vector<std::shared_ptr<IBatchPresenter>> m_batchPresenters;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -91,14 +91,14 @@ void MainWindowView::initLayout() {
 
   // Create the presenter
   m_presenter = std::make_unique<MainWindowPresenter>(
-      this, std::move(makeBatchPresenter));
+      this, messageHandler, std::move(makeBatchPresenter));
 
   m_notifyee->notifyNewBatchRequested();
   m_notifyee->notifyNewBatchRequested();
 }
 
 void MainWindowView::onTabCloseRequested(int tabIndex) {
-  m_ui.mainTabs->removeTab(tabIndex);
+  m_notifyee->notifyCloseBatchRequested(tabIndex);
 }
 
 void MainWindowView::onNewBatchRequested(bool) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -128,7 +128,8 @@ Handles attempt to close main window
 */
 void MainWindowView::closeEvent(QCloseEvent *event) {
   // Close only if reduction has been paused
-  if (!m_presenter->isProcessing()) {
+  if (!m_presenter->isAnyBatchProcessing() ||
+      m_presenter->isAnyBatchAutoreducing()) {
     event->accept();
   } else {
     event->ignore();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -41,6 +41,8 @@ public:
   virtual void autoreductionPaused() = 0;
   virtual void autoreductionCompleted() = 0;
   virtual void autoreductionResumed() = 0;
+  virtual void anyBatchAutoreductionResumed() = 0;
+  virtual void anyBatchAutoreductionPaused() = 0;
   virtual void instrumentChanged(std::string const &instrumentName) = 0;
   virtual void settingsChanged() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -223,6 +223,14 @@ void RunsPresenter::autoreductionPaused() {
   tablePresenter()->autoreductionPaused();
 }
 
+void RunsPresenter::anyBatchAutoreductionResumed() {
+  updateWidgetEnabledState();
+}
+
+void RunsPresenter::anyBatchAutoreductionPaused() {
+  updateWidgetEnabledState();
+}
+
 void RunsPresenter::autoreductionCompleted() {
   // Return to polling state
   m_runNotifier->startPolling();
@@ -284,6 +292,10 @@ bool RunsPresenter::isProcessing() const {
 
 bool RunsPresenter::isAutoreducing() const {
   return m_mainPresenter->isAutoreducing();
+}
+
+bool RunsPresenter::isAnyBatchAutoreducing() const {
+  return m_mainPresenter->isAnyBatchAutoreducing();
 }
 
 bool RunsPresenter::searchInProgress() const {
@@ -402,8 +414,8 @@ void RunsPresenter::updateWidgetEnabledState() const {
   m_view->setInstrumentComboEnabled(!isProcessing() && !isAutoreducing());
   m_view->setSearchTextEntryEnabled(!isAutoreducing() && !searchInProgress());
   m_view->setSearchButtonEnabled(!isAutoreducing() && !searchInProgress());
-  m_view->setAutoreduceButtonEnabled(!isAutoreducing() && !isProcessing() &&
-                                     !searchInProgress());
+  m_view->setAutoreduceButtonEnabled(!isAnyBatchAutoreducing() &&
+                                     !isProcessing() && !searchInProgress());
   m_view->setAutoreducePauseButtonEnabled(isAutoreducing());
   m_view->setTransferButtonEnabled(!isProcessing() && !isAutoreducing());
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -88,6 +88,8 @@ public:
   void autoreductionResumed() override;
   void autoreductionPaused() override;
   void autoreductionCompleted() override;
+  void anyBatchAutoreductionResumed() override;
+  void anyBatchAutoreductionPaused() override;
   void instrumentChanged(std::string const &instrumentName) override;
   void settingsChanged() override;
 
@@ -136,6 +138,8 @@ private:
   /// The name to use for the live data workspace
   Mantid::API::IAlgorithm_sptr m_monitorAlg;
   double m_thetaTolerance;
+
+  bool isAnyBatchAutoreducing() const;
 
   /// searching
   bool search(ISearcher::SearchType searchType);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -613,7 +613,7 @@ void RunsTablePresenter::pasteRowsOntoRows(
     auto replacementRows = m_clipboard.createRowsForAllRoots();
     auto replacementRow = replacementRows.begin();
     auto replacementPoint = replacementRoots.cbegin();
-    for (; replacementRow < replacementRows.end(),
+    for (; replacementRow < replacementRows.end() &&
            replacementPoint < replacementRoots.cend();
          ++replacementRow, ++replacementPoint) {
       auto &group = groups[groupOf(*replacementPoint)];

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
@@ -90,6 +90,30 @@ public:
     verifyAndClear();
   }
 
+  void testChildPresentersUpdatedWhenAnyBatchAutoreductionResumed() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(*m_runsPresenter, anyBatchAutoreductionResumed()).Times(1);
+    presenter.anyBatchAutoreductionResumed();
+    verifyAndClear();
+  }
+
+  void testChildPresentersUpdatedWhenAnyBatchAutoreductionPaused() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(*m_runsPresenter, anyBatchAutoreductionPaused()).Times(1);
+    presenter.anyBatchAutoreductionPaused();
+    verifyAndClear();
+  }
+
+  void testMainPresenterQueriedWhenCheckingAnyBatchAutoreducing() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_mainPresenter, isAnyBatchAutoreducing())
+        .Times(1)
+        .WillOnce(Return(true));
+    auto result = presenter.isAnyBatchAutoreducing();
+    TS_ASSERT_EQUALS(result, true);
+    verifyAndClear();
+  }
+
   void testAutoreductionCompletedWhenReductionResumedWithNoRemainingJobs() {
     auto presenter = makePresenter();
     EXPECT_CALL(*m_jobRunner, getAlgorithms())
@@ -366,6 +390,7 @@ public:
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobRunner> *m_jobRunner;
+  NiceMock<MockMainWindowPresenter> m_mainPresenter;
   NiceMock<MockRunsPresenter> *m_runsPresenter;
   NiceMock<MockEventPresenter> *m_eventPresenter;
   NiceMock<MockExperimentPresenter> *m_experimentPresenter;
@@ -424,6 +449,7 @@ private:
         &m_view, makeModel(), std::move(runsPresenter),
         std::move(eventPresenter), std::move(experimentPresenter),
         std::move(instrumentPresenter), std::move(savePresenter));
+    presenter.acceptMainPresenter(&m_mainPresenter);
     // Replace the constructed job runner with a mock
     m_jobRunner = new NiceMock<MockBatchJobRunner>();
     presenter.m_jobRunner.reset(m_jobRunner);

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -63,7 +63,10 @@ public:
 class MockMainWindowPresenter : public IMainWindowPresenter {
 public:
   MOCK_METHOD1(settingsChanged, void(int));
-  bool isProcessing() const override { return false; }
+  MOCK_CONST_METHOD0(isAnyBatchProcessing, bool());
+  MOCK_CONST_METHOD0(isAnyBatchAutoreducing, bool());
+  MOCK_METHOD0(notifyAutoreductionResumed, void());
+  MOCK_METHOD0(notifyAutoreductionPaused, void());
 
   ~MockMainWindowPresenter() override{};
 };
@@ -75,6 +78,8 @@ public:
   MOCK_METHOD0(notifyAutoreductionResumed, void());
   MOCK_METHOD0(notifyAutoreductionPaused, void());
   MOCK_METHOD0(notifyAutoreductionCompleted, void());
+  MOCK_METHOD0(anyBatchAutoreductionResumed, void());
+  MOCK_METHOD0(anyBatchAutoreductionPaused, void());
 
   MOCK_CONST_METHOD1(getOptionsForAngle, OptionsQMap(const double));
   MOCK_CONST_METHOD0(hasPerAngleOptions, bool());
@@ -83,10 +88,14 @@ public:
   MOCK_METHOD0(notifySettingsChanged, void());
   MOCK_CONST_METHOD0(isProcessing, bool());
   MOCK_CONST_METHOD0(isAutoreducing, bool());
+  MOCK_CONST_METHOD0(isAnyBatchAutoreducing, bool());
   MOCK_CONST_METHOD0(percentComplete, int());
   MOCK_CONST_METHOD0(rowProcessingProperties, AlgorithmRuntimeProps());
   MOCK_CONST_METHOD0(requestClose, bool());
   MOCK_CONST_METHOD0(instrument, Mantid::Geometry::Instrument_const_sptr());
+
+  // Calls we don't care about
+  void acceptMainPresenter(IMainWindowPresenter *) override{};
 };
 
 class MockRunsPresenter : public IRunsPresenter {
@@ -107,6 +116,8 @@ public:
   MOCK_METHOD0(autoreductionPaused, void());
   MOCK_METHOD0(autoreductionResumed, void());
   MOCK_METHOD0(autoreductionCompleted, void());
+  MOCK_METHOD0(anyBatchAutoreductionPaused, void());
+  MOCK_METHOD0(anyBatchAutoreductionResumed, void());
   MOCK_METHOD1(instrumentChanged, void(std::string const &));
   MOCK_METHOD0(settingsChanged, void());
   MOCK_CONST_METHOD0(isProcessing, bool());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -284,6 +284,20 @@ public:
     verifyAndClear();
   }
 
+  void testAutoreductionDisabledWhenAnotherBatchAutoreducing() {
+    auto presenter = makePresenter();
+    expectAutoreduceButtonDisabledWhenAnotherBatchAutoreducing();
+    presenter.anyBatchAutoreductionResumed();
+    verifyAndClear();
+  }
+
+  void testAutoreductionDisabledWhenAnotherBatchNotAutoreducing() {
+    auto presenter = makePresenter();
+    expectAutoreduceButtonEnabledWhenAnotherBatchNotAutoreducing();
+    presenter.anyBatchAutoreductionPaused();
+    verifyAndClear();
+  }
+
   void testNotifyCheckForNewRuns() {
     auto presenter = makePresenter();
     expectCheckForNewRuns();
@@ -674,16 +688,40 @@ private:
     EXPECT_CALL(m_view, setTransferButtonEnabled(true));
   }
 
+  void expectAutoreduceButtonDisabledWhenAnotherBatchAutoreducing() {
+    expectIsNotProcessing();
+    expectIsNotAutoreducing();
+    EXPECT_CALL(m_mainPresenter, isAnyBatchAutoreducing())
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(true));
+    EXPECT_CALL(m_view, setAutoreduceButtonEnabled(false));
+    EXPECT_CALL(m_view, setAutoreducePauseButtonEnabled(false));
+  }
+
+  void expectAutoreduceButtonEnabledWhenAnotherBatchNotAutoreducing() {
+    expectIsNotProcessing();
+    expectIsNotAutoreducing();
+    EXPECT_CALL(m_mainPresenter, isAnyBatchAutoreducing())
+        .Times(AtLeast(1))
+        .WillRepeatedly(Return(false));
+    EXPECT_CALL(m_view, setAutoreduceButtonEnabled(true));
+    EXPECT_CALL(m_view, setAutoreducePauseButtonEnabled(false));
+  }
+
   void expectIsAutoreducing() {
     EXPECT_CALL(m_mainPresenter, isAutoreducing())
         .Times(AtLeast(1))
         .WillRepeatedly(Return(true));
+    ON_CALL(m_mainPresenter, isAnyBatchAutoreducing())
+        .WillByDefault(Return(true));
   }
 
   void expectIsNotAutoreducing() {
     EXPECT_CALL(m_mainPresenter, isAutoreducing())
         .Times(AtLeast(1))
         .WillRepeatedly(Return(false));
+    ON_CALL(m_mainPresenter, isAnyBatchAutoreducing())
+        .WillByDefault(Return(false));
   }
 
   void expectIsProcessing() {


### PR DESCRIPTION
This PR adds coordination via the top level MainWindowPresenter to avoid multiple autoprocessing processes running simultaneously, which could cause errors if the user autoprocesses e.g. the same thing at the same time as workspaces would be overwritten.

**To test:**

- Open the ISIS Reflectometry interface
- Enter instrument INTER and investigation 1120015 and click Autoprocess
- Go to Batch 2 and check the Autoprocess button is disabled.
- Check that Batch 1 tab cannot be closed
- Go to the Batch menu and click New. Check that Autoprocess is disabled in the new batch.
- Pause the running autoprocessing and check that the Autoprocess buttons are all re-enabled and Batch 1 tab can now be closed.

Refs #26025

*This does not require release notes* because **it implements behaviour which was in the original GUI**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
