### PR TITLE
Reflectometry GUI: Fix workspace group processing

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -303,7 +303,12 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         # which by default is just the first run. Set it to the concatenated name,
         # e.g. 13461+13462
         ws = AnalysisDataService.retrieve(summed)
-        ws.run().addProperty('run_number', concatenated_names, True)
+        if isinstance(ws, WorkspaceGroup):
+            for workspaceName in ws.getNames():
+                grouped_ws = AnalysisDataService.retrieve(workspaceName)
+                grouped_ws.run().addProperty('run_number', concatenated_names, True)
+        else:
+            ws.run().addProperty('run_number', concatenated_names, True)
         return summed
 
     def _slicingEnabled(self):


### PR DESCRIPTION
**Description of work.**
Reflectometry GUI should now allow workspace groups to be processed

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open the ISIS Reflectometry interface
- Change instrument to OFFSPEC
- Enter a row with Runs=44956+44957 and angle 0.5
- Click Process
- You should not get the error 'WorkspaceGroup' object has no attribute 'run'

<!-- Instructions for testing. -->

Fixes #26168 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
FIXES A BROKEN NEW FEATURE SO NO RELEASE NOTES

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
