### PR TITLE
SNAPReduce accumulation fix

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -469,6 +469,8 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
         else:
             if removelogs:
                 RemoveLogs(Workspace=chunkname)  # accumulation has them already
+            RebinToWorkspace(WorkspaceToRebin=chunkname, WorkspaceToMatch=sumname,
+                             OutputWorkspace=chunkname)
             Plus(LHSWorkspace=sumname, RHSWorkspace=chunkname, OutputWorkspace=sumname,
                  ClearRHSWorkspace=self.kwargs['PreserveEvents'])
             DeleteWorkspace(Workspace=chunkname)

--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -414,7 +414,8 @@ class SNAPReduce(DataProcessorAlgorithm):
         finalUnits = self.getPropertyValue("FinalUnits")
 
         # default arguments for AlignAndFocusPowder
-        self.alignAndFocusArgs = {'TMax': 50000,
+        self.alignAndFocusArgs = {'Tmin': 0,
+                                  'TMax': 50000,
                                   'RemovePromptPulseWidth': 1600,
                                   'PreserveEvents': False,
                                   'Dspacing': True,  # binning parameters in d-space


### PR DESCRIPTION
For some runs on SNAP the data is being chunked but the binning didn't match when it came time to accumulate. This simply adds `RebinToWorkspace` to make sure they match.

**Report to:** SNAP team

**To test:**
```python
SNAPReduce(RunNumbers=41045, Binning=(.3,-.004,7), GroupDetectorsBy='All')
```

*There is no associated issue.*

*This does not require release notes* because it is a minor change to fix edge cases.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
