### PR TITLE
Reflectometry GUI: Handle an error "better" when slicing by log value.

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -12,6 +12,7 @@
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
+#include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 
 namespace MantidQt {
@@ -21,9 +22,11 @@ using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
 using AlgorithmRuntimeProps = std::map<std::string, std::string>;
 
-namespace { // unnamed namespace
-// These functions update properties in an AlgorithmRuntimeProps for specific
-// properties for the row reduction algorithm
+namespace {
+Mantid::Kernel::Logger g_log("RowProcessingAlgorithm");
+
+// These functions update properties in an AlgorithmRuntimeProps for
+// specific properties for the row reduction algorithm
 void updateInputWorkspacesProperties(
     AlgorithmRuntimeProps &properties,
     std::vector<std::string> const &inputRunNumbers) {
@@ -240,7 +243,12 @@ private:
 void updateEventProperties(AlgorithmRuntimeProps &properties,
                            Slicing const &slicing) {
   if (isValid(slicing))
-    boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
+    try {
+      boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
+    } catch (...) {
+      g_log.error(
+          "Error occured when updating EventProperties from Event Handling");
+    }
 }
 
 boost::optional<double> getDouble(IAlgorithm_sptr algorithm,


### PR DESCRIPTION
**Description of work.**
Handle the exception

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Workbench
- Open ISIS Reflectometry Interface
- Switch to `Event Handling` tab
- Select `Slicing by Log Value`
- Enter `1,2,3` into `python list`
- Switch back to `Runs` tab
- Instrument to INTER
- Add a Group and Row if not already present
- On the row add 13460 as the first cell and for angle 0.5
- Click Process in the bottom right
- It should not crash and should post an error has occurred into the results log.

<!-- Instructions for testing. -->

Fixes #26127 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

FIXES A BROKEN NEW FEATURE

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
