### PR TITLE
Add link to C++ intro page to developer documentation

### DIFF
--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -49,6 +49,9 @@ Guides
 :doc:`Python3`
    Building with Python 3 (Linux only).
 
+`C++ Introduction <https://www.mantidproject.org/New_Starter_C%2B%2B_introduction>`_
+   Exercises for learning C++.
+
 ===================
 Development Process
 ===================


### PR DESCRIPTION
**Description of work.**
The developer documentation now contains a link to https://www.mantidproject.org/New_Starter_C%2B%2B_introduction under Guides so that it can be easily accessed.

**To test:**
1. Open the main developer documentation page (index).
2. Check that under Guides there is a link to the C++ introduction page.
3. Check that the link takes you to the correct page.

Fixes #26039 

*This does not require release notes* because it is documentation.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
