### PR TITLE
Fix unhandled exception with slicing by log value

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -199,7 +199,7 @@ public:
     // No slicing specified so there is nothing to do
   }
   void operator()(InvalidSlicing const &) const {
-    throw std::runtime_error("Program error: Invalid slicing");
+    // No valid slicing so there is nothing to do
   }
   void operator()(UniformSlicingByTime const &slicing) const {
     enableSlicing();
@@ -217,12 +217,12 @@ public:
                                 m_properties);
   }
   void operator()(SlicingByEventLog const &slicing) const {
-    if (slicing.sliceAtValues().size() < 1)
+    // If we don't have an interval, there's nothing to do. Also, we don't
+    // currently support multiple intervals, so skip that as well.
+    if (slicing.sliceAtValues().size() < 1 ||
+        slicing.sliceAtValues().size() > 1)
       return;
-    if (slicing.sliceAtValues().size() > 1)
-      throw std::runtime_error("Custom log value intervals are not "
-                               "implemented; please specify a single "
-                               "interval width");
+
     enableSlicing();
     AlgorithmProperties::update("LogName", slicing.blockName(), m_properties);
     AlgorithmProperties::update("LogValueInterval", slicing.sliceAtValues()[0],
@@ -239,8 +239,7 @@ private:
 
 void updateEventProperties(AlgorithmRuntimeProps &properties,
                            Slicing const &slicing) {
-  if (isValid(slicing))
-    boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
+  boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
 }
 
 boost::optional<double> getDouble(IAlgorithm_sptr algorithm,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -106,7 +106,11 @@ void EventPresenter::setLogValueSlicingFromView() {
   auto maybeBreakpoints =
       parseList(m_view->logBreakpoints(), parseNonNegativeDouble);
   auto blockName = m_view->logBlockName();
-  if (maybeBreakpoints.is_initialized()) {
+  // Currently we don't support multiple log intervals, so for now if we have
+  // more than one item in the list then show that as invalid. We intend to add
+  // this though which is why this is still a free text field rather than a
+  // spin box
+  if (maybeBreakpoints.is_initialized() && maybeBreakpoints.get().size() <= 1) {
     m_view->showLogBreakpointsValid();
     m_slicing = SlicingByEventLog(maybeBreakpoints.get(), blockName);
   } else {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventWidget.ui
@@ -234,7 +234,7 @@
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Python list</string>
+         <string>Log value interval</string>
         </property>
        </widget>
       </item>
@@ -244,7 +244,7 @@
          <bool>false</bool>
         </property>
         <property name="toolTip">
-         <string>A comma separated list of values indicating the log values at which to slice the data</string>
+         <string>Delta of log value to be sliced into</string>
         </property>
        </widget>
       </item>

--- a/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
@@ -97,9 +97,8 @@ public:
     auto presenter = makePresenter();
     auto const sliceType = SliceType::LogValue;
     auto const logBlockName = std::string("Param");
-    auto const expectedSliceValues =
-        std::vector<double>({11.0, 0.1, 12.0, 33.0, 23.2});
-    auto const sliceValuesList = std::string("11,0.1, 12,33, 23.2");
+    auto const expectedSliceValues = std::vector<double>({11.0});
+    auto const sliceValuesList = std::string("11");
 
     EXPECT_CALL(m_view, logBreakpoints()).WillOnce(Return(sliceValuesList));
     EXPECT_CALL(m_view, logBlockName()).WillOnce(Return(logBlockName));


### PR DESCRIPTION
In the ISIS Reflectometry GUI, we don't currently support multiple log value intervals and this was throwing an unhandled exception. Rather than throwing here, this PR makes a change to ignore the error, and improves the input widget's label, description and validation to help the user understand what to enter.

The documentation for the interface needs updating but this will be done as part of #26025 

Fixes #26127

**To test:**

See the linked issue and check that the exception no longer occurs

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
