### PR TITLE
Remove Qt5 libraries from macOS MantidPlot.app bundle

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -385,11 +385,13 @@ if !File.exist?(mpltoolkit_init)
   `touch #{mpltoolkit_init}`
 end
 
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
+files = ["cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
 files.each do |file|
   copyFile("#{pip_site_packages}/#{file}")
 end
 
+# gnureadline is only present on older versions of readline
+copyOptionalFile("#{pip_site_packages}/gnureadline.so")
 # mistune.so isn't present in v0.7
 copyOptionalFile("#{pip_site_packages}/mistune.so")
 

--- a/qt/applications/workbench/make_package.rb.in
+++ b/qt/applications/workbench/make_package.rb.in
@@ -348,11 +348,13 @@ if !File.exist?(mpltoolkit_init)
   `touch #{mpltoolkit_init}`
 end
 
-files = ["gnureadline.so","cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
+files = ["cycler.py","readline.py","pyparsing.py","mistune.py","decorator.py","kiwisolver.so","subprocess32.py","six.py"]
 files.each do |file|
   copyFile("#{pip_site_packages}/#{file}")
 end
 
+# gnureadline is only present on older versions of readline
+copyOptionalFile("#{pip_site_packages}/gnureadline.so")
 # mistune.so isn't present in v0.7
 copyOptionalFile("#{pip_site_packages}/mistune.so")
 

--- a/qt/icons/CMakeLists.txt
+++ b/qt/icons/CMakeLists.txt
@@ -47,7 +47,6 @@ if(ENABLE_WORKBENCH)
                         ${Boost_LIBRARIES}
                         ${JSONCPP_LIBRARIES}
                       INSTALL_DIR
-                        ${LIB_DIR}
                         ${WORKBENCH_LIB_DIR}
                       OSX_INSTALL_RPATH
                         @loader_path/../MacOS

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -879,7 +879,6 @@ mtd_add_qt_library(TARGET_NAME
                    ${_webwidgets_tgt}
                    Qt5::Qscintilla
                    INSTALL_DIR
-                   ${LIB_DIR}
                    ${WORKBENCH_LIB_DIR}
                    OSX_INSTALL_RPATH
                    @loader_path/../MacOS

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -200,7 +200,6 @@ mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                      MantidQtWidgetsCommon
                      MantidQtWidgetsMplCpp
                    INSTALL_DIR
-                     ${LIB_DIR}
                      ${WORKBENCH_LIB_DIR}
                    OSX_INSTALL_RPATH
                      @loader_path/../MacOS

--- a/qt/widgets/mplcpp/CMakeLists.txt
+++ b/qt/widgets/mplcpp/CMakeLists.txt
@@ -77,7 +77,6 @@ mtd_add_qt_library(
   MTD_QT_LINK_LIBS
     MantidQtWidgetsCommon
   INSTALL_DIR
-    ${LIB_DIR}
     ${WORKBENCH_LIB_DIR}
   OSX_INSTALL_RPATH
     @loader_path/../MacOS


### PR DESCRIPTION
**Description of work.**

During development for 4.1 it was noticed that the package for OSX had grown to > 900MB and this was slightly surprising. Further investigation found that the `MantidPlot.app` bundle contained some Qt5 libraries and dependencies that were not meant to be there. This removes the offending libraries from the `MantidPlot.app` bundle and keeps them only for workbench.

This has reduced the package size by ~65MB.

**To test:**

Build a package on macOS and observe it is smaller after these changes.

*There is no associated issue.*

*This does not require release notes* because **it is a maintenance issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
