### PR TITLE
Reset GUI to previously loaded data on load failure

### DIFF
--- a/scripts/Muon/GUI/Common/load_file_widget/model.py
+++ b/scripts/Muon/GUI/Common/load_file_widget/model.py
@@ -113,3 +113,7 @@ class BrowseFileWidgetModel(object):
     @current_runs.setter
     def current_runs(self, value):
         self._data_context.current_runs = value
+
+    @property
+    def current_filenames(self):
+        return self._data_context.current_filenames

--- a/scripts/Muon/GUI/Common/load_file_widget/presenter.py
+++ b/scripts/Muon/GUI/Common/load_file_widget/presenter.py
@@ -112,13 +112,20 @@ class BrowseFileWidgetPresenter(object):
         self._load_thread = self.create_load_thread()
         self._load_thread.threadWrapperSetUp(self.disable_loading,
                                              self.handle_load_thread_finished,
-                                             self._view.warning_popup)
+                                             self.handle_load_error)
         self._load_thread.loadData(filenames)
         self._load_thread.start()
+
+    def handle_load_error(self, message):
+        self.thread_success = False
+        self._view.warning_popup(message)
 
     def handle_load_thread_finished(self):
         self._load_thread.deleteLater()
         self._load_thread = None
+
+        if not self.thread_success:
+            self.filenames = self._model.current_filenames
 
         self.on_loading_finished()
 
@@ -152,6 +159,7 @@ class BrowseFileWidgetPresenter(object):
         self._model.clear()
 
     def disable_loading(self):
+        self.thread_success = True
         self._view.disable_load_buttons()
 
     def enable_loading(self):

--- a/scripts/Muon/GUI/Common/load_file_widget/presenter.py
+++ b/scripts/Muon/GUI/Common/load_file_widget/presenter.py
@@ -103,6 +103,7 @@ class BrowseFileWidgetPresenter(object):
             self._model.execute()
         except ValueError as error:
             self._view.warning_popup(error.args[0])
+            self.filenames = self._model.current_filenames
         self.on_loading_finished()
 
     def handle_load_thread_start(self, filenames):

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -211,6 +211,7 @@ class LoadRunWidgetPresenter(object):
             self._model.execute()
         except ValueError as error:
             self._view.warning_popup(error.args[0])
+            self.run_list = flatten_run_list(self._model.current_runs)
         finished_callback()
 
     def on_loading_start(self):

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -12,6 +12,7 @@ from Muon.GUI.Common import thread_model
 import Muon.GUI.Common.utilities.run_string_utils as run_utils
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
 import Muon.GUI.Common.utilities.load_utils as load_utils
+from Muon.GUI.Common.utilities.run_string_utils import flatten_run_list
 from Muon.GUI.Common.observer_pattern import Observable
 
 
@@ -65,6 +66,7 @@ class LoadRunWidgetPresenter(object):
 
     def disable_loading(self):
         self._view.disable_load_buttons()
+        self.thread_success = True
 
     def enable_loading(self):
         if not self._instrument == "PSI":
@@ -226,6 +228,7 @@ class LoadRunWidgetPresenter(object):
         self._load_thread.start()
 
     def error_callback(self, error_message):
+        self.thread_success = False
         self.enable_notifier.notify_subscribers()
         self._view.warning_popup(error_message)
 
@@ -233,6 +236,8 @@ class LoadRunWidgetPresenter(object):
         self._load_thread.deleteLater()
         self._load_thread = None
 
+        if not self.thread_success:
+            self.run_list = flatten_run_list(self._model.current_runs)
         self.on_loading_finished()
 
     def on_loading_finished(self):

--- a/scripts/Muon/GUI/Common/utilities/run_string_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/run_string_utils.py
@@ -179,3 +179,7 @@ def decrement_run_string(run_string, decrement_by=1):
     run_list = run_string_to_list(run_string)
     run_list = decrement_run_list(run_list, decrement_by)
     return run_list_to_string(run_list)
+
+
+def flatten_run_list(run_list):
+    return [item for sublist in run_list for item in sublist]

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -230,22 +230,6 @@ class LoadFileWidgetPresenterMultipleFileModeTest(GuiTest):
         self.assertEqual(self.view.get_file_edit_text(), "C:/dir1/file1.nxs;C:/dir1/file2.nxs")
 
     @run_test_with_and_without_threading
-    def test_that_loading_multiple_files_from_browse_ignores_loads_which_throw(self):
-        workspace = self.create_fake_workspace(1)
-
-        files = ["C:/dir1/file1.nxs", "C:/dir2/file2.nxs", "C:/dir2/file3.nxs"]
-        self.view.show_file_browser_and_return_selection = mock.Mock(return_value=files)
-        load_return_values = [(workspace, 1234 + i, filename, False) for i, filename in enumerate(files)]
-        self.load_utils_patcher.side_effect = iter(IteratorWithException(load_return_values, [1]))
-
-        self.presenter.on_browse_button_clicked()
-        self.wait_for_thread(self.presenter._load_thread)
-
-        self.assertEqual(self.model.loaded_filenames, ["C:/dir1/file1.nxs", "C:/dir2/file3.nxs"])
-        self.assertEqual(self.model.loaded_runs, [[1234], [1236]])
-        self.assertEqual(self.view.get_file_edit_text(), "C:/dir1/file1.nxs;C:/dir2/file3.nxs")
-
-    @run_test_with_and_without_threading
     def test_that_browse_allows_loading_of_additional_files(self):
         workspace_1 = self.create_fake_workspace(1)
         workspace_2 = self.create_fake_workspace(2)

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -146,7 +146,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(GuiTest):
         self.wait_for_thread(self.presenter._load_thread)
 
         self.assert_model_has_not_changed()
-        self.assertEqual(self.view.get_run_edit_text(), '')
+        self.assertEqual(self.view.get_run_edit_text(), '1234')
 
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_the_data_are_returned_to_previous_state(self):
@@ -156,7 +156,7 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(GuiTest):
         self.wait_for_thread(self.presenter._load_thread)
 
         self.assert_model_has_not_changed()
-        self.assertEqual(self.view.get_run_edit_text(), '')
+        self.assertEqual(self.view.get_run_edit_text(), '1234')
 
     @run_test_with_and_without_threading
     def test_that_if_decrement_run_fails_warning_message_is_displayed(self):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -145,7 +145,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(GuiTest):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[2], [3], [4]])
         six.assertCountEqual(self, self.model.loaded_runs, [[2], [3], [4]])
 
-        self.assertEqual(self.view.get_run_edit_text(), '')
+        self.assertEqual(self.view.get_run_edit_text(), '2-4')
 
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_the_data_are_returned_to_previous_state(self):
@@ -160,7 +160,7 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(GuiTest):
         six.assertCountEqual(self, self.model.loaded_workspaces, [[2], [3], [4]])
         six.assertCountEqual(self, self.model.loaded_runs, [[2], [3], [4]])
 
-        self.assertEqual(self.view.get_run_edit_text(), '')
+        self.assertEqual(self.view.get_run_edit_text(), '2-4')
 
     @run_test_with_and_without_threading
     def test_that_if_increment_run_fails_warning_message_is_displayed(self):


### PR DESCRIPTION
**Description of work.**

When the Muon Analysis 2 GUI fails to load some data it resets the entire GUI to empty. This PR updates the failure handling to instead revert to the previous state after displaying an error message.  

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
 * In workbench open the Muon Analysis 2 GUI, and load a run (EMU19489 is the in unit test directory)
 * Go to the grouping tab and click on guess alpha
 * Try to load a non-existent run from the run box, an error message should be shown and the GUI reset to previous state. 
 * Try to load a non Muon run from the file browser, an error message should be shown and the GUI reset to previous state.

<!-- Instructions for testing. -->

Fixes #26194  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because this fixes an issue introduced in this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
