### PR TITLE
Update name of InstrumentView variable, now mask displayed

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/masking_table_presenter.py
@@ -483,4 +483,4 @@ class MaskingTablePresenter(object):
                 instrument_win.show()
             else:
                 instrument_win = InstrumentViewPresenter(masked_workspace)
-                instrument_win.view.show()
+                instrument_win.container.show()


### PR DESCRIPTION
**Description of work.**
The error occurred as the name of the `InstrumentView` member of `mantidqt.widgets.instrumentview.presenter.InstrumentViewPresenter` is `container` while the `masking_table_presenter.py` file tried to access it as `view`.

**To test:**
- Workbench->Interfaces->SANS->ISIS SANS
- In Runs set User file to loqdemo/MaskFile.txt from ISIS sample data file
- set Batch File to loqdemo/batch_mode_reduction.csv
- In Settings->Mask press Display Mask, the view of the mask should appear

Fixes #26202.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
