### PR TITLE
Run button in ILL indirect reduction GUI

### DIFF
--- a/Framework/API/inc/MantidAPI/IndexProperty.h
+++ b/Framework/API/inc/MantidAPI/IndexProperty.h
@@ -39,6 +39,7 @@ public:
   IndexProperty *clone() const override;
 
   using Kernel::ArrayProperty<int64_t>::operator=;
+  using Kernel::ArrayProperty<int64_t>::operator const std::vector<int64_t> &;
 
   bool isDefault() const override;
   std::string isValid() const override;

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -44,7 +44,6 @@
 #include "MantidAPI/Algorithm.tcc"
 
 using namespace Mantid::Kernel;
-using VectorStringProperty = PropertyWithValue<std::vector<std::string>>;
 
 namespace Mantid {
 namespace API {

--- a/Framework/DataHandling/test/LoadHFIRSANSTest.h
+++ b/Framework/DataHandling/test/LoadHFIRSANSTest.h
@@ -55,7 +55,7 @@ public:
       spice2d.initialize();
 
     // No parameters have been set yet, so it should throw
-    TS_ASSERT_THROWS(spice2d.execute(), std::runtime_error);
+    TS_ASSERT_THROWS(spice2d.execute(), const std::runtime_error &);
 
     // Set the file name
     spice2d.setPropertyValue("Filename", inputFile);
@@ -181,7 +181,7 @@ public:
       spice2d.initialize();
 
     // No parameters have been set yet, so it should throw
-    TS_ASSERT_THROWS(spice2d.execute(), std::runtime_error);
+    TS_ASSERT_THROWS(spice2d.execute(), const std::runtime_error &);
 
     // Set the file name
     spice2d.setPropertyValue("Filename", inputFile);

--- a/Framework/DataHandling/test/SaveStlTest.h
+++ b/Framework/DataHandling/test/SaveStlTest.h
@@ -81,7 +81,7 @@ public:
                               V3D(-5, 5, -15),  V3D(5, -5, 15), V3D(5, 5, 15),
                               V3D(-5, 5, 15),   V3D(-5, -5, 15)};
     auto writer = SaveStl(path, triangle, vertices, ScaleUnits::metres);
-    TS_ASSERT_THROWS(writer.writeStl(), std::runtime_error);
+    TS_ASSERT_THROWS(writer.writeStl(), const std::runtime_error &);
     TS_ASSERT(!Poco::File(path).exists());
   }
 

--- a/Framework/Geometry/test/InstrumentDefinitionParserTest.h
+++ b/Framework/Geometry/test/InstrumentDefinitionParserTest.h
@@ -936,13 +936,13 @@ public:
     detid_t numDetectors = 3;
 
     TS_ASSERT_THROWS(loadInstrLocations(locations, numDetectors, true),
-                     Exception::InstrumentDefinitionError);
+                     const Exception::InstrumentDefinitionError &);
 
     locations =
         R"(<locations n-elements="3" name-count-start="5" name-count-increment="-7" name="det" />)";
 
     TS_ASSERT_THROWS(loadInstrLocations(locations, numDetectors, true),
-                     Exception::InstrumentDefinitionError);
+                     const Exception::InstrumentDefinitionError &);
   }
 
   void testLocationsStaticValues() {

--- a/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
+++ b/Framework/Parallel/inc/MantidParallel/IO/NXEventDataLoader.h
@@ -102,15 +102,9 @@ std::unique_ptr<AbstractEventDataPartitioner<TimeOffsetType>>
 makeEventDataPartitioner(const H5::Group &group, const int numWorkers) {
   const auto timeZero = group.openDataSet("event_time_zero");
   int64_t time_zero_offset{0};
-  // libhdf5 on Ubuntu 14.04 is too old to support timeZero.attrExists("offset")
-  // and Attribute::readAttribute, check and read manually.
-  hid_t attr_id = H5Aopen(timeZero.getId(), "offset", H5P_DEFAULT);
-  if (attr_id > 0) {
-    const H5::Attribute attr(attr_id);
-    std::string offset;
-    attr.read(attr.getDataType(), offset);
+  if (timeZero.attrExists("offset")) {
+    const auto &offset = readAttribute(timeZero, "offset");
     time_zero_offset = Types::Core::DateAndTime(offset).totalNanoseconds();
-    H5Aclose(attr_id);
   }
   return std::make_unique<
       EventDataPartitioner<IndexType, TimeZeroType, TimeOffsetType>>(

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -12,11 +12,14 @@ or by importing them into MantidPlot.
 File change history is stored at: <https://github.com/mantidproject/systemtests>.
 """
 from __future__ import (absolute_import, division, print_function)
+
 # == for testing conda build of mantid-framework ==========
 import os
+
 if os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
     # conda build of mantid-framework sometimes require importing matplotlib before mantid
     import matplotlib
+
 # =========================================================
 from six import PY3
 import datetime
@@ -30,7 +33,6 @@ from mantid.simpleapi import AlgorithmManager, Load, SaveNexus
 import numpy
 import platform
 import re
-import shutil
 import subprocess
 import shutil
 import sys
@@ -1193,7 +1195,6 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
                     total_number_of_tests, maximum_name_length,
                     tests_done, process_number, lock, required_files_dict,
                     locked_files_dict):
-
     reporter = XmlResultReporter(showSkipped=options.showskipped,
                                  total_number_of_tests=total_number_of_tests,
                                  maximum_name_length=maximum_name_length)
@@ -1202,18 +1203,18 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
                         escape_quotes=True, clean=options.clean)
 
     # Make sure the status is 1 to begin with as it will be replaced
-    res_array[process_number + 2*options.ncores] = 1
+    res_array[process_number + 2 * options.ncores] = 1
 
     # Begin loop: as long as there are still some test modules that
     # have not been run, keep looping
-    while (tests_left.value > 0):
+    while tests_left.value > 0:
         # Empty test list
         local_test_list = None
         # Get the lock to inspect the global list of tests
         lock.acquire()
         # Run through the list of test modules, starting from the ith
         # element where i is the process number.
-        for i in range(process_number,len(tests_lock)):
+        for i in range(process_number, len(tests_lock)):
             # If the lock for this particular module is 0, it means
             # this module has not yet been run and it will be chosen
             # for this particular loop
@@ -1243,9 +1244,9 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
         # then there is no test list
         if local_test_list:
 
-            if (not options.quiet):
+            if not options.quiet:
                 print("##### Thread %2i will execute module: [%3i] %s (%i tests)" \
-                       % (process_number, imodule, modname, len(local_test_list)))
+                      % (process_number, imodule, modname, len(local_test_list)))
                 sys.stdout.flush()
 
             # Create a TestManager, giving it a pre-compiled list_of_tests
@@ -1271,8 +1272,8 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
             # Update the test results in the array shared across cores
             res_array[process_number] += mgr._skippedTests
             res_array[process_number + options.ncores] += mgr._failedTests
-            res_array[process_number + 2*options.ncores] = min(int(reporter.reportStatus()),\
-                res_array[process_number + 2*options.ncores])
+            res_array[process_number + 2 * options.ncores] = min(int(reporter.reportStatus()), \
+                                                                 res_array[process_number + 2 * options.ncores])
 
             # Delete the TestManager
             del mgr
@@ -1291,5 +1292,3 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict,
 
     for key in local_dict.keys():
         stat_dict[key] = local_dict[key]
-
-    return

--- a/docs/source/release/index.rst
+++ b/docs/source/release/index.rst
@@ -12,6 +12,7 @@ Release Notes
    */index
 
 
+* :doc:`v4.2.0 <v4.2.0/index>`
 * :doc:`v4.1.0 <v4.1.0/index>`
 * :doc:`v4.0.0 <v4.0.0/index>`
 * :doc:`v3.13.0 <v3.13.0/index>`

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -1,0 +1,24 @@
+===================
+Diffraction Changes
+===================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Powder Diffraction
+------------------
+
+Engineering Diffraction
+-----------------------
+
+Single Crystal Diffraction
+--------------------------
+
+Imaging
+-------
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/direct_geometry.rst
+++ b/docs/source/release/v4.2.0/direct_geometry.rst
@@ -1,0 +1,12 @@
+=======================
+Direct Geometry Changes
+=======================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -1,0 +1,24 @@
+=================
+Framework Changes
+=================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Concepts
+--------
+
+Algorithms
+----------
+
+Data Objects
+------------
+
+Python
+------
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/index.rst
+++ b/docs/source/release/v4.2.0/index.rst
@@ -1,0 +1,89 @@
+.. _v4.2.0:
+
+===========================
+Mantid 4.2.0 Release Notes
+===========================
+
+.. figure:: ../../images/ImageNotFound.png
+   :class: screenshot
+   :width: 385px
+   :align: right
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: This release is still under construction. The changes can be found in the nightly builds on the `download page`_.
+
+We are proud to announce version 4.2.0 of Mantid.
+
+**TODO: Add paragraph summarizing big changes**
+
+This is just one of many improvements in this release, so please take a
+look at the release notes, which are filled with details of the
+important changes and improvements in many areas. The development team
+has put a great effort into making all of these improvements within
+Mantid, and we would like to thank all of our beta testers for their
+time and effort helping us to make this another reliable version of Mantid.
+
+Throughout the Mantid project we put a lot of effort into ensuring
+Mantid is a robust and reliable product. Thank you to everyone that has
+reported any issues to us. Please keep on reporting any problems you
+have, or crashes that occur on our `forum`_.
+
+Installation packages can be found on our `download page`_
+which now links to sourceforge to mirror our download files around the world, you can also
+access the source code on `GitHub release page`_.
+
+Citation
+--------
+
+Please cite any usage of Mantid as follows:
+
+- *Mantid 4.2.0: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID4.2 <http://dx.doi.org/10.5286/SOFTWARE/MANTID4.2>`_
+
+- Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments
+  and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166
+  `doi: 10.1016/j.nima.2014.07.029 <https://doi.org/10.1016/j.nima.2014.07.029>`_
+  (`download bibtex <https://raw.githubusercontent.com/mantidproject/mantid/master/docs/source/mantid.bib>`_)
+
+
+Changes
+-------
+
+.. toctree::
+   :hidden:
+   :glob:
+
+   *
+
+- :doc:`Framework <framework>`
+- :doc:`General UI & Usability <ui>`
+
+  - :doc:`MantidPlot <mantidplot>`
+
+  - :doc:`MantidWorkbench <mantidworkbench>`
+- :doc:`Diffraction <diffraction>`
+- :doc:`Muon Analysis <muon>`
+- Low Q
+
+  - :doc:`Reflectometry <reflectometry>`
+
+  - :doc:`SANS <sans>`
+- Spectroscopy
+
+  - :doc:`Direct Geometry <direct_geometry>`
+
+  - :doc:`Indirect Geometry <indirect_geometry>`
+
+Full Change Listings
+--------------------
+
+For a full list of all issues addressed during this release please see the `GitHub milestone`_.
+
+.. _download page: http://download.mantidproject.org
+
+.. _forum: http://forum.mantidproject.org
+
+.. _GitHub milestone: http://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3ARelease 4.2+is%3Amerged
+
+.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v4.2.0

--- a/docs/source/release/v4.2.0/indirect_geometry.rst
+++ b/docs/source/release/v4.2.0/indirect_geometry.rst
@@ -1,0 +1,12 @@
+=========================
+Indirect Geometry Changes
+=========================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/mantidplot.rst
+++ b/docs/source/release/v4.2.0/mantidplot.rst
@@ -1,0 +1,14 @@
+==================
+MantidPlot Changes
+==================
+
+.. contents:: Table of Contents
+   :local:
+
+Improvements
+############
+
+Bugfixes
+########
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -1,0 +1,14 @@
+=======================
+MantidWorkbench Changes
+=======================
+
+.. contents:: Table of Contents
+   :local:
+
+Improvements
+############
+
+Bugfixes
+########
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -1,0 +1,13 @@
+============
+MuSR Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -1,0 +1,12 @@
+=====================
+Reflectometry Changes
+=====================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/sans.rst
+++ b/docs/source/release/v4.2.0/sans.rst
@@ -1,0 +1,12 @@
+============
+SANS Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/ui.rst
+++ b/docs/source/release/v4.2.0/ui.rst
@@ -1,0 +1,28 @@
+======================
+UI & Usability Changes
+======================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Installation
+------------
+
+MantidPlot
+----------
+
+See :doc:`mantidplot`.
+
+MantidWorkbench
+---------------
+
+See :doc:`mantidworkbench`.
+
+SliceViewer and Vates Simple Interface
+--------------------------------------
+
+:ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/ILLEnergyTransfer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>672</width>
-    <height>585</height>
+    <height>663</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -846,66 +846,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="gbRun">
-     <property name="title">
-      <string>Run</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_5">
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>7</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>233</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="pbRun">
-        <property name="minimumSize">
-         <size>
-          <width>150</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>180</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>Run</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>233</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
     <widget class="QGroupBox" name="gbOutput">
      <property name="title">
       <string>Output Options</string>
@@ -1032,6 +972,66 @@
          </widget>
         </item>
        </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gbRun">
+     <property name="title">
+      <string>Run</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>7</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>233</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="pbRun">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>180</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Run</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>233</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
      </layout>
     </widget>
@@ -1607,7 +1607,7 @@
   </connection>
  </connections>
  <buttongroups>
-  <buttongroup name="buttonGroup"/>
   <buttongroup name="buttonGroup_2"/>
+  <buttongroup name="buttonGroup"/>
  </buttongroups>
 </ui>

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
@@ -109,7 +109,8 @@ private:
         5, 100.0, 500.0, {1.0, 2.0, 3.0, 4.0, 5.0}, paramsType);
     auto instrument = workspace->getInstrument();
     ExperimentOptionDefaults experimentDefaults;
-    TS_ASSERT_THROWS(experimentDefaults.get(instrument), std::invalid_argument);
+    TS_ASSERT_THROWS(experimentDefaults.get(instrument),
+                     const std::invalid_argument &);
   }
 };
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
@@ -93,7 +93,8 @@ private:
         5, 100.0, 500.0, {1.0, 2.0, 3.0, 4.0, 5.0}, paramsType);
     auto instrument = workspace->getInstrument();
     InstrumentOptionDefaults instrumentDefaults;
-    TS_ASSERT_THROWS(instrumentDefaults.get(instrument), std::invalid_argument);
+    TS_ASSERT_THROWS(instrumentDefaults.get(instrument),
+                     const std::invalid_argument &);
   }
 };
 

--- a/qt/widgets/mplcpp/test/MantidAxesTest.h
+++ b/qt/widgets/mplcpp/test/MantidAxesTest.h
@@ -84,7 +84,7 @@ public:
         create<Workspace2D>(2, Histogram(BinEdges{1, 2, 4})).release());
     MantidAxes axes{pyAxes()};
     TS_ASSERT_THROWS(axes.plot(ws, 2, "red", "mylabel"),
-                     Python::ErrorAlreadySet);
+                     const Python::ErrorAlreadySet &);
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
Puts the run button at the very end of the dialog. Currently it is before output options, which does not make sense for us.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Set facility to ILL, open interfaces>indirect>data reduction.
Run button should be at the end of the dialog.
<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
