### PR TITLE
Reflectometry GUI: No longer duplicate first option when processing.

### DIFF
--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -234,6 +234,7 @@ std::string optionsToString(std::map<std::string, std::string> const &options) {
 
     auto const &firstKvp = (*optionsKvpIt);
     resultStream << firstKvp.first << "='" << firstKvp.second << '\'';
+    ++optionsKvpIt;
 
     for (; optionsKvpIt != options.cend(); ++optionsKvpIt) {
       auto kvp = (*optionsKvpIt);


### PR DESCRIPTION
**Description of work.**
Fixed an issue causing duplicate options

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open the ISIS Reflectometry interface
- Add a group and row to the table and enter the run number 13460, angle 0.5, and in the Options column enter ProcessingInstructions='4'
- Select the row and click Process
- Note that the Options column should not now contain ProcessingInstructions='4', ProcessingInstructions='4'


<!-- Instructions for testing. -->

Fixes #26062 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

FIXES NEW FEATURE SO NO RELEASE NOTES

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
