### PR TITLE
Indirect Fix Corrections Crashes

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -84,6 +84,8 @@ Bug Fixes
 #########
 - Fixed a bug where the output plots on the Calculate Paalman Pings and Calculate Monte Carlo Absorption tabs had
   the wrong axis labels and units.
+- Fixed a bug where Calculate Paalman Pings would crash if an EFixed value had not been provided.
+- Fixed a bug where Apply Aborption Corrections would crash when provided an invalid corrections workspace.
 
 
 Data Reduction Interface

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -9,6 +9,9 @@
 
 #include "CorrectionsTab.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidAPI/WorkspaceGroup_fwd.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
 #include "ui_ApplyAbsorptionCorrections.h"
 
 namespace MantidQt {
@@ -44,12 +47,16 @@ private:
   void setup() override;
   void run() override;
   bool validate() override;
+  void validateCorrections(UserInputValidator &uiv) const;
+  void validateCorrections(UserInputValidator &uiv,
+                           std::string const &name) const;
+  void validateCorrections(
+      UserInputValidator &uiv,
+      Mantid::API::WorkspaceGroup_sptr correctionsWorkspace) const;
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
 
   std::size_t getOutWsNumberOfSpectra() const;
-  Mantid::API::MatrixWorkspace_const_sptr
-  getADSWorkspace(std::string const &name) const;
 
   void addInterpolationStep(Mantid::API::MatrixWorkspace_sptr toInterpolate,
                             std::string toMatch);

--- a/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
@@ -121,8 +121,7 @@ boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(
     try {
       eFixed = getEFixed(ws);
     } catch (std::exception const &) {
-      showMessageBox(
-          "An Efixed value could not be found, please enter an Efixed value.");
+      showMessageBox("Please enter an Efixed value.");
       return boost::none;
     }
   }

--- a/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
+++ b/qt/scientific_interfaces/Indirect/CorrectionsTab.cpp
@@ -94,10 +94,9 @@ bool CorrectionsTab::checkWorkspaceBinningMatches(
  * @param eMode Emode to use (if not set will determine based on current X unit)
  * @return Name of output workspace
  */
-std::string CorrectionsTab::addConvertUnitsStep(MatrixWorkspace_sptr ws,
-                                                const std::string &unitID,
-                                                const std::string &suffix,
-                                                std::string eMode) {
+boost::optional<std::string> CorrectionsTab::addConvertUnitsStep(
+    MatrixWorkspace_sptr ws, std::string const &unitID,
+    std::string const &suffix, std::string eMode, double eFixed) {
   std::string outputName = ws->getName();
 
   if (suffix != "UNIT")
@@ -118,8 +117,18 @@ std::string CorrectionsTab::addConvertUnitsStep(MatrixWorkspace_sptr ws,
 
   convertAlg->setProperty("EMode", eMode);
 
+  if (eMode == "Indirect" && eFixed == 0.0) {
+    try {
+      eFixed = getEFixed(ws);
+    } catch (std::exception const &) {
+      showMessageBox(
+          "An Efixed value could not be found, please enter an Efixed value.");
+      return boost::none;
+    }
+  }
+
   if (eMode == "Indirect")
-    convertAlg->setProperty("EFixed", getEFixed(ws));
+    convertAlg->setProperty("EFixed", eFixed);
 
   m_batchAlgoRunner->addAlgorithm(convertAlg);
 

--- a/qt/scientific_interfaces/Indirect/CorrectionsTab.h
+++ b/qt/scientific_interfaces/Indirect/CorrectionsTab.h
@@ -81,10 +81,11 @@ protected:
   checkWorkspaceBinningMatches(Mantid::API::MatrixWorkspace_const_sptr left,
                                Mantid::API::MatrixWorkspace_const_sptr right);
   /// Adds a unit conversion step to the algorithm queue
-  std::string addConvertUnitsStep(Mantid::API::MatrixWorkspace_sptr ws,
-                                  const std::string &unitID,
-                                  const std::string &suffix = "UNIT",
-                                  std::string eMode = "");
+  boost::optional<std::string>
+  addConvertUnitsStep(Mantid::API::MatrixWorkspace_sptr ws,
+                      const std::string &unitID,
+                      const std::string &suffix = "UNIT",
+                      std::string eMode = "", double eFixed = 0.0);
   /// Displays and logs the error for a workspace with an invalid type
   void displayInvalidWorkspaceTypeError(const std::string &workspaceName,
                                         Mantid::Kernel::Logger &log);

--- a/qt/scientific_interfaces/Indirect/Elwin.cpp
+++ b/qt/scientific_interfaces/Indirect/Elwin.cpp
@@ -572,8 +572,11 @@ void Elwin::updateIntegrationRange() {
 }
 
 void Elwin::twoRanges(QtProperty *prop, bool val) {
-  if (prop == m_properties["BackgroundSubtraction"])
+  if (prop == m_properties["BackgroundSubtraction"]) {
     m_uiForm.ppPlot->getRangeSelector("ElwinBackgroundRange")->setVisible(val);
+    m_properties["BackgroundStart"]->setEnabled(val);
+    m_properties["BackgroundEnd"]->setEnabled(val);
+  }
 }
 
 void Elwin::minChanged(double val) {


### PR DESCRIPTION
**Description of work.**
This PR fixes two bugs (to save some time):
- A crash on CalculatePaalmanPings when Efixed cannot be found for an instrument.
- A crash when attempting to use an incorrect Corrections workspace on ApplyAbsorptionCorrections.

**To test:**
1.`Interfaces`->`Indirect`->`Data Corrections`->`CalculatePaalmanPings`
See instructions in #26183 
A message should appear asking the user to enter an Efixed value.

1.`Interfaces`->`Indirect`->`Data Corrections`->`ApplyAbsorptionCorrections`
See instructions in #26157 
A message should appear asking the user to enter a group workspace.

Fixes #26183  , #26157 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
