### PR TITLE
Now uses MantidDesktopServices to open the link correctly

### DIFF
--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -176,6 +176,7 @@ set(MANTID_SRCS
     src/Mantid/AlgorithmMonitor.cpp
     src/Mantid/ErrorBarSettings.cpp
     src/Mantid/FirstTimeSetup.cpp
+    src/Mantid/ReportUsageDisableDialog.cpp
     src/Mantid/FitParameterTie.cpp
     src/Mantid/IFunctionWrapper.cpp
     src/Mantid/ImportWorkspaceDlg.cpp
@@ -373,6 +374,7 @@ set(MANTID_HDRS
     src/Mantid/AlgorithmMonitor.h
     src/Mantid/ErrorBarSettings.h
     src/Mantid/FirstTimeSetup.h
+    src/Mantid/ReportUsageDisableDialog.h
     src/Mantid/FitParameterTie.h
     src/Mantid/IFunctionWrapper.h
     src/Mantid/ImportWorkspaceDlg.h
@@ -602,6 +604,7 @@ set(MANTID_MOC_FILES
     src/Mantid/AlgorithmMonitor.h
     src/Mantid/ErrorBarSettings.h
     src/Mantid/FirstTimeSetup.h
+    src/Mantid/ReportUsageDisableDialog.h
     src/Mantid/IFunctionWrapper.h
     src/Mantid/ImportWorkspaceDlg.h
     src/Mantid/LabelToolLogValuesDialog.h

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -10,11 +10,14 @@
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/ManageUserDirectories.h"
 #include "MantidQtWidgets/Common/MantidDesktopServices.h"
+#include "ReportUsageDisableDialog.h"
 
+#include <QDialog>
 #include <QMessageBox>
 #include <QPainter>
 #include <QSettings>
 #include <QUrl>
+#include <iostream>
 
 using MantidQt::API::MantidDesktopServices;
 
@@ -51,6 +54,9 @@ void FirstTimeSetup::initLayout() {
           SLOT(openPythonInMantid()));
   connect(m_uiForm.clbExtendingMantid, SIGNAL(clicked()), this,
           SLOT(openExtendingMantid()));
+
+  connect(m_uiForm.lblPrivacyPolicy, SIGNAL(linkActivated(const QString &)),
+          this, SLOT(openExternalLink(const QString &)));
 
   // set first use
   QSettings settings;
@@ -140,29 +146,9 @@ void FirstTimeSetup::cancel() {
 
 void FirstTimeSetup::allowUsageDataStateChanged(int checkedState) {
   if (checkedState == Qt::Unchecked) {
-    QMessageBox msgBox(this);
-    msgBox.setWindowTitle("Mantid: Report Usage Data ");
-    msgBox.setTextFormat(Qt::RichText); // this is what makes the links
-                                        // clickable
-    msgBox.setText("Are you sure you want to disable reporting of <a "
-                   "href='http://reports.mantidproject.org'>usage data</a>?"
-                   "\t(full details in our <a "
-                   "href='http://www.mantidproject.org/"
-                   "MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid'"
-                   ">Privacy Policy</a>)");
-    msgBox.setInformativeText(
-        "All usage data is anonymous and untraceable.\n"
-        "We use the usage data to inform the future development of Mantid.\n"
-        "If you click \"Yes\" aspects you need risk being deprecated in "
-        "future versions if we think they are not used.\n\n"
-        "Are you sure you still want to disable reporting usage data?\n"
-        "Please click \"No\".");
-    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-    msgBox.setDefaultButton(QMessageBox::No);
-    msgBox.setEscapeButton(QMessageBox::No);
-    msgBox.setIcon(QMessageBox::Question);
+    auto widget = new ReportUsageDisableDialog(this);
 
-    int ret = msgBox.exec();
+    int ret = widget->exec();
     if ((ret == QMessageBox::No) || (ret == QMessageBox::NoButton)) {
       // No was clicked, or no button was clicked
       // set the checkbox back to checked
@@ -207,4 +193,7 @@ void FirstTimeSetup::openPythonInMantid() {
 void FirstTimeSetup::openExtendingMantid() {
   MantidDesktopServices::openUrl(
       QUrl("http://www.mantidproject.org/Extending_Mantid_With_Python"));
+}
+void FirstTimeSetup::openExternalLink(const QString &link) {
+  MantidDesktopServices::openUrl(link);
 }

--- a/MantidPlot/src/Mantid/FirstTimeSetup.cpp
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.cpp
@@ -17,7 +17,6 @@
 #include <QPainter>
 #include <QSettings>
 #include <QUrl>
-#include <iostream>
 
 using MantidQt::API::MantidDesktopServices;
 

--- a/MantidPlot/src/Mantid/FirstTimeSetup.h
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.h
@@ -25,6 +25,9 @@ public:
 private:
   void initLayout();
 
+public slots:
+  void openExternalLink(const QString &);
+
 private slots:
   void confirm();
   void cancel();

--- a/MantidPlot/src/Mantid/FirstTimeSetup.ui
+++ b/MantidPlot/src/Mantid/FirstTimeSetup.ui
@@ -634,13 +634,13 @@ background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0, stop:0 rgb
                 <item>
                  <widget class="QLabel" name="lblPrivacyPolicy">
                   <property name="text">
-                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.mantidproject.org/MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Privacy Policy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                   <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.mantidproject.org/MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Privacy Policy&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                   </property>
                   <property name="textFormat">
                    <enum>Qt::RichText</enum>
                   </property>
                   <property name="openExternalLinks">
-                   <bool>true</bool>
+                   <bool>false</bool>
                   </property>
                  </widget>
                 </item>

--- a/MantidPlot/src/Mantid/ReportUsageDisableDialog.cpp
+++ b/MantidPlot/src/Mantid/ReportUsageDisableDialog.cpp
@@ -1,0 +1,88 @@
+#include "ReportUsageDisableDialog.h"
+#include "FirstTimeSetup.h"
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPushButton>
+#include <QSpacerItem>
+#include <QStyle>
+#include <QVBoxLayout>
+
+ReportUsageDisableDialog::ReportUsageDisableDialog(FirstTimeSetup *parent)
+    : QDialog(parent) {
+  auto parentLayout = new QHBoxLayout(this);
+  this->setLayout(parentLayout);
+
+  this->addLeftSide(parentLayout);
+  this->addRightSide(parentLayout, parent);
+}
+
+void ReportUsageDisableDialog::addLeftSide(QHBoxLayout *parentLayout) {
+  auto iconLayout = new QVBoxLayout();
+  auto style = this->style();
+  auto icon = style->standardIcon(QStyle::SP_MessageBoxQuestion);
+
+  auto labelButActuallyAnIcon = new QLabel(this);
+  labelButActuallyAnIcon->setPixmap(icon.pixmap(32, 32));
+  iconLayout->addWidget(labelButActuallyAnIcon);
+
+  auto vspacer =
+      new QSpacerItem(1, 1, QSizePolicy::Minimum, QSizePolicy::Expanding);
+  iconLayout->addSpacerItem(vspacer);
+
+  parentLayout->addLayout(iconLayout);
+}
+
+void ReportUsageDisableDialog::addRightSide(QHBoxLayout *parentLayout,
+                                            FirstTimeSetup *parent) {
+  auto textLayout = new QVBoxLayout();
+  this->setWindowTitle("Mantid: Report Usage Data ");
+
+  auto label = new QLabel(this);
+  label->setTextFormat(Qt::RichText);
+  label->setText("Are you sure you want to disable reporting of <a "
+                 "href='https://reports.mantidproject.org'>usage data</a>?"
+                 "\t(full details in our <a "
+                 "href='https://www.mantidproject.org/"
+                 "MantidProject:Privacy_policy#Usage_Data_recorded_in_Mantid'"
+                 ">Privacy Policy</a>)");
+  label->setOpenExternalLinks(false);
+  connect(label, SIGNAL(linkActivated(const QString &)), parent,
+          SLOT(openExternalLink(const QString &)));
+  textLayout->addWidget(label);
+
+  auto labelInformation = new QLabel(this);
+  labelInformation->setText(
+      "All usage data is anonymous and untraceable.\n"
+      "We use the usage data to inform the future development of Mantid.\n"
+      "If you click \"Yes\" aspects you need risk being deprecated in "
+      "future versions if we think they are not used.\n\n"
+      "Are you sure you still want to disable reporting usage data?\n"
+      "Please click \"No\".");
+  textLayout->addWidget(labelInformation);
+
+  auto buttonLayout = new QHBoxLayout();
+  {
+
+    auto leftSpacer =
+        new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Minimum);
+    buttonLayout->addSpacerItem(leftSpacer);
+
+    auto noBtn = new QPushButton("No", this);
+    buttonLayout->addWidget(noBtn);
+    connect(noBtn, SIGNAL(clicked()), this, SLOT(reject()));
+  }
+
+  {
+    auto yesBtn = new QPushButton("Yes", this);
+    connect(yesBtn, SIGNAL(clicked()), this, SLOT(accept()));
+
+    buttonLayout->addWidget(yesBtn);
+
+    auto rightSpacer =
+        new QSpacerItem(1, 1, QSizePolicy::Expanding, QSizePolicy::Minimum);
+    buttonLayout->addSpacerItem(rightSpacer);
+  }
+  textLayout->addLayout(buttonLayout);
+
+  parentLayout->addLayout(textLayout);
+}

--- a/MantidPlot/src/Mantid/ReportUsageDisableDialog.h
+++ b/MantidPlot/src/Mantid/ReportUsageDisableDialog.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDPLOT_REPORT_USAGE_DISABLE_DIALOG
+#define MANTIDPLOT_REPORT_USAGE_DISABLE_DIALOG
+
+#include <QDialog>
+
+class FirstTimeSetup;
+class QHBoxLayout;
+
+class ReportUsageDisableDialog : public QDialog {
+  Q_OBJECT
+
+public:
+  explicit ReportUsageDisableDialog(FirstTimeSetup *parent = nullptr);
+
+private:
+  /// Adds the left side of the dialog layout into the parameter layout
+  void addLeftSide(QHBoxLayout *parentLayout);
+
+  /// Adds the right side of the dialog layout into the parameter layout
+  void addRightSide(QHBoxLayout *parentLayout, FirstTimeSetup *parent);
+};
+
+#endif // MANTIDPLOT_REPORT_USAGE_DISABLE_DIALOG


### PR DESCRIPTION
**Description of work.**

The dialog shown when there is an attempt to disable "Report usage data" is now a new class - `ReportUsageDisableDialog`. It should behave exactly the same, and look nearly the same.

**To test:**
#### Ubuntu
- Have Firefox as default web browser
- Open MantidPlot, wait for the "First time usage" window.
- Click "Privacy Policy", it should open in Firefox.
- Try to disable `Report usage data` (if already disabled, then enable and disable again)
- Consider if the dialog makes you want to press "No"
- If even then you pressed "Yes" the checkbox should be disabled
- Otherwise, pressing no should keep the checkbox enabled
- Pressing `Escape`, with the dialog focussed, should behave like pressing "No"

-----------

#### Windows
- Make sure "Privacy Policy" still works as before

Fixes #26128

Tagging @hsautessella for testing on Windows and how the dialog looks on 4K, and @Pasarus for Ubuntu

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
