### PR TITLE
Workbench: fix Ubuntu AttributeError

### DIFF
--- a/Framework/PythonInterface/mantid/utils.py
+++ b/Framework/PythonInterface/mantid/utils.py
@@ -8,6 +8,13 @@ from contextlib import contextmanager
 from importlib import import_module
 
 
+def is_required_version(required_version, version):
+    for version_part, required_version_part in zip(version.split('.'), required_version.split('.')):
+        if int(version_part) < int(required_version_part):
+            return False
+    return True
+
+
 def import_mantid_cext(modulename, package="", caller_globals=None):
     """
     Import a Mantid module built from the PythonInterface.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -22,6 +22,7 @@ from functools import partial
 from mantid.api import FrameworkManagerImpl
 from mantid.kernel import (ConfigService, UsageService, logger, version_str as mantid_version_str)
 from mantid.py3compat import setswitchinterval
+from mantid.utils import is_required_version
 from workbench.plugins.exception_handler import exception_logger
 from workbench.widgets.settings.presenter import SettingsPresenter
 
@@ -97,8 +98,7 @@ def qapplication():
         # The report is sent when the FrameworkManager kicks up
         UsageService.setApplicationName(APPNAME)
 
-        # removes the ? button from the title bar of dialog windows
-        if qVersion >= 5.10:
+        if is_required_version(required_version='5.10.0', version=qVersion()):
             app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
 
     return app

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -41,7 +41,7 @@ requirements.check_qt()
 # -----------------------------------------------------------------------------
 # Qt
 # -----------------------------------------------------------------------------
-from qtpy.QtCore import (QEventLoop, Qt, QCoreApplication, QPoint, QSize)  # noqa
+from qtpy.QtCore import (QEventLoop, Qt, QCoreApplication, QPoint, QSize, qVersion)  # noqa
 from qtpy.QtGui import (QColor, QGuiApplication, QIcon, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog,
                             QMainWindow, QSplashScreen)  # noqa
@@ -98,7 +98,8 @@ def qapplication():
         UsageService.setApplicationName(APPNAME)
 
         # removes the ? button from the title bar of dialog windows
-        app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
+        if qVersion >= 5.10:
+            app.setAttribute(Qt.AA_DisableWindowContextHelpButton)
 
     return app
 


### PR DESCRIPTION
**Description of work.**
Checks the QT version being used so that the code to remove the ```?``` button from the title bar of dialog windows doesn't run on older QT vesions. Stops Workbench being unable to launch on Ubuntu.

**To test:**
1. Try opening Workbench on Ubuntu.

Fixes #26502

This doesn't require release notes because it fixes an unreleased bug.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
