### PR TITLE
First Time Setup - Do not show until next release remove instrument check

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -617,7 +617,7 @@ bool ApplicationWindow::shouldWeShowFirstTimeSetup(
   auto &config = ConfigService::Instance();
   std::string facility = config.getString("default.facility");
   std::string instrument = config.getString("default.instrument");
-  if (facility.empty() || instrument.empty()) {
+  if (facility.empty()) {
     return true;
   } else {
     // check we can get the facility and instrument


### PR DESCRIPTION
**Description of work.**
This PR ensures that the `Do not show until next release` checkbox in the First Time Setup window will stop the window from opening until the next release, when loading mantid.
It was decided that the check on the instrument was not important as certain parts of mantid can still be used without setting an instrument. 
Previously, checking the `Do not show until next release` checkbox would do nothing if an instrument was not selected. This caused confusion with some users, and looks as if the option does not work.

**To test:**
1. Open mantid
2. Check `Do not show until next release`  and close mantid
3. Open mantid and make sure the FirstTimeSetup does not re-appear.
4. Repeat this, but with no instrument selected in the FirstTimeSetup window (change `<build-folder>\bin\Debug\mantid.user.properties` so that `default.instrument = ALF` is instead `default.instrument =`)
5. Repeat but with `Do not show until next release` unchecked

Fixes #25926

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
