### PR TITLE
Indirect Tools - Added chemical formula validation check

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -138,3 +138,10 @@ Bug Fixes
 #########
 - Fixed a crash in MolDyn caused by plotting output data.
 
+
+Tools Interface
+---------------
+
+Improvements
+############
+- Added a verification for the chemical formula input on the Transmission tab.

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/ExperimentInfo.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/Material.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include <QTreeWidgetItem>
@@ -53,7 +54,15 @@ bool IndirectTransmissionCalc::validate() {
   uiv.checkFieldIsNotEmpty("Chemical Formula", m_uiForm.leChemicalFormula,
                            m_uiForm.valChemicalFormula);
 
-  QString error = uiv.generateErrorMessage();
+  auto const chemicalFormula = m_uiForm.leChemicalFormula->text().toStdString();
+  try {
+    Mantid::Kernel::Material::parseChemicalFormula(chemicalFormula);
+  } catch (std::runtime_error const &) {
+    uiv.addErrorMessage("Chemical Formula for Sample was not recognised.");
+    uiv.setErrorLabel(m_uiForm.valChemicalFormula, false);
+  }
+
+  auto const error = uiv.generateErrorMessage();
   showMessageBox(error);
 
   return error.isEmpty();


### PR DESCRIPTION
**Description of work.**
This PR adds a validation check for the Chemical Formula input on the Indirect Tools interface.

**To test:**
1.`Interface`->`Indirect`->`Tools`
2. Enter `SSSSS` as a Chemical Formula
3. Clicked `Run`
There should be a message box which appears saying the Chem formula is incorrect.

Fixes #26251

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
