### PR TITLE
Add missing property to workflow algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -154,7 +154,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             'TransmissionProcessingInstructions', 'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
             'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax', 'ScaleFactor',
             'PolarizationAnalysis', 'CPp', 'CAp', 'CRho', 'CAlpha', 'FloodCorrection',
-            'FloodWorkspace', 'Debug']
+            'FloodWorkspace', 'Debug', 'ScaleRHSWorkspace']
         self.copyProperties('ReflectometryReductionOneAuto', self._reduction_properties)
 
     def _getInputWorkspaces(self, runs, isTrans):


### PR DESCRIPTION
**Report to:** Max at ISIS

Add a missing property ScaleRHSWorkspace to ReflectometryISISLoadAndProcess so that it gets passed through to CreateTransmissionWorkspace.

Refs #26025

**To test:**

- Open the ISIS Reflectometry interface
- Add a group and row with run=13460, angle=0.5, FirstTrans=13463, SecondTrans=13464 and Options column text set to `ScaleRHSWorkspace=0`
- Click Process and check there is no error about this property not existing

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
