### PR TITLE
Elemental Analysis: fix the segfault from occuring on multiplot window close

### DIFF
--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -123,7 +123,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def removeSubplotConnection(self, slot):
         self.plots.connect_rm_subplot_signal(slot)
 
-    def disconnectCloseSignal(selft):
+    def disconnectCloseSignal(self):
         self.closeSignal.disconnect()
 
     def removeSubplotDisonnect(self):
@@ -134,7 +134,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def _if_empty_close(self):
         if not self._context.subplots:
             self.closeSignal.emit()
-            self.close
+            self.close()
 
     def _update_quick_edit(self, subplotName):
         names = self.quickEdit.get_selection()
@@ -180,7 +180,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
             self._x_range_changed(xrange)
             self._y_range_changed(yrange)
 
-    def _autoscale_changed(self, state):
+    def _autoscale_changed(self, _):
         names = self.quickEdit.get_selection()
         self.plots.set_y_autoscale(names, True)
 


### PR DESCRIPTION
**Description of work.**
Elemental Analysis' multiplot caused a segfault when it closed. It now should not do this.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open Interfaces->muon->Elemental Analysis
Load 2965
Select GE1 and GE2
Close the plot window

<!-- Instructions for testing. -->

Fixes #26288  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

RELEASE NOTES ARE NOT REQUIRED FOR THIS BECAUSE THIS FIXES A NEW FEATURE

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
