### PR TITLE
Add VSCode task for debugging C++ in Workbench

### DIFF
--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -100,8 +100,6 @@ attempt to make a useful task for you. However it may be better to use this exam
 The commands can be switched out with the command and various args for the generator
 used to generate your CMake with.
 
-
-
 .. code-block:: javascript
 
     {
@@ -215,7 +213,7 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
           "ignoreFailures": true
         }
       ]
-    },
+    }
 
 
 

--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -66,7 +66,7 @@ Features
 Auto Formatting
 ---------------
 It is required in the mantid project to format code using clang-format, this can be done
-in multiple ways but VSCode makes it easier. With a formatter installed as an extension 
+in multiple ways but VSCode makes it easier. With a formatter installed as an extension
 it is possible to format any open file in VSCode. It is recommended to use this `Clang-Format <https://marketplace.visualstudio.com/items?itemName=xaver.clang-format>`_ extension.
 It is possible to format your code using on save, type, paste and save timeout. To set
 when you want to format:
@@ -99,6 +99,8 @@ attempt to make a useful task for you. However it may be better to use this exam
 **Linux/OSX:**
 The commands can be switched out with the command and various args for the generator
 used to generate your CMake with.
+
+
 
 .. code-block:: javascript
 
@@ -158,6 +160,8 @@ If this fails
 For this section the guide will show you how to use GDB debugging. Inside the launch.json
 you will want to make your file look something a little like this:
 
+*MantidPlot*
+
 .. code-block:: javascript
 
     {
@@ -186,7 +190,36 @@ you will want to make your file look something a little like this:
         ]
     }
 
-**Window:**
+*Workbench*
+
+To debug C++ and start directly into the Workbench, add this to the configuration list in ``launch.json``.
+
+.. code-block:: javascript
+
+    {
+      "name": "(gdb) Workbench C++ Only",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "/usr/bin/python2.7", // Path to your used Python interpreter, here and below
+      "args": ["Path/To/Build/Directory/bin/workbench", "&&","gdb","/usr/bin/python2.7","$!"], // $! gets the process ID
+      "stopAtEntry": false,
+      "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "preLaunchTask": "Build Mantid",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
+
+
+
+**Windows:**
 
 For this section of the guide it will discuss use of the MSVC debugger. Please
 follow on with the `guide <https://code.visualstudio.com/docs/cpp/config-msvc>`_.
@@ -306,7 +339,7 @@ Keybindings
 -----------
 
 To get a list of all of possible keybindings the open your command line
-(Ctrl+Shift+P or ⌘+Shift+P) and search for "Help: Keyboard Shortcuts 
+(Ctrl+Shift+P or ⌘+Shift+P) and search for "Help: Keyboard Shortcuts
 Reference" and hit Enter.
 
 **Very commonly used keybindings:**


### PR DESCRIPTION
**Description of work.**
Adds a debug task to VSCode for starting the Workbench and attaching `gdb`

**To test:**
Add task to `launch.json`. Change paths for your setup. Run task, it should start the workbench and attach `gdb`.

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
