### PR TITLE
Fixed crash undo button

### DIFF
--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -82,9 +82,12 @@ class ResultsTabPresenter(QObject):
         fit_context = self.model._fit_context
         workspace_list = []
         fit_list = fit_context.fit_list
+        if fit_list == []:
+            return workspace_list, ''
+
         for ii in range(1, fit_context._number_of_fits + 1):
             workspace_list.append(fit_list[-ii].parameter_workspace_name)
-        return workspace_list, fit_list[len(fit_list) - 1].fit_function_name
+        return workspace_list, fit_list[-1].fit_function_name
 
     def _update_fit_results_view_on_new_fit(self):
         """Update the view of results workspaces based on the current model"""


### PR DESCRIPTION
**To test:**
1. Interfaces->Muon->Data Analysis v2
2. Load a run (eg. EMU0062265)
3. Go to Fitting tab and select a function (eg. ExpDecay)
4. Press Undo Latest Fit, the fit should be undone successfully.

Fixes #26340.

<!-- delete this if you added release notes
*This does not require release notes* because it applies to a new feature.
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
