### PR TITLE
Project Save: Improve error handling with nested groups of groups

### DIFF
--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -525,6 +525,10 @@ bool SaveNexusProcessed::processGroups() {
   if (!workspaces.empty()) {
     for (size_t entry = 0; entry < workspaces.size(); entry++) {
       const Workspace_sptr ws = workspaces[entry];
+      if (ws->isGroup()) {
+        throw std::runtime_error("SaveNexusProcessed: NeXus files do not "
+                                 "support nested groups of groups");
+      }
       this->doExec(ws, nexusFile, true /*keepFile*/, entry);
       g_log.information() << "Saving group index " << entry << "\n";
     }

--- a/docs/source/release/v4.1.0/framework.rst
+++ b/docs/source/release/v4.1.0/framework.rst
@@ -44,6 +44,7 @@ Improvements
 - :ref:`FilterEvents <algm-FilterEvents>` has a property `InformativeOutputNames` which changes the name of output workspace to include the start and end time of the slice.
 - :ref:`algm-SumOverlappingTubes` was speeded up due to parallelization of the actual histogramming step.
 - :ref:`CylinderAbsorption <algm-CylinderAbsorption>` now has a `CylinderAxis` property to set the direction of the cylinder axis.
+- :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>` now throws a clearer error on saving of nested groups of groups.
 
 Instrument Definition Files
 ###########################

--- a/docs/source/release/v4.1.0/mantidworkbench.rst
+++ b/docs/source/release/v4.1.0/mantidworkbench.rst
@@ -87,6 +87,7 @@ Bugfixes
 - Workbench's scaling of fonts when moved between monitors with different resolutions has been improved
 - The ErrorReporter window is now resizeable
 - The "Fit" button is now visible when plotting a spectrum with error bars
+- Project save handles workspace saving erros more gracefully
 
 Known Issues
 ############

--- a/qt/python/mantidqt/project/workspacesaver.py
+++ b/qt/python/mantidqt/project/workspacesaver.py
@@ -50,8 +50,8 @@ class WorkspaceSaver(object):
                 else:
                     # Save normally using SaveNexusProcessed
                     SaveNexusProcessed(InputWorkspace=workspace_name, Filename=place_to_save_workspace + ".nxs")
-            except Exception:
-                logger.warning("Couldn't save workspace in project: " + workspace)
+            except Exception as exc:
+                logger.warning("Couldn't save workspace in project: \"" + workspace_name + "\" because " + str(exc))
 
             self.output_list.append(workspace_name)
 


### PR DESCRIPTION
**Description of work.**
Project save falls over at present, this stops it from falling over and displays a useful error.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Muon Analysis 2
- Load Instrument: EMU run-number: 62260
- Save Project
- A clear error will be displayed

<!-- Instructions for testing. -->

Fixes #26440 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
