### PR TITLE
Outputing covariance matrix from Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -97,7 +97,8 @@ class FittingTabModel(object):
             self, parameters_dict):
         alg = mantid.AlgorithmManager.create("Fit")
 
-        output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix = run_simultaneous_Fit(parameters_dict, alg)
+        output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix\
+            = run_simultaneous_Fit(parameters_dict, alg)
         if len(parameters_dict['InputWorkspace']) > 1:
             for input_workspace, output in zip(parameters_dict['InputWorkspace'], output_workspace.getNames()):
                 CopyLogs(InputWorkspace=input_workspace, OutputWorkspace=output, StoreInADS=False)

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -20,39 +20,39 @@ class FittingTabModel(object):
 
     def do_single_fit(self, parameter_dict):
         fit_group_name = parameter_dict.pop('FitGroupName')
-        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared = \
+        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix = \
             self.do_single_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
 
         self._handle_single_fit_results(parameter_dict['InputWorkspace'], function_object,
-                                        fitting_parameters_table, output_workspace, fit_group_name)
+                                        fitting_parameters_table, output_workspace, fit_group_name, covariance_matrix)
 
         return function_object.clone(), output_status, output_chi_squared
 
     def do_single_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
         alg = mantid.AlgorithmManager.create("Fit")
-        output_workspace, output_parameters, function_object, output_status, output_chi = run_Fit(parameters_dict, alg)
+        output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix = run_Fit(parameters_dict, alg)
         CopyLogs(InputWorkspace=parameters_dict['InputWorkspace'], OutputWorkspace=output_workspace, StoreInADS=False)
-        return output_workspace, output_parameters, function_object, output_status, output_chi
+        return output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix
 
     def do_single_tf_fit(self, parameter_dict, output_workspace_group):
         alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
-        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared =\
+        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix =\
             run_CalculateMuonAsymmetry(parameter_dict, alg)
 
         self._handle_single_fit_results(parameter_dict['ReNormalizedWorkspaceList'], function_object,
-                                        fitting_parameters_table, output_workspace, output_workspace_group)
+                                        fitting_parameters_table, output_workspace, output_workspace_group, covariance_matrix)
 
         return function_object.clone(), output_status, output_chi_squared
 
     def do_simultaneous_tf_fit(self, parameter_dict, global_parameters, fit_group_name):
         alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
-        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared =\
+        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix =\
             run_CalculateMuonAsymmetry(parameter_dict, alg)
 
         self._handle_simultaneous_fit_results(parameter_dict['ReNormalizedWorkspaceList'], function_object,
                                               fitting_parameters_table, output_workspace,
-                                              fit_group_name, global_parameters)
+                                              fit_group_name, global_parameters, covariance_matrix)
 
         return function_object, output_status, output_chi_squared
 
@@ -84,12 +84,12 @@ class FittingTabModel(object):
 
     def do_simultaneous_fit(self, parameter_dict, global_parameters):
         fit_group_name = parameter_dict.pop('FitGroupName')
-        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared = \
+        output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix = \
             self.do_simultaneous_fit_and_return_workspace_parameters_and_fit_function(parameter_dict)
 
         self._handle_simultaneous_fit_results(parameter_dict['InputWorkspace'], function_object,
                                               fitting_parameters_table, output_workspace,
-                                              fit_group_name, global_parameters)
+                                              fit_group_name, global_parameters, covariance_matrix)
 
         return function_object, output_status, output_chi_squared
 
@@ -97,13 +97,13 @@ class FittingTabModel(object):
             self, parameters_dict):
         alg = mantid.AlgorithmManager.create("Fit")
 
-        output_workspace, output_parameters, function_object, output_status, output_chi = run_simultaneous_Fit(parameters_dict, alg)
+        output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix = run_simultaneous_Fit(parameters_dict, alg)
         if len(parameters_dict['InputWorkspace']) > 1:
             for input_workspace, output in zip(parameters_dict['InputWorkspace'], output_workspace.getNames()):
                 CopyLogs(InputWorkspace=input_workspace, OutputWorkspace=output, StoreInADS=False)
         else:
             CopyLogs(InputWorkspace=parameters_dict['InputWorkspace'][0], OutputWorkspace=output_workspace, StoreInADS=False)
-        return output_workspace, output_parameters, function_object, output_status, output_chi
+        return output_workspace, output_parameters, function_object, output_status, output_chi, covariance_matrix
 
     def rename_members_of_fitted_workspace_group(self, group_workspace, inputworkspace_list, function, group_name):
         self.context.ads_observer.observeRename(False)
@@ -198,7 +198,7 @@ class FittingTabModel(object):
         return ConvertFitFunctionForMuonTFAsymmetry(StoreInADS=False, **algorithm_parameters)
 
     def _handle_simultaneous_fit_results(self, input_workspace_list, fit_function, fitting_parameters_table,
-                                         output_workspace, fit_group_name, global_parameters):
+                                         output_workspace, fit_group_name, global_parameters, covariance_matrix):
         if len(input_workspace_list) > 1:
             table_name, table_directory = self.create_parameter_table_name(input_workspace_list[0] + '+ ...',
                                                                            fit_function, fit_group_name)
@@ -206,6 +206,7 @@ class FittingTabModel(object):
                 input_workspace_list[0],
                 fit_function, fit_group_name)
             self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
+            self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
             workspace_name = self.rename_members_of_fitted_workspace_group(output_workspace,
                                                                            input_workspace_list,
                                                                            fit_function,
@@ -218,6 +219,7 @@ class FittingTabModel(object):
                 input_workspace_list[0],
                 fit_function, fit_group_name)
             self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
+            self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
             workspace_name = [workspace_name]
 
         wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name,
@@ -229,7 +231,7 @@ class FittingTabModel(object):
                                 global_parameters)
 
     def _handle_single_fit_results(self, input_workspace, fit_function, fitting_parameters_table,
-                                   output_workspace, fit_group_name):
+                                   output_workspace, fit_group_name, covariance_matrix):
         workspace_name, workspace_directory = self.create_fitted_workspace_name(
             input_workspace,
             fit_function,
@@ -239,6 +241,7 @@ class FittingTabModel(object):
                                                                        fit_group_name)
 
         self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
+        self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
         wrapped_parameter_workspace = self.add_workspace_to_ADS(fitting_parameters_table, table_name, table_directory)
         self.add_fit_to_context(wrapped_parameter_workspace,
                                 fit_function,

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -143,7 +143,8 @@ def run_Fit(parameters_dict, alg):
     alg.setProperty('EndX', parameters_dict['EndX'])
     alg.execute()
     return alg.getProperty("OutputWorkspace").value, alg.getProperty("OutputParameters").value, alg.getProperty(
-        "Function").value, alg.getProperty('OutputStatus').value, alg.getProperty('OutputChi2overDoF').value
+        "Function").value, alg.getProperty('OutputStatus').value, alg.getProperty('OutputChi2overDoF').value, \
+        alg.getProperty("OutputNormalisedCovarianceMatrix").value
 
 
 def run_simultaneous_Fit(parameters_dict, alg):
@@ -165,7 +166,7 @@ def run_simultaneous_Fit(parameters_dict, alg):
 
     return alg.getProperty('OutputWorkspace').value, alg.getProperty('OutputParameters').value, alg.getProperty('Function').value,\
         alg.getProperty('OutputStatus').value, alg.getProperty(
-            'OutputChi2overDoF').value
+            'OutputChi2overDoF').value, alg.getProperty("OutputNormalisedCovarianceMatrix").value
 
 
 def run_CalculateMuonAsymmetry(parameters_dict, alg):
@@ -176,7 +177,7 @@ def run_CalculateMuonAsymmetry(parameters_dict, alg):
     alg.execute()
     return alg.getProperty('OutputWorkspace').value, alg.getProperty('OutputParameters').value,\
         alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value,\
-        alg.getProperty('ChiSquared').value
+        alg.getProperty('ChiSquared').value, alg.getProperty("OutputNormalisedCovarianceMatrix").value
 
 
 def run_AppendSpectra(ws1, ws2):

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -57,7 +57,7 @@ class FittingTabModelTest(GuiTest):
         parameter_dict = {'Function': trial_function, 'InputWorkspace': workspace, 'Minimizer': 'Levenberg-Marquardt',
                           'StartX': 0.0, 'EndX': 100.0, 'EvaluationType': 'CentrePoint'}
 
-        output_workspace, parameter_table, fitting_function, fit_status, fit_chi_squared = self.model.do_single_fit_and_return_workspace_parameters_and_fit_function(
+        output_workspace, parameter_table, fitting_function, fit_status, fit_chi_squared, covariance_matrix = self.model.do_single_fit_and_return_workspace_parameters_and_fit_function(
             parameter_dict)
 
         self.assertAlmostEqual(parameter_table.row(0)['Value'], 5.0)


### PR DESCRIPTION
**Description of work.**

Currently the covariance matrix of fits done with muon analysis is not output to the ADS, this PR updates the fitting model so it writes these out to the ADS in the appropriate place.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
 * In Muon analysis do a single, sequential and simultaneous fit in both tf asymmetry mode and normal mode. Check that everything proceeds without error and covariance matrixes with appropriate names are added to the ADS.

<!-- Instructions for testing. -->


*There is no associated issue.*


*This does not require release notes* because this is adding minor functionality to a new GUI


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
