### PR TITLE
Instrument View for MantidPlot: Pick tab miniplot fixes

### DIFF
--- a/docs/source/release/v4.1.0/mantidplot.rst
+++ b/docs/source/release/v4.1.0/mantidplot.rst
@@ -19,5 +19,6 @@ Bugfixes
 ########
 
 * Help documentation for the manage user directories interface now correctly displays when launched from the interface.
+* Fix for the Instrument View pick tab miniplot where the x axis label was not updated when a new unit was selected.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -249,7 +249,7 @@ public:
 
   void setPlotType(PlotType type) { m_plotType = type; }
   PlotType getPlotType() const { return m_plotType; }
-  void setTubeXUnits(TubeXUnits units) { m_tubeXUnits = units; }
+  void setTubeXUnits(TubeXUnits units);
   TubeXUnits getTubeXUnits() const { return m_tubeXUnits; }
   QString getTubeXUnitsName() const;
   QString getTubeXUnitsUnits() const;

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1688,6 +1688,18 @@ QString DetectorPlotController::getTubeXUnitsName() const {
  * Return symbolic name of units of current TubeXUnit.
  */
 QString DetectorPlotController::getTubeXUnitsUnits() const {
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+  switch (m_tubeXUnits) {
+  case LENGTH:
+    return "(m)";
+  case PHI:
+    return "(radians)";
+  case OUT_OF_PLANE_ANGLE:
+    return "(radians)";
+  default:
+    return "";
+  }
+#else
   switch (m_tubeXUnits) {
   case LENGTH:
     return "m";
@@ -1698,13 +1710,20 @@ QString DetectorPlotController::getTubeXUnitsUnits() const {
   default:
     return "";
   }
+#endif
+}
+
+void DetectorPlotController::setTubeXUnits(TubeXUnits units) {
+  m_tubeXUnits = units;
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+  m_plot->setXLabel(getTubeXUnitsName() + " " + getTubeXUnitsUnits());
+#endif
 }
 
 /**
  * Get the plot caption for the current plot type.
  */
 QString DetectorPlotController::getPlotCaption() const {
-
   switch (m_plotType) {
   case Single:
     return "Plotting detector spectra";


### PR DESCRIPTION
**Description of work.**
When you select the integrated Axes in the miniplot the labels should be
out of plane angle -> Angle (rad)
Phi -> Phi (rad)
Tube Length -> Length (m)
Detector ID -> Detector ID

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Load some data
1. oen the instrument view
1. go to the pick tab
1. select the tube selection tool 
![image](https://user-images.githubusercontent.com/1017173/60977257-0b4a9500-a327-11e9-8da2-25369f099a0e.png)
1. right click on the miniplot and select integrate
1. right click on the miniplot and change the axes
<!-- Instructions for testing. -->

Fixes #26278 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
