### PR TITLE
Skip over empty chunks in AlignAndFocusPowderFromFiles

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -342,6 +342,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         canSkipLoadingLogs = False
 
         # inner loop is over chunks
+        haveAccumulationForFile = False
         for (j, chunk) in enumerate(chunks):
             prog_start = file_prog_start + float(j) * float(numSteps - 1) * prog_per_chunk_step
 
@@ -357,7 +358,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             # load a chunk - this is a bit crazy long because we need to get an output property from `Load` when it
             # is run and the algorithm history doesn't exist until the parent algorithm (this) has finished
             loader = self.__createLoader(filename, chunkname,
-                                         skipLoadingLogs=(len(chunks) > 1 and canSkipLoadingLogs),
+                                         skipLoadingLogs=(len(chunks) > 1 and canSkipLoadingLogs and haveAccumulationForFile),
                                          progstart=prog_start, progstop=prog_start + prog_per_chunk_step,
                                          **chunk)
             loader.execute()
@@ -365,7 +366,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 self.__setupCalibration(chunkname)
 
             # copy the necessary logs onto the workspace
-            if len(chunks) > 1 and canSkipLoadingLogs:
+            if haveAccumulationForFile and len(chunks) > 1 and canSkipLoadingLogs:
                 CopyLogs(InputWorkspace=wkspname, OutputWorkspace=chunkname, MergeStrategy='WipeExisting')
 
             # get the underlying loader name if we used the generic one
@@ -378,6 +379,10 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
             if determineCharacterizations and j == 0:
                 self.__determineCharacterizations(filename, chunkname)  # updates instance variable
                 determineCharacterizations = False
+
+            if self.__loaderName == 'LoadEventNexus' and mtd[chunkname].getNumberEvents() == 0:
+                self.log().notice('Chunk {} of {} contained no events. Skipping to next chunk.'.format(j+1,len(chunks)))
+                continue
 
             prog_start += prog_per_chunk_step
             if self.filterBadPulses > 0.:
@@ -420,9 +425,13 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                                 **self.kwargs)
             prog_start += 2. * prog_per_chunk_step  # AlignAndFocusPowder counts for two steps
 
-            self.__accumulate(chunkname, wkspname, unfocusname_chunk, unfocusname, j == 0,
+            self.__accumulate(chunkname, wkspname, unfocusname_chunk, unfocusname, not haveAccumulationForFile,
                               removelogs=canSkipLoadingLogs)
+
+            haveAccumulationForFile = True
         # end of inner loop
+        if not mtd.doesExist(wkspname):
+            raise RuntimeError('Failed to process any data from file "{}"'.format(filename))
 
         # write out the cachefile for the main reduced data independent of whether
         # the unfocussed workspace was requested

--- a/docs/source/release/v4.1.0/diffraction.rst
+++ b/docs/source/release/v4.1.0/diffraction.rst
@@ -46,6 +46,8 @@ Bug Fixes
 
 - Pearl no longer produces an output of NaN when long-mode is changed after focusing.
 
+- :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles>` no longer errors out if the first chunk has no events
+
 Engineering Diffraction
 -----------------------
 


### PR DESCRIPTION
Running
```
SNAPReduce(RunNumbers='44539', Binning='0.2,0.003,6', GroupDetectorsBy='Column')
```
before this change attempted to process the file in two chunks, the first of which was empty. This change logs it in the notice channel and continues on to the next chunk.


**Report to:** SNAP team

Refs #26015

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
