### PR TITLE
Add missing transmission run inputs to reflectometry GUI

### DIFF
--- a/docs/source/release/v4.1.0/reflectometry.rst
+++ b/docs/source/release/v4.1.0/reflectometry.rst
@@ -23,6 +23,8 @@ New
 - Tabs are now grouped inside "Batches" rather than having two separate "Groups" within each tab. This makes it easier to see which set of settings will be used together. Batches can be added/removed using the menu and the Batch tabs on the left.
 - The Settings tab has been split into two separate tabs, Experiment Settings and Instrument Settings.
 - The first and second transmission runs are now entered via two separate boxes. Multiple runs can be summed for either of these inputs by entering the run numbers as a comma-separated list.
+- New inputs have been added to control stitching of transmission runs: you can select whether to scale the left or right workspace; you can enter rebin parameters specifically for transmission run stitching (previously the same parameters as stitching of the output workspaces were used).
+- Spectra of interest can be specified for the transmission runs via a new column on the Experiment Settings tab (previously the same spectra as the run workspaces was used).
 - Default values for the current instrument are automatically set in the Experiment and Instrument Settings tabs when the interface is opened or the instrument is changed.
 - Processing in event mode is now done asynchronously. Previously this used to lock up MantidPlot.
 - Error handling has been improved to catch invalid inputs earlier. Errors are highlighted in red or (for the table) with a red star.

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
@@ -295,8 +295,9 @@ std::vector<PerThetaDefaults> makePerThetaDefaultsWithTwoAnglesAndWildcard() {
                        RangeInQ(0.008, 0.02, 1.2), 0.8,
                        ProcessingInstructions("2-3")),
       PerThetaDefaults(
-          2.3, TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
-                                   std::vector<std::string>{"22358", "22359"}),
+          2.3,
+          TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
+                              std::vector<std::string>{"22358", "22359"}),
           ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9,
           ProcessingInstructions("4-6"))};
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
@@ -322,15 +322,20 @@ FloodCorrections makeFloodCorrections() {
                           boost::optional<std::string>("test_workspace"));
 }
 
-RangeInLambda makeTransmissionRunRange() { return RangeInLambda(7.5, 9.2); }
+TransmissionStitchOptions makeTransmissionStitchOptions() {
+  return TransmissionStitchOptions(RangeInLambda{7.5, 9.2}, RebinParameters(),
+                                   true);
+}
 
-RangeInLambda makeEmptyTransmissionRunRange() { return RangeInLambda{0, 0}; }
+TransmissionStitchOptions makeEmptyTransmissionStitchOptions() {
+  return TransmissionStitchOptions(RangeInLambda{0, 0}, std::string(), false);
+}
 
 Experiment makeExperiment() {
   return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample,
                     SummationType::SumInQ, true, true,
                     makePolarizationCorrections(), makeFloodCorrections(),
-                    makeTransmissionRunRange(), makeStitchOptions(),
+                    makeTransmissionStitchOptions(), makeStitchOptions(),
                     makePerThetaDefaultsWithTwoAnglesAndWildcard());
 }
 
@@ -339,7 +344,8 @@ Experiment makeEmptyExperiment() {
                     SummationType::SumInLambda, false, false,
                     PolarizationCorrections(PolarizationCorrectionType::None),
                     FloodCorrections(FloodCorrectionType::Workspace),
-                    boost::none, std::map<std::string, std::string>(),
+                    TransmissionStitchOptions(),
+                    std::map<std::string, std::string>(),
                     std::vector<PerThetaDefaults>());
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
@@ -277,7 +277,7 @@ ReductionJobs emptyReductionJobs() {
 
 std::vector<PerThetaDefaults> makePerThetaDefaults() {
   auto perThetaDefaults =
-      PerThetaDefaults(boost::none, TransmissionRunPair(),
+      PerThetaDefaults(boost::none, TransmissionRunPair(), boost::none,
                        RangeInQ(boost::none, boost::none, boost::none),
                        boost::none, boost::none);
   return std::vector<PerThetaDefaults>{std::move(perThetaDefaults)};
@@ -287,17 +287,17 @@ std::vector<PerThetaDefaults> makePerThetaDefaultsWithTwoAnglesAndWildcard() {
   return std::vector<PerThetaDefaults>{
       // wildcard row with no angle
       PerThetaDefaults(boost::none, TransmissionRunPair("22345", "22346"),
-                       RangeInQ(0.007, 0.01, 1.1), 0.7,
+                       boost::none, RangeInQ(0.007, 0.01, 1.1), 0.7,
                        ProcessingInstructions("1")),
       // two angle rows
-      PerThetaDefaults(0.5, TransmissionRunPair("22347", ""),
+      PerThetaDefaults(0.5, TransmissionRunPair("22347", ""), boost::none,
                        RangeInQ(0.008, 0.02, 1.2), 0.8,
                        ProcessingInstructions("2-3")),
       PerThetaDefaults(
-          2.3,
-          TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
-                              std::vector<std::string>{"22358", "22359"}),
-          RangeInQ(0.009, 0.03, 1.3), 0.9, ProcessingInstructions("4-6"))};
+          2.3, TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
+                                   std::vector<std::string>{"22358", "22359"}),
+          boost::none, RangeInQ(0.009, 0.03, 1.3), 0.9,
+          ProcessingInstructions("4-6"))};
 }
 
 std::map<std::string, std::string> makeStitchOptions() {

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.cpp
@@ -287,7 +287,8 @@ std::vector<PerThetaDefaults> makePerThetaDefaultsWithTwoAnglesAndWildcard() {
   return std::vector<PerThetaDefaults>{
       // wildcard row with no angle
       PerThetaDefaults(boost::none, TransmissionRunPair("22345", "22346"),
-                       boost::none, RangeInQ(0.007, 0.01, 1.1), 0.7,
+                       ProcessingInstructions("5-6"),
+                       RangeInQ(0.007, 0.01, 1.1), 0.7,
                        ProcessingInstructions("1")),
       // two angle rows
       PerThetaDefaults(0.5, TransmissionRunPair("22347", ""), boost::none,
@@ -296,7 +297,7 @@ std::vector<PerThetaDefaults> makePerThetaDefaultsWithTwoAnglesAndWildcard() {
       PerThetaDefaults(
           2.3, TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
                                    std::vector<std::string>{"22358", "22359"}),
-          boost::none, RangeInQ(0.009, 0.03, 1.3), 0.9,
+          ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9,
           ProcessingInstructions("4-6"))};
 }
 
@@ -323,8 +324,8 @@ FloodCorrections makeFloodCorrections() {
 }
 
 TransmissionStitchOptions makeTransmissionStitchOptions() {
-  return TransmissionStitchOptions(RangeInLambda{7.5, 9.2}, RebinParameters(),
-                                   true);
+  return TransmissionStitchOptions(RangeInLambda{7.5, 9.2},
+                                   RebinParameters("-0.02"), true);
 }
 
 TransmissionStitchOptions makeEmptyTransmissionStitchOptions() {

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ModelCreationHelper.h
@@ -76,7 +76,8 @@ MANTIDQT_ISISREFLECTOMETRY_DLL PolarizationCorrections
 makeEmptyPolarizationCorrections();
 MANTIDQT_ISISREFLECTOMETRY_DLL FloodCorrections makeFloodCorrections();
 MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda makeTransmissionRunRange();
-MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda makeEmptyTransmissionRunRange();
+MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions
+makeEmptyTransmissionStitchOptions();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperiment();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeEmptyExperiment();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -140,6 +140,9 @@ void updatePerThetaDefaultProperties(AlgorithmRuntimeProps &properties,
 
   updateTransmissionWorkspaceProperties(
       properties, perThetaDefaults->transmissionWorkspaceNames());
+  AlgorithmProperties::update(
+      "TransmissionProcessingInstructions",
+      perThetaDefaults->transmissionProcessingInstructions(), properties);
   updateMomentumTransferProperties(properties, perThetaDefaults->qRange());
   AlgorithmProperties::update("ScaleFactor", perThetaDefaults->scaleFactor(),
                               properties);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -60,17 +60,25 @@ void updateRowProperties(AlgorithmRuntimeProps &properties, Row const &row) {
   AlgorithmProperties::updateFromMap(properties, row.reductionOptions());
 }
 
-void updateTransmissionRangeProperties(
+void updateTransmissionStitchProperties(
     AlgorithmRuntimeProps &properties,
-    boost::optional<RangeInLambda> const &range) {
-  if (!range)
-    return;
+    TransmissionStitchOptions const &options) {
+  auto range = options.overlapRange();
+  if (range) {
+    if (range->minSet())
+      AlgorithmProperties::update("StartOverlap", range->min(), properties);
 
-  if (range->minSet())
-    AlgorithmProperties::update("StartOverlap", range->min(), properties);
+    if (range->maxSet())
+      AlgorithmProperties::update("EndOverlap", range->max(), properties);
+  }
 
-  if (range->maxSet())
-    AlgorithmProperties::update("EndOverlap", range->max(), properties);
+  if (!options.rebinParameters().empty()) {
+    AlgorithmProperties::update("Params", options.rebinParameters(),
+                                properties);
+  }
+
+  AlgorithmProperties::update("ScaleRHSWorkspace", options.scaleRHS(),
+                              properties);
 }
 
 void updatePolarizationCorrectionProperties(
@@ -118,8 +126,8 @@ void updateExperimentProperties(AlgorithmRuntimeProps &properties,
                               properties);
   AlgorithmProperties::update("IncludePartialBins",
                               experiment.includePartialBins(), properties);
-  updateTransmissionRangeProperties(properties,
-                                    experiment.transmissionRunRange());
+  updateTransmissionStitchProperties(properties,
+                                     experiment.transmissionStitchOptions());
   updatePolarizationCorrectionProperties(properties,
                                          experiment.polarizationCorrections());
   updateFloodCorrectionProperties(properties, experiment.floodCorrections());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -51,9 +51,16 @@ getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   auto transmissionRunRange = RangeInLambda(
       defaults.getDoubleOrZero("StartOverlap", "TransRunStartOverlap"),
       defaults.getDoubleOrZero("EndOverlap", "TransRunEndOverlap"));
-
   if (!transmissionRunRange.isValid(false))
     throw std::invalid_argument("Transmission run overlap range is invalid");
+
+  auto transmissionStitchParams = defaults.getStringOrEmpty(
+      "TransmissionStitchParams", "TransmissionStitchParams");
+  auto transmissionScaleRHS =
+      defaults.getBoolOrTrue("TransmissionScaleRHS", "TransmissionScaleRHS");
+
+  auto transmissionStitchOptions = TransmissionStitchOptions(
+      transmissionRunRange, transmissionStitchParams, transmissionScaleRHS);
 
   // We currently don't specify stitch parameters in the parameters file
   auto stitchParameters = std::map<std::string, std::string>();
@@ -94,7 +101,7 @@ getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   return Experiment(
       analysisMode, reductionType, summationType, includePartialBins, debug,
       std::move(polarizationCorrections), std::move(floodCorrections),
-      std::move(transmissionRunRange), std::move(stitchParameters),
+      std::move(transmissionStitchOptions), std::move(stitchParameters),
       std::move(perThetaValidationResult.assertValid()));
 }
 } // unnamed namespace

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -54,10 +54,10 @@ getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   if (!transmissionRunRange.isValid(false))
     throw std::invalid_argument("Transmission run overlap range is invalid");
 
-  auto transmissionStitchParams = defaults.getStringOrEmpty(
-      "TransmissionStitchParams", "TransmissionStitchParams");
+  auto transmissionStitchParams =
+      defaults.getStringOrEmpty("Params", "TransmissionStitchParams");
   auto transmissionScaleRHS =
-      defaults.getBoolOrTrue("TransmissionScaleRHS", "TransmissionScaleRHS");
+      defaults.getBoolOrTrue("ScaleRHSWorkspace", "TransmissionScaleRHS");
 
   auto transmissionStitchOptions = TransmissionStitchOptions(
       transmissionRunRange, transmissionStitchParams, transmissionScaleRHS);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -64,6 +64,9 @@ getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   auto const theta = std::string("");
   auto const firstTransmissionRun = std::string("");
   auto const secondTransmissionRun = std::string("");
+  auto const transmissionProcessingInstructions =
+      defaults.getStringOrEmpty("TransmissionProcessingInstructions",
+                                "TransmissionProcessingInstructions");
   auto const qMin = stringValueOrEmpty(
       defaults.getOptionalValue<double>("MomentumTransferMin", "QMin"));
   auto const qMax = stringValueOrEmpty(
@@ -75,11 +78,12 @@ getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   auto const scaleFactor = stringValueOrEmpty(maybeScaleFactor);
   auto const processingInstructions = defaults.getStringOrEmpty(
       "ProcessingInstructions", "ProcessingInstructions");
-  auto perThetaDefaultsRow = std::array<std::string, 8>{
-      {theta, firstTransmissionRun, secondTransmissionRun, qMin, qMax, qStep,
-       scaleFactor, processingInstructions}};
+  auto perThetaDefaultsRow = PerThetaDefaults::ValueArray{
+      {theta, firstTransmissionRun, secondTransmissionRun,
+       transmissionProcessingInstructions, qMin, qMax, qStep, scaleFactor,
+       processingInstructions}};
   auto perThetaDefaults =
-      std::vector<std::array<std::string, 8>>{perThetaDefaultsRow};
+      std::vector<PerThetaDefaults::ValueArray>{perThetaDefaultsRow};
   auto validate = PerThetaDefaultsTableValidator();
   auto const tolerance = 0.0; // irrelevant because theta is empty
   auto perThetaValidationResult = validate(perThetaDefaults, tolerance);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -5,6 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ExperimentPresenter.h"
+#include "Common/Parse.h"
 #include "GUI/Batch/IBatchPresenter.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "PerThetaDefaultsTableValidator.h"
@@ -188,6 +189,31 @@ ExperimentPresenter::transmissionRunRangeFromView() {
     return range;
 }
 
+std::string ExperimentPresenter::transmissionStitchParamsFromView() {
+  auto stitchParams = m_view->getTransmissionStitchParams();
+  // It's valid if empty
+  if (stitchParams.empty())
+    return stitchParams;
+
+  // If set, the params should be a list containing an odd number of double
+  // values (as per the Params property of Rebin)
+  auto maybeParamsList = parseList(stitchParams, parseDouble);
+  if (maybeParamsList.is_initialized() && maybeParamsList->size() % 2 == 0)
+    return stitchParams;
+
+  m_view->showTransmissionStitchParamsInvalid();
+  return std::string();
+}
+
+TransmissionStitchOptions
+ExperimentPresenter::transmissionStitchOptionsFromView() {
+  auto transmissionRunRange = transmissionRunRangeFromView();
+  auto stitchParams = transmissionStitchParamsFromView();
+  auto scaleRHS = m_view->getTransmissionScaleRHSWorkspace();
+  return TransmissionStitchOptions(transmissionRunRange, stitchParams,
+                                   scaleRHS);
+}
+
 std::map<std::string, std::string>
 ExperimentPresenter::stitchParametersFromView() {
   auto maybeStitchParameters = parseOptions(m_view->getStitchOptions());
@@ -212,15 +238,15 @@ ExperimentValidationResult ExperimentPresenter::validateExperimentFromView() {
         summationTypeFromString(m_view->getSummationType());
     auto const includePartialBins = m_view->getIncludePartialBins();
     auto const debugOption = m_view->getDebugOption();
-    auto transmissionRunRange = transmissionRunRangeFromView();
+    auto transmissionStitchOptions = transmissionStitchOptionsFromView();
     auto polarizationCorrections = polarizationCorrectionsFromView();
     auto floodCorrections = floodCorrectionsFromView();
     auto stitchParameters = stitchParametersFromView();
     return ExperimentValidationResult(
         Experiment(analysisMode, reductionType, summationType,
                    includePartialBins, debugOption, polarizationCorrections,
-                   floodCorrections, transmissionRunRange, stitchParameters,
-                   perThetaValidationResult.assertValid()));
+                   floodCorrections, transmissionStitchOptions,
+                   stitchParameters, perThetaValidationResult.assertValid()));
   } else {
     return ExperimentValidationResult(
         ExperimentValidationErrors(perThetaValidationResult.assertError()));
@@ -266,13 +292,19 @@ void ExperimentPresenter::updateViewFromModel() {
   m_view->setIncludePartialBins(m_model.includePartialBins());
   m_view->setDebugOption(m_model.debug());
   m_view->setPerAngleOptions(m_model.perThetaDefaultsArray());
-  if (m_model.transmissionRunRange()) {
-    m_view->setTransmissionStartOverlap(m_model.transmissionRunRange()->min());
-    m_view->setTransmissionEndOverlap(m_model.transmissionRunRange()->max());
+  if (m_model.transmissionStitchOptions().overlapRange()) {
+    m_view->setTransmissionStartOverlap(
+        m_model.transmissionStitchOptions().overlapRange()->min());
+    m_view->setTransmissionEndOverlap(
+        m_model.transmissionStitchOptions().overlapRange()->max());
   } else {
     m_view->setTransmissionStartOverlap(0.0);
     m_view->setTransmissionEndOverlap(0.0);
   }
+  m_view->setTransmissionStitchParams(
+      m_model.transmissionStitchOptions().rebinParameters());
+  m_view->setTransmissionScaleRHSWorkspace(
+      m_model.transmissionStitchOptions().scaleRHS());
   m_view->setPolarizationCorrectionType(polarizationCorrectionTypeToString(
       m_model.polarizationCorrections().correctionType()));
   m_view->setFloodCorrectionType(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -198,8 +198,10 @@ std::string ExperimentPresenter::transmissionStitchParamsFromView() {
   // If set, the params should be a list containing an odd number of double
   // values (as per the Params property of Rebin)
   auto maybeParamsList = parseList(stitchParams, parseDouble);
-  if (maybeParamsList.is_initialized() && maybeParamsList->size() % 2 == 0)
+  if (maybeParamsList.is_initialized() && maybeParamsList->size() % 2 != 0) {
+    m_view->showTransmissionStitchParamsValid();
     return stitchParams;
+  }
 
   m_view->showTransmissionStitchParamsInvalid();
   return std::string();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -192,8 +192,10 @@ ExperimentPresenter::transmissionRunRangeFromView() {
 std::string ExperimentPresenter::transmissionStitchParamsFromView() {
   auto stitchParams = m_view->getTransmissionStitchParams();
   // It's valid if empty
-  if (stitchParams.empty())
+  if (stitchParams.empty()) {
+    m_view->showTransmissionStitchParamsValid();
     return stitchParams;
+  }
 
   // If set, the params should be a list containing an odd number of double
   // values (as per the Params property of Rebin)

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -79,6 +79,9 @@ private:
   PolarizationCorrections polarizationCorrectionsFromView();
   FloodCorrections floodCorrectionsFromView();
   boost::optional<RangeInLambda> transmissionRunRangeFromView();
+  std::string transmissionStitchParamsFromView();
+  TransmissionStitchOptions transmissionStitchOptionsFromView();
+
   std::map<std::string, std::string> stitchParametersFromView();
 
   ExperimentValidationResult updateModelFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
@@ -112,7 +112,7 @@ void ExperimentView::initializeTableRow(QTableWidget &table, int row) {
 }
 
 void ExperimentView::initializeTableRow(QTableWidget &table, int row,
-                                        std::array<std::string, 8> rowValues) {
+                                        OptionsTableRow rowValues) {
   m_ui.optionsTable->blockSignals(true);
   for (auto column = 0; column < table.columnCount(); ++column)
     table.setItem(
@@ -126,7 +126,7 @@ void ExperimentView::initOptionsTable() {
 
   // Set angle and scale columns to a small width so everything fits
   table->resizeColumnsToContents();
-  table->setColumnCount(8);
+  table->setColumnCount(OPTIONS_TABLE_COLUMN_COUNT);
   table->setRowCount(1);
   initializeTableItems(*table);
 
@@ -643,13 +643,13 @@ ExperimentView::textFromCell(QTableWidgetItem const *maybeNullItem) const {
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
 GNU_DIAG_OFF("missing-braces")
-std::vector<std::array<std::string, 8>>
-ExperimentView::getPerAngleOptions() const {
+auto ExperimentView::getPerAngleOptions() const
+    -> std::vector<OptionsTableRow> {
   auto const &table = *m_ui.optionsTable;
-  auto rows = std::vector<std::array<std::string, 8>>();
+  auto rows = std::vector<OptionsTableRow>();
   rows.reserve(table.rowCount());
   for (auto row = 0; row < table.rowCount(); ++row) {
-    rows.emplace_back(std::array<std::string, 8>{
+    rows.emplace_back(OptionsTableRow{
         textFromCell(table.item(row, 0)), textFromCell(table.item(row, 1)),
         textFromCell(table.item(row, 2)), textFromCell(table.item(row, 3)),
         textFromCell(table.item(row, 4)), textFromCell(table.item(row, 5)),
@@ -659,8 +659,7 @@ ExperimentView::getPerAngleOptions() const {
 }
 GNU_DIAG_ON("missing-braces")
 
-void ExperimentView::setPerAngleOptions(
-    std::vector<std::array<std::string, 8>> rows) {
+void ExperimentView::setPerAngleOptions(std::vector<OptionsTableRow> rows) {
   auto &table = *m_ui.optionsTable;
   table.blockSignals(true);
   auto numberOfRows = static_cast<int>(rows.size());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
@@ -111,8 +111,8 @@ void ExperimentView::initializeTableRow(QTableWidget &table, int row) {
   m_ui.optionsTable->blockSignals(false);
 }
 
-void ExperimentView::initializeTableRow(QTableWidget &table, int row,
-                                        OptionsTableRow rowValues) {
+void ExperimentView::initializeTableRow(
+    QTableWidget &table, int row, PerThetaDefaults::ValueArray rowValues) {
   m_ui.optionsTable->blockSignals(true);
   for (auto column = 0; column < table.columnCount(); ++column)
     table.setItem(
@@ -126,7 +126,7 @@ void ExperimentView::initOptionsTable() {
 
   // Set angle and scale columns to a small width so everything fits
   table->resizeColumnsToContents();
-  table->setColumnCount(OPTIONS_TABLE_COLUMN_COUNT);
+  table->setColumnCount(PerThetaDefaults::OPTIONS_TABLE_COLUMN_COUNT);
   table->setRowCount(1);
   initializeTableItems(*table);
 
@@ -136,7 +136,7 @@ void ExperimentView::initOptionsTable() {
     totalRowHeight += table->rowHeight(i);
   }
 
-  const int padding = 2;
+  const int padding = 20;
   table->setMinimumHeight(totalRowHeight + header->height() + padding);
 }
 
@@ -643,23 +643,25 @@ ExperimentView::textFromCell(QTableWidgetItem const *maybeNullItem) const {
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629
 GNU_DIAG_OFF("missing-braces")
-auto ExperimentView::getPerAngleOptions() const
-    -> std::vector<OptionsTableRow> {
+std::vector<PerThetaDefaults::ValueArray>
+ExperimentView::getPerAngleOptions() const {
   auto const &table = *m_ui.optionsTable;
-  auto rows = std::vector<OptionsTableRow>();
+  auto rows = std::vector<PerThetaDefaults::ValueArray>();
   rows.reserve(table.rowCount());
   for (auto row = 0; row < table.rowCount(); ++row) {
-    rows.emplace_back(OptionsTableRow{
+    rows.emplace_back(PerThetaDefaults::ValueArray{
         textFromCell(table.item(row, 0)), textFromCell(table.item(row, 1)),
         textFromCell(table.item(row, 2)), textFromCell(table.item(row, 3)),
         textFromCell(table.item(row, 4)), textFromCell(table.item(row, 5)),
-        textFromCell(table.item(row, 6)), textFromCell(table.item(row, 7))});
+        textFromCell(table.item(row, 6)), textFromCell(table.item(row, 7)),
+        textFromCell(table.item(row, 8))});
   }
   return rows;
 }
 GNU_DIAG_ON("missing-braces")
 
-void ExperimentView::setPerAngleOptions(std::vector<OptionsTableRow> rows) {
+void ExperimentView::setPerAngleOptions(
+    std::vector<PerThetaDefaults::ValueArray> rows) {
   auto &table = *m_ui.optionsTable;
   table.blockSignals(true);
   auto numberOfRows = static_cast<int>(rows.size());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
@@ -24,6 +24,18 @@ void showAsInvalid(QDoubleSpinBox &spinBox) {
 }
 
 void showAsValid(QDoubleSpinBox &spinBox) { spinBox.setStyleSheet(""); }
+
+void showAsInvalid(QLineEdit &lineEdit) {
+  auto palette = lineEdit.palette();
+  palette.setColor(QPalette::Base, QColor("#ffb8ad"));
+  lineEdit.setPalette(palette);
+}
+
+void showAsValid(QLineEdit &lineEdit) {
+  auto palette = lineEdit.palette();
+  palette.setColor(QPalette::Base, Qt::transparent);
+  lineEdit.setPalette(palette);
+}
 } // namespace
 
 /** Constructor
@@ -58,15 +70,11 @@ void ExperimentView::showPerAngleThetasNonUnique(double tolerance) {
 }
 
 void ExperimentView::showStitchParametersValid() {
-  auto palette = stitchOptionsLineEdit().palette();
-  palette.setColor(QPalette::Base, Qt::transparent);
-  stitchOptionsLineEdit().setPalette(palette);
+  showAsValid(stitchOptionsLineEdit());
 }
 
 void ExperimentView::showStitchParametersInvalid() {
-  auto palette = stitchOptionsLineEdit().palette();
-  palette.setColor(QPalette::Base, QColor("#ffb8ad"));
-  stitchOptionsLineEdit().setPalette(palette);
+  showAsInvalid(stitchOptionsLineEdit());
 }
 
 void ExperimentView::subscribe(ExperimentViewSubscriber *notifyee) {
@@ -726,6 +734,14 @@ void ExperimentView::showTransmissionRangeInvalid() {
 void ExperimentView::showTransmissionRangeValid() {
   showAsValid(*m_ui.startOverlapEdit);
   showAsValid(*m_ui.endOverlapEdit);
+}
+
+void ExperimentView::showTransmissionStitchParamsValid() {
+  showAsValid(*m_ui.transStitchParamsEdit);
+}
+
+void ExperimentView::showTransmissionStitchParamsInvalid() {
+  showAsInvalid(*m_ui.transStitchParamsEdit);
 }
 
 void ExperimentView::setPolarizationCorrectionType(std::string const &type) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.cpp
@@ -198,6 +198,8 @@ void ExperimentView::setEnabledStateForAllWidgets(bool enabled) {
   m_ui.analysisModeComboBox->setEnabled(enabled);
   m_ui.startOverlapEdit->setEnabled(enabled);
   m_ui.endOverlapEdit->setEnabled(enabled);
+  m_ui.transStitchParamsEdit->setEnabled(enabled);
+  m_ui.transScaleRHSCheckBox->setEnabled(enabled);
   m_ui.polCorrComboBox->setEnabled(enabled);
   m_ui.CRhoEdit->setEnabled(enabled);
   m_ui.CAlphaEdit->setEnabled(enabled);
@@ -226,6 +228,8 @@ void ExperimentView::registerExperimentSettingsWidgets(
   registerSettingWidget(*m_ui.analysisModeComboBox, "AnalysisMode", alg);
   registerSettingWidget(*m_ui.startOverlapEdit, "StartOverlap", alg);
   registerSettingWidget(*m_ui.endOverlapEdit, "EndOverlap", alg);
+  registerSettingWidget(*m_ui.transStitchParamsEdit, "Params", alg);
+  registerSettingWidget(*m_ui.transScaleRHSCheckBox, "ScaleRHSWorkspace", alg);
   registerSettingWidget(*m_ui.polCorrComboBox, "PolarizationAnalysis", alg);
   registerSettingWidget(*m_ui.CRhoEdit, "cRho", alg);
   registerSettingWidget(*m_ui.CAlphaEdit, "cAlpha", alg);
@@ -248,6 +252,8 @@ void ExperimentView::connectExperimentSettingsWidgets() {
   connectSettingsChange(*m_ui.analysisModeComboBox);
   connectSettingsChange(*m_ui.startOverlapEdit);
   connectSettingsChange(*m_ui.endOverlapEdit);
+  connectSettingsChange(*m_ui.transStitchParamsEdit);
+  connectSettingsChange(*m_ui.transScaleRHSCheckBox);
   connectSettingsChange(*m_ui.polCorrComboBox);
   connectSettingsChange(*m_ui.CRhoEdit);
   connectSettingsChange(*m_ui.CAlphaEdit);
@@ -267,6 +273,8 @@ void ExperimentView::disconnectExperimentSettingsWidgets() {
   disconnectSettingsChange(*m_ui.analysisModeComboBox);
   disconnectSettingsChange(*m_ui.startOverlapEdit);
   disconnectSettingsChange(*m_ui.endOverlapEdit);
+  disconnectSettingsChange(*m_ui.transStitchParamsEdit);
+  disconnectSettingsChange(*m_ui.transScaleRHSCheckBox);
   disconnectSettingsChange(*m_ui.polCorrComboBox);
   disconnectSettingsChange(*m_ui.CRhoEdit);
   disconnectSettingsChange(*m_ui.CAlphaEdit);
@@ -689,6 +697,26 @@ double ExperimentView::getTransmissionEndOverlap() const {
   return m_ui.endOverlapEdit->value();
 }
 
+void ExperimentView::setTransmissionEndOverlap(double end) {
+  m_ui.endOverlapEdit->setValue(end);
+}
+
+std::string ExperimentView::getTransmissionStitchParams() const {
+  return getText(*m_ui.transStitchParamsEdit);
+}
+
+void ExperimentView::setTransmissionStitchParams(std::string const &params) {
+  setText(*m_ui.transStitchParamsEdit, params);
+}
+
+bool ExperimentView::getTransmissionScaleRHSWorkspace() const {
+  return m_ui.transScaleRHSCheckBox->isChecked();
+}
+
+void ExperimentView::setTransmissionScaleRHSWorkspace(bool enable) {
+  setChecked(*m_ui.transScaleRHSCheckBox, enable);
+}
+
 void ExperimentView::showTransmissionRangeInvalid() {
   showAsInvalid(*m_ui.startOverlapEdit);
   showAsInvalid(*m_ui.endOverlapEdit);
@@ -697,10 +725,6 @@ void ExperimentView::showTransmissionRangeInvalid() {
 void ExperimentView::showTransmissionRangeValid() {
   showAsValid(*m_ui.startOverlapEdit);
   showAsValid(*m_ui.endOverlapEdit);
-}
-
-void ExperimentView::setTransmissionEndOverlap(double end) {
-  m_ui.endOverlapEdit->setValue(end);
 }
 
 void ExperimentView::setPolarizationCorrectionType(std::string const &type) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
@@ -72,6 +72,8 @@ public:
   void setTransmissionScaleRHSWorkspace(bool enable) override;
   void showTransmissionRangeInvalid() override;
   void showTransmissionRangeValid() override;
+  void showTransmissionStitchParamsInvalid() override;
+  void showTransmissionStitchParamsValid() override;
 
   std::string getPolarizationCorrectionType() const override;
   void setPolarizationCorrectionType(std::string const &type) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
@@ -25,6 +25,9 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL ExperimentView : public QWidget,
                                                       public IExperimentView {
   Q_OBJECT
 public:
+  static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 8;
+  using OptionsTableRow = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
+
   ExperimentView(Mantid::API::IAlgorithm_sptr algorithmForTooltips,
                  QWidget *parent = nullptr);
   void subscribe(ExperimentViewSubscriber *notifyee) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
@@ -66,6 +66,10 @@ public:
   void setTransmissionStartOverlap(double start) override;
   double getTransmissionEndOverlap() const override;
   void setTransmissionEndOverlap(double end) override;
+  std::string getTransmissionStitchParams() const override;
+  void setTransmissionStitchParams(std::string const &params) override;
+  bool getTransmissionScaleRHSWorkspace() const override;
+  void setTransmissionScaleRHSWorkspace(bool enable) override;
   void showTransmissionRangeInvalid() override;
   void showTransmissionRangeValid() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentView.h
@@ -25,9 +25,6 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL ExperimentView : public QWidget,
                                                       public IExperimentView {
   Q_OBJECT
 public:
-  static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 8;
-  using OptionsTableRow = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
-
   ExperimentView(Mantid::API::IAlgorithm_sptr algorithmForTooltips,
                  QWidget *parent = nullptr);
   void subscribe(ExperimentViewSubscriber *notifyee) override;
@@ -56,9 +53,9 @@ public:
   bool getDebugOption() const override;
   void setDebugOption(bool enable) override;
 
-  std::vector<std::array<std::string, 8>> getPerAngleOptions() const override;
+  std::vector<PerThetaDefaults::ValueArray> getPerAngleOptions() const override;
   void
-      setPerAngleOptions(std::vector<std::array<std::string, 8>> rows) override;
+  setPerAngleOptions(std::vector<PerThetaDefaults::ValueArray> rows) override;
   void showPerAngleOptionsAsInvalid(int row, int column) override;
   void showPerAngleOptionsAsValid(int row) override;
   void showPerAngleThetasNonUnique(double thetaTolerance) override;
@@ -129,7 +126,7 @@ private:
   void initializeTableItems(QTableWidget &table);
   void initializeTableRow(QTableWidget &table, int row);
   void initializeTableRow(QTableWidget &table, int row,
-                          std::array<std::string, 8> rowValues);
+                          PerThetaDefaults::ValueArray rowValues);
   QString messageFor(
       std::vector<MissingInstrumentParameterValue> const &missingValues) const;
   QString messageFor(const InstrumentParameterTypeMissmatch &typeError) const;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -26,7 +26,7 @@
   <property name="windowTitle">
    <string>Settings Tab</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
+  <layout class="QHBoxLayout" name="horizontalLayout" stretch="0">
    <property name="leftMargin">
     <number>5</number>
    </property>
@@ -40,7 +40,7 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="expSettingsGrid" rowstretch="1,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="1,0,0,0">
+    <layout class="QGridLayout" name="expSettingsGrid" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,1,0,1,0">
      <property name="leftMargin">
       <number>10</number>
      </property>
@@ -53,7 +53,200 @@
      <property name="bottomMargin">
       <number>10</number>
      </property>
-     <item row="3" column="1" rowspan="3" colspan="3">
+     <item row="10" column="0">
+      <widget class="QLabel" name="polCorrLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Polarisation Corrections</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="startOverlapLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Transmission Run Overlap Start</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="2">
+      <widget class="QLabel" name="floodWorkspaceWsSelectorLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Flood Workspace</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QCheckBox" name="includePartialBinsCheckBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="2">
+      <widget class="QLabel" name="transmissionScaleRHSLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Scale RHS Transmission</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QComboBox" name="reductionTypeComboBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Normal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>DivergentBeam</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>NonFlatSample</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="floodCorLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Flood Correction</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="3">
+      <widget class="QDoubleSpinBox" name="endOverlapEdit">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="startOverlapEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="analysisModeComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>PointDetectorAnalysis</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>MultiDetectorAnalysis</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QPushButton" name="addPerAngleOptionsButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>Add another row to the per-angle options table</string>
+       </property>
+       <property name="whatsThis">
+        <string>Adds another row to the per-angle options table so that additional angles can be added</string>
+       </property>
+       <property name="text">
+        <string>Add row</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="3">
+      <widget class="MantidQt::MantidWidgets::WorkspaceSelector" name="floodWorkspaceWsSelector">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1" rowspan="3" colspan="3">
       <widget class="QTableWidget" name="optionsTable">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
@@ -83,7 +276,7 @@
         <number>3</number>
        </property>
        <property name="columnCount">
-        <number>8</number>
+        <number>9</number>
        </property>
        <attribute name="horizontalHeaderVisible">
         <bool>true</bool>
@@ -122,12 +315,17 @@
        </column>
        <column>
         <property name="text">
-         <string>First Transmission Run</string>
+         <string>1st Transmission Run(s)</string>
         </property>
        </column>
        <column>
         <property name="text">
-         <string>Second Transmission Run</string>
+         <string>2nd Transmission Run(s)</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Transmission Spectra</string>
         </property>
        </column>
        <column>
@@ -152,99 +350,121 @@
        </column>
        <column>
         <property name="text">
-         <string>ProcessingInstructions</string>
+         <string>Run Spectra</string>
         </property>
        </column>
       </widget>
      </item>
-     <item row="7" column="2">
-      <widget class="QLabel" name="endOverlapLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>TransRunEndOverlap</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="transmissionStitchParamsLabel">
-       <property name="text">
-        <string>Transmission Run Stitch Params</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="summationTypeLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>SummationType</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QDoubleSpinBox" name="CRhoEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="3">
-      <widget class="QDoubleSpinBox" name="CAlphaEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="polCorrLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>PolarisationCorrections</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
+     <item row="1" column="3">
       <widget class="QCheckBox" name="debugCheckBox">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="debugLabel">
+     <item row="11" column="2">
+      <widget class="QLabel" name="CAlphaLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Debug</string>
+        <string>CAlpha</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="3">
-      <widget class="QDoubleSpinBox" name="CPpEdit">
+     <item row="9" column="1">
+      <widget class="QLineEdit" name="transStitchParamsEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QLabel" name="includePartialBinsLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>IncludePartialBins</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="reductionTypeLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>ReductionType</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="CApLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>CAp</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="1">
+      <widget class="QComboBox" name="floodCorComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Workspace</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>ParameterFile</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="analysisModeLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>AnalysisMode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
+      <widget class="QDoubleSpinBox" name="CApEdit">
        <property name="decimals">
         <number>5</number>
        </property>
@@ -256,17 +476,10 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="CRhoLabel">
-       <property name="text">
-        <string>CRho</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QComboBox" name="summationTypeComboBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -283,127 +496,10 @@
        </item>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="analysisModeLabel">
-       <property name="text">
-        <string>AnalysisMode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QPushButton" name="addPerAngleOptionsButton">
-       <property name="toolTip">
-        <string>Add another row to the per-angle options table</string>
-       </property>
-       <property name="whatsThis">
-        <string>Adds another row to the per-angle options table so that additional angles can be added</string>
-       </property>
-       <property name="text">
-        <string>Add row</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="3">
-      <widget class="QDoubleSpinBox" name="endOverlapEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="analysisModeComboBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <item>
-        <property name="text">
-         <string>PointDetectorAnalysis</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>MultiDetectorAnalysis</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="perAngleTableLabel">
-       <property name="text">
-        <string>Per-angle defaults</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="CApLabel">
-       <property name="text">
-        <string>CAp</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QDoubleSpinBox" name="CApEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="stitchLabel">
-       <property name="text">
-        <string>Stitch1DMany</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QLabel" name="includePartialBinsLabel">
-       <property name="text">
-        <string>IncludePartialBins</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="QCheckBox" name="includePartialBinsCheckBox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="2">
-      <widget class="QLabel" name="CAlphaLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>CAlpha</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="3">
-      <widget class="MantidQt::MantidWidgets::WorkspaceSelector" name="floodWorkspaceWsSelector"/>
-     </item>
-     <item row="9" column="1">
+     <item row="10" column="1">
       <widget class="QComboBox" name="polCorrComboBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
@@ -430,7 +526,62 @@
        </item>
       </widget>
      </item>
-     <item row="11" column="2">
+     <item row="11" column="0">
+      <widget class="QLabel" name="CRhoLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>CRho</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QDoubleSpinBox" name="CRhoEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="QLabel" name="endOverlapLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Overlap End</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="perAngleTableLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Per-angle defaults</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="2">
       <widget class="QLabel" name="CPpLabel">
        <property name="minimumSize">
         <size>
@@ -443,64 +594,8 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="floodCorLabel">
-       <property name="text">
-        <string>Flood Correction</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="2">
-      <widget class="QLabel" name="floodWorkspaceWsSelectorLabel">
-       <property name="text">
-        <string>Flood Workspace</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QComboBox" name="floodCorComboBox">
-       <item>
-        <property name="text">
-         <string>Workspace</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>ParameterFile</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="reductionTypeComboBox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <item>
-        <property name="text">
-         <string>Normal</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>DivergentBeam</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>NonFlatSample</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="reductionTypeLabel">
+     <item row="9" column="0">
+      <widget class="QLabel" name="transmissionStitchParamsLabel">
        <property name="minimumSize">
         <size>
          <width>117</width>
@@ -508,71 +603,130 @@
         </size>
        </property>
        <property name="text">
-        <string>ReductionType</string>
+        <string>Transmission Stitch Params</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="startOverlapLabel">
+     <item row="15" column="0">
+      <widget class="QLabel" name="stitchLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>TransRunStartOverlap</string>
+        <string>Output Stitch Params</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="1">
-      <widget class="QDoubleSpinBox" name="startOverlapEdit">
+     <item row="9" column="3">
+      <widget class="QCheckBox" name="transScaleRHSCheckBox">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>CheckBox</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QLabel" name="debugLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Debug</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="3">
+      <widget class="QDoubleSpinBox" name="CAlphaEdit">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="decimals">
         <number>5</number>
        </property>
        <property name="maximum">
         <double>100000.000000000000000</double>
        </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QLineEdit" name="transStitchParamsEdit"/>
-     </item>
-     <item row="8" column="2">
-      <widget class="QLabel" name="transmissionScaleRHSLabel">
-       <property name="text">
-        <string>Scale RHS Transmission Run</string>
+       <property name="value">
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="8" column="3">
-      <widget class="QCheckBox" name="transScaleRHSCheckBox">
-       <property name="text">
-        <string>CheckBox</string>
+     <item row="2" column="0">
+      <widget class="QLabel" name="summationTypeLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
        </property>
+       <property name="text">
+        <string>SummationType</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="3">
+      <widget class="QDoubleSpinBox" name="CPpEdit">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="3">
+      <widget class="QPushButton" name="getExpDefaultsButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>71</width>
+         <height>32</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::RightToLeft</enum>
+       </property>
+       <property name="text">
+        <string>Restore Defaults</string>
+       </property>
+       <property name="fixedWidth" stdset="0">
+        <number>70</number>
+       </property>
+       <property name="fixedHeight" stdset="0">
+        <number>100</number>
+       </property>
+       <layout class="QHBoxLayout" name="getExpDefaultsButtonLayout"/>
       </widget>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QPushButton" name="getExpDefaultsButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>71</width>
-       <height>32</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Restore Defaults</string>
-     </property>
-     <property name="fixedWidth" stdset="0">
-      <number>70</number>
-     </property>
-     <property name="fixedHeight" stdset="0">
-      <number>100</number>
-     </property>
-     <layout class="QHBoxLayout" name="getExpDefaultsButtonLayout"/>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -629,7 +629,7 @@
         </size>
        </property>
        <property name="text">
-        <string>CheckBox</string>
+        <string/>
        </property>
       </widget>
      </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -40,7 +40,7 @@
     <number>5</number>
    </property>
    <item>
-    <layout class="QGridLayout" name="expSettingsGrid" rowstretch="1,1,1,1,1,1,1,1,0,0,0,0,0" columnstretch="1,1,1,1">
+    <layout class="QGridLayout" name="expSettingsGrid" rowstretch="1,0,0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="1,0,0,0">
      <property name="leftMargin">
       <number>10</number>
      </property>
@@ -53,169 +53,6 @@
      <property name="bottomMargin">
       <number>10</number>
      </property>
-     <item row="1" column="0">
-      <widget class="QLabel" name="summationTypeLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>SummationType</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="CRhoEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="startOverlapLabel">
-       <property name="text">
-        <string>TransRunStartOverlap</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="3">
-      <widget class="QDoubleSpinBox" name="CAlphaEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QDoubleSpinBox" name="startOverlapEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="polCorrLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>PolarisationCorrections</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="debugLabel">
-       <property name="text">
-        <string>Debug</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="3">
-      <widget class="QDoubleSpinBox" name="CPpEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QCheckBox" name="debugCheckBox">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="2">
-      <widget class="QLabel" name="endOverlapLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>TransRunEndOverlap</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="CRhoLabel">
-       <property name="text">
-        <string>CRho</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="summationTypeComboBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <item>
-        <property name="text">
-         <string>SumInLambda</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>SumInQ</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="analysisModeLabel">
-       <property name="text">
-        <string>AnalysisMode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QPushButton" name="addPerAngleOptionsButton">
-       <property name="toolTip">
-        <string>Add another row to the per-angle options table</string>
-       </property>
-       <property name="whatsThis">
-        <string>Adds another row to the per-angle options table so that additional angles can be added</string>
-       </property>
-       <property name="text">
-        <string>Add row</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="3">
-      <widget class="QDoubleSpinBox" name="endOverlapEdit">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="1" rowspan="3" colspan="3">
       <widget class="QTableWidget" name="optionsTable">
        <property name="sizePolicy">
@@ -320,6 +157,159 @@
        </column>
       </widget>
      </item>
+     <item row="7" column="2">
+      <widget class="QLabel" name="endOverlapLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>TransRunEndOverlap</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="transmissionStitchParamsLabel">
+       <property name="text">
+        <string>Transmission Run Stitch Params</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="summationTypeLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>SummationType</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="CRhoEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="3">
+      <widget class="QDoubleSpinBox" name="CAlphaEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="polCorrLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>PolarisationCorrections</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QCheckBox" name="debugCheckBox">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="debugLabel">
+       <property name="text">
+        <string>Debug</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="3">
+      <widget class="QDoubleSpinBox" name="CPpEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="CRhoLabel">
+       <property name="text">
+        <string>CRho</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="summationTypeComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>SumInLambda</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>SumInQ</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="analysisModeLabel">
+       <property name="text">
+        <string>AnalysisMode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QPushButton" name="addPerAngleOptionsButton">
+       <property name="toolTip">
+        <string>Add another row to the per-angle options table</string>
+       </property>
+       <property name="whatsThis">
+        <string>Adds another row to the per-angle options table so that additional angles can be added</string>
+       </property>
+       <property name="text">
+        <string>Add row</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="3">
+      <widget class="QDoubleSpinBox" name="endOverlapEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
       <widget class="QComboBox" name="analysisModeComboBox">
        <property name="sizePolicy">
@@ -350,14 +340,14 @@
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
+     <item row="11" column="0">
       <widget class="QLabel" name="CApLabel">
        <property name="text">
         <string>CAp</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="1">
+     <item row="11" column="1">
       <widget class="QDoubleSpinBox" name="CApEdit">
        <property name="decimals">
         <number>5</number>
@@ -370,7 +360,7 @@
        </property>
       </widget>
      </item>
-     <item row="12" column="0">
+     <item row="13" column="0">
       <widget class="QLabel" name="stitchLabel">
        <property name="text">
         <string>Stitch1DMany</string>
@@ -394,7 +384,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="2">
+     <item row="10" column="2">
       <widget class="QLabel" name="CAlphaLabel">
        <property name="minimumSize">
         <size>
@@ -407,7 +397,10 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="12" column="3">
+      <widget class="MantidQt::MantidWidgets::WorkspaceSelector" name="floodWorkspaceWsSelector"/>
+     </item>
+     <item row="9" column="1">
       <widget class="QComboBox" name="polCorrComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -437,7 +430,7 @@
        </item>
       </widget>
      </item>
-     <item row="10" column="2">
+     <item row="11" column="2">
       <widget class="QLabel" name="CPpLabel">
        <property name="minimumSize">
         <size>
@@ -450,24 +443,21 @@
        </property>
       </widget>
      </item>
-     <item row="11" column="3">
-      <widget class="MantidQt::MantidWidgets::WorkspaceSelector" name="floodWorkspaceWsSelector" native="true"/>
-     </item>
-     <item row="11" column="2">
-      <widget class="QLabel" name="floodWorkspaceWsSelectorLabel">
-       <property name="text">
-        <string>Flood Workspace</string>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="0">
+     <item row="12" column="0">
       <widget class="QLabel" name="floodCorLabel">
        <property name="text">
         <string>Flood Correction</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1">
+     <item row="12" column="2">
+      <widget class="QLabel" name="floodWorkspaceWsSelectorLabel">
+       <property name="text">
+        <string>Flood Workspace</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
       <widget class="QComboBox" name="floodCorComboBox">
        <item>
         <property name="text">
@@ -479,19 +469,6 @@
          <string>ParameterFile</string>
         </property>
        </item>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="reductionTypeLabel">
-       <property name="minimumSize">
-        <size>
-         <width>117</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>ReductionType</string>
-       </property>
       </widget>
      </item>
      <item row="2" column="1">
@@ -520,6 +497,53 @@
          <string>NonFlatSample</string>
         </property>
        </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="reductionTypeLabel">
+       <property name="minimumSize">
+        <size>
+         <width>117</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>ReductionType</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="startOverlapLabel">
+       <property name="text">
+        <string>TransRunStartOverlap</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
+      <widget class="QDoubleSpinBox" name="startOverlapEdit">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLineEdit" name="transStitchParamsEdit"/>
+     </item>
+     <item row="8" column="2">
+      <widget class="QLabel" name="transmissionScaleRHSLabel">
+       <property name="text">
+        <string>Scale RHS Transmission Run</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="3">
+      <widget class="QCheckBox" name="transScaleRHSCheckBox">
+       <property name="text">
+        <string>CheckBox</string>
+       </property>
       </widget>
      </item>
     </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -92,6 +92,8 @@ public:
   virtual void setTransmissionScaleRHSWorkspace(bool enable) = 0;
   virtual void showTransmissionRangeInvalid() = 0;
   virtual void showTransmissionRangeValid() = 0;
+  virtual void showTransmissionStitchParamsInvalid() = 0;
+  virtual void showTransmissionStitchParamsValid() = 0;
 
   virtual std::string getPolarizationCorrectionType() const = 0;
   virtual void setPolarizationCorrectionType(std::string const &type) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -12,6 +12,7 @@
 #include "Common/InstrumentParameters.h"
 #include "MantidAPI/Algorithm.h"
 #include "MantidQtWidgets/Common/Hint.h"
+#include "Reduction/PerThetaDefaults.h"
 #include <map>
 #include <vector>
 
@@ -63,10 +64,10 @@ public:
   virtual bool getDebugOption() const = 0;
   virtual void setDebugOption(bool enable) = 0;
 
-  virtual std::vector<std::array<std::string, 8>>
+  virtual std::vector<PerThetaDefaults::ValueArray>
   getPerAngleOptions() const = 0;
   virtual void
-      setPerAngleOptions(std::vector<std::array<std::string, 8>> rows) = 0;
+  setPerAngleOptions(std::vector<PerThetaDefaults::ValueArray> rows) = 0;
   virtual void showPerAngleOptionsAsInvalid(int row, int column) = 0;
   virtual void showPerAngleOptionsAsValid(int row) = 0;
   virtual void showAllPerAngleOptionsAsValid() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -85,6 +85,10 @@ public:
   virtual void setTransmissionStartOverlap(double start) = 0;
   virtual double getTransmissionEndOverlap() const = 0;
   virtual void setTransmissionEndOverlap(double end) = 0;
+  virtual std::string getTransmissionStitchParams() const = 0;
+  virtual void setTransmissionStitchParams(std::string const &params) = 0;
+  virtual bool getTransmissionScaleRHSWorkspace() const = 0;
+  virtual void setTransmissionScaleRHSWorkspace(bool enable) = 0;
   virtual void showTransmissionRangeInvalid() = 0;
   virtual void showTransmissionRangeValid() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
@@ -16,7 +16,7 @@ namespace CustomInterfaces {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaultsTableValidator {
 public:
-  using ContentType = std::vector<std::array<std::string, 8>>;
+  using ContentType = std::vector<PerThetaDefaults::ValueArray>;
   using ResultType = ValidationResult<std::vector<PerThetaDefaults>,
                                       PerThetaDefaultsTableValidationError>;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentWidget.ui
@@ -47,9 +47,9 @@
      <property name="checkable">
       <bool>false</bool>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout" stretch="10,2">
+     <layout class="QHBoxLayout" name="horizontalLayout" stretch="10">
       <item>
-       <layout class="QGridLayout" name="instSettingsLayout0" rowstretch="1,1,1,1,1,1" columnstretch="1,1,1,1">
+       <layout class="QGridLayout" name="instSettingsLayout0" rowstretch="0,0,0,0,0,0,0,0,0,1" columnstretch="0,0,0,0,1">
         <property name="leftMargin">
          <number>10</number>
         </property>
@@ -62,11 +62,17 @@
         <property name="bottomMargin">
          <number>10</number>
         </property>
-        <item row="5" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="correctDetectorsLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>117</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
@@ -75,31 +81,17 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="3">
-         <widget class="QComboBox" name="detectorCorrectionTypeComboBox">
+        <item row="3" column="0">
+         <widget class="QLabel" name="lamMinLabel">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
-          <item>
-           <property name="text">
-            <string>VerticalShift</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>RotateAroundSample</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="lamMinLabel">
           <property name="minimumSize">
            <size>
-            <width>117</width>
+            <width>17</width>
             <height>0</height>
            </size>
           </property>
@@ -108,10 +100,29 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="monIntMinLabel">
+        <item row="0" column="0">
+         <widget class="QLabel" name="intMonCheckLabel">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>IntegratedMonitors</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="QLabel" name="detectorCorrectionTypeLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -123,38 +134,32 @@
            </size>
           </property>
           <property name="text">
-           <string>MonitorIntegralMin</string>
+           <string>DetectorCorrectionType</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="I0MonIndexLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>I0MonitorIndex</string>
+        <item row="2" column="3">
+         <widget class="QDoubleSpinBox" name="monBgMaxEdit">
+          <property name="decimals">
+           <number>3</number>
           </property>
          </widget>
         </item>
-        <item row="3" column="2">
-         <widget class="QLabel" name="lamMaxLabel">
-          <property name="minimumSize">
-           <size>
-            <width>117</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>LambdaMax</string>
+        <item row="1" column="3">
+         <widget class="QDoubleSpinBox" name="monIntMaxEdit">
+          <property name="decimals">
+           <number>3</number>
           </property>
          </widget>
         </item>
         <item row="2" column="2">
          <widget class="QLabel" name="monBgMaxLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>117</width>
@@ -175,9 +180,15 @@
         </item>
         <item row="2" column="0">
          <widget class="QLabel" name="monBgMinLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>117</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
@@ -186,23 +197,66 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="2">
-         <widget class="QLabel" name="monIntMaxLabel">
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="I0MonitorIndex"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="monIntMinLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
-            <width>117</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="text">
-           <string>MonitorIntegralMax</string>
+           <string>MonitorIntegralMin</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="intMonCheckLabel">
+        <item row="3" column="3">
+         <widget class="QDoubleSpinBox" name="lamMaxEdit">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QDoubleSpinBox" name="lamMinEdit">
+          <property name="decimals">
+           <number>3</number>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="3">
+         <widget class="QComboBox" name="detectorCorrectionTypeComboBox">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <item>
+           <property name="text">
+            <string>VerticalShift</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>RotateAroundSample</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QLabel" name="lamMaxLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
@@ -214,12 +268,18 @@
            </size>
           </property>
           <property name="text">
-           <string>IntegratedMonitors</string>
+           <string>LambdaMax</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QCheckBox" name="correctDetectorsCheckBox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -228,8 +288,33 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="2">
-         <widget class="QLabel" name="detectorCorrectionTypeLabel">
+        <item row="4" column="0">
+         <widget class="QLabel" name="I0MonIndexLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>I0MonitorIndex</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QLabel" name="monIntMaxLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="minimumSize">
            <size>
             <width>117</width>
@@ -237,22 +322,12 @@
            </size>
           </property>
           <property name="text">
-           <string>DetectorCorrectionType</string>
+           <string>MonitorIntegralMax</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QSpinBox" name="I0MonitorIndex"/>
-        </item>
-        <item row="3" column="1">
-         <widget class="QDoubleSpinBox" name="lamMinEdit">
-          <property name="decimals">
-           <number>3</number>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="3">
-         <widget class="QDoubleSpinBox" name="lamMaxEdit">
+        <item row="1" column="1">
+         <widget class="QDoubleSpinBox" name="monIntMinEdit">
           <property name="decimals">
            <number>3</number>
           </property>
@@ -265,54 +340,36 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="3">
-         <widget class="QDoubleSpinBox" name="monBgMaxEdit">
-          <property name="decimals">
-           <number>3</number>
+        <item row="9" column="4">
+         <widget class="QPushButton" name="getInstDefaultsButton">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QDoubleSpinBox" name="monIntMinEdit">
-          <property name="decimals">
-           <number>3</number>
+          <property name="minimumSize">
+           <size>
+            <width>71</width>
+            <height>32</height>
+           </size>
           </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QDoubleSpinBox" name="monIntMaxEdit">
-          <property name="decimals">
-           <number>3</number>
+          <property name="layoutDirection">
+           <enum>Qt::RightToLeft</enum>
           </property>
+          <property name="text">
+           <string>Restore Defaults</string>
+          </property>
+          <property name="fixedWidth" stdset="0">
+           <number>70</number>
+          </property>
+          <property name="fixedHeight" stdset="0">
+           <number>100</number>
+          </property>
+          <layout class="QHBoxLayout" name="getInstDefaultsButtonLayout"/>
          </widget>
         </item>
        </layout>
-      </item>
-      <item>
-       <widget class="QPushButton" name="getInstDefaultsButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>71</width>
-          <height>32</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Restore Defaults</string>
-        </property>
-        <property name="fixedWidth" stdset="0">
-         <number>70</number>
-        </property>
-        <property name="fixedHeight" stdset="0">
-         <number>100</number>
-        </property>
-        <layout class="QHBoxLayout" name="getInstDefaultsButtonLayout"/>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/CMakeLists.txt
@@ -11,6 +11,7 @@ set(REDUCTION_SRC_FILES
     Slicing.cpp
     ParseReflectometryStrings.cpp
     TransmissionRunPair.cpp
+    TransmissionStitchOptions.cpp
     Batch.cpp
     DetectorCorrections.cpp
     Experiment.cpp
@@ -40,6 +41,7 @@ set(REDUCTION_INC_FILES
     ParseReflectometryStrings.h
     ProcessingInstructions.h
     TransmissionRunPair.h
+    TransmissionStitchOptions.h
     ValidatePerThetaDefaults.h
     AnalysisMode.h
     Batch.h

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -18,7 +18,7 @@ Experiment::Experiment()
       m_debug(false), m_polarizationCorrections(PolarizationCorrections(
                           PolarizationCorrectionType::None)),
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)),
-      m_transmissionRunRange(boost::none),
+      m_transmissionStitchOptions(),
       m_stitchParameters(std::map<std::string, std::string>()),
       m_perThetaDefaults(std::vector<PerThetaDefaults>({PerThetaDefaults(
           boost::none, TransmissionRunPair(), boost::none, RangeInQ(),
@@ -29,7 +29,7 @@ Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType,
                        bool debug,
                        PolarizationCorrections polarizationCorrections,
                        FloodCorrections floodCorrections,
-                       boost::optional<RangeInLambda> transmissionRunRange,
+                       TransmissionStitchOptions transmissionStitchOptions,
                        // cppcheck-suppress passedByValue
                        std::map<std::string, std::string> stitchParameters,
                        // cppcheck-suppress passedByValue
@@ -39,7 +39,7 @@ Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType,
       m_debug(debug),
       m_polarizationCorrections(std::move(polarizationCorrections)),
       m_floodCorrections(std::move(floodCorrections)),
-      m_transmissionRunRange(std::move(transmissionRunRange)),
+      m_transmissionStitchOptions(std::move(transmissionStitchOptions)),
       m_stitchParameters(std::move(stitchParameters)),
       m_perThetaDefaults(std::move(perThetaDefaults)) {}
 
@@ -55,8 +55,8 @@ FloodCorrections const &Experiment::floodCorrections() const {
   return m_floodCorrections;
 }
 
-boost::optional<RangeInLambda> Experiment::transmissionRunRange() const {
-  return m_transmissionRunRange;
+TransmissionStitchOptions Experiment::transmissionStitchOptions() const {
+  return m_transmissionStitchOptions;
 }
 
 std::map<std::string, std::string> Experiment::stitchParameters() const {
@@ -120,7 +120,7 @@ bool operator==(Experiment const &lhs, Experiment const &rhs) {
          lhs.debug() == rhs.debug() &&
          lhs.polarizationCorrections() == rhs.polarizationCorrections() &&
          lhs.floodCorrections() == rhs.floodCorrections() &&
-         lhs.transmissionRunRange() == rhs.transmissionRunRange() &&
+         lhs.transmissionStitchOptions() == rhs.transmissionStitchOptions() &&
          lhs.stitchParameters() == rhs.stitchParameters() &&
          lhs.perThetaDefaults() == rhs.perThetaDefaults();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -20,9 +20,9 @@ Experiment::Experiment()
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)),
       m_transmissionRunRange(boost::none),
       m_stitchParameters(std::map<std::string, std::string>()),
-      m_perThetaDefaults(std::vector<PerThetaDefaults>(
-          {PerThetaDefaults(boost::none, TransmissionRunPair(), RangeInQ(),
-                            boost::none, ProcessingInstructions())})) {}
+      m_perThetaDefaults(std::vector<PerThetaDefaults>({PerThetaDefaults(
+          boost::none, TransmissionRunPair(), boost::none, RangeInQ(),
+          boost::none, ProcessingInstructions())})) {}
 
 Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType,
                        SummationType summationType, bool includePartialBins,
@@ -71,9 +71,9 @@ std::vector<PerThetaDefaults> const &Experiment::perThetaDefaults() const {
   return m_perThetaDefaults;
 }
 
-std::vector<std::array<std::string, 8>>
+std::vector<PerThetaDefaults::ValueArray>
 Experiment::perThetaDefaultsArray() const {
-  auto result = std::vector<std::array<std::string, 8>>();
+  auto result = std::vector<PerThetaDefaults::ValueArray>();
   for (auto const &perThetaDefaults : m_perThetaDefaults)
     result.push_back(perThetaDefaultsToArray(perThetaDefaults));
   return result;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -12,9 +12,9 @@
 #include "FloodCorrections.h"
 #include "PerThetaDefaults.h"
 #include "PolarizationCorrections.h"
-#include "RangeInLambda.h"
 #include "ReductionType.h"
 #include "SummationType.h"
+#include "TransmissionStitchOptions.h"
 #include <map>
 #include <string>
 #include <vector>
@@ -34,7 +34,7 @@ public:
              SummationType summationType, bool includePartialBins, bool debug,
              PolarizationCorrections polarizationCorrections,
              FloodCorrections floodCorrections,
-             boost::optional<RangeInLambda> transmissionRunRange,
+             TransmissionStitchOptions transmissionStitchOptions,
              std::map<std::string, std::string> stitchParameters,
              std::vector<PerThetaDefaults> perThetaDefaults);
 
@@ -45,7 +45,7 @@ public:
   bool debug() const;
   PolarizationCorrections const &polarizationCorrections() const;
   FloodCorrections const &floodCorrections() const;
-  boost::optional<RangeInLambda> transmissionRunRange() const;
+  TransmissionStitchOptions transmissionStitchOptions() const;
   std::map<std::string, std::string> stitchParameters() const;
   std::string stitchParametersString() const;
   std::vector<PerThetaDefaults> const &perThetaDefaults() const;
@@ -64,7 +64,7 @@ private:
 
   PolarizationCorrections m_polarizationCorrections;
   FloodCorrections m_floodCorrections;
-  boost::optional<RangeInLambda> m_transmissionRunRange;
+  TransmissionStitchOptions m_transmissionStitchOptions;
 
   std::map<std::string, std::string> m_stitchParameters;
   std::vector<PerThetaDefaults> m_perThetaDefaults;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -49,7 +49,7 @@ public:
   std::map<std::string, std::string> stitchParameters() const;
   std::string stitchParametersString() const;
   std::vector<PerThetaDefaults> const &perThetaDefaults() const;
-  std::vector<std::array<std::string, 8>> perThetaDefaultsArray() const;
+  std::vector<PerThetaDefaults::ValueArray> perThetaDefaultsArray() const;
 
   PerThetaDefaults const *defaultsForTheta(double thetaAngle,
                                            double tolerance) const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.cpp
@@ -12,12 +12,15 @@ namespace CustomInterfaces {
 PerThetaDefaults::PerThetaDefaults(
     boost::optional<double> theta,
     // cppcheck-suppress passedByValue
-    TransmissionRunPair transmissionRuns, RangeInQ qRange,
-    boost::optional<double> scaleFactor,
+    TransmissionRunPair transmissionRuns,
+    boost::optional<ProcessingInstructions> transmissionProcessingInstructions,
+    RangeInQ qRange, boost::optional<double> scaleFactor,
     boost::optional<ProcessingInstructions> processingInstructions)
     : m_theta(std::move(theta)),
       m_transmissionRuns(std::move(transmissionRuns)),
       m_qRange(std::move(qRange)), m_scaleFactor(std::move(scaleFactor)),
+      m_transmissionProcessingInstructions(
+          std::move(transmissionProcessingInstructions)),
       m_processingInstructions(std::move(processingInstructions)) {}
 
 TransmissionRunPair const &
@@ -42,10 +45,17 @@ PerThetaDefaults::processingInstructions() const {
   return m_processingInstructions;
 }
 
+boost::optional<ProcessingInstructions>
+PerThetaDefaults::transmissionProcessingInstructions() const {
+  return m_transmissionProcessingInstructions;
+}
+
 bool operator==(PerThetaDefaults const &lhs, PerThetaDefaults const &rhs) {
   return lhs.thetaOrWildcard() == rhs.thetaOrWildcard() &&
          lhs.qRange() == rhs.qRange() &&
          lhs.scaleFactor() == rhs.scaleFactor() &&
+         lhs.transmissionProcessingInstructions() ==
+             rhs.transmissionProcessingInstructions() &&
          lhs.processingInstructions() == rhs.processingInstructions();
 }
 
@@ -53,23 +63,25 @@ bool operator!=(PerThetaDefaults const &lhs, PerThetaDefaults const &rhs) {
   return !(lhs == rhs);
 }
 
-std::array<std::string, 8>
+PerThetaDefaults::ValueArray
 perThetaDefaultsToArray(PerThetaDefaults const &perThetaDefaults) {
-  auto result = std::array<std::string, 8>();
+  auto result = PerThetaDefaults::ValueArray();
   if (perThetaDefaults.thetaOrWildcard())
     result[0] = std::to_string(*perThetaDefaults.thetaOrWildcard());
   result[1] = perThetaDefaults.transmissionWorkspaceNames().firstRunList();
   result[2] = perThetaDefaults.transmissionWorkspaceNames().secondRunList();
+  if (perThetaDefaults.transmissionProcessingInstructions())
+    result[3] = *perThetaDefaults.transmissionProcessingInstructions();
   if (perThetaDefaults.qRange().min())
-    result[3] = std::to_string(*perThetaDefaults.qRange().min());
+    result[4] = std::to_string(*perThetaDefaults.qRange().min());
   if (perThetaDefaults.qRange().max())
-    result[4] = std::to_string(*perThetaDefaults.qRange().max());
+    result[5] = std::to_string(*perThetaDefaults.qRange().max());
   if (perThetaDefaults.qRange().step())
-    result[5] = std::to_string(*perThetaDefaults.qRange().step());
+    result[6] = std::to_string(*perThetaDefaults.qRange().step());
   if (perThetaDefaults.scaleFactor())
-    result[6] = std::to_string(*perThetaDefaults.scaleFactor());
+    result[7] = std::to_string(*perThetaDefaults.scaleFactor());
   if (perThetaDefaults.processingInstructions())
-    result[7] = *perThetaDefaults.processingInstructions();
+    result[8] = *perThetaDefaults.processingInstructions();
   return result;
 }
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -25,6 +25,20 @@ namespace CustomInterfaces {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaults {
 public:
+  enum Column {
+    // 0-based column indices for cells in a row. The Actual values are
+    // important here so set them explicitly
+    THETA = 0,
+    FIRST_TRANS = 1,
+    SECOND_TRANS = 2,
+    TRANS_SPECTRA = 3,
+    QMIN = 4,
+    QMAX = 5,
+    QSTEP = 6,
+    SCALE = 7,
+    RUN_SPECTRA = 8
+  };
+
   static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 9;
   using ValueArray = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -25,8 +25,13 @@ namespace CustomInterfaces {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaults {
 public:
+  static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 9;
+  using ValueArray = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
+
   PerThetaDefaults(
       boost::optional<double> theta, TransmissionRunPair tranmissionRuns,
+      boost::optional<ProcessingInstructions>
+          transmissionProcessingInstructions,
       RangeInQ qRange, boost::optional<double> scaleFactor,
       boost::optional<ProcessingInstructions> processingInstructions);
 
@@ -35,6 +40,8 @@ public:
   boost::optional<double> thetaOrWildcard() const;
   RangeInQ const &qRange() const;
   boost::optional<double> scaleFactor() const;
+  boost::optional<ProcessingInstructions>
+  transmissionProcessingInstructions() const;
   boost::optional<ProcessingInstructions> processingInstructions() const;
 
 private:
@@ -42,6 +49,7 @@ private:
   TransmissionRunPair m_transmissionRuns;
   RangeInQ m_qRange;
   boost::optional<double> m_scaleFactor;
+  boost::optional<ProcessingInstructions> m_transmissionProcessingInstructions;
   boost::optional<ProcessingInstructions> m_processingInstructions;
 };
 
@@ -49,7 +57,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(PerThetaDefaults const &lhs,
                                                PerThetaDefaults const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(PerThetaDefaults const &lhs,
                                                PerThetaDefaults const &rhs);
-std::array<std::string, 8>
+PerThetaDefaults::ValueArray
 perThetaDefaultsToArray(PerThetaDefaults const &perThetaDefaults);
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
@@ -9,6 +9,9 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
+TransmissionStitchOptions::TransmissionStitchOptions()
+    : m_overlapRange(boost::none), m_rebinParameters(), m_scaleRHS(false) {}
+
 TransmissionStitchOptions::TransmissionStitchOptions(
     boost::optional<RangeInLambda> overlapRange,
     RebinParameters rebinParameters, bool scaleRHS)
@@ -27,9 +30,9 @@ bool TransmissionStitchOptions::scaleRHS() const { return m_scaleRHS; }
 
 bool operator==(TransmissionStitchOptions const &lhs,
                 TransmissionStitchOptions const &rhs) {
-  lhs.overlapRange() == rhs.overlapRange() &&
-      lhs.rebinParameters() == rhs.rebinParameters() &&
-      lhs.scaleRHS() == rhs.scaleRHS();
+  return lhs.overlapRange() == rhs.overlapRange() &&
+         lhs.rebinParameters() == rhs.rebinParameters() &&
+         lhs.scaleRHS() == rhs.scaleRHS();
 }
 
 bool operator!=(TransmissionStitchOptions const &lhs,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
@@ -1,0 +1,40 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "TransmissionStitchOptions.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+TransmissionStitchOptions::TransmissionStitchOptions(
+    boost::optional<RangeInLambda> overlapRange,
+    RebinParameters rebinParameters, bool scaleRHS)
+    : m_overlapRange(std::move(overlapRange)),
+      m_rebinParameters(std::move(rebinParameters)), m_scaleRHS(scaleRHS) {}
+
+boost::optional<RangeInLambda> TransmissionStitchOptions::overlapRange() const {
+  return m_overlapRange;
+}
+
+RebinParameters TransmissionStitchOptions::rebinParameters() const {
+  return m_rebinParameters;
+}
+
+bool TransmissionStitchOptions::scaleRHS() const { return m_scaleRHS; }
+
+bool operator==(TransmissionStitchOptions const &lhs,
+                TransmissionStitchOptions const &rhs) {
+  lhs.overlapRange() == rhs.overlapRange() &&
+      lhs.rebinParameters() == rhs.rebinParameters() &&
+      lhs.scaleRHS() == rhs.scaleRHS();
+}
+
+bool operator!=(TransmissionStitchOptions const &lhs,
+                TransmissionStitchOptions const &rhs) {
+  return !(lhs == rhs);
+}
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -1,0 +1,50 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_
+#define MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_
+#include "Common/DllConfig.h"
+#include "ProcessingInstructions.h"
+#include "RangeInLambda.h"
+#include <boost/optional.hpp>
+#include <string>
+namespace MantidQt {
+namespace CustomInterfaces {
+
+// For now just pass rebin params as a string but in future we may want to
+// expand this
+using RebinParameters = std::string;
+
+/** @class TransmissionStitchOptions
+
+    The TransmissionStitchOptions model holds information about stitching
+   properties that should be applied during reduction for the transmission
+   runs, if both the first and second transmission runs are specified.
+ */
+class MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions {
+public:
+  TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange,
+                            RebinParameters rebinParameters, bool scaleRHS);
+
+  boost::optional<RangeInLambda> overlapRange() const;
+  RebinParameters rebinParameters() const;
+  bool scaleRHS() const;
+
+private:
+  boost::optional<RangeInLambda> m_overlapRange;
+  RebinParameters m_rebinParameters;
+  bool m_scaleRHS;
+};
+
+MANTIDQT_ISISREFLECTOMETRY_DLL bool
+operator==(TransmissionStitchOptions const &lhs,
+           TransmissionStitchOptions const &rhs);
+MANTIDQT_ISISREFLECTOMETRY_DLL bool
+operator!=(TransmissionStitchOptions const &lhs,
+           TransmissionStitchOptions const &rhs);
+} // namespace CustomInterfaces
+} // namespace MantidQt
+#endif // MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -26,6 +26,7 @@ using RebinParameters = std::string;
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions {
 public:
+  TransmissionStitchOptions();
   TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange,
                             RebinParameters rebinParameters, bool scaleRHS);
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
@@ -40,8 +40,7 @@ private:
   int m_baseColumn;
 };
 
-using CellText =
-    std::array<std::string, PerThetaDefaultsValidator::INPUT_FIELD_COUNT>;
+using CellText = PerThetaDefaults::ValueArray;
 
 boost::optional<boost::optional<double>>
 PerThetaDefaultsValidator::parseThetaOrWhitespace(CellText const &cellText) {
@@ -67,10 +66,20 @@ PerThetaDefaultsValidator::parseTransmissionRuns(CellText const &cellText) {
       transmissionRunsOrError);
 }
 
+boost::optional<boost::optional<std::string>>
+PerThetaDefaultsValidator::parseTransmissionProcessingInstructions(
+    CellText const &cellText) {
+  auto optionalInstructionsOrNoneIfError =
+      ::MantidQt::CustomInterfaces::parseProcessingInstructions(cellText[3]);
+  if (!optionalInstructionsOrNoneIfError.is_initialized())
+    m_invalidColumns.emplace_back(3);
+  return optionalInstructionsOrNoneIfError;
+}
+
 boost::optional<RangeInQ>
 PerThetaDefaultsValidator::parseQRange(CellText const &cellText) {
   auto qRangeOrError = ::MantidQt::CustomInterfaces::parseQRange(
-      cellText[3], cellText[4], cellText[5]);
+      cellText[4], cellText[5], cellText[6]);
   return boost::apply_visitor(
       AppendErrorIfNotType<RangeInQ>(m_invalidColumns, 3), qRangeOrError);
 }
@@ -78,9 +87,9 @@ PerThetaDefaultsValidator::parseQRange(CellText const &cellText) {
 boost::optional<boost::optional<double>>
 PerThetaDefaultsValidator::parseScaleFactor(CellText const &cellText) {
   auto optionalScaleFactorOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseScaleFactor(cellText[6]);
+      ::MantidQt::CustomInterfaces::parseScaleFactor(cellText[7]);
   if (!optionalScaleFactorOrNoneIfError.is_initialized())
-    m_invalidColumns.emplace_back(6);
+    m_invalidColumns.emplace_back(7);
   return optionalScaleFactorOrNoneIfError;
 }
 
@@ -88,9 +97,9 @@ boost::optional<boost::optional<std::string>>
 PerThetaDefaultsValidator::parseProcessingInstructions(
     CellText const &cellText) {
   auto optionalInstructionsOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseProcessingInstructions(cellText[7]);
+      ::MantidQt::CustomInterfaces::parseProcessingInstructions(cellText[8]);
   if (!optionalInstructionsOrNoneIfError.is_initialized())
-    m_invalidColumns.emplace_back(7);
+    m_invalidColumns.emplace_back(8);
   return optionalInstructionsOrNoneIfError;
 }
 
@@ -98,11 +107,14 @@ ValidationResult<PerThetaDefaults, std::vector<int>> PerThetaDefaultsValidator::
 operator()(CellText const &cellText) {
   auto maybeTheta = parseThetaOrWhitespace(cellText);
   auto maybeTransmissionRuns = parseTransmissionRuns(cellText);
+  auto maybeTransmissionProcessingInstructions =
+      parseTransmissionProcessingInstructions(cellText);
   auto maybeQRange = parseQRange(cellText);
   auto maybeScaleFactor = parseScaleFactor(cellText);
   auto maybeProcessingInstructions = parseProcessingInstructions(cellText);
   auto maybeDefaults = makeIfAllInitialized<PerThetaDefaults>(
-      maybeTheta, maybeTransmissionRuns, maybeQRange, maybeScaleFactor,
+      maybeTheta, maybeTransmissionRuns,
+      maybeTransmissionProcessingInstructions, maybeQRange, maybeScaleFactor,
       maybeProcessingInstructions);
 
   if (maybeDefaults.is_initialized())

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
@@ -81,7 +81,7 @@ PerThetaDefaultsValidator::parseQRange(CellText const &cellText) {
   auto qRangeOrError = ::MantidQt::CustomInterfaces::parseQRange(
       cellText[4], cellText[5], cellText[6]);
   return boost::apply_visitor(
-      AppendErrorIfNotType<RangeInQ>(m_invalidColumns, 3), qRangeOrError);
+      AppendErrorIfNotType<RangeInQ>(m_invalidColumns, 4), qRangeOrError);
 }
 
 boost::optional<boost::optional<double>>

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
@@ -24,31 +24,31 @@ namespace CustomInterfaces {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaultsValidator {
 public:
-  static auto constexpr INPUT_FIELD_COUNT = 8;
-
   ValidationResult<PerThetaDefaults, std::vector<int>>
-  operator()(std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
+  operator()(PerThetaDefaults::ValueArray const &cellText);
 
 private:
-  boost::optional<boost::optional<double>> parseThetaOrWhitespace(
-      std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
-  boost::optional<TransmissionRunPair> parseTransmissionRuns(
-      std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
-  boost::optional<RangeInQ>
-  parseQRange(std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
   boost::optional<boost::optional<double>>
-  parseScaleFactor(std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
+  parseThetaOrWhitespace(PerThetaDefaults::ValueArray const &cellText);
+  boost::optional<TransmissionRunPair>
+  parseTransmissionRuns(PerThetaDefaults::ValueArray const &cellText);
+  boost::optional<boost::optional<std::string>>
+  parseTransmissionProcessingInstructions(
+      PerThetaDefaults::ValueArray const &cellText);
+  boost::optional<RangeInQ>
+  parseQRange(PerThetaDefaults::ValueArray const &cellText);
+  boost::optional<boost::optional<double>>
+  parseScaleFactor(PerThetaDefaults::ValueArray const &cellText);
   boost::optional<std::map<std::string, std::string>>
-  parseOptions(std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
-  boost::optional<boost::optional<std::string>> parseProcessingInstructions(
-      std::array<std::string, INPUT_FIELD_COUNT> const &cellText);
+  parseOptions(PerThetaDefaults::ValueArray const &cellText);
+  boost::optional<boost::optional<std::string>>
+  parseProcessingInstructions(PerThetaDefaults::ValueArray const &cellText);
 
   std::vector<int> m_invalidColumns;
 };
 
-ValidationResult<PerThetaDefaults, std::vector<int>> validatePerThetaDefaults(
-    std::array<std::string, PerThetaDefaultsValidator::INPUT_FIELD_COUNT> const
-        &cellText);
+ValidationResult<PerThetaDefaults, std::vector<int>>
+validatePerThetaDefaults(PerThetaDefaults::ValueArray const &cellText);
 
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
@@ -72,12 +72,13 @@ public:
   }
 
   void testStitchParamsSetFromStitchingOptions() {
-    auto experiment = Experiment(
-        AnalysisMode::PointDetector, ReductionType::Normal,
-        SummationType::SumInLambda, false, false,
-        PolarizationCorrections(PolarizationCorrectionType::None),
-        FloodCorrections(FloodCorrectionType::Workspace), boost::none,
-        makeStitchOptions(), std::vector<PerThetaDefaults>());
+    auto experiment =
+        Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
+                   SummationType::SumInLambda, false, false,
+                   PolarizationCorrections(PolarizationCorrectionType::None),
+                   FloodCorrections(FloodCorrectionType::Workspace),
+                   TransmissionStitchOptions(), makeStitchOptions(),
+                   std::vector<PerThetaDefaults>());
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -87,13 +88,13 @@ public:
   }
 
   void testPerThetaDefaultsQResolutionUsedForParamsIfStitchingOptionsEmpty() {
-    auto experiment =
-        Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
-                   SummationType::SumInLambda, false, false,
-                   PolarizationCorrections(PolarizationCorrectionType::None),
-                   FloodCorrections(FloodCorrectionType::Workspace),
-                   boost::none, std::map<std::string, std::string>(),
-                   makePerThetaDefaultsWithTwoAnglesAndWildcard());
+    auto experiment = Experiment(
+        AnalysisMode::PointDetector, ReductionType::Normal,
+        SummationType::SumInLambda, false, false,
+        PolarizationCorrections(PolarizationCorrectionType::None),
+        FloodCorrections(FloodCorrectionType::Workspace),
+        TransmissionStitchOptions(), std::map<std::string, std::string>(),
+        makePerThetaDefaultsWithTwoAnglesAndWildcard());
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -101,13 +102,13 @@ public:
   }
 
   void testQResolutionForFirstValidRowUsedForParamsIfStitchingOptionsEmpty() {
-    auto experiment =
-        Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
-                   SummationType::SumInLambda, false, false,
-                   PolarizationCorrections(PolarizationCorrectionType::None),
-                   FloodCorrections(FloodCorrectionType::Workspace),
-                   boost::none, std::map<std::string, std::string>(),
-                   makePerThetaDefaultsWithTwoAnglesAndWildcard());
+    auto experiment = Experiment(
+        AnalysisMode::PointDetector, ReductionType::Normal,
+        SummationType::SumInLambda, false, false,
+        PolarizationCorrections(PolarizationCorrectionType::None),
+        FloodCorrections(FloodCorrectionType::Workspace),
+        TransmissionStitchOptions(), std::map<std::string, std::string>(),
+        makePerThetaDefaultsWithTwoAnglesAndWildcard());
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithMixedQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);
@@ -116,13 +117,13 @@ public:
 
   void
   testQOutputResolutionForFirstValidRowUsedForParamsIfStitchingOptionsEmpty() {
-    auto experiment =
-        Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
-                   SummationType::SumInLambda, false, false,
-                   PolarizationCorrections(PolarizationCorrectionType::None),
-                   FloodCorrections(FloodCorrectionType::Workspace),
-                   boost::none, std::map<std::string, std::string>(),
-                   makePerThetaDefaultsWithTwoAnglesAndWildcard());
+    auto experiment = Experiment(
+        AnalysisMode::PointDetector, ReductionType::Normal,
+        SummationType::SumInLambda, false, false,
+        PolarizationCorrections(PolarizationCorrectionType::None),
+        FloodCorrections(FloodCorrectionType::Workspace),
+        TransmissionStitchOptions(), std::map<std::string, std::string>(),
+        makePerThetaDefaultsWithTwoAnglesAndWildcard());
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithOutputQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
@@ -44,6 +44,8 @@ public:
     TS_ASSERT_EQUALS(result["FloodWorkspace"], "test_workspace");
     TS_ASSERT_EQUALS(result["StartOverlap"], "7.500000");
     TS_ASSERT_EQUALS(result["EndOverlap"], "9.200000");
+    TS_ASSERT_EQUALS(result["Params"], "-0.02");
+    TS_ASSERT_EQUALS(result["ScaleRHSWorkspace"], "1");
   }
 
   void testExperimentSettingsWithEmptyRow() {
@@ -69,6 +71,7 @@ public:
     auto result = createAlgorithmRuntimeProps(model, row);
     TS_ASSERT_EQUALS(result["FirstTransmissionRunList"], "22348, 22349");
     TS_ASSERT_EQUALS(result["SecondTransmissionRunList"], "22358, 22359");
+    TS_ASSERT_EQUALS(result["TransmissionProcessingInstructions"], "4");
     TS_ASSERT_EQUALS(result["MomentumTransferMin"], "0.009000");
     TS_ASSERT_EQUALS(result["MomentumTransferStep"], "0.030000");
     TS_ASSERT_EQUALS(result["MomentumTransferMax"], "1.300000");
@@ -83,6 +86,7 @@ public:
     auto result = createAlgorithmRuntimeProps(model, row);
     TS_ASSERT_EQUALS(result["FirstTransmissionRunList"], "22345");
     TS_ASSERT_EQUALS(result["SecondTransmissionRunList"], "22346");
+    TS_ASSERT_EQUALS(result["TransmissionProcessingInstructions"], "5-6");
     TS_ASSERT_EQUALS(result["MomentumTransferMin"], "0.007000");
     TS_ASSERT_EQUALS(result["MomentumTransferStep"], "0.010000");
     TS_ASSERT_EQUALS(result["MomentumTransferMax"], "1.100000");

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
@@ -61,8 +61,8 @@ public:
   void testValidPerThetaOptions() {
     auto result = getDefaults("Experiment");
     auto expected = PerThetaDefaults(boost::none, TransmissionRunPair(),
-                                     RangeInQ(0.01, 0.03, 0.2), 0.7,
-                                     std::string("390-415"));
+                                     boost::none, RangeInQ(0.01, 0.03, 0.2),
+                                     0.7, std::string("390-415"));
     TS_ASSERT_EQUALS(result.perThetaDefaults().size(), 1);
     TS_ASSERT_EQUALS(result.perThetaDefaults().front(), expected);
   }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
@@ -72,7 +72,8 @@ public:
   void testValidTransmissionRunRange() {
     auto result = getDefaults("Experiment");
     auto const expected = RangeInLambda{10.0, 12.0};
-    TS_ASSERT_EQUALS(result.transmissionRunRange(), expected);
+    TS_ASSERT_EQUALS(result.transmissionStitchOptions().overlapRange(),
+                     expected);
   }
 
   void testInvalidTransmissionRunRange() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -341,7 +341,8 @@ public:
   void testMultipleWildcardRowsAreInvalid() {
     OptionsTable const optionsTable = {optionsRowWithWildcard(),
                                        optionsRowWithWildcard()};
-    runTestForInvalidPerAngleOptions(optionsTable, {0, 1}, 0);
+    runTestForInvalidPerAngleOptions(optionsTable, {0, 1},
+                                     PerThetaDefaults::Column::THETA);
   }
 
   void testSetFirstTransmissionRun() {
@@ -349,9 +350,24 @@ public:
     runTestForValidPerAngleOptions(optionsTable);
   }
 
+  void testFirstTransmissionRunInvalid() {
+    OptionsTable const optionsTable = {
+        optionsRowWithFirstTransmissionRunInvalid()};
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::FIRST_TRANS);
+  }
+
   void testSetSecondTransmissionRun() {
     OptionsTable const optionsTable = {optionsRowWithSecondTransmissionRun()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 1);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::FIRST_TRANS);
+  }
+
+  void testSecondTransmissionRunInvalid() {
+    OptionsTable const optionsTable = {
+        optionsRowWithSecondTransmissionRunInvalid()};
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::SECOND_TRANS);
   }
 
   void testSetBothTransmissionRuns() {
@@ -366,7 +382,8 @@ public:
 
   void testSetQMinInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQMinInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 3);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::QMIN);
   }
 
   void testSetQMax() {
@@ -376,7 +393,8 @@ public:
 
   void testSetQMaxInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQMaxInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 4);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::QMAX);
   }
 
   void testSetQStep() {
@@ -386,7 +404,8 @@ public:
 
   void testSetQStepInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQStepInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 5);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::QSTEP);
   }
 
   void testSetScale() {
@@ -396,7 +415,8 @@ public:
 
   void testSetScaleInvalid() {
     OptionsTable const optionsTable = {optionsRowWithScaleInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 6);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::SCALE);
   }
 
   void testSetProcessingInstructions() {
@@ -407,7 +427,8 @@ public:
   void testSetProcessingInstructionsInvalid() {
     OptionsTable const optionsTable = {
         optionsRowWithProcessingInstructionsInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0, 7);
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::RUN_SPECTRA);
   }
 
   void testChangingSettingsNotifiesMainPresenter() {
@@ -504,7 +525,7 @@ public:
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     auto const expected = std::vector<PerThetaDefaults::ValueArray>{
-        {"", "", "", "0.010000", "0.200000", "0.030000", "0.700000",
+        {"", "", "", "", "0.010000", "0.200000", "0.030000", "0.700000",
          "390-415"}};
     EXPECT_CALL(m_view, setPerAngleOptions(expected)).Times(1);
     presenter.notifyRestoreDefaultsRequested();
@@ -803,23 +824,31 @@ private:
   OptionsRow optionsRowWithBothTransmissionRuns() {
     return {"", "13463", "13464"};
   }
-  OptionsRow optionsRowWithQMin() { return {"", "", "", "0.008"}; }
-  OptionsRow optionsRowWithQMinInvalid() { return {"", "", "", "bad"}; }
-  OptionsRow optionsRowWithQMax() { return {"", "", "", "", "0.1"}; }
-  OptionsRow optionsRowWithQMaxInvalid() { return {"", "", "", "", "bad"}; }
-  OptionsRow optionsRowWithQStep() { return {"", "", "", "", "", "0.02"}; }
+  OptionsRow optionsRowWithQMin() { return {"", "", "", "", "0.008"}; }
+  OptionsRow optionsRowWithQMinInvalid() { return {"", "", "", "", "bad"}; }
+  OptionsRow optionsRowWithQMax() { return {"", "", "", "", "", "0.1"}; }
+  OptionsRow optionsRowWithQMaxInvalid() { return {"", "", "", "", "", "bad"}; }
+  OptionsRow optionsRowWithQStep() { return {"", "", "", "", "", "", "0.02"}; }
   OptionsRow optionsRowWithQStepInvalid() {
-    return {"", "", "", "", "", "bad"};
-  }
-  OptionsRow optionsRowWithScale() { return {"", "", "", "", "", "", "1.4"}; }
-  OptionsRow optionsRowWithScaleInvalid() {
     return {"", "", "", "", "", "", "bad"};
   }
+  OptionsRow optionsRowWithScale() {
+    return {"", "", "", "", "", "", "", "1.4"};
+  }
+  OptionsRow optionsRowWithScaleInvalid() {
+    return {"", "", "", "", "", "", "", "bad"};
+  }
+  OptionsRow optionsRowWithTransProcessingInstructions() {
+    return {"", "", "", "1-4"};
+  }
+  OptionsRow optionsRowWithTransProcessingInstructionsInvalid() {
+    return {"", "", "", "bad"};
+  }
   OptionsRow optionsRowWithProcessingInstructions() {
-    return {"", "", "", "", "", "", "", "1-4"};
+    return {"", "", "", "", "", "", "", "", "1-4"};
   }
   OptionsRow optionsRowWithProcessingInstructionsInvalid() {
-    return {"", "", "", "", "", "", "", "bad"};
+    return {"", "", "", "", "", "", "", "", "bad"};
   }
 
   void runTestForValidPerAngleOptions(OptionsTable const &optionsTable) {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -34,7 +34,7 @@ using testing::_;
 GNU_DIAG_OFF("missing-braces")
 
 class ExperimentPresenterTest : public CxxTest::TestSuite {
-  using OptionsRow = std::array<std::string, 8>;
+  using OptionsRow = PerThetaDefaults::ValueArray;
   using OptionsTable = std::vector<OptionsRow>;
 
 public:
@@ -497,13 +497,13 @@ public:
   }
 
   void testRestoreDefaultsUpdatesPerThetaInView() {
-    auto perThetaDefaults = PerThetaDefaults(boost::none, TransmissionRunPair(),
-                                             RangeInQ(0.01, 0.03, 0.2), 0.7,
-                                             std::string("390-415"));
+    auto perThetaDefaults = PerThetaDefaults(
+        boost::none, TransmissionRunPair(), boost::none,
+        RangeInQ(0.01, 0.03, 0.2), 0.7, std::string("390-415"));
     auto model = makeModelWithPerThetaDefaults(std::move(perThetaDefaults));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
-    auto const expected = std::vector<std::array<std::string, 8>>{
+    auto const expected = std::vector<PerThetaDefaults::ValueArray>{
         {"", "", "", "0.010000", "0.200000", "0.030000", "0.700000",
          "390-415"}};
     EXPECT_CALL(m_view, setPerAngleOptions(expected)).Times(1);
@@ -513,14 +513,14 @@ public:
 
   void testRestoreDefaultsUpdatesPerThetaInModel() {
     auto model = makeModelWithPerThetaDefaults(PerThetaDefaults(
-        boost::none, TransmissionRunPair(), RangeInQ(0.01, 0.03, 0.2), 0.7,
-        std::string("390-415")));
+        boost::none, TransmissionRunPair(), boost::none,
+        RangeInQ(0.01, 0.03, 0.2), 0.7, std::string("390-415")));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyRestoreDefaultsRequested();
     auto expected = PerThetaDefaults(boost::none, TransmissionRunPair(),
-                                     RangeInQ(0.01, 0.03, 0.2), 0.7,
-                                     std::string("390-415"));
+                                     boost::none, RangeInQ(0.01, 0.03, 0.2),
+                                     0.7, std::string("390-415"));
     TS_ASSERT_EQUALS(presenter.experiment().perThetaDefaults().size(), 1);
     TS_ASSERT_EQUALS(presenter.experiment().perThetaDefaults().front(),
                      expected);
@@ -780,14 +780,14 @@ private:
   // either as an input array of strings or an output model
   OptionsRow optionsRowWithFirstAngle() { return {"0.5", "13463", ""}; }
   PerThetaDefaults defaultsWithFirstAngle() {
-    return PerThetaDefaults(0.5, TransmissionRunPair("13463", ""), RangeInQ(),
-                            boost::none, boost::none);
+    return PerThetaDefaults(0.5, TransmissionRunPair("13463", ""), boost::none,
+                            RangeInQ(), boost::none, boost::none);
   }
 
   OptionsRow optionsRowWithSecondAngle() { return {"2.3", "13463", "13464"}; }
   PerThetaDefaults defaultsWithSecondAngle() {
     return PerThetaDefaults(2.3, TransmissionRunPair("13463", "13464"),
-                            RangeInQ(), boost::none, boost::none);
+                            boost::none, RangeInQ(), boost::none, boost::none);
   }
   OptionsRow optionsRowWithWildcard() { return {"", "13463", "13464"}; }
   OptionsRow optionsRowWithFirstTransmissionRun() { return {"", "13463"}; }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -435,6 +435,19 @@ public:
     runTestForValidPerAngleOptions(optionsTable);
   }
 
+  void testSetTransmissionProcessingInstructionsValid() {
+    OptionsTable const optionsTable = {
+        optionsRowWithTransProcessingInstructions()};
+    runTestForValidPerAngleOptions(optionsTable);
+  }
+
+  void testSetTransmissionProcessingInstructionsInvalid() {
+    OptionsTable const optionsTable = {
+        optionsRowWithTransProcessingInstructionsInvalid()};
+    runTestForInvalidPerAngleOptions(optionsTable, 0,
+                                     PerThetaDefaults::Column::TRANS_SPECTRA);
+  }
+
   void testSetQMin() {
     OptionsTable const optionsTable = {optionsRowWithQMin()};
     runTestForValidPerAngleOptions(optionsTable);
@@ -884,6 +897,12 @@ private:
   OptionsRow optionsRowWithBothTransmissionRuns() {
     return {"", "13463", "13464"};
   }
+  OptionsRow optionsRowWithTransProcessingInstructions() {
+    return {"", "", "", "1-4"};
+  }
+  OptionsRow optionsRowWithTransProcessingInstructionsInvalid() {
+    return {"", "", "", "bad"};
+  }
   OptionsRow optionsRowWithQMin() { return {"", "", "", "", "0.008"}; }
   OptionsRow optionsRowWithQMinInvalid() { return {"", "", "", "", "bad"}; }
   OptionsRow optionsRowWithQMax() { return {"", "", "", "", "", "0.1"}; }
@@ -897,12 +916,6 @@ private:
   }
   OptionsRow optionsRowWithScaleInvalid() {
     return {"", "", "", "", "", "", "", "bad"};
-  }
-  OptionsRow optionsRowWithTransProcessingInstructions() {
-    return {"", "", "", "1-4"};
-  }
-  OptionsRow optionsRowWithTransProcessingInstructionsInvalid() {
-    return {"", "", "", "bad"};
   }
   OptionsRow optionsRowWithProcessingInstructions() {
     return {"", "", "", "", "", "", "", "", "1-4"};

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -410,24 +410,10 @@ public:
     runTestForValidPerAngleOptions(optionsTable);
   }
 
-  void testFirstTransmissionRunInvalid() {
-    OptionsTable const optionsTable = {
-        optionsRowWithFirstTransmissionRunInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0,
-                                     PerThetaDefaults::Column::FIRST_TRANS);
-  }
-
   void testSetSecondTransmissionRun() {
     OptionsTable const optionsTable = {optionsRowWithSecondTransmissionRun()};
     runTestForInvalidPerAngleOptions(optionsTable, 0,
                                      PerThetaDefaults::Column::FIRST_TRANS);
-  }
-
-  void testSecondTransmissionRunInvalid() {
-    OptionsTable const optionsTable = {
-        optionsRowWithSecondTransmissionRunInvalid()};
-    runTestForInvalidPerAngleOptions(optionsTable, 0,
-                                     PerThetaDefaults::Column::SECOND_TRANS);
   }
 
   void testSetBothTransmissionRuns() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -544,7 +544,9 @@ public:
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyRestoreDefaultsRequested();
     auto const expected = RangeInLambda{10.0, 12.0};
-    TS_ASSERT_EQUALS(presenter.experiment().transmissionRunRange(), expected);
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().overlapRange(),
+        expected);
     verifyAndClear();
   }
 
@@ -591,28 +593,29 @@ private:
   double m_thetaTolerance{0.01};
 
   Experiment makeModelWithAnalysisMode(AnalysisMode analysisMode) {
-    return Experiment(analysisMode, ReductionType::Normal,
-                      SummationType::SumInLambda, false, false,
-                      makeEmptyPolarizationCorrections(),
-                      makeFloodCorrections(), makeEmptyTransmissionRunRange(),
-                      makeEmptyStitchOptions(), makePerThetaDefaults());
+    return Experiment(
+        analysisMode, ReductionType::Normal, SummationType::SumInLambda, false,
+        false, makeEmptyPolarizationCorrections(), makeFloodCorrections(),
+        makeEmptyTransmissionStitchOptions(), makeEmptyStitchOptions(),
+        makePerThetaDefaults());
   }
 
   Experiment makeModelWithReduction(SummationType summationType,
                                     ReductionType reductionType,
                                     bool includePartialBins) {
-    return Experiment(AnalysisMode::PointDetector, reductionType, summationType,
-                      includePartialBins, false,
-                      makeEmptyPolarizationCorrections(),
-                      makeFloodCorrections(), makeEmptyTransmissionRunRange(),
-                      makeEmptyStitchOptions(), makePerThetaDefaults());
+    return Experiment(
+        AnalysisMode::PointDetector, reductionType, summationType,
+        includePartialBins, false, makeEmptyPolarizationCorrections(),
+        makeFloodCorrections(), makeEmptyTransmissionStitchOptions(),
+        makeEmptyStitchOptions(), makePerThetaDefaults());
   }
 
   Experiment makeModelWithDebug(bool debug) {
     return Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
                       SummationType::SumInLambda, false, debug,
                       makeEmptyPolarizationCorrections(),
-                      makeFloodCorrections(), makeEmptyTransmissionRunRange(),
+                      makeFloodCorrections(),
+                      makeEmptyTransmissionStitchOptions(),
                       makeEmptyStitchOptions(), makePerThetaDefaults());
   }
 
@@ -622,16 +625,18 @@ private:
     return Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
                       SummationType::SumInLambda, false, false,
                       makeEmptyPolarizationCorrections(),
-                      makeFloodCorrections(), makeEmptyTransmissionRunRange(),
+                      makeFloodCorrections(),
+                      makeEmptyTransmissionStitchOptions(),
                       makeEmptyStitchOptions(), std::move(perThetaList));
   }
 
   Experiment makeModelWithTransmissionRunRange(RangeInLambda range) {
-    return Experiment(AnalysisMode::PointDetector, ReductionType::Normal,
-                      SummationType::SumInLambda, false, false,
-                      makeEmptyPolarizationCorrections(),
-                      makeFloodCorrections(), std::move(range),
-                      makeEmptyStitchOptions(), makePerThetaDefaults());
+    return Experiment(
+        AnalysisMode::PointDetector, ReductionType::Normal,
+        SummationType::SumInLambda, false, false,
+        makeEmptyPolarizationCorrections(), makeFloodCorrections(),
+        TransmissionStitchOptions(std::move(range), std::string(), false),
+        makeEmptyStitchOptions(), makePerThetaDefaults());
   }
 
   Experiment
@@ -641,8 +646,8 @@ private:
                       SummationType::SumInLambda, false, false,
                       std::move(polarizationCorrections),
                       std::move(floodCorrections),
-                      makeEmptyTransmissionRunRange(), makeEmptyStitchOptions(),
-                      makePerThetaDefaults());
+                      makeEmptyTransmissionStitchOptions(),
+                      makeEmptyStitchOptions(), makePerThetaDefaults());
   }
 
   ExperimentPresenter
@@ -759,7 +764,9 @@ private:
         .WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showTransmissionRangeValid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.experiment().transmissionRunRange(), result);
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().overlapRange(),
+        result);
     verifyAndClear();
   }
 
@@ -771,8 +778,9 @@ private:
         .WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showTransmissionRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.experiment().transmissionRunRange(),
-                     boost::none);
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().overlapRange(),
+        boost::none);
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -245,6 +245,20 @@ public:
     runTestForValidTransmissionRunRange(range, boost::none);
   }
 
+  void testSetValidTransmissionParams() {
+    auto presenter = makePresenter();
+    auto const params = "-0.02";
+
+    EXPECT_CALL(m_view, getTransmissionStitchParams()).WillOnce(Return(params));
+    EXPECT_CALL(m_view, showTransmissionStitchParamsValid());
+    presenter.notifySettingsChanged();
+
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().rebinParameters(),
+        params);
+    verifyAndClear();
+  }
+
   void testSetStitchOptions() {
     auto presenter = makePresenter();
     auto const optionsString = "Params=0.02";

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -245,17 +245,63 @@ public:
     runTestForValidTransmissionRunRange(range, boost::none);
   }
 
-  void testSetValidTransmissionParams() {
+  void testTransmissionParamsAreValidWithPositiveValue() {
+    runTestForValidTransmissionParams("0.02");
+  }
+
+  void testTransmissionParamsAreValidWithNoValues() {
+    runTestForValidTransmissionParams("");
+  }
+
+  void testTransmissionParamsAreValidWithNegativeValue() {
+    runTestForValidTransmissionParams("-0.02");
+  }
+
+  void testTransmissionParamsAreValidWithThreeValues() {
+    runTestForValidTransmissionParams("0.1, -0.02, 5");
+  }
+
+  void testTransmissionParamsAreValidWithFiveValues() {
+    runTestForValidTransmissionParams("0.1, -0.02, 5, 6, 7.9");
+  }
+
+  void testTransmissionParamsIgnoresWhitespace() {
+    runTestForValidTransmissionParams("    0.1  , -0.02 , 5   ");
+  }
+
+  void testTransmissionParamsAreInvalidWithTwoValues() {
+    runTestForInvalidTransmissionParams("1, 2");
+  }
+
+  void testTransmissionParamsAreInvalidWithFourValues() {
+    runTestForInvalidTransmissionParams("1, 2, 3, 4");
+  }
+
+  void testSetTransmissionScaleRHSProperty() {
     auto presenter = makePresenter();
-    auto const params = "-0.02";
+    auto const scaleRHS = false;
+
+    EXPECT_CALL(m_view, getTransmissionScaleRHSWorkspace())
+        .WillOnce(Return(scaleRHS));
+    presenter.notifySettingsChanged();
+
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().scaleRHS(),
+        scaleRHS);
+    verifyAndClear();
+  }
+
+  void testSetTransmissionParamsAreInvalidIfContainNonNumericValue() {
+    auto presenter = makePresenter();
+    auto const params = "1,bad";
 
     EXPECT_CALL(m_view, getTransmissionStitchParams()).WillOnce(Return(params));
-    EXPECT_CALL(m_view, showTransmissionStitchParamsValid());
+    EXPECT_CALL(m_view, showTransmissionStitchParamsInvalid());
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(
         presenter.experiment().transmissionStitchOptions().rebinParameters(),
-        params);
+        "");
     verifyAndClear();
   }
 
@@ -897,6 +943,28 @@ private:
     EXPECT_CALL(m_view, getPerAngleOptions()).WillOnce(Return(optionsTable));
     EXPECT_CALL(m_view, showPerAngleThetasNonUnique(m_thetaTolerance)).Times(1);
     presenter.notifyPerAngleDefaultsChanged(0, 0);
+    verifyAndClear();
+  }
+
+  void runTestForValidTransmissionParams(std::string const &params) {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getTransmissionStitchParams()).WillOnce(Return(params));
+    EXPECT_CALL(m_view, showTransmissionStitchParamsValid());
+    presenter.notifySettingsChanged();
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().rebinParameters(),
+        params);
+    verifyAndClear();
+  }
+
+  void runTestForInvalidTransmissionParams(std::string const &params) {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getTransmissionStitchParams()).WillOnce(Return(params));
+    EXPECT_CALL(m_view, showTransmissionStitchParamsInvalid());
+    presenter.notifySettingsChanged();
+    TS_ASSERT_EQUALS(
+        presenter.experiment().transmissionStitchOptions().rebinParameters(),
+        "");
     verifyAndClear();
   }
 };

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -73,6 +73,8 @@ public:
   MOCK_METHOD1(setTransmissionScaleRHSWorkspace, void(bool));
   MOCK_METHOD0(showTransmissionRangeValid, void(void));
   MOCK_METHOD0(showTransmissionRangeInvalid, void(void));
+  MOCK_METHOD0(showTransmissionStitchParamsValid, void(void));
+  MOCK_METHOD0(showTransmissionStitchParamsInvalid, void(void));
   MOCK_CONST_METHOD0(getPolarizationCorrectionType, std::string());
   MOCK_METHOD1(setPolarizationCorrectionType, void(std::string const &));
   MOCK_CONST_METHOD0(getCRho, double());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -49,9 +49,9 @@ public:
   MOCK_CONST_METHOD0(getDebugOption, bool());
   MOCK_METHOD1(setDebugOption, void(bool));
   MOCK_CONST_METHOD0(getPerAngleOptions,
-                     std::vector<std::array<std::string, 8>>());
+                     std::vector<PerThetaDefaults::ValueArray>());
   MOCK_METHOD1(setPerAngleOptions,
-               void(std::vector<std::array<std::string, 8>>));
+               void(std::vector<PerThetaDefaults::ValueArray>));
   MOCK_METHOD2(showPerAngleOptionsAsInvalid, void(int row, int column));
   MOCK_METHOD1(showPerAngleOptionsAsValid, void(int row));
   MOCK_METHOD0(showAllPerAngleOptionsAsValid, void());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -67,6 +67,10 @@ public:
   MOCK_METHOD1(setTransmissionStartOverlap, void(double));
   MOCK_CONST_METHOD0(getTransmissionEndOverlap, double());
   MOCK_METHOD1(setTransmissionEndOverlap, void(double));
+  MOCK_CONST_METHOD0(getTransmissionStitchParams, std::string());
+  MOCK_METHOD1(setTransmissionStitchParams, void(std::string const &));
+  MOCK_CONST_METHOD0(getTransmissionScaleRHSWorkspace, bool());
+  MOCK_METHOD1(setTransmissionScaleRHSWorkspace, void(bool));
   MOCK_METHOD0(showTransmissionRangeValid, void(void));
   MOCK_METHOD0(showTransmissionRangeInvalid, void(void));
   MOCK_CONST_METHOD0(getPolarizationCorrectionType, std::string());

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
@@ -95,32 +95,46 @@ public:
         TransmissionRunPair("some workspace", "another_workspace"));
   }
 
+  void testValidTransmissionProcessingInstructions() {
+    auto table = Table({Cells({"", "", "", "1-3"})});
+    auto results = runTestValid(table);
+    TS_ASSERT_EQUALS(results.size(), 1);
+    TS_ASSERT(results[0].transmissionProcessingInstructions().is_initialized());
+    TS_ASSERT_EQUALS(results[0].transmissionProcessingInstructions().get(),
+                     "1-3");
+  }
+
+  void testInvalidTransmissionProcessingInstructions() {
+    auto table = Table({Cells({"", "", "", "bad"})});
+    runTestInvalidCells(table, expectedErrors({0}, {3}));
+  }
+
   void testValidQRange() {
-    auto table = Table({Cells({"", "", "", "0.05", "1.3", "0.021"})});
+    auto table = Table({Cells({"", "", "", "", "0.05", "1.3", "0.021"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
     TS_ASSERT_EQUALS(results[0].qRange(), RangeInQ(0.05, 0.021, 1.3));
   }
 
   void testInvalidQRange() {
-    auto table = Table({Cells({"", "", "", "bad", "bad", "bad"})});
-    runTestInvalidCells(table, expectedErrors({0}, {3, 4, 5}));
+    auto table = Table({Cells({"", "", "", "", "bad", "bad", "bad"})});
+    runTestInvalidCells(table, expectedErrors({0}, {4, 5, 6}));
   }
 
   void testValidScaleFactor() {
-    auto table = Table({Cells({"", "", "", "", "", "", "1.4"})});
+    auto table = Table({Cells({"", "", "", "", "", "", "", "1.4"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
     TS_ASSERT_EQUALS(results[0].scaleFactor(), 1.4);
   }
 
   void testInvalidScaleFactor() {
-    auto table = Table({Cells({"", "", "", "", "", "", "bad"})});
-    runTestInvalidCells(table, expectedErrors({0}, {6}));
+    auto table = Table({Cells({"", "", "", "", "", "", "", "bad"})});
+    runTestInvalidCells(table, expectedErrors({0}, {7}));
   }
 
   void testValidProcessingInstructions() {
-    auto table = Table({Cells({"", "", "", "", "", "", "", "1-3"})});
+    auto table = Table({Cells({"", "", "", "", "", "", "", "", "1-3"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
     TS_ASSERT(results[0].processingInstructions().is_initialized());
@@ -128,8 +142,8 @@ public:
   }
 
   void testInvalidProcessingInstructions() {
-    auto table = Table({Cells({"", "", "", "", "", "", "", "bad"})});
-    runTestInvalidCells(table, expectedErrors({0}, {7}));
+    auto table = Table({Cells({"", "", "", "", "", "", "", "", "bad"})});
+    runTestInvalidCells(table, expectedErrors({0}, {8}));
   }
 
   void testAnglesThatDifferByTolerance() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
@@ -28,7 +28,7 @@ public:
     delete suite;
   }
   static auto constexpr TOLERANCE = 0.001;
-  using Cells = std::array<std::string, 8>;
+  using Cells = PerThetaDefaults::ValueArray;
   using Table = std::vector<Cells>;
 
   void testEmptyTable() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
@@ -68,39 +68,58 @@ public:
                      expected);
   }
 
+  void testParseTransmissionProcessingInstructions() {
+    PerThetaDefaultsValidator validator;
+    auto result = validator({"", "", "", "4-7"});
+    TS_ASSERT(result.isValid());
+    TS_ASSERT(result.assertValid()
+                  .transmissionProcessingInstructions()
+                  .is_initialized());
+    TS_ASSERT_EQUALS(
+        result.assertValid().transmissionProcessingInstructions().get(), "4-7");
+  }
+
+  void testParseTransmissionProcessingInstructionsError() {
+    PerThetaDefaultsValidator validator;
+    auto result = validator({"", "", "", "bad"});
+    std::vector<int> errorCells = {3};
+    TS_ASSERT(result.isError());
+    TS_ASSERT_EQUALS(result.assertError(), errorCells);
+  }
+
   void testParseQRange() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "0.05", "1.3", "0.02"});
+    auto result = validator({"", "", "", "", "0.05", "1.3", "0.02"});
     TS_ASSERT(result.isValid());
     TS_ASSERT_EQUALS(result.assertValid().qRange(), RangeInQ(0.05, 0.02, 1.3));
   }
 
   void testParseQRangeError() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "bad", "bad", "bad"});
-    std::vector<int> errorCells = {3, 4, 5};
+    auto result = validator({"", "", "", "", "bad", "bad", "bad"});
+    std::vector<int> errorCells = {4, 5, 6};
     TS_ASSERT(result.isError());
     TS_ASSERT_EQUALS(result.assertError(), errorCells);
   }
 
   void testParseScaleFactor() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "", "", "", "1.4"});
+    auto result = validator({"", "", "", "", "", "", "", "1.4"});
     TS_ASSERT(result.isValid());
     TS_ASSERT_EQUALS(result.assertValid().scaleFactor(), 1.4);
   }
 
   void testParseScaleFactorError() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "", "", "", "bad"});
-    std::vector<int> errorCells = {6};
+    auto result = validator({"", "", "", "", "", "", "", "bad"});
+    std::vector<int> errorCells = {7};
     TS_ASSERT(result.isError());
     TS_ASSERT_EQUALS(result.assertError(), errorCells);
   }
 
   void testParseProcessingInstructions() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "", "", "", "", "1-3"});
+    auto result = validator({"", "", "", "", "", "", "", "", "1-3"});
     TS_ASSERT(result.isValid());
     TS_ASSERT(result.assertValid().processingInstructions().is_initialized());
     TS_ASSERT_EQUALS(result.assertValid().processingInstructions().get(),
@@ -109,8 +128,8 @@ public:
 
   void testParseProcessingInstructionsError() {
     PerThetaDefaultsValidator validator;
-    auto result = validator({"", "", "", "", "", "", "", "bad"});
-    std::vector<int> errorCells = {7};
+    auto result = validator({"", "", "", "", "", "", "", "", "bad"});
+    std::vector<int> errorCells = {8};
     TS_ASSERT(result.isError());
     TS_ASSERT_EQUALS(result.assertError(), errorCells);
   }


### PR DESCRIPTION
This PR contains:
- addition of new input widgets for two missing stitching properties for transmission runs (ScaleRHSWorkspace and Params)
- addition of an input column on the per-theta defaults table for transmission processing instructions
- tidying to remove some hard-coded column indices in the tables (there are still some occurances of hard-coded indices but it's beyond the scope of this PR to fix all of them - I've added a note to #26025 to tidy this up in future).
- tidying of the Experiment and Instrument Settings tabs to improve the layout and improve some label names

**To test:**

- Open the ISIS Reflectometry interface
- Set the instrument to INTER and in the table enter run number 13460 and angle 0.5
- On the Experiment tab, enter 1st trans run 13463 and 2nd trans run 13464
- Enter Transmission Spectra = 4
- Untick ScaleRHSWorkspace
- Enter Transmission stitch params = -0.02
- On the Runs tab, click Process
- Check the history of IvsQ_binned_13460. It should have the following properties set in the input for ReflectometryISISLoadAndProcess:
  - FirstTransmissionRunList=13463
  - SecondTransmissionRunList=13464
  - Params=-0.02
  - ScaleRHSWorkspace=0
  - TransmissionProcessingInstructions=4

Fixes #26063 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
