### PR TITLE
Removed disabling of centering boxes

### DIFF
--- a/docs/source/release/v4.1.0/sans.rst
+++ b/docs/source/release/v4.1.0/sans.rst
@@ -40,7 +40,7 @@ Improvements
 - The path to the user file used to reduce the data is now added to the workspace sample logs. This user file path is added to canSAS file metadata.
 - The **diagnostic** page icon has been changed from a question mark to a stethoscope, to distinguish it from the **Help** page icon. The **Export Table** button now has an icon. There have been minor icon changes elsewhere on the interface.
 - Sample thickness, height, and width can be read from a batch file. These parameters are also included in the batch file generated from exporting the table.
-- The beam centre HAB/LAB update checkboxes are automatically disabled if you select LAB/HAB as the reduction mode, respectively.
+- The beam centre HAB/LAB update checkboxes are automatically deselected if you select LAB/HAB as the reduction mode, respectively.
 - The run numbers for sample transmission, sample direct, can scatter, and can direct workspaces are now added to NXCanSAS and CanSAS files.
 
 

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -156,11 +156,9 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
         self.run_button.setEnabled(True)
 
     def enable_update_hab(self, enabled):
-        self.update_hab_check_box.setEnabled(enabled)
         self.update_hab_check_box.setChecked(enabled)
 
     def enable_update_lab(self, enabled):
-        self.update_lab_check_box.setEnabled(enabled)
         self.update_lab_check_box.setChecked(enabled)
 
     # ------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Leaving as draft as need to confirm requirements with scientists.

**Description of work.**

After the merging of #26000 feedback was received that the default should be updated as in the PR but that the boxes should not be disabled so that the defaults could be overridden if desired. This changes the behavior so that the boxes are checked or unchecked but not disabled.

**Report to:** Steve King


**To test:**
  * Open the new ISIS SANS interface, and load in a LOQ user file. A userfile called MaskFile.txt can be found in the ISISSampleData in the loqdemo folder.
  * Go to the Beam Centre tab on the left and check that box update check-boxes are checked.
  * Go to Settings->General,Scale,Event,Slice,Sample and change the reduction mode to HAB, check on the Beam Centre tab that only update HAB is selected. 
* Go to Settings->General,Scale,Event,Slice,Sample and change the reduction mode to main-detector, check on the Beam Centre tab that only update main-detector is selected.

*There is no associated issue.*





---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
