### PR TITLE
Add required memory to allow for WISH file

### DIFF
--- a/Testing/SystemTests/tests/analysis/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/analysis/LoadLotsOfFiles.py
@@ -291,6 +291,9 @@ class LoadLotsOfFiles(systemtesting.MantidSystemTest):
         del wksp
         return result
 
+    def requiredMemoryMB(self):
+        return 18000
+
     def runTest(self):
         """Main entry point for the test suite"""
         files = self.__getDataFileList__()


### PR DESCRIPTION
**Description of work.**

`LoadLotsOfFiles` requires ~16.6Gb (from `/usr/bin/time`). Implement required memory function to skip the tests on less powerful nodes. Required for the current Ubuntu 18.04 builder.

**To test:**

Run the system test on a system with less than 18Gb of RAM and it should be skipped.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **this is an internal change.**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
