### PR TITLE
refs #25326. Fixed file loader, clearing old lines

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -23,6 +23,7 @@ Improvements
 ############
 
 * Phase table and phase Quad options from frequency domain transform tab moved to phase calculations tab.
+* When plotting peaks in the Elemental Analysis interface, different elements will appear in different colours.
 
 Bug Fixes
 #########
@@ -30,3 +31,4 @@ Bug Fixes
 * Muon Analysis (original) no longer crashes when `TF Asymmetry` mode is activated.
 * Muon Analysis (original) can now produce results tables when columns contain both ranges and single values.
 * Issue where imaginary box was reappearing for FFT transforms after being unselected fixed.
+* Elemental Analysis no longer crashes when an ill formatted data file is loaded.

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -25,12 +25,18 @@ class PeakSelectorView(QtWidgets.QListWidget):
         self.setWindowTitle(element)
         self.list = QtWidgets.QVBoxLayout(self)
 
-        primary = peak_data["Primary"]
-        self.primary_checkboxes = self._create_checkbox_list(
-            "Primary", primary)
-        secondary = peak_data["Secondary"]
-        self.secondary_checkboxes = self._create_checkbox_list(
-            "Secondary", secondary, checked=False)
+        try:
+            primary = peak_data["Primary"]
+            self.primary_checkboxes = self._create_checkbox_list(
+                "Primary", primary)
+        except KeyError:
+            self.primary_checkboxes = []
+        try:
+            secondary = peak_data["Secondary"]
+            self.secondary_checkboxes = self._create_checkbox_list(
+                "Secondary", secondary, checked=False)
+        except KeyError:
+            self.secondary_checkboxes = []
         try:
             gammas = peak_data["Gammas"]
             self.gamma_checkboxes = self._create_checkbox_list(

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -10,12 +10,11 @@ from qtpy import QtWidgets, QtCore
 from six import iteritems
 
 from Muon.GUI.Common.checkbox import Checkbox
-from Muon.GUI.Common import message_box
 
 
 # Check that the new data format contains at least A, Z, primary (they can be empty)
-def is_valid_data(peak_data):
-    data_label = [str(k) for k in peak_data.keys()]
+def valid_data(peak_data):
+    data_label = peak_data.keys()
     if any(['Z' not in data_label,
             'A' not in data_label,
             'Primary' not in data_label,
@@ -33,7 +32,7 @@ class PeakSelectorView(QtWidgets.QListWidget):
         widget = QtWidgets.QWidget()
 
         self.new_data = {}
-        if not is_valid_data(peak_data):
+        if not valid_data(peak_data):
             raise ValueError
 
         self.update_new_data(peak_data)

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -10,6 +10,17 @@ from qtpy import QtWidgets, QtCore
 from six import iteritems
 
 from Muon.GUI.Common.checkbox import Checkbox
+from Muon.GUI.Common import message_box
+
+
+# Check that the new data format contains at least A, Z, primary (they can be empty)
+def is_valid_data(peak_data):
+    data_present = [str(k) for k in peak_data.keys()]
+    if any(['Z' not in data_present,
+            'A' not in data_present]):
+        return False
+
+    return True
 
 
 class PeakSelectorView(QtWidgets.QListWidget):
@@ -20,15 +31,18 @@ class PeakSelectorView(QtWidgets.QListWidget):
         widget = QtWidgets.QWidget()
 
         self.new_data = {}
+        if not is_valid_data(peak_data):
+            raise ValueError
+
         self.update_new_data(peak_data)
         self.element = element
         self.setWindowTitle(element)
         self.list = QtWidgets.QVBoxLayout(self)
 
+        # Labels might not be present, if so return empty list
         try:
             primary = peak_data["Primary"]
-            self.primary_checkboxes = self._create_checkbox_list(
-                "Primary", primary)
+            self.primary_checkboxes = self._create_checkbox_list("Primary", primary)
         except KeyError:
             self.primary_checkboxes = []
         try:
@@ -69,7 +83,11 @@ class PeakSelectorView(QtWidgets.QListWidget):
         for el, values in iteritems(data):
             if values is None:
                 data[el] = {}
-        new_data = data["Primary"].copy()
+        try:
+            new_data = data["Primary"].copy()
+        except KeyError:
+            new_data = {}
+
         self.new_data = new_data
 
     def _setup_checkbox(self, name, checked):

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -15,9 +15,11 @@ from Muon.GUI.Common import message_box
 
 # Check that the new data format contains at least A, Z, primary (they can be empty)
 def is_valid_data(peak_data):
-    data_present = [str(k) for k in peak_data.keys()]
-    if any(['Z' not in data_present,
-            'A' not in data_present]):
+    data_label = [str(k) for k in peak_data.keys()]
+    if any(['Z' not in data_label,
+            'A' not in data_label,
+            'Primary' not in data_label,
+            'Secondary' not in data_label]):
         return False
 
     return True
@@ -40,17 +42,10 @@ class PeakSelectorView(QtWidgets.QListWidget):
         self.list = QtWidgets.QVBoxLayout(self)
 
         # Labels might not be present, if so return empty list
-        try:
-            primary = peak_data["Primary"]
-            self.primary_checkboxes = self._create_checkbox_list("Primary", primary)
-        except KeyError:
-            self.primary_checkboxes = []
-        try:
-            secondary = peak_data["Secondary"]
-            self.secondary_checkboxes = self._create_checkbox_list(
-                "Secondary", secondary, checked=False)
-        except KeyError:
-            self.secondary_checkboxes = []
+        primary = peak_data["Primary"]
+        self.primary_checkboxes = self._create_checkbox_list("Primary", primary)
+        secondary = peak_data["Secondary"]
+        self.secondary_checkboxes = self._create_checkbox_list("Secondary", secondary, checked=False)
         try:
             gammas = peak_data["Gammas"]
             self.gamma_checkboxes = self._create_checkbox_list(
@@ -83,10 +78,7 @@ class PeakSelectorView(QtWidgets.QListWidget):
         for el, values in iteritems(data):
             if values is None:
                 data[el] = {}
-        try:
-            new_data = data["Primary"].copy()
-        except KeyError:
-            new_data = {}
+        new_data = data["Primary"].copy()
 
         self.new_data = new_data
 

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_model.py
@@ -15,11 +15,11 @@ from Muon.GUI import ElementalAnalysis
 class PeriodicTableModel(object):
     def __init__(self):
         self._peak_data = {}
-        self._peak_data_file = os.path.join(
-            os.path.dirname(
-                ElementalAnalysis.__file__),
-            "peak_data.json")
+        self._peak_data_file = self.get_default_peak_data_file()
         self.load_peak_data()
+
+    def get_default_peak_data_file(self):
+        return os.path.join(os.path.dirname(ElementalAnalysis.__file__), "peak_data.json")
 
     def load_peak_data(self):
         # using os.path.isfile allows file modifications to take place before opening:

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/periodic_table_presenter.py
@@ -73,9 +73,12 @@ class PeriodicTablePresenter(object):
         except TypeError:
             return
 
-    def set_peak_datafile(self, filename):
+    def set_peak_datafile(self, filename=None):
         try:
-            self.model.peak_data_file = filename
+            if filename:
+                self.model.peak_data_file = filename
+            else:
+                self.model.peak_data_file = self.model.get_default_peak_data_file()
             self.set_buttons()
         except Exception as error:
             message_box.warning(error)

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -30,6 +30,8 @@ from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_presenter import PeakSelectorPresenter
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_view import PeakSelectorView
 
+from Muon.GUI.Common import message_box
+
 import mantid.simpleapi as mantid
 
 offset = 0.9
@@ -54,8 +56,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.menu.addAction("Normalise")
 
         # periodic table stuff
-        self.ptable = PeriodicTablePresenter(
-            PeriodicTableView(), PeriodicTableModel())
+        self.ptable = PeriodicTablePresenter(PeriodicTableView(), PeriodicTableModel())
         self.ptable.register_table_lclicked(self.table_left_clicked)
         self.ptable.register_table_rclicked(self.table_right_clicked)
 
@@ -308,7 +309,13 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # these are commneted out as they are a bug
         # see issue 25326
         #self._clear_lines_after_data_file_selected()
-        self._generate_element_widgets()
+        try:
+            self._generate_element_widgets()
+        except ValueError:
+            # todo: add link to elemental analysis documentation after it is merged
+            message_box.warning('The file does not contain correctly formatted data, resetting to default data file')
+            self.ptable.set_peak_datafile(None)
+            self._generate_element_widgets()
         for element in old_lines:
             if element not in self.element_widgets.keys():
                 self._remove_element_lines(element)

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -316,8 +316,11 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             message_box.warning('The file does not contain correctly formatted data, resetting to default data file')
             self.ptable.set_peak_datafile(None)
             self._generate_element_widgets()
+
         for element in old_lines:
-            if element not in self.element_widgets.keys():
+            if element in self.element_widgets.keys():
+                self.ptable.select_element(element)
+            else:
                 self._remove_element_lines(element)
         #self._generate_element_data()
 

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -297,6 +297,8 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
     # sets data file for periodic table
     def select_data_file(self):
+        old_lines = deepcopy(list(self.element_lines.keys()))
+
         filename = QtWidgets.QFileDialog.getOpenFileName()
         if isinstance(filename, tuple):
             filename = filename[0]
@@ -307,6 +309,9 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # see issue 25326
         #self._clear_lines_after_data_file_selected()
         self._generate_element_widgets()
+        for element in old_lines:
+            if element not in self.element_widgets.keys():
+                self._remove_element_lines(element)
         #self._generate_element_data()
 
     # general checked data

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -312,8 +312,9 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         try:
             self._generate_element_widgets()
         except ValueError:
-            # todo: add link to elemental analysis documentation after it is merged
-            message_box.warning('The file does not contain correctly formatted data, resetting to default data file')
+            message_box.warning('The file does not contain correctly formatted data, resetting to default data file.'
+                                'See "https://docs.mantidproject.org/nightly/interfaces/'
+                                'Muon%20Elemental%20Analysis.html" for more information.')
             self.ptable.set_peak_datafile(None)
             self._generate_element_widgets()
 


### PR DESCRIPTION
**do not merge until after #26242.**

**Description of work.**

Fixed loader for peak data file in elemental analysis.
When lines are plotted and a new data file loaded, if the element does not appear in the new file the line will be deleted

**To test:**
 - open elemental analysis
 - create a .json file with peak data, see #23222 for example file
 - load the file
 - all elements not present in the peak file should appear grey in the periodic table
 - all lines of elements not present should be deleted

Fixes  #25326. 


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
