### PR TITLE
Fix flaky ScalesTest

### DIFF
--- a/Framework/PythonInterface/mantid/plots/scales.py
+++ b/Framework/PythonInterface/mantid/plots/scales.py
@@ -125,9 +125,13 @@ class PowerScale(ScaleBase):
                 # an odd denominator then we can write the power as
                 #     (-a)^(1/b) = (-1)^1(a^(1/b)) = -1*a^(1/b)
                 negative_indices = (a < 0.)
-                out = np.negative(a, where=negative_indices)
-                out = np.power(out, 1. / self._gamma)
-                out = np.negative(out, where=negative_indices)
+                if np.any(negative_indices):
+                    out = np.copy(a)
+                    np.negative(a, where=negative_indices, out=out)
+                    np.power(out, 1. / self._gamma, out=out)
+                    np.negative(out, where=negative_indices, out=out)
+                else:
+                    out = np.power(a, 1. / self._gamma)
 
             return out
 

--- a/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
@@ -26,20 +26,59 @@ class ScalesTest(unittest.TestCase):
         self.assertTrue(isinstance(scale_factory('power', axis=None, gamma=3),
                                    PowerScale))
 
-    def test_power_transform(self):
+    def test_power_transform_all_positive(self):
         gamma = 3
         scale = PowerScale(None, gamma=gamma)
-        x = np.linspace(0, 10, 1)
+        x = np.linspace(0, 10)
         transform = scale.get_transform()
         testhelpers.assert_almost_equal(np.power(x, gamma),
                                        transform.transform_non_affine(x))
 
-    def test_power_inverse_transform(self):
+    def test_power_transform_mix_positive_negative(self):
         gamma = 3
         scale = PowerScale(None, gamma=gamma)
-        x = np.linspace(0, 10, 1)
+        x = np.linspace(-5, 5)
+        transform = scale.get_transform()
+        testhelpers.assert_almost_equal(np.power(x, gamma),
+                                       transform.transform_non_affine(x))
+
+    def test_power_transform_all_negative(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(-10, 0)
+        transform = scale.get_transform()
+        testhelpers.assert_almost_equal(np.power(x, gamma),
+                                       transform.transform_non_affine(x))
+
+    def test_power_inverse_transform_all_positive(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(0, 10)
         inv_transform = scale.get_transform().inverted()
         testhelpers.assert_almost_equal(np.power(x, 1./gamma),
+                                       inv_transform.transform_non_affine(x))
+
+    def test_power_inverse_transform_mix_positive_negative(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(-5, 5)
+        negative_pos = (x < 0.0)
+        expected = np.copy(x)
+        np.negative(x, where=negative_pos, out=expected)
+        expected = np.power(expected, 1./gamma)
+        np.negative(expected, where=negative_pos, out=expected)
+        inv_transform = scale.get_transform().inverted()
+
+        testhelpers.assert_almost_equal(expected,
+                                        inv_transform.transform_non_affine(x))
+
+    def test_power_inverse_transform_all_negative(self):
+        gamma = 3
+        scale = PowerScale(None, gamma=gamma)
+        x = np.linspace(-10, 0)
+        expected = np.negative(np.power(np.negative(x), 1./gamma))
+        inv_transform = scale.get_transform().inverted()
+        testhelpers.assert_almost_equal(expected,
                                        inv_transform.transform_non_affine(x))
 
 


### PR DESCRIPTION
**Description of work.**

It turned out there was an actual bug with using the `where` argument of numpy `negative` function. The [documentation](https://docs.scipy.org/doc/numpy/reference/generated/numpy.negative.html) states *Values of True indicate to calculate the ufunc at that position, values of False indicate to leave the value in the output alone*. This was originally interpreted to mean any non-negative values will be as is in the output. In actual fact no operation is performed on them at all and if the output goes into a new array then the values at those positions will be left uninitialized - hence the flaky test.

Relevant discussion: https://github.com/numpy/numpy/issues/11072

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because **fixes an unreliable test**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
