### PR TITLE
FunctionBrowser crash editing Convolution

### DIFF
--- a/Framework/CurveFitting/src/Functions/Convolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Convolution.cpp
@@ -446,6 +446,9 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
  * 1 for the model
  */
 size_t Convolution::addFunction(IFunction_sptr f) {
+  if (!boost::dynamic_pointer_cast<IFunction1D>(f)) {
+    throw std::runtime_error("Convolution can work only with IFunction1D");
+  }
   if (nFunctions() == 0 && getAttribute("FixResolution").asBool()) {
     for (size_t i = 0; i < f->nParams(); i++) {
       f->fix(i);

--- a/Framework/CurveFitting/src/Functions/Convolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Convolution.cpp
@@ -160,7 +160,7 @@ void Convolution::functionFFTMode(const FunctionDomain &domain,
     IFunction1D_sptr fun =
         boost::dynamic_pointer_cast<IFunction1D>(getFunction(0));
     if (!fun) {
-      throw std::runtime_error("Convolution can work only with IFunction1D");
+      throw std::runtime_error("Convolution can work only with 1D functions");
     }
     fun->function1D(m_resolution.data(), xr.data(), nData);
 
@@ -345,7 +345,7 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
   IFunction1D_sptr resolution =
       boost::dynamic_pointer_cast<IFunction1D>(getFunction(0));
   if (!resolution) {
-    throw std::runtime_error("Convolution can work only with IFunction1D");
+    throw std::runtime_error("Convolution can work only with 1D functions");
   }
   if (m_resolution.empty()) {
     m_resolution.resize(nData);

--- a/Framework/CurveFitting/src/Functions/Convolution.cpp
+++ b/Framework/CurveFitting/src/Functions/Convolution.cpp
@@ -446,8 +446,8 @@ void Convolution::functionDirectMode(const FunctionDomain &domain,
  * 1 for the model
  */
 size_t Convolution::addFunction(IFunction_sptr f) {
-  if (!boost::dynamic_pointer_cast<IFunction1D>(f)) {
-    throw std::runtime_error("Convolution can work only with IFunction1D");
+  if (boost::dynamic_pointer_cast<Convolution>(f)) {
+    throw std::runtime_error("Nested convolutions are not allowed.");
   }
   if (nFunctions() == 0 && getAttribute("FixResolution").asBool()) {
     for (size_t i = 0; i < f->nParams(); i++) {

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -664,7 +664,13 @@ double MultiDatasetFit::getLocalParameterValue(const QString &parName,
 void MultiDatasetFit::reset() {
   m_functionBrowser->setNumberOfDatasets(getNumberOfSpectra());
   setParameterNamesForPlotting();
-  m_plotController->setGuessFunction(m_functionBrowser->getFunctionString());
+  try {
+    m_plotController->setGuessFunction(m_functionBrowser->getFunctionString());
+  } catch (const std::runtime_error &e) {
+    m_plotController->setGuessFunction("");
+    m_functionBrowser->clear();
+    QMessageBox::warning(this, "Mantid - Warning", e.what());
+  }
 }
 
 /// Check if a local parameter is fixed

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -131,7 +131,7 @@ protected:
   /// Set a function
   void setFunction(QtProperty *prop, Mantid::API::IFunction_sptr fun);
   /// Add a function
-  void addFunction(QtProperty *prop, Mantid::API::IFunction_sptr fun);
+  bool addFunction(QtProperty *prop, Mantid::API::IFunction_sptr fun);
   /// Add a function property
   AProperty addFunctionProperty(QtProperty *parent, QString funName);
   /// Add a parameter property

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -132,7 +132,7 @@ void MultiDomainFunctionModel::removeFunction(const QString &functionIndex) {
                                " is not composite.");
     }
     cf->removeFunction(index);
-    if (cf->nFunctions() == 1 && prefix.isEmpty()) {
+    if (cf->nFunctions() == 1 && prefix.isEmpty() && cf->name() == "CompositeFunction") {
       m_function->replaceFunction(i, cf->getFunction(0));
     }
   }

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -132,7 +132,8 @@ void MultiDomainFunctionModel::removeFunction(const QString &functionIndex) {
                                " is not composite.");
     }
     cf->removeFunction(index);
-    if (cf->nFunctions() == 1 && prefix.isEmpty() && cf->name() == "CompositeFunction") {
+    if (cf->nFunctions() == 1 && prefix.isEmpty() &&
+        cf->name() == "CompositeFunction") {
       m_function->replaceFunction(i, cf->getFunction(0));
     }
   }

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -414,10 +414,12 @@ void FunctionTreeView::setFunction(QtProperty *prop,
 /**
  * Add a function.
  * @param prop :: Property of the parent composite function or NULL
- * @param fun :: FunctionFactory function creation string
+ * @param fun :: A function to add
  */
 bool FunctionTreeView::addFunction(QtProperty *prop,
                                    Mantid::API::IFunction_sptr fun) {
+  if (!fun)
+    return false;
   if (!prop) {
     AProperty ap =
         addFunctionProperty(nullptr, QString::fromStdString(fun->name()));

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1483,7 +1483,7 @@ void FunctionTreeView::removeFunction() {
       // which means more than two subproperties
       size_t nFunctions = props[0]->subProperties().size() - 1;
 
-      if (nFunctions == 1) {
+      if (nFunctions == 1 && cf->name() == "CompositeFunction") {
         // If only one function remains, remove the composite function:
         // Temporary copy the remaining function
         auto func = getFunction(m_browser->properties()[0]->subProperties()[1]);


### PR DESCRIPTION
**Description of work.**
Throw and catch exception to make sure the GUI is in a correct state.

**To test:**
1. Open Multi-Dataset Interface
1. Add Convolution to FunctionBrowser
1. Add another Convolution.
You should see a dialog with an error message. The second Convolution not added.

Fixes #26144

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
