### PR TITLE
Add a decorator to start QApplication and delete object on exit

### DIFF
--- a/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
@@ -9,6 +9,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import unittest
+
 import matplotlib
 matplotlib.use("AGG")  # noqa
 import matplotlib.pyplot as plt
@@ -17,7 +19,7 @@ from qtpy.QtWidgets import QMenu
 # Pulling in the MantidAxes registers the 'mantid' projection
 from mantid.plots import MantidAxes  # noqa:F401
 from mantid.simpleapi import CreateWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 
 
@@ -43,7 +45,8 @@ def plot_things(make_them_errors):
     return function_reference
 
 
-class FigureErrorsManagerTest(GuiTest):
+@start_qapplication
+class FigureErrorsManagerTest(unittest.TestCase):
     """
     Test class that covers the interaction of the FigureErrorsManager with plots
     that use the mantid projection and have MantidAxes
@@ -105,7 +108,8 @@ class FigureErrorsManagerTest(GuiTest):
         self.assertFalse(self.ax.containers[0][2][0].get_visible())
 
 
-class ScriptedPlotFigureErrorsManagerTest(GuiTest):
+@start_qapplication
+class ScriptedPlotFigureErrorsManagerTest(unittest.TestCase):
     """
     Test class that covers the interaction of the FigureErrorsManager with plots that
     do not use the MantidAxes, which happens if they are scripted.

--- a/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from mock import MagicMock, patch
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from workbench.plotting.figuremanager import FigureCanvasQTAgg, FigureManagerWorkbench
 
@@ -25,7 +25,8 @@ class MockLine2d(object):
         return self.y
 
 
-class FigureManagerWorkbenchTest(GuiTest):
+@start_qapplication
+class FigureManagerWorkbenchTest(unittest.TestCase):
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_construction(self, mock_qappthread):

--- a/qt/applications/workbench/workbench/plugins/test/test_editor.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_editor.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import QMainWindow
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plugins.editor import MultiFileEditor
 
 
@@ -20,7 +20,8 @@ def raise_exception(exception):
     raise exception
 
 
-class MultiFileEditorTest(GuiTest):
+@start_qapplication
+class MultiFileEditorTest(unittest.TestCase):
 
     def test_tab_session_restore(self):
         editor = MultiFileEditor(QMainWindow())

--- a/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_jupyterconsole.py
@@ -13,14 +13,15 @@ from __future__ import (absolute_import)
 import unittest
 
 # third-party library imports
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QMainWindow
 
 # local package imports
 from workbench.plugins.jupyterconsole import InProcessJupyterConsole, JupyterConsole
 
 
-class JupyterConsoleTest(GuiTest):
+@start_qapplication
+class JupyterConsoleTest(unittest.TestCase):
 
     def test_construction_creates_inprocess_console_widget(self):
         main_window = QMainWindow()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import QMainWindow, QApplication
 from mantid.simpleapi import (CreateEmptyTableWorkspace, CreateWorkspace,
                               GroupWorkspaces)
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 import matplotlib as mpl
 mpl.use('Agg')  # noqa
@@ -28,7 +28,8 @@ ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
 app = QApplication([])
 
 
-class WorkspaceWidgetTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
 
     @classmethod
     def setUpClass(cls):

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_projectrecoverywidgetview.py
@@ -9,12 +9,15 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
+import unittest
+
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.projectrecovery.recoverygui.projectrecoverywidgetview import ProjectRecoveryWidgetView
 
 
-class ProjectRecoveryWidgetViewTest(GuiTest):
+@start_qapplication
+class ProjectRecoveryWidgetViewTest(unittest.TestCase):
     def setUp(self):
         self.prw = ProjectRecoveryWidgetView(mock.MagicMock())
         self.prw.ui = mock.MagicMock()

--- a/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py
+++ b/qt/applications/workbench/workbench/projectrecovery/recoverygui/test/test_recoveryfailureview.py
@@ -9,14 +9,17 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
+import unittest
+
 from qtpy.QtWidgets import QTableWidgetItem
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.projectrecovery.recoverygui.recoveryfailureview import RecoveryFailureView
 
 
-class RecoveryFailureViewTest(GuiTest):
+@start_qapplication
+class RecoveryFailureViewTest(unittest.TestCase):
     def setUp(self):
         self.prw = RecoveryFailureView(mock.MagicMock())
 

--- a/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/test/test_plotselector_view.py
@@ -15,12 +15,13 @@ from qtpy.QtTest import QTest
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.widgets.plotselector.presenter import PlotSelectorPresenter
 from workbench.widgets.plotselector.view import EXPORT_TYPES, PlotSelectorView, Column
 
 
-class PlotSelectorWidgetTest(GuiTest):
+@start_qapplication
+class PlotSelectorWidgetTest(unittest.TestCase):
 
     def setUp(self):
         self.presenter = mock.Mock(spec=PlotSelectorPresenter)

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -7,8 +7,10 @@
 #  This file is part of the mantid workbench
 from __future__ import absolute_import, unicode_literals
 
+import unittest
+
 from mantid.py3compat.mock import call, patch, Mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from workbench.widgets.settings.general.presenter import GeneralSettings
 
@@ -39,7 +41,8 @@ class MockConfigService(object):
         self.setString = StrictMock()
 
 
-class GeneralSettingsTest(GuiTest):
+@start_qapplication
+class GeneralSettingsTest(unittest.TestCase):
     CONFIG_SERVICE_CLASSPATH = "workbench.widgets.settings.general.presenter.ConfigService"
     WORKBENCH_CONF_CLASSPATH = "workbench.widgets.settings.general.presenter.CONF"
 

--- a/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
+++ b/qt/applications/workbench/workbench/widgets/settings/test/test_settings_view.py
@@ -7,10 +7,12 @@
 #  This file is part of the mantid workbench
 from __future__ import absolute_import, unicode_literals
 
+import unittest
+
 from qtpy.QtWidgets import QApplication, QWidget
 
 from mantid.py3compat.mock import MagicMock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from workbench.widgets.settings.presenter import SettingsPresenter
 
@@ -40,7 +42,8 @@ class MockWorkspaceWidget(QWidget):
         self.close()
 
 
-class SettingsViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class SettingsViewTest(unittest.TestCase, QtWidgetFinder):
     def test_deletes_on_close(self):
         with MockWorkspaceWidget() as temp_widget:
             widget = SettingsPresenter(temp_widget)

--- a/qt/python/mantidqt/dialogs/test/test_algorithm_dialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_algorithm_dialog.py
@@ -16,7 +16,7 @@ from mantid.kernel import Direction, FloatArrayProperty
 from mantidqt.dialogs.algorithmdialog import AlgorithmDialog
 from mantidqt.dialogs.genericdialog import GenericDialog
 from mantidqt.interfacemanager import InterfaceManager
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
 class AlgorithmDialogMockAlgorithm(PythonAlgorithm):
@@ -34,7 +34,8 @@ class AlgorithmDialogMockAlgorithm(PythonAlgorithm):
         pass
 
 
-class TestAlgorithmDialog(GuiTest):
+@start_qapplication
+class TestAlgorithmDialog(unittest.TestCase):
 
     def setUp(self):
         AlgorithmFactory.subscribe(AlgorithmDialogMockAlgorithm)

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -13,10 +13,11 @@ from mantid.api import WorkspaceFactory
 from mantid.py3compat import mock
 from mantidqt.dialogs.spectraselectordialog import parse_selection_str, SpectraSelectionDialog
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class SpectraSelectionDialogTest(GuiTest):
+@start_qapplication
+class SpectraSelectionDialogTest(unittest.TestCase):
     _mock_get_icon = None
     _single_spec_ws = None
     _multi_spec_ws = None

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
@@ -5,16 +5,20 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
-from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QDialog
+from __future__ import absolute_import
+
+import unittest
 
 from mantid.api import WorkspaceFactory
 from mantid.py3compat import mock
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
+from qtpy.QtGui import QIcon
+from qtpy.QtWidgets import QDialog
 
 
-class SpectraSelectionUtilsTest(GuiTest):
+@start_qapplication
+class SpectraSelectionUtilsTest(unittest.TestCase):
     _mock_get_icon = None
     _single_spec_ws = None
     _multi_spec_ws = None

--- a/qt/python/mantidqt/icons/test/test_icons.py
+++ b/qt/python/mantidqt/icons/test/test_icons.py
@@ -6,15 +6,16 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
-
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+import unittest
 
 from mantidqt.icons import get_icon
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class IconsTest(GuiTest):
+@start_qapplication
+class IconsTest(unittest.TestCase):
     def test_get_icon_name(self):
         icon = get_icon("mdi.run-fast")
         self.assertEqual(icon.isNull(), False)
@@ -31,3 +32,7 @@ class IconsTest(GuiTest):
         icon = get_icon(["mdi.run-fast", "mdi.run"], [{"color": "red", "scaleFactor": 1.5},
                                                       {"color": "green", "scaleFactor": 1.2}])
         self.assertEqual(icon.isNull(), False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/project/test/test_encoderfactory.py
+++ b/qt/python/mantidqt/project/test/test_encoderfactory.py
@@ -8,15 +8,18 @@
 #
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+import unittest
+
 from mantidqt.project.encoderfactory import EncoderFactory
 from mantidqt.widgets.instrumentview.io import InstrumentViewEncoder
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
 from mantid.simpleapi import CreateSampleWorkspace
 from mantid.api import AnalysisDataService as ADS
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class EncoderFactoryTest(GuiTest):
+@start_qapplication
+class EncoderFactoryTest(unittest.TestCase):
     def setUp(self):
         EncoderFactory.register_encoder(InstrumentViewEncoder)
         CreateSampleWorkspace(OutputWorkspace="ws")

--- a/qt/python/mantidqt/utils/qt/testing/__init__.py
+++ b/qt/python/mantidqt/utils/qt/testing/__init__.py
@@ -12,25 +12,30 @@
 """
 from __future__ import absolute_import
 
-from unittest import TestCase
-
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, QObject
 
 from .application import get_application
 from .modal_tester import ModalTester
 from .gui_window_test import GuiWindowTest
 
 
-class GuiTest(TestCase):
-    """Base class for tests that require a QApplication instance
-    GuiTest ensures that a QApplication exists before tests are run
+def start_qapplication(cls):
     """
-    @classmethod
+    Unittest decorator. Adds or augments the setUpClass classmethod
+    to the given class. It starts the QApplication object
+    if it is not already started
+    @param cls: Class being decorated
+    """
+    def do_nothing(_):
+        pass
+
     def setUpClass(cls):
-        """Prepare for test execution.
-        Ensure that a (single copy of) QApplication has been created
-        """
-        get_application(cls.__name__)
+        get_application()
+        setUpClass_orig()
+
+    setUpClass_orig = cls.setUpClass if hasattr(cls, 'setUpClass') else do_nothing
+    setattr(cls, 'setUpClass', classmethod(setUpClass))
+    return cls
 
 
 def select_item_in_tree(tree, item_label):

--- a/qt/python/mantidqt/utils/qt/testing/application.py
+++ b/qt/python/mantidqt/utils/qt/testing/application.py
@@ -11,7 +11,9 @@ import atexit
 import sys
 import traceback
 
+from qtpy import PYQT4
 from qtpy.QtWidgets import QApplication
+import sip
 
 from mantidqt.utils.qt.plugins import setup_library_paths
 
@@ -25,6 +27,8 @@ def cleanup_qapp_ref():
     Remove the global reference to the QApplication object here
     """
     global _QAPP
+    if _QAPP is not None:
+        sip.delete(_QAPP)
     del _QAPP
 
 
@@ -43,6 +47,11 @@ def get_application(name=''):
     if _QAPP is None:
         setup_library_paths()
         _QAPP = QApplication([name])
+        if PYQT4:
+            # Do not destroy C++ Qtcore objects on exit
+            # Matches PyQt5 behaviour to avoid random segfaults
+            # https://www.riverbankcomputing.com/static/Docs/PyQt5/pyqt4_differences.html#object-destruction-on-exit
+            sip.setdestroyonexit(False)
         sys.excepthook = exception_handler
 
     return _QAPP

--- a/qt/python/mantidqt/utils/test/test_modal_tester.py
+++ b/qt/python/mantidqt/utils/test/test_modal_tester.py
@@ -14,10 +14,11 @@ import unittest
 from qtpy.QtWidgets import QInputDialog
 
 from mantid.py3compat.mock import patch
-from mantidqt.utils.qt.testing import GuiTest, ModalTester
+from mantidqt.utils.qt.testing import start_qapplication, ModalTester
 
 
-class TestModalTester(GuiTest):
+@start_qapplication
+class TestModalTester(unittest.TestCase):
 
     def test_pass_widget_closed(self):
         def testing_function(widget):

--- a/qt/python/mantidqt/utils/test/test_qt_utils.py
+++ b/qt/python/mantidqt/utils/test/test_qt_utils.py
@@ -22,11 +22,12 @@ try:
 except ImportError:
     NEW_STYLE_SIGNAL = True
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt import add_actions, create_action
 
 
-class CreateActionTest(GuiTest):
+@start_qapplication
+class CreateActionTest(unittest.TestCase):
 
     def test_parent_and_name_only_required(self):
         class Parent(QObject):
@@ -75,7 +76,8 @@ class CreateActionTest(GuiTest):
         self.assertEqual(Qt.WindowShortcut, action.shortcutContext())
 
 
-class AddActionsTest(GuiTest):
+@start_qapplication
+class AddActionsTest(unittest.TestCase):
 
     def test_add_actions_with_qmenu_target(self):
         test_act_1 = create_action(None, "Test Action 1")

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -13,7 +13,7 @@ from qtpy.QtCore import QCoreApplication, QObject
 import unittest
 
 from mantid.py3compat.mock import patch
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.writetosignal import WriteToSignal
 
 
@@ -24,7 +24,8 @@ class Receiver(QObject):
         self.captured_txt = txt
 
 
-class WriteToSignalTest(GuiTest):
+@start_qapplication
+class WriteToSignalTest(unittest.TestCase):
 
     def test_run_with_output_present(self):
         with patch("sys.stdout") as mock_stdout:

--- a/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/test/test_algorithmselector.py
@@ -10,16 +10,16 @@
 from __future__ import absolute_import
 
 from collections import Counter, namedtuple
-
-import qtpy
-from mantid.py3compat.mock import Mock, patch, call
 import unittest
 
+import qtpy
 from qtpy.QtCore import Qt
 from qtpy.QtTest import QTest
 
 from mantid.api import AlgorithmFactoryImpl
-from mantidqt.utils.qt.testing import select_item_in_combo_box, select_item_in_tree, GuiTest
+from mantid.py3compat.mock import Mock, patch, call
+from mantidqt.utils.qt.testing import (select_item_in_combo_box,
+                                       select_item_in_tree, start_qapplication)
 from mantidqt.widgets.algorithmselector.model import AlgorithmSelectorModel
 from mantidqt.widgets.algorithmselector.widget import AlgorithmSelectorWidget
 
@@ -79,7 +79,8 @@ createDialogFromName_func_name = ('mantidqt.interfacemanager.InterfaceManager.'
 
 
 @patch.object(AlgorithmFactoryImpl, 'getDescriptors', mock_get_algorithm_descriptors)
-class WidgetTest(GuiTest):
+@start_qapplication
+class WidgetTest(unittest.TestCase):
 
     # def setUp(self):
     #     self.getDescriptors_orig = AlgorithmFactoryImpl.getDescriptors

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
@@ -7,9 +7,11 @@
 #  This file is part of the mantidqt package
 from __future__ import absolute_import
 
+import unittest
+
 from qtpy.QtWidgets import QAction, QApplication, QWidget
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_assertions_helper import QtAssertionsHelper
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.utils.testing.strict_mock import StrictMock
@@ -37,7 +39,8 @@ class MockMultiFileInterpreter(QWidget):
         super(MockMultiFileInterpreter, self).closeEvent(event)
 
 
-class CodeEditorTabWidgetTest(GuiTest, QtWidgetFinder, QtAssertionsHelper):
+@start_qapplication
+class CodeEditorTabWidgetTest(unittest.TestCase, QtWidgetFinder, QtAssertionsHelper):
 
     def test_deleted_on_close(self):
         mock_mfp = MockMultiFileInterpreter()
@@ -77,3 +80,7 @@ class CodeEditorTabWidgetTest(GuiTest, QtWidgetFinder, QtAssertionsHelper):
         mock_mfp.close()
         QApplication.processEvents()
         self.assert_no_toplevel_widgets()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_codecommenter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_codecommenter.py
@@ -11,12 +11,13 @@ from copy import copy
 
 from qtpy.QtGui import QFont
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.codeeditor.codecommenter import CodeCommenter
 from mantidqt.widgets.codeeditor.editor import CodeEditor
 
 
-class CodeCommenterTest(GuiTest):
+@start_qapplication
+class CodeCommenterTest(unittest.TestCase):
 
     def setUp(self):
         self.lines = [

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_codeeditor.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_codeeditor.py
@@ -14,12 +14,13 @@ import unittest
 
 # local imports
 from mantidqt.widgets.codeeditor.editor import CodeEditor
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 TEST_LANG = "Python"
 
 
-class CodeEditorTest(GuiTest):
+@start_qapplication
+class CodeEditorTest(unittest.TestCase):
 
     # ---------------------------------------------------------------
     # Success tests

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_execution.py
@@ -18,7 +18,7 @@ import unittest
 from qtpy.QtCore import QCoreApplication, QObject
 
 # local imports
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.codeeditor.execution import PythonCodeExecution
 
 
@@ -45,7 +45,8 @@ class ReceiverWithProgress(Receiver):
         self.lines_received.append(lineno)
 
 
-class PythonCodeExecutionTest(GuiTest):
+@start_qapplication
+class PythonCodeExecutionTest(unittest.TestCase):
 
     def test_default_construction_yields_empty_context(self):
         executor = PythonCodeExecution()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter.py
@@ -12,11 +12,12 @@ from __future__ import (absolute_import, unicode_literals)
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
 
 
-class PythonFileInterpreterTest(GuiTest):
+@start_qapplication
+class PythonFileInterpreterTest(unittest.TestCase):
 
     def test_construction(self):
         w = PythonFileInterpreter()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_interpreter_view.py
@@ -9,12 +9,15 @@
 #
 from __future__ import (absolute_import, unicode_literals)
 
-from mantidqt.utils.qt.testing import GuiTest
+import unittest
+
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.codeeditor.interpreter import PythonFileInterpreter
 
 
-class PythonFileInterpreterViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class PythonFileInterpreterViewTest(unittest.TestCase, QtWidgetFinder):
     def test_find_replace_dialog(self):
         w = PythonFileInterpreter()
 

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, unicode_literals)
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
 
@@ -21,7 +21,8 @@ PERMISSION_BOX_FUNC = ('mantidqt.widgets.codeeditor.scriptcompatibility.'
                        'permission_box_to_prepend_import')
 
 
-class MultiPythonFileInterpreterTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
 
     def test_default_contains_single_editor(self):
         widget = MultiPythonFileInterpreter()

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_multifileinterpreter_view.py
@@ -13,12 +13,13 @@ import unittest
 
 from qtpy.QtWidgets import QApplication
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.codeeditor.multifileinterpreter import MultiPythonFileInterpreter
 
 
-class MultiPythonFileInterpreterDeletionTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class MultiPythonFileInterpreterDeletionTest(unittest.TestCase, QtWidgetFinder):
     def test_editor_widget_not_leaked(self):
         widget = MultiPythonFileInterpreter()
         self.assertEqual(1, widget.editor_count)

--- a/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
+++ b/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
@@ -8,11 +8,13 @@
 #
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+import unittest
+
 from mantidqt.project.encoderfactory import EncoderFactory
 from mantidqt.project.decoderfactory import DecoderFactory
 from mantidqt.widgets.instrumentview.io import InstrumentViewEncoder, InstrumentViewDecoder
 from mantid.simpleapi import CreateSampleWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
 INSTRUMENT_VIEW_DICT = {u'workspaceName': u'ws',
@@ -51,7 +53,8 @@ INSTRUMENT_VIEW_DICT = {u'workspaceName': u'ws',
                         u'currentTab': 0}
 
 
-class InstrumentViewEncoderTest(GuiTest):
+@start_qapplication
+class InstrumentViewEncoderTest(unittest.TestCase):
     def setUp(self):
         self.encoder = InstrumentViewEncoder()
         CreateSampleWorkspace(OutputWorkspace="ws")
@@ -70,7 +73,8 @@ class InstrumentViewEncoderTest(GuiTest):
         self.assertDictEqual(self.encoder.encode(self.instrumentView), INSTRUMENT_VIEW_DICT)
 
 
-class InstrumentViewDecoderTest(GuiTest):
+@start_qapplication
+class InstrumentViewDecoderTest(unittest.TestCase):
     def setUp(self):
         self.decoder = InstrumentViewDecoder()
 

--- a/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
+++ b/qt/python/mantidqt/widgets/instrumentview/test/test_instrumentview_view.py
@@ -7,15 +7,18 @@
 #  This file is part of the mantid workbench.
 from __future__ import absolute_import, unicode_literals
 
+import unittest
+
 from qtpy.QtWidgets import QApplication
 
 from mantid.simpleapi import CreateSampleWorkspace, LoadInstrument
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
 
 
-class InstrumentViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class InstrumentViewTest(unittest.TestCase, QtWidgetFinder):
     def test_window_deleted_correctly(self):
         ws = CreateSampleWorkspace()
         LoadInstrument(ws, InstrumentName='MARI', RewriteSpectraMap=False)

--- a/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -5,17 +5,21 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from qtpy.QtWidgets import QApplication
+from __future__ import absolute_import
+
+import unittest
 
 import matplotlib as mpl
 mpl.use('Agg')  # noqa
 from mantid.simpleapi import CreateSampleWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
+from qtpy.QtWidgets import QApplication
 
 
-class SampleLogsViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class SampleLogsViewTest(unittest.TestCase, QtWidgetFinder):
     def test_deleted_on_close(self):
         ws = CreateSampleWorkspace()
         pres = SampleLogs(ws)

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -5,17 +5,21 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from qtpy.QtWidgets import QApplication
+from __future__ import absolute_import
+
+import unittest
 
 import matplotlib as mpl
 mpl.use('Agg')  # noqa
 from mantid.simpleapi import CreateMDHistoWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
+from qtpy.QtWidgets import QApplication
 
 
-class SliceViewerViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
     def test_deleted_on_close(self):
         ws = CreateMDHistoWorkspace(Dimensionality=3,
                                     Extents='-3,3,-10,10,-1,1',

--- a/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
+++ b/qt/python/mantidqt/widgets/test/test_jupyterconsole.py
@@ -18,10 +18,11 @@ import unittest
 
 # local package imports
 from mantidqt.widgets.jupyterconsole import InProcessJupyterConsole
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class InProcessJupyterConsoleTest(GuiTest):
+@start_qapplication
+class InProcessJupyterConsoleTest(unittest.TestCase):
 
     def test_construction_raises_no_errors(self):
         widget = InProcessJupyterConsole()

--- a/qt/python/mantidqt/widgets/test/test_messagedisplay.py
+++ b/qt/python/mantidqt/widgets/test/test_messagedisplay.py
@@ -13,10 +13,11 @@ from __future__ import (absolute_import, division, print_function,
 import unittest
 
 from mantidqt.widgets.messagedisplay import MessageDisplay
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class MessageDisplayTest(GuiTest):
+@start_qapplication
+class MessageDisplayTest(unittest.TestCase):
     """Minimal testing as it is exported from C++"""
 
     def test_widget_creation(self):

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
@@ -6,8 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
+from __future__ import absolute_import
 
-from mantidqt.utils.qt.testing import GuiTest
+import unittest
+
+from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import CreateSampleWorkspace
 from mantidqt.widgets.workspacedisplay.matrix.io import MatrixWorkspaceDisplayDecoder, MatrixWorkspaceDisplayEncoder
 from mantidqt.widgets.workspacedisplay.matrix import StatusBarView, MatrixWorkspaceDisplay
@@ -16,7 +19,8 @@ from mantidqt.widgets.workspacedisplay.matrix import StatusBarView, MatrixWorksp
 MATRIXWORKSPACEDISPLAY_DICT = {"workspace": "ws"}
 
 
-class MatrixWorkspaceDisplayEncoderTest(GuiTest):
+@start_qapplication
+class MatrixWorkspaceDisplayEncoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = CreateSampleWorkspace(OutputWorkspace="ws")
         self.encoder = MatrixWorkspaceDisplayEncoder()
@@ -26,7 +30,8 @@ class MatrixWorkspaceDisplayEncoderTest(GuiTest):
         self.assertEqual(MATRIXWORKSPACEDISPLAY_DICT, self.encoder.encode(self.view))
 
 
-class MatrixWorkspaceDisplayDecoderTest(GuiTest):
+@start_qapplication
+class MatrixWorkspaceDisplayDecoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = CreateSampleWorkspace(OutputWorkspace="ws")
         self.decoder = MatrixWorkspaceDisplayDecoder()

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_view.py
@@ -5,15 +5,19 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from qtpy.QtWidgets import QApplication
+from __future__ import absolute_import
+
+import unittest
 
 from mantid.simpleapi import CreateSampleWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDisplay
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
+from qtpy.QtWidgets import QApplication
 
 
-class MatrixWorkspaceDisplayViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class MatrixWorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
     def test_window_deleted_correctly(self):
         ws = CreateSampleWorkspace()
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
@@ -6,8 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
+from __future__ import (absolute_import, print_function)
 
-from mantidqt.utils.qt.testing import GuiTest
+import unittest
+
+from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import Load
 from mantidqt.widgets.workspacedisplay.table.io import TableWorkspaceDisplayDecoder, TableWorkspaceDisplayEncoder
 from mantidqt.widgets.workspacedisplay.table import StatusBarView
@@ -18,7 +21,8 @@ TABLEWORKSPACEDISPLAY_DICT = {"markedColumns": {"as_y": [2], "as_x": [1],
                               "workspace": "ws", "windowName": "ws"}
 
 
-class TableWorkspaceDisplayEncoderTest(GuiTest):
+@start_qapplication
+class TableWorkspaceDisplayEncoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = Load("SavedTableWorkspace.nxs", OutputWorkspace="ws")
         self.encoder = TableWorkspaceDisplayEncoder()
@@ -28,7 +32,8 @@ class TableWorkspaceDisplayEncoderTest(GuiTest):
         self.assertEqual(TABLEWORKSPACEDISPLAY_DICT, self.encoder.encode(self.view))
 
 
-class TableWorkspaceDisplayDecoderTest(GuiTest):
+@start_qapplication
+class TableWorkspaceDisplayDecoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = Load("SavedTableWorkspace.nxs", OutputWorkspace="ws")
         self.decoder = TableWorkspaceDisplayDecoder()
@@ -51,3 +56,7 @@ class TableWorkspaceDisplayDecoderTest(GuiTest):
             TABLEWORKSPACEDISPLAY_DICT["markedColumns"]["as_y_err"][0]["labelIndex"],
             view.presenter.model.marked_columns.as_y_err[0].label_index)
         self.assertEqual(1, len(view.presenter.model.marked_columns.as_y_err))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
@@ -5,15 +5,20 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from __future__ import (absolute_import, print_function)
+
+import unittest
+
 from qtpy.QtWidgets import QApplication
 
 from mantid.simpleapi import CreateEmptyTableWorkspace
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 
-class TableWorkspaceDisplayViewTest(GuiTest, QtWidgetFinder):
+@start_qapplication
+class TableWorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_window_deleted_correctly(self):
         ws = CreateEmptyTableWorkspace()
@@ -40,3 +45,7 @@ class TableWorkspaceDisplayViewTest(GuiTest, QtWidgetFinder):
         self.assertEqual(None, p.ads_observer)
         self.assert_widget_not_present("work")
         self.assert_no_toplevel_widgets()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
+++ b/qt/python/mantidqt/widgets/workspacewidget/test/test_workspacetreewidget.py
@@ -12,11 +12,12 @@ from __future__ import absolute_import, print_function
 import unittest
 
 from mantidqt.widgets.workspacewidget.workspacetreewidget import WorkspaceTreeWidget
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 import sip
 
 
-class WorkspaceWidgetTest(GuiTest):
+@start_qapplication
+class WorkspaceWidgetTest(unittest.TestCase):
     """Minimal testing as it is exported from C++"""
 
     def test_widget_creation(self):

--- a/scripts/test/MultiPlotting/AxisChangerTwoView_test.py
+++ b/scripts/test/MultiPlotting/AxisChangerTwoView_test.py
@@ -7,12 +7,13 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from MultiPlotting.AxisChanger.axis_changer_view import AxisChangerView
 
 
-class AxisChangerTwoViewTest(GuiTest):
+@start_qapplication
+class AxisChangerTwoViewTest(unittest.TestCase):
     def setUp(self):
         label = "test"
         self.view = AxisChangerView(label)

--- a/scripts/test/MultiPlotting/MultiPlotWidget_test.py
+++ b/scripts/test/MultiPlotting/MultiPlotWidget_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from MultiPlotting.multi_plotting_context import PlottingContext
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
@@ -41,7 +41,8 @@ def data():
     return values
 
 
-class MultiPlotWidgetTest(GuiTest):
+@start_qapplication
+class MultiPlotWidgetTest(unittest.TestCase):
 
     def setUp(self):
         context = PlottingContext()

--- a/scripts/test/MultiPlotting/QuickEditWidget_test.py
+++ b/scripts/test/MultiPlotting/QuickEditWidget_test.py
@@ -7,13 +7,14 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from MultiPlotting.QuickEdit.quickEdit_presenter import QuickEditPresenter
 from MultiPlotting.QuickEdit.quickEdit_widget import QuickEditWidget
 
 
-class QuickEditWidgetTest(GuiTest):
+@start_qapplication
+class QuickEditWidgetTest(unittest.TestCase):
     def setUp(self):
         self.pres = mock.create_autospec(QuickEditPresenter)
         self.widget = QuickEditWidget()

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -8,7 +8,7 @@ import unittest
 from matplotlib.gridspec import GridSpec
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from MultiPlotting.multi_plotting_context import PlottingContext
 from MultiPlotting.subplot.subplot import subplot
@@ -21,7 +21,8 @@ def rm_logic(name):
     return True
 
 
-class SubplotTest(GuiTest):
+@start_qapplication
+class SubplotTest(unittest.TestCase):
 
     def setUp(self):
         context = PlottingContext()

--- a/scripts/test/Muon/LoadWidgetPresenter_test.py
+++ b/scripts/test/Muon/LoadWidgetPresenter_test.py
@@ -7,14 +7,15 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.load_widget.load_presenter import LoadPresenter
 from Muon.GUI.Common.load_widget.load_view import LoadView
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
 
 
-class LoadPresenterTest(GuiTest):
+@start_qapplication
+class LoadPresenterTest(unittest.TestCase):
     def setUp(self):
         self._view = mock.create_autospec(LoadView)
         self._load_model = mock.create_autospec(LoadModel)

--- a/scripts/test/Muon/LoadWidgetView_test.py
+++ b/scripts/test/Muon/LoadWidgetView_test.py
@@ -7,12 +7,13 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.load_widget.load_view import LoadView
 
 
-class LoadViewTest(GuiTest):
+@start_qapplication
+class LoadViewTest(unittest.TestCase):
     def setUp(self):
         self.view = LoadView()
         self.slot = mock.Mock()

--- a/scripts/test/Muon/PeriodicTablePresenter_test.py
+++ b/scripts/test/Muon/PeriodicTablePresenter_test.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, print_function
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table import PeriodicTable as silxPT, PeriodicTableItem
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import PeriodicTableModel
@@ -17,7 +17,8 @@ from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter import Pe
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
 
 
-class PeriodicTablePresenterTest(GuiTest):
+@start_qapplication
+class PeriodicTablePresenterTest(unittest.TestCase):
 
     def setUp(self):
         self._model = mock.create_autospec(PeriodicTableModel)

--- a/scripts/test/Muon/PlottingView_test.py
+++ b/scripts/test/Muon/PlottingView_test.py
@@ -12,7 +12,7 @@ import unittest
 from matplotlib.figure import Figure
 from mantid import WorkspaceFactory, plots
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.ElementalAnalysis.Plotting.subPlot_object import subPlot
 from Muon.GUI.ElementalAnalysis.Plotting.plotting_view import PlotView
@@ -38,7 +38,8 @@ def get_subPlot(name):
 
 @unittest.skipIf(lambda: sys.platform=='win32'(),
                  "Test segfaults on Windows and code will be removed soon")
-class PlottingViewHelperFunctionTests(GuiTest):
+@start_qapplication
+class PlottingViewHelperFunctionTests(unittest.TestCase):
 
     def setUp(self):
         self.view = PlotView()
@@ -292,7 +293,8 @@ class PlottingViewHelperFunctionTests(GuiTest):
 
 
 @unittest.skipIf(lambda: sys.platform=='win32'(), "Test segfaults on Windows and code will be removed soon")
-class PlottingViewPlotFunctionsTests(GuiTest):
+@start_qapplication
+class PlottingViewPlotFunctionsTests(unittest.TestCase):
 
     def setUp(self):
 

--- a/scripts/test/Muon/fft_presenter_context_interaction_test.py
+++ b/scripts/test/Muon/fft_presenter_context_interaction_test.py
@@ -8,7 +8,7 @@ import unittest
 
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
@@ -27,7 +27,8 @@ def retrieve_combobox_info(combo_box):
     return output_list
 
 
-class FFTPresenterTest(GuiTest):
+@start_qapplication
+class FFTPresenterTest(unittest.TestCase):
     def setUp(self):
         self.context = setup_context(True)
 

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, unicode_literals)
 
 from collections import OrderedDict
 import unittest
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from mantid.api import AnalysisDataService, WorkspaceFactory, WorkspaceGroup
 from mantid.kernel import FloatTimeSeriesProperty, StringPropertyWithValue
@@ -83,7 +83,8 @@ def create_test_fit_parameters(test_parameters, global_parameters=None):
     return FitParameters(parameter_workspace, global_parameters)
 
 
-class FittingContextTest(GuiTest):
+@start_qapplication
+class FittingContextTest(unittest.TestCase):
     def setUp(self):
         self.fitting_context = FittingContext()
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -10,10 +10,11 @@ from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from mantid.api import FunctionFactory, AnalysisDataService
 from mantid.simpleapi import CreateWorkspace
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class FittingTabModelTest(GuiTest):
+@start_qapplication
+class FittingTabModelTest(unittest.TestCase):
     def setUp(self):
         self.model = FittingTabModel(setup_context())
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -8,7 +8,7 @@ import unittest
 
 from mantid.api import FunctionFactory
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy import QtWidgets
 
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
@@ -33,7 +33,8 @@ def wait_for_thread(thread_model):
         QtWidgets.QApplication.instance().processEvents()
 
 
-class FittingTabPresenterTest(GuiTest):
+@start_qapplication
+class FittingTabPresenterTest(unittest.TestCase):
     def setUp(self):
         self.context = setup_context()
         self.context.data_context.current_runs = [[62260]]

--- a/scripts/test/Muon/fitting_tab_widget/workspace_selector_dialog_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/workspace_selector_dialog_presenter_test.py
@@ -7,13 +7,14 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.fitting_tab_widget.workspace_selector_view import WorkspaceSelectorView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
-class WorkspaceSelectorPresenterTest(GuiTest):
+@start_qapplication
+class WorkspaceSelectorPresenterTest(unittest.TestCase):
     def setUp(self):
         self.current_runs = [[22725]]
         self.context = setup_context()

--- a/scripts/test/Muon/frequency_domain_context_test.py
+++ b/scripts/test/Muon/frequency_domain_context_test.py
@@ -18,10 +18,11 @@ if sys.version_info.major < 2:
     from unittest import mock
 else:
     import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 
-class MuonDataContextTest(GuiTest):
+@start_qapplication
+class MuonDataContextTest(unittest.TestCase):
     def setUp(self):
         setup_context_for_tests(self)
         self.gui_variable_observer = Observer()

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -7,7 +7,7 @@
 import unittest
 import six
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_presenter import GroupingTabPresenter
@@ -20,7 +20,8 @@ from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import Pairi
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
-class GroupingTabPresenterTest(GuiTest):
+@start_qapplication
+class GroupingTabPresenterTest(unittest.TestCase):
     def setUp(self):
         self.loaded_data = MuonLoadData()
 

--- a/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_table_presenter_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
@@ -27,7 +27,8 @@ def group_name():
     return name
 
 
-class GroupingTablePresenterTest(GuiTest):
+@start_qapplication
+class GroupingTablePresenterTest(unittest.TestCase):
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_alpha_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
@@ -26,7 +26,8 @@ def pair_name():
     return name
 
 
-class AlphaTest(GuiTest):
+@start_qapplication
+class AlphaTest(unittest.TestCase):
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_group_selector_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import GroupingTabModel
@@ -24,7 +24,8 @@ def pair_name():
     return name
 
 
-class GroupSelectorTest(GuiTest):
+@start_qapplication
+class GroupSelectorTest(unittest.TestCase):
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 import six
 from qtpy.QtWidgets import QWidget
 
@@ -24,7 +24,8 @@ def pair_name():
         name.append("pair_" + str(i+1))
     return name
 
-class PairingTablePresenterTest(GuiTest):
+@start_qapplication
+class PairingTablePresenterTest(unittest.TestCase):
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/scripts/test/Muon/help_widget_presenter_test.py
+++ b/scripts/test/Muon/help_widget_presenter_test.py
@@ -7,14 +7,15 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.help_widget.help_widget_presenter import HelpWidgetPresenter
 from Muon.GUI.Common.help_widget.help_widget_view import HelpWidgetView
 
 
 
-class HelpWidgetPresenterTest(GuiTest):
+@start_qapplication
+class HelpWidgetPresenterTest(unittest.TestCase):
     def setUp(self):
         self.view = HelpWidgetView("test")
         self.presenter = HelpWidgetPresenter(self.view)

--- a/scripts/test/Muon/home_grouping_widget_test.py
+++ b/scripts/test/Muon/home_grouping_widget_test.py
@@ -8,7 +8,7 @@ import unittest
 from mantid import ConfigService
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 import Muon.GUI.Common.utilities.load_utils as load_utils
@@ -51,7 +51,8 @@ def perform_musr_file_finder(self):
     self.presenter.update_group_pair_list()
 
 
-class HomeTabGroupingPresenterTest(GuiTest):
+@start_qapplication
+class HomeTabGroupingPresenterTest(unittest.TestCase):
     def setUp(self):
         self.obj = QWidget()
         setup_context_for_tests(self)

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -9,7 +9,7 @@ import unittest
 
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_model import InstrumentWidgetModel
@@ -21,7 +21,8 @@ from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_view import D
     DEADTIME_WORKSPACE, DEADTIME_OTHER_FILE, DEADTIME_NONE
 
 
-class HomeTabInstrumentPresenterTest(GuiTest):
+@start_qapplication
+class HomeTabInstrumentPresenterTest(unittest.TestCase):
     def setUp(self):
         self.obj = QWidget()
         setup_context_for_tests(self)

--- a/scripts/test/Muon/home_plot_widget_test.py
+++ b/scripts/test/Muon/home_plot_widget_test.py
@@ -7,14 +7,15 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from Muon.GUI.Common.home_plot_widget.home_plot_widget_presenter import HomePlotWidgetPresenter
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.contexts.fitting_context import FitInformation
 
 
-class HomeTabPlotPresenterTest(GuiTest):
+@start_qapplication
+class HomeTabPlotPresenterTest(unittest.TestCase):
     def setUp(self):
         self.context = mock.MagicMock()
         self.plotting_window_model = mock.MagicMock()

--- a/scripts/test/Muon/home_runinfo_presenter_test.py
+++ b/scripts/test/Muon/home_runinfo_presenter_test.py
@@ -7,7 +7,7 @@
 import unittest
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
 
 import Muon.GUI.Common.utilities.load_utils as load_utils
@@ -19,7 +19,8 @@ from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class HomeTabRunInfoPresenterTest(GuiTest):
+@start_qapplication
+class HomeTabRunInfoPresenterTest(unittest.TestCase):
     def setUp(self):
         self.obj = QWidget()
         setup_context_for_tests(self)

--- a/scripts/test/Muon/list_selector/list_selector_presenter_test.py
+++ b/scripts/test/Muon/list_selector/list_selector_presenter_test.py
@@ -7,12 +7,13 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.list_selector.list_selector_presenter import ListSelectorPresenter
 
 
-class TestListSelectorPresenter(GuiTest):
+@start_qapplication
+class TestListSelectorPresenter(unittest.TestCase):
     def setUp(self):
         self.view = mock.MagicMock()
         self.model = {

--- a/scripts/test/Muon/list_selector/list_selector_view_test.py
+++ b/scripts/test/Muon/list_selector/list_selector_view_test.py
@@ -7,13 +7,14 @@
 
 import unittest
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy import QtCore
 
 from Muon.GUI.Common.list_selector.list_selector_view import ListSelectorView
 
 
-class TestListSelectorView(GuiTest):
+@start_qapplication
+class TestListSelectorView(unittest.TestCase):
     def setUp(self):
         self.view = ListSelectorView()
 

--- a/scripts/test/Muon/load_file_widget/loadfile_model_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_model_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import unittest
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 import six
 
@@ -14,7 +14,8 @@ from Muon.GUI.Common.load_file_widget.model import BrowseFileWidgetModel
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadFileWidgetModelTest(GuiTest):
+@start_qapplication
+class LoadFileWidgetModelTest(unittest.TestCase):
 
     def setUp(self):
         setup_context_for_tests(self)

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication
 import six
 
@@ -45,7 +45,8 @@ class IteratorWithException:
     next = __next__
 
 
-class LoadFileWidgetPresenterMultipleFileModeTest(GuiTest):
+@start_qapplication
+class LoadFileWidgetPresenterMultipleFileModeTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
         def run_twice(self):
             test_function(self)

--- a/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication
 
 from Muon.GUI.Common.load_file_widget.model import BrowseFileWidgetModel
@@ -16,7 +16,8 @@ from Muon.GUI.Common.load_file_widget.view import BrowseFileWidgetView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadFileWidgetPresenterTest(GuiTest):
+@start_qapplication
+class LoadFileWidgetPresenterTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
 
         def run_twice(self):

--- a/scripts/test/Muon/load_file_widget/loadfile_view_test.py
+++ b/scripts/test/Muon/load_file_widget/loadfile_view_test.py
@@ -6,12 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.load_file_widget.view import BrowseFileWidgetView
 
 
-class LoadFileWidgetViewTest(GuiTest):
+@start_qapplication
+class LoadFileWidgetViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = BrowseFileWidgetView()

--- a/scripts/test/Muon/load_run_widget/loadrun_model_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_model_test.py
@@ -7,14 +7,15 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 from Muon.GUI.Common.utilities.muon_test_helpers import IteratorWithException
 
 
-class LoadRunWidgetModelTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetModelTest(unittest.TestCase):
     def setUp(self):
         setup_context_for_tests(self)
         self.data_context.instrument = 'EMU'

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 import Muon.GUI.Common.utilities.muon_file_utils as fileUtils
@@ -16,7 +16,8 @@ from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadRunWidgetLoadCurrentRunTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
         def run_twice(self):
             test_function(self)

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -8,7 +8,7 @@ import os
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
@@ -17,7 +17,8 @@ from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadRunWidgetIncrementDecrementSingleFileModeTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
         def run_twice(self):
             test_function(self)

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 import six
 
@@ -17,7 +17,8 @@ from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadRunWidgetIncrementDecrementMultipleFileModeTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
         def run_twice(self):
             test_function(self)

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 from Muon.GUI.Common.load_run_widget.load_run_model import LoadRunWidgetModel
@@ -16,7 +16,8 @@ from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
 
-class LoadRunWidgetPresenterTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetPresenterTest(unittest.TestCase):
     def run_test_with_and_without_threading(test_function):
         def run_twice(self):
             test_function(self)

--- a/scripts/test/Muon/load_run_widget/loadrun_view_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_view_test.py
@@ -6,12 +6,13 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.load_run_widget.load_run_view import LoadRunWidgetView
 
 
-class LoadRunWidgetViewTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = LoadRunWidgetView()

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
@@ -24,7 +24,8 @@ from mantid.simpleapi import CreateSampleWorkspace, LoadInstrument
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 
 
-class LoadRunWidgetPresenterLoadFailTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetPresenterLoadFailTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
@@ -9,7 +9,7 @@ import unittest
 from mantid import ConfigService
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 from Muon.GUI.Common.load_file_widget.model import BrowseFileWidgetModel
@@ -25,7 +25,8 @@ from Muon.GUI.MuonAnalysis.load_widget.load_widget_presenter import LoadWidgetPr
 from Muon.GUI.MuonAnalysis.load_widget.load_widget_view import LoadWidgetView
 
 
-class LoadRunWidgetPresenterMultipleFileTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetPresenterMultipleFileTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()

--- a/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
+++ b/scripts/test/Muon/loading_tab/loadwidget_presenter_test.py
@@ -7,7 +7,7 @@
 import unittest
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
 
 import Muon.GUI.Common.utilities.muon_file_utils as file_utils
@@ -25,7 +25,8 @@ from mantid.simpleapi import CreateSampleWorkspace, LoadInstrument
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 
 
-class LoadRunWidgetPresenterTest(GuiTest):
+@start_qapplication
+class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()

--- a/scripts/test/Muon/max_ent_presenter_load_interaction_test.py
+++ b/scripts/test/Muon/max_ent_presenter_load_interaction_test.py
@@ -10,7 +10,7 @@ import unittest
 
 from mantid.api import FileFinder
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy import QtCore
 
 from Muon.GUI.FrequencyDomainAnalysis.MaxEnt import maxent_view_new
@@ -31,7 +31,8 @@ def retrieve_combobox_info(combo_box):
     return output_list
 
 
-class MaxEntPresenterTest(GuiTest):
+@start_qapplication
+class MaxEntPresenterTest(unittest.TestCase):
     def setUp(self):
         self.context = setup_context(True)
 

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -5,7 +5,7 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from mantid.api import AnalysisDataService, FileFinder
 from mantid import ConfigService
@@ -17,7 +17,8 @@ from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapp
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
-class MuonContextTest(GuiTest):
+@start_qapplication
+class MuonContextTest(unittest.TestCase):
     def setUp(self):
         AnalysisDataService.clear()
         ConfigService['MantidOptions.InvisibleWorkspaces'] = 'True'

--- a/scripts/test/Muon/muon_data_context_test.py
+++ b/scripts/test/Muon/muon_data_context_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import copy
 import unittest
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from mantid.api import AnalysisDataService, FileFinder
 from mantid.py3compat import mock
@@ -16,7 +16,8 @@ from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 
 
-class MuonDataContextTest(GuiTest):
+@start_qapplication
+class MuonDataContextTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super(MuonDataContextTest, cls).setUpClass()

--- a/scripts/test/Muon/muon_gui_context_test.py
+++ b/scripts/test/Muon/muon_gui_context_test.py
@@ -9,14 +9,15 @@ import unittest
 
 from Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
 from Muon.GUI.Common.observer_pattern import Observer
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 if sys.version_info.major < 2:
     from unittest import mock
 else:
     import mock
 
-class MuonGUIContextTest(GuiTest):
+@start_qapplication
+class MuonGUIContextTest(unittest.TestCase):
     def test_can_set_variables(self):
         context = MuonGuiContext()
 

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication
 from qtpy import QtCore
 from Muon.GUI.Common.phase_table_widget.phase_table_presenter import PhaseTablePresenter
@@ -16,7 +16,8 @@ from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
-class PhaseTablePresenterTest(GuiTest):
+@start_qapplication
+class PhaseTablePresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model:
             thread_model._thread.wait()

--- a/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/scripts/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -16,7 +16,7 @@ from mantid.api import AnalysisDataService, ITableWorkspace, WorkspaceFactory, W
 from mantid.kernel import FloatTimeSeriesProperty, StringPropertyWithValue
 from mantid.py3compat import iteritems, mock, string_types
 from mantid.simpleapi import Load
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.results_tab_widget.results_tab_model import (
     DEFAULT_TABLE_NAME, ResultsTabModel, TableColumnType)
@@ -115,7 +115,8 @@ def add_logs(workspace_name, logs):
     return workspace
 
 
-class ResultsTabModelTest(GuiTest):
+@start_qapplication
+class ResultsTabModelTest(unittest.TestCase):
     def setUp(self):
         self.f0_height = (2309.2, 16)
         self.f0_centre = (2.1, 0.002)

--- a/scripts/test/Muon/transformWidget_test.py
+++ b/scripts/test/Muon/transformWidget_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 
 from Muon.GUI.Common.utilities import load_utils
 from Muon.GUI.FrequencyDomainAnalysis.FFT import fft_presenter
@@ -19,7 +19,8 @@ from Muon.GUI.FrequencyDomainAnalysis.Transform import transform_widget
 from Muon.GUI.FrequencyDomainAnalysis.TransformSelection import transform_selection_view
 
 
-class TransformTest(GuiTest):
+@start_qapplication
+class TransformTest(unittest.TestCase):
     def setUp(self):
         self.load = mock.MagicMock()
         self.fft = mock.create_autospec(fft_presenter.FFTPresenter, spec_Set=True)

--- a/scripts/test/Muon/utilities/thread_model_test.py
+++ b/scripts/test/Muon/utilities/thread_model_test.py
@@ -7,7 +7,7 @@
 import unittest
 
 from mantid.py3compat import mock
-from mantidqt.utils.qt.testing import GuiTest
+from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication
 
 from Muon.GUI.Common.thread_model import ThreadModel
@@ -58,7 +58,8 @@ class testModel:
         pass
 
 
-class LoadFileWidgetViewTest(GuiTest):
+@start_qapplication
+class LoadFileWidgetViewTest(unittest.TestCase):
     class Runner:
         """This runner class creates a main event loop for threaded code to run within (otherwise the threaded
         code will not connect signals/slots properly).


### PR DESCRIPTION
**Description of work.**

Implements a decorator to start the `QApplication` and delete it on application exit. 

**To test:**

Run the python tests many times and see that none fail.


*This does not require release notes* because **it is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
