### PR TITLE
Install missing Qt5 libraries/plugins in Workbench on Mac

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
@@ -91,8 +91,9 @@ mtd_add_qt_library(TARGET_NAME
                    MantidQtIcons
                    MantidQtWidgetsMplCpp
                    INSTALL_DIR_BASE
-                   ${PLUGINS_DIR}
+                   ${WORKBENCH_PLUGINS_DIR}
                    OSX_INSTALL_RPATH
                    @loader_path/../../Contents/MacOS
+                   @loader_path/../../plugins/qt5
                    LINUX_INSTALL_RPATH
                    "\$ORIGIN/../../${LIB_DIR}")

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -395,7 +395,8 @@ mtd_add_qt_library(
     MantidQtWidgetsPlotting
     MantidQtWidgetsMplCpp
     MantidQtIcons
-  INSTALL_DIR_BASE ${PLUGINS_DIR}
+  INSTALL_DIR_BASE
+    ${WORKBENCH_PLUGINS_DIR}
   OSX_INSTALL_RPATH
     @loader_path/../../Contents/MacOS
     @loader_path/../../plugins/qt5

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -188,15 +188,15 @@ mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesMuon
                      ${TCMALLOC_LIBRARIES_LINKTIME}
                      ${CORE_MANTIDLIBS}
                      ${POCO_LIBRARIES}
-					 ${PYTHON_LIBRARIES}
+                     ${PYTHON_LIBRARIES}
                      ${Boost_LIBRARIES}
                      ${JSONCPP_LIBRARIES}
                    MTD_QT_LINK_LIBS
                      MantidQtWidgetsCommon
-					 MantidQtWidgetsMplCpp
+     		     MantidQtWidgetsMplCpp
                      MantidQtWidgetsPlotting
                    INSTALL_DIR_BASE
-                     ${PLUGINS_DIR}
+                     ${WORKBENCH_PLUGINS_DIR}
                    OSX_INSTALL_RPATH
                      @loader_path/../../Contents/MacOS
                      @loader_path/../../plugins/qt5

--- a/qt/widgets/plotting/CMakeLists.txt
+++ b/qt/widgets/plotting/CMakeLists.txt
@@ -192,7 +192,7 @@ mtd_add_qt_library (TARGET_NAME MantidQtWidgetsPlotting
     MantidQtWidgetsCommon
     MantidQtWidgetsMplCpp
   INSTALL_DIR
-    ${LIB_DIR}
+    ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH
     @loader_path/../MacOS
   LINUX_INSTALL_RPATH


### PR DESCRIPTION
**Description of work.**

The Mac has 2 separate packages and install rules were putting the Qt5 libraries in MantidPlot instead of Workbench.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Build a package on Mac, start it and see that the Muon ALC, ISIS Reflectometry and Indirect interfaces are present.

Fixes #26420 

*This does not require release notes* because **the interfaces are new this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
