### PR TITLE
Change the units for time remaining in the algorithm progress bar from h-h to h-min

### DIFF
--- a/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
@@ -82,7 +82,7 @@ void AlgorithmDockWidget::updateProgress(void *alg, const double p,
         int hours = static_cast<int>(estimatedTime / 3600);
         int min = static_cast<int>((estimatedTime - hours * 3600) / 60);
         mess << hours << "h" << std::setfill('0') << std::setw(2) << min
-             << "min";
+             << "m";
       }
       mess << ")";
     }

--- a/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
@@ -81,8 +81,7 @@ void AlgorithmDockWidget::updateProgress(void *alg, const double p,
       } else {
         int hours = static_cast<int>(estimatedTime / 3600);
         int min = static_cast<int>((estimatedTime - hours * 3600) / 60);
-        mess << hours << "h" << std::setfill('0') << std::setw(2) << min
-             << "m";
+        mess << hours << "h" << std::setfill('0') << std::setw(2) << min << "m";
       }
       mess << ")";
     }

--- a/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
@@ -81,7 +81,8 @@ void AlgorithmDockWidget::updateProgress(void *alg, const double p,
       } else {
         int hours = static_cast<int>(estimatedTime / 3600);
         int min = static_cast<int>((estimatedTime - hours * 3600) / 60);
-        mess << hours << "h" << std::setfill('0') << std::setw(2) << min << "min";
+        mess << hours << "h" << std::setfill('0') << std::setw(2) << min
+             << "min";
       }
       mess << ")";
     }

--- a/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
+++ b/MantidPlot/src/Mantid/AlgorithmDockWidget.cpp
@@ -81,7 +81,7 @@ void AlgorithmDockWidget::updateProgress(void *alg, const double p,
       } else {
         int hours = static_cast<int>(estimatedTime / 3600);
         int min = static_cast<int>((estimatedTime - hours * 3600) / 60);
-        mess << hours << "h" << std::setfill('0') << std::setw(2) << min << "h";
+        mess << hours << "h" << std::setfill('0') << std::setw(2) << min << "min";
       }
       mess << ")";
     }

--- a/docs/source/release/v4.2.0/mantidplot.rst
+++ b/docs/source/release/v4.2.0/mantidplot.rst
@@ -10,5 +10,6 @@ Improvements
 
 Bugfixes
 ########
+- Algorithm progress bar now shows correct units for time remaining.
 
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
**Description of work.**
When executing an algorithm that takes more than an hour in MantidPlot, the progress bar showing the time remaining now has the correct units of h-min instead of h-h.

**To test:**
1. In MantidPlot, run an algorithm that takes over an hour. Example: CalculatePolynomialBackground with a high degree (30+).
2. Check that the time remaining is in the correct units.

Fixes #23640 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
