### PR TITLE
Flattened muon ADS lists

### DIFF
--- a/docs/source/release/v4.1.0/muon.rst
+++ b/docs/source/release/v4.1.0/muon.rst
@@ -70,5 +70,10 @@ Bug Fixes
 * Elemental Analysis no longer crashes when an ill formatted data file is loaded.
 * Changed the y-axis label in Elemental Analysis to `Counts`.
 
+Known Issues
+############
+
+* Plotting can be very slow to update if large numbers of workspaces are plotted. This can lead to unresponsive behaviour when large numbers of workspaces are fitted with sequential fits. As a temporary solution closing the plot window before performing large sequential fits can avoid this slowdown.
+
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -83,10 +83,7 @@ def get_pair_data_workspace_name(context, pair_name, run, rebin):
 
 
 def get_base_data_directory(context, run):
-    if context.data_context.is_multi_period():
-        return context.data_context._base_run_name(run) + context.workspace_suffix + "/"
-    else:
-        return context.data_context._base_run_name(run) + context.workspace_suffix + "/"
+    return context.data_context._base_run_name(run) + context.workspace_suffix + "/"
 
 
 def get_raw_data_directory(context, run):

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -84,9 +84,9 @@ def get_pair_data_workspace_name(context, pair_name, run, rebin):
 
 def get_base_data_directory(context, run):
     if context.data_context.is_multi_period():
-        return context.data_context.base_directory + "/" + context.data_context._base_run_name(run) + context.workspace_suffix + "/"
+        return context.data_context._base_run_name(run) + context.workspace_suffix + "/"
     else:
-        return context.data_context.base_directory + "/" + context.data_context._base_run_name(run) + context.workspace_suffix + "/"
+        return context.data_context._base_run_name(run) + context.workspace_suffix + "/"
 
 
 def get_raw_data_directory(context, run):

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -111,7 +111,7 @@ def get_pair_data_directory(context, run):
 
 def get_phase_table_workspace_name(raw_workspace, forward_group, backward_group):
     workspace_name = raw_workspace.replace('_raw_data', '; PhaseTable')
-    workspace_name += '; ' + forward_group + ', ' + backward_group
+    workspace_name += '; ' + forward_group + '; ' + backward_group
     return workspace_name
 
 

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -8,8 +8,7 @@ from __future__ import (absolute_import, division, unicode_literals)
 
 from Muon.GUI.Common.ADSHandler.workspace_naming import (get_raw_data_workspace_name, get_group_data_workspace_name,
                                                          get_pair_data_workspace_name, get_base_data_directory,
-                                                         get_raw_data_directory, get_group_data_directory,
-                                                         get_pair_data_directory, get_group_asymmetry_name,
+                                                         get_group_asymmetry_name,
                                                          get_group_asymmetry_unnorm_name)
 from Muon.GUI.Common.calculate_pair_and_group import calculate_group_data, calculate_pair_data, \
     estimate_group_asymmetry_data

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -86,7 +86,7 @@ class MuonContext(object):
             for group_name in self._group_pair_context.group_names:
                 run_as_string = run_list_to_string(run)
 
-                directory = get_base_data_directory(self, run_as_string) + get_group_data_directory(self, run_as_string)
+                directory = get_base_data_directory(self, run_as_string)
 
                 name = get_group_data_workspace_name(self, group_name, run_as_string, rebin=False)
                 asym_name = get_group_asymmetry_name(self, group_name, run_as_string, rebin=False)
@@ -114,8 +114,6 @@ class MuonContext(object):
                     run_as_string,
                     rebin=False)
                 directory = get_base_data_directory(
-                    self,
-                    run_as_string) + get_pair_data_directory(
                     self,
                     run_as_string)
 
@@ -185,8 +183,6 @@ class MuonContext(object):
                 self.data_context._loaded_data.get_data(run=run, instrument=self.data_context.instrument)['workspace'][
                     'OutputWorkspace']
             directory = get_base_data_directory(
-                self,
-                run_string) + get_raw_data_directory(
                 self,
                 run_string)
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -9,7 +9,6 @@ from __future__ import (absolute_import, division, unicode_literals)
 from Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_simultaneous_Fit, run_CalculateMuonAsymmetry
 import mantid
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
-from Muon.GUI.Common.ADSHandler.workspace_naming import get_fit_workspace_directory
 from mantid.simpleapi import RenameWorkspace, ConvertFitFunctionForMuonTFAsymmetry, CopyLogs
 
 
@@ -62,22 +61,25 @@ class FittingTabModel(object):
         return workspace_wrapper
 
     def create_fitted_workspace_name(self, input_workspace_name, function_name, group_name):
-        directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
-                                                self.context.workspace_suffix)
-        name = input_workspace_name + '; Fitted; ' + self.function_name
+        # directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
+        #                                         self.context.workspace_suffix)
+        directory = input_workspace_name + '; Fitted; ' + self.function_name + '/'
+        name = input_workspace_name + '; Fitted; ' + self.function_name + '; Workspace'
 
         return name, directory
 
     def create_multi_domain_fitted_workspace_name(self, input_workspace, function, group_name):
-        directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
-                                                self.context.workspace_suffix)
+        # directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
+        #                                         self.context.workspace_suffix)
+        directory = input_workspace + '; Fitted; ' + self.function_name + '/'
         name = input_workspace + '+ ...; Fitted; ' + self.function_name
 
         return name, directory
 
     def create_parameter_table_name(self, input_workspace_name, function_name, group_name):
-        directory = get_fit_workspace_directory(group_name, '_parameter_tables', self.context.data_context.base_directory,
-                                                self.context.workspace_suffix)
+        # directory = get_fit_workspace_directory(group_name, '_parameter_tables', self.context.data_context.base_directory,
+        #                                         self.context.workspace_suffix)
+        directory = input_workspace_name + '; Fitted; ' + self.function_name + '/'
         name = input_workspace_name + '; Fitted Parameters; ' + self.function_name
 
         return name, directory
@@ -206,12 +208,12 @@ class FittingTabModel(object):
             workspace_name, workspace_directory = self.create_multi_domain_fitted_workspace_name(
                 input_workspace_list[0],
                 fit_function, fit_group_name)
-            self.add_workspace_to_ADS(output_workspace, workspace_name, workspace_directory)
-            self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
+            self.add_workspace_to_ADS(output_workspace, workspace_name, '')
             workspace_name = self.rename_members_of_fitted_workspace_group(output_workspace,
                                                                            input_workspace_list,
                                                                            fit_function,
                                                                            fit_group_name)
+            self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
         else:
             table_name, table_directory = self.create_parameter_table_name(input_workspace_list[0],
                                                                            fit_function,

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -61,24 +61,18 @@ class FittingTabModel(object):
         return workspace_wrapper
 
     def create_fitted_workspace_name(self, input_workspace_name, function_name, group_name):
-        # directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
-        #                                         self.context.workspace_suffix)
         directory = input_workspace_name + '; Fitted; ' + self.function_name + '/'
         name = input_workspace_name + '; Fitted; ' + self.function_name + '; Workspace'
 
         return name, directory
 
     def create_multi_domain_fitted_workspace_name(self, input_workspace, function, group_name):
-        # directory = get_fit_workspace_directory(group_name, '_workspaces', self.context.data_context.base_directory,
-        #                                         self.context.workspace_suffix)
         directory = input_workspace + '; Fitted; ' + self.function_name + '/'
         name = input_workspace + '+ ...; Fitted; ' + self.function_name
 
         return name, directory
 
     def create_parameter_table_name(self, input_workspace_name, function_name, group_name):
-        # directory = get_fit_workspace_directory(group_name, '_parameter_tables', self.context.data_context.base_directory,
-        #                                         self.context.workspace_suffix)
         directory = input_workspace_name + '; Fitted; ' + self.function_name + '/'
         name = input_workspace_name + '; Fitted Parameters; ' + self.function_name
 

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -213,7 +213,7 @@ class FittingTabModel(object):
                                                                            input_workspace_list,
                                                                            fit_function,
                                                                            fit_group_name)
-            self.add_workspace_to_ADS(covariance_matrix, workspace_name + '_CovarianceMatrix', table_directory)
+            self.add_workspace_to_ADS(covariance_matrix, workspace_name[0] + '_CovarianceMatrix', table_directory)
         else:
             table_name, table_directory = self.create_parameter_table_name(input_workspace_list[0],
                                                                            fit_function,

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -128,6 +128,9 @@ class GroupingTabPresenter(object):
         file_filter = file_utils.filter_for_extensions(["xml"])
         filename = self._view.show_file_browser_and_return_selection(file_filter, [""])
 
+        if filename == '':
+            return
+
         groups, pairs, description, default = xml_utils.load_grouping_from_XML(filename)
 
         self._model.clear()

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -114,7 +114,7 @@ class PhaseTablePresenter(object):
         phasequad_workspace_name = get_phase_quad_workspace_name(input_workspace, input_phase_table)
         phase_table_group = get_phase_table_workspace_group_name(phasequad_workspace_name,
                                                                  self.context.data_context.instrument, self.context.workspace_suffix)
-        directory = get_base_data_directory(self.context, run) + phase_table_group
+        directory = get_base_data_directory(self.context, run)
 
         muon_workspace_wrapper = MuonWorkspaceWrapper(phase_quad, directory + phasequad_workspace_name)
         muon_workspace_wrapper.show()
@@ -161,7 +161,7 @@ class PhaseTablePresenter(object):
         phase_table_group = get_phase_table_workspace_group_name(base_name,
                                                                  self.context.data_context.instrument,
                                                                  self.context.workspace_suffix)
-        directory = get_base_data_directory(self.context, run) + phase_table_group
+        directory = get_base_data_directory(self.context, run)
         muon_workspace_wrapper = MuonWorkspaceWrapper(detector_table, directory + base_name)
         muon_workspace_wrapper.show()
 

--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -112,8 +112,7 @@ class PhaseTablePresenter(object):
     def add_phase_quad_to_ADS(self, input_workspace, input_phase_table, phase_quad):
         run = re.search('[0-9]+', input_workspace).group()
         phasequad_workspace_name = get_phase_quad_workspace_name(input_workspace, input_phase_table)
-        phase_table_group = get_phase_table_workspace_group_name(phasequad_workspace_name,
-                                                                 self.context.data_context.instrument, self.context.workspace_suffix)
+
         directory = get_base_data_directory(self.context, run)
 
         muon_workspace_wrapper = MuonWorkspaceWrapper(phase_quad, directory + phasequad_workspace_name)
@@ -158,9 +157,6 @@ class PhaseTablePresenter(object):
     def add_phase_table_to_ADS(self, base_name, detector_table):
         run = re.search('[0-9]+', base_name).group()
 
-        phase_table_group = get_phase_table_workspace_group_name(base_name,
-                                                                 self.context.data_context.instrument,
-                                                                 self.context.workspace_suffix)
         directory = get_base_data_directory(self.context, run)
         muon_workspace_wrapper = MuonWorkspaceWrapper(detector_table, directory + base_name)
         muon_workspace_wrapper.show()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
@@ -9,10 +9,11 @@ from __future__ import (absolute_import, division, print_function)
 import mantid.simpleapi as mantid
 
 from Muon.GUI.Common import thread_model
-from Muon.GUI.Common.utilities.algorithm_utils import run_PaddingAndApodization, run_FFT, convert_to_field, extract_single_spec
+from Muon.GUI.Common.utilities.algorithm_utils import run_PaddingAndApodization, run_FFT, convert_to_field, \
+    extract_single_spec
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapper
 from Muon.GUI.Common.ADSHandler.workspace_naming import get_fft_workspace_name, get_fft_workspace_group_name, \
-    get_base_data_directory, get_group_or_pair_from_name
+    get_group_or_pair_from_name
 import re
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from Muon.GUI.Common.observer_pattern import GenericObservable
@@ -169,7 +170,8 @@ class FFTPresenter(object):
         if self.view.imaginary_data:
             if 'PhaseQuad' in self.view.workspace:
                 imaginary_workspace_input = real_workspace_input
-                imaginary_workspace_padding_parameters['InputWorkspace'] = real_workspace_padding_parameters['InputWorkspace']
+                imaginary_workspace_padding_parameters['InputWorkspace'] = real_workspace_padding_parameters[
+                    'InputWorkspace']
                 imaginary_workspace_index = 1
             else:
                 imaginary_workspace_input = run_PaddingAndApodization(imaginary_workspace_padding_parameters)
@@ -187,23 +189,26 @@ class FFTPresenter(object):
     def add_fft_workspace_to_ADS(self, input_workspace, imaginary_input_workspace, fft_workspace):
         run = re.search('[0-9]+', input_workspace).group()
         Im_run = ""
-        if imaginary_input_workspace is not "":
+        if imaginary_input_workspace != "":
             Im_run = re.search('[0-9]+', imaginary_input_workspace).group()
         fft_workspace_name = get_fft_workspace_name(input_workspace, imaginary_input_workspace)
-        group = get_fft_workspace_group_name(fft_workspace_name, self.load.data_context.instrument, self.load.workspace_suffix)
-        directory = get_base_data_directory(self.load, run) + group
+        group = get_fft_workspace_group_name(fft_workspace_name, self.load.data_context.instrument,
+                                             self.load.workspace_suffix)
+        directory = group
 
         Re = get_group_or_pair_from_name(input_workspace)
         Im = get_group_or_pair_from_name(imaginary_input_workspace)
         shift = 3 if fft_workspace.getNumberHistograms() == 6 else 0
-        spectra = {"_"+FREQUENCY_EXTENSIONS["RE"]:0+shift, "_"+FREQUENCY_EXTENSIONS["IM"]:1+shift, "_"+FREQUENCY_EXTENSIONS["MOD"]:2+shift}
+        spectra = {"_" + FREQUENCY_EXTENSIONS["RE"]: 0 + shift, "_" + FREQUENCY_EXTENSIONS["IM"]: 1 + shift,
+                   "_" + FREQUENCY_EXTENSIONS["MOD"]: 2 + shift}
         for spec_type in list(spectra.keys()):
-            extracted_ws = extract_single_spec(fft_workspace,spectra[spec_type])
+            extracted_ws = extract_single_spec(fft_workspace, spectra[spec_type])
 
             if 'PhaseQuad' in self.view.workspace:
-                self.load._frequency_context.add_FFT(fft_workspace_name + spec_type, run, Re,Im_run, Im, phasequad = True)
+                self.load._frequency_context.add_FFT(fft_workspace_name + spec_type, run, Re, Im_run, Im,
+                                                     phasequad=True)
             else:
-                self.load._frequency_context.add_FFT(fft_workspace_name  + spec_type, run, Re,Im_run, Im)
+                self.load._frequency_context.add_FFT(fft_workspace_name + spec_type, run, Re, Im_run, Im)
 
             muon_workspace_wrapper = MuonWorkspaceWrapper(extracted_ws, directory + fft_workspace_name + spec_type)
             muon_workspace_wrapper.show()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
@@ -193,7 +193,7 @@ class FFTPresenter(object):
             Im_run = re.search('[0-9]+', imaginary_input_workspace).group()
         fft_workspace_name = get_fft_workspace_name(input_workspace, imaginary_input_workspace)
         directory = get_fft_workspace_group_name(fft_workspace_name, self.load.data_context.instrument,
-                                             self.load.workspace_suffix)
+                                                 self.load.workspace_suffix)
         Re = get_group_or_pair_from_name(input_workspace)
         Im = get_group_or_pair_from_name(imaginary_input_workspace)
         shift = 3 if fft_workspace.getNumberHistograms() == 6 else 0

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter_new.py
@@ -192,10 +192,8 @@ class FFTPresenter(object):
         if imaginary_input_workspace != "":
             Im_run = re.search('[0-9]+', imaginary_input_workspace).group()
         fft_workspace_name = get_fft_workspace_name(input_workspace, imaginary_input_workspace)
-        group = get_fft_workspace_group_name(fft_workspace_name, self.load.data_context.instrument,
+        directory = get_fft_workspace_group_name(fft_workspace_name, self.load.data_context.instrument,
                                              self.load.workspace_suffix)
-        directory = group
-
         Re = get_group_or_pair_from_name(input_workspace)
         Im = get_group_or_pair_from_name(imaginary_input_workspace)
         shift = 3 if fft_workspace.getNumberHistograms() == 6 else 0

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
@@ -14,8 +14,7 @@ import mantid.simpleapi as mantid
 
 from Muon.GUI.Common import thread_model
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
-from Muon.GUI.Common.ADSHandler.workspace_naming import get_maxent_workspace_group_name, get_maxent_workspace_name, \
-    get_base_data_directory
+from Muon.GUI.Common.ADSHandler.workspace_naming import get_maxent_workspace_group_name, get_maxent_workspace_name
 from Muon.GUI.Common.observer_pattern import GenericObserver, GenericObservable
 from Muon.GUI.Common.thread_model_wrapper import ThreadModelWrapper
 from Muon.GUI.Common.utilities.algorithm_utils import run_MuonMaxent
@@ -155,7 +154,7 @@ class MaxEntPresenter(object):
         run = re.search('[0-9]+', input_workspace).group()
         base_name = get_maxent_workspace_name(input_workspace)
         group = get_maxent_workspace_group_name(base_name, self.load.data_context.instrument, self.load.workspace_suffix)
-        directory = get_base_data_directory(self.load, run) + group
+        directory = group
 
         muon_workspace_wrapper = MuonWorkspaceWrapper(maxent_workspace, directory + base_name)
         muon_workspace_wrapper.show()

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/MaxEnt/maxent_presenter_new.py
@@ -153,8 +153,7 @@ class MaxEntPresenter(object):
     def add_maxent_workspace_to_ADS(self, input_workspace, maxent_workspace, alg):
         run = re.search('[0-9]+', input_workspace).group()
         base_name = get_maxent_workspace_name(input_workspace)
-        group = get_maxent_workspace_group_name(base_name, self.load.data_context.instrument, self.load.workspace_suffix)
-        directory = group
+        directory = get_maxent_workspace_group_name(base_name, self.load.data_context.instrument, self.load.workspace_suffix)
 
         muon_workspace_wrapper = MuonWorkspaceWrapper(maxent_workspace, directory + base_name)
         muon_workspace_wrapper.show()

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_model_test.py
@@ -27,8 +27,8 @@ class FittingTabModelTest(GuiTest):
     def test_create_fitted_workspace_name(self):
         input_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1'
         trial_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
-        expected_directory_name = 'Muon Data/Fitting Output MA/Fitting Output_workspaces MA/'
-        expected_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted; GausOsc'
+        expected_directory_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted; GausOsc/'
+        expected_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted; GausOsc; Workspace'
         self.model.function_name = 'GausOsc'
 
         name, directory = self.model.create_fitted_workspace_name(input_workspace_name, trial_function,
@@ -40,7 +40,7 @@ class FittingTabModelTest(GuiTest):
     def test_create_parameter_table_name(self):
         input_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1'
         trial_function = FunctionFactory.createInitialized('name=GausOsc,A=0.2,Sigma=0.2,Frequency=0.1,Phi=0')
-        expected_directory_name = 'Muon Data/Fitting Output MA/Fitting Output_parameter_tables MA/'
+        expected_directory_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted; GausOsc/'
         expected_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted Parameters; GausOsc'
         self.model.function_name = 'GausOsc'
 
@@ -85,7 +85,7 @@ class FittingTabModelTest(GuiTest):
             ' n = 0, A0 = 0,$domains = i;name = Polynomial, n = 0, A0 = 0,'
             '$domains = i;name = Polynomial, n = 0, A0 = 0,$domains = i;'
             'name = Polynomial, n = 0, A0 = 0,$domains = i')
-        expected_directory_name = 'Muon Data/Fitting Output MA/Fitting Output_workspaces MA/'
+        expected_directory_name = 'MUSR22725; Group; top; Asymmetry; #1; Fitted; Polynomial/'
         expected_workspace_name = 'MUSR22725; Group; top; Asymmetry; #1+ ...; Fitted; Polynomial'
         self.model.function_name = 'Polynomial'
 

--- a/scripts/test/Muon/max_ent_presenter_load_interaction_test.py
+++ b/scripts/test/Muon/max_ent_presenter_load_interaction_test.py
@@ -106,7 +106,7 @@ class MaxEntPresenterTest(GuiTest):
         self.presenter.add_maxent_workspace_to_ADS('MUSR22725_MaxEnt', maxent_workspace, mock.MagicMock())
 
         workspace_wrapper_mock.assert_called_once_with(maxent_workspace,
-                                                       'Muon Data/MUSR22725 MA/MUSR22725 Maxent MA/MUSR22725_MaxEnt; MaxEnt')
+                                                       'MUSR22725 Maxent MA/MUSR22725_MaxEnt; MaxEnt')
         workspace_wrapper_mock.return_value.show.assert_called_once_with()
 
     def test_get_output_options_defaults_returns_correctly(self):

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -76,9 +76,9 @@ class MuonContextTest(GuiTest):
         self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
                           Counter(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
                                    '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
-                                   'EMU19489 Groups MA', 'EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA',
+                                   'EMU19489 MA', 'EMU19489; Group; bwd; Asymmetry; MA',
                                    'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; fwd; Asymmetry; MA',
-                                   'EMU19489; Group; fwd; Counts; MA', 'Muon Data']))
+                                   'EMU19489; Group; fwd; Counts; MA']))
 
     def test_that_show_all_calculates_and_shows_all_groups_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -90,19 +90,18 @@ class MuonContextTest(GuiTest):
                           Counter(['__EMU19489; Group; bwd; Asymmetry; MA_unnorm',
                                    '__EMU19489; Group; bwd; Asymmetry; Rebin; MA_unnorm',
                                    '__EMU19489; Group; fwd; Asymmetry; MA_unnorm',
-                                   '__EMU19489; Group; fwd; Asymmetry; Rebin; MA_unnorm', 'EMU19489 Groups MA',
+                                   '__EMU19489; Group; fwd; Asymmetry; Rebin; MA_unnorm',
                                    'EMU19489 MA',
                                    'EMU19489; Group; bwd; Asymmetry; MA', 'EMU19489; Group; bwd; Asymmetry; Rebin; MA',
                                    'EMU19489; Group; bwd; Counts; MA', 'EMU19489; Group; bwd; Counts; Rebin; MA',
                                    'EMU19489; Group; fwd; Asymmetry; MA', 'EMU19489; Group; fwd; Asymmetry; Rebin; MA',
-                                   'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA',
-                                   'Muon Data']))
+                                   'EMU19489; Group; fwd; Counts; MA', 'EMU19489; Group; fwd; Counts; Rebin; MA']))
 
     def test_show_all_pairs_calculates_and_shows_all_pairs(self):
         self.context.show_all_pairs()
 
         self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
-                          Counter(['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA', 'Muon Data']))
+                          Counter(['EMU19489 MA', 'EMU19489; Pair Asym; long; MA']))
 
     def test_that_show_all_calculates_and_shows_all_pairs_with_rebin(self):
         self.gui_context['RebinType'] = 'Fixed'
@@ -111,8 +110,8 @@ class MuonContextTest(GuiTest):
         self.context.show_all_pairs()
 
         self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
-                          Counter(['EMU19489 MA', 'EMU19489 Pairs MA', 'EMU19489; Pair Asym; long; MA',
-                                   'EMU19489; Pair Asym; long; Rebin; MA', 'Muon Data']))
+                          Counter(['EMU19489 MA', 'EMU19489; Pair Asym; long; MA',
+                                   'EMU19489; Pair Asym; long; Rebin; MA']))
 
     def test_update_current_data_sets_current_run_in_data_context(self):
         self.context.update_current_data()
@@ -129,7 +128,7 @@ class MuonContextTest(GuiTest):
         self.context.show_raw_data()
 
         self.assertEquals(Counter(AnalysisDataService.getObjectNames()),
-                          Counter(['EMU19489 MA', 'EMU19489 Raw Data MA', 'EMU19489_raw_data MA', 'Muon Data']))
+                          Counter(['EMU19489 MA', 'EMU19489_raw_data MA']))
 
     def test_that_first_good_data_returns_correctly_when_from_file_chosen_option(self):
         self.gui_context.update({'FirstGoodDataFromFile': True})

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -61,7 +61,7 @@ class PhaseTablePresenterTest(GuiTest):
 
         self.assertEqual(result, {'BackwardSpectra': [2, 4, 6, 8, 10], 'FirstGoodData': 0.1, 'ForwardSpectra': [1, 3, 5, 7, 9],
                                    'InputWorkspace': workspace_name, 'LastGoodData': 15,
-                                   'DetectorTable': 'input_workspace_name; PhaseTable; fwd, bwd'})
+                                   'DetectorTable': 'input_workspace_name; PhaseTable; fwd; bwd'})
 
     def test_correctly_retrieves_workspace_names_associsated_to_current_runs(self):
         self.view.set_input_combo_box = mock.MagicMock()
@@ -102,7 +102,7 @@ class PhaseTablePresenterTest(GuiTest):
         self.presenter.handle_calulate_phase_table_clicked()
         self.wait_for_thread(self.presenter.calculation_thread)
 
-        self.presenter.add_phase_table_to_ADS.assert_called_once_with('MUSR22222; PhaseTable_period_1; fwd, bwd', detector_table_mock)
+        self.presenter.add_phase_table_to_ADS.assert_called_once_with('MUSR22222; PhaseTable_period_1; fwd; bwd', detector_table_mock)
         self.assertTrue(self.view.isEnabled())
 
     @mock.patch('Muon.GUI.Common.phase_table_widget.phase_table_presenter.run_CalMuonDetectorPhases')

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -86,8 +86,7 @@ class PhaseTablePresenterTest(GuiTest):
 
         self.presenter.add_phase_table_to_ADS('MUSR22222_period_1; PhaseTable', mock_phase_table)
 
-        mock_workspace_wrapper.assert_called_once_with(mock_phase_table, 'Muon Data/MUSR22222 MA/MUSR22222 Phase Tab MA'
-                                                                         '/MUSR22222_period_1; PhaseTable')
+        mock_workspace_wrapper.assert_called_once_with(mock_phase_table, 'MUSR22222 MA/MUSR22222_period_1; PhaseTable')
         workspace_wrapper.show.assert_called_once_with()
 
     @mock.patch('Muon.GUI.Common.phase_table_widget.phase_table_presenter.run_CalMuonDetectorPhases')
@@ -149,8 +148,7 @@ class PhaseTablePresenterTest(GuiTest):
         self.presenter.add_phase_quad_to_ADS('MUSR22222_PhaseQuad_phase_table_MUSR22222', 'MUSR22222 PhaseTable',
                                              phase_quad)
 
-        mock_workspace_wrapper.assert_called_once_with(phase_quad, 'Muon Data/MUSR22222 MA/MUSR22222 Phase Tab MA/MUSR22222_'
-                                                                   'PhaseQuad_phase_table_MUSR22222 MUSR22222 PhaseTable')
+        mock_workspace_wrapper.assert_called_once_with(phase_quad, 'MUSR22222 MA/MUSR22222_PhaseQuad_phase_table_MUSR22222 MUSR22222 PhaseTable')
         mock_workspace_wrapper.return_value.show.assert_called_once_with()
 
     @mock.patch('Muon.GUI.Common.phase_table_widget.phase_table_presenter.run_PhaseQuad')
@@ -225,8 +223,7 @@ class PhaseTablePresenterTest(GuiTest):
 
         self.presenter.add_fitting_info_to_ADS_if_required('MUSR22222_PhaseTable',fit_information)
 
-        workspace_wrapper_mock.assert_called_once_with(fit_information, 'Muon Data/MUSR22222 MA/MUSR22222 Phase Tab MA/'
-                                                                        'MUSR22222_PhaseTable; fit_information')
+        workspace_wrapper_mock.assert_called_once_with(fit_information, 'MUSR22222 MA/MUSR22222 Phase Tab MA/MUSR22222_PhaseTable; fit_information')
         workspace_wrapper_mock.return_value.show.assert_called_once_with()
 
 


### PR DESCRIPTION
**Description of work.**

The Muon GUI used nested workspace groups in the ADS, this did not work with project saving. This PR flattens the nested workspace groups into a flatter structure so that it works with project saving.

**To test:**
 * Run through the Muon Acceptance tests, Check that workspaces in the ADS appear in the correct place and that project saving now works.

http://developer.mantidproject.org/Testing/MuonInterface/MuonTesting.html
<!-- Instructions for testing. -->

Fixes #26440  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this is fixing a issue with a new interface


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
