### PR TITLE
No longer tries to plot TableWorkspaces/PeaksWS

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -182,7 +182,13 @@ class WorkspaceWidget(PluginWidget):
                     logger.warning("{}: {}".format(type(exception).__name__, exception))
 
     def _action_double_click_workspace(self, name):
-        plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+        try:
+            # if this is a table workspace (or peaks workspace),
+            # then it can't be plotted automatically, so the data is shown instead
+            TableWorkspaceDisplay.supports(self._ads.retrieve(name))
+            self._do_show_data([name])
+        except ValueError:
+            plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
 
     def refresh_workspaces(self):
         self.workspacewidget.refreshWorkspaces()


### PR DESCRIPTION
**Description of work.**

Checks if the workspace is supported by TableWorkspace.supports() - this should handle Table and Peaks workspaces, and does "Show Data" if that is the case.

If the workspace is not supported then it is something we can plot, e.g. MatrixWorkspace.

**To test:**
- Load a bunch of different types of workspaces
  - I dragged all the workspaces from SampleData-ISIS into the workspace widget to load them all
- Table/Peaks workspaces should be open with "show data"
- Matrix workspaces should open the plot dialog

Fixes #26170
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
