### PR TITLE
Fix compiler warning with llvm clang 4

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Converters/NDArrayToVector.cpp
@@ -28,23 +28,22 @@ namespace Mantid {
 namespace PythonInterface {
 namespace Converters {
 
-extern template int NDArrayTypeIndex<bool>::typenum;
-extern template int NDArrayTypeIndex<int>::typenum;
-extern template int NDArrayTypeIndex<long>::typenum;
-extern template int NDArrayTypeIndex<long long>::typenum;
-extern template int NDArrayTypeIndex<unsigned int>::typenum;
-extern template int NDArrayTypeIndex<unsigned long>::typenum;
-extern template int NDArrayTypeIndex<unsigned long long>::typenum;
-extern template int NDArrayTypeIndex<float>::typenum;
-extern template int NDArrayTypeIndex<double>::typenum;
-extern template char NDArrayTypeIndex<bool>::typecode;
-extern template char NDArrayTypeIndex<int>::typecode;
-extern template char NDArrayTypeIndex<long>::typecode;
-extern template char NDArrayTypeIndex<long long>::typecode;
-extern template char NDArrayTypeIndex<unsigned int>::typecode;
-extern template char NDArrayTypeIndex<unsigned long>::typecode;
-extern template char NDArrayTypeIndex<unsigned long long>::typecode;
-extern template char NDArrayTypeIndex<double>::typecode;
+/// Macro to declare template instantiations as extern; those are defined in
+/// NDArrayTypeIndex.cpp
+#define DECLARE_EXTERN(HeldType)                                               \
+  extern template int NDArrayTypeIndex<HeldType>::typenum;                     \
+  extern template char NDArrayTypeIndex<HeldType>::typecode;
+
+DECLARE_EXTERN(bool)
+DECLARE_EXTERN(int)
+DECLARE_EXTERN(long)
+DECLARE_EXTERN(long long)
+DECLARE_EXTERN(unsigned int)
+DECLARE_EXTERN(unsigned long)
+DECLARE_EXTERN(unsigned long long)
+DECLARE_EXTERN(double)
+DECLARE_EXTERN(float)
+
 } // namespace Converters
 
 namespace {


### PR DESCRIPTION
**Description of work.**
This fixes a compiler warning on macOS with llvm clang 4.
Basically adds a missing extern for template instantiation for `NDArrayTypeIndex<float>::typecode`.
Also adds a macro to simplify the declarations.

**To test:**
<!-- Instructions for testing. -->
There should be no warning with clang 4 unlike current master.

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
