### PR TITLE
Avoid calculating cos(arccos(cos(x))) in SolidAngle

### DIFF
--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -118,6 +118,7 @@ struct GenericShape : public SolidAngleCalculator {
 struct Rectangle : public SolidAngleCalculator {
   using SolidAngleCalculator::SolidAngleCalculator;
   double solidAngle(size_t index) const override {
+    const V3D sampleDetVec = m_detectorInfo.position(index) - m_samplePos;
     const double cosTheta = sampleDetVec.cosAngle(m_beamLine);
     const double l2 = m_detectorInfo.l2(index);
     const V3D scaleFactor = m_componentInfo.scaleFactor(index);
@@ -142,6 +143,7 @@ struct Tube : public SolidAngleCalculator {
 struct Wing : public SolidAngleCalculator {
   using SolidAngleCalculator::SolidAngleCalculator;
   double solidAngle(size_t index) const override {
+    const V3D sampleDetVec = m_detectorInfo.position(index) - m_samplePos;
     const double cosTheta = sampleDetVec.cosAngle(m_beamLine);
     const double cosAlpha = m_alphaAngleCalculator->getAlpha(index);
     const double l2 = m_detectorInfo.l2(index);

--- a/Framework/Kernel/inc/MantidKernel/V3D.h
+++ b/Framework/Kernel/inc/MantidKernel/V3D.h
@@ -314,6 +314,8 @@ public:
   double zenith(const V3D &) const noexcept;
   /// Angle between this and another vector
   double angle(const V3D &) const;
+  /// cos(Angle) between this and another vector
+  double cosAngle(const V3D &) const;
   /// Direction angles
   V3D directionAngles(bool inDegrees = true) const;
   /// Maximum absolute integer value

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -189,7 +189,7 @@ double V3D::cosAngle(const V3D &v) const {
     throw std::runtime_error(
         "Cannot calculate an angle when one of the vectors has zero length.");
   }
-  return this->scalar_prod(v) / n1 * n2;
+  return this->scalar_prod(v) / (n1 * n2);
 }
 
 /**

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -183,13 +183,13 @@ double V3D::angle(const V3D &v) const {
  *  @return cosine of the angle between the vectors
  */
 double V3D::cosAngle(const V3D &v) const {
-  const double n1 = norm2();
-  const double n2 = v.norm2();
+  const double n1 = norm();
+  const double n2 = v.norm();
   if (n1 == 0. || n2 == 0.) {
     throw std::runtime_error(
         "Cannot calculate an angle when one of the vectors has zero length.");
   }
-  return this->scalar_prod(v) / std::sqrt(n1 * n2);
+  return this->scalar_prod(v) / n1 * n2;
 }
 
 /**

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -168,20 +168,28 @@ double V3D::zenith(const V3D &v) const noexcept {
  *  @return The angle between the vectors in radians (0 < theta < pi)
  */
 double V3D::angle(const V3D &v) const {
-  const double n1 = norm();
-  const double n2 = v.norm();
-  if (n1 == 0. || n2 == 0.) {
-    throw std::runtime_error(
-        "Cannot calculate an angle when one of the vectors has zero length.");
-  }
-  const double ratio = this->scalar_prod(v) / (n1 * n2);
-
+  const double ratio = this->cosAngle(v);
   if (ratio >= 1.0)       // NOTE: Due to rounding errors, if v is
     return 0.0;           //       is nearly the same as "this" or
   else if (ratio <= -1.0) //       as "-this", ratio can be slightly
     return M_PI;          //       more than 1 in absolute value.
                           //       That causes acos() to return NaN.
   return acos(ratio);
+}
+
+/** Calculates the cosine of angle between this and another vector.
+ *
+ *  @param v :: The other vector
+ *  @return cosine of the angle between the vectors
+ */
+double V3D::cosAngle(const V3D &v) const {
+  const double n1 = norm2();
+  const double n2 = v.norm2();
+  if (n1 == 0. || n2 == 0.) {
+    throw std::runtime_error(
+        "Cannot calculate an angle when one of the vectors has zero length.");
+  }
+  return this->scalar_prod(v) / std::sqrt(n1 * n2);
 }
 
 /**

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -280,6 +280,17 @@ public:
     TS_ASSERT_DELTA(a.angle(d), M_PI, 0.0001);
   }
 
+  void testCosAngle() {
+    a(2.0, 0.0, 0.0);
+    b(0.0, 1.0, 0.0);
+    c(1.0, 1.0, 0.0);
+    d(-1.0, 0.0, 0.0);
+    TS_ASSERT_DELTA(a.CosAngle(a), 1.0, 0.0001);
+    TS_ASSERT_DELTA(a.CosAngle(b), 0.0, 0.0001);
+    TS_ASSERT_DELTA(a.CosAngle(c), 1.0 / std::sqrt(2.0), 0.0001);
+    TS_ASSERT_DELTA(a.CosAngle(d), -1.0, 0.0001);
+  }
+
   void testRotate() {
     V3D direc(1, 1, 1);
     const double theta = 45.0 * M_PI / 180.0;

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -285,10 +285,10 @@ public:
     b(0.0, 1.0, 0.0);
     c(1.0, 1.0, 0.0);
     d(-1.0, 0.0, 0.0);
-    TS_ASSERT_DELTA(a.CosAngle(a), 1.0, 0.0001);
-    TS_ASSERT_DELTA(a.CosAngle(b), 0.0, 0.0001);
-    TS_ASSERT_DELTA(a.CosAngle(c), M_SQRT1_2, 0.0001);
-    TS_ASSERT_DELTA(a.CosAngle(d), -1.0, 0.0001);
+    TS_ASSERT_DELTA(a.cosAngle(a), 1.0, 0.0001);
+    TS_ASSERT_DELTA(a.cosAngle(b), 0.0, 0.0001);
+    TS_ASSERT_DELTA(a.cosAngle(c), M_SQRT1_2, 0.0001);
+    TS_ASSERT_DELTA(a.cosAngle(d), -1.0, 0.0001);
   }
 
   void testRotate() {

--- a/Framework/Kernel/test/V3DTest.h
+++ b/Framework/Kernel/test/V3DTest.h
@@ -287,7 +287,7 @@ public:
     d(-1.0, 0.0, 0.0);
     TS_ASSERT_DELTA(a.CosAngle(a), 1.0, 0.0001);
     TS_ASSERT_DELTA(a.CosAngle(b), 0.0, 0.0001);
-    TS_ASSERT_DELTA(a.CosAngle(c), 1.0 / std::sqrt(2.0), 0.0001);
+    TS_ASSERT_DELTA(a.CosAngle(c), M_SQRT1_2, 0.0001);
     TS_ASSERT_DELTA(a.CosAngle(d), -1.0, 0.0001);
   }
 

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -113,6 +113,8 @@ void export_V3D() {
            "Returns the distance between this vector and another")
       .def("angle", &V3D::angle, (arg("self"), arg("other")),
            "Returns the angle between this vector and another")
+      .def("cosAngle", &V3D::cosAngle, (arg("self"), arg("other")),
+           "Returns cos(angle) between this vector and another")
       .def("zenith", &V3D::zenith, (arg("self"), arg("other")),
            "Returns the zenith between this vector and another")
       .def("scalar_prod", &V3D::scalar_prod, (arg("self"), arg("other")),

--- a/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
@@ -49,7 +49,7 @@ class V3DTest(unittest.TestCase):
         self.assertAlmostEquals(a.cosAngle(a), 1.0)
         self.assertAlmostEquals(a.cosAngle(b), 0.0)
         self.assertAlmostEquals(a.cosAngle(c), 1.0 / np.sqrt(2.))
-        self.assertAlmostEquals(a.cosAangle(d), -1.0)
+        self.assertAlmostEquals(a.cosAngle(d), -1.0)
 
     def test_zenith(self):
         b = V3D(0.0, 0.0, 0.0)

--- a/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/V3DTest.py
@@ -41,6 +41,16 @@ class V3DTest(unittest.TestCase):
         self.assertAlmostEquals(a.angle(c), math.pi / 4.0)
         self.assertAlmostEquals(a.angle(d), math.pi)
 
+    def test_cos_angle(self):
+        a = V3D(2.0, 0.0, 0.0)
+        b = V3D(0.0, 1.0, 0.0)
+        c = V3D(1.0, 1.0, 0.0)
+        d = V3D(-1.0, 0.0, 0.0)
+        self.assertAlmostEquals(a.cosAngle(a), 1.0)
+        self.assertAlmostEquals(a.cosAngle(b), 0.0)
+        self.assertAlmostEquals(a.cosAngle(c), 1.0 / np.sqrt(2.))
+        self.assertAlmostEquals(a.cosAangle(d), -1.0)
+
     def test_zenith(self):
         b = V3D(0.0, 0.0, 0.0)
         a = V3D(9.9, 7.6, 0.0)


### PR DESCRIPTION
**Description of work.**

This adds `V3D::cosAngle(const V3D &)` to more efficiently calculate this quantity. Added unit tests and Python export.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because implementation detail.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
