### PR TITLE
Default dead time muon analysis

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -34,7 +34,7 @@ class MuonContext(object):
         self.workspace_suffix = workspace_suffix
         self.ads_observer = MuonContextADSObserver(self.remove_workspace_by_name, self.clear_context)
 
-        self.gui_context.update({'DeadTimeSource': 'None', 'LastGoodDataFromFile': True, 'selected_group_pair': ''})
+        self.gui_context.update({'DeadTimeSource': 'FromFile', 'LastGoodDataFromFile': True, 'selected_group_pair': ''})
 
         self.update_view_from_model_notifier = Observable()
 

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -34,7 +34,7 @@ class MuonContext(object):
         self.workspace_suffix = workspace_suffix
         self.ads_observer = MuonContextADSObserver(self.remove_workspace_by_name, self.clear_context)
 
-        self.gui_context.update({'DeadTimeSource': 'FromFile', 'LastGoodDataFromFile': True, 'selected_group_pair': ''})
+        self.gui_context.update({'DeadTimeSource': 'None', 'LastGoodDataFromFile': True, 'selected_group_pair': ''})
 
         self.update_view_from_model_notifier = Observable()
 

--- a/scripts/Muon/GUI/Common/contexts/muon_data_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_data_context.py
@@ -59,7 +59,7 @@ class MuonDataContext(object):
     The MuonContext is the core class for the MuonAnalysis 2 interface. It stores all the data and parameters used
     in the interface and serves as the model part of the MVP design pattern for every widget in the interface.
     By sharing a common instance of this class, the interface remains synchronized by use of the observer pattern to
-    notify subcribers of changes, whi will then respond by updating their view from this commonly shared model.
+    notify subcribers of changes, who will then respond by updating their view from this commonly shared model.
 
     The actual processing of data occurs via this class (as it should as the model).
     """

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -122,15 +122,12 @@ class InstrumentWidgetModel(object):
         return True
 
     def set_dead_time_to_none(self):
-        self._context.gui_context['DeadTimeSource'] = 'None'
         self._context.gui_context.update_and_send_signal(DeadTimeSource='None')
 
     def set_dead_time_from_data(self):
-        self._context.gui_context['DeadTimeSource'] = 'FromFile'
         self._context.gui_context.update_and_send_signal(DeadTimeSource='FromFile')
 
     def set_user_dead_time_from_ADS(self, name):
-        self._context.gui_context['DeadTimeSource'] = 'FromADS'
         dtc = api.AnalysisDataService.retrieve(str(name))
         self._context.gui_context.update_and_send_signal(DeadTimeTable=dtc)
 

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -122,9 +122,11 @@ class InstrumentWidgetModel(object):
         return True
 
     def set_dead_time_to_none(self):
+        self._context.gui_context['DeadTimeSource'] = 'None'
         self._context.gui_context.update_and_send_signal(DeadTimeSource='None')
 
     def set_dead_time_from_data(self):
+        self._context.gui_context['DeadTimeSource'] = 'FromFile'
         self._context.gui_context.update_and_send_signal(DeadTimeSource='FromFile')
 
     def set_user_dead_time_from_ADS(self, name):

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -48,6 +48,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
         self.handle_loaded_time_zero_checkState_change()
         self.handle_loaded_first_good_data_checkState_change()
         self.handle_loaded_last_good_data_checkState_change()
+        #self.handle_user_selects_dead_time_from_data()
 
     def show(self):
         self._view.show()
@@ -189,17 +190,21 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
         """User chooses to load dead time from the currently loaded workspace."""
         dtc = self._model.get_dead_time_table_from_data()
         if dtc is not None:
-            self._model.set_dead_time_from_data()
             dead_times = dtc.toDict()['dead-time']
             dead_time_text = self.dead_time_from_data_text(dead_times)
             self._view.set_dead_time_label(dead_time_text)
         else:
             self._view.set_dead_time_label("No loaded dead time")
 
-        if self._view.dead_time_selector.currentIndex() == 0:
+        index = self._view.dead_time_selector.currentIndex()
+        if index == 0:
+            self._model.set_dead_time_from_data()
             self._view.dead_time_label_3.setVisible(True)
-        else:
+        elif index == 1:
             self._view.dead_time_label_3.hide()
+            self._model.set_user_dead_time_from_ADS()
+        else:
+            self._model.set_dead_time_to_none()
 
     def set_dead_time_text_to_default(self):
         """by default the dead time text should onl contain 0.0."""

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -10,7 +10,7 @@ from Muon.GUI.Common.home_tab.home_tab_presenter import HomeTabSubWidget
 import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.utilities.muon_file_utils import filter_for_extensions
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import DEADTIME_DATA_FILE,\
-    DEADTIME_WORKSPACE, DEADTIME_OTHER_FILE, DEADTIME_NONE
+    DEADTIME_WORKSPACE
 
 
 class InstrumentWidgetPresenter(HomeTabSubWidget):

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -71,6 +71,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             self._view.set_time_zero(time_zero)
 
         self._view.set_instrument(self._model._data.instrument)
+        self.handle_user_selects_dead_time_from_data()
 
     def clear_view(self):
         self._view.set_time_zero(0.0)
@@ -192,6 +193,10 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             dead_times = dtc.toDict()['dead-time']
             dead_time_text = self.dead_time_from_data_text(dead_times)
             self._view.set_dead_time_label(dead_time_text)
+            if self._view.dead_time_selector.currentIndex() == 0:
+                self._view.dead_time_label_3.setVisible(True)
+            else:
+                self._view.dead_time_label_3.hide()
         else:
             self._view.set_dead_time_label("No loaded dead time")
 

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -193,12 +193,13 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             dead_times = dtc.toDict()['dead-time']
             dead_time_text = self.dead_time_from_data_text(dead_times)
             self._view.set_dead_time_label(dead_time_text)
-            if self._view.dead_time_selector.currentIndex() == 0:
-                self._view.dead_time_label_3.setVisible(True)
-            else:
-                self._view.dead_time_label_3.hide()
         else:
             self._view.set_dead_time_label("No loaded dead time")
+
+        if self._view.dead_time_selector.currentIndex() == 0:
+            self._view.dead_time_label_3.setVisible(True)
+        else:
+            self._view.dead_time_label_3.hide()
 
     def set_dead_time_text_to_default(self):
         """by default the dead time text should onl contain 0.0."""

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -179,7 +179,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             return
 
         # switch the view to the "from table workspace" option
-        self._view.set_dead_time_selection(2)
+        self._view.set_dead_time_selection(1)
         is_set = self._view.set_dead_time_file_selection_text(name)
         if not is_set:
             self._view.warning_popup("Dead time table cannot be loaded")

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -9,6 +9,8 @@ from __future__ import (absolute_import, division, print_function)
 from Muon.GUI.Common.home_tab.home_tab_presenter import HomeTabSubWidget
 import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.utilities.muon_file_utils import filter_for_extensions
+from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import DEADTIME_DATA_FILE,\
+    DEADTIME_WORKSPACE, DEADTIME_OTHER_FILE, DEADTIME_NONE
 
 
 class InstrumentWidgetPresenter(HomeTabSubWidget):
@@ -181,7 +183,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             return
 
         # switch the view to the "from table workspace" option
-        self._view.set_dead_time_selection(self._view.DEADTIME_WORKSPACE)
+        self._view.set_dead_time_selection(DEADTIME_WORKSPACE)
         is_set = self._view.set_dead_time_file_selection_text(name)
         if not is_set:
             self._view.warning_popup("Dead time table cannot be loaded")
@@ -197,10 +199,10 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             self._view.set_dead_time_label("No loaded dead time")
 
         index = self._view.dead_time_selector.currentIndex()
-        if index == self._view.DEADTIME_DATA_FILE:
+        if index == DEADTIME_DATA_FILE:
             self._model.set_dead_time_from_data()
             self._view.dead_time_label_3.setVisible(True)
-        elif index == self._view.DEADTIME_WORKSPACE:
+        elif index == DEADTIME_WORKSPACE:
             self._view.dead_time_label_3.hide()
             self._model.set_user_dead_time_from_ADS()
         else:

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -181,7 +181,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             return
 
         # switch the view to the "from table workspace" option
-        self._view.set_dead_time_selection(1)
+        self._view.set_dead_time_selection(self._view.DEADTIME_WORKSPACE)
         is_set = self._view.set_dead_time_file_selection_text(name)
         if not is_set:
             self._view.warning_popup("Dead time table cannot be loaded")
@@ -197,10 +197,10 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
             self._view.set_dead_time_label("No loaded dead time")
 
         index = self._view.dead_time_selector.currentIndex()
-        if index == 0:
+        if index == self._view.DEADTIME_DATA_FILE:
             self._model.set_dead_time_from_data()
             self._view.dead_time_label_3.setVisible(True)
-        elif index == 1:
+        elif index == self._view.DEADTIME_WORKSPACE:
             self._view.dead_time_label_3.hide()
             self._model.set_user_dead_time_from_ADS()
         else:

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -19,6 +19,7 @@ DEADTIME_WORKSPACE = 1
 DEADTIME_OTHER_FILE = 2
 DEADTIME_NONE = 3
 
+
 class InstrumentWidgetView(QtWidgets.QWidget):
     dataChanged = Signal()
 

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -491,6 +491,7 @@ class InstrumentWidgetView(QtWidgets.QWidget):
 
     def set_dead_time_label(self, text):
         self.dead_time_label_3.setText(text)
+        #self.dead_time_label_3.setVisible(True)
 
     def on_dead_time_combo_changed(self, index):
         if index == 0:

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -491,7 +491,6 @@ class InstrumentWidgetView(QtWidgets.QWidget):
 
     def set_dead_time_label(self, text):
         self.dead_time_label_3.setText(text)
-        #self.dead_time_label_3.setVisible(True)
 
     def on_dead_time_combo_changed(self, index):
         if index == 0:

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -14,6 +14,10 @@ from Muon.GUI.Common.utilities.muon_file_utils import allowed_instruments, show_
 from Muon.GUI.Common.utilities.run_string_utils import valid_float_regex
 from Muon.GUI.Common.message_box import warning
 
+DEADTIME_DATA_FILE = 0
+DEADTIME_WORKSPACE = 1
+DEADTIME_OTHER_FILE = 2
+DEADTIME_NONE = 3
 
 class InstrumentWidgetView(QtWidgets.QWidget):
     dataChanged = Signal()
@@ -107,7 +111,7 @@ class InstrumentWidgetView(QtWidgets.QWidget):
         self.rebin_selector.setCurrentIndex(0)
         self.rebin_fixed_hidden(True)
         self.rebin_variable_hidden(True)
-        self.dead_time_selector.setCurrentIndex(0)
+        self.dead_time_selector.setCurrentIndex(DEADTIME_DATA_FILE)
         self.dead_time_data_info_hidden(True)
         self.dead_time_file_loader_hidden(True)
 
@@ -161,13 +165,11 @@ class InstrumentWidgetView(QtWidgets.QWidget):
 
     def on_instrument_changed(self, slot):
         self.instrument_selector.currentIndexChanged.connect(slot)
-        self.instrument_selector.currentIndexChanged.connect(
-            self.cache_instrument)
+        self.instrument_selector.currentIndexChanged.connect(self.cache_instrument)
 
     def cache_instrument(self):
         self._cached_instrument.pop(0)
-        self._cached_instrument.append(
-            str(self.instrument_selector.currentText()))
+        self._cached_instrument.append(str(self.instrument_selector.currentText()))
 
     @property
     def cached_instrument(self):
@@ -493,22 +495,22 @@ class InstrumentWidgetView(QtWidgets.QWidget):
         self.dead_time_label_3.setText(text)
 
     def on_dead_time_combo_changed(self, index):
-        if index == 0:
+        if index == DEADTIME_DATA_FILE:
             self._on_dead_time_from_data_selected()
             self.dead_time_file_loader_hidden(True)
             self.dead_time_data_info_hidden(False)
             self.dead_time_other_file_hidden(True)
-        if index == 1:
+        if index == DEADTIME_WORKSPACE:
             self._on_dead_time_from_file_selected()
             self.dead_time_file_loader_hidden(False)
             self.dead_time_data_info_hidden(False)
             self.dead_time_other_file_hidden(True)
-        if index == 2:
+        if index == DEADTIME_OTHER_FILE:
             self._on_dead_time_from_other_file_selected()
             self.dead_time_file_loader_hidden(True)
             self.dead_time_data_info_hidden(True)
             self.dead_time_other_file_hidden(False)
-        if index == 3:
+        if index == DEADTIME_NONE:
             self._on_dead_time_unselected()
             self.dead_time_file_loader_hidden(True)
             self.dead_time_data_info_hidden(True)

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -392,7 +392,7 @@ class InstrumentWidgetView(QtWidgets.QWidget):
         self.dead_time_label_2.setText("Dead Time Workspace : ")
 
         self.dead_time_label_3 = QtWidgets.QLabel(self)
-        self.dead_time_label_3.setText("")
+        self.dead_time_label_3.setText("No loaded dead time")
 
         self.dead_time_file_selector = QtWidgets.QComboBox(self)
         self.dead_time_file_selector.addItem("None")
@@ -442,9 +442,9 @@ class InstrumentWidgetView(QtWidgets.QWidget):
     def populate_dead_time_combo(self, names):
         self.dead_time_file_selector.blockSignals(True)
         self.dead_time_file_selector.clear()
+        self.dead_time_file_selector.addItem("None")
         for name in names:
             self.dead_time_file_selector.addItem(name)
-        self.dead_time_file_selector.addItem("None")
         self.dead_time_file_selector.blockSignals(False)
 
     def get_dead_time_file_selection(self):

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_view.py
@@ -383,10 +383,10 @@ class InstrumentWidgetView(QtWidgets.QWidget):
 
         self.dead_time_selector = QtWidgets.QComboBox(self)
         self.dead_time_selector.addItems(
-            ["None",
-             "From data file",
+            ["From data file",
              "From table workspace",
-             "From other file"])
+             "From other file",
+             "None"])
 
         self.dead_time_label_2 = QtWidgets.QLabel(self)
         self.dead_time_label_2.setText("Dead Time Workspace : ")
@@ -442,9 +442,9 @@ class InstrumentWidgetView(QtWidgets.QWidget):
     def populate_dead_time_combo(self, names):
         self.dead_time_file_selector.blockSignals(True)
         self.dead_time_file_selector.clear()
-        self.dead_time_file_selector.addItem("None")
         for name in names:
             self.dead_time_file_selector.addItem(name)
+        self.dead_time_file_selector.addItem("None")
         self.dead_time_file_selector.blockSignals(False)
 
     def get_dead_time_file_selection(self):
@@ -494,25 +494,25 @@ class InstrumentWidgetView(QtWidgets.QWidget):
 
     def on_dead_time_combo_changed(self, index):
         if index == 0:
-            self._on_dead_time_unselected()
-            self.dead_time_file_loader_hidden(True)
-            self.dead_time_data_info_hidden(True)
-            self.dead_time_other_file_hidden(True)
-        if index == 1:
             self._on_dead_time_from_data_selected()
             self.dead_time_file_loader_hidden(True)
             self.dead_time_data_info_hidden(False)
             self.dead_time_other_file_hidden(True)
-        if index == 2:
+        if index == 1:
             self._on_dead_time_from_file_selected()
             self.dead_time_file_loader_hidden(False)
             self.dead_time_data_info_hidden(False)
             self.dead_time_other_file_hidden(True)
-        if index == 3:
+        if index == 2:
             self._on_dead_time_from_other_file_selected()
             self.dead_time_file_loader_hidden(True)
             self.dead_time_data_info_hidden(True)
             self.dead_time_other_file_hidden(False)
+        if index == 3:
+            self._on_dead_time_unselected()
+            self.dead_time_file_loader_hidden(True)
+            self.dead_time_data_info_hidden(True)
+            self.dead_time_other_file_hidden(True)
 
     def on_dead_time_from_other_file_selected(self, slot):
         self._on_dead_time_from_other_file_selected = slot

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -174,16 +174,16 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 3)
 
     def test_that_on_dead_time_unselected_deadtime_model_set_to_none(self):
-        self.view.dead_time_selector.setCurrentIndex(0)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_DATA_FILE)
         self.context.gui_context['DeadTimeSource'] = 'FromFile'
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_NONE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), self.presenter.dead_time_from_data_text([0.0]))
         self.assertEqual(self.model._data.current_data["DeadTimeTable"], None)
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'None'})
 
     def test_that_on_deadtime_data_selected_updates_with_no_loaded_data(self):
-        self.view.dead_time_selector.setCurrentIndex(0)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_DATA_FILE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "No loaded dead time")
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -204,7 +204,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         get_table_names_mock.return_value = ['table_1', 'table_2', 'table_3']
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(1)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_WORKSPACE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertFalse(self.view.dead_time_file_selector.isHidden())
@@ -216,9 +216,9 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
 
     def test_that_returning_to_None_options_hides_table_workspace_selector(self):
-        self.view.dead_time_selector.setCurrentIndex(1)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_WORKSPACE)
         self.context.gui_context['DeadTimeSource'] = 'FromADS'
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_NONE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
@@ -227,7 +227,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_button_displayed_when_from_other_file_selected(self):
         self.assertTrue(self.view.dead_time_browse_button.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
 
         self.assertFalse(self.view.dead_time_browse_button.isHidden())
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -237,7 +237,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_displays_warning_popup_if_file_does_not_contain_table(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock()
         load_deadtime_mock.return_value = ''
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -251,7 +251,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         'Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter.load_utils.load_dead_time_from_filename')
     def test_browse_clicked_does_nothing_if_no_file_selected(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=[''])
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -264,11 +264,11 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_fails_if_table_not_loaded_into_ADS(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=['filename'])
         load_deadtime_mock.return_value = 'dead_time_table_name'
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), 1)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), InstrumentWidgetView.DEADTIME_WORKSPACE)
         self.view.warning_popup.assert_called_once_with("Dead time table cannot be loaded")
         self.gui_variable_observer.update.assert_not_called()
 
@@ -279,7 +279,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), 1)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), InstrumentWidgetView.DEADTIME_WORKSPACE)
         self.view.warning_popup.assert_not_called()
         self.assertEqual(self.view.dead_time_file_selector.currentText(), 'MUSR00015196_deadTimes')
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeTable': mock.ANY})

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -17,6 +17,8 @@ from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter imp
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import InstrumentWidgetView
 from Muon.GUI.Common.observer_pattern import Observer
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
+from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import DEADTIME_DATA_FILE,\
+    DEADTIME_WORKSPACE, DEADTIME_OTHER_FILE, DEADTIME_NONE
 
 
 class HomeTabInstrumentPresenterTest(GuiTest):
@@ -174,16 +176,16 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 3)
 
     def test_that_on_dead_time_unselected_deadtime_model_set_to_none(self):
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_DATA_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_DATA_FILE)
         self.context.gui_context['DeadTimeSource'] = 'FromFile'
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_NONE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_NONE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), self.presenter.dead_time_from_data_text([0.0]))
         self.assertEqual(self.model._data.current_data["DeadTimeTable"], None)
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'None'})
 
     def test_that_on_deadtime_data_selected_updates_with_no_loaded_data(self):
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_DATA_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_DATA_FILE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "No loaded dead time")
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -204,7 +206,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         get_table_names_mock.return_value = ['table_1', 'table_2', 'table_3']
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_WORKSPACE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_WORKSPACE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertFalse(self.view.dead_time_file_selector.isHidden())
@@ -216,9 +218,9 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
 
     def test_that_returning_to_None_options_hides_table_workspace_selector(self):
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_WORKSPACE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_WORKSPACE)
         self.context.gui_context['DeadTimeSource'] = 'FromADS'
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_NONE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_NONE)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
@@ -227,7 +229,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_button_displayed_when_from_other_file_selected(self):
         self.assertTrue(self.view.dead_time_browse_button.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_OTHER_FILE)
 
         self.assertFalse(self.view.dead_time_browse_button.isHidden())
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -237,7 +239,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_displays_warning_popup_if_file_does_not_contain_table(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock()
         load_deadtime_mock.return_value = ''
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -251,7 +253,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         'Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter.load_utils.load_dead_time_from_filename')
     def test_browse_clicked_does_nothing_if_no_file_selected(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=[''])
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -264,11 +266,11 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_fails_if_table_not_loaded_into_ADS(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=['filename'])
         load_deadtime_mock.return_value = 'dead_time_table_name'
-        self.view.dead_time_selector.setCurrentIndex(InstrumentWidgetView.DEADTIME_OTHER_FILE)
+        self.view.dead_time_selector.setCurrentIndex(DEADTIME_OTHER_FILE)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), InstrumentWidgetView.DEADTIME_WORKSPACE)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), DEADTIME_WORKSPACE)
         self.view.warning_popup.assert_called_once_with("Dead time table cannot be loaded")
         self.gui_variable_observer.update.assert_not_called()
 
@@ -279,7 +281,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), InstrumentWidgetView.DEADTIME_WORKSPACE)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), DEADTIME_WORKSPACE)
         self.view.warning_popup.assert_not_called()
         self.assertEqual(self.view.dead_time_file_selector.currentText(), 'MUSR00015196_deadTimes')
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeTable': mock.ANY})

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -174,16 +174,16 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 3)
 
     def test_that_on_dead_time_unselected_deadtime_model_set_to_none(self):
-        self.view.dead_time_selector.setCurrentIndex(1)
-        self.context.gui_context['DeadTimeSource'] = 'FromFile'
         self.view.dead_time_selector.setCurrentIndex(0)
+        self.context.gui_context['DeadTimeSource'] = 'FromFile'
+        self.view.dead_time_selector.setCurrentIndex(3)
 
         self.assertEqual(self.view.dead_time_label_3.text(), self.presenter.dead_time_from_data_text([0.0]))
         self.assertEqual(self.model._data.current_data["DeadTimeTable"], None)
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'None'})
 
     def test_that_on_deadtime_data_selected_updates_with_no_loaded_data(self):
-        self.view.dead_time_selector.setCurrentIndex(1)
+        self.view.dead_time_selector.setCurrentIndex(0)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "No loaded dead time")
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -192,8 +192,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         dead_time_data = mock.MagicMock()
         dead_time_data.toDict.return_value = {'dead-time': [0.001, 0.002, 0.003]}
         self.presenter._model.get_dead_time_table_from_data = mock.MagicMock(return_value=dead_time_data)
-
-        self.view.dead_time_selector.setCurrentIndex(1)
+        self.presenter.handle_user_selects_dead_time_from_data()
 
         self.assertEqual(self.view.dead_time_label_3.text(), 'From 0.001 to 0.003 (ave. 0.002)')
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'FromFile'})
@@ -205,7 +204,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         get_table_names_mock.return_value = ['table_1', 'table_2', 'table_3']
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(1)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertFalse(self.view.dead_time_file_selector.isHidden())
@@ -217,9 +216,9 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
 
     def test_that_returning_to_None_options_hides_table_workspace_selector(self):
-        self.view.dead_time_selector.setCurrentIndex(2)
+        self.view.dead_time_selector.setCurrentIndex(1)
         self.context.gui_context['DeadTimeSource'] = 'FromADS'
-        self.view.dead_time_selector.setCurrentIndex(0)
+        self.view.dead_time_selector.setCurrentIndex(3)
 
         self.assertEqual(self.view.dead_time_label_3.text(), "From 0.000 to 0.000 (ave. 0.000)")
         self.assertTrue(self.view.dead_time_file_selector.isHidden())
@@ -228,7 +227,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_button_displayed_when_from_other_file_selected(self):
         self.assertTrue(self.view.dead_time_browse_button.isHidden())
 
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(2)
 
         self.assertFalse(self.view.dead_time_browse_button.isHidden())
         self.assertEqual(self.gui_variable_observer.update.call_count, 0)
@@ -238,7 +237,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_displays_warning_popup_if_file_does_not_contain_table(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock()
         load_deadtime_mock.return_value = ''
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(2)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -252,7 +251,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
         'Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter.load_utils.load_dead_time_from_filename')
     def test_browse_clicked_does_nothing_if_no_file_selected(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=[''])
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(2)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
@@ -265,11 +264,11 @@ class HomeTabInstrumentPresenterTest(GuiTest):
     def test_browse_clicked_fails_if_table_not_loaded_into_ADS(self, load_deadtime_mock):
         self.view.show_file_browser_and_return_selection = mock.MagicMock(return_value=['filename'])
         load_deadtime_mock.return_value = 'dead_time_table_name'
-        self.view.dead_time_selector.setCurrentIndex(3)
+        self.view.dead_time_selector.setCurrentIndex(2)
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), 2)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), 1)
         self.view.warning_popup.assert_called_once_with("Dead time table cannot be loaded")
         self.gui_variable_observer.update.assert_not_called()
 
@@ -280,7 +279,7 @@ class HomeTabInstrumentPresenterTest(GuiTest):
 
         self.view.dead_time_browse_button.clicked.emit(True)
 
-        self.assertEqual(self.view.dead_time_selector.currentIndex(), 2)
+        self.assertEqual(self.view.dead_time_selector.currentIndex(), 1)
         self.view.warning_popup.assert_not_called()
         self.assertEqual(self.view.dead_time_file_selector.currentText(), 'MUSR00015196_deadTimes')
         self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeTable': mock.ANY})


### PR DESCRIPTION
**Description of work.**

Changed the default dead time in the Muon Analysis 2 interface from `None` to `From Data File`

**To test:**

- `Interfaces->Muon->Muon Analysis 2->Home`
- The default `Dead Time` should be `From data file` and the message _No loaded dead time_ should appear to its right
- Load a run (eg. `62260`)
- Now the dead time label will have changed (eg. for run `62260` now it should be _From 0.001 to 0.019 (ave. 0.009)_)

Fixes #26245.
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
