### PR TITLE
Add python3 requirements for rhel7

### DIFF
--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.31
+Version:        1.32
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -110,6 +110,10 @@ Requires: python3-mock
 Requires: boost-python3-devel
 %endif
 
+%{?el7:Requires: boost-python36-devel}
+%{?el7:Requires: python36-devel}
+%{?el7:Requires: python36-numpy}
+
 BuildArch: noarch
 
 %description
@@ -131,6 +135,9 @@ required for Mantid development.
 %files
 
 %changelog
+
+* Thu Jun 27 2019 Peter Peterson <petersonpf@ornl.gov>
+- Added python3 dependencies for framework on rhel7
 
 * Thu Apr 25 2019 Samuel Jones <samuel.jones@stfc.ac.uk>
 - Removed qtawesome


### PR DESCRIPTION
... but only the ones needed to build framework. This is some of them, but certainly not all as it doesn't include a python3 version of matplotlib or h5py.

This gives a taste of how much work needs to be done to get even framework running under python3 on rhel7.

**To test:**

Create a developer rpm for rhel7 and see that it can be installed.

*There is no associated issue.*

*This does not require release notes* because it is a change to the developer package.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
