### PR TITLE
Fix a bug handling existing workspace names

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -9,6 +9,7 @@
 #include "Common/Parse.h"
 #include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
+#include <boost/algorithm/string.hpp>
 #include <set>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -37,13 +38,16 @@ parseRunNumbersOrWhitespace(std::string const &runNumberString) {
 
 boost::optional<std::string>
 parseRunNumber(std::string const &runNumberString) {
-  auto asInt = parseNonNegativeInt(std::move(runNumberString));
-  if (asInt.is_initialized()) {
-    auto withoutWhitespaceAndDefinatelyPositive = std::to_string(asInt.get());
-    return withoutWhitespaceAndDefinatelyPositive;
-  } else {
+  // We support any workspace name, as well as run numbers, so for just return
+  // the input string, but trimmed of whitespace (or none if the result is
+  // empty)
+  auto result = std::string(runNumberString);
+  boost::trim(result);
+
+  if (result.empty())
     return boost::none;
-  }
+
+  return result;
 }
 
 boost::optional<std::string>

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -349,21 +349,9 @@ public:
     runTestForValidPerAngleOptions(optionsTable);
   }
 
-  void testFirstTransmissionRunInvalid() {
-    OptionsTable const optionsTable = {
-        optionsRowWithFirstTransmissionRunInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 1);
-  }
-
   void testSetSecondTransmissionRun() {
     OptionsTable const optionsTable = {optionsRowWithSecondTransmissionRun()};
     runTestForInvalidPerAngleOptions(optionsTable, 0, 1);
-  }
-
-  void testSecondTransmissionRunInvalid() {
-    OptionsTable const optionsTable = {
-        optionsRowWithSecondTransmissionRunInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 2);
   }
 
   void testSetBothTransmissionRuns() {
@@ -803,11 +791,7 @@ private:
   }
   OptionsRow optionsRowWithWildcard() { return {"", "13463", "13464"}; }
   OptionsRow optionsRowWithFirstTransmissionRun() { return {"", "13463"}; }
-  OptionsRow optionsRowWithFirstTransmissionRunInvalid() { return {"", "bad"}; }
   OptionsRow optionsRowWithSecondTransmissionRun() { return {"", "", "13464"}; }
-  OptionsRow optionsRowWithSecondTransmissionRunInvalid() {
-    return {"", "", "bad"};
-  }
   OptionsRow optionsRowWithBothTransmissionRuns() {
     return {"", "13463", "13464"};
   }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
@@ -86,9 +86,13 @@ public:
                      TransmissionRunPair("13463", "13464"));
   }
 
-  void testInvalidTransmissionRuns() {
-    auto table = Table({Cells({"", "bad", "bad"})});
-    runTestInvalidCells(table, expectedErrors({0}, {1, 2}));
+  void testTransmissionRunsAreWorkspaceNames() {
+    auto table = Table({Cells({"", "some workspace", "another_workspace"})});
+    auto results = runTestValid(table);
+    TS_ASSERT_EQUALS(results.size(), 1);
+    TS_ASSERT_EQUALS(
+        results[0].transmissionWorkspaceNames(),
+        TransmissionRunPair("some workspace", "another_workspace"));
   }
 
   void testValidQRange() {
@@ -146,10 +150,10 @@ public:
 
   void testCorrectRowMarkedAsInvalidInMultiRowTable() {
     auto row1 = Cells({"0.5"});
-    auto row2 = Cells({"1.2", "bad"});
+    auto row2 = Cells({"1.2", "", "", "bad"});
     auto row3 = Cells({"2.3"});
     auto table = Table({row1, row2, row3});
-    runTestInvalidCells(table, expectedErrors({1}, {1}));
+    runTestInvalidCells(table, expectedErrors({1}, {3}));
   }
 
 private:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
@@ -39,14 +39,9 @@ public:
     TS_ASSERT(!result.is_initialized());
   }
 
-  void testRunNumberHandlesInvalidCharacters() {
-    auto result = parseRunNumber("bad");
-    TS_ASSERT(!result.is_initialized());
-  }
-
-  void testParseRunNumberConsidersFloatingPointInvalid() {
-    auto result = parseRunNumber("13.460");
-    TS_ASSERT(!result.is_initialized());
+  void testRunNumberHandlesFreeTextInput() {
+    auto result = parseRunNumber("some workspace name");
+    TS_ASSERT(result.is_initialized());
   }
 
   void testParseRunNumberOrWhitespaceExtractsRun() {
@@ -212,9 +207,9 @@ public:
     TS_ASSERT(!result.is_initialized());
   }
 
-  void testParseRunNumbersInvalid() {
-    auto result = parseRunNumbers("13460, bad");
-    TS_ASSERT(!result.is_initialized());
+  void testParseRunNumbersHandlesFreeTextInput() {
+    auto result = parseRunNumbers("13460, some workspace");
+    TS_ASSERT(result.is_initialized());
   }
 
   void testParseTransmissionRuns() {
@@ -245,18 +240,18 @@ public:
     TS_ASSERT_EQUALS(boost::get<std::vector<int>>(result), expected);
   }
 
-  void testParseTransmissionRunsFirstInvalid() {
-    auto result = parseTransmissionRuns("bad", "13464");
-    std::vector<int> expected = {0};
-    TS_ASSERT_EQUALS(result.which(), ERROR);
-    TS_ASSERT_EQUALS(boost::get<std::vector<int>>(result), expected);
+  void testParseTransmissionRunsHandlesFreeTextInputForFirst() {
+    auto result = parseTransmissionRuns("some workspace", "13464");
+    TransmissionRunPair expected = {"some workspace", "13464"};
+    TS_ASSERT_EQUALS(result.which(), VALUE);
+    TS_ASSERT_EQUALS(boost::get<TransmissionRunPair>(result), expected);
   }
 
-  void testParseTransmissionRunsSecondInvalid() {
-    auto result = parseTransmissionRuns("13463", "bad");
-    std::vector<int> expected = {1};
-    TS_ASSERT_EQUALS(result.which(), ERROR);
-    TS_ASSERT_EQUALS(boost::get<std::vector<int>>(result), expected);
+  void testParseTransmissionRunsHandlesFreeTextInputForSecond() {
+    auto result = parseTransmissionRuns("13463", "some workspace");
+    TransmissionRunPair expected = {"13463", "some workspace"};
+    TS_ASSERT_EQUALS(result.which(), VALUE);
+    TS_ASSERT_EQUALS(boost::get<TransmissionRunPair>(result), expected);
   }
 
 private:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
@@ -59,12 +59,13 @@ public:
                      expected);
   }
 
-  void testParseTransmissionRunsError() {
+  void testParseTransmissionRunsWithWorkspaceNames() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "bad", "bad"});
-    std::vector<int> errorCells = {1, 2};
-    TS_ASSERT(result.isError());
-    TS_ASSERT_EQUALS(result.assertError(), errorCells);
+    auto result = validator({"", "some workspace", "another_workspace"});
+    auto expected = TransmissionRunPair("some workspace", "another_workspace");
+    TS_ASSERT(result.isValid());
+    TS_ASSERT_EQUALS(result.assertValid().transmissionWorkspaceNames(),
+                     expected);
   }
 
   void testParseQRange() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
@@ -127,21 +127,21 @@ public:
   void testParsesSingleRunNumber() {
     TS_ASSERT_EQUALS(std::vector<std::string>({"100"}),
                      parseRunNumbers("100").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"102"}),
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102"}),
                      parseRunNumbers("000102").get());
   }
 
   void testParsesMultipleRunNumbersSeparatedByPlus() {
     TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}),
                      parseRunNumbers("100+1002").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"102", "111102", "10"}),
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}),
                      parseRunNumbers("000102+111102+010").get());
   }
 
   void testParsesMultipleRunNumbersSeparatedByComma() {
     TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}),
                      parseRunNumbers("100,1002").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"102", "111102", "10"}),
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}),
                      parseRunNumbers("000102+111102+010").get());
   }
 
@@ -152,10 +152,13 @@ public:
     TS_ASSERT_EQUALS(boost::none, parseRunNumbers("+"));
   }
 
-  void testFailsForBadRunNumbersMixedWithGood() {
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("00001+00012A+111249"));
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("000A01+00012+111249"));
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("00001+00012+11124D9"));
+  void testParsesRunNumbersMixedWithWorkspaceNames() {
+    TS_ASSERT_EQUALS(std::vector<std::string>({"00001", "00012A", "111249"}),
+                     parseRunNumbers("00001+00012A+111249"));
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000A01", "00012", "111249"}),
+                     parseRunNumbers("000A01+00012+111249"));
+    TS_ASSERT_EQUALS(std::vector<std::string>({"00001", "00012", "11124D9"}),
+                     parseRunNumbers("00001+00012+11124D9"));
   }
 
   void testParseThetaParsesValidThetaValues() {
@@ -224,22 +227,13 @@ public:
         boost::get<std::vector<int>>(parseTransmissionRuns("", "1000")));
   }
 
-  void testFailsForInvalidFirstTransmissionRun() {
-    TS_ASSERT_EQUALS(
-        std::vector<int>({0}),
-        boost::get<std::vector<int>>(parseTransmissionRuns("HDSK~", "1000")));
-  }
-
-  void testFailsForInvalidSecondTransmissionRun() {
-    TS_ASSERT_EQUALS(
-        std::vector<int>({1}),
-        boost::get<std::vector<int>>(parseTransmissionRuns("1000", "10ABSC")));
-  }
-
-  void testFailsForInvalidFirstAndSecondTransmissionRun() {
-    TS_ASSERT_EQUALS(std::vector<int>({0, 1}),
-                     boost::get<std::vector<int>>(
-                         parseTransmissionRuns("1bad000", "10ABSC")));
+  void testParsesWorkspaceNamesForTransmissionRuns() {
+    auto const expected =
+        TransmissionRunPair(std::vector<std::string>{"trans1a", "trans1b"},
+                            std::vector<std::string>{"trans2 a", "trans2 b"});
+    auto const result = boost::get<TransmissionRunPair>(
+        parseTransmissionRuns("trans1a,trans1b", "trans2 a, trans2 b"));
+    TS_ASSERT_EQUALS(expected, result);
   }
 };
 #endif // MANTID_CUSTOMINTERFACES_VALIDATEROWTEST_H_


### PR DESCRIPTION
The GUI was being too restrictive in its validation, expecting only (integer) run numbers for the runs or transmission runs. This PR allows support for existing workspaces names, which can be pretty much any free text. We still trim whitespace from the start/end.

**Report to:** Max at ISIS

**To test:**

See the linked issue and check that the workspace names are no longer marked as invalid, and are used in the algorithm history for the output workspace.

Fixes #26225

*This does not require release notes* because **it fixes a regression in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
