### PR TITLE
Muon Analysis 2 - Fix load current run

### DIFF
--- a/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
+from mantid.api import FileFinder
 from qtpy import PYQT4, QtWidgets
 allowed_instruments = ["EMU", "MUSR", "CHRONUS", "HIFI", "ARGUS", "PSI"]
 allowed_extensions = ["nxs", "bin"]
@@ -45,21 +46,19 @@ def get_current_run_filename(instrument):
     if instrument_directory is None:
         return ""
 
-    autosave_file_name = _instrument_data_directory(instrument_directory) + FILE_SEP + "autosave.run"
-    autosave_points_to = ""
+    file_path = _instrument_data_directory(instrument_directory) + FILE_SEP
+    autosave_file_name = file_path + "autosave.run"
+    current_run_filename = ""
     if not check_file_exists(autosave_file_name):
         raise ValueError("Cannot find file : " + autosave_file_name)
     with open(autosave_file_name, 'r') as autosave_file:
         for line in autosave_file:
-            if os.path.isfile(line):
-                autosave_points_to = line
-    if autosave_points_to == "":
-        # Default to auto_A (replicates MuonAnalysis 1.0 behaviour)
-        current_run_filename = _instrument_data_directory(instrument_directory) \
-                               + FILE_SEP + instrument_directory + "auto_A.tmp"
-    else:
-        current_run_filename = _instrument_data_directory(instrument_directory) \
-                               + FILE_SEP + autosave_points_to
+            line.replace(" ", "")
+            file_name = file_path + line
+            if check_file_exists(FileFinder.getFullPath(file_name)):
+                current_run_filename = file_name
+    if current_run_filename == "":
+        raise ValueError("Failed to find latest run")
     return current_run_filename
 
 

--- a/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/muon_file_utils.py
@@ -8,6 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import os
 from mantid.api import FileFinder
+from Muon.GUI.Common.message_box import warning
 from qtpy import PYQT4, QtWidgets
 allowed_instruments = ["EMU", "MUSR", "CHRONUS", "HIFI", "ARGUS", "PSI"]
 allowed_extensions = ["nxs", "bin"]
@@ -58,7 +59,10 @@ def get_current_run_filename(instrument):
             if check_file_exists(FileFinder.getFullPath(file_name)):
                 current_run_filename = file_name
     if current_run_filename == "":
-        raise ValueError("Failed to find latest run")
+        # Default to auto_A (replicates MuonAnalysis 1.0 behaviour)
+        current_run_filename = file_path + instrument_directory + "auto_A.tmp"
+        warning("Failed to find latest run, defaulting to " + current_run_filename)
+
     return current_run_filename
 
 

--- a/scripts/test/Muon/utilities/muon_file_utils_test.py
+++ b/scripts/test/Muon/utilities/muon_file_utils_test.py
@@ -5,6 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
+from io import StringIO
 import unittest
 
 from mantid.py3compat import mock
@@ -62,6 +63,18 @@ class MuonFileUtilsTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             utils.get_current_run_filename("EMU")
 
+    def test_that_get_current_run_returns_correct_run(self):
+        utils.check_file_exists = mock.Mock(return_value=True)
+        file_name = os.sep + os.sep + "EMU" + os.sep + "data" + os.sep + "autoA"
+        file = StringIO(u"autoA")
+        utils.open = mock.Mock(return_value = file)
+        current_file_name = utils.get_current_run_filename("EMU")
+        self.assertEqual(current_file_name, file_name)
+
+    def test_that_get_current_run_throws_if_no_valid_run_in_autosave_run(self):
+        utils.check_file_exists = mock.Mock(side_effect = [True, False])
+        with self.assertRaises(ValueError):
+            utils.get_current_run_filename("EMU")
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/utilities/muon_file_utils_test.py
+++ b/scripts/test/Muon/utilities/muon_file_utils_test.py
@@ -65,11 +65,11 @@ class MuonFileUtilsTest(unittest.TestCase):
 
     def test_that_get_current_run_returns_correct_run(self):
         utils.check_file_exists = mock.Mock(return_value=True)
-        file_name = os.sep + os.sep + "EMU" + os.sep + "data" + os.sep + "autoA"
-        file = StringIO(u"autoA")
-        utils.open = mock.Mock(return_value = file)
+        expected_file_name = os.sep + os.sep + "EMU" + os.sep + "data" + os.sep + "autoA"
+        test_file_name = StringIO(u"autoA")
+        utils.open = mock.Mock(return_value = test_file_name)
         current_file_name = utils.get_current_run_filename("EMU")
-        self.assertEqual(current_file_name, file_name)
+        self.assertEqual(current_file_name, expected_file_name)
 
     def test_that_get_current_run_throws_if_no_valid_run_in_autosave_run(self):
         utils.check_file_exists = mock.Mock(side_effect = [True, False])


### PR DESCRIPTION
**Description of work.**
This PR fixes the `Load current run` button in Muon Analysis 2. It should now find the newest run or give an error if it has not been found.

**To test:**
Open Muon Analysis 2 GUI
Click load current run
It should load a file called `\\<Instrument>\data\<Instrument>auto_C.tmp` (the letter will vary depending on most recent run)
To check this is right open the old Muon Analysis GUI and load current run, it should be the same 

Fixes #26216

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
