### PR TITLE
Changed Elemental Analysis y-axis label to "counts"

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -32,4 +32,4 @@ Bug Fixes
 * Muon Analysis (original) can now produce results tables when columns contain both ranges and single values.
 * Issue where imaginary box was reappearing for FFT transforms after being unselected fixed.
 * Elemental Analysis no longer crashes when an ill formatted data file is loaded.
-* Changed the y-axis unit in Elemental Analysis from `(keV)^-1` to `Counts`.
+* Changed the y-axis unit in Elemental Analysis to `Counts`.

--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -32,3 +32,4 @@ Bug Fixes
 * Muon Analysis (original) can now produce results tables when columns contain both ranges and single values.
 * Issue where imaginary box was reappearing for FFT transforms after being unselected fixed.
 * Elemental Analysis no longer crashes when an ill formatted data file is loaded.
+* Changed the y-axis unit in Elemental Analysis from `(keV)^-1` to `Counts`.

--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -32,4 +32,4 @@ Bug Fixes
 * Muon Analysis (original) can now produce results tables when columns contain both ranges and single values.
 * Issue where imaginary box was reappearing for FFT transforms after being unselected fixed.
 * Elemental Analysis no longer crashes when an ill formatted data file is loaded.
-* Changed the y-axis unit in Elemental Analysis to `Counts`.
+* Changed the y-axis label in Elemental Analysis to `Counts`.

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -32,13 +32,16 @@ class PlottingContext(object):
 
     def addLine(self, subplotName, workspace, specNum):
         try:
+            ws = None
             if isinstance(workspace, str):
                 ws = mantid.AnalysisDataService.retrieve(workspace)
             elif len(workspace) > 1:
                 ws = workspace.OutputWorkspace
             else:
                 ws = workspace
-            self.subplots[subplotName].addLine(ws, specNum)
+
+            if ws is not None:
+                self.subplots[subplotName].addLine(ws, specNum)
         except:
             return
 

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -34,13 +34,11 @@ class PlottingContext(object):
         try:
             if isinstance(workspace, str):
                 ws = mantid.AnalysisDataService.retrieve(workspace)
-                self.subplots[subplotName].addLine(ws, specNum)
-
             elif len(workspace) > 1:
-                self.subplots[subplotName].addLine(
-                    workspace.OutputWorkspace, specNum)
+                ws = workspace.OutputWorkspace
             else:
-                self.subplots[subplotName].addLine(workspace, specNum)
+                ws = workspace
+            self.subplots[subplotName].addLine(ws, specNum)
         except:
             return
 

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -92,7 +92,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def rm_vline(self, subplotName, name):
         self.plots.rm_vline(subplotName, name)
 
-    # gets inital values for quickEdit
+    # gets initial values for quickEdit
     def set_all_values(self):
         names = self.quickEdit.get_selection()
         xrange = list(self._context.subplots[names[0]].xbounds)
@@ -123,7 +123,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def removeSubplotConnection(self, slot):
         self.plots.connect_rm_subplot_signal(slot)
 
-    def disconnectCloseSignal(selft):
+    def disconnectCloseSignal(self):
         self.closeSignal.disconnect()
 
     def removeSubplotDisonnect(self):

--- a/scripts/MultiPlotting/subplot/subplot_context.py
+++ b/scripts/MultiPlotting/subplot/subplot_context.py
@@ -26,7 +26,6 @@ class subplotContext(object):
         self._subplot.set_position(tmp)
         self._subplot.set_subplotspec(gridspec[j])
 
-    # todo: add color suppport
     def add_vline(self, xvalue, name, color):
         self._vLines[name] = self._subplot.axvline(xvalue, 0, 1, color=color)
 
@@ -37,8 +36,7 @@ class subplotContext(object):
         if label.in_x_range(x_range):
             self._labels[label.text] = self._subplot.annotate(
                 label.text,
-                xy=(label.get_xval(x_range),
-                    label.get_yval(y_range)),
+                xy=(label.get_xval(x_range), label.get_yval(y_range)),
                 xycoords="axes fraction",
                 rotation=label.rotation)
 
@@ -49,9 +47,9 @@ class subplotContext(object):
         for label in list(self._labelObjects.keys()):
             self.add_annotate(self._labelObjects[label])
 
-    def addLine(self, ws, specNum=1):
+    def addLine(self, ws, specNum=1, distribution=True):
         # make plot/get label
-        line, = plots.plotfunctions.plot(self._subplot, ws, specNum=specNum)
+        line, = plots.plotfunctions.plot(self._subplot, ws, specNum=specNum, distribution=distribution)
         label = line.get_label()
         if self._errors:
             line, cap_lines, bar_lines = plots.plotfunctions.errorbar(
@@ -70,7 +68,7 @@ class subplotContext(object):
         else:
             self._ws[ws].append(label)
 
-    def redraw(self, label):
+    def redraw(self, label, distribution=True):
         # get current colour and marker
         colour = copy(self._lines[label][0].get_color())
         marker = copy(self._lines[label][0].get_marker())
@@ -87,8 +85,8 @@ class subplotContext(object):
             all_lines.extend(bar_lines)
             self._lines[label] = all_lines
         else:
-            line, = plots.plotfunctions.plot(self._subplot, self.get_ws(
-                label), specNum=self.specNum[label], color=colour, marker=marker, label=label)
+            line, = plots.plotfunctions.plot(self._subplot, self.get_ws(label), specNum=self.specNum[label],
+                                             color=colour, marker=marker, label=label, distribution=distribution)
             self._lines[label] = [line]
 
     def replace_ws(self, ws):

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -222,8 +222,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         last_run = self.load_widget.last_loaded_run()
         if last_run is None:
             return
-        to_plot = deepcopy([det.isChecked()
-                           for det in self.detectors.detectors])
+        to_plot = deepcopy([det.isChecked() for det in self.detectors.detectors])
         if self.plot_window is None and any(to_plot) is False:
             return
         # generate plots - if new run clear old plot(s) and replace it
@@ -241,6 +240,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     def add_detector_to_plot(self, detector, name):
         self.plotting.add_subplot(detector)
         for ws in mantid.mtd[name]:
+            ws.setYUnit('Counts')
             self.plotting.plot(detector, ws.getName())
         # add current selection of lines
         for element in self.ptable.selection:

--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -54,7 +54,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([line()])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3)
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
 
     def test_add_line_errors(self):
         ws = mock.MagicMock()
@@ -103,7 +103,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([lines])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3)
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
             # redraw
             self.context.redraw(lines.get_label())
             self.assertEqual(patch.call_count, 2)
@@ -113,7 +113,8 @@ class SubPlotContextTest(unittest.TestCase):
                 specNum=3,
                 color=lines.get_color(),
                 marker=lines.get_marker(),
-                label=lines.get_label())
+                label=lines.get_label(),
+                distribution=True)
 
     def test_change_errors(self):
         self.context._lines = {"one": 1, "two": 2, "three": 3}


### PR DESCRIPTION
**To test:**
1. `Interfaces->Muon->Elemental Analysis`
2. Load a run (eg. `2695`)
3. Plot one of more detector
4. Y-axis label should be `Counts` not `(keV)^-1`

Fixes #26307.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
