### PR TITLE
Added missing view update Re #26145

### DIFF
--- a/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_presenter.py
@@ -60,6 +60,7 @@ class ListSelectorPresenter(object):
 
     def handle_selection_changed(self, name, state):
         self.model[name][model_selected] = state
+        self.update_view_from_model()
 
     def handle_select_all_checkbox_changed(self, state):
         for item in self.get_filtered_list():


### PR DESCRIPTION
**Description of work.**
This ensures the view of the workspace selector widget is manually updated after the selection is changed.

**To test:**

Test instructions in the issue #26145

<!-- Instructions for testing. -->

Fixes #26145  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is an issue with new functionality


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
