### PR TITLE
Indirect Connect up the Error bars for external workbench plots

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -14,7 +14,7 @@ Indirect Geometry Changes
 Instrument Definitions
 ----------------------
 
-The IDF of IN16B has been rewritten to properly model the neutronic positions of the pixels as reflections wrt spherical analysers.
+The IDF of IN16B has been rewritten to properly model the neutronic positions of the pixels as reflections with respect to spherical analysers.
 This is needed for the new inverted time-of-flight mode (BATS), but also improves the model for the standard doppler mode.
 Particularly, this will allow to calculate correct absorption corrections before grouping the pixels tube by tube.
 With the new IDF the flight-paths inside the sample will properly take into account the off-plane angle, which was not the case with the previous IDF.
@@ -153,6 +153,7 @@ The Workbench
   :align: center
   :figwidth: 90%
   :alt: The Indirect Data Reduction GUI in the Workbench.
+
 
 Tools Interface
 ---------------

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -120,6 +120,7 @@ QStringList convertToQStringList(std::string const &str,
  *
  * @param workspaceNames List of names of workspaces to plot
  * @param indices The workspace indices to plot
+ * @param errorBars True if error bars are enabled
  * @param kwargs Other arguments for plotting
  */
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -124,13 +124,16 @@ QStringList convertToQStringList(std::string const &str,
  * @param kwargs Other arguments for plotting
  */
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-void workbenchPlot(
-    QStringList const &workspaceNames, std::vector<int> const &indices,
-    bool errorBars,
-    QHash<QString, QVariant> &kwargs = QHash<QString, QVariant>()) {
-  using MantidQt::Widgets::MplCpp::plot;
+void workbenchPlot(QStringList const &workspaceNames,
+                   std::vector<int> const &indices, bool errorBars,
+                   boost::optional<QHash<QString, QVariant>> kwargs) {
+  QHash<QString, QVariant> plotKwargs;
+  if (kwargs)
+    plotKwargs = kwargs.get();
   if (errorBars)
-    kwargs["capsize"] = 3;
+    plotKwargs["capsize"] = 3;
+
+  using MantidQt::Widgets::MplCpp::plot;
   plot(workspaceNames, boost::none, indices, boost::none, kwargs, boost::none,
        boost::none, errorBars);
 }
@@ -459,7 +462,7 @@ void IndirectTab::plotMultipleSpectra(
   }
   m_pythonRunner.runPythonCode(pyInput);
 #else
-  workbenchPlot(workspaceNames, workspaceIndices, m_plotErrorBars);
+  workbenchPlot(workspaceNames, workspaceIndices, m_plotErrorBars, boost::none);
 #endif
 }
 
@@ -487,7 +490,8 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
 
     m_pythonRunner.runPythonCode(pyInput);
 #else
-    workbenchPlot(workspaceNames, std::vector<int>{wsIndex}, m_plotErrorBars);
+    workbenchPlot(workspaceNames, std::vector<int>{wsIndex}, m_plotErrorBars,
+                  boost::none);
 #endif
   }
 }
@@ -543,7 +547,7 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int specStart,
   const auto nSpectra = specEnd - specStart + 1;
   std::vector<int> wkspIndices(nSpectra);
   std::iota(std::begin(wkspIndices), std::end(wkspIndices), specStart);
-  workbenchPlot(workspaceNames, wkspIndices, m_plotErrorBars);
+  workbenchPlot(workspaceNames, wkspIndices, m_plotErrorBars, boost::none);
 #endif
 }
 
@@ -597,7 +601,7 @@ void IndirectTab::plotSpectra(const QStringList &workspaceNames,
   pyInput += ", error_bars=" + errors + ")\n";
   m_pythonRunner.runPythonCode(pyInput);
 #else
-  workbenchPlot(workspaceNames, wsIndices, m_plotErrorBars);
+  workbenchPlot(workspaceNames, wsIndices, m_plotErrorBars, boost::none);
 #endif
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -468,7 +468,8 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
     m_pythonRunner.runPythonCode(pyInput);
 #else
     using MantidQt::Widgets::MplCpp::plot;
-    plot(workspaceNames, boost::none, std::vector<int>{wsIndex});
+    plot(workspaceNames, boost::none, std::vector<int>{wsIndex}, boost::none,
+         boost::none, boost::none, boost::none, m_plotErrorBars);
 #endif
   }
 }
@@ -687,7 +688,7 @@ void IndirectTab::plotTimeBin(const QStringList &workspaceNames, int binIndex) {
   QHash<QString, QVariant> plotKwargs{
       {"axis", static_cast<int>(MantidAxType::Bin)}};
   plot(workspaceNames, boost::none, std::vector<int>{binIndex}, boost::none,
-       plotKwargs);
+       plotKwargs, boost::none, boost::none, m_plotErrorBars);
 #endif
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -468,8 +468,9 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames,
     m_pythonRunner.runPythonCode(pyInput);
 #else
     using MantidQt::Widgets::MplCpp::plot;
+    QHash<QString, QVariant> plotKwargs{{"capsize", 3}};
     plot(workspaceNames, boost::none, std::vector<int>{wsIndex}, boost::none,
-         boost::none, boost::none, boost::none, m_plotErrorBars);
+         plotKwargs, boost::none, boost::none, m_plotErrorBars);
 #endif
   }
 }
@@ -525,7 +526,8 @@ void IndirectTab::plotSpectrum(const QStringList &workspaceNames, int specStart,
   const auto nSpectra = specEnd - specStart + 1;
   std::vector<int> wkspIndices(nSpectra);
   std::iota(std::begin(wkspIndices), std::end(wkspIndices), specStart);
-  plot(workspaceNames, boost::none, wkspIndices, boost::none, boost::none,
+  QHash<QString, QVariant> plotKwargs{{"capsize", 3}};
+  plot(workspaceNames, boost::none, wkspIndices, boost::none, plotKwargs,
        boost::none, boost::none, m_plotErrorBars);
 #endif
 }
@@ -581,7 +583,8 @@ void IndirectTab::plotSpectra(const QStringList &workspaceNames,
   m_pythonRunner.runPythonCode(pyInput);
 #else
   using MantidQt::Widgets::MplCpp::plot;
-  plot(workspaceNames, boost::none, wsIndices, boost::none, boost::none,
+  QHash<QString, QVariant> plotKwargs{{"capsize", 3}};
+  plot(workspaceNames, boost::none, wsIndices, boost::none, plotKwargs,
        boost::none, boost::none, m_plotErrorBars);
 #endif
 }
@@ -686,7 +689,7 @@ void IndirectTab::plotTimeBin(const QStringList &workspaceNames, int binIndex) {
   using MantidQt::Widgets::MplCpp::MantidAxType;
   using MantidQt::Widgets::MplCpp::plot;
   QHash<QString, QVariant> plotKwargs{
-      {"axis", static_cast<int>(MantidAxType::Bin)}};
+      {"axis", static_cast<int>(MantidAxType::Bin)}, {"capsize", 3}};
   plot(workspaceNames, boost::none, std::vector<int>{binIndex}, boost::none,
        plotKwargs, boost::none, boost::none, m_plotErrorBars);
 #endif

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -134,8 +134,8 @@ void workbenchPlot(QStringList const &workspaceNames,
     plotKwargs["capsize"] = 3;
 
   using MantidQt::Widgets::MplCpp::plot;
-  plot(workspaceNames, boost::none, indices, boost::none, kwargs, boost::none,
-       boost::none, errorBars);
+  plot(workspaceNames, boost::none, indices, boost::none, plotKwargs,
+       boost::none, boost::none, errorBars);
 }
 #endif
 


### PR DESCRIPTION
**Description of work.**
This PR ensures that error bars are plotted on the external plots within indirect when the Error bars are switched on via the Indirect Settings GUI.
It also makes a small change to the Indirect release notes.

No release notes required as the Settings GUI is new.

**To test:**
1. Load the workbench
2. `Interfaces`->`Indirect`->`Data Reduction`->`Moments` tab
3. Make sure Error bars are turned on in the Indirect settings GUI. Accessed via the
![image](https://user-images.githubusercontent.com/40830825/60962617-894a7400-a306-11e9-844f-bed3dec7f54a.png) button.

4. Load the data below.
5. Click `Run` and wait for it to finish
6. Click `Plot Result`. An external plot of three spectra will appear. 

There should be error bars:
![image](https://user-images.githubusercontent.com/40830825/60965386-9d45a400-a30d-11e9-8e3c-9b654e151b49.png)

**Data Files**
[iris26174_graphite002_sqw.zip](https://github.com/mantidproject/mantid/files/3377050/iris26174_graphite002_sqw.zip)

Fixes #26271

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
