### PR TITLE
Workbench Plot Guess with NaN values

### DIFF
--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -193,16 +193,23 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         if fun == '' or ws_name == '':
             return
         ws_index = self.workspaceIndex()
+        startX = self.startX()
+        endX = self.endX()
         out_ws_name = '{}_guess'.format(ws_name)
+        try:
+            alg = AlgorithmManager.createUnmanaged('EvaluateFunction')
+            alg.setChild(True)
+            alg.initialize()
+            alg.setProperty('Function', fun)
+            alg.setProperty('InputWorkspace', ws_name)
+            alg.setProperty('WorkspaceIndex', ws_index)
+            alg.setProperty('StartX', startX)
+            alg.setProperty('EndX', endX)
+            alg.setProperty('OutputWorkspace', out_ws_name)
+            alg.execute()
+        except RuntimeError:
+            return
 
-        alg = AlgorithmManager.createUnmanaged('EvaluateFunction')
-        alg.setChild(True)
-        alg.initialize()
-        alg.setProperty('Function', fun)
-        alg.setProperty('InputWorkspace', ws_name)
-        alg.setProperty('WorkspaceIndex', ws_index)
-        alg.setProperty('OutputWorkspace', out_ws_name)
-        alg.execute()
         out_ws = alg.getProperty('OutputWorkspace').value
 
         plot([out_ws], wksp_indices=[1], fig=self.canvas.figure, overplot=True, plot_kwargs={'label': out_ws_name})


### PR DESCRIPTION
**Description of work.**
This PR passes through the start and end X values to plot guess so it will plot a workspace contains NaN values if they are cropped out.

**To test:**
Follow steps in #26332. It should no longer produce an error and instead plot a line on the graph 

Fixes #26332 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
