### PR TITLE
Disable unreliable test on macOS

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
@@ -6,8 +6,11 @@ set(TEST_PY_FILES
   helperfunctionsTest.py
   plotfunctionsTest.py
   plotfunctions3DTest.py
-  plots__init__Test.py
-  ScalesTest.py)
+  plots__init__Test.py)
+
+if(NOT APPLE)
+  list(APPEND TEST_PY_FILES ScalesTest.py)
+endif()
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 


### PR DESCRIPTION
**Description of work.**

Disable unreliable `ScalesTest` on macOS until it is investigated.

**To test:**

Code review and see the mac tests pass.

*There is no associated issue.*

*This does not require release notes* because **it is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
