### PR TITLE
Muon Analysis, adding in recalculation update when loading default groups

### DIFF
--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -185,6 +185,8 @@ class GroupingTabPresenter(object):
         self.grouping_table_widget.update_view_from_model()
         self.pairing_table_widget.update_view_from_model()
         self.update_description_text()
+        self.groupingNotifier.notify_subscribers()
+        self.handle_update_all_clicked()
 
     def on_clear_requested(self):
         self._model.clear()


### PR DESCRIPTION
**Description of work.**

When reloading in the default groups in Muon Analysis, the group recalculation was not being triggered.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * Check that the issue in the related PR is resolved. 

<!-- Instructions for testing. -->

Fixes #26244  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is fixing an issue introduced in this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
