### PR TITLE
Results  table fix for muon analysis 1

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -28,4 +28,5 @@ Bug Fixes
 #########
 
 * Muon Analysis (original) no longer crashes when `TF Asymmetry` mode is activated.
+* Muon Analysis (original) can now produce results tables when columns contain both ranges and single values.
 * Frequency Domain Analysis GUI added to workbench.

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -496,24 +496,27 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
 
     // Write log values in each column
     for (int i = 0; i < m_logs.size(); ++i) {
-      Mantid::API::Column_sptr col = table->getColumn(i);
+      // need to add one to the column number
+      // as the first (0th) one is done elsewhere
+      Mantid::API::Column_sptr col = table->getColumn(i+1);
+      auto col_type = col->type();
+  
       const auto &log = m_logs[i];
       const QVariant &val = logValues[log];
+
       QString valueToWrite;
       // Special case: if log is time in sec, subtract the first start time
       if (log.endsWith(" (s)")) {
         auto seconds =
             val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
         valueToWrite = QString::number(seconds);
-      } else if (MuonAnalysisHelper::isNumber(val.toString()) &&
-                 !log.endsWith(" (text)")) {
+      } else if (col_type =="double") {
         valueToWrite = QString::number(val.toDouble());
       } else {
         valueToWrite = val.toString();
       }
 
-      if (MuonAnalysisHelper::isNumber(val.toString()) &&
-          !log.endsWith(" (text)")) {
+      if (col_type == "double") {
         row << valueToWrite.toDouble();
       } else {
         row << valueToWrite.toStdString();

--- a/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisResultTableCreator.cpp
@@ -498,9 +498,9 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
     for (int i = 0; i < m_logs.size(); ++i) {
       // need to add one to the column number
       // as the first (0th) one is done elsewhere
-      Mantid::API::Column_sptr col = table->getColumn(i+1);
+      Mantid::API::Column_sptr col = table->getColumn(i + 1);
       auto col_type = col->type();
-  
+
       const auto &log = m_logs[i];
       const QVariant &val = logValues[log];
 
@@ -510,7 +510,7 @@ void MuonAnalysisResultTableCreator::writeDataForSingleFit(
         auto seconds =
             val.toDouble() - static_cast<double>(m_firstStart_ns) * 1.e-9;
         valueToWrite = QString::number(seconds);
-      } else if (col_type =="double") {
+      } else if (col_type == "double") {
         valueToWrite = QString::number(val.toDouble());
       } else {
         valueToWrite = val.toString();


### PR DESCRIPTION
Fixes a bug in muon analysis results table that causes the table to fail if the column values are a mix of ranges and values.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open mantidplot
Open muon analysis
Load EMU 20918
Go to Data Analysis tab
Add a flat background to fitting browser
Fit
Go to results table
Check run_number and sample_temp, and check both fitting results
Create Table
You should be able to plot sample_temp and the flat background value
Go back to the data analysis tab
In runs load EMU 20918-20
Without changing any settings use Fit again
Go to results table
Check run_number and sample_temp, and check both fitting results
Create Table
Fixes #26120. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
