### PR TITLE
Indirect Tools - No valid Analyzers bug

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -116,7 +116,8 @@ void IndirectDiffractionReduction::initLayout() {
   validateCalOnly();
 
   // Update instrument dependant widgets
-  m_uiForm.iicInstrumentConfiguration->newInstrumentConfiguration();
+  m_uiForm.iicInstrumentConfiguration->updateInstrumentConfigurations(
+      m_uiForm.iicInstrumentConfiguration->getInstrumentName());
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTransmissionCalc.cpp
@@ -31,6 +31,9 @@ IndirectTransmissionCalc::IndirectTransmissionCalc(QWidget *parent)
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this,
           SLOT(algorithmComplete(bool)));
+
+  m_uiForm.iicInstrumentConfiguration->updateInstrumentConfigurations(
+      m_uiForm.iicInstrumentConfiguration->getInstrumentName());
 }
 
 /*


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem on Indirect Tools where no valid analysers are found upon loading the GUI.
It may also fix a problem seen when opening the diffraction interface, however the error caused could not be reproduced on windows or ubuntu.

**To test:**
Workbench
Open diffraction

**No release notes required as the bug was not in the last release**

Fixes #26370

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
