### PR TITLE
fix positions of 4 A-row packs for SEQ

### DIFF
--- a/instrument/SEQUOIA_Definition.xml
+++ b/instrument/SEQUOIA_Definition.xml
@@ -55,30 +55,31 @@
       <location/>
     </component>
   </type>
+
   <type name="A23">
     <component type="eightpack">
-      <location x="0.48679868" y="-2.55070008" z="5.34839183">
+      <location x="0.50646395" y="-2.55070008" z="5.48792794">
         <rot axis-x="0" axis-y="1" axis-z="0" val="185.20060450"/>
       </location>
     </component>
   </type>
   <type name="A24">
     <component type="eightpack">
-      <location x="0.30105326" y="-2.55070008" z="5.35989552">
+      <location x="0.29015287" y="-2.55070008" z="5.49609451">
         <rot axis-x="0" axis-y="1" axis-z="0" val="-177.15940965"/>
       </location>
     </component>
   </type>
   <type name="A25">
     <component type="eightpack">
-      <location x="0.04504793" y="-2.55070008" z="5.37939514">
+      <location x="0.06170000" y="-2.55070008" z="5.47092117">
         <rot axis-x="0" axis-y="1" axis-z="0" val="-179.51939634"/>
       </location>
     </component>
   </type>
   <type name="A26">
     <component type="eightpack">
-      <location x="-0.20796271" y="-2.55070008" z="5.36647180">
+      <location x="-0.18492334" y="-2.55070008" z="5.50032064">
         <rot axis-x="0" axis-y="1" axis-z="0" val="177.78079345"/>
       </location>
     </component>


### PR DESCRIPTION
**Description of work.**
In current SEQ instrument def file https://github.com/mantidproject/mantid/blob/de4e3123bf0397fb3e3821c5d868ffc6e833061c/instrument/SEQUOIA_Definition.xml#L58
the packs were placed to align with row B. Should be aligned to row C instead. It causes the incident energy calculation to be off for those packs. This PR updated their positions using corresponding packs in row C. More careful calibration will be done later.

Before this fix
![Screen Shot 2019-07-18 at 10 41 36 AM](https://user-images.githubusercontent.com/1796155/61467303-6264f100-a949-11e9-940a-ec853af0d4d5.png)

After this fix
![Screen Shot 2019-07-18 at 10 45 48 AM](https://user-images.githubusercontent.com/1796155/61467330-6bee5900-a949-11e9-9c8c-4e206af890d0.png)


**To test:**

* In mantid, load a recent run, for example 182230.
* run LoadInstrument and load the new xml
* run DGSReduction
* Use slice viewer to see the reduced spectrum (example above)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
