### PR TITLE
Build PythonInterface with FrameworkTests

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -53,6 +53,7 @@ include(TargetFunctions)
 
 add_custom_target(FrameworkTests) # target for all framework tests
 add_dependencies(check FrameworkTests)
+add_dependencies(FrameworkTests Framework)
 
 include_directories(Types/inc)
 add_subdirectory(Types)

--- a/qt/CMakeLists.txt
+++ b/qt/CMakeLists.txt
@@ -29,7 +29,6 @@ if(ENABLE_WORKBENCH AND NOT PYRCC5_CMD)
 endif()
 
 # Qt-based targets
-
 add_subdirectory(icons)
 add_subdirectory(widgets)
 add_subdirectory(python)

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -46,7 +46,7 @@ if(ENABLE_WORKBENCH)
                    PythonInterface)
 
   if(ENABLE_MANTIDPLOT)
-    add_dependencies(mantidqt mantidqt_commonqt4)
+    add_dependencies(mantidqt mantidqt_commonqt4 mantidqt_iconsqt4)
   endif()
 
   if(MSVC)
@@ -60,7 +60,7 @@ if(ENABLE_WORKBENCH)
   endif()
 
   # Testing
-
+  add_dependencies(GUITests mantidqt)
   # ctest targets
   set(
     PYTHON_TEST_FILES


### PR DESCRIPTION
**Description of work.**
Makes FrameworkTests dependent of PythonInterface. 

Adds building `mantidqt_iconsqt4` on builds with `ENABLE_MANTIDPLOT=ON`

**To test:**
Checkout PR, build `AllTests` and try running `ctest -R test_`. No tests should fail due to missing imports - `_commonqt5`, `_iconsqt5` etc.

<!-- Instructions for testing. -->

Fixes #16054

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
