### PR TITLE
Restore workbench-script startup file on Linux package

### DIFF
--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -1,8 +1,14 @@
 # Defines functions to help deal with python packages
 
 # Function to create links to python packages in the source tree
-# If the EXECUTABLE option is provided then it additional build rules are
-# defined to ensure startup scripts are regenerated appropriately
+# Optional keyword arguments:
+#   - EXECUTABLE: If this option provided then it is assumed the package contains a
+#                 startup script and this is installed in the package bin
+#                 directory
+#   - EGGLINKNAME: Pass in a new name for the egg link, e.g. EGGLINKNAME mylink,
+#                  creates a new egg link called mylink
+#   - EXCLUDE_ON_INSTALL: Specifies a regex of files to exclude from the install
+#   -                     command
 function ( add_python_package pkg_name )
   # Create a setup.py file if necessary
   set ( _setup_py ${CMAKE_CURRENT_SOURCE_DIR}/setup.py )
@@ -35,18 +41,21 @@ CustomInstallLib = patch_setuptools_command('install_lib')
 
   set ( _egg_link_dir ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR} )
 
-  # Parses ARGN and adds the expected parameter EGGLINKNAME as a new variable
-  cmake_parse_arguments(_additional_args "" "EGGLINKNAME" "" ${ARGN})
+  # Create variables for additional arguments
+  cmake_parse_arguments(_parsed_arg
+                        "EXECUTABLE"
+                        "EGGLINKNAME;EXCLUDE_FROM_INSTALL"
+                        "" ${ARGN})
 
-  # If a custom egg-link name WAs specified use that for the link
-  if (_additional_args_EGGLINKNAME)
-    set ( _egg_link ${_egg_link_dir}/${_egg_link_name}.egg-link )
+  # If a custom egg-link name was specified use that for the link
+  if (_parsed_arg_EGGLINKNAME)
+    set ( _egg_link ${_egg_link_dir}/${_parsed_arg_EGGLINKNAME}.egg-link )
   else()
     # if no egg-link name is specified, then use the target name
     set ( _egg_link ${_egg_link_dir}/${pkg_name}.egg-link )
   endif()
 
-  if ( ARGC GREATER 1 AND "${ARGN}" STREQUAL "EXECUTABLE" )
+  if ( _parsed_arg_EXECUTABLE )
     if ( WIN32 )
       # add .exe in the executable name for Windows, otherwise it can't find it during the install step
       set ( _executable_name ${pkg_name}.exe )
@@ -95,12 +104,11 @@ CustomInstallLib = patch_setuptools_command('install_lib')
     endif ()
 
     # Registers the "installed" components with CMake so it will carry them over
-    if ( ARGC GREATER 2 AND "${ARGV2}" STREQUAL "EXCLUDE_RESOURCES" )
+    if ( _parsed_arg_EXCLUDE_FROM_INSTALL )
       install(DIRECTORY ${_package_source_directory}
               DESTINATION ${_package_install_destination}
               PATTERN "test" EXCLUDE
-              PATTERN "resources.py" EXCLUDE
-              PATTERN "resources.pyc" EXCLUDE)
+              REGEX "${_parsed_arg_EXCLUDE_FROM_INSTALL}" EXCLUDE)
     else ()
       install(DIRECTORY ${_package_source_directory}
               DESTINATION ${_package_install_destination}
@@ -118,7 +126,7 @@ CustomInstallLib = patch_setuptools_command('install_lib')
     endif()
 
     # install the generated executable - only tested with "workbench"
-    if ( ARGC GREATER 1 AND "${ARGN}" STREQUAL "EXECUTABLE" )
+    if ( _parsed_arg_EXECUTABLE )
         # On UNIX systems install the workbench executable directly.
         # The Windows case is handled with a custom startup script installed in WindowsNSIS
         if ( NOT WIN32 )

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -1,5 +1,14 @@
 # Create egg link to binary output directory
-add_python_package(workbench EXECUTABLE "EXCLUDE_RESOURCES")
+if(WIN32)
+  # handled separately below
+  set(_exclude_on_install "resources\.pyc?")
+else()
+  set(_exclude_on_install "")
+endif()
+add_python_package(workbench
+  EXECUTABLE
+  EXCLUDE_FROM_INSTALL ${_exclude_on_install}
+)
 
 set(_images_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
 
@@ -46,7 +55,7 @@ else()
                      COMMENT "Generating workbench resources module"
                      DEPENDS ${_images_qrc_file})
   add_custom_target(workbench_resources ALL DEPENDS ${_output_res_py})
-endif()     
+endif()
 
 # Dependency chain
 add_dependencies(workbench workbench_resources mantidqt)


### PR DESCRIPTION
**Description of work.**

Puts back the missing generated `workbench-script` on Linux that causes workbench not to start.

**To test:**

Build a package on linux and install it.
Start the workbench with `/opt/mantidunstable/bin/mantidworkbench` and it should start.

Fixes #26111  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- delete this if you added release notes
*This does not require release notes* because **this fixes an internal bug in this dev cycle.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
