### PR TITLE
Added try catch clause around failing call

### DIFF
--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -597,7 +597,10 @@ class SANSDataProcessorGui(QMainWindow,
         self._call_settings_listeners(lambda listener: listener.on_user_file_load())
 
     def on_user_file_load_failure(self):
-        self.gui_properties_handler.set_setting("user_file", "")
+        try:
+            self.gui_properties_handler.set_setting("user_file", "")
+        except AttributeError:
+            pass
         self.user_file_line_edit.setText("")
 
     def set_out_default_user_file(self):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -323,7 +323,8 @@ class RunTabPresenter(object):
                                                                    str)},
                                                     line_edits={"user_file":
                                                                 self._view.user_file_line_edit})
-            self._view.gui_properties_handler.set_setting("user_file", self._view.get_user_file_path())
+            if self._view.get_user_file_path() == '':
+                self._view.gui_properties_handler.set_setting("user_file", '')
 
     def on_user_file_load(self):
         """

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -323,6 +323,7 @@ class RunTabPresenter(object):
                                                                    str)},
                                                     line_edits={"user_file":
                                                                 self._view.user_file_line_edit})
+            self._view.gui_properties_handler.set_setting("user_file", self._view.get_user_file_path())
 
     def on_user_file_load(self):
         """


### PR DESCRIPTION
**Description of work.**

In the ISIS sans GUI, the last user file loaded is remembered and automatically loaded on the next start-up.  If the loading of this user file fails the GUI refuses to open as an un-handled exception is thrown. This adds a simple try catch block so this assertion is caught and handled.

**To test:**
[user_file.txt](https://github.com/mantidproject/mantid/files/3410785/user_file.txt)

  * Download the user file above
  * Open mantid, open the ISIS Sans interface and load in this user file.
  * Close mantid and rename the user file.
  * Open mantid again and try to open the ISIS Sans interface. A warning box should appear and then the gui should open with no userfile loaded
  * Check that the settings ini file has had the user file line removed
  * Repeat the step above and check that the interface opens empty with no error displayed.
  
<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because this a regression introduced in this release.



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
