### PR TITLE
Make building the docs optional (default on)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,28 +228,31 @@ endif()
 add_subdirectory(scripts)
 
 # Docs requirements
-find_package(Sphinx 1.2)
-if(SPHINX_FOUND)
-  # run python to see if the theme is installed
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
-                          "import sphinx_bootstrap_theme"
-                  OUTPUT_VARIABLE SPHINX_BOOTSTRAP_THEME_OUT
-                  ERROR_VARIABLE SPHINX_BOOTSTRAP_THEME_ERR
-                  OUTPUT_STRIP_TRAILING_WHITESPACE
-                  ERROR_STRIP_TRAILING_WHITESPACE)
-  if(SPHINX_BOOTSTRAP_THEME_ERR)
-    message(ERROR " Did not find sphinx_bootstrap_theme")
-    message(STATUS "${PYTHON_EXECUTABLE} -c \"import sphinx_bootstrap_theme\"")
-    message(STATUS "${SPHINX_BOOTSTRAP_THEME_ERR}")
-    message(
-      FATAL_ERROR
-        " Install instructions at https://pypi.python.org/pypi/sphinx-bootstrap-theme/"
-      )
-  endif()
+option(ENABLE_DOCS "Enable Building user and developer documentation" ON)
+if (ENABLE_DOCS)
+  find_package(Sphinx 1.2)
+  if(SPHINX_FOUND)
+    # run python to see if the theme is installed
+    execute_process(COMMAND ${PYTHON_EXECUTABLE} -c
+                            "import sphinx_bootstrap_theme"
+                    OUTPUT_VARIABLE SPHINX_BOOTSTRAP_THEME_OUT
+                    ERROR_VARIABLE SPHINX_BOOTSTRAP_THEME_ERR
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    ERROR_STRIP_TRAILING_WHITESPACE)
+    if(SPHINX_BOOTSTRAP_THEME_ERR)
+      message(ERROR " Did not find sphinx_bootstrap_theme")
+      message(STATUS "${PYTHON_EXECUTABLE} -c \"import sphinx_bootstrap_theme\"")
+      message(STATUS "${SPHINX_BOOTSTRAP_THEME_ERR}")
+      message(
+        FATAL_ERROR
+          " Install instructions at https://pypi.python.org/pypi/sphinx-bootstrap-theme/"
+        )
+    endif()
 
-  add_subdirectory(dev-docs)
-  if(ENABLE_MANTIDPLOT)
-    add_subdirectory(docs)
+    add_subdirectory(dev-docs)
+    if(ENABLE_MANTIDPLOT)
+      add_subdirectory(docs)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
This is a minor change to cmake to make building the user and developer docs optional. This is being done to simplify a framework-only build with python3 on rhel7.

**To test:**

Checkout the branch and run `cmake .`. Nothing will have changed.

*This does not require release notes* because it only affects developers.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
