### PR TITLE
Avoid incrementing/decrementing shared_ptr in SolidAngle

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SolidAngle.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SolidAngle.h
@@ -45,8 +45,8 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
-  void initSpectrum(const API::MatrixWorkspace &input, API::MatrixWorkspace &output,
-                    const size_t j);
+  void initSpectrum(const API::MatrixWorkspace &input,
+                    API::MatrixWorkspace &output, const size_t j);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/SolidAngle.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SolidAngle.h
@@ -45,8 +45,8 @@ private:
   // Overridden Algorithm methods
   void init() override;
   void exec() override;
-  void initSpectrum(API::MatrixWorkspace_const_sptr, API::MatrixWorkspace_sptr,
-                    const size_t);
+  void initSpectrum(const API::MatrixWorkspace &input, API::MatrixWorkspace &output,
+                    const size_t j);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -317,8 +317,7 @@ void SolidAngle::exec() {
  * solid angle is not calculated.
  */
 void SolidAngle::initSpectrum(const MatrixWorkspace &inputWS,
-                              MatrixWorkspace &outputWS,
-                              const size_t wsIndex) {
+                              MatrixWorkspace &outputWS, const size_t wsIndex) {
   outputWS.mutableX(wsIndex)[0] = inputWS.x(wsIndex).front();
   outputWS.mutableX(wsIndex)[1] = inputWS.x(wsIndex).back();
   outputWS.mutableE(wsIndex) = 0.;

--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -268,7 +268,7 @@ void SolidAngle::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS, *inputWS))
   for (int j = m_MinSpec; j <= m_MaxSpec; ++j) {
     PARALLEL_START_INTERUPT_REGION
-    initSpectrum(inputWS, outputWS, j);
+    initSpectrum(*inputWS, *outputWS, j);
     if (spectrumInfo.hasDetectors(j)) {
       double solidAngle = 0.0;
       for (const auto detID : inputWS->getSpectrum(j).getDetectorIDs()) {
@@ -291,7 +291,7 @@ void SolidAngle::exec() {
   auto &outputSpectrumInfo = outputWS->mutableSpectrumInfo();
   // Loop over the histograms (detector spectra)
   for (int j = 0; j < m_MinSpec; ++j) {
-    initSpectrum(inputWS, outputWS, j);
+    initSpectrum(*inputWS, *outputWS, j);
     // SpectrumInfo::setMasked is NOT threadsafe.
     outputSpectrumInfo.setMasked(j, true);
     prog.report();
@@ -299,7 +299,7 @@ void SolidAngle::exec() {
 
   // Loop over the histograms (detector spectra)
   for (int j = m_MaxSpec + 1; j < numberOfSpectra; ++j) {
-    initSpectrum(inputWS, outputWS, j);
+    initSpectrum(*inputWS, *outputWS, j);
     // SpectrumInfo::setMasked is NOT threadsafe.
     outputSpectrumInfo.setMasked(j, true);
     prog.report();
@@ -316,13 +316,12 @@ void SolidAngle::exec() {
  * SolidAngle::initSpectrum Sets the default value for the spectra for which
  * solid angle is not calculated.
  */
-void SolidAngle::initSpectrum(MatrixWorkspace_const_sptr inputWS,
-                              MatrixWorkspace_sptr outputWS,
+void SolidAngle::initSpectrum(const MatrixWorkspace &inputWS,
+                              MatrixWorkspace &outputWS,
                               const size_t wsIndex) {
-  outputWS->mutableX(wsIndex)[0] = inputWS->x(wsIndex).front();
-  outputWS->mutableX(wsIndex)[1] = inputWS->x(wsIndex).back();
-  outputWS->mutableE(wsIndex) = 0.;
-  outputWS->mutableY(wsIndex) = 0.; // default value for not calculated
+  outputWS.mutableX(wsIndex) = {inputWS.x(wsIndex).front(), inputWS.x(wsIndex).back()};
+  outputWS.mutableE(wsIndex) = 0.;
+  outputWS.mutableY(wsIndex) = 0.; // default value for not calculated
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -319,7 +319,8 @@ void SolidAngle::exec() {
 void SolidAngle::initSpectrum(const MatrixWorkspace &inputWS,
                               MatrixWorkspace &outputWS,
                               const size_t wsIndex) {
-  outputWS.mutableX(wsIndex) = {inputWS.x(wsIndex).front(), inputWS.x(wsIndex).back()};
+  outputWS.mutableX(wsIndex)[0] = inputWS.x(wsIndex).front();
+  outputWS.mutableX(wsIndex)[1] = inputWS.x(wsIndex).back();
   outputWS.mutableE(wsIndex) = 0.;
   outputWS.mutableY(wsIndex) = 0.; // default value for not calculated
 }


### PR DESCRIPTION
**Description of work.**

Avoids incrementing/decrementing two `shared_ptr`s each time `initSpectrum is called. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Code review is sufficient.

*There is no associated issue.*

*This does not require release notes* because no functional change to end users

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
