### PR TITLE
Multi plot canvas bug and fixes Muon grouping tab test

### DIFF
--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -28,6 +28,7 @@ class MultiPlotWindow(QtWidgets.QMainWindow):
 
     def closeEvent(self, event):
         self.multi_plot.removeSubplotDisonnect()
+        self.multi_plot.plots._ADSObserver.unsubscribe()
         self.multi_plot.plots._ADSObserver = None
         self.windowClosedSignal.emit()
 

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -123,7 +123,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def removeSubplotConnection(self, slot):
         self.plots.connect_rm_subplot_signal(slot)
 
-    def disconnectCloseSignal(selft):
+    def disconnectCloseSignal(self):
         self.closeSignal.disconnect()
 
     def removeSubplotDisonnect(self):
@@ -134,7 +134,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def _if_empty_close(self):
         if not self._context.subplots:
             self.closeSignal.emit()
-            self.close
+            self.close()
 
     def _update_quick_edit(self, subplotName):
         names = self.quickEdit.get_selection()
@@ -180,7 +180,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
             self._x_range_changed(xrange)
             self._y_range_changed(yrange)
 
-    def _autoscale_changed(self, state):
+    def _autoscale_changed(self, _):
         names = self.quickEdit.get_selection()
         self.plots.set_y_autoscale(names, True)
 

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -28,6 +28,7 @@ class MultiPlotWindow(QtWidgets.QMainWindow):
 
     def closeEvent(self, event):
         self.multi_plot.removeSubplotDisonnect()
+        self.multi_plot.plots._ADSObserver = None
         self.windowClosedSignal.emit()
 
 

--- a/scripts/MultiPlotting/subplot/subplot_ADS_observer.py
+++ b/scripts/MultiPlotting/subplot/subplot_ADS_observer.py
@@ -19,6 +19,11 @@ class SubplotADSObserver(AnalysisDataServiceObserver):
         self.observeDelete(True)
         self.observeReplace(True)
 
+    def unsubscribe(self):
+        self._subplot = None
+        self.observeDelete(False)
+        self.observeReplace(False)
+
     def deleteHandle(self, workspace_name, workspace):
         """
         Called when the ADS has deleted a workspace. Checks

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -9,10 +9,6 @@ import six
 from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import GuiTest
 
-from Muon.GUI.Common.contexts.muon_context import MuonContext
-from Muon.GUI.Common.contexts.muon_data_context import MuonDataContext
-from Muon.GUI.Common.contexts.muon_group_pair_context import MuonGroupPairContext
-from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_presenter import GroupingTabPresenter
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_view import GroupingTabView
@@ -21,6 +17,7 @@ from Muon.GUI.Common.grouping_table_widget.grouping_table_widget_view import Gro
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter, MuonPair
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
+from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
 class GroupingTabPresenterTest(GuiTest):
@@ -29,8 +26,7 @@ class GroupingTabPresenterTest(GuiTest):
         self.data_context = MuonDataContext(self.loaded_data)
         self.gui_context = MuonGuiContext()
         self.group_context = MuonGroupPairContext(self.data_context.check_group_contains_valid_detectors)
-        self.context = MuonContext(muon_data_context=self.data_context, muon_group_context=self.group_context,
-                                   muon_gui_context=self.gui_context)
+        self.context = self.context = setup_context(False)
 
         self.model = GroupingTabModel(context=self.context)
 

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -23,11 +23,14 @@ from Muon.GUI.Common.test_helpers.context_setup import setup_context
 class GroupingTabPresenterTest(GuiTest):
     def setUp(self):
         self.loaded_data = MuonLoadData()
-        self.data_context = MuonDataContext(self.loaded_data)
-        self.gui_context = MuonGuiContext()
-        self.group_context = MuonGroupPairContext(self.data_context.check_group_contains_valid_detectors)
-        self.context = self.context = setup_context(False)
 
+        self.context = setup_context(False)
+
+        self.data_context =self.context.data_context 
+        self.gui_context = self.context.gui_context
+        self.group_context=self.context.group_pair_context  
+
+ 
         self.model = GroupingTabModel(context=self.context)
 
         self.grouping_table_view = GroupingTableView()


### PR DESCRIPTION
~~**MERGED AFTER #26289**~~

**Description of work.**
The multiple plotting window would throw an error after being closed and reopened. This fixes it. 
The problem was due to the ADS observer sticking around. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open Interface->Muon->Elemental Analysis
Load 2695
Click GE1 or any of the others
Close the whole window
Open and load again
No error should appear

Fixes #26291. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
