### PR TITLE
MantidQtIcons: Icons display as gray when disabled.

### DIFF
--- a/qt/icons/src/CharIconPainter.cpp
+++ b/qt/icons/src/CharIconPainter.cpp
@@ -13,8 +13,8 @@ namespace MantidQt {
 namespace Icons {
 
 namespace {
-const QString defaultColor("black");
-const QString defaultDeactivatedColor("#c7c7c7");
+const QString DEFAULT_COLOR("black");
+const QString DEFAULT_DEACTIVATED_COLOR("#c7c7c7");
 } // namespace
 
 void CharIconPainter::paint(IconicFont *iconic, QPainter *painter, QRect rect,
@@ -46,10 +46,10 @@ void CharIconPainter::paintIcon(IconicFont *iconic, QPainter *painter,
       iconic->findCharacterFromCharMap(prefix, charecterOption);
 
   // Set some defaults so it doesn't fail later if nothing was set
-  QString color(defaultColor);
+  QString color(DEFAULT_COLOR);
   double scaleFactor(1.0);
   if (mode == QIcon::Mode::Disabled) {
-    color = defaultDeactivatedColor; // gray
+    color = DEFAULT_DEACTIVATED_COLOR; // gray
   } else if (colorVariant.canConvert<QString>()) {
     color = colorVariant.toString();
   }

--- a/qt/icons/src/CharIconPainter.cpp
+++ b/qt/icons/src/CharIconPainter.cpp
@@ -28,8 +28,8 @@ void CharIconPainter::paintIcon(IconicFont *iconic, QPainter *painter,
   // down this far. This is because they can be used for defining variable
   // changes based on state of the buttons/QObject that the Icon is present in.
   // Since we currently don't use this feature availible with QIcon they have
-  // not yet been implemented.
-  UNUSED_ARG(mode);
+  // not yet been implemented. Mode has now been implemented however it will
+  // only ever be gray in it's current mode when disabled.
   UNUSED_ARG(state);
 
   painter->save();
@@ -43,7 +43,9 @@ void CharIconPainter::paintIcon(IconicFont *iconic, QPainter *painter,
   // Set some defaults so it doesn't fail later if nothing was set
   QString color("black");
   double scaleFactor(1.0);
-  if (colorVariant.canConvert<QString>()) {
+  if (mode == QIcon::Mode::Disabled) {
+    color = "#c7c7c7"; // gray
+  } else if (colorVariant.canConvert<QString>()) {
     color = colorVariant.toString();
   }
   if (scaleVariant.canConvert<double>()) {

--- a/qt/icons/src/CharIconPainter.cpp
+++ b/qt/icons/src/CharIconPainter.cpp
@@ -12,6 +12,11 @@
 namespace MantidQt {
 namespace Icons {
 
+namespace {
+const QString defaultColor("black");
+const QString defaultDeactivatedColor("#c7c7c7");
+} // namespace
+
 void CharIconPainter::paint(IconicFont *iconic, QPainter *painter, QRect rect,
                             QIcon::Mode mode, QIcon::State state,
                             QList<QHash<QString, QVariant>> &options) {
@@ -41,10 +46,10 @@ void CharIconPainter::paintIcon(IconicFont *iconic, QPainter *painter,
       iconic->findCharacterFromCharMap(prefix, charecterOption);
 
   // Set some defaults so it doesn't fail later if nothing was set
-  QString color("black");
+  QString color(defaultColor);
   double scaleFactor(1.0);
   if (mode == QIcon::Mode::Disabled) {
-    color = "#c7c7c7"; // gray
+    color = defaultDeactivatedColor; // gray
   } else if (colorVariant.canConvert<QString>()) {
     color = colorVariant.toString();
   }


### PR DESCRIPTION
**Description of work.**
Currently in workbench and any GUI from C++ or Python that uses the MantidQtIcons library doesn't have icons that look disabled when they are part of a button which is disabled. This fixes it by making them a specific shade of gray.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open MantidPlot and do the same for Mantid Workbench
- Open Interfaces->Reflectometry->ISIS Reflectometry
- Change instrument to INTER
- Add search id 1120015
- Click AutoProcess and sign in to ICat
- Given a successful sign in a large proportion of the buttons should show the Icon being disabled.

- Open Mantid Workbench and look for icons that go grey when they are parts of buttons which are disabled. 

<!-- Instructions for testing. -->

Re #26025 
*There is no associated issue.*
-->

This is an improvement to a feature already in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
