### PR TITLE
Muon Analysis 2: When the instrument changes, a plot should close.

### DIFF
--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
@@ -103,6 +103,8 @@ class HomePlotWidgetModel(object):
         """
         self.plot_figure = None
         self.plotted_workspaces = []
+        self.plotted_workspaces_inverse_binning = []
+        self.plotted_fit_workspaces = []
 
     def force_redraw(self):
         if not self.plot_figure:

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
@@ -58,7 +58,7 @@ class HomePlotWidgetModel(object):
         self.plot_figure.canvas.set_window_title('Muon Analysis')
         self.plot_figure.gca().set_title(title)
 
-        self.plot_figure.canvas.window().closing.connect(self._close_plot)
+        self.plot_figure.canvas.window().closing.connect(self.close_plot)
 
         workspaces_to_remove = [workspace for workspace in self.plotted_workspaces if workspace not in workspace_list]
         for workspace in workspaces_to_remove:
@@ -96,7 +96,7 @@ class HomePlotWidgetModel(object):
         self.plotted_workspaces = [item for item in self.plotted_workspaces if item != workspace_name]
         self.plotted_fit_workspaces = [item for item in self.plotted_fit_workspaces if item != workspace_name]
 
-    def _close_plot(self):
+    def close_plot(self):
         """
         callback to call when the plot window is closed. Removes the reference and resets plotted workspaces
         :return:

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
@@ -25,7 +25,6 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
         self._view = view
         self._model = model
         self.context = context
-        self._plot_window = None
         self._view.on_plot_button_clicked(self.handle_data_updated)
         self._view.on_rebin_options_changed(self.handle_use_raw_workspaces_changed)
         self._view.on_plot_type_changed(self.handle_plot_type_changed)
@@ -33,6 +32,7 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
         self.fit_observer = GenericObserver(self.handle_fit_completed)
         self.group_pair_observer = GenericObserver(self.handle_group_pair_to_plot_changed)
         self.rebin_options_set_observer = GenericObserver(self.handle_rebin_options_set)
+        self.instrument_observer = GenericObserver(self.handle_instrument_changed)
         self.keep = False
 
     def show(self):
@@ -182,3 +182,9 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
             self._view.set_raw_checkbox_state(False)
         else:
             self._view.set_raw_checkbox_state(True)
+
+    def handle_instrument_changed(self):
+        if self._model.plot_figure is not None:
+            from matplotlib import pyplot as plt
+            plt.close(self._model.plot_figure)
+        self._model.close_plot()

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
@@ -187,4 +187,3 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
         if self._model.plot_figure is not None:
             from matplotlib import pyplot as plt
             plt.close(self._model.plot_figure)
-        self._model.close_plot()

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -193,6 +193,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.phase_tab.phase_table_presenter.instrument_changed_observer)
 
+        self.context.data_context.instrumentNotifier.add_subscriber(
+            self.home_tab.plot_widget.instrument_observer)
+
     def setup_group_calculation_enable_notifer(self):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
             self.home_tab.home_tab_widget.enable_observer)


### PR DESCRIPTION
**Description of work.**
There was an issue where loading the data of another instrument caused havoc when updating the plots. So plots now close on instrument change.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Muon Analysis 2 in Workbench
- The instrument should be EMU, load run 15098
- A plot should have appeared
- Change the instrument to any other
- The Plot should close.

<!-- Instructions for testing. -->

Fixes #26201 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

NEW FEATURE FIX SO NO NEW RELEASE NOTES

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
