### PR TITLE
Indirect - Fix Settings Cancel bug

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
@@ -30,9 +30,8 @@ void IndirectInterface::help() {
 
 void IndirectInterface::settings() {
   m_settings->loadSettings();
-  m_settings->show();
-  m_settings->setFocus();
   m_settings->setWindowModality(Qt::ApplicationModal);
+  m_settings->show();
 }
 
 void IndirectInterface::applySettings() {

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -69,9 +69,26 @@ std::map<std::string, QVariant> IndirectSettings::getSettings() const {
 void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }
 
 void IndirectSettings::closeSettings() {
-  if (window())
-    window()->close();
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+  getDockedOrFloatingWindow()->close();
+#else
+  if (auto settingsWindow = window())
+    settingsWindow->close();
+#endif
 }
+
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+QWidget *IndirectSettings::getDockedOrFloatingWindow() const {
+  auto widget = parentWidget();
+  while (widget) {
+    auto const className = std::string(widget->metaObject()->className());
+    if (className == "DockedWindow" || className == "FloatingWindow")
+      return widget;
+    widget = widget->parentWidget();
+  }
+  return window();
+}
+#endif
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -54,6 +54,8 @@ private:
 
   void connectIndirectInterface(QPointer<UserSubWindow> window);
 
+  QWidget *getDockedOrFloatingWindow() const;
+
   std::unique_ptr<IndirectSettingsPresenter> m_presenter;
   Ui::IndirectSettings m_uiForm;
 };


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where cancelling the Indirect settings GUI would close MantidPlot when the window was docked in mantidplot.

**To test:**
1. Open the Indirect settings interface. `Interfaces`->`Indirect`->`Settings`
2. Change the window to be docked using the option seen under `Window` in the menubar at the top of mantidplot.
3. Click `Cancel` on the Settings GUI. Only the settings GUI should be closed.

Fixes #26158

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
