### PR TITLE
Only set min/max bounds for range selector if they are provided.

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -760,10 +760,11 @@ void IndirectTab::setRangeSelector(
     const boost::optional<QPair<double, double>> &range) {
   m_dblManager->setValue(lower, bounds.first);
   m_dblManager->setValue(upper, bounds.second);
-  rs->setRange(bounds.first, bounds.second);
   if (range) {
     rs->setMinimum(range.get().first);
     rs->setMaximum(range.get().second);
+    // clamp the bounds of the selector
+    rs->setRange(range.get().first, range.get().second);
   } else {
     rs->setMinimum(bounds.first);
     rs->setMaximum(bounds.second);


### PR DESCRIPTION
**Description of work.**

Fixes range selector being clamped when dragged on Indirect ResNorm interface.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Follow the instructions in the issue. 

Fixes #26393.

*This does not require release notes* because **it is a regression in this release.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
