### PR TITLE
Muon Analysis 2: Update results table selection on new fit

### DIFF
--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -85,12 +85,11 @@ class ResultsTabModel(object):
         """
         return self._fit_context.fit_function_names()
 
-    def fit_selection(self, existing_selection):
+    def fit_selection(self, to_select):
         """
         Combine the existing selection state of workspaces with the workspace names
         of fits stored here. New workspaces are always checked for inclusion.
-        :param existing_selection: A dict defining any current selection model. The
-        format matches that of the ListSelectorPresenter class' model.
+        :param to_select A list of workspace names to select
         :return: The workspaces that have had fits performed on them along with their selection status. The
         format matches that of the ListSelectorPresenter class' model.
         """
@@ -99,11 +98,7 @@ class ResultsTabModel(object):
             if fit.fit_function_name != self.selected_fit_function():
                 continue
             name = fit.parameters.parameter_workspace_name
-            if name in existing_selection:
-                checked = existing_selection[name][1]
-            else:
-                checked = True
-            selection[name] = [index, checked, True]
+            selection[name] = [index, name in to_select, True]
 
         return selection
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -80,9 +80,17 @@ class ResultsTabPresenter(QObject):
 
     def _update_fit_results_view(self):
         """Update the view of results workspaces based on the current model"""
-        self.view.set_fit_result_workspaces(
-            self.model.fit_selection(
-                existing_selection=self.view.fit_result_workspaces()))
+        def get_workspace_list(fit_context):
+            workspace_list = []
+            fit_list = fit_context.fit_list
+            for ii in range(1, fit_context._number_of_fits + 1):
+                workspace_list.append(fit_list[len(fit_list) - ii].parameter_workspace_name)
+            return workspace_list, fit_list[0].fit_function_name
+        workspace_list, function_name = get_workspace_list(self.model._fit_context)
+
+        self.model.set_selected_fit_function(function_name)
+        selection = self.model.fit_selection(workspace_list)
+        self.view.set_fit_result_workspaces(selection)
 
     def _update_logs_view(self):
         """Update the view of logs based on the current model"""

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -78,16 +78,17 @@ class ResultsTabPresenter(QObject):
         self._update_logs_view()
         self.view.set_output_results_button_enabled(True)
 
+    def _get_workspace_list(self):
+        fit_context = self.model._fit_context
+        workspace_list = []
+        fit_list = fit_context.fit_list
+        for ii in range(1, fit_context._number_of_fits + 1):
+            workspace_list.append(fit_list[len(fit_list) - ii].parameter_workspace_name)
+        return workspace_list, fit_list[0].fit_function_name
+
     def _update_fit_results_view(self):
         """Update the view of results workspaces based on the current model"""
-        def get_workspace_list(fit_context):
-            workspace_list = []
-            fit_list = fit_context.fit_list
-            for ii in range(1, fit_context._number_of_fits + 1):
-                workspace_list.append(fit_list[len(fit_list) - ii].parameter_workspace_name)
-            return workspace_list, fit_list[0].fit_function_name
-        workspace_list, function_name = get_workspace_list(self.model._fit_context)
-
+        workspace_list, function_name = self._get_workspace_list()
         self.model.set_selected_fit_function(function_name)
         selection = self.model.fit_selection(workspace_list)
         self.view.set_fit_result_workspaces(selection)

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -74,7 +74,7 @@ class ResultsTabPresenter(QObject):
     def _on_new_fit_performed_impl(self):
         """Use as part of an invokeMethod call to call across threads"""
         self.view.set_fit_function_names(self.model.fit_functions())
-        self._update_fit_results_view()
+        self._update_fit_results_view_on_new_fit()
         self._update_logs_view()
         self.view.set_output_results_button_enabled(True)
 
@@ -83,13 +83,19 @@ class ResultsTabPresenter(QObject):
         workspace_list = []
         fit_list = fit_context.fit_list
         for ii in range(1, fit_context._number_of_fits + 1):
-            workspace_list.append(fit_list[len(fit_list) - ii].parameter_workspace_name)
-        return workspace_list, fit_list[0].fit_function_name
+            workspace_list.append(fit_list[-ii].parameter_workspace_name)
+        return workspace_list, fit_list[len(fit_list) - 1].fit_function_name
+
+    def _update_fit_results_view_on_new_fit(self):
+        """Update the view of results workspaces based on the current model"""
+        workspace_list, function_name = self._get_workspace_list()
+        self.view.set_selected_fit_function(function_name)
+        selection = self.model.fit_selection(workspace_list)
+        self.view.set_fit_result_workspaces(selection)
 
     def _update_fit_results_view(self):
         """Update the view of results workspaces based on the current model"""
-        workspace_list, function_name = self._get_workspace_list()
-        self.model.set_selected_fit_function(function_name)
+        workspace_list, _ = self._get_workspace_list()
         selection = self.model.fit_selection(workspace_list)
         self.view.set_fit_result_workspaces(selection)
 

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -64,11 +64,7 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         function_selector.clear()
         function_selector.addItems(names)
         if original_selection in names:
-            if PYQT4:
-                function_selector.setCurrentIndex(
-                    function_selector.findText(original_selection))
-            else:
-                function_selector.setCurrentText(original_selection)
+            self.set_selected_fit_function(original_selection)
         function_selector.blockSignals(False)
 
     def selected_result_workspaces(self):
@@ -90,6 +86,16 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         state for the workspace list selector
         """
         self.fit_selector_presenter.update_model(workspace_list_state)
+
+    def set_selected_fit_function(self, function):
+        """
+        Set the fit function in the QComboBox
+        """
+        if PYQT4:
+            self.fit_function_selector.setCurrentIndex(
+                self.fit_function_selector.findText(function))
+        else:
+            self.fit_function_selector.setCurrentText(function)
 
     def selected_fit_function(self):
         """Return the text of the selected item in the function

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -178,8 +178,8 @@ class ResultsTabModelTest(unittest.TestCase):
                                      [], self.logs)
 
         expected_list_state = {
-            'ws1_Parameters': [0, True, True],
-            'ws2_Parameters': [1, True, True]
+            'ws1_Parameters': [0, False, True],
+            'ws2_Parameters': [1, False, True]
         }
         self.assertDictEqual(expected_list_state, model.fit_selection({}))
 
@@ -187,7 +187,7 @@ class ResultsTabModelTest(unittest.TestCase):
         _, model = create_test_model(('ws1', 'ws2'), 'func1', self.parameters,
                                      [], self.logs)
 
-        orig_list_state = {'ws1_Parameters': [0, False, True]}
+        orig_list_state = ["ws2_Parameters"]
         expected_list_state = {
             'ws1_Parameters': [0, False, True],
             'ws2_Parameters': [1, True, True]

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -56,41 +56,32 @@ class ResultsTabPresenterTest(unittest.TestCase):
         new_name = 'func 2'
         self.mock_view.selected_fit_function.return_value = new_name
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter._get_workspace_list = mock.MagicMock(return_value=(['ws1', 'ws3'], "func 2"))
         presenter.on_function_selection_changed()
 
         self.mock_view.selected_fit_function.assert_called_once_with()
-        self.mock_model.set_selected_fit_function.assert_called_once_with(
-            new_name)
+        self.mock_model.set_selected_fit_function.assert_called_with(new_name)
+        self.assertEqual(2, self.mock_model.set_selected_fit_function.call_count)
 
     def test_adding_new_fit_to_existing_fits_preserves_current_selections(
             self):
-        orig_ws_list_state = {
-            name: [index, checked, True]
-            for index, (name, checked) in enumerate((('ws1', True), ('ws2',
-                                                                     False)))
-        }
-        final_ws_list_state = {
-            name: [index, checked, True]
-            for index, (name, checked) in enumerate((('ws1', True),
-                                                     ('ws2', False), ('ws3',
-                                                                      True)))
-        }
+        orig_ws_list_state = ['ws1', 'ws3']
+        final_ws_list_state = ['ws1', 'ws3']
         test_functions = ['func1', 'func2']
         self.mock_model.fit_functions.return_value = test_functions
         self.mock_model.fit_selection.return_value = final_ws_list_state
         self.mock_view.fit_result_workspaces.return_value = orig_ws_list_state
 
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter._get_workspace_list = mock.MagicMock(return_value=(['ws1', 'ws3'], "func1"))
         # previous test verifies this is correct on construction
         self.mock_view.set_output_results_button_enabled.reset_mock()
         presenter.on_new_fit_performed()
 
         self.mock_model.fit_functions.assert_called_once_with()
-        self.mock_model.fit_selection.assert_called_once_with(
-            existing_selection=orig_ws_list_state)
+        self.mock_model.fit_selection.assert_called_once_with(orig_ws_list_state)
         self.mock_view.set_fit_function_names.assert_called_once_with(
             test_functions)
-        self.mock_view.fit_result_workspaces.assert_called_once_with()
         self.mock_view.set_fit_result_workspaces.assert_called_once_with(
             final_ws_list_state)
         self.mock_view.set_output_results_button_enabled.assert_called_once_with(
@@ -110,6 +101,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_model.log_selection.return_value = final_selection
 
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter._get_workspace_list = mock.MagicMock(return_value=(['ws1', 'ws3'], "func1"))
         # previous test verifies this is correct on construction
         self.mock_view.set_output_results_button_enabled.reset_mock()
         presenter.on_new_fit_performed()

--- a/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -60,8 +60,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
         presenter.on_function_selection_changed()
 
         self.mock_view.selected_fit_function.assert_called_once_with()
-        self.mock_model.set_selected_fit_function.assert_called_with(new_name)
-        self.assertEqual(2, self.mock_model.set_selected_fit_function.call_count)
+        self.mock_model.set_selected_fit_function.assert_called_once_with(new_name)
 
     def test_adding_new_fit_to_existing_fits_preserves_current_selections(
             self):


### PR DESCRIPTION
**Description of work.**
When a fit occurs the only things that should be automatically selected should be the 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Workbench
- Open Muon Analysis 2
- Fit MUSR62206
- Fit MUSR62260
- Make sure only MUSR62260 Fitted Parameter is selected in the bottom table of the results table.

<!-- Instructions for testing. -->

Fixes #26193  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
