### PR TITLE
Reflectometry GUI (Old): Push back deprecation date

### DIFF
--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -12,6 +12,11 @@ Reflectometry Changes
 ISIS Reflectometry Interface
 ----------------------------
 
+Changes
+#######
+
+- Pushed back deprecation of ISIS Reflectometry (Old) GUI to November 2019 from July 2019.
+
 New
 ###
 

--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -52,7 +52,7 @@ class ReflGui(QtGui.QMainWindow, Ui_windowRefl):
 
     def show_deprecation_warning(self):
         logger.warning("""
-The ISIS Reflectometry (Old) interface has been deprecated and will be removed from Mantid in July 2019
+The ISIS Reflectometry (Old) interface has been deprecated and will be removed from Mantid in November 2019
 We recommend you use ISIS Reflectometry instead, If this is not possible contact the development team using the "Help->Ask For Help" menu.
 """)
 


### PR DESCRIPTION
**Description of work.**
Push back deprecation date of the Reflectometry GUI Old to November 2019

**To test:**
- Open MantidPlot
- Open Reflectometry->ISISReflectometry (Old)
- Should see a deprecation notice in the results log stating November 2019
<!-- Instructions for testing. -->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
