### PR TITLE
Search hidden algorithms in workbench

### DIFF
--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -18,7 +18,8 @@ User interface
 - Mantid's offline help is now available in Workbench.
 - You can now save, load and delete custom layouts from the settings menu with quick access to user layout in the view
   menu.
-  
+- Typing an algorithm name in the algorithms search box now searches all algorithms including those in hidden categories.
+
 .. figure:: ../../images/wb_sliceviewer.png
    :class: screenshot
    :width: 500px

--- a/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
@@ -54,14 +54,19 @@ class ModelTest(unittest.TestCase):
         names, descriptors = model.get_algorithm_data()
         self.assertTrue(isinstance(names, list))
         self.assertTrue(isinstance(descriptors, dict))
-        self.assertTrue('Load' in names)
-        self.assertTrue('Rebin' in names)
+        self.assertEqual(5, len(names))
+        self.assertEqual('ComesFirst', names[0])
+        self.assertEqual('DoStuff', names[1])
+        self.assertEqual('GoesSecond', names[2])
+        self.assertEqual('Load', names[3])
+        self.assertEqual('Rebin', names[4])
+
         self.assertTrue('Rebin' in descriptors['Transform'][AlgorithmSelectorModel.algorithm_key])
         self.assertTrue('Rebin' in descriptors['Transform']['Rebin'][AlgorithmSelectorModel.algorithm_key])
         counter = Counter(names)
         self.assertEqual(counter['Rebin'], 1)
         self.assertEqual(counter['DoStuff'], 1)
-        self.assertEqual(mock_get_algorithm_descriptors.mock_calls[-1], call(False))
+        self.assertEqual(mock_get_algorithm_descriptors.mock_calls, [call(False), call(True)])
 
     def test_include_hidden_algorithms(self):
         model = AlgorithmSelectorModel(None, include_hidden=True)


### PR DESCRIPTION
**Description of work.**

Updates the algorithm selector so that the search box will always search every algorithm regardless of the state of the tree. This matches the implementation in MantidPlot and is what users have come to expect. 

**To test:**

Add `algorithms.categories.hidden = Transforms\\Splitting` to your `Mantid.user.properties` file.

Start the workbench and verify that the algorithm tree display does *not* have the `Transforms\\Splitting` category.

Type `CropWorkspace` in the search box and verify that it can be found in that list and executed when selected.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
