### PR TITLE
Log selector size

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/LogValueSelector.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/LogValueSelector.ui
@@ -41,6 +41,12 @@
      </item>
      <item>
       <widget class="QComboBox" name="log">
+       <property name="minimumSize">
+        <size>
+         <width>200</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose log value to take&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
@@ -102,19 +108,6 @@
         </property>
        </item>
       </widget>
-     </item>
-     <item>
-      <spacer name="logSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>185</width>
-         <height>6</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
**Description of work.**
The log value selector in the ALC interface was too narrow to display the log names in full. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open Mantid and set the instrument to MUSR
Open ALC (under muons)
For first enter 62260
Check that the log values in the combo box can be read easily.

Grep the code base for the log value selector and make sure those interfaces look ok too. 
Fixes #26315. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
