### PR TITLE
LoadPSIMuonBin: Allow all expected PSI muon bin data to be loadable

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPSIMuonBin.h
@@ -46,8 +46,8 @@ struct headerData {
   std::string timeEnd;
   std::string monDeviation;
   int32_t scalars[18];
-  std::string labels_scalars[18]; // 18 Strings with 4 max length
-  int32_t labelsOfHistograms[16];
+  std::string labels_scalars[18];     // 18 Strings with 4 max length
+  std::string labelsOfHistograms[16]; // 18 Strings with 4 max length
   int16_t integerT0[16];
   int16_t firstGood[16];
   int16_t lastGood[16];

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -377,6 +377,7 @@ void LoadPSIMuonBin::readInHistograms(
                         m_header.lengthOfDataRecordsBin;
     std::vector<double> &nextHistogram = m_histograms[histogramIndex];
     streamReader.moveStreamToPosition(offset * sizeInt32_t + headerSize);
+    nextHistogram.reserve(m_header.lengthOfHistograms);
     for (auto rowIndex = 0; rowIndex < m_header.lengthOfHistograms;
          ++rowIndex) {
       int32_t nextReadValue;

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -329,7 +329,7 @@ void LoadPSIMuonBin::readArrayVariables(
 
   for (auto i = 0u; i <= 15; ++i) {
     streamReader.moveStreamToPosition(948 + (i * 4));
-    streamReader >> m_header.labelsOfHistograms[i];
+    streamReader.read(m_header.labelsOfHistograms[i], 4);
 
     streamReader.moveStreamToPosition(458 + (i * 2));
     streamReader >> m_header.integerT0[i];
@@ -529,10 +529,19 @@ void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
     if (m_header.labels_scalars[i] == "NONE")
       // Break out of for loop
       break;
-    addToSampleLog("Label Spectra " + std::to_string(i),
+    addToSampleLog("Scalar Label Spectra " + std::to_string(i),
                    m_header.labels_scalars[i], outputWorkspace);
     addToSampleLog("Scalar Spectra " + std::to_string(i), m_header.scalars[i],
                    outputWorkspace);
+  }
+
+  constexpr auto sizeOfLabels = sizeof(m_header.labelsOfHistograms) /
+                                sizeof(*m_header.labelsOfHistograms);
+  for (auto i = 0u; i < sizeOfLabels; ++i) {
+    if (m_header.labelsOfHistograms[i] == "")
+      break;
+    addToSampleLog("Label Spectra " + std::to_string(i),
+                   m_header.labelsOfHistograms[i], outputWorkspace);
   }
 
   addToSampleLog("Orientation", m_header.orientation, outputWorkspace);

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -10,4 +10,12 @@ MuSR Changes
     improvements, followed by bug fixes.
 
 
+Algorithms
+----------
+
+Improvements
+############
+
+- :ref:`LoadPSIMuonBin <algm-LoadPSIMuonBin>` has been improved to correctly load data other than data from Dolly at the SmuS/PSI.
+
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
**Description of work.**
Previously for some unknown reason, dolly instrument data from PSI was loadable whilst other muon instruments were not. This makes it work for all of the instruments.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
If unit tests pass and the code looks fine.

Ask me for the data as it should not be made public:
- Open Workbench
- Open Muon Analysis 2
- Click browse
- Open a dolly .bin file
- Check everything looks alright
- Open a gps .bin file
- Check everything looks alright
- Repeat for gpd, ltf, and lem.

<!-- Instructions for testing. -->

Fixes #26494 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
