### PR TITLE
Reflectometry GUI: Ensure there is always a batch present

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -44,7 +44,7 @@ void MainWindowView::removeBatch(int batchIndex) {
   m_batchViews.erase(m_batchViews.begin() + batchIndex);
   m_ui.mainTabs->removeTab(batchIndex);
   if (m_ui.mainTabs->count() == 0) {
-    newBatch();
+    m_notifyee->notifyNewBatchRequested();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowView.cpp
@@ -43,6 +43,9 @@ IBatchView *MainWindowView::newBatch() {
 void MainWindowView::removeBatch(int batchIndex) {
   m_batchViews.erase(m_batchViews.begin() + batchIndex);
   m_ui.mainTabs->removeTab(batchIndex);
+  if (m_ui.mainTabs->count() == 0) {
+    newBatch();
+  }
 }
 
 std::vector<IBatchView *> MainWindowView::batches() const {


### PR DESCRIPTION
**Description of work.**
There should always be 1 open batch in the reflectometry GUI

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open MantidPlot/Workbench
- Open Interfaces->Reflectometry->ISIS Reflectometry
- Add a new batch tab
- Remove both current tabs
- There should be a new tab

<!-- Instructions for testing. -->

Re #26025  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
Fixes a unreleased feature

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
