### PR TITLE
Fix a bug where row highlighting is lost

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -125,6 +125,7 @@ void RunsPresenter::notifySearchFailed() {
 
 void RunsPresenter::notifyTransfer() {
   transfer(m_view->getSelectedSearchRows(), TransferMatch::Any);
+  notifyRowStateChanged();
 }
 
 void RunsPresenter::notifyInstrumentChanged() {
@@ -180,6 +181,7 @@ void RunsPresenter::notifyRowOutputsChanged(
 void RunsPresenter::reductionResumed() {
   updateWidgetEnabledState();
   tablePresenter()->reductionResumed();
+  notifyRowStateChanged();
 }
 
 void RunsPresenter::reductionPaused() {


### PR DESCRIPTION
Add notifications to update row state after new runs are transferred to the table. Previously this was causing the highlighting to be lost so updating the state fixes it

**To test:**

- Open the ISIS Reflectometry interface
- Select instrument INTER and enter investigation ID 1120015
- Click Search. Select all the results and click Transfer.
- Select the first group in the main table and click Process.
- Expand the group and note that all rows are green when processing is finished.
- Select all rows in the search results again and click Transfer. Ensure that the green highlighting is not lost.
- Click Autoprocess and click Yes if prompted to replace the table. Wait till the first group has been processed then click Pause.
- Click Autoprocess again. Autoprocessing should continue from where it left off. Ensure that the green highlighting for existing rows is not lost.

*There is no associated issue.*

*This does not require release notes* because **it fixes a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
