### PR TITLE
Reflectometry GUI: Hide Load Batch 

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -54,6 +54,10 @@ Initialise the Interface
 */
 void MainWindowView::initLayout() {
   m_ui.setupUi(this);
+  // Until this is implemented we should hide this action
+  m_ui.loadBatch->setEnabled(false);
+  m_ui.loadBatch->setVisible(false);
+
   connect(m_ui.helpButton, SIGNAL(clicked()), this, SLOT(helpPressed()));
   connect(m_ui.mainTabs, SIGNAL(tabCloseRequested(int)), this,
           SLOT(onTabCloseRequested(int)));


### PR DESCRIPTION
**Description of work.**
Load Batch is not yet implemented so this button needs to be hidden

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open MantidPlot/Workbench
- Open Reflectometry->ISIS Reflectometry
- Click Batch in the top left
- It should only display new and not contain a Load option

<!-- Instructions for testing. -->

Re #26025<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
CHANGE TO UNRELEASED FEATURE

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
