### PR TITLE
Fix bug in check for if time belongs in a filter region

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -2548,19 +2548,15 @@ std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector() const {
   if (m_filter.empty()) {
     return this->valuesAsVector(); // no filtering to do
   }
-
-  std::vector<TYPE> filteredValues;
-
   if (!m_filterApplied) {
     applyFilter();
   }
-
   sortIfNecessary();
 
-  const auto &valueMap = valueAsCorrectMap();
-  for (const auto &entry : valueMap) {
-    if (isTimeFiltered(entry.first)) {
-      filteredValues.push_back(entry.second);
+  std::vector<TYPE> filteredValues;
+  for (const auto &value : m_values) {
+    if (isTimeFiltered(value.time())) {
+      filteredValues.emplace_back(value.value());
     }
   }
 
@@ -2569,7 +2565,9 @@ std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector() const {
 
 /**
  * Find out if the given time is included in the filtered data
- * i.e. it does not lie in an excluded region
+ * i.e. it does not lie in an excluded region. This function assumes
+ * the filter is not empty, it has been applied and the values are
+ * sorted by time.
  * @param time :: [input] Time to check
  * @returns :: True if time is in an included region, false if the filter
  * excludes it.
@@ -2577,24 +2575,29 @@ std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector() const {
 template <typename TYPE>
 bool TimeSeriesProperty<TYPE>::isTimeFiltered(
     const Types::Core::DateAndTime &time) const {
-  if (m_filter.empty()) {
-    return false; // no filter
-  }
+  // Each time/value pair in the filter defines a point where the region defined
+  // after that time is either included/excluded depending on the boolean value.
+  // By definition of the filter construction the region before a given filter
+  // time must have the opposite value. For times outside the filter region:
+  //   1. time < first filter time: inverse of the first filter value
+  //   2. time > last filter time: value of the last filter value
+  // If time == a filter time then the value is taken to belong to that filter
+  // region and not the previous
 
-  if (!m_filterApplied) {
-    applyFilter();
-  }
-
-  // Find which range it lives in
+  // Find first fitler time strictly greater than time
   auto filterEntry = std::lower_bound(
       m_filter.begin(), m_filter.end(), time,
       [](const std::pair<Types::Core::DateAndTime, bool> &filterEntry,
-         const Types::Core::DateAndTime &t) { return filterEntry.first < t; });
+         const Types::Core::DateAndTime &t) { return filterEntry.first <= t; });
 
-  if (filterEntry != m_filter.begin()) {
-    --filterEntry; // get the latest time BEFORE the given time
+  if (filterEntry == m_filter.begin()) {
+    return !filterEntry->second;
+  } else {
+    // iterator points to filter greater than time and but we want the previous
+    // region
+    --filterEntry;
+    return filterEntry->second;
   }
-  return filterEntry->second;
 }
 
 /**

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -13,7 +13,7 @@ Concepts
 - Support has been added for negative indexing of :ref:`WorkspaceGroups <WorkspaceGroup>`.
   Try :code:`ws_group[-1]` to get the last workspace in the WorkspaceGroup :code:`ws_group`.
 - Updated the clone method of IFunction to copy parameter errors across as well as parameter values.
-  
+
 Algorithms
 ----------
 
@@ -54,6 +54,8 @@ Bug fixes
 
 - :ref:`SetSample <algm-SetSample>` now correctly handles the Sample number density being passed as a string, before the algorithm would execute, but silently ignored the provided number density, the number density is now properly used.
 - Mantid no longer crashed when invalid period logs encountered in `LoadEventNexus <algm-LoadEventNexus>`. A clear error message is displayed which explains the problem.
+- ISIS sample logs are now correctly filtered by status and period on loading.
+- A bug has been fixed in status log filtering where if a log contained times before the first running log entry then they would be included rather than excluded.
 
 Removed
 #######


### PR DESCRIPTION
**Description of work.**

Fixes check of if a time is in a filter region to exclude values before the first filter value.

**To test:**

Run the script in the issue and check that the filtered and unfiltered mean are different and the values stated.

Fixes #26264


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
