### PR TITLE
Minor change to column labels in the reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -315,17 +315,17 @@
        </column>
        <column>
         <property name="text">
-         <string>1st Transmission Run(s)</string>
+         <string>1st Trans Run(s)</string>
         </property>
        </column>
        <column>
         <property name="text">
-         <string>2nd Transmission Run(s)</string>
+         <string>2nd Trans Run(s)</string>
         </property>
        </column>
        <column>
         <property name="text">
-         <string>Transmission Spectra</string>
+         <string>Trans Spectra</string>
         </property>
        </column>
        <column>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
@@ -22,9 +22,8 @@ RunsTableView::RunsTableView(std::vector<std::string> const &instruments,
   m_ui.setupUi(this);
   m_ui.progressBar->setRange(0, 100);
   m_jobs = std::make_unique<MantidQt::MantidWidgets::Batch::JobTreeView>(
-      QStringList({"Run(s)", "Angle", "First Transmission Run",
-                   "Second Transmission Run", "Q min", "Q max", "dQ/Q", "Scale",
-                   "Options"}),
+      QStringList({"Run(s)", "Angle", "1st Trans Run(s)", "2nd Trans Run(s)",
+                   "Q min", "Q max", "dQ/Q", "Scale", "Options"}),
       MantidQt::MantidWidgets::Batch::Cell(""), this);
   m_ui.mainLayout->insertWidget(2, m_jobs.get());
   showAlgorithmPropertyHintsInOptionsColumn();


### PR DESCRIPTION
Following discussions with Max, we agreed to make some minor changes to the labels on the reflectometry GUI:
- On the Experiment Settings tab, reduce the length of the labels to save space.
- Update the Runs tab's column headings with the same labels for the 1st and 2nd transmission runs columns.

**To test:**

- Open the ISIS Reflectometry GUI
- Check that the new labels appear on the Runs and Experiment Settings tabs, as per these images:

![image](https://user-images.githubusercontent.com/12895056/60905781-a8e18e00-a26d-11e9-9809-38d8e249777d.png)

![image](https://user-images.githubusercontent.com/12895056/60905806-b6971380-a26d-11e9-82a6-1f8946dde46c.png)


*There is no associated issue.*

*This does not require release notes* because **it is a very minor change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
