### PR TITLE
Add remaining packages to build mantid-framework py3 on rhel7

### DIFF
--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.32
+Version:        1.33
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -110,9 +110,13 @@ Requires: python3-mock
 Requires: boost-python3-devel
 %endif
 
-%{?el7:Requires: boost-python36-devel}
-%{?el7:Requires: python36-devel}
-%{?el7:Requires: python36-numpy}
+%if 0%{el7}
+Requires: boost-python36-devel
+Requires: python36-devel
+Requires: python36-h5py
+Requires: python36-numpy
+Requires: python36-PyYAML
+%endif
 
 BuildArch: noarch
 


### PR DESCRIPTION
This adds the rest of the "easy" packages for python3 on rhel7. Unfortunately, it only gets through framework and is missing `sphinx-boostrap-theme`.

**To test:**

Do the additions look reasonable?

*There is no associated issue.*

*This does not require release notes* because it only affects developers.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
