### PR TITLE
Indirect Make WorkspaceSelectors empty initially

### DIFF
--- a/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/AbsorptionCorrections.cpp
@@ -160,6 +160,10 @@ AbsorptionCorrections::AbsorptionCorrections(QWidget *parent)
           SLOT(doValidation()));
   connect(m_uiForm.ckUseCan, SIGNAL(stateChanged(int)), this,
           SLOT(doValidation()));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSampleInput->isOptional(true);
+  m_uiForm.dsCanInput->isOptional(true);
 }
 
 AbsorptionCorrections::~AbsorptionCorrections() {}

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -64,6 +64,11 @@ ApplyAbsorptionCorrections::ApplyAbsorptionCorrections(QWidget *parent)
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSample->isOptional(true);
+  m_uiForm.dsContainer->isOptional(true);
+  m_uiForm.dsCorrections->isOptional(true);
+
   m_uiForm.spPreviewSpec->setMinimum(0);
   m_uiForm.spPreviewSpec->setMaximum(0);
 }

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -84,6 +84,10 @@ CalculatePaalmanPings::CalculatePaalmanPings(QWidget *parent)
   connect(m_uiForm.spCanDensity, SIGNAL(valueChanged(double)), this,
           SLOT(setCanDensity(double)));
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSample->isOptional(true);
+  m_uiForm.dsContainer->isOptional(true);
+
   UserInputValidator uiv;
   if (uiv.checkFieldIsNotEmpty("Can Chemical Formula",
                                m_uiForm.leCanChemicalFormula,

--- a/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
+++ b/qt/scientific_interfaces/Indirect/ContainerSubtraction.cpp
@@ -44,6 +44,10 @@ ContainerSubtraction::ContainerSubtraction(QWidget *parent)
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSample->isOptional(true);
+  m_uiForm.dsContainer->isOptional(true);
+
   m_uiForm.spPreviewSpec->setMinimum(0);
   m_uiForm.spPreviewSpec->setMaximum(0);
 }

--- a/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISEnergyTransfer.cpp
@@ -252,6 +252,9 @@ ISISEnergyTransfer::ISISEnergyTransfer(IndirectDataReduction *idrUI,
           SLOT(updateRunButton(bool, std::string const &, QString const &,
                                QString const &)));
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsCalibrationFile->isOptional(true);
+
   // Update UI widgets to show default values
   mappingOptionSelected(m_uiForm.cbGroupingOptions->currentText());
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -35,6 +35,9 @@ IndirectFitDataView::IndirectFitDataView(QWidget *parent)
           SIGNAL(removeClicked()));
 
   connect(this, SIGNAL(currentChanged(int)), this, SLOT(emitViewSelected(int)));
+
+  m_dataForm->dsSample->isOptional(true);
+  m_dataForm->dsResolution->isOptional(true);
 }
 
 QTableWidget *IndirectFitDataView::getDataTable() const {

--- a/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMolDyn.cpp
@@ -55,6 +55,9 @@ IndirectMolDyn::IndirectMolDyn(QWidget *parent)
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsResolution->isOptional(true);
 }
 
 void IndirectMolDyn::setup() {}

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -71,6 +71,9 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
           SLOT(updateRunButton(bool, std::string const &, QString const &,
                                QString const &)));
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsInput->isOptional(true);
+
   // Disables searching for run files in the data archive
   m_uiForm.dsInput->isForRunFiles(false);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -85,6 +85,9 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
   m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
 #endif
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSampleInput->isOptional(true);
+
   // Disables searching for run files in the data archive
   m_uiForm.dsSampleInput->isForRunFiles(false);
 }

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -151,6 +151,9 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI,
   m_uiForm.pbRun->setEnabled(false);
   m_uiForm.pbPreview->setEnabled(false);
 
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsInput->isOptional(true);
+
   // Disables searching for run files in the data archive
   m_uiForm.dsInput->isForRunFiles(false);
 }

--- a/qt/scientific_interfaces/Indirect/Iqt.cpp
+++ b/qt/scientific_interfaces/Indirect/Iqt.cpp
@@ -261,6 +261,9 @@ void Iqt::setup() {
 
   connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this,
           SLOT(updateEnergyRange(int)));
+
+  m_uiForm.dsInput->isOptional(true);
+  m_uiForm.dsResolution->isOptional(true);
 }
 
 void Iqt::run() {

--- a/qt/scientific_interfaces/Indirect/Quasi.cpp
+++ b/qt/scientific_interfaces/Indirect/Quasi.cpp
@@ -81,6 +81,10 @@ Quasi::Quasi(QWidget *parent) : IndirectBayesTab(parent), m_previewSpec(0) {
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSample->isOptional(true);
+  m_uiForm.dsResolution->isOptional(true);
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ResNorm.cpp
+++ b/qt/scientific_interfaces/Indirect/ResNorm.cpp
@@ -80,6 +80,10 @@ ResNorm::ResNorm(QWidget *parent) : IndirectBayesTab(parent), m_previewSpec(0) {
   connect(m_uiForm.pbPlot, SIGNAL(clicked()), this, SLOT(plotClicked()));
   connect(m_uiForm.pbPlotCurrent, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsVanadium->isOptional(true);
+  m_uiForm.dsResolution->isOptional(true);
 }
 
 void ResNorm::setFileExtensionsByName(bool filter) {

--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -95,6 +95,10 @@ Stretch::Stretch(QWidget *parent)
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveWorkspaces()));
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this,
           SLOT(plotCurrentPreview()));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsSample->isOptional(true);
+  m_uiForm.dsResolution->isOptional(true);
 }
 
 void Stretch::setFileExtensionsByName(bool filter) {

--- a/qt/widgets/common/src/DataSelector.cpp
+++ b/qt/widgets/common/src/DataSelector.cpp
@@ -176,12 +176,13 @@ bool DataSelector::isValid() {
     if (isValid && m_autoLoad) {
       auto const wsName = getCurrentDataName().toStdString();
 
-      if (!doesExistInADS(wsName)) {
+      if (!wsName.empty() && !doesExistInADS(wsName)) {
         // attempt to reload if we can
         // don't use algorithm runner because we need to know instantly.
         auto const filepath =
             m_uiForm.rfFileInput->getUserInput().toString().toStdString();
-        loadFile(filepath, wsName);
+        if (!filepath.empty())
+          loadFile(filepath, wsName);
 
         isValid = doesExistInADS(wsName);
 


### PR DESCRIPTION
**Description of work.**
This PR ensures that an empty workspaceSelector is shown when changing to the workspace selector mode. Previously, changing mode would automatically select the first workspace in the selector. This could cause warning messages to appear if the first workspace in the selector was invalid - this was an annoyance for some scientists.

**No release notes as it is a minor non-scientific fix**

**To test:**
1. Load the below data into mantid
2. `Interfaces`->`Indirect`->`Data Analysis`->`FQFit`
3. Go to the combobox which says `File`, and select `Workspace`.
4. The neighbouring widget should change to an empty combobox

**Data Files**
[iris26176_graphite002_s0-17_Result.zip](https://github.com/mantidproject/mantid/files/3363375/iris26176_graphite002_s0-17_Result.zip)

Fixes #26227 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
