### PR TITLE
Added warning if saving >10GB on workbench. 

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -234,3 +234,7 @@ projectRecovery.secondsBetween = 60
 
 # The number of checkpoints to retain in the recovery folder
 projectRecovery.numberOfCheckpoints = 5
+
+# The size of the project before a warning is given in bytes.
+# 10 GB = 10737418240 bytes
+projectSaving.warningSize = 10737418240

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -234,6 +234,15 @@ See :ref:`project recovery <Project Recovery>` for more details.
 | ``projectRecovery.secondsBetween``      |How often to save checkpoints in seconds       | ``60``           |
 +-----------------------------------------+-----------------------------------------------+------------------+
 
+Project Saving
+**************
+
++---------------------------------+------------------------------------------------------------------+------------------+
+|Property                         |Description                                                       |Example value     |
++=================================+==================================================================+==================+
+| ``projectSaving.warningSize``   |Size in bytes of a project before the user is warned when saving  |  ``10737418240`` |
++---------------------------------+------------------------------------------------------------------+------------------+
+
 
 Getting access to Mantid properties
 ***********************************

--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -8,6 +8,8 @@ MantidWorkbench Changes
 Improvements
 ############
 
+- Attempting to save files that are larger than (by default) 10GB now results in a dialog box to inform the user that it may take a long time and gives them the opportunity to cancel.
+
 Bugfixes
 ########
 

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -109,9 +109,7 @@ class Project(AnalysisDataServiceObserver):
     def _save(self):
         workspaces_to_save = AnalysisDataService.getObjectNames()
         # Calculate the size of the workspaces in the project.
-        project_size = 0
-        for name in workspaces_to_save:
-            project_size += AnalysisDataService.retrieve(name).getMemorySize()
+        project_size = self._get_project_size(workspaces_to_save)
         warning_size = int(ConfigService.getString("projectSaving.warningSize"))
         # If a project is > the value in the properties file, question the user if they want to continue.
         saving = True
@@ -126,6 +124,12 @@ class Project(AnalysisDataServiceObserver):
             project_saver.save_project(file_name=self.last_project_location, workspace_to_save=workspaces_to_save,
                                        plots_to_save=plots_to_save, interfaces_to_save=interfaces_to_save)
             self.__saved = True
+
+    def _get_project_size(self, workspace_names):
+        project_size = 0
+        for name in workspace_names:
+            project_size += AnalysisDataService.retrieve(name).getMemorySize()
+        return project_size
 
     def load(self):
         """

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -19,7 +19,6 @@ from mantidqt.project.projectloader import ProjectLoader
 from mantidqt.project.projectsaver import ProjectSaver
 
 
-# noinspection PyTypeChecker
 class Project(AnalysisDataServiceObserver):
     def __init__(self, globalfiguremanager_instance, interface_populating_function):
         """
@@ -112,12 +111,10 @@ class Project(AnalysisDataServiceObserver):
         project_size = self._get_project_size(workspaces_to_save)
         warning_size = int(ConfigService.getString("projectSaving.warningSize"))
         # If a project is > the value in the properties file, question the user if they want to continue.
-        saving = True
+        result = None
         if project_size > warning_size:
-            result = self.offer_large_size_confirmation()
-            if result == QMessageBox.Cancel:
-                saving = False
-        if saving:
+            result = self._offer_large_size_confirmation()
+        if isinstance(result, None) or result != QMessageBox.Cancel:
             plots_to_save = self.plot_gfm.figs
             interfaces_to_save = self.interface_populating_function()
             project_saver = ProjectSaver(self.project_file_ext)
@@ -125,7 +122,8 @@ class Project(AnalysisDataServiceObserver):
                                        plots_to_save=plots_to_save, interfaces_to_save=interfaces_to_save)
             self.__saved = True
 
-    def _get_project_size(self, workspace_names):
+    @staticmethod
+    def _get_project_size(workspace_names):
         project_size = 0
         for name in workspace_names:
             project_size += AnalysisDataService.retrieve(name).getMemorySize()
@@ -186,7 +184,7 @@ class Project(AnalysisDataServiceObserver):
             return QMessageBox.No
 
     @staticmethod
-    def offer_large_size_confirmation():
+    def _offer_large_size_confirmation():
         """
         Asks the user to confirm that they want to save a large project.
         :return: QMessageBox; The response from the user. Default is Yes.

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -114,7 +114,7 @@ class Project(AnalysisDataServiceObserver):
         result = None
         if project_size > warning_size:
             result = self._offer_large_size_confirmation()
-        if isinstance(result, None) or result != QMessageBox.Cancel:
+        if result is None or result != QMessageBox.Cancel:
             plots_to_save = self.plot_gfm.figs
             interfaces_to_save = self.interface_populating_function()
             project_saver = ProjectSaver(self.project_file_ext)

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -161,6 +161,22 @@ class ProjectTest(unittest.TestCase):
 
         self.assertEqual(1, self.project.anyChangeHandle.call_count)
 
+    def test_large_file_dialog_appears_for_large_file(self):
+        CreateSampleWorkspace(OutputWorkspace="ws1")
+        # 10GB = 10737418240 bytes
+        self.project._get_project_size = mock.MagicMock(return_value=10737418241)
+        self.project.offer_large_size_confirmation = mock.MagicMock()
+        self.project._save()
+        self.assertEqual(self.project.offer_large_size_confirmation.call_count, 1)
+
+    def test_large_file_dialog_does_not_appear_for_small_file(self):
+        CreateSampleWorkspace(OutputWorkspace="ws1")
+        # 10GB = 10737418240 bytes
+        self.project._get_project_size = mock.MagicMock(return_value=10737418239)
+        self.project.offer_large_size_confirmation = mock.MagicMock()
+        self.project._save()
+        self.assertEqual(self.project.offer_large_size_confirmation.call_count, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -15,6 +15,7 @@ import unittest
 from qtpy.QtWidgets import QMessageBox
 
 from mantid.api import AnalysisDataService as ADS
+from mantid.kernel import ConfigService
 from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, RenameWorkspace, UnGroupWorkspace
 from mantid.py3compat import mock
 from mantidqt.project.project import Project
@@ -163,16 +164,16 @@ class ProjectTest(unittest.TestCase):
 
     def test_large_file_dialog_appears_for_large_file(self):
         CreateSampleWorkspace(OutputWorkspace="ws1")
-        # 10GB = 10737418240 bytes
-        self.project._get_project_size = mock.MagicMock(return_value=10737418241)
+        self.project._get_project_size = mock.MagicMock(return_value=
+                                                        int(ConfigService.getString("projectSaving.warningSize")) + 1)
         self.project.offer_large_size_confirmation = mock.MagicMock()
         self.project._save()
         self.assertEqual(self.project.offer_large_size_confirmation.call_count, 1)
 
     def test_large_file_dialog_does_not_appear_for_small_file(self):
         CreateSampleWorkspace(OutputWorkspace="ws1")
-        # 10GB = 10737418240 bytes
-        self.project._get_project_size = mock.MagicMock(return_value=10737418239)
+        self.project._get_project_size = mock.MagicMock(return_value=
+                                                        int(ConfigService.getString("projectSaving.warningSize")) - 1)
         self.project.offer_large_size_confirmation = mock.MagicMock()
         self.project._save()
         self.assertEqual(self.project.offer_large_size_confirmation.call_count, 0)

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -166,17 +166,17 @@ class ProjectTest(unittest.TestCase):
         CreateSampleWorkspace(OutputWorkspace="ws1")
         self.project._get_project_size = mock.MagicMock(return_value=
                                                         int(ConfigService.getString("projectSaving.warningSize")) + 1)
-        self.project.offer_large_size_confirmation = mock.MagicMock()
+        self.project._offer_large_size_confirmation = mock.MagicMock()
         self.project._save()
-        self.assertEqual(self.project.offer_large_size_confirmation.call_count, 1)
+        self.assertEqual(self.project._offer_large_size_confirmation.call_count, 1)
 
     def test_large_file_dialog_does_not_appear_for_small_file(self):
         CreateSampleWorkspace(OutputWorkspace="ws1")
         self.project._get_project_size = mock.MagicMock(return_value=
                                                         int(ConfigService.getString("projectSaving.warningSize")) - 1)
-        self.project.offer_large_size_confirmation = mock.MagicMock()
+        self.project._offer_large_size_confirmation = mock.MagicMock()
         self.project._save()
-        self.assertEqual(self.project.offer_large_size_confirmation.call_count, 0)
+        self.assertEqual(self.project._offer_large_size_confirmation.call_count, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**
User is now presented with a dialog box if the project that they are saving is over 10GB in size, telling them that the project may take a long time to save. 
The user can decide to continue with the save or cancel it. 

**To test:**
1. Create a project with >10GB of workspaces.
     a. Alternatively, change the `mantid.properties` file's `projectSaving.warningSize` value to a more reasonable number to reach. 
2. Attempt to save the project.
3. Check that clicking Cancel/x button does not save the project and clicking Yes does.
4. Clear the project and ensure that the dialog does not appear when saving a small project. 

Resolves #26048 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
