### PR TITLE
SNAPReduce Cannot skip logs if the accumulation workspace doesn't exist

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -374,7 +374,7 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 self.__loaderName = loader.getPropertyValue('LoaderName')
             # only LoadEventNexus can turn off loading logs, but FilterBadPulses
             # requires them to be loaded from the file
-            canSkipLoadingLogs = self.__loaderName == 'LoadEventNexus' and self.filterBadPulses <= 0.
+            canSkipLoadingLogs = self.__loaderName == 'LoadEventNexus' and self.filterBadPulses <= 0. and haveAccumulationForFile
 
             if determineCharacterizations and j == 0:
                 self.__determineCharacterizations(filename, chunkname)  # updates instance variable


### PR DESCRIPTION
Originally reported by the SNAP team with the screenshot:
![image](https://user-images.githubusercontent.com/404003/61558577-771eb300-aa35-11e9-82fa-64ce9b02779e.png)
which can be reproduced using
```python
SNAPReduce(RunNumbers='43681', Calibration='Calibration File',
           CalibrationFilename='/SNS/SNAP/IPTS-22258/shared/SNAP_calibrate_d43677_2019_03_13.h5',
           Normalization='Extracted from Data', PeakClippingWindowSize=20, SmoothingRange=8)
```
where the "..._old" spectrum has the peaks in the correct positions. The main problem was a missed check for an existing workspace to copy the logs from in the process.

**Report to:** SNAP team

**To test:**

Try out the above script with `GroupDetectorsBy='Column'` before and after the change. With this change the peaks will line up in the reduced data.

*There is no associated issue.*

*This does not require release notes* because it was covered in an existing release note for SNAP.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
