### PR TITLE
Reordered columns in list selector

### DIFF
--- a/scripts/Muon/GUI/Common/list_selector/list_selector_view.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_view.py
@@ -26,7 +26,7 @@ class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
         self.item_table_widget = TableWidgetDragRows()
 
         self.item_table_widget.setColumnCount(2)
-        self.item_table_widget.setColumnWidth(CHECKBOX_COLUMN, 10)
+        self.item_table_widget.setColumnWidth(CHECKBOX_COLUMN, 30)
         self.item_table_widget.verticalHeader().setVisible(False)
         self.item_table_widget.horizontalHeader().setStretchLastSection(True)
         self.item_table_widget.horizontalHeader().setVisible(False)

--- a/scripts/Muon/GUI/Common/list_selector/list_selector_view.py
+++ b/scripts/Muon/GUI/Common/list_selector/list_selector_view.py
@@ -14,6 +14,8 @@ from mantidqt.utils.qt import load_ui
 from Muon.GUI.Common.utilities import table_utils
 
 ui_list_selector, _ = load_ui(__file__, "list_selector.ui")
+CHECKBOX_COLUMN = 0
+WORKSPACE_NAME_COLUMN = 1
 
 
 class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
@@ -24,7 +26,7 @@ class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
         self.item_table_widget = TableWidgetDragRows()
 
         self.item_table_widget.setColumnCount(2)
-        self.item_table_widget.setColumnWidth(0, 350)
+        self.item_table_widget.setColumnWidth(CHECKBOX_COLUMN, 10)
         self.item_table_widget.verticalHeader().setVisible(False)
         self.item_table_widget.horizontalHeader().setStretchLastSection(True)
         self.item_table_widget.horizontalHeader().setVisible(False)
@@ -44,8 +46,8 @@ class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
         for index, row in enumerate(item_list):
             insertion_index = self.item_table_widget.rowCount()
             self.item_table_widget.setRowCount(insertion_index + 1)
-            table_utils.setRowName(self.item_table_widget, insertion_index, row[0])
-            table_utils.addCheckBoxToTable(self.item_table_widget, row[1], insertion_index, 1)
+            table_utils.setRowName(self.item_table_widget, insertion_index, row[0], col=WORKSPACE_NAME_COLUMN)
+            table_utils.addCheckBoxToTable(self.item_table_widget, row[1], insertion_index, CHECKBOX_COLUMN)
             self.set_row_enabled(insertion_index, row[2])
         self.item_table_widget.blockSignals(False)
 
@@ -56,14 +58,14 @@ class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
         self.item_table_widget.blockSignals(False)
 
     def set_row_enabled(self, row, enabled):
-        item = self.item_table_widget.item(row, 0)
+        item = self.item_table_widget.item(row, WORKSPACE_NAME_COLUMN)
         if enabled:
             item.setFlags(
                 Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled)
         else:
             item.setFlags(
                 Qt.ItemIsSelectable | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled)
-        item = self.item_table_widget.item(row, 1)
+        item = self.item_table_widget.item(row, CHECKBOX_COLUMN)
         if enabled:
             item.setFlags(
                 Qt.ItemIsUserCheckable | Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled | Qt.ItemIsDropEnabled)
@@ -91,9 +93,9 @@ class ListSelectorView(QtWidgets.QWidget, ui_list_selector):
         self.item_table_widget.rowMoved.connect(action)
 
     def handle_cell_changed_signal(self, row, col):
-        if col == 1:
-            name = self.item_table_widget.item(row, 0).text()
-            state = self.item_table_widget.item(row, 1).checkState() == Qt.Checked
+        if col == CHECKBOX_COLUMN:
+            name = self.item_table_widget.item(row, WORKSPACE_NAME_COLUMN).text()
+            state = self.item_table_widget.item(row, CHECKBOX_COLUMN).checkState() == Qt.Checked
             self._item_selection_changed_action(name, state)
 
     def update_number_of_selected_label(self, number_selected, number_selected_displayed):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -164,5 +164,4 @@ def _create_empty_list_selector(parent, col_zero_width):
     :return: A new presenter that controls the widget
     """
     presenter = ListSelectorPresenter(ListSelectorView(parent), {})
-    presenter.view.item_table_widget.setColumnWidth(0, col_zero_width)
     return presenter

--- a/scripts/Muon/GUI/Common/utilities/table_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/table_utils.py
@@ -77,10 +77,10 @@ class ValidatedTableItem(QtWidgets.QTableWidgetItem):
         setattr(self, "setData", self.validator_before_set(self.setData, self.validator))
 
 
-def setRowName(table, row, name):
+def setRowName(table, row, name, col=0):
     text = QtWidgets.QTableWidgetItem((name))
     text.setFlags(QtCore.Qt.ItemIsEnabled)
-    table.setItem(row, 0, text)
+    table.setItem(row, col, text)
 
 
 def addComboToTable(table,row,options,col=1):

--- a/scripts/test/Muon/list_selector/list_selector_view_test.py
+++ b/scripts/test/Muon/list_selector/list_selector_view_test.py
@@ -23,12 +23,12 @@ class TestListSelectorView(GuiTest):
         self.view.addItems(item_list)
 
         self.assertEqual(self.view.item_table_widget.rowCount(), 2)
-        self.assertEqual(self.view.item_table_widget.item(0, 0).text(), item_list[0][0])
-        self.assertEqual(self.view.item_table_widget.item(1, 0).text(), item_list[1][0])
-        self.assertEqual(self.view.item_table_widget.item(1, 1).checkState(), QtCore.Qt.Unchecked)
-        self.assertEqual(self.view.item_table_widget.item(0, 1).checkState(), QtCore.Qt.Checked)
-        self.assertEqual(self.view.item_table_widget.item(0, 1).checkState(), QtCore.Qt.Checked)
-        self.assertEqual(self.view.item_table_widget.item(1, 1).checkState(), QtCore.Qt.Unchecked)
+        self.assertEqual(self.view.item_table_widget.item(0, 1).text(), item_list[0][0])
+        self.assertEqual(self.view.item_table_widget.item(1, 1).text(), item_list[1][0])
+        self.assertEqual(self.view.item_table_widget.item(1, 0).checkState(), QtCore.Qt.Unchecked)
+        self.assertEqual(self.view.item_table_widget.item(0, 0).checkState(), QtCore.Qt.Checked)
+        self.assertEqual(self.view.item_table_widget.item(0, 0).checkState(), QtCore.Qt.Checked)
+        self.assertEqual(self.view.item_table_widget.item(1, 0).checkState(), QtCore.Qt.Unchecked)
 
     def test_that_clear_removes_all_items(self):
         item_list = [('property_one', True, True), ('property_two', False, False)]


### PR DESCRIPTION
**Description of work.**
Originally the checkbox column in the workspace selector is to the right of the workspace name. This led to the checkbox sometimes being forced out of visibility. The check boxes have now been moved to the left hand side of the table so they are always displayed.

**To test:**

  * You will need access to the ISIS data archive to test this PR.
  * Open the new Muon Analysis GUI and load MUSR62260
  * Go to the fitting tab and click on select data to fit, check that the check boxes are on the left and that this still functions as expected.
  * Go to the results tab and try and create a results table.

<!-- Instructions for testing. -->

Fixes #26287  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is a change to a piece of functionality added this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
