### PR TITLE
Workbench: Remove ? button from title bar of dialog windows

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -10,5 +10,6 @@ Improvements
 
 Bugfixes
 ########
+- Dialog windows no longer contain a useless ? button in their title bar.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -97,6 +97,9 @@ def qapplication():
         # The report is sent when the FrameworkManager kicks up
         UsageService.setApplicationName(APPNAME)
 
+        # removes the ? button from the title bar of dialog windows
+        app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
+
     return app
 
 


### PR DESCRIPTION
**Description of work.**
Some dialog windows have a useless ```?``` button in their title bar, which when clicked does nothing but change the cursor to a cross. The button is now removed.

**To test:**
1. In Workbench, open the dialog windows which previously had the ```?``` button.
    Examples:
    - File -> Manage User Directories
    - Interfaces -> Direct -> DGS Reduction
    - Load a workspace and double click it (the plot window).
    - Double click a graph's title and axes (the windows for editing these).
2. Check that the button is no longer there but the rest of the window's functionality is the same.

Fixes part of #26134 (the issue still exists in MantidPlot)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
