### PR TITLE
Prevents rename_plot being triggered by unexpected focus grab

### DIFF
--- a/qt/applications/workbench/workbench/widgets/plotselector/model.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/model.py
@@ -17,6 +17,7 @@ class PlotSelectorModel(object):
     This is the model for the plot selector widget. Essentially this
     is just a wrapper to the true model - GlobalFigureManager.
     """
+
     def __init__(self, presenter, global_figure_manager):
         """
         Initialise the model, keeping references to the presenter and

--- a/qt/applications/workbench/workbench/widgets/plotselector/view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/view.py
@@ -618,9 +618,15 @@ class PlotNameWidget(QWidget):
         self.line_edit = QLineEdit(self.presenter.get_plot_name_from_number(plot_number))
         self.line_edit.setReadOnly(True)
         self.line_edit.setFrame(False)
-        self.line_edit.setStyleSheet("* { background-color: rgba(0, 0, 0, 0); }")
+        # changes the line edit to look like normal even when
+        self.line_edit.setStyleSheet("""* { background-color: rgba(0, 0, 0, 0); }
+        QLineEdit:disabled { color: black; }""")
         self.line_edit.setAttribute(Qt.WA_TransparentForMouseEvents, True)
         self.line_edit.editingFinished.connect(self.rename_plot)
+        # Disabling the line edit prevents it from temporarily
+        # grabbing focus when changing code editors - this triggered
+        # the editingFinished signal, which was causing #26305
+        self.line_edit.setDisabled(True)
 
         shown_icon = get_icon('mdi.eye')
         self.hide_button = QPushButton(shown_icon, "")
@@ -694,6 +700,7 @@ class PlotNameWidget(QWidget):
                                      button state
         """
         self.line_edit.setReadOnly(not editable)
+        self.line_edit.setDisabled(not editable)
         self.line_edit.setAttribute(Qt.WA_TransparentForMouseEvents, not editable)
 
         # This is a sneaky way to avoid the issue of two calls to
@@ -734,6 +741,7 @@ class PlotNameWidget(QWidget):
         do the real renaming of the plot
         """
         self.presenter.rename_figure(self.plot_number, self.line_edit.text())
+
         self.toggle_plot_name_editable(False)
 
 

--- a/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -145,6 +145,7 @@ class MultiPythonFileInterpreter(QWidget):
         :param allow_zero_tabs: If True then closing the last tab does not add a new empty tab.
         :return: True if tab is to be closed, False if cancelled
         """
+
         if idx >= self.editor_count:
             return True
         # Make the current tab active so that it is clear what you


### PR DESCRIPTION
**Description of work.**
Workbench shouldn't show error on close anymore.

Plotting from script and changing the code editor tabs would cause the last plot's line edit in the plotselector widget to steal focus temporarily. On losing the focus it would trigger the `QLineEdit::editingFinished` slot which would call `plotselector.view.rename_plot`. This also happened on Workbench closing, which would then try to update the name from the plotselector widget that has been deleted, and would throw the exception.

This PR is a workaround that abuses the inability of disabled widgets to be focused - which prevents `editingFinished` from being triggered unexpectedly. The actual issue seems to be some weird tab order or focus-stealing issue. If it need be further investigated it should be done as a separate issue, maybe a maintenance task.



**To test:**
- Put this in one editor:
```
import numpy as np
import matplotlib.pyplot as plt

fig = plt.figure()
plt.errorbar([0, 1], [0, 1], [0.1, 0.1])
plt.show()
```

- Open another file in another editor.
  - It's better if they are both saved files, as that seems to make the issue easier to replicate
- Run the code from the first editor to create the plot
- Close the Workbench, no errors should show
  - Do this a few times as it doesn't always happen (the best kind of bugs), but more often than not it does
- Do everything without closing the Workbench, plot multiple times
- From the Plot Selector: rename the plots, see if the line edit looks normal (it contains the plot's title)
  - The line edit is now disabled until the "rename" button is clicked, but the stylesheet change should force it to look as if it is not disabled at all.
  - Double clicking a plot should open/focus its window


Fixes #26305
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
