### PR TITLE
Add warning to sequential fit 

### DIFF
--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -26,6 +26,10 @@
 namespace MantidQt {
 using API::MantidDesktopServices;
 
+namespace {
+Mantid::Kernel::Logger g_log("SequentialFitDialog");
+}
+
 namespace MantidWidgets {
 
 /// Constructor
@@ -59,13 +63,21 @@ SequentialFitDialog::SequentialFitDialog(FitPropertyBrowser *fitBrowser,
   connect(fitBrowser, SIGNAL(functionChanged()), this, SLOT(functionChanged()));
 
   // When a fit is completed finishHandle is called which emits needShowPlot
-  connect(
+  bool connected = connect(
       this,
       SIGNAL(needShowPlot(Ui::SequentialFitDialog *,
                           MantidQt::MantidWidgets::FitPropertyBrowser *)),
       mantidui,
       SLOT(showSequentialPlot(Ui::SequentialFitDialog *,
                               MantidQt::MantidWidgets::FitPropertyBrowser *)));
+
+  // This has been added to warn users of a known bug #26333
+  // It should be removed once the bug has been fixed
+  if (!connected) {
+    g_log.warning("Unable to update plot and parameters in the fit function "
+                  "browser but the sequential fit has completed and is in the "
+                  "ADS. This is a known bug");
+  }
   connect(ui.tWorkspaces, SIGNAL(cellChanged(int, int)), this,
           SLOT(spectraChanged(int, int)));
   connect(ui.tWorkspaces, SIGNAL(itemSelectionChanged()), this,

--- a/qt/widgets/common/src/SequentialFitDialog.cpp
+++ b/qt/widgets/common/src/SequentialFitDialog.cpp
@@ -76,7 +76,7 @@ SequentialFitDialog::SequentialFitDialog(FitPropertyBrowser *fitBrowser,
   if (!connected) {
     g_log.warning("Unable to update plot and parameters in the fit function "
                   "browser but the sequential fit has completed and is in the "
-                  "ADS. This is a known bug");
+                  "Workspace Toolbox. This will be fixed in r4.2");
   }
   connect(ui.tWorkspaces, SIGNAL(cellChanged(int, int)), this,
           SLOT(spectraChanged(int, int)));


### PR DESCRIPTION
**Description of work.**
This PR adds a warning to users for the known bug in #26333. 

**To test:**
Follow instructions in #26333. When you press ok for the sequential fit a warning message should be outputted to the user. 

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
