### PR TITLE
Fixed error "FigureCanvasQTAgg has been deleted" in elemental analysis

### DIFF
--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -123,7 +123,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def removeSubplotConnection(self, slot):
         self.plots.connect_rm_subplot_signal(slot)
 
-    def disconnectCloseSignal(selft):
+    def disconnectCloseSignal(self):
         self.closeSignal.disconnect()
 
     def removeSubplotDisonnect(self):
@@ -134,7 +134,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def _if_empty_close(self):
         if not self._context.subplots:
             self.closeSignal.emit()
-            self.close
+            self.close()
 
     def _update_quick_edit(self, subplotName):
         names = self.quickEdit.get_selection()
@@ -180,7 +180,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
             self._x_range_changed(xrange)
             self._y_range_changed(yrange)
 
-    def _autoscale_changed(self, state):
+    def _autoscale_changed(self, _):
         names = self.quickEdit.get_selection()
         self.plots.set_y_autoscale(names, True)
 

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -252,6 +252,19 @@ class subplot(QtWidgets.QWidget):
                 self._remove_subplot(subplot)
 
     def _replaced_ws(self, workspace):
+        # Close all old subplots and create a new canvas
+        subplot_names = self._context.subplots.keys()
+        for to_del in subplot_names:
+            try:
+                self.figure.delaxes(self.plotObjects[to_del])
+                del self.plotObjects[to_del]
+            except KeyError:
+                pass
+            self._context.delete(to_del)
+            self._context.update_gridspec(len(list(self.plotObjects.keys())))
+        self.canvas = FigureCanvas(self.figure)
+        self.canvas.mpl_connect("draw_event", self.draw_event_callback)
+
         for subplot in self._context.subplots.keys():
             redraw = self._context.subplots[subplot].replace_ws(workspace)
             if redraw:

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -253,7 +253,7 @@ class subplot(QtWidgets.QWidget):
 
     def _replaced_ws(self, workspace):
         # Close all old subplots and create a new canvas
-        subplot_names = self._context.subplots.keys()
+        subplot_names = deepcopy(self._context.subplots.keys())
         for to_del in subplot_names:
             try:
                 self.figure.delaxes(self.plotObjects[to_del])
@@ -265,7 +265,8 @@ class subplot(QtWidgets.QWidget):
         self.canvas = FigureCanvas(self.figure)
         self.canvas.mpl_connect("draw_event", self.draw_event_callback)
 
-        for subplot in self._context.subplots.keys():
+        subplot_names = deepcopy(self._context.subplots.keys())
+        for subplot in subplot_names:
             redraw = self._context.subplots[subplot].replace_ws(workspace)
             if redraw:
                 self.canvas.draw()

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -169,9 +169,7 @@ class SubplotTest(GuiTest):
         self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = False)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,0)
-
-
+        self.assertEqual(self.subplot._context.subplots, {})
 
     def test_replaced_ws(self):
         one = mock.Mock()
@@ -184,9 +182,7 @@ class SubplotTest(GuiTest):
         self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = True)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,1)
-
-
+        self.assertEqual(self.subplot._context.subplots, {})
 
     def test_replaced_ws_true(self):
         one = mock.Mock()
@@ -195,11 +191,12 @@ class SubplotTest(GuiTest):
         self.subplot._context.subplots["two"] = two
         self.subplot.canvas.draw = mock.Mock()
         ws = mock.Mock()
+
         self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value = True)
         self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = True)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,2)
+        self.assertEqual(self.subplot._context.subplots, {})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**To test:**


1. Open `Interface->Muon->Elemental Analysis`
2. Load 2695
3. Click GE1 or any of the others
4. Close the whole window
5. Open and load again
6. No error should appear


Fixes #26291.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
