### PR TITLE
Indirect Remove Plot Raw from ISIS Calibration

### DIFF
--- a/docs/source/interfaces/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/Indirect Data Reduction.rst
@@ -73,7 +73,7 @@ units of :math:`\Delta E`. See the algorithm :ref:`ISISIndirectEnergyTransfer <a
 ISIS Energy Transfer Options
 ############################
 
-Run Files
+Input Runs
   Allows you to select the raw data files for an experiment. You can enter these
   either by clicking on the Browse button and selecting them, or entering the run
   numbers. Multiple files can be selected, multiple run numbers can be separated
@@ -162,7 +162,7 @@ The ISIS Energy Transfer tab operates on raw TOF data files. Before starting thi
 1. Set the **Instrument** to be OSIRIS, the **Analyser** to be graphite and the **Reflection** to
    be 002.
 
-2. In **Run Files**, enter the run numbers 104371-104375 and press enter.
+2. In **Input Runs**, enter the run numbers 104371-104375 and press enter.
 
 3. Change the **Spectra Min** and **Spectra Max** if you want to avoid some of the detectors. For
    the purposes of this demonstration, keep them at their default values.
@@ -362,7 +362,7 @@ The calibration file is normalised to an average of 1.
 ISIS Calibration Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Run No
+Input Runs
   This allows you to select a run for the function to use, either by selecting the
   *.raw* file with the Browse button or through entering the number in the box.
 
@@ -444,7 +444,7 @@ The ISIS Calibration tab operates on raw TOF data files. Before starting this wo
 1. Set the **Instrument** to be IRIS, the **Analyser** to be graphite and the **Reflection** to
    be 002.
 
-2. In **Run Files**, enter the run number 26176 and press enter.
+2. In **Input Runs**, enter the run number 26176 and press enter.
 
 3. Tick **Create RES File**. This will create a workspace ending in _res.
 
@@ -472,7 +472,7 @@ MODES. It is only available when the default facility is set to ISIS.
 ISIS Diagnostics Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Input Files
+Input Runs
   This allows you to select a run for the function to use, either by selecting the
   *.raw* file with the Browse button or through entering the number in the box.
   Multiple files can be selected, in the same manner as described for the Energy
@@ -524,7 +524,7 @@ The ISIS Diagnostics tab operates on raw TOF data files. Before starting this wo
 1. Set the **Instrument** to be IRIS, the **Analyser** to be graphite and the **Reflection** to
    be 002.
 
-2. In **Run Files**, enter the run number 26176 and press enter.
+2. In **Input Runs**, enter the run number 26176 and press enter.
 
 3. Tick **Use Calibration** and load the file named ``irs26173_graphite002_calib``.
 
@@ -559,10 +559,10 @@ Transmission Options
 ~~~~~~~~~~~~~~~~~~~~
 
 Sample
-  Allows the selection of a raw file or workspace to be used as the sample.
+  Allows the selection of a raw file to be used as the sample.
 
 Background
-  Allows the selection of a raw file or workspace to be used as the background.
+  Allows the selection of a raw file to be used as the background.
 
 Run
   Runs the processing configured on the current tab.

--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -93,6 +93,7 @@ Improvements
 ############
 - Added an option called *Group Output* to group the output files from a reduction on ISISEnergyTransfer.
 - Improved ISISEnergyTransfer by automatically loading the Detailed Balance from the sample logs if available.
+- Removed the obsolete *Plot Raw* button.
 
 Bug Fixes
 #########
@@ -125,3 +126,12 @@ New Features
 
 - The *Settings* GUI allows you to turn off the restriction of input data based on their name.
 - The *Settings* GUI allows you to turn on error bars for the output plots.
+
+
+Simulations Interface
+---------------------
+
+Bug Fixes
+#########
+- Fixed a crash in MolDyn caused by plotting output data.
+

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -151,8 +151,6 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
           SLOT(calUpdateRS(QtProperty *, double)));
   // Plot miniplots after a file has loaded
   connect(m_uiForm.leRunNo, SIGNAL(filesFound()), this, SLOT(calPlotRaw()));
-  // Plot miniplots when the user clicks Plot Raw
-  connect(m_uiForm.pbPlotRaw, SIGNAL(clicked()), this, SLOT(calPlotRaw()));
   // Toggle RES file options when user toggles Create RES File checkbox
   connect(m_uiForm.ckCreateResolution, SIGNAL(toggled(bool)), this,
           SLOT(resCheck(bool)));
@@ -412,7 +410,7 @@ void ISISCalibration::calPlotRaw() {
   QString filename = m_uiForm.leRunNo->getFirstFilename();
 
   // Don't do anything if the file we would plot has not changed
-  if (filename == m_lastCalPlotFilename)
+  if (filename.isEmpty() || filename == m_lastCalPlotFilename)
     return;
 
   m_lastCalPlotFilename = filename;

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -53,16 +53,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="pbPlotRaw">
-          <property name="toolTip">
-           <string>Plot first detector spectra</string>
-          </property>
-          <property name="text">
-           <string>Plot Raw</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="ckSumFiles">
           <property name="text">
            <string>Sum Files</string>

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -37,7 +37,7 @@
            </sizepolicy>
           </property>
           <property name="label" stdset="0">
-           <string>Run No</string>
+           <string>Input Runs</string>
           </property>
           <property name="multipleFiles" stdset="0">
            <bool>true</bool>

--- a/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
+++ b/qt/scientific_interfaces/Indirect/ISISDiagnostics.ui
@@ -40,7 +40,7 @@
            <bool>true</bool>
           </property>
           <property name="label" stdset="0">
-           <string>Input Files</string>
+           <string>Input Runs</string>
           </property>
           <property name="multipleFiles" stdset="0">
            <bool>true</bool>
@@ -258,15 +258,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>MantidQt::MantidWidgets::DataSelector</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Common/DataSelector.h</header>
+  </customwidget>
+  <customwidget>
    <class>MantidQt::API::MWRunFiles</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/MWRunFiles.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::DataSelector</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/DataSelector.h</header>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::PreviewPlot</class>

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.ui
@@ -80,7 +80,7 @@
          </sizepolicy>
         </property>
         <property name="label" stdset="0">
-         <string>Run Files</string>
+         <string>Input Runs</string>
         </property>
         <property name="multipleFiles" stdset="0">
          <bool>true</bool>
@@ -246,7 +246,7 @@
          <number>0</number>
         </property>
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="pgMapFile">
          <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -1124,6 +1124,7 @@
    <class>MantidQt::API::MWRunFiles</class>
    <extends>QWidget</extends>
    <header>MantidQtWidgets/Common/MWRunFiles.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmission.cpp
@@ -39,6 +39,9 @@ IndirectTransmission::IndirectTransmission(IndirectDataReduction *idrUI,
           this,
           SLOT(updateRunButton(bool, std::string const &, QString const &,
                                QString const &)));
+
+  m_uiForm.dsSampleInput->setTypeSelectorVisible(false);
+  m_uiForm.dsCanInput->setTypeSelectorVisible(false);
 }
 
 //----------------------------------------------------------------------------------------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -86,6 +86,8 @@ public:
   QString getCurrentDataName() const;
   /// Sets which selector (file or workspace) is visible
   void setSelectorIndex(int index);
+  /// Sets if the option to choose selector is visible
+  void setTypeSelectorVisible(bool visible);
   /// Set the index of the combobox containing the loaded workspace
   void setWorkspaceSelectorIndex(QString const &workspaceName);
   /// Get whether the file selector is currently being shown

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -132,6 +132,13 @@ void DataSelector::setSelectorIndex(int index) {
 }
 
 /**
+ * Sets whether the file or workspace type selector is visible
+ */
+void DataSelector::setTypeSelectorVisible(bool visible) {
+  m_uiForm.cbInputType->setVisible(visible);
+}
+
+/**
  * Get if the file selector is currently being shown.
  *
  * @return :: true if it is visible, otherwise false


### PR DESCRIPTION
**Description of work.**
This PR fixes two bugs:
- It removes the unhelpful `Plot Raw` button from `ISIS Calibration`. This in turn prevents a previously seen error message.
- Fixes a crash on Indirect Simulations MolDyn.

**To test:**
1.`Interfaces`->`Indirect`->`Data Reduction`->`ISIS Calibration`
Make sure there is no `Plot Raw` button next to the `Input Runs` box.

2.`Interfaces`->`Indirect`->`Simulations`->`MolDyn`
See the instructions in issue #26164 

Fixes #26164  , #26149

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
