### PR TITLE
Watch for KeyboardInterrupt and gracefully terminate all subprocesses

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -12,11 +12,14 @@ or by importing them into MantidPlot.
 File change history is stored at: <https://github.com/mantidproject/systemtests>.
 """
 from __future__ import (absolute_import, division, print_function)
+
 # == for testing conda build of mantid-framework ==========
 import os
+
 if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
     # conda build of mantid-framework sometimes require importing matplotlib before mantid
     import matplotlib
+
 # =========================================================
 from six import PY3
 import datetime
@@ -30,7 +33,6 @@ from mantid.simpleapi import AlgorithmManager, Load, SaveNexus
 import numpy
 import platform
 import re
-import shutil
 import subprocess
 import shutil
 import sys
@@ -1193,7 +1195,6 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
                     total_number_of_tests, maximum_name_length,
                     tests_done, process_number, lock, required_files_dict,
                     locked_files_dict):
-
     reporter = XmlResultReporter(showSkipped=options.showskipped,
                                  total_number_of_tests=total_number_of_tests,
                                  maximum_name_length=maximum_name_length)
@@ -1202,18 +1203,18 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
                         escape_quotes=True, clean=options.clean)
 
     # Make sure the status is 1 to begin with as it will be replaced
-    res_array[process_number + 2*options.ncores] = 1
+    res_array[process_number + 2 * options.ncores] = 1
 
     # Begin loop: as long as there are still some test modules that
     # have not been run, keep looping
-    while (tests_left.value > 0):
+    while tests_left.value > 0:
         # Empty test list
         local_test_list = None
         # Get the lock to inspect the global list of tests
         lock.acquire()
         # Run through the list of test modules, starting from the ith
         # element where i is the process number.
-        for i in range(process_number,len(tests_lock)):
+        for i in range(process_number, len(tests_lock)):
             # If the lock for this particular module is 0, it means
             # this module has not yet been run and it will be chosen
             # for this particular loop
@@ -1243,9 +1244,9 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
         # then there is no test list
         if local_test_list:
 
-            if (not options.quiet):
+            if not options.quiet:
                 print("##### Thread %2i will execute module: [%3i] %s (%i tests)" \
-                       % (process_number, imodule, modname, len(local_test_list)))
+                      % (process_number, imodule, modname, len(local_test_list)))
                 sys.stdout.flush()
 
             # Create a TestManager, giving it a pre-compiled list_of_tests
@@ -1271,8 +1272,8 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
             # Update the test results in the array shared across cores
             res_array[process_number] += mgr._skippedTests
             res_array[process_number + options.ncores] += mgr._failedTests
-            res_array[process_number + 2*options.ncores] = min(int(reporter.reportStatus()),\
-                res_array[process_number + 2*options.ncores])
+            res_array[process_number + 2 * options.ncores] = min(int(reporter.reportStatus()), \
+                                                                 res_array[process_number + 2 * options.ncores])
 
             # Delete the TestManager
             del mgr
@@ -1291,5 +1292,3 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
 
     for key in local_dict.keys():
         stat_dict[key] = local_dict[key]
-
-    return


### PR DESCRIPTION
**Description of work.**
Adds a try except around process' `join` method, which captures KeyboardInterrupt if `ctrl+c` is pressed, or any other unexpected exception. In both cases it terminates all child processes, and exits with code 1.

Lots of formatting changes - look for accidentally deleted imports, courtesy of PyCharm

**To test:**
- Open System Monitor
- Filter for `systemtest`
- Go to build directory, the script is `systemtest`
- Run with `./systemtest -j8` for 8 child processes
- They should show up in the system monitor
- Press ctrl+c
- Everything from the system monitor should disappear

Fixes #26259

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
