### PR TITLE
Proxy improve error handling

### DIFF
--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -98,7 +98,7 @@ void DownloadInstrument::exec() {
     GitHubApiHelper inetHelper;
     g_log.debug(inetHelper.getRateLimitDescription());
   } catch (Mantid::Kernel::Exception::InternetError &ex) {
-    g_log.debug() << "Unable to get the rate limit from GitGub: " << ex.what()
+    g_log.debug() << "Unable to get the rate limit from GitHub: " << ex.what()
                   << '\n';
   }
 

--- a/Framework/DataHandling/src/DownloadInstrument.cpp
+++ b/Framework/DataHandling/src/DownloadInstrument.cpp
@@ -94,19 +94,28 @@ void DownloadInstrument::exec() {
 
   // to aid in general debugging, always ask github for what the rate limit
   // status is. This doesn't count against rate limit.
-  GitHubApiHelper inetHelper;
-  g_log.information(inetHelper.getRateLimitDescription());
+  try {
+    GitHubApiHelper inetHelper;
+    g_log.debug(inetHelper.getRateLimitDescription());
+  } catch (Mantid::Kernel::Exception::InternetError &ex) {
+    g_log.debug() << "Unable to get the rate limit from GitGub: " << ex.what()
+                  << '\n';
+  }
 
   try {
     fileMap = processRepository();
   } catch (Mantid::Kernel::Exception::InternetError &ex) {
     std::string errorText(ex.what());
     if (errorText.find("rate limit") != std::string::npos) {
-      g_log.notice() << "Instrument Definition Update: " << errorText << '\n';
+      g_log.information() << "Instrument Definition Update: " << errorText
+                          << '\n';
     } else {
       // log the failure at Notice Level
-      g_log.notice("Internet Connection Failed - cannot update instrument "
-                   "definitions.");
+      g_log.notice(
+          "Internet Connection Failed - cannot update instrument "
+          "definitions. Please check your connection. If you are behind a "
+          "proxy server, consider setting proxy.host and proxy.port in "
+          "the Mantid properties file or using the config object.");
       // log this error at information level
       g_log.information() << errorText << '\n';
     }


### PR DESCRIPTION
**Description of work.**
Catches the error when getting the rate limit fails.
Makes the notice log more user friendly.
Of course on macOS, if the `proxy.host` and `proxy.port` are not set in mantid configurations, internet connection will fail, just in a friendlier way.
Proper fix of connection should follow after the release; if those are not defined in mantid configs, it should be able to get from the environment variables/system settings.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Code review.

<!-- Instructions for testing. -->


*There is no associated issue.*
*This does not require release notes*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
