### PR TITLE
Error Reporter: Allow resizeable window so that smaller screens can use it.

### DIFF
--- a/docs/source/release/v4.1.0/mantidplot.rst
+++ b/docs/source/release/v4.1.0/mantidplot.rst
@@ -13,12 +13,13 @@ MantidPlot Changes
 Improvements
 ############
 
-The vast mojority of development effort for user interfaces is now directed towards the :doc:`Mantid workbench <mantidworkbench>`, for now only significant bugs will be fixed within MantidPlot.
+The vast majority of development effort for user interfaces is now directed towards the :doc:`Mantid workbench <mantidworkbench>`, for now only significant bugs will be fixed within MantidPlot.
 
 Bugfixes
 ########
 
 * Help documentation for the manage user directories interface now correctly displays when launched from the interface.
 * Fix for the Instrument View pick tab miniplot where the x axis label was not updated when a new unit was selected.
+* The ErrorReporter window is now resizeable
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -84,5 +84,6 @@ Bugfixes
 - Restore Default Layout no longer resizes the main window.
 - Entering an invalid number into a plot's axis editor no longer causes an uncaught error
 - Workbench's scaling of fonts when moved between monitors with different resolutions has been improved
+- The ErrorReporter window is now resizeable
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -34,7 +34,6 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         if not show_continue_terminate:
             self.continue_terminate_frame.hide()
             self.adjustSize()
-        self.setFixedSize(self.width(), self.height())
 
         self.quit_signal.connect(QtWidgets.QApplication.instance().quit)
 


### PR DESCRIPTION
**Description of work.**
Allow resizeable window so that smaller screens can use it. Anything that has a smaller pixel size than roughly 600x400 may struggle but besides that, it should be usable.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open MantidPlot/Workbench from a launch script (so that the error reporter will actually show up)
- Make sure you have report usage data ticked on!
- Run Segfault(0) in a script window or as an algorithm without dry-run being selected
- Resize the window.
- Try the smallest display size you have on your monitor (should definitely be ok for 800x600)

<!-- Instructions for testing. -->

Fixes #26326 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
