### PR TITLE
Changed colour cycle of peak lines in elemental analysis to default one

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, print_function
 
 from qtpy import QtWidgets
 from copy import deepcopy
+import matplotlib as mpl
 
 from six import iteritems
 
@@ -90,7 +91,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
         # plotting
         self.plot_window = None
-        self.colors = ['b', 'g', 'r', 'y', 'c', 'm', 'b']
+        self.num_colors = len(mpl.rcParams['axes.prop_cycle'])
         self.color_index = 0
 
         # layout
@@ -109,8 +110,8 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
     # Return an unused colour, if all used then start with the first one
     def get_color(self):
-        color = self.colors[self.color_index]
-        self.color_index = (self.color_index + 1) % len(self.colors)
+        color = "C%d" % self.color_index
+        self.color_index = (self.color_index + 1) % self.num_colors
 
         return color
 


### PR DESCRIPTION
The colour of peak lines in elemental analysis is now set using the default cycle found in `matplotlib.rcParams['axes.prop_cycle']`

**To test:**
- Interface->Muon->Elemental 
- Load some data, eg. 2695
- Plot data from one or more detectors and peak lines for more than one element
- The colours should be the same as in https://matplotlib.org/2.2.4/users/dflt_style_changes.html#colors-color-cycles-and-color-maps

Fixes #26279.
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
