### PR TITLE
GroupWorkspaces: Can overwrite group workspaces with input workspaces again

### DIFF
--- a/Framework/Algorithms/src/GroupWorkspaces.cpp
+++ b/Framework/Algorithms/src/GroupWorkspaces.cpp
@@ -73,8 +73,10 @@ std::map<std::string, std::string> GroupWorkspaces::validateInputs() {
   // same name as the group/output workspace
   for (const auto &ws : inputWorkspaces) {
     if (ws == outputWorkspace) {
-      results["OutputWorkspace"] = "The Output workspace has the same name as "
-                                   "one of the input workspaces";
+      if (!AnalysisDataService::Instance().retrieve(ws)->isGroup())
+        results["OutputWorkspace"] =
+            "The output workspace has the same name as "
+            "one of the input workspaces";
     }
   }
 

--- a/Framework/Algorithms/test/GroupWorkspacesTest.h
+++ b/Framework/Algorithms/test/GroupWorkspacesTest.h
@@ -38,9 +38,9 @@ public:
   }
 
   void testInit() {
+    using Mantid::Algorithms::GroupWorkspaces;
     using Mantid::API::WorkspaceGroup;
     using Mantid::API::WorkspaceProperty;
-    using Mantid::Algorithms::GroupWorkspaces;
 
     GroupWorkspaces alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
@@ -400,6 +400,20 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "ws1"));
     TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
     TS_ASSERT(!alg.isExecuted());
+    removeFromADS("", inputs);
+  }
+
+  void test_OutputWorkspace_can_overwrite_input_group_workspaces() {
+    const std::vector<std::string> inputs{"ws1", "ws2", "ws3"};
+    addTestMatrixWorkspacesToADS(inputs);
+    const std::vector<std::string> group1{"ws1", "ws2"};
+    runAlgorithm(group1, "Group", false);
+
+    const std::vector<std::string> group2{"Group", "ws3"};
+    runAlgorithm(group2, "Group", false);
+
+    checkGroupExistsWithMembers("Group", {"ws1", "ws2", "ws3"});
+    removeFromADS("Group", inputs);
   }
 
 private:

--- a/Framework/Algorithms/test/GroupWorkspacesTest.h
+++ b/Framework/Algorithms/test/GroupWorkspacesTest.h
@@ -38,9 +38,9 @@ public:
   }
 
   void testInit() {
-    using Mantid::Algorithms::GroupWorkspaces;
     using Mantid::API::WorkspaceGroup;
     using Mantid::API::WorkspaceProperty;
+    using Mantid::Algorithms::GroupWorkspaces;
 
     GroupWorkspaces alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());


### PR DESCRIPTION
**Description of work.**
Allow previously expected functionality from 4.0 to work for GroupWorkspaces again. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Run this script and it should be successful:
```python
from mantid.simpleapi import *

CreateSampleWorkspace(OutputWorkspace='164200') 
CreateSampleWorkspace(OutputWorkspace='164199')
CreateSampleWorkspace(OutputWorkspace='164198')
GroupWorkspaces(InputWorkspaces="164199,164198", OutputWorkspace="NewGroup")
GroupWorkspaces(InputWorkspaces="NewGroup,164200", OutputWorkspace="NewGroup")
```

This script should not be:
```python
from mantid.simpleapi import *

CreateSampleWorkspace(OutputWorkspace='164200')
CreateSampleWorkspace(OutputWorkspace='164199')
CreateSampleWorkspace(OutputWorkspace='164198')
GroupWorkspaces(InputWorkspaces="164199,164198", OutputWorkspace="NewGroup")
GroupWorkspaces(InputWorkspaces="NewGroup,164200", OutputWorkspace="164200")
```
<!-- Instructions for testing. -->

Fixes #26137  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

NO RELEASE NOTES AS I AM RESTORING PREVIOUS FUNCTIONALITY THAT WAS REMOVED

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
