### PR TITLE
Added cleanup methods to muon context

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -45,6 +45,10 @@ class MuonContext(object):
 
         self.update_view_from_model_notifier = Observable()
 
+    def __del__(self):
+        self.ads_observer.unsubscribe()
+        self.ads_observer = None
+
     @property
     def window_title(self):
         if self._frequency_context:

--- a/scripts/Muon/GUI/Common/contexts/muon_context_ADS_observer.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context_ADS_observer.py
@@ -61,3 +61,8 @@ class MuonContextADSObserver(AnalysisDataServiceObserver):
         Called when the ADS has been cleared, removes all data and rests the GUI
         """
         self.clear_callback()
+
+    def unsubscribe(self):
+        self.observeDelete(False)
+        self.observeRename(False)
+        self.observeClear(False)


### PR DESCRIPTION
**Description of work.**

There are some sporadically failing tests which seem to occur when the ADSObserver within the muon_context class is not properly cleaned up. This adds a cleanup method which should be called when the class is garbage collected.

**To test:**

  * Code review

*There is no associated issue.*


*This does not require release notes* because this fixes a developer facing issue.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
