### PR TITLE
Indirect Data analysis interface fitting crash

### DIFF
--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -913,9 +913,11 @@ void PropertyHandler::updateAttributes() {
  * @param attribute :: An attribute of the function
  */
 void PropertyHandler::updateAttribute(QtProperty *attribute) {
-  auto const attributeValue =
-      function()->getAttribute(attribute->propertyName().toStdString());
-  setAttribute(attribute->propertyName(), attributeValue);
+  if (m_attributes.contains(attribute)) {
+    auto const attributeValue =
+        function()->getAttribute(attribute->propertyName().toStdString());
+    setAttribute(attribute->propertyName(), attributeValue);
+  }
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
Added a check on pointers before using them.

**To test:**

* Interaces->Indirect->Data analysis->ConvFit
* in single input load Sample and resolution file (eg. irs26176_graphite002_red.nxs and irs26173_graphite002_res.nxs)
* In Fit function->Fit Type select ElasticDiffRotDiscreteCircle
* No crashing
* Expand `Functions->f0-ElasticDiffRotDiscreteCircle` item. Check that `N`, `Q` and `WorkspaceIndex` properties have sensible values.
* Try other fit types.

Fixes #26154

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
