### PR TITLE
Muon Fix crash when Selector is removed

### DIFF
--- a/qt/widgets/mplcpp/src/RangeMarker.cpp
+++ b/qt/widgets/mplcpp/src/RangeMarker.cpp
@@ -9,9 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
-using Mantid::PythonInterface::callMethodNoCheck;
 using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::PythonException;
+using Mantid::PythonInterface::callMethodNoCheck;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 

--- a/qt/widgets/mplcpp/src/RangeMarker.cpp
+++ b/qt/widgets/mplcpp/src/RangeMarker.cpp
@@ -9,8 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
-using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::callMethodNoCheck;
+using Mantid::PythonInterface::GlobalInterpreterLock;
+using Mantid::PythonInterface::PythonException;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -62,7 +63,13 @@ void RangeMarker::redraw() { callMethodNoCheck<void>(pyobj(), "redraw"); }
 /**
  * @brief Remove the RangeMarker from the plot
  */
-void RangeMarker::remove() { callMethodNoCheck<void>(pyobj(), "remove"); }
+void RangeMarker::remove() {
+  try {
+    callMethodNoCheck<void>(pyobj(), "remove");
+  } catch (PythonException const &) {
+    // Marker has already been removed
+  }
+}
 
 /**
  * @brief Sets the color of the RangeMarker.

--- a/qt/widgets/mplcpp/src/SingleMarker.cpp
+++ b/qt/widgets/mplcpp/src/SingleMarker.cpp
@@ -9,9 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
-using Mantid::PythonInterface::callMethodNoCheck;
 using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::PythonException;
+using Mantid::PythonInterface::callMethodNoCheck;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 

--- a/qt/widgets/mplcpp/src/SingleMarker.cpp
+++ b/qt/widgets/mplcpp/src/SingleMarker.cpp
@@ -9,8 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
-using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::callMethodNoCheck;
+using Mantid::PythonInterface::GlobalInterpreterLock;
+using Mantid::PythonInterface::PythonException;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -65,7 +66,13 @@ void SingleMarker::redraw() { callMethodNoCheck<void>(pyobj(), "redraw"); }
 /**
  * @brief Remove the marker from the plot
  */
-void SingleMarker::remove() { callMethodNoCheck<void>(pyobj(), "remove"); }
+void SingleMarker::remove() {
+  try {
+    callMethodNoCheck<void>(pyobj(), "remove");
+  } catch (PythonException const &) {
+    // Marker has already been removed
+  }
+}
 
 /**
  * @brief Sets the color of the marker.


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash caused by attempting to remove a marker which has already been removed from the patch.

No release notes required as this is only present for workbench, and ALC wasn't in the workbench for the last release.

**To test:**
Open workbench
Set default instrument to EMU
Open ALC
For first enter 94183
for Last enter 94185
Click Load
Go to baseline modelling
Add a fitting function and region
Do a fit
Go to peak fitting and do a fit
Go back to data loading
Then for first and last browse to some HIFI data
Click Load
Mantid should load the data, and there should be no popup error.

Fixes #26250

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
