### PR TITLE
Indirect Data Reduction - Load parameter file only once

### DIFF
--- a/docs/source/release/v4.1.0/indirect_geometry.rst
+++ b/docs/source/release/v4.1.0/indirect_geometry.rst
@@ -99,6 +99,7 @@ Improvements
 - Improved ISISEnergyTransfer by automatically loading the Detailed Balance from the sample logs if available.
 - Removed the obsolete *Plot Raw* button in ISIS Calibration.
 - Improved the validation checks for input data on all tabs.
+- Improved performance of starting up the interface, by optimising the loading of parameter files.
 
 Bug Fixes
 #########

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
@@ -56,10 +56,9 @@ public:
 
   Mantid::API::MatrixWorkspace_sptr instrumentWorkspace();
 
-  Mantid::API::MatrixWorkspace_sptr
-  loadInstrumentIfNotExist(const std::string &instrumentName,
-                           const std::string &analyser = "",
-                           const std::string &reflection = "");
+  void loadInstrumentIfNotExist(const std::string &instrumentName,
+                                const std::string &analyser = "",
+                                const std::string &reflection = "");
 
   std::vector<std::pair<std::string, std::vector<std::string>>>
   getInstrumentModes();
@@ -88,6 +87,8 @@ private:
   std::string documentationPage() const override;
 
   void applySettings(std::map<std::string, QVariant> const &settings) override;
+
+  void loadInstrumentDetails();
 
   QString
   getInstrumentParameterFrom(Mantid::Geometry::IComponent_const_sptr comp,
@@ -156,10 +157,12 @@ private:
   QString m_dataDir; ///< default data search directory
   QString m_saveDir; ///< default data save directory
 
-  // Pointer to the current empty instrument workspace
+  /// Pointer to the current empty instrument workspace
   Mantid::API::MatrixWorkspace_sptr m_instWorkspace;
   /// The currently loaded instrument parameter file
   std::string m_ipfFilename;
+  /// Stores the details of the instrument
+  QMap<QString, QString> m_instDetails;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
@@ -54,7 +54,9 @@ public:
   /// Handled configuration changes
   void handleConfigChange(Mantid::Kernel::ConfigValChangeNotification_ptr pNf);
 
-  static Mantid::API::MatrixWorkspace_sptr
+  Mantid::API::MatrixWorkspace_sptr instrumentWorkspace();
+
+  Mantid::API::MatrixWorkspace_sptr
   loadInstrumentIfNotExist(const std::string &instrumentName,
                            const std::string &analyser = "",
                            const std::string &reflection = "");
@@ -156,6 +158,8 @@ private:
 
   // Pointer to the current empty instrument workspace
   Mantid::API::MatrixWorkspace_sptr m_instWorkspace;
+  /// The currently loaded instrument parameter file
+  std::string m_ipfFilename;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -68,23 +68,13 @@ void IndirectDataReductionTab::tabExecutionComplete(bool error) {
 }
 
 /**
- * Loads an empty instrument into a workspace (__empty_INST) unless the
- * workspace already exists.
+ * Gets the current instrument workspace
  *
- * If an analyser and reflection are supplied then the corresponding IPF is also
- * loaded.
- *
- * @param instrumentName Name of the instrument to load
- * @param analyser Analyser being used (optional)
- * @param reflection Relection being used (optional)
  * @returns Pointer to instrument workspace
  */
 Mantid::API::MatrixWorkspace_sptr
-IndirectDataReductionTab::loadInstrumentIfNotExist(std::string instrumentName,
-                                                   std::string analyser,
-                                                   std::string reflection) {
-  return m_idrUI->loadInstrumentIfNotExist(instrumentName, analyser,
-                                           reflection);
+IndirectDataReductionTab::instrumentWorkspace() const {
+  return m_idrUI->instrumentWorkspace();
 }
 
 /**
@@ -174,9 +164,7 @@ std::map<std::string, double> IndirectDataReductionTab::getRangesFromInstrument(
   std::map<std::string, double> ranges;
 
   // Get the instrument
-  auto instWs = loadInstrumentIfNotExist(
-      instName.toStdString(), analyser.toStdString(), reflection.toStdString());
-  auto inst = instWs->getInstrument();
+  auto inst = instrumentWorkspace()->getInstrument();
 
   // Get the analyser component
   auto comp = inst->getComponentByName(analyser.toStdString());

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.h
@@ -66,10 +66,7 @@ signals:
   void newInstrumentConfiguration();
 
 protected:
-  Mantid::API::MatrixWorkspace_sptr
-  loadInstrumentIfNotExist(std::string instrumentName,
-                           std::string analyser = "",
-                           std::string reflection = "");
+  Mantid::API::MatrixWorkspace_sptr instrumentWorkspace() const;
 
   QMap<QString, QString> getInstrumentDetails() const;
   QString getInstrumentDetail(QString const &key) const;

--- a/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.cpp
@@ -127,7 +127,6 @@ void IndirectInstrumentConfig::enableDiffraction(bool enabled) {
     forceDiffraction(false);
 
   m_removeDiffraction = !enabled;
-  updateInstrumentConfigurations(getInstrumentName());
 }
 
 /**
@@ -149,7 +148,6 @@ void IndirectInstrumentConfig::forceDiffraction(bool forced) {
     enableDiffraction(true);
 
   m_forceDiffraction = forced;
-  updateInstrumentConfigurations(getInstrumentName());
 }
 
 /**
@@ -397,8 +395,6 @@ void IndirectInstrumentConfig::filterDisabledInstruments() {
       ++i;
     }
   }
-
-  updateInstrumentConfigurations(getInstrumentName());
 }
 
 } /* namespace MantidWidgets */

--- a/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.h
+++ b/qt/scientific_interfaces/Indirect/IndirectInstrumentConfig.h
@@ -86,6 +86,8 @@ public:
 public slots:
   /// Called when an instrument configuration is selected
   void newInstrumentConfiguration();
+  /// Handles an instrument being selected
+  void updateInstrumentConfigurations(const QString &instrumentName);
 
 signals:
   /// Emitted when the instrument configuration is changed
@@ -94,8 +96,6 @@ signals:
                                       const QString &reflectionName);
 
 private slots:
-  /// Handles an instrument being selected
-  void updateInstrumentConfigurations(const QString &instrumentName);
   /// Updates the list of analysers when an instrument is selected
   bool updateAnalysersList(Mantid::API::MatrixWorkspace_sptr ws);
   /// Updates the list of reflections when an analyser is selected


### PR DESCRIPTION
**Description of work.**
This PR ensures the instrument parameter file for the Data Reduction interface is only loaded once when opening the interface.
This means the interface will open slightly faster (windows):
  MantidPlot (Previous time: ~3s  Now: ~2s)
  Workbench (Previous time: ~5s  Now: ~3.5s)

Previously I was getting a sparsely reproducible crash on Workbench which occurred when waiting for the data reduction interface to open. Since making these changes, I have not seen this crash happen again -  however this crash cannot be consistently reproduced.

**No release notes required as this is a 'behind the scenes' change**

**To test:**
Code review, and compare the time it takes to open Data Reduction to master on the workbench.

Fixes #26352

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
