### PR TITLE
Allow cmake to handle the future change in name of the GSL cblas library on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,12 @@ if(ENABLE_WORKBENCH)
 endif()
 
 # gsl is currently needed by Geometry, Algorithms, Curvefitting, & MantidPlot
+if(WIN32 AND GSL_CBLAS_LIBRARY AND NOT EXISTS ${GSL_CBLAS_LIBRARY})
+  # The GSL cblas library changes its name between v1 and v2 on Windows. Workaround
+  # the fact that CMake has cached the old path to a non-existant library.
+  unset(GSL_CBLAS_LIBRARY CACHE)
+  unset(GSL_CBLAS_LIBRARY_DEBUG CACHE)
+endif()
 find_package(GSL REQUIRED)
 
 # Now add in all the components


### PR DESCRIPTION
**Description of work.**

A maintenance task for v4.2 is to upgrade GSL on Windows to match the other distributions to avoid places where we have to check for the version on different OSs. The cblas library that ships with the GSL changes its name in v2 causing issues with CMake finding the new version as CMake caches the paths to the old library. This adds code to check if the library path actually exists and erases it to force `find_package` to run again.

It will be helpful for this to be in `release-next` so that if we need to perform a patch release then the builders will automatically detect the changing library names without needing to perform clean builds all of the time.

Note that the library has **not** been upgraded here.

**To test:**

Code review and builds should pass.

Refs #26262 

*This does not require release notes* because **it is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
