### PR TITLE
Indirect Fix LoadLog Error Message and Crash

### DIFF
--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -735,15 +735,16 @@ void LoadRawHelper::runLoadLog(const std::string &fileName,
       setChildStartProgress(progStart);
       setChildEndProgress(progEnd);
     }
-    // Now execute the Child Algorithm. Catch and log any error, but don't stop.
+    // Now execute the Child Algorithm. Catch any error, but don't stop.
     try {
+      loadLog->setLogging(false);
       loadLog->execute();
-    } catch (std::exception &) {
-      g_log.error("Unable to successfully run LoadLog Child Algorithm");
-    }
+      if (!loadLog->isExecuted())
+        g_log.warning("Unable to successfully run LoadLog Child Algorithm");
 
-    if (!loadLog->isExecuted()) {
-      g_log.error("Unable to successfully run LoadLog Child Algorithm");
+    } catch (std::exception &ex) {
+      g_log.warning("Unable to successfully run LoadLog Child Algorithm: ");
+      g_log.warning(ex.what());
     }
   }
   // Make log creator object and add the run status log if we have the

--- a/docs/source/algorithms/OSIRISDiffractionReduction-v1.rst
+++ b/docs/source/algorithms/OSIRISDiffractionReduction-v1.rst
@@ -13,7 +13,7 @@ Performs a diffraction reduction for OSIRIS using normalisation to a set of
 vanadium sample runs.
 
 The dRanges are numbered as per the `OSIRIS manual
-<http://www.isis.stfc.ac.uk/instruments/osiris/documents/osiris-user-guide6672.pdf>`_.
+<https://www.isis.stfc.ac.uk/Pages/osiris-user-guide.pdf>`_.
 Otherwise the dRange is determined based on the table provided in the manual.
 
 Workflow

--- a/docs/source/interfaces/Indirect Diffraction.rst
+++ b/docs/source/interfaces/Indirect Diffraction.rst
@@ -89,7 +89,7 @@ files are remembered by the interface so they only have to be set once per cycle
 There is also the option to manually set the dRange used in all of the sample
 runs, note that in this case all sample files must correspond to the same dRange.
 The dRanges are numbered as per the `OSIRIS manual
-<http://www.isis.stfc.ac.uk/instruments/osiris/documents/osiris-user-guide6672.pdf>`_.
+<https://www.isis.stfc.ac.uk/Pages/osiris-user-guide.pdf>`_.
 Otherwise the dRange is determined based on the table provided in the manual.
 
 Note: There must be a corresponding vanadium file with the same dRanges for each

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -91,6 +91,7 @@ Bug Fixes
 #########
 - Fixed a bug in the :ref:`Integration <algm-Integration>` algorithm causing the Moments tab to crash.
 - Fixed an unexpected error when opening the Data Reduction interface with an unrelated facility selected.
+- Fixed a crash on the Symmetrise, Sqw and Moments tab caused by attempting to load raw data.
 
 
 Indirect Settings Interface

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -67,6 +67,9 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
           this,
           SLOT(updateRunButton(bool, std::string const &, QString const &,
                                QString const &)));
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsInput->isForRunFiles(false);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -67,6 +67,9 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
   m_uiForm.rqwPlot2D->setColourBarVisible(false);
   m_uiForm.rqwPlot2D->setXAxisLabel("Energy (meV)");
   m_uiForm.rqwPlot2D->setYAxisLabel("Q (A-1)");
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsSampleInput->isForRunFiles(false);
 }
 
 IndirectSqw::~IndirectSqw() {}

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -162,6 +162,9 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
   // Disable run until preview is clicked
   m_uiForm.pbRun->setEnabled(false);
   m_uiForm.pbPreview->setEnabled(false);
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsInput->isForRunFiles(false);
 }
 
 //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work.**
This PR fixes a couple of minor things:
- An error message which appeared when loading the `26176` run number in Data Reduction
- A crash on Symmetrise, Sqw and Moments tabs of Data Reduction when attempting to load raw data (which shouldn't be possible)
- Updates the links pointing at the OSIRIS user guide.

No release notes required for the first bug as it didn't appear in he previous release.

**To test:**
**Bug 1 Test**
1. `Interfaces`->`Indirect`->`Data Reduction`->`ISISEnergyTransfer` tab
2. Enter run number `26176` and press enter. No error message should appear in the results log (only a warning message).

**Bug 2 Test**
1. `Symmetrise` tab
2. Enter run number `26176`. Nothing should happen - no crash

Fixes #25928 and #25927 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
