### PR TITLE
Indirect Sqw - Check Q and E are within the plot range

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -62,6 +62,7 @@ Bug Fixes
 - Fixed a crash caused by changing the Preview Spectrum on Elwin after clicking Run.
 - Fixed a bug where the loaded workspace in Data Analysis doesn't update after being changed on a different
   interface.
+- Fixed a bug with the StartX and EndX selectors seen on the Preview Plots.
 - Fixed a bug causing the errors calculated on Iqt to be too small towards the end of the spectra.
 
 .. figure:: ../../images/Iqt_Errors_Bug.PNG
@@ -95,7 +96,8 @@ Improvements
 ############
 - Added an option called *Group Output* to group the output files from a reduction on ISISEnergyTransfer.
 - Improved ISISEnergyTransfer by automatically loading the Detailed Balance from the sample logs if available.
-- Removed the obsolete *Plot Raw* button.
+- Removed the obsolete *Plot Raw* button in ISIS Calibration.
+- Improved the validation checks for input data on all tabs.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -21,8 +21,8 @@ using namespace Mantid::API;
 namespace {
 Mantid::Kernel::Logger g_log("ApplyAbsorptionCorrections");
 
-template <typename T = MatrixWorkspace, typename R = MatrixWorkspace_sptr>
-R getADSWorkspace(std::string const &workspaceName) {
+template <typename T = MatrixWorkspace>
+boost::shared_ptr<T> getADSWorkspace(std::string const &workspaceName) {
   return AnalysisDataService::Instance().retrieveWS<T>(workspaceName);
 }
 
@@ -253,8 +253,8 @@ void ApplyAbsorptionCorrections::run() {
 
   QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
 
-  auto const corrections = getADSWorkspace<WorkspaceGroup, WorkspaceGroup_sptr>(
-      correctionsWsName.toStdString());
+  auto const corrections =
+      getADSWorkspace<WorkspaceGroup>(correctionsWsName.toStdString());
   bool interpolateAll = false;
   for (std::size_t i = 0; i < corrections->size(); i++) {
     MatrixWorkspace_sptr factorWs =

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -5,6 +5,8 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ApplyAbsorptionCorrections.h"
+#include "IndirectDataValidationHelper.h"
+
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
@@ -18,10 +20,6 @@ using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("ApplyAbsorptionCorrections");
-
-bool doesExistInADS(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().doesExist(workspaceName);
-}
 
 template <typename T = MatrixWorkspace, typename R = MatrixWorkspace_sptr>
 R getADSWorkspace(std::string const &workspaceName) {
@@ -472,64 +470,24 @@ void ApplyAbsorptionCorrections::postProcessComplete(bool error) {
 bool ApplyAbsorptionCorrections::validate() {
   UserInputValidator uiv;
 
-  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  // Validate the sample workspace
+  validateDataIsOneOf(uiv, m_uiForm.dsSample, "Sample", DataType::Red,
+                      {DataType::Sqw});
 
-  const auto sampleName = m_uiForm.dsSample->getCurrentDataName();
-  const auto sampleWsName = sampleName.toStdString();
-  bool sampleExists = AnalysisDataService::Instance().doesExist(sampleWsName);
+  // Validate the container workspace
+  if (m_uiForm.ckUseCan->isChecked())
+    validateDataIsOneOf(uiv, m_uiForm.dsContainer, "Container", DataType::Red,
+                        {DataType::Sqw});
 
-  if (sampleExists && !getADSWorkspace(sampleWsName)) {
-    uiv.addErrorMessage(
-        "Invalid sample workspace. Ensure a MatrixWorkspace is provided.");
-  }
-
-  bool useCan = m_uiForm.ckUseCan->isChecked();
-
-  if (useCan)
-    uiv.checkDataSelectorIsValid("Container", m_uiForm.dsContainer);
-
-  validateCorrections(uiv);
+  // Validate the corrections workspace
+  validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections",
+                       DataType::Corrections);
 
   // Show errors if there are any
   if (!uiv.isAllInputValid())
     emit showMessageBox(uiv.generateErrorMessage());
 
   return uiv.isAllInputValid();
-}
-
-void ApplyAbsorptionCorrections::validateCorrections(
-    UserInputValidator &uiv) const {
-  auto const correctionsName =
-      m_uiForm.dsCorrections->getCurrentDataName().toStdString();
-
-  if (correctionsName.empty())
-    uiv.addErrorMessage("Please load a corrections workspace.");
-  else
-    validateCorrections(uiv, correctionsName);
-}
-
-void ApplyAbsorptionCorrections::validateCorrections(
-    UserInputValidator &uiv, std::string const &name) const {
-  if (doesExistInADS(name)) {
-    if (auto const corrections =
-            getADSWorkspace<WorkspaceGroup, WorkspaceGroup_sptr>(name))
-      validateCorrections(uiv, corrections);
-    else
-      uiv.addErrorMessage(
-          "The corrections workspace should be a WorkspaceGroup.");
-
-  } else {
-    uiv.addErrorMessage("The corrections workspace could not be found. Please "
-                        "re-load the corrections workspace.");
-  }
-}
-
-void ApplyAbsorptionCorrections::validateCorrections(
-    UserInputValidator &uiv, WorkspaceGroup_sptr correctionsWorkspace) const {
-  for (auto const workspace : *correctionsWorkspace)
-    if (!workspace)
-      uiv.addErrorMessage(
-          "The corrections WorkspaceGroup contains an invalid workspace.");
 }
 
 void ApplyAbsorptionCorrections::loadSettings(const QSettings &settings) {

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -16,6 +16,7 @@
 
 #include <QStringList>
 
+using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 
 namespace {

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -47,12 +47,6 @@ private:
   void setup() override;
   void run() override;
   bool validate() override;
-  void validateCorrections(UserInputValidator &uiv) const;
-  void validateCorrections(UserInputValidator &uiv,
-                           std::string const &name) const;
-  void validateCorrections(
-      UserInputValidator &uiv,
-      Mantid::API::WorkspaceGroup_sptr correctionsWorkspace) const;
   void loadSettings(const QSettings &settings) override;
   void setFileExtensionsByName(bool filter) override;
 

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
   IndirectDataReduction.cpp
   IndirectDataReductionTab.cpp
   IndirectDataTablePresenter.cpp
+  IndirectDataValidationHelper.cpp
   IndirectDiffractionReduction.cpp
   IndirectEditResultsDialog.cpp
   IndirectFitAnalysisTab.cpp
@@ -83,6 +84,7 @@ set(
   QT4_INC_FILES
   ConvFitModel.h
   DllConfig.h
+  IndirectDataValidationHelper.h
   IndirectFitData.h
   IndirectFitOutput.h
   IndirectFitOutputOptionsModel.h
@@ -268,6 +270,7 @@ set(
   IndirectCorrections.cpp
   IndirectDataReduction.cpp
   IndirectDataReductionTab.cpp
+  IndirectDataValidationHelper.cpp
   IndirectDiffractionReduction.cpp
   IndirectInstrumentConfig.cpp
   IndirectInterface.cpp
@@ -327,7 +330,10 @@ set(
   IndirectTransmissionCalc.h
 )
 
-set(INC_FILES)
+set(
+  INC_FILES
+  IndirectDataValidationHelper.h
+)
 
 set(
   UI_FILES

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -286,7 +286,6 @@ bool ISISEnergyTransfer::validate() {
     uiv.checkDataSelectorIsValid("Calibration", m_uiForm.dsCalibrationFile);
     uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
         calibName, "MatrixWorkspace");
-    uiv.checkWorkspaceNumberOfHistograms(calibName, 1);
   }
 
   QString groupingError = validateDetectorGrouping();

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -278,6 +278,7 @@ void ISISEnergyTransfer::setup() {}
  *
  */
 void ISISEnergyTransfer::handleDataReady(QString const &dataName) {
+  UNUSED_ARG(dataName);
   UserInputValidator uiv;
   validateDataIsOfType(uiv, m_uiForm.dsCalibrationFile, "Calibration",
                        DataType::Calib);

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -15,6 +15,7 @@
 
 #include <boost/algorithm/string.hpp>
 
+using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 using MantidQt::API::BatchAlgorithmRunner;
 

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.h
@@ -33,6 +33,7 @@ public slots:
   bool validate() override;
 
 private slots:
+  void handleDataReady(QString const &dataName) override;
   void algorithmComplete(bool error);
 
   void setCurrentGroupingOption(QString const &option);

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -89,6 +89,7 @@ protected:
                           QString reflection = "");
 
 private slots:
+  virtual void handleDataReady(QString const &dataName) = 0;
   void tabExecutionComplete(bool error);
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -89,7 +89,9 @@ protected:
                           QString reflection = "");
 
 private slots:
-  virtual void handleDataReady(QString const &dataName) = 0;
+  virtual void handleDataReady(QString const &dataName) {
+    UNUSED_ARG(dataName);
+  };
   void tabExecutionComplete(bool error);
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -89,9 +89,6 @@ protected:
                           QString reflection = "");
 
 private slots:
-  virtual void handleDataReady(QString const &dataName) {
-    UNUSED_ARG(dataName);
-  };
   void tabExecutionComplete(bool error);
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
@@ -1,0 +1,182 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+
+using namespace Mantid::API;
+using namespace MantidQt::MantidWidgets;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+/**
+ * Validates that the data selector contains data which is of one of the types
+ * specified.
+ *
+ * @param uiv The UserInputValidator used to generate any error messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or Container).
+ * @param types The types the data is allowed to be (e.g. red or sqw).
+ * @param primaryType The most important type.
+ * @return True if the data is valid.
+ */
+bool validateDataIsOneOf(UserInputValidator &uiv, DataSelector *dataSelector,
+                         std::string const &inputType,
+                         DataType const &primaryType,
+                         std::vector<DataType> const &otherTypes, bool silent) {
+  for (auto const type : otherTypes)
+    if (validateDataIsOfType(uiv, dataSelector, inputType, type, true))
+      return true;
+
+  return validateDataIsOfType(uiv, dataSelector, inputType, primaryType,
+                              silent);
+}
+
+/**
+ * Validates that the data selector contains data of the type specified.
+ *
+ * @param uiv The UserInputValidator used to generate any error messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or Container).
+ * @param type The type of the data (e.g. red or sqw).
+ * @return True if the data is valid.
+ */
+bool validateDataIsOfType(UserInputValidator &uiv, DataSelector *dataSelector,
+                          std::string const &inputType, DataType const &type,
+                          bool silent) {
+  switch (type) {
+  case DataType::Red:
+    return validateDataIsAReducedFile(uiv, dataSelector, inputType, silent);
+  case DataType::Sqw:
+    return validateDataIsASqwFile(uiv, dataSelector, inputType, silent);
+  case DataType::Calib:
+    return validateDataIsACalibrationFile(uiv, dataSelector, inputType, silent);
+  case DataType::Corrections:
+    return validateDataIsACorrectionsFile(uiv, dataSelector, inputType, silent);
+  default:
+    return false;
+  }
+}
+
+/**
+ * Validates that the data selector is holding a reduced file or workspace.
+ *
+ * @param uiv The UserInputValidator used to generate any error
+ * messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or
+ * Container).
+ * @return True if the data is valid.
+ */
+bool validateDataIsAReducedFile(UserInputValidator &uiv,
+                                DataSelector *dataSelector,
+                                std::string const &inputType, bool silent) {
+  auto const dataName = dataSelector->getCurrentDataName();
+  uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
+                               silent);
+  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+      dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
+
+  return uiv.isAllInputValid();
+};
+
+/**
+ * Validates that the data selector is holding a S(Q,w) file or workspace.
+ *
+ * @param uiv The UserInputValidator used to generate any error messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or Container).
+ * @return True if the data is valid.
+ */
+bool validateDataIsASqwFile(UserInputValidator &uiv, DataSelector *dataSelector,
+                            std::string const &inputType, bool silent) {
+  auto const dataName = dataSelector->getCurrentDataName();
+  uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
+                               silent);
+  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+      dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
+
+  return uiv.isAllInputValid();
+};
+
+/**
+ * Validates that the data selector is holding a S(Q,w) file or workspace.
+ *
+ * @param uiv The UserInputValidator used to generate any error messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or Container).
+ * @return True if the data is valid.
+ */
+bool validateDataIsACalibrationFile(UserInputValidator &uiv,
+                                    DataSelector *dataSelector,
+                                    std::string const &inputType, bool silent) {
+  auto const dataName = dataSelector->getCurrentDataName();
+  uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
+                               silent);
+  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+      dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
+
+  return uiv.isAllInputValid();
+};
+
+/**
+ * Validates that the data selector is holding a corrections file or workspace.
+ *
+ * @param uiv The UserInputValidator used to generate any error messages.
+ * @param dataSelector The DataSelector containing the data.
+ * @param inputType The type of the input (e.g. Sample or Container).
+ * @return True if the data is valid.
+ */
+bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
+                                    DataSelector *dataSelector,
+                                    std::string const &inputType, bool silent) {
+  auto const dataName = dataSelector->getCurrentDataName();
+  uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
+                               silent);
+  uiv.checkWorkspaceType<WorkspaceGroup, WorkspaceGroup_sptr>(
+      dataName, QString::fromStdString(inputType), "WorkspaceGroup", silent);
+  uiv.checkWorkspaceGroupIsValid(dataName, QString::fromStdString(inputType),
+                                 silent);
+
+  return uiv.isAllInputValid();
+};
+
+// bool validateDataHasIdenticalDimensions(
+//    UserInputValidator &uiv, DataAxis const &dataAxis,
+//    std::map<std::string, DataSelector *> const &data) {
+//  switch (dataAxis) {
+//  case DataAxis::Histograms:
+//    return validateDataHasSameNumberOfHistograms(uiv, data);
+//  case DataAxis::Bins:
+//    return validateDataHasSameNumberOfBins(uiv, data);
+//  default:
+//    return false;
+//  }
+//}
+//
+// bool validateDataHasSameNumberOfHistograms(
+//    UserInputValidator &uiv,
+//    std::map<std::string, DataSelector *> const &data) {
+//
+//  auto &ads = AnalysisDataService::Instance();
+//  auto workspaceName =
+//  data.begin()->second->getCurrentDataName().toStdString(); if
+//  (ads.doesExist(workspaceName))
+//    if (auto workspace = ads.retrieveWS<MatrixWorkspace>(workspaceName))
+//      auto numberOfHistograms = workspace->getNumberHistograms();
+//
+//  for (auto iter = data.begin(); iter != data.end(); ++iter) {
+//
+//    uiv.checkWorkspaceNumberOfHistograms();
+//  }
+//}
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
@@ -81,11 +81,11 @@ bool validateDataIsAReducedFile(UserInputValidator &uiv,
   auto const dataName = dataSelector->getCurrentDataName();
   uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
                                silent);
-  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+  uiv.checkWorkspaceType<MatrixWorkspace>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
-};
+}
 
 /**
  * Validates that the data selector is holding a S(Q,w) file or workspace.
@@ -100,11 +100,11 @@ bool validateDataIsASqwFile(UserInputValidator &uiv, DataSelector *dataSelector,
   auto const dataName = dataSelector->getCurrentDataName();
   uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
                                silent);
-  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+  uiv.checkWorkspaceType<MatrixWorkspace>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
-};
+}
 
 /**
  * Validates that the data selector is holding a S(Q,w) file or workspace.
@@ -120,11 +120,11 @@ bool validateDataIsACalibrationFile(UserInputValidator &uiv,
   auto const dataName = dataSelector->getCurrentDataName();
   uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
                                silent);
-  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+  uiv.checkWorkspaceType<MatrixWorkspace>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
   // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
-};
+}
 
 /**
  * Validates that the data selector is holding a corrections file or workspace.
@@ -140,13 +140,13 @@ bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
   auto const dataName = dataSelector->getCurrentDataName();
   uiv.checkDataSelectorIsValid(QString::fromStdString(inputType), dataSelector,
                                silent);
-  uiv.checkWorkspaceType<WorkspaceGroup, WorkspaceGroup_sptr>(
+  uiv.checkWorkspaceType<WorkspaceGroup>(
       dataName, QString::fromStdString(inputType), "WorkspaceGroup", silent);
   uiv.checkWorkspaceGroupIsValid(dataName, QString::fromStdString(inputType),
                                  silent);
   // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
-};
+}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
@@ -12,9 +12,9 @@
 
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
+using namespace MantidQt::CustomInterfaces;
 
-namespace MantidQt {
-namespace CustomInterfaces {
+namespace IndirectDataValidationHelper {
 
 /**
  * Validates that the data selector contains data which is of one of the types
@@ -148,5 +148,4 @@ bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
   return uiv.isAllInputValid();
 }
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace IndirectDataValidationHelper

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp
@@ -83,7 +83,7 @@ bool validateDataIsAReducedFile(UserInputValidator &uiv,
                                silent);
   uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
-
+  // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
 };
 
@@ -102,7 +102,7 @@ bool validateDataIsASqwFile(UserInputValidator &uiv, DataSelector *dataSelector,
                                silent);
   uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
-
+  // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
 };
 
@@ -122,7 +122,7 @@ bool validateDataIsACalibrationFile(UserInputValidator &uiv,
                                silent);
   uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
       dataName, QString::fromStdString(inputType), "MatrixWorkspace", silent);
-
+  // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
 };
 
@@ -144,39 +144,9 @@ bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
       dataName, QString::fromStdString(inputType), "WorkspaceGroup", silent);
   uiv.checkWorkspaceGroupIsValid(dataName, QString::fromStdString(inputType),
                                  silent);
-
+  // TODO :: check the axis labels for the data units
   return uiv.isAllInputValid();
 };
-
-// bool validateDataHasIdenticalDimensions(
-//    UserInputValidator &uiv, DataAxis const &dataAxis,
-//    std::map<std::string, DataSelector *> const &data) {
-//  switch (dataAxis) {
-//  case DataAxis::Histograms:
-//    return validateDataHasSameNumberOfHistograms(uiv, data);
-//  case DataAxis::Bins:
-//    return validateDataHasSameNumberOfBins(uiv, data);
-//  default:
-//    return false;
-//  }
-//}
-//
-// bool validateDataHasSameNumberOfHistograms(
-//    UserInputValidator &uiv,
-//    std::map<std::string, DataSelector *> const &data) {
-//
-//  auto &ads = AnalysisDataService::Instance();
-//  auto workspaceName =
-//  data.begin()->second->getCurrentDataName().toStdString(); if
-//  (ads.doesExist(workspaceName))
-//    if (auto workspace = ads.retrieveWS<MatrixWorkspace>(workspaceName))
-//      auto numberOfHistograms = workspace->getNumberHistograms();
-//
-//  for (auto iter = data.begin(); iter != data.end(); ++iter) {
-//
-//    uiv.checkWorkspaceNumberOfHistograms();
-//  }
-//}
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
@@ -9,43 +9,41 @@
 
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
-namespace MantidQt {
-namespace CustomInterfaces {
+namespace IndirectDataValidationHelper {
 
 enum DataType { Red, Sqw, Calib, Corrections };
 
-bool validateDataIsOneOf(UserInputValidator &uiv,
-                         MantidWidgets::DataSelector *dataSelector,
+bool validateDataIsOneOf(MantidQt::CustomInterfaces::UserInputValidator &uiv,
+                         MantidQt::MantidWidgets::DataSelector *dataSelector,
                          std::string const &inputType,
                          DataType const &primaryType,
                          std::vector<DataType> const &otherTypes,
                          bool silent = false);
 
-bool validateDataIsOfType(UserInputValidator &uiv,
-                          MantidWidgets::DataSelector *dataSelector,
+bool validateDataIsOfType(MantidQt::CustomInterfaces::UserInputValidator &uiv,
+                          MantidQt::MantidWidgets::DataSelector *dataSelector,
                           std::string const &inputType, DataType const &type,
                           bool silent = false);
 
-bool validateDataIsAReducedFile(UserInputValidator &uiv,
-                                MantidWidgets::DataSelector *dataSelector,
-                                std::string const &inputType,
-                                bool silent = false);
+bool validateDataIsAReducedFile(
+    MantidQt::CustomInterfaces::UserInputValidator &uiv,
+    MantidQt::MantidWidgets::DataSelector *dataSelector,
+    std::string const &inputType, bool silent = false);
 
-bool validateDataIsASqwFile(UserInputValidator &uiv,
-                            MantidWidgets::DataSelector *dataSelector,
+bool validateDataIsASqwFile(MantidQt::CustomInterfaces::UserInputValidator &uiv,
+                            MantidQt::MantidWidgets::DataSelector *dataSelector,
                             std::string const &inputType, bool silent = false);
 
-bool validateDataIsACalibrationFile(UserInputValidator &uiv,
-                                    MantidWidgets::DataSelector *dataSelector,
-                                    std::string const &inputType,
-                                    bool silent = false);
+bool validateDataIsACalibrationFile(
+    MantidQt::CustomInterfaces::UserInputValidator &uiv,
+    MantidQt::MantidWidgets::DataSelector *dataSelector,
+    std::string const &inputType, bool silent = false);
 
-bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
-                                    MantidWidgets::DataSelector *dataSelector,
-                                    std::string const &inputType,
-                                    bool silent = false);
+bool validateDataIsACorrectionsFile(
+    MantidQt::CustomInterfaces::UserInputValidator &uiv,
+    MantidQt::MantidWidgets::DataSelector *dataSelector,
+    std::string const &inputType, bool silent = false);
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace IndirectDataValidationHelper
 
 #endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_
+#define MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_
+
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+enum DataType { Red, Sqw, Calib, Corrections } const;
+enum DataAxis { Histograms, Bins } const;
+
+bool validateDataIsOneOf(UserInputValidator &uiv,
+                         MantidWidgets::DataSelector *dataSelector,
+                         std::string const &inputType,
+                         DataType const &primaryType,
+                         std::vector<DataType> const &otherTypes,
+                         bool silent = false);
+
+bool validateDataIsOfType(UserInputValidator &uiv,
+                          MantidWidgets::DataSelector *dataSelector,
+                          std::string const &inputType, DataType const &type,
+                          bool silent = false);
+
+bool validateDataIsAReducedFile(UserInputValidator &uiv,
+                                MantidWidgets::DataSelector *dataSelector,
+                                std::string const &inputType,
+                                bool silent = false);
+
+bool validateDataIsASqwFile(UserInputValidator &uiv,
+                            MantidWidgets::DataSelector *dataSelector,
+                            std::string const &inputType, bool silent = false);
+
+bool validateDataIsACalibrationFile(UserInputValidator &uiv,
+                                    MantidWidgets::DataSelector *dataSelector,
+                                    std::string const &inputType,
+                                    bool silent = false);
+
+bool validateDataIsACorrectionsFile(UserInputValidator &uiv,
+                                    MantidWidgets::DataSelector *dataSelector,
+                                    std::string const &inputType,
+                                    bool silent = false);
+
+} // namespace CustomInterfaces
+} // namespace MantidQt
+
+#endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPER_H_ */

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
@@ -13,7 +13,6 @@ namespace MantidQt {
 namespace CustomInterfaces {
 
 enum DataType { Red, Sqw, Calib, Corrections } const;
-enum DataAxis { Histograms, Bins } const;
 
 bool validateDataIsOneOf(UserInputValidator &uiv,
                          MantidWidgets::DataSelector *dataSelector,

--- a/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.h
@@ -12,7 +12,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-enum DataType { Red, Sqw, Calib, Corrections } const;
+enum DataType { Red, Sqw, Calib, Corrections };
 
 bool validateDataIsOneOf(UserInputValidator &uiv,
                          MantidWidgets::DataSelector *dataSelector,

--- a/qt/scientific_interfaces/Indirect/IndirectInterfaceProperties.xml
+++ b/qt/scientific_interfaces/Indirect/IndirectInterfaceProperties.xml
@@ -41,20 +41,20 @@ xsi:schemaLocation="http://www.w3schools.com IndirectInterfacePropertiesSchema.x
 	
 	<INTERFACE id="CalculatePaalmanPings">
 		<EXTENSIONS all=".nxs"/>
-		<FILE-SUFFIXES sample="_red.nxs,_sqw.nxs" container="_red.nxs,_sqw.nxs"/>
-		<WORKSPACE-SUFFIXES sample="_red,_sqw" container="_red,_sqw"/>
+		<FILE-SUFFIXES sample="_red.nxs" container="_red.nxs"/>
+		<WORKSPACE-SUFFIXES sample="_red" container="_red"/>
 	</INTERFACE>
 	
 	<INTERFACE id="CalculateMonteCarlo">
 		<EXTENSIONS all=".nxs"/>
-		<FILE-SUFFIXES sample="_red.nxs,_sqw.nxs" container="_red.nxs,_sqw.nxs"/>
-		<WORKSPACE-SUFFIXES sample="_red,_sqw" container="_red,_sqw"/>
+		<FILE-SUFFIXES sample="_red.nxs" container="_red.nxs"/>
+		<WORKSPACE-SUFFIXES sample="_red" container="_red"/>
 	</INTERFACE>
 	
 	<INTERFACE id="ApplyCorrections">
 		<EXTENSIONS all=".nxs"/>
-		<FILE-SUFFIXES sample="_red.nxs,_sqw.nxs" container="_red.nxs,_sqw.nxs" corrections="_Corrections.nxs"/>
-		<WORKSPACE-SUFFIXES sample="_red,_sqw" container="_red,_sqw" corrections="_Corrections"/>
+		<FILE-SUFFIXES sample="_red.nxs" container="_red.nxs" corrections="_Corrections.nxs"/>
+		<WORKSPACE-SUFFIXES sample="_red" container="_red" corrections="_Corrections"/>
 	</INTERFACE>
 	
 	<INTERFACE id="Elwin">

--- a/qt/scientific_interfaces/Indirect/IndirectInterfaceSettings.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectInterfaceSettings.ui
@@ -78,7 +78,7 @@
          <item>
           <widget class="QCheckBox" name="ckRestrictInputDataNames">
            <property name="text">
-            <string>Restrict allowed input files by name</string>
+            <string>Restrict allowed input files by name (recommended)</string>
            </property>
            <property name="checked">
             <bool>true</bool>

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -14,6 +14,7 @@
 #include <QDoubleValidator>
 #include <QFileInfo>
 
+using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 
 namespace MantidQt {

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -35,8 +35,6 @@ public:
   bool validate() override;
 
 protected slots:
-  // Handle when a file/workspace is ready for plotting
-  void handleSampleInputReady(const QString & /*filename*/);
   /// Slot for when the range selector changes
   void rangeChanged(double min, double max);
   /// Slot to update the guides when the range properties change
@@ -58,7 +56,11 @@ protected slots:
                        QString const tooltip = "");
   void setPlotIsPlotting(bool plotting);
 
+private slots:
+  void handleDataReady(QString const &dataName) override;
+
 private:
+  void plotNewData(QString const &filename);
   void setFileExtensionsByName(bool filter) override;
 
   Ui::IndirectMoments m_uiForm;

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.cpp
@@ -28,6 +28,17 @@ void IndirectSettingsPresenter::setUpPresenter() {
   connect(m_view.get(), SIGNAL(cancelClicked()), this, SLOT(closeDialog()));
 
   loadSettings();
+
+  // Temporary until better validation is used when loading data into interfaces
+  setDefaultRestrictData();
+}
+
+void IndirectSettingsPresenter::setDefaultRestrictData() const {
+  auto const settingsGroup =
+      QString::fromStdString(m_model->getSettingsGroup());
+  auto const isisFacility = m_model->getFacility() == "ISIS";
+  if (isisFacility)
+    m_view->setSetting(settingsGroup, "restrict-input-by-name", isisFacility);
 }
 
 IIndirectSettingsView *IndirectSettingsPresenter::getView() {
@@ -53,8 +64,6 @@ void IndirectSettingsPresenter::loadSettings() {
   m_view->setRestrictInputByNameChecked(
       getSetting("restrict-input-by-name").toBool());
   m_view->setPlotErrorBarsChecked(getSetting("plot-error-bars").toBool());
-
-  // emit applySettings();
 }
 
 QVariant IndirectSettingsPresenter::getSetting(std::string const &settingName) {

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsPresenter.h
@@ -44,6 +44,7 @@ private slots:
 
 private:
   void setUpPresenter();
+  void setDefaultRestrictData() const;
   void saveSettings();
 
   void setApplyingChanges(bool applyingChanges);

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -62,8 +62,8 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
     : IndirectDataReductionTab(idrUI, parent) {
   m_uiForm.setupUi(parent);
 
-  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(const QString &)), this,
-          SLOT(handleDataReady()));
+  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(QString const &)), this,
+          SLOT(handleDataReady(QString const &)));
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(sqwAlgDone(bool)));
 
@@ -231,17 +231,15 @@ void IndirectSqw::setPlotSpectrumIndexMax(int maximum) {
  * Handles the event of data being loaded. Validates the loaded data.
  *
  */
-void IndirectSqw::handleDataReady() {
-  auto const sampleName = m_uiForm.dsSampleInput->getCurrentDataName();
-
+void IndirectSqw::handleDataReady(QString const &dataName) {
   UserInputValidator uiv;
   uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSampleInput);
   uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
-      sampleName, "MatrixWorkspace");
+      dataName, "MatrixWorkspace");
 
   auto const errorMessage = uiv.generateErrorMessage();
   if (errorMessage.isEmpty()) {
-    plotRqwContour(sampleName.toStdString());
+    plotRqwContour(dataName.toStdString());
     setDefaultQAndEnergy();
   } else {
     emit showMessageBox(errorMessage);

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -14,6 +14,7 @@
 
 #include <QFileInfo>
 
+using namespace IndirectDataValidationHelper;
 using namespace Mantid::API;
 using MantidQt::API::BatchAlgorithmRunner;
 

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -31,7 +31,7 @@ public:
   bool validate() override;
 
 private slots:
-  void handleDataReady();
+  void handleDataReady(QString const &dataName) override;
   void sqwAlgDone(bool error);
 
   void runClicked();
@@ -51,8 +51,6 @@ private:
   void setEnergyRange(std::tuple<double, double> const &axisRange);
   void setFileExtensionsByName(bool filter) override;
 
-  Mantid::API::MatrixWorkspace_const_sptr
-  getADSWorkspace(std::string const &name) const;
   std::size_t getOutWsNumberOfSpectra() const;
 
   void setPlotSpectrumIndexMax(int maximum);

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -31,8 +31,7 @@ public:
   bool validate() override;
 
 private slots:
-  void plotRqwContour();
-  void setDefaultQAndEnergy();
+  void handleDataReady();
   void sqwAlgDone(bool error);
 
   void runClicked();
@@ -46,6 +45,8 @@ private slots:
                        QString const tooltip = "");
 
 private:
+  void plotRqwContour(std::string const &sampleName);
+  void setDefaultQAndEnergy();
   void setQRange(std::tuple<double, double> const &axisRange);
   void setEnergyRange(std::tuple<double, double> const &axisRange);
   void setFileExtensionsByName(bool filter) override;

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Logger.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Plotting/SingleSelector.h"
 
 namespace {
@@ -113,8 +114,8 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(replotNewSpectrum(QtProperty *, double)));
   // Plot miniplot when file has finished loading
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this,
-          SLOT(plotRawInput(const QString &)));
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this,
+          SLOT(handleDataReady(QString const &)));
   // Preview symmetrise
   connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SLOT(preview()));
   // X range selectors
@@ -163,17 +164,27 @@ IndirectSymmetrise::~IndirectSymmetrise() {}
 void IndirectSymmetrise::setup() {}
 
 bool IndirectSymmetrise::validate() {
-  // Check for a valid input file
-  if (!m_uiForm.dsInput->isValid())
-    return false;
+  auto const sampleName = m_uiForm.dsInput->getCurrentDataName();
+
+  UserInputValidator uiv;
+  // Validate the sample workspace
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
+  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+      sampleName, "MatrixWorkspace");
 
   // EMin and EMax must be positive
   if (m_dblManager->value(m_properties["EMin"]) <= 0.0)
-    return false;
+    uiv.addErrorMessage("EMin must be positive.");
   if (m_dblManager->value(m_properties["EMax"]) <= 0.0)
-    return false;
+    uiv.addErrorMessage("EMax must be positive.");
 
-  return true;
+  auto const errorMessage = uiv.generateErrorMessage();
+
+  // Show an error message if needed
+  if (!errorMessage.isEmpty())
+    emit showMessageBox(errorMessage);
+
+  return errorMessage.isEmpty();
 }
 
 void IndirectSymmetrise::run() {
@@ -228,16 +239,34 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
 }
 
 /**
+ * Handles the event of data being loaded. Validates the loaded data.
+ *
+ * @param dataName The name of the data that has been loaded
+ */
+void IndirectSymmetrise::handleDataReady(QString const &dataName) {
+  UserInputValidator uiv;
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
+  uiv.checkWorkspaceType<MatrixWorkspace, MatrixWorkspace_sptr>(
+      dataName, "MatrixWorkspace");
+
+  auto const errorMessage = uiv.generateErrorMessage();
+  if (errorMessage.isEmpty()) {
+    plotNewData(dataName);
+  } else {
+    emit showMessageBox(errorMessage);
+  }
+}
+
+/**
  * Plots a new workspace in the mini plot when it is loaded form the data
  *selector.
  *
- * @param workspaceName Name of the workspace that has been laoded
+ * @param workspaceName Name of the workspace that has been loaded
  */
-void IndirectSymmetrise::plotRawInput(const QString &workspaceName) {
+void IndirectSymmetrise::plotNewData(QString const &workspaceName) {
   // Set the preview spectrum number to the first spectrum in the workspace
-  MatrixWorkspace_sptr sampleWS =
-      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-          workspaceName.toStdString());
+  auto sampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+      workspaceName.toStdString());
   int minSpectrumRange = sampleWS->getSpectrum(0).getSpectrumNo();
   m_dblManager->setValue(m_properties["PreviewSpec"],
                          static_cast<double>(minSpectrumRange));

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -13,11 +13,12 @@
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Plotting/SingleSelector.h"
 
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
 namespace {
 Mantid::Kernel::Logger g_log("IndirectSymmetrise");
 }
-
-using namespace Mantid::API;
 
 namespace MantidQt {
 using MantidWidgets::AxisID;

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -51,7 +51,8 @@ public:
 
 private slots:
   void algorithmComplete(bool error);
-  void plotRawInput(const QString &workspaceName);
+  void handleDataReady(QString const &dataName) override;
+  void plotNewData(QString const &workspaceName);
   void updateMiniPlots();
   void replotNewSpectrum(QtProperty *prop, double value);
   void verifyERange(QtProperty *prop, double value);

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -251,6 +251,11 @@ protected:
   Mantid::Types::Core::DateAndTime m_tabEndTime;
   std::string m_pythonExportWsName;
 
+private slots:
+  virtual void handleDataReady(QString const &dataName) {
+    UNUSED_ARG(dataName);
+  };
+
 private:
   std::string getInterfaceProperty(std::string const &interfaceName,
                                    std::string const &propertyName,

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -1,23 +1,25 @@
 # Testing
-set(TEST_FILES
-    ConvFitDataPresenterTest.h
-    ConvFitModelTest.h
-    IndirectDataTablePresenterTest.h
-    IndirectFitDataPresenterTest.h
-    IndirectFitDataTest.h
-    IndirectFitOutputOptionsModelTest.h
-    IndirectFitOutputOptionsPresenterTest.h
-    IndirectFitOutputTest.h
-    IndirectFitPlotModelTest.h
-    IndirectFitPlotPresenterTest.h
-    IndirectFittingModelTest.h
-    IndirectSettingsModelTest.h
-    IndirectSettingsPresenterTest.h
-    IndirectSpectrumSelectionPresenterTest.h
-    IqtFitModelTest.h
-    JumpFitDataPresenterTest.h
-    JumpFitModelTest.h
-    MSDFitModelTest.h)
+set(
+  TEST_FILES
+  ConvFitDataPresenterTest.h
+  ConvFitModelTest.h
+  IndirectDataTablePresenterTest.h
+  IndirectFitDataPresenterTest.h
+  IndirectFitDataTest.h
+  IndirectFitOutputOptionsModelTest.h
+  IndirectFitOutputOptionsPresenterTest.h
+  IndirectFitOutputTest.h
+  IndirectFitPlotModelTest.h
+  IndirectFitPlotPresenterTest.h
+  IndirectFittingModelTest.h
+  IndirectSettingsModelTest.h
+  IndirectSettingsPresenterTest.h
+  IndirectSpectrumSelectionPresenterTest.h
+  IqtFitModelTest.h
+  JumpFitDataPresenterTest.h
+  JumpFitModelTest.h
+  MSDFitModelTest.h
+)
 
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesIndirectTest

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -4,6 +4,7 @@ set(
   ConvFitDataPresenterTest.h
   ConvFitModelTest.h
   IndirectDataTablePresenterTest.h
+  IndirectDataValidationHelperTest.h
   IndirectFitDataPresenterTest.h
   IndirectFitDataTest.h
   IndirectFitOutputOptionsModelTest.h
@@ -36,6 +37,7 @@ mtd_add_qt_tests(
     ../../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
     ../../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
     ../../../../Framework/TestHelpers/src/TearDownWorld.cpp
+    ../IndirectDataValidationHelper.cpp
   LINK_LIBS
     ${TCMALLOC_LIBRARIES_LINKTIME}
     ${CORE_MANTIDLIBS}

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
@@ -1,0 +1,307 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_
+#define MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "IndirectDataValidationHelper.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/DataSelector.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+using namespace Mantid::DataObjects;
+using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::MantidWidgets;
+using namespace testing;
+
+namespace {
+
+auto constexpr WORKSPACE_NAME = "WorkspaceName";
+auto constexpr ERROR_LABEL = "Sample";
+
+std::string const ERROR_MESSAGE_START = "Please correct the following:\n";
+
+std::string workspaceTypeError(std::string const &errorLabel,
+                               std::string const &validType) {
+  return ERROR_MESSAGE_START + "The " + errorLabel + " workspace is not a " +
+         validType + ".";
+}
+
+std::string emptyWorkspaceGroupError() {
+  return ERROR_MESSAGE_START + "The group workspace " + WORKSPACE_NAME +
+         " is empty.";
+}
+
+MatrixWorkspace_sptr convertWorkspace2DToMatrix(Workspace2D_sptr workspace) {
+  return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
+}
+
+MatrixWorkspace_sptr
+createMatrixWorkspace(std::size_t const &numberOfHistograms,
+                      std::size_t const &numberOfBins) {
+  return convertWorkspace2DToMatrix(WorkspaceCreationHelper::create2DWorkspace(
+      numberOfHistograms, numberOfBins));
+}
+
+TableWorkspace_sptr createTableWorkspace(std::size_t const &size) {
+  return boost::make_shared<TableWorkspace>(size);
+}
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+/// Mock object to mock the data selector
+class MockDataSelector : public DataSelector {
+public:
+  /// Public Methods
+  MOCK_CONST_METHOD0(getCurrentDataName, QString());
+  MOCK_METHOD0(isValid, bool());
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+} // namespace
+
+class IndirectDataValidationHelperTest : public CxxTest::TestSuite {
+public:
+  IndirectDataValidationHelperTest() : m_ads(AnalysisDataService::Instance()) {
+    m_ads.clear();
+  }
+
+  static IndirectDataValidationHelperTest *createSuite() {
+    return new IndirectDataValidationHelperTest();
+  }
+
+  static void destroySuite(IndirectDataValidationHelperTest *suite) {
+    delete suite;
+  }
+
+  void setUp() override {
+    m_uiv = std::make_unique<UserInputValidator>();
+    m_dataSelector = std::make_unique<MockDataSelector>();
+  }
+
+  void tearDown() override {
+    TS_ASSERT(Mock::VerifyAndClearExpectations(m_dataSelector.get()));
+
+    m_ads.clear();
+    m_uiv.reset();
+  }
+
+  /// The validateDataIsOfType function only checks the DataSelector against one
+  /// data type, so 'isValid' should only be called once
+  void test_that_validateDataIsOfType_will_only_call_the_isValid_method_once() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertTheDataIsCheckedOneTime(validateDataIsOfType, DataType::Sqw);
+  }
+
+  void
+  test_that_validateDataIsOneOf_will_call_the_isValid_method_once_if_the_data_matches_with_a_non_primary_data_types() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertTheDataIsCheckedNTimes(validateDataIsOneOf, 1, DataType::Red,
+                                 {DataType::Sqw});
+  }
+
+  void
+  test_that_validateDataIsOneOf_will_call_the_isValid_method_twice_if_the_data_does_not_match_with_the_non_primary_data_type() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertTheDataIsCheckedNTimes(validateDataIsOneOf, 2, DataType::Red,
+                                 {DataType::Corrections});
+  }
+
+  void
+  test_that_validateDataIsOneOf_will_call_the_isValid_method_three_times_if_all_three_data_types_do_not_match_the_provided_data() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertTheDataIsCheckedNTimes(validateDataIsOneOf, 3, DataType::Red,
+                                 {DataType::Sqw, DataType::Calib});
+  }
+
+  void
+  test_that_validateDataIsAReducedFile_will_pass_if_the_workspace_is_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertThatTheDataIsValid(WORKSPACE_NAME, ERROR_LABEL,
+                             validateDataIsAReducedFile);
+  }
+
+  void
+  test_that_validateDataIsAReducedFile_will_fail_if_the_workspace_is_a_not_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertThatTheDataIsInvalid(WORKSPACE_NAME, ERROR_LABEL,
+                               validateDataIsAReducedFile);
+  }
+
+  void
+  test_that_validateDataIsAReducedFile_will_return_the_correct_error_message_if_the_workspace_is_not_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertErrorMessage(WORKSPACE_NAME, ERROR_LABEL, validateDataIsAReducedFile,
+                       workspaceTypeError(ERROR_LABEL, "MatrixWorkspace"));
+  }
+
+  void
+  test_that_validateDataIsASqwFile_will_pass_if_the_workspace_is_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertThatTheDataIsValid(WORKSPACE_NAME, ERROR_LABEL,
+                             validateDataIsASqwFile);
+  }
+
+  void
+  test_that_validateDataIsASqwFile_will_fail_if_the_workspace_is_not_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertThatTheDataIsInvalid(WORKSPACE_NAME, ERROR_LABEL,
+                               validateDataIsASqwFile);
+  }
+
+  void
+  test_that_validateDataIsASqwFile_will_return_the_correct_error_message_if_the_workspace_is_not_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertErrorMessage(WORKSPACE_NAME, ERROR_LABEL, validateDataIsASqwFile,
+                       workspaceTypeError(ERROR_LABEL, "MatrixWorkspace"));
+  }
+
+  void
+  test_that_validateDataIsACalibrationFile_will_pass_if_the_workspace_is_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertThatTheDataIsValid(WORKSPACE_NAME, ERROR_LABEL,
+                             validateDataIsACalibrationFile);
+  }
+
+  void
+  test_that_validateDataIsACalibrationFile_will_fail_if_the_workspace_is_not_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertThatTheDataIsInvalid(WORKSPACE_NAME, ERROR_LABEL,
+                               validateDataIsACalibrationFile);
+  }
+
+  void
+  test_that_validateDataIsACalibrationFile_will_return_the_correct_error_message_if_the_workspace_is_not_a_matrix_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createTableWorkspace(5));
+    assertErrorMessage(WORKSPACE_NAME, ERROR_LABEL,
+                       validateDataIsACalibrationFile,
+                       workspaceTypeError(ERROR_LABEL, "MatrixWorkspace"));
+  }
+
+  void
+  test_that_validateDataIsACorrectionsFile_will_pass_if_the_workspace_is_a_group_workspace() {
+    m_ads.addOrReplace(
+        WORKSPACE_NAME,
+        WorkspaceCreationHelper::createWorkspaceGroup(2, 5, 5, "stem"));
+    assertThatTheDataIsValid(WORKSPACE_NAME, ERROR_LABEL,
+                             validateDataIsACorrectionsFile);
+  }
+
+  void
+  test_that_validateDataIsACorrectionsFile_will_fail_if_the_workspace_is_not_a_group_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertThatTheDataIsInvalid(WORKSPACE_NAME, ERROR_LABEL,
+                               validateDataIsACorrectionsFile);
+  }
+
+  void
+  test_that_validateDataIsACorrectionsFile_will_return_the_correct_error_message_if_the_workspace_is_not_a_group_workspace() {
+    m_ads.addOrReplace(WORKSPACE_NAME, createMatrixWorkspace(5, 5));
+    assertErrorMessage(WORKSPACE_NAME, ERROR_LABEL,
+                       validateDataIsACorrectionsFile,
+                       workspaceTypeError(ERROR_LABEL, "WorkspaceGroup"));
+  }
+
+  void
+  test_that_validateDataIsACorrectionsFile_will_fail_if_the_workspace_group_is_empty() {
+    m_ads.addOrReplace(WORKSPACE_NAME, boost::make_shared<WorkspaceGroup>());
+    assertThatTheDataIsInvalid(WORKSPACE_NAME, ERROR_LABEL,
+                               validateDataIsACorrectionsFile);
+  }
+
+  void
+  test_that_validateDataIsACorrectionsFile_will_return_the_correct_error_message_if_the_workspace_group_is_empty() {
+    m_ads.addOrReplace(WORKSPACE_NAME, boost::make_shared<WorkspaceGroup>());
+    assertErrorMessage(WORKSPACE_NAME, ERROR_LABEL,
+                       validateDataIsACorrectionsFile,
+                       emptyWorkspaceGroupError());
+  }
+
+private:
+  template <typename Functor>
+  void assertTheDataIsCheckedOneTime(Functor const &functor,
+                                     DataType const &primaryType) {
+    ON_CALL(*m_dataSelector, getCurrentDataName())
+        .WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
+    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_dataSelector, getCurrentDataName()).Times(1);
+    EXPECT_CALL(*m_dataSelector, isValid()).Times(1);
+
+    (void)functor(*m_uiv, m_dataSelector.get(), ERROR_LABEL, primaryType,
+                  false);
+  }
+
+  template <typename Functor>
+  void assertTheDataIsCheckedNTimes(Functor const &functor, int nTimes,
+                                    DataType const &primaryType,
+                                    std::vector<DataType> const &otherTypes) {
+    ON_CALL(*m_dataSelector, getCurrentDataName())
+        .WillByDefault(Return(QString::fromStdString(WORKSPACE_NAME)));
+    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+
+    EXPECT_CALL(*m_dataSelector, getCurrentDataName()).Times(nTimes);
+    EXPECT_CALL(*m_dataSelector, isValid()).Times(nTimes);
+
+    (void)functor(*m_uiv, m_dataSelector.get(), ERROR_LABEL, primaryType,
+                  otherTypes, false);
+  }
+
+  template <typename Functor>
+  void assertThatTheDataIsValid(std::string const &workspaceName,
+                                std::string const &errorLabel,
+                                Functor const &functor) {
+    ON_CALL(*m_dataSelector, getCurrentDataName())
+        .WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+
+    TS_ASSERT(functor(*m_uiv, m_dataSelector.get(), errorLabel, false));
+    TS_ASSERT(m_uiv->generateErrorMessage().isEmpty());
+  }
+
+  template <typename Functor>
+  void assertThatTheDataIsInvalid(std::string const &workspaceName,
+                                  std::string const &errorLabel,
+                                  Functor const &functor) {
+    ON_CALL(*m_dataSelector, getCurrentDataName())
+        .WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+
+    TS_ASSERT(!functor(*m_uiv, m_dataSelector.get(), errorLabel, false));
+    TS_ASSERT(!m_uiv->generateErrorMessage().isEmpty());
+  }
+
+  template <typename Functor>
+  void assertErrorMessage(std::string const &workspaceName,
+                          std::string const &errorLabel, Functor const &functor,
+                          std::string const &errorMessage) {
+    ON_CALL(*m_dataSelector, getCurrentDataName())
+        .WillByDefault(Return(QString::fromStdString(workspaceName)));
+    ON_CALL(*m_dataSelector, isValid()).WillByDefault(Return(true));
+
+    (void)functor(*m_uiv, m_dataSelector.get(), errorLabel, false);
+
+    TS_ASSERT_EQUALS(m_uiv->generateErrorMessage().toStdString(), errorMessage);
+  }
+
+  AnalysisDataServiceImpl &m_ads;
+  std::unique_ptr<UserInputValidator> m_uiv;
+  std::unique_ptr<MockDataSelector> m_dataSelector;
+};
+
+#endif /* MANTID_CUSTOMINTERFACES_INDIRECTDATAVALIDATIONHELPERTEST_H_ */

--- a/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectDataValidationHelperTest.h
@@ -61,6 +61,8 @@ TableWorkspace_sptr createTableWorkspace(std::size_t const &size) {
   return boost::make_shared<TableWorkspace>(size);
 }
 
+} // namespace
+
 GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 /// Mock object to mock the data selector
@@ -72,8 +74,6 @@ public:
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
-
-} // namespace
 
 class IndirectDataValidationHelperTest : public CxxTest::TestSuite {
 public:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/DataSelector.h
@@ -83,7 +83,7 @@ public:
   /// Get the workspace name from the list of files
   QString getWsNameFromFiles() const;
   /// Get the currently available file or workspace name
-  QString getCurrentDataName() const;
+  virtual QString getCurrentDataName() const;
   /// Sets which selector (file or workspace) is visible
   void setSelectorIndex(int index);
   /// Sets if the option to choose selector is visible
@@ -95,7 +95,7 @@ public:
   /// Get whether the workspace selector is currently being shown
   bool isWorkspaceSelectorVisible() const;
   /// Checks if widget is in a valid state
-  bool isValid();
+  virtual bool isValid();
   /// Get file problem, empty string means no error.
   QString getProblem() const;
   /// Read settings from the given group

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -107,6 +107,7 @@ public:
   bool isAllInputValid();
 
 private:
+  /// Gets a workspace from the ADS
   template <typename T = Mantid::API::MatrixWorkspace,
             typename R = Mantid::API::MatrixWorkspace_sptr>
   R getADSWorkspace(std::string const &workspaceName);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -50,7 +50,8 @@ public:
   /// Check that the given MWRunFiles widget has valid files.
   bool checkMWRunFilesIsValid(const QString &name, MWRunFiles *widget);
   /// Check that the given DataSelector widget has valid input.
-  bool checkDataSelectorIsValid(const QString &name, DataSelector *widget);
+  bool checkDataSelectorIsValid(const QString &name, DataSelector *widget,
+                                bool silent = false);
   /// Check that the given start and end range is valid.
   bool checkValidRange(const QString &name, std::pair<double, double> range);
   /// Check that the given ranges dont overlap.
@@ -74,9 +75,10 @@ public:
   template <typename T = Mantid::API::MatrixWorkspace,
             typename R = Mantid::API::MatrixWorkspace_sptr>
   bool checkWorkspaceType(QString const &workspaceName,
-                          QString const &validType);
+                          QString const &inputType, QString const &validType,
+                          bool silent = false);
   /// Checks that a workspace exists in the ADS
-  bool checkWorkspaceExists(QString const &workspaceName);
+  bool checkWorkspaceExists(QString const &workspaceName, bool silent = false);
   /// Checks the number of histograms in a workspace
   bool checkWorkspaceNumberOfHistograms(QString const &workspaceName,
                                         std::size_t const &validSize);
@@ -87,9 +89,13 @@ public:
                                   std::size_t const &validSize);
   bool checkWorkspaceNumberOfBins(Mantid::API::MatrixWorkspace_sptr,
                                   std::size_t const &validSize);
+  /// Checks that a workspace group contains valid matrix workspace's
+  bool checkWorkspaceGroupIsValid(QString const &groupName,
+                                  QString const &inputType,
+                                  bool silent = false);
 
   /// Add a custom error message to the list.
-  void addErrorMessage(const QString &message);
+  void addErrorMessage(const QString &message, bool silent = false);
 
   /// Sets a validation label
   void setErrorLabel(QLabel *errorLabel, bool valid);
@@ -118,10 +124,14 @@ private:
  */
 template <typename T, typename R>
 bool UserInputValidator::checkWorkspaceType(QString const &workspaceName,
-                                            QString const &validType) {
-  if (checkWorkspaceExists(workspaceName)) {
+                                            QString const &inputType,
+                                            QString const &validType,
+                                            bool silent) {
+  if (checkWorkspaceExists(workspaceName, silent)) {
     if (!getADSWorkspace<T, R>(workspaceName.toStdString())) {
-      addErrorMessage(workspaceName + " is not a " + validType + ".");
+      addErrorMessage("The " + inputType + " workspace is not a " + validType +
+                          ".",
+                      silent);
       return false;
     } else
       return true;
@@ -137,7 +147,8 @@ bool UserInputValidator::checkWorkspaceType(QString const &workspaceName,
  */
 template <typename T, typename R>
 R UserInputValidator::getADSWorkspace(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().retrieveWS<T>(workspaceName);
+  return Mantid::API::AnalysisDataService::Instance().retrieveWS<T>(
+      workspaceName);
 }
 
 } // namespace CustomInterfaces

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -120,7 +120,9 @@ private:
  * Checks if the workspace has the correct type.
  *
  * @param workspaceName The name of the workspace
+ * @param inputType What the workspace is used for (e.g. Sample)
  * @param validType The type which is valid
+ * @param silent True if an error should not be added to the validator.
  * @return True if the workspace has the correct type
  */
 template <typename T, typename R>

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -112,6 +112,8 @@ private:
 
   /// Any raised error messages.
   QStringList m_errorMessages;
+  /// True if there has been an error.
+  bool m_error;
 };
 
 /**

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -21,15 +21,6 @@ class QLabel;
 class QString;
 class QStringList;
 
-namespace {
-
-template <typename T = MatrixWorkspace, typename R = MatrixWorkspace_sptr>
-R getADSWorkspace(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().retrieveWS<T>(workspaceName);
-}
-
-} // namespace
-
 namespace MantidQt {
 namespace CustomInterfaces {
 /**
@@ -86,6 +77,16 @@ public:
                           QString const &validType);
   /// Checks that a workspace exists in the ADS
   bool checkWorkspaceExists(QString const &workspaceName);
+  /// Checks the number of histograms in a workspace
+  bool checkWorkspaceNumberOfHistograms(QString const &workspaceName,
+                                        std::size_t const &validSize);
+  bool checkWorkspaceNumberOfHistograms(Mantid::API::MatrixWorkspace_sptr,
+                                        std::size_t const &validSize);
+  /// Checks the number of bins in a workspace
+  bool checkWorkspaceNumberOfBins(QString const &workspaceName,
+                                  std::size_t const &validSize);
+  bool checkWorkspaceNumberOfBins(Mantid::API::MatrixWorkspace_sptr,
+                                  std::size_t const &validSize);
 
   /// Add a custom error message to the list.
   void addErrorMessage(const QString &message);
@@ -100,6 +101,10 @@ public:
   bool isAllInputValid();
 
 private:
+  template <typename T = Mantid::API::MatrixWorkspace,
+            typename R = Mantid::API::MatrixWorkspace_sptr>
+  R getADSWorkspace(std::string const &workspaceName);
+
   /// Any raised error messages.
   QStringList m_errorMessages;
 };
@@ -114,14 +119,25 @@ private:
 template <typename T, typename R>
 bool UserInputValidator::checkWorkspaceType(QString const &workspaceName,
                                             QString const &validType) {
-  if (this->checkWorkspaceExists(workspaceName)) {
+  if (checkWorkspaceExists(workspaceName)) {
     if (!getADSWorkspace<T, R>(workspaceName.toStdString())) {
-      m_errorMessages.append(workspaceName + " is not a " + validType + ".");
+      addErrorMessage(workspaceName + " is not a " + validType + ".");
       return false;
     } else
       return true;
   }
   return false;
+}
+
+/**
+ * Gets a workspace from the ADS.
+ *
+ * @param workspaceName The name of the workspace
+ * @return The workspace
+ */
+template <typename T, typename R>
+R UserInputValidator::getADSWorkspace(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().retrieveWS<T>(workspaceName);
 }
 
 } // namespace CustomInterfaces

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/UserInputValidator.h
@@ -72,8 +72,7 @@ public:
                      double tolerance = 0.00000001);
 
   /// Checks that a workspace has the correct workspace type
-  template <typename T = Mantid::API::MatrixWorkspace,
-            typename R = Mantid::API::MatrixWorkspace_sptr>
+  template <typename T = Mantid::API::MatrixWorkspace>
   bool checkWorkspaceType(QString const &workspaceName,
                           QString const &inputType, QString const &validType,
                           bool silent = false);
@@ -108,9 +107,8 @@ public:
 
 private:
   /// Gets a workspace from the ADS
-  template <typename T = Mantid::API::MatrixWorkspace,
-            typename R = Mantid::API::MatrixWorkspace_sptr>
-  R getADSWorkspace(std::string const &workspaceName);
+  template <typename T = Mantid::API::MatrixWorkspace>
+  boost::shared_ptr<T> getADSWorkspace(std::string const &workspaceName);
 
   /// Any raised error messages.
   QStringList m_errorMessages;
@@ -125,13 +123,13 @@ private:
  * @param silent True if an error should not be added to the validator.
  * @return True if the workspace has the correct type
  */
-template <typename T, typename R>
+template <typename T>
 bool UserInputValidator::checkWorkspaceType(QString const &workspaceName,
                                             QString const &inputType,
                                             QString const &validType,
                                             bool silent) {
   if (checkWorkspaceExists(workspaceName, silent)) {
-    if (!getADSWorkspace<T, R>(workspaceName.toStdString())) {
+    if (!getADSWorkspace<T>(workspaceName.toStdString())) {
       addErrorMessage("The " + inputType + " workspace is not a " + validType +
                           ".",
                       silent);
@@ -148,8 +146,9 @@ bool UserInputValidator::checkWorkspaceType(QString const &workspaceName,
  * @param workspaceName The name of the workspace
  * @return The workspace
  */
-template <typename T, typename R>
-R UserInputValidator::getADSWorkspace(std::string const &workspaceName) {
+template <typename T>
+boost::shared_ptr<T>
+UserInputValidator::getADSWorkspace(std::string const &workspaceName) {
   return Mantid::API::AnalysisDataService::Instance().retrieveWS<T>(
       workspaceName);
 }

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -34,9 +34,12 @@ bool doesExistInADS(std::string const &workspaceName) {
 
 boost::optional<std::string>
 containsInvalidWorkspace(WorkspaceGroup_const_sptr group) {
+  if (group->isEmpty())
+    return "The group workspace " + group->getName() + " is empty.";
+
   for (auto workspace : *group)
     if (!workspace)
-      return "The group workspace called " + group->getName() +
+      return "The group workspace " + group->getName() +
              " contains an invalid workspace.";
   return boost::none;
 }
@@ -45,7 +48,7 @@ containsInvalidWorkspace(WorkspaceGroup_const_sptr group) {
 
 namespace MantidQt {
 namespace CustomInterfaces {
-UserInputValidator::UserInputValidator() : m_errorMessages() {}
+UserInputValidator::UserInputValidator() : m_errorMessages(), m_error(false) {}
 
 /**
  * Check that a given QLineEdit field (with given name) is not empty.  If it is
@@ -412,6 +415,7 @@ bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName,
 void UserInputValidator::addErrorMessage(const QString &message, bool silent) {
   if (!silent && !m_errorMessages.contains(message))
     m_errorMessages.append(message);
+  m_error = true;
 }
 
 /**
@@ -431,7 +435,7 @@ QString UserInputValidator::generateErrorMessage() {
  *
  * @return True if all input is valid, false otherwise
  */
-bool UserInputValidator::isAllInputValid() { return m_errorMessages.isEmpty(); }
+bool UserInputValidator::isAllInputValid() { return !m_error; }
 
 /**
  * Sets a validation label that is displyed next to the widget on the UI.

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -389,10 +389,10 @@ bool UserInputValidator::checkWorkspaceNumberOfBins(
 bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName,
                                                     QString const &inputType,
                                                     bool silent) {
-  if (checkWorkspaceType<WorkspaceGroup, WorkspaceGroup_sptr>(
-          groupName, inputType, "WorkspaceGroup", silent)) {
-    if (auto const group = getADSWorkspace<WorkspaceGroup, WorkspaceGroup_sptr>(
-            groupName.toStdString())) {
+  if (checkWorkspaceType<WorkspaceGroup>(groupName, inputType, "WorkspaceGroup",
+                                         silent)) {
+    if (auto const group =
+            getADSWorkspace<WorkspaceGroup>(groupName.toStdString())) {
       if (auto const error = containsInvalidWorkspace(group)) {
         addErrorMessage(QString::fromStdString(error.get()), silent);
         return false;

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -5,12 +5,15 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/UserInputValidator.h"
+#include "MantidAPI/AnalysisDataService.h"
+
 #include <QLabel>
 #include <QLineEdit>
 #include <QString>
 #include <QValidator>
 #include <cmath>
 
+using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 
 namespace // anonymous
@@ -22,6 +25,11 @@ template <typename T> void sortPair(std::pair<T, T> &pair) {
     pair.second = temp;
   }
 }
+
+bool doesExistInADS(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().doesExist(workspaceName);
+}
+
 } // anonymous namespace
 
 namespace MantidQt {
@@ -272,6 +280,20 @@ bool UserInputValidator::checkNotEqual(const QString &name, double x, double y,
     return false;
   }
 
+  return true;
+}
+
+/**
+ * Checks that a workspace exists within the ADS.
+ *
+ * @param workspaceName Name of the workspace
+ * @return True if the workspace is in the ADS
+ */
+bool UserInputValidator::checkWorkspaceExists(QString const &workspaceName) {
+  if (!doesExistInADS(workspaceName.toStdString())) {
+    m_errorMessages.append(workspaceName + " could not be found.");
+    return false;
+  }
   return true;
 }
 

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -138,6 +138,7 @@ bool UserInputValidator::checkMWRunFilesIsValid(const QString &name,
  *
  * @param name   :: the "name" of the widget so as to be recognised by the user.
  * @param widget :: the widget to check
+ * @param silent True if an error should not be added to the validator.
  * @returns True if the input was valid
  */
 bool UserInputValidator::checkDataSelectorIsValid(const QString &name,

--- a/qt/widgets/common/src/UserInputValidator.cpp
+++ b/qt/widgets/common/src/UserInputValidator.cpp
@@ -295,6 +295,7 @@ bool UserInputValidator::checkNotEqual(const QString &name, double x, double y,
  * Checks that a workspace exists within the ADS.
  *
  * @param workspaceName Name of the workspace
+ * @param silent True if an error should not be added to the validator.
  * @return True if the workspace is in the ADS
  */
 bool UserInputValidator::checkWorkspaceExists(QString const &workspaceName,
@@ -380,6 +381,8 @@ bool UserInputValidator::checkWorkspaceNumberOfBins(
  * workspaces.
  *
  * @param groupName The name of the workspace group
+ * @param inputType The name to put in the error message (e.g. "Sample")
+ * @param silent True if an error should not be added to the validator.
  * @return True if the workspace group is valid
  */
 bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName,
@@ -403,6 +406,7 @@ bool UserInputValidator::checkWorkspaceGroupIsValid(QString const &groupName,
  * Add a custom error message to the list.
  *
  * @param message :: the message to add to the list
+ * @param silent True if an error should not be added to the validator.
  */
 void UserInputValidator::addErrorMessage(const QString &message, bool silent) {
   if (!silent && !m_errorMessages.contains(message))

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/RangeSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/RangeSelector.h
@@ -69,7 +69,7 @@ private:
   void setMinLinePos(double /*val*/);
   void setMaxLinePos(double /*val*/);
   void verify();
-  bool inRange(double /*x*/);
+  bool inRange(double x, double dx = 0.0);
   bool changingMin(double /*x*/, double /*xPlusdx*/);
   bool changingMax(double /*x*/, double /*xPlusdx*/);
   bool eventFilter(QObject * /*unused*/, QEvent * /*unused*/) override;

--- a/qt/widgets/plotting/src/Qwt/RangeSelector.cpp
+++ b/qt/widgets/plotting/src/Qwt/RangeSelector.cpp
@@ -117,7 +117,7 @@ bool RangeSelector::eventFilter(QObject *obj, QEvent *evn) {
       xPlusdx = m_plot->invTransform(QwtPlot::yLeft, p.y() + 3);
       break;
     }
-    if (inRange(x)) {
+    if (inRange(x, fabs(x - xPlusdx))) {
       if (changingMin(x, xPlusdx)) {
         m_minChanging = true;
         m_canvas->setCursor(m_movCursor);
@@ -143,18 +143,20 @@ bool RangeSelector::eventFilter(QObject *obj, QEvent *evn) {
   {
     if (m_minChanging || m_maxChanging) {
       QPoint p = ((QMouseEvent *)evn)->pos();
-      double x(0.0);
+      double x(0.0), xPlusdx(0.0);
       switch (m_type) {
       case XMINMAX:
       case XSINGLE:
         x = m_plot->invTransform(QwtPlot::xBottom, p.x());
+        xPlusdx = m_plot->invTransform(QwtPlot::xBottom, p.x() + 3);
         break;
       case YMINMAX:
       case YSINGLE:
         x = m_plot->invTransform(QwtPlot::yLeft, p.y());
+        xPlusdx = m_plot->invTransform(QwtPlot::yLeft, p.y() + 3);
         break;
       }
-      if (inRange(x)) {
+      if (inRange(x, fabs(x - xPlusdx))) {
         if (m_minChanging) {
           if (x <= m_max) {
             setMin(x);
@@ -433,6 +435,6 @@ void RangeSelector::verify() {
  * @param x
  * @return true if position within the allowed range
  */
-bool RangeSelector::inRange(double x) {
-  return (x >= m_lower && x <= m_higher);
+bool RangeSelector::inRange(double x, double dx) {
+  return (x >= m_lower - dx && x <= m_higher + dx);
 }


### PR DESCRIPTION
~~Merge #25956 First~~
----------------------

**Description of work.**
This PR adds better validation checks for data when it is loaded in to the Data Reduction interface.

**To test:**
1. `Interfaces`->`Indirect`->`Data Reduction`->`Sqw` tab
2. Load data below
3. Change the Q Low value to be 0.2. (This is out of the acceptable range)
4. Click `Run`. A useful message should appear.

**Data Files**
[irs26176_graphite002_red.zip](https://github.com/mantidproject/mantid/files/3363322/irs26176_graphite002_red.zip)

Fixes #26209 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
