### PR TITLE
Workbench: ISIS Reflectometry pause button is disabled on opening

### DIFF
--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -9,4 +9,14 @@ Reflectometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+ISIS Reflectometry Interface
+----------------------------
+
+Bug fixes
+#########
+
+The following bugs have been fixed since the last release:
+
+- The pause button is now disabled upon opening the interface and becomes enabled when a process starts.
+
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -65,6 +65,7 @@ public:
   void notifySettingsChanged() override;
   void anyBatchAutoreductionResumed() override;
   void anyBatchAutoreductionPaused() override;
+  void reductionPaused() override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;
@@ -85,7 +86,6 @@ private:
   void resumeReduction();
   void reductionResumed();
   void pauseReduction();
-  void reductionPaused();
   void resumeAutoreduction();
   void autoreductionResumed();
   void pauseAutoreduction();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -40,6 +40,7 @@ public:
   virtual void notifySettingsChanged() = 0;
   virtual void anyBatchAutoreductionResumed() = 0;
   virtual void anyBatchAutoreductionPaused() = 0;
+  virtual void reductionPaused() = 0;
 
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -84,6 +84,10 @@ bool MainWindowPresenter::isAnyBatchAutoreducing() const {
 void MainWindowPresenter::addNewBatch(IBatchView *batchView) {
   m_batchPresenters.emplace_back(m_batchPresenterFactory.make(batchView));
   m_batchPresenters.back()->acceptMainPresenter(this);
+
+  // starts in the paused state
+  m_batchPresenters.back()->reductionPaused();
+
   // Ensure autoreduce button is enabled/disabled correctly for the new batch
   if (isAnyBatchAutoreducing())
     m_batchPresenters.back()->anyBatchAutoreductionResumed();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
@@ -215,9 +215,6 @@ void RunsTableView::addToolbarActions() {
   connect(addToolbarItem(Action::FillDown, "mdi.arrow-expand-down",
                          "Fill down selected rows for selected column"),
           SIGNAL(triggered(bool)), this, SLOT(onFillDownPressed(bool)));
-
-  // Sets the pause button to disabled when the window first opens
-  setActionEnabled(Action::Pause, false);
 }
 
 MantidQt::MantidWidgets::Batch::IJobTreeView &RunsTableView::jobs() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
@@ -216,7 +216,6 @@ void RunsTableView::addToolbarActions() {
                          "Fill down selected rows for selected column"),
           SIGNAL(triggered(bool)), this, SLOT(onFillDownPressed(bool)));
 
-
   // Sets the pause button to disabled when the window first opens
   setActionEnabled(Action::Pause, false);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTableView.cpp
@@ -215,6 +215,10 @@ void RunsTableView::addToolbarActions() {
   connect(addToolbarItem(Action::FillDown, "mdi.arrow-expand-down",
                          "Fill down selected rows for selected column"),
           SIGNAL(triggered(bool)), this, SLOT(onFillDownPressed(bool)));
+
+
+  // Sets the pause button to disabled when the window first opens
+  setActionEnabled(Action::Pause, false);
 }
 
 MantidQt::MantidWidgets::Batch::IJobTreeView &RunsTableView::jobs() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -76,6 +76,7 @@ public:
   MOCK_METHOD0(notifyAutoreductionCompleted, void());
   MOCK_METHOD0(anyBatchAutoreductionResumed, void());
   MOCK_METHOD0(anyBatchAutoreductionPaused, void());
+  MOCK_METHOD0(reductionPaused, void());
 
   MOCK_METHOD1(notifyInstrumentChanged, void(const std::string &));
   MOCK_METHOD0(notifyRestoreDefaultsRequested, void());


### PR DESCRIPTION
**Description of work.**
The pause button in the ISIS Reflectometry interface is now disabled when the interface is first opened, and becomes enabled when processing is started.

**To test:**
1. Open Workbench -> Interfaces -> ISIS Reflectometry.
2. The pause button should be disabled.
3. Begin processing. Example numbers: Run number 13460 Angle 0.05, Run number 13463 Angle 0.05. (set instrument to INTER).
4. The pause button should become enabled. Try pausing and unpausing to ensure the button becomes enabled and disabled correctly.

Fixes #26394 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
