### PR TITLE
Frequency Domain Analysis imaginary workspace re-appearing

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -18,6 +18,7 @@ New
 * Frequency Domain Analysis GUI added to workbench.
 * Muon ALC GUI added to workbench.
 * Added phase tab for calculating :ref:`phase tables <algm-CalMuonDetectorPhases>` and :ref:`PhaseQuad <algm-PhaseQuad>` workspaces to Frequency Domain Analysis GUI.
+* Frequency Domain Analysis GUI added to workbench.
 
 Improvements
 ############
@@ -28,4 +29,4 @@ Bug Fixes
 #########
 
 * Muon Analysis (original) no longer crashes when `TF Asymmetry` mode is activated.
-* Frequency Domain Analysis GUI added to workbench.
+* Issue where imaginary box was reappearing for FFT transforms after being unselected fixed.

--- a/scripts/Muon/GUI/Common/phase_table_widget/muon_phases_tab.ui
+++ b/scripts/Muon/GUI/Common/phase_table_widget/muon_phases_tab.ui
@@ -129,12 +129,12 @@
      </row>
      <column>
       <property name="text">
-       <string>Value</string>
+       <string>Property</string>
       </property>
      </column>
      <column>
       <property name="text">
-       <string>Property</string>
+       <string>Value</string>
       </property>
      </column>
     </widget>

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_view_new.py
@@ -167,7 +167,7 @@ class FFTView(QtWidgets.QWidget):
 
     def phaseQuadChanged(self):
         # hide complex ws
-        self.FFTTable.setRowHidden(2, "PhaseQuad" in self.workspace)
+        self.FFTTable.setRowHidden(2, "PhaseQuad" in self.workspace or self.Im_box.checkState() != QtCore.Qt.Checked)
 
     def set_raw_checkbox_state(self, state):
         if state:


### PR DESCRIPTION
**Description of work.**

The frequency domain analysis transform tab was redisplaying a hidden row when new data was loaded. This was due to a check for phase quad erroneously re showing it.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Check that the bug described in the issue no longer exists.
<!-- Instructions for testing. -->

Fixes #25770  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
