### PR TITLE
refs #26238. Improved handling ESC in Remove plot

### DIFF
--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -68,7 +68,6 @@ class subplot(QtWidgets.QWidget):
         self._context.add_annotate(subplotName, label)
         self.canvas.draw()
 
-    # todo: add color suppport
     def add_vline(self, subplotName, xvalue, name, color):
         if subplotName not in self._context.subplots.keys():
             return
@@ -157,56 +156,41 @@ class subplot(QtWidgets.QWidget):
 
     def _rm(self):
         names = list(self._context.subplots.keys())
-        # if the remove window is not visable
-        if self._rm_window is not None:
-            self._raise_rm_window()
-        # if the selector is not visable
-        elif self._selector_window is not None:
-            self._raise_selector_window()
-        # if only one subplot just skip selector
-        elif len(names) == 1:
-            self._get_rm_window(names[0])
-        # if no selector and no remove window -> let user pick which subplot to
-        # change
+        if len(names) == 1:
+            if self._rm_window is not None:
+                self._rm_window.show()
+            else:
+                self._get_rm_window(names[0])
         else:
+            if self._rm_window is not None:
+                self._rm_window.close()
+                self._rm_window = None
+            self._close_selector_window()
+
             self._selector_window = self._createSelectWindow(names)
-            self._selector_window.subplotSelectorSignal.connect(
-                self._get_rm_window)
-            self._selector_window.closeEventSignal.connect(
-                self._close_selector_window)
+            self._selector_window.subplotSelectorSignal.connect(self._get_rm_window)
+            self._selector_window.closeEventSignal.connect(self._close_selector_window)
             self._selector_window.setMinimumSize(300, 100)
             self._selector_window.show()
 
     def _rm_subplot(self):
         names = list(self._context.subplots.keys())
-        # if the selector is not visable
-        if self._selector_window is not None:
-            self._raise_selector_window()
-        # if no selector and no remove window -> let user pick which subplot to
-        # change
-        else:
-            self._selector_window = self._createSelectWindow(names)
-            self._selector_window.subplotSelectorSignal.connect(
-                self._remove_subplot)
-            self._selector_window.subplotSelectorSignal.connect(
-                self._close_selector_window)
-            self._selector_window.closeEventSignal.connect(
-                self._close_selector_window)
-            self._selector_window.setMinimumSize(300, 100)
-            self._selector_window.show()
+        # If the selector is hidden then close it
+        self._close_selector_window()
+
+        self._selector_window = self._createSelectWindow(names)
+        self._selector_window.subplotSelectorSignal.connect(self._remove_subplot)
+        self._selector_window.subplotSelectorSignal.connect(self._close_selector_window)
+        self._selector_window.closeEventSignal.connect(self._close_selector_window)
+        self._selector_window.setMinimumSize(300, 100)
+        self._selector_window.show()
 
     def _createSelectWindow(self, names):
         return SelectSubplot(names)
 
-    def _raise_rm_window(self):
-        self._rm_window.raise_()
-
-    def _raise_selector_window(self):
-        self._selector_window.raise_()
-
     def _close_selector_window(self):
         if self._selector_window is not None:
-            self._selector_window.close
+            self._selector_window.close()
             self._selector_window = None
 
     def _create_rm_window(self, subplotName):

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -55,7 +55,7 @@ class SubplotTest(GuiTest):
         self.setup_rm()
         self.subplot._rm()
 
-        self.assertEqual(self.subplot._raise_rm_window.call_count, 1)
+        self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
@@ -84,9 +84,9 @@ class SubplotTest(GuiTest):
         self.subplot._rm()
 
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._raise_selector_window.call_count, 1)
+        self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
+        self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
 
     def test_rmTwoPlotsoldRmWindow(self):
         self.subplot._rm_window = mock.Mock()
@@ -97,10 +97,10 @@ class SubplotTest(GuiTest):
         self.setup_rm()
         self.subplot._rm()
 
-        self.assertEqual(self.subplot._raise_rm_window.call_count, 1)
+        self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
+        self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
 
     def setup_applyRm(self):
         self.subplot._rm_window = mock.Mock()


### PR DESCRIPTION
In Muon Elemental Analysis, when plotting data and wanting to remove a subplot/data line a dialog window appears. If this is closed by pressing `esc` it should be completely closed, not hidden.

**To test:**
- `Interfaces->Muon->Elemental Analysis`
- Load a data run (eg. `2695`)
- Plot data from one or more detectors
- Open dialog for `Remove subplot`
- Close it by pressing `ESC`
- Open it again, you should be able to do so
- Do the same with `Remove line`
- Both should also work as expected

Fixes #26238.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
