### PR TITLE
Fix save to workspace in instrument view

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -163,7 +163,10 @@ public:
   double getIntegratedCounts(size_t index) const;
   /// Sum the counts in detectors
   void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x,
-                    std::vector<double> &y, size_t size = 0) const;
+                    std::vector<double> &y, size_t size) const;
+  /// Sum the counts in detectors.
+  void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x,
+                    std::vector<double> &y) const;
   /// Calc indexes for min and max bin values
   void getBinMinMaxIndex(size_t wi, size_t &imin, size_t &imax) const;
 

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -452,7 +452,7 @@ double InstrumentActor::getIntegratedCounts(size_t index) const {
  * @param x :: (output) Time of flight values (or whatever values the x axis
  * has) to plot against.
  * @param y :: (output) The sums of the counts for each bin.
- * @param size :: (optional input) Size of the output vectors. If not given it
+ * @param size :: Size of the output vectors. If not given it
  * will be determined automatically.
  */
 void InstrumentActor::sumDetectors(const std::vector<size_t> &dets,
@@ -478,6 +478,16 @@ void InstrumentActor::sumDetectors(const std::vector<size_t> &dets,
     // should be faster than ragged
     sumDetectorsUniform(dets, x, y);
   }
+}
+
+/**
+ * @overload InstrumentActor::sumDetectors(const std::vector<size_t> &dets,
+ * std::vector<double> &x, std::vector<double> &y, size_t size = 0)
+ */
+void InstrumentActor::sumDetectors(const std::vector<size_t> &dets,
+                                   std::vector<double> &x,
+                                   std::vector<double> &y) const {
+  sumDetectors(dets, x, y, getWorkspace()->blocksize());
 }
 
 /**

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1579,19 +1579,19 @@ void DetectorPlotController::savePlotToWorkspace() {
                              "curve will be saved.");
       }
     } else if (parts.size() == 3) {
-      int detid = parts[1].toInt();
+      const auto detindex = actor.getDetectorByDetID(parts[1].toInt());
       QString SumOrIntegral = parts[2].trimmed();
       if (SumOrIntegral == "Sum") {
-        prepareDataForSumsPlot(detid, x, y, &e);
+        prepareDataForSumsPlot(detindex, x, y, &e);
         unitX = parentWorkspace->getAxis(0)->unit()->unitID();
       } else {
-        prepareDataForIntegralsPlot(detid, x, y, &e);
+        prepareDataForIntegralsPlot(detindex, x, y, &e);
         unitX = SumOrIntegral.split('/')[1].toStdString();
       }
     } else if (parts.size() == 1) {
       // second word is detector id
-      int detid = parts[0].split(QRegExp("\\s+"))[1].toInt();
-      prepareDataForSinglePlot(detid, x, y, &e);
+      const auto detid = parts[0].split(QRegExp("\\s+"))[1].toInt();
+      prepareDataForSinglePlot(actor.getDetectorByDetID(detid), x, y, &e);
       unitX = parentWorkspace->getAxis(0)->unit()->unitID();
       // save det ids for the output workspace
       detids.push_back(static_cast<Mantid::detid_t>(detid));


### PR DESCRIPTION
**Description of work.**

Fixes a bug reported by a user where the "Save to Workspace" functionality in both the miniplot and 3d view on the instrument view pick tab had stopped working. On workbench the latter caused a crash.

**Report to:** Pascal. ISIS.

**To test:**

1. Follow the instructions in the associated issue and see that a workspace now appears when requesting one from the miniplot.
2. To test that the plot works from the main 3D view then run the instrument view in workbench, and right click on a detector in the 3D view of the pick tab and click "save to workspace".

Fixes #26136 

*This does not require release notes* because **it was broken in this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
