### PR TITLE
Handled 'None' in peak data file

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -134,17 +134,17 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         if name not in self.element_lines[element]:
             self.element_lines[element].append(name)
         # make sure the names are strings and x values are numbers
-        return Label(str(name), float(x_value), False, offset, True, rotation=-90, protected=True)
+        return Label(str(name), x_value, False, offset, True, rotation=-90, protected=True)
 
     def _plot_line(self, name, x_value_in, color, element=None):
         label = self._gen_label(name, x_value_in, element)
         if self.plot_window is None:
             return
         for subplot in self.plotting.get_subplots():
-            self._plot_line_once(subplot, float(x_value_in), label, color)
+            self._plot_line_once(subplot, x_value_in, label, color)
 
     def _plot_line_once(self, subplot, x_value, label, color):
-        self.plotting.add_vline_and_annotate(subplot, float(x_value), label, color)
+        self.plotting.add_vline_and_annotate(subplot, x_value, label, color)
 
     def _rm_line(self, name):
         if self.plot_window is None:
@@ -188,6 +188,10 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         color = self.get_color()
 
         for name, x_value in iteritems(data):
+            try:
+                x_value = float(x_value)
+            except:
+                continue
             full_name = gen_name(element, name)
             self._plot_line(full_name, x_value, color, element)
 
@@ -260,9 +264,13 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             data = self.element_widgets[element].get_checked()
         color = self.get_color()
         for name, x_value in iteritems(data):
+            try:
+                x_value = float(x_value)
+            except:
+                continue
             full_name = gen_name(element, name)
             label = self._gen_label(full_name, x_value, element)
-            self._plot_line_once(subplot, float(x_value), label, color)
+            self._plot_line_once(subplot, x_value, label, color)
 
     def _update_peak_data(self, element, data=None):
         if self.ptable.is_selected(element):


### PR DESCRIPTION
**Description of work.**
If in the gamma peaks there was one with x_value of `None`, the Elemental Analysis would raise an exception. Now that's fixed

**To test:**
1. `Interfaces->Muon->Elemental Analysis`
2. Load a run (eg. 2695)
3. Select only `Gamma peaks`
4. Select `Ge`, 2 peaks should appear

Fixes #26346.

<!-- delete this if you added release notes
*This does not require release notes* because it concerns a newly released interface.
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
