### PR TITLE
Fix ILLDetectorEfficiencyCorUser from being skipped on system test package builds

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskAngleTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from mantid.simpleapi import *
 from mantid.api import *
-from testhelpers import *
+from testhelpers import WorkspaceCreationHelper
 from numpy import *
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MaskBTPTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from mantid.simpleapi import *
 from mantid.api import *
-from testhelpers import *
+from testhelpers import WorkspaceCreationHelper
 from numpy import *
 
 # tests run x10 slower with this on, but it may be useful to track down issues refactoring

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SortDetectorsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SortDetectorsTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 from mantid.simpleapi import *
 from mantid.api import *
-from testhelpers import *
+from testhelpers import WorkspaceCreationHelper
 from numpy import *
 
 

--- a/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
+++ b/Framework/PythonInterface/test/testhelpers/CMakeLists.txt
@@ -1,22 +1,11 @@
 # testhelpers Python module
 
-set(PY_FILES
-    __init__.py
-    algorithm_decorator.py
-    illhelpers.py
-    tempfile_wrapper.py
-    testrunner.py
-    mlzhelpers.py)
-
-# Copy python files to output directory
-set(OUTPUT_DIR
-    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/testhelpers)
-
-# Copy the files for the testhelpers to the build directory
-copy_files_to_dir("${PY_FILES}"
-                  ${CMAKE_CURRENT_SOURCE_DIR}
-                  ${OUTPUT_DIR}
-                  PYTHON_INSTALL_FILES)
+# Copying no longer happens but old builds have this
+# Remove the directory if it exists
+# TODO: Remove in 4.2 maintenance
+if(EXISTS "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/testhelpers")
+  file(REMOVE_RECURSE "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/testhelpers")
+endif()
 
 # Create the targets for this directory
 set(FRAMEWORK_DIR ../../..)
@@ -28,16 +17,15 @@ include_directories(${FRAMEWORK_DIR}/CurveFitting/inc
 
 # WorkspaceCreationHelper
 set(SRC_FILES
-    WorkspaceCreationHelperModule.cpp
+    WorkspaceCreationHelper/WorkspaceCreationHelperModule.cpp
     ${FRAMEWORK_DIR}/TestHelpers/src/ComponentCreationHelper.cpp
     ${FRAMEWORK_DIR}/TestHelpers/src/MDEventsTestHelper.cpp
     ${FRAMEWORK_DIR}/TestHelpers/src/InstrumentCreationHelper.cpp
     ${FRAMEWORK_DIR}/TestHelpers/src/WorkspaceCreationHelper.cpp)
 add_library(PythonWorkspaceCreationHelper
             ${SRC_FILES}
-            ${INC_FILES}
-            ${PYTHON_INSTALL_FILES})
-set_python_properties(PythonWorkspaceCreationHelper WorkspaceCreationHelper)
+            ${INC_FILES})
+set_python_properties(PythonWorkspaceCreationHelper _WorkspaceCreationHelper)
 
 # Override folder
 set_property(TARGET PythonWorkspaceCreationHelper
@@ -59,6 +47,18 @@ target_link_libraries(PythonWorkspaceCreationHelper
                       ${POCO_LIBRARIES})
 
 # Overall testhelpers target
-add_custom_target(testhelpers DEPENDS PythonWorkspaceCreationHelper)
+# .pth file for discovery (only needed for development)
+set(_testhelpers_pth_src "${CMAKE_CURRENT_BINARY_DIR}/testhelpers.pth")
+set(_testhelpers_pth_dest
+    "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/testhelpers.pth")
+file(WRITE ${_testhelpers_pth_src} "${CMAKE_CURRENT_LIST_DIR}/..\n")
+add_custom_command(OUTPUT ${_testhelpers_pth_dest}
+                   COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                           ${_testhelpers_pth_src} ${_testhelpers_pth_dest}
+                   DEPENDS ${_testhelpers_pth_src}
+                   COMMENT "Generating testhelpers .pth file")
+add_custom_target(testhelpers DEPENDS PythonWorkspaceCreationHelper ${_testhelpers_pth_dest})
+add_dependencies(PythonInterface ScriptsDotPth)
+
 add_dependencies(FrameworkTests testhelpers)
 set_property(TARGET testhelpers PROPERTY FOLDER "UnitTests/Python")

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelper/WorkspaceCreationHelperModule.cpp
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelper/WorkspaceCreationHelperModule.cpp
@@ -45,7 +45,7 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
 
-BOOST_PYTHON_MODULE(WorkspaceCreationHelper) {
+BOOST_PYTHON_MODULE(_WorkspaceCreationHelper) {
   using namespace boost::python;
 
   // Doc string options - User defined, python arguments, C++ call signatures

--- a/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelper/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/WorkspaceCreationHelper/__init__.py
@@ -1,0 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import absolute_import
+
+from _WorkspaceCreationHelper import *

--- a/Framework/PythonInterface/test/testhelpers/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/__init__.py
@@ -14,8 +14,6 @@ from distutils.version import LooseVersion
 
 # Import mantid to set MANTIDPATH for any ConfigService call that may be done
 import mantid  # noqa
-# Add workspace creation namespace
-import WorkspaceCreationHelper
 
 import numpy
 

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -46,6 +46,12 @@ THIS_MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
 # Some windows paths can contain sequences such as \r, e.g. \release_systemtests
 # and need escaping to be able to add to the python path
 TESTING_FRAMEWORK_DIR = THIS_MODULE_DIR.replace('\\', '\\\\')
+# Path to PythonInterface/test directory for testhelpers module
+FRAMEWORK_PYTHONINTERFACE_TEST_DIR = os.path.realpath(os.path.join(TESTING_FRAMEWORK_DIR, "..", "..", "..", "..",
+                                                                   "Framework", "PythonInterface", "test"))
+
+if not os.path.exists(FRAMEWORK_PYTHONINTERFACE_TEST_DIR):
+    raise ImportError("Expected 'Framework/PythonInterface/test' to be found at '{}' but it wasn'target. Has the directory moved?")
 
 
 #########################################################################
@@ -641,13 +647,14 @@ except AttributeError:
     pass
 
 import sys
-for p in ('{test_framework}', '{test_dir}'):
+for p in ('{test_framework}', '{pythoninterface_test_dir}', '{test_dir}'):
     sys.path.append(p)
 from {test_modname} import {test_cls}
 systest = {test_cls}()
 if {exclude_in_pr}:
     systest.excludeInPullRequests = lambda: False
-""".format(test_framework=TESTING_FRAMEWORK_DIR, test_dir=self._test_dir, test_modname=self._modname,
+""".format(test_framework=TESTING_FRAMEWORK_DIR, pythoninterface_test_dir=FRAMEWORK_PYTHONINTERFACE_TEST_DIR,
+           test_dir=self._test_dir, test_modname=self._modname,
            test_cls=self._test_cls_name, exclude_in_pr=self._exclude_in_pr_builds)
         if (not clean):
             code += "systest.execute()\n" + \

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -108,6 +108,9 @@ def main():
     sys.path.append(options.frameworkLoc)
     import systemtesting
 
+    # allow PythonInterface/test to be discoverable
+    sys.path.append(systemtesting.FRAMEWORK_PYTHONINTERFACE_TEST_DIR)
+
     #########################################################################
     # Configure mantid
     #########################################################################

--- a/Testing/SystemTests/tests/analysis/PVPythonTest.py
+++ b/Testing/SystemTests/tests/analysis/PVPythonTest.py
@@ -6,10 +6,12 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #pylint: disable=W0232,R0903
 import systemtesting
-from paraview.simple import *
 
 
 class PVPythonTest(systemtesting.MantidSystemTest):
 
     def runTest(self):
+        # Make Vates/ParaView a soft requirement rather than failing on module import
+        # when determining what tests to run.
+        from paraview.simple import GetParaViewVersion
         self.assertEqual(GetParaViewVersion().major, 5)


### PR DESCRIPTION
**Description of work.**

In recent [system builds](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-rhel7/953/console) it was noticed that the `ILLDetectorEfficiencyCorUser` were being skipped due to an import error. This was due to #26418 and the requirement of `testhelpers` being accessible. When running from a developers build this package is available but when running from the package it is not so this error went undetected.

This work fixes the problem with loading the test modules and also adds code to fail early if all test modules cannot be loaded in an attempt to mitigate this in the future.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Simulate a package build by:
* `rm -fr bin/testhelpers`
* `rm bin/mantid.egg-link`

and try to run `./systemtest -R ILLDetectorEfficiencyCorUser` before merging this fix. The tests will say the ILL ones are skipped due to errors.

Merge this change and the `./systemtest` command should now fail early with better errors.

*This does not require release notes* because **as it is a developer change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
