### PR TITLE
Workbench Single and Range Selectors disappear when moving legend

### DIFF
--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/RangeMarker.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/RangeMarker.h
@@ -32,6 +32,11 @@ public:
   void remove();
 
   void setColor(QString const &color);
+
+  void setBounds(double lowerBound, double upperBound);
+  void setLowerBound(double lowerBound);
+  void setUpperBound(double upperBound);
+
   void setRange(double minimum, double maximum);
   std::tuple<double, double> getRange() const;
 

--- a/qt/widgets/mplcpp/src/RangeMarker.cpp
+++ b/qt/widgets/mplcpp/src/RangeMarker.cpp
@@ -9,9 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
-using Mantid::PythonInterface::callMethodNoCheck;
 using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::PythonException;
+using Mantid::PythonInterface::callMethodNoCheck;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 

--- a/qt/widgets/mplcpp/src/RangeMarker.cpp
+++ b/qt/widgets/mplcpp/src/RangeMarker.cpp
@@ -9,9 +9,9 @@
 #include "MantidQtWidgets/Common/Python/QHashToDict.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
+using Mantid::PythonInterface::callMethodNoCheck;
 using Mantid::PythonInterface::GlobalInterpreterLock;
 using Mantid::PythonInterface::PythonException;
-using Mantid::PythonInterface::callMethodNoCheck;
 using namespace MantidQt::Widgets::Common;
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -77,6 +77,31 @@ void RangeMarker::remove() {
  */
 void RangeMarker::setColor(QString const &color) {
   callMethodNoCheck<void>(pyobj(), "set_color", color.toLatin1().constData());
+}
+
+/**
+ * @brief Sets the bounds of the RangeMarker.
+ * @param lowerBound The lower bound.
+ * @param upperBound The upper bound.
+ */
+void RangeMarker::setBounds(double lowerBound, double upperBound) {
+  callMethodNoCheck<void>(pyobj(), "set_bounds", lowerBound, upperBound);
+}
+
+/**
+ * @brief Sets the lower bound of the RangeMarker.
+ * @param minimum The lower bound.
+ */
+void RangeMarker::setLowerBound(double lowerBound) {
+  callMethodNoCheck<void>(pyobj(), "set_lower_bound", lowerBound);
+}
+
+/**
+ * @brief Sets the upper bound of the RangeMarker.
+ * @param upperBound The upper bound.
+ */
+void RangeMarker::setUpperBound(double upperBound) {
+  callMethodNoCheck<void>(pyobj(), "set_upper_bound", upperBound);
 }
 
 /**

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -99,6 +99,7 @@ signals:
   void mouseMove(const QPoint &point);
 
   void redraw();
+  void resetSelectorBounds();
 
 public:
   QColor canvasColour() const;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
@@ -53,6 +53,7 @@ private slots:
   void handleMouseMove(const QPoint &point);
   void handleMouseUp(const QPoint &point);
 
+  void resetBounds();
   void redrawMarker();
 
 private:
@@ -63,6 +64,8 @@ private:
   PreviewPlot *m_plot;
   /// The range marker
   std::unique_ptr<MantidQt::Widgets::MplCpp::RangeMarker> m_rangeMarker;
+  /// The type of the range marker
+  SelectType m_type;
   /// Is the marker visible or hidden
   bool m_visible;
   ///	Is the marker moving

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/SingleSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/SingleSelector.h
@@ -51,6 +51,7 @@ private slots:
   void handleMouseMove(const QPoint &point);
   void handleMouseUp(const QPoint &point);
 
+  void resetBounds();
   void redrawMarker();
 
 private:
@@ -61,6 +62,8 @@ private:
   PreviewPlot *m_plot;
   /// The single marker
   std::unique_ptr<MantidQt::Widgets::MplCpp::SingleMarker> m_singleMarker;
+  /// The type of the single marker
+  SelectType m_type;
   /// Is the marker visible or hidden
   bool m_visible;
   ///	Is the marker moving

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -136,7 +136,9 @@ void PreviewPlot::addSpectrum(const QString &lineName,
 
   regenerateLegend();
   axes.relim();
-  this->replot();
+
+  emit resetSelectorBounds();
+  replot();
 }
 
 /**

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -388,6 +388,7 @@ bool PreviewPlot::handleMouseReleaseEvent(QMouseEvent *evt) {
     const auto position = evt->pos();
     if (!position.isNull())
       emit mouseUp(position);
+    QTimer::singleShot(0, this, SLOT(replot()));
   }
   return stopEvent;
 }

--- a/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
+++ b/qt/widgets/plotting/src/Mpl/RangeSelector.cpp
@@ -29,7 +29,7 @@ RangeSelector::RangeSelector(PreviewPlot *plot, SelectType type, bool visible,
           m_plot->canvas(), colour.name(QColor::HexRgb),
           std::get<0>(getAxisRange(type)), std::get<1>(getAxisRange(type)),
           selectTypeAsQString(type), defaultLineKwargs())),
-      m_visible(visible), m_markerMoving(false) {
+      m_type(type), m_visible(visible), m_markerMoving(false) {
   Q_UNUSED(infoOnly);
 
   m_plot->canvas()->draw();
@@ -40,6 +40,7 @@ RangeSelector::RangeSelector(PreviewPlot *plot, SelectType type, bool visible,
           SLOT(handleMouseMove(QPoint)));
   connect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
 
+  connect(m_plot, SIGNAL(resetSelectorBounds()), this, SLOT(resetBounds()));
   connect(m_plot, SIGNAL(redraw()), this, SLOT(redrawMarker()));
 }
 
@@ -64,6 +65,11 @@ QString RangeSelector::selectTypeAsQString(const SelectType &type) const {
   }
   throw std::runtime_error("Incorrect SelectType provided. Select types are "
                            "XMINMAX and YMINMAX.");
+}
+
+void RangeSelector::resetBounds() {
+  auto const axisRange = getAxisRange(m_type);
+  m_rangeMarker->setBounds(std::get<0>(axisRange), std::get<1>(axisRange));
 }
 
 void RangeSelector::setRange(const std::pair<double, double> &range) {

--- a/qt/widgets/plotting/src/Mpl/SingleSelector.cpp
+++ b/qt/widgets/plotting/src/Mpl/SingleSelector.cpp
@@ -30,7 +30,7 @@ SingleSelector::SingleSelector(PreviewPlot *plot, SelectType type,
           m_plot->canvas(), colour.name(QColor::HexRgb), position,
           std::get<0>(getAxisRange(type)), std::get<1>(getAxisRange(type)),
           selectTypeAsQString(type), defaultLineKwargs())),
-      m_visible(visible), m_markerMoving(false) {
+      m_type(type), m_visible(visible), m_markerMoving(false) {
 
   m_plot->canvas()->draw();
 
@@ -40,6 +40,7 @@ SingleSelector::SingleSelector(PreviewPlot *plot, SelectType type,
           SLOT(handleMouseMove(QPoint)));
   connect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
 
+  connect(m_plot, SIGNAL(resetSelectorBounds()), this, SLOT(resetBounds()));
   connect(m_plot, SIGNAL(redraw()), this, SLOT(redrawMarker()));
 }
 
@@ -64,6 +65,11 @@ QString SingleSelector::selectTypeAsQString(const SelectType &type) const {
   }
   throw std::runtime_error("Incorrect SelectType provided. Select types are "
                            "XSINGLE and YSINGLE.");
+}
+
+void SingleSelector::resetBounds() {
+  auto const axisRange = getAxisRange(m_type);
+  m_singleMarker->setBounds(std::get<0>(axisRange), std::get<1>(axisRange));
 }
 
 void SingleSelector::setBounds(const std::pair<double, double> &bounds) {


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the SingleSelectors and RangeSelectors on a PreviewPlot would disappear when attempting to move the legend by dragging it.

The solution was to make the selectors visible again once the legend has been dropped back onto the plot.

**No release notes required as the selectors are new for this release**

**To test:**
1. Workbench
1.`Interfaces`->`Indirect`->`Data Reduction`->`ISIS Calibration`
2. Select instrument `IRIS`.
3. Load run number `26173` and wait
4. Move the legend in the top graph by dragging it.
5. The range selectors will disappear while you are dragging, but should reappear once you have dropped the legend.

Fixes #26310

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
