### PR TITLE
LoadPSIMuonBin: Handle poorly converted bin files better

### DIFF
--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -472,9 +472,16 @@ void LoadPSIMuonBin::assignOutputWorkspaceParticulars(
   // Set Start date and time and end date and time
   auto startDate = getFormattedDateTime(m_header.dateStart, m_header.timeStart);
   auto endDate = getFormattedDateTime(m_header.dateEnd, m_header.timeEnd);
-  Mantid::Types::Core::DateAndTime start(startDate);
-  Mantid::Types::Core::DateAndTime end(endDate);
-  outputWorkspace->mutableRun().setStartAndEndTime(start, end);
+  try {
+    Mantid::Types::Core::DateAndTime start(startDate);
+    Mantid::Types::Core::DateAndTime end(endDate);
+    outputWorkspace->mutableRun().setStartAndEndTime(start, end);
+  } catch (const std::logic_error &) {
+    Mantid::Types::Core::DateAndTime start;
+    Mantid::Types::Core::DateAndTime end;
+    outputWorkspace->mutableRun().setStartAndEndTime(start, end);
+    g_log.warning("The date in the .bin file was invalid");
+  }
 
   addToSampleLog("run_end", startDate, outputWorkspace);
   addToSampleLog("run_start", endDate, outputWorkspace);

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -9,5 +9,20 @@ MuSR Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Algorithms
+----------
+
+Improvements
+############
+
+- Improve the handling of :ref:`LoadPSIMuonBin<algm-LoadPSIMuonBin-v1>` where a poor date is provided.
+
+Interfaces
+----------
+
+Muon Analysis 2
+###############
+
+- When loading PSI data if the groups given are poorly stored in the file, it should now produce unique names in the grouping tab for groups.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -17,15 +17,28 @@ from mantid.kernel import ConfigServiceImpl
 from Muon.GUI.Common.observer_pattern import Observable
 
 
+def get_incremental_number_for_value_in_list(name, list_copy, current_number=1):
+    if name + str(current_number) in list_copy:
+        return get_incremental_number_for_value_in_list(name, list_copy, current_number+1)
+    else:
+        return str(current_number)
+
+
 def get_grouping_psi(workspace):
     grouping_list = []
-
+    sample_log_value_list = []
     for ii in range(0, workspace.getNumberHistograms()):
         sample_log_label_name = "Label Spectra " + str(ii)
         workspace_run = workspace.getRun()
+
         if workspace_run.hasProperty(sample_log_label_name):
             sample_log_value = workspace_run.getProperty(sample_log_label_name).value
-            grouping_list.append(MuonGroup(sample_log_value, [ii+1]))
+            if sample_log_value not in sample_log_value_list:
+                grouping_list.append(MuonGroup(sample_log_value, [ii+1]))
+            else:
+                sample_log_value += get_incremental_number_for_value_in_list(sample_log_value, sample_log_value_list)
+                grouping_list.append(MuonGroup(sample_log_value, [ii+1]))
+            sample_log_value_list.append(sample_log_value)
 
     return grouping_list, [], ''
 


### PR DESCRIPTION
**PR #26507 should be merged first**


**Description of work.**
In some cases during conversion, some group data is cut off and dates can be scrambled. This gracefully handles it.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open workbench
- Open Muon Analysis 2
- Load this file: 
[004567.zip](https://github.com/mantidproject/mantid/files/3442401/004567.zip)
- There should be Dete, Dete1, Dete2 etc in the grouping tab and 2098--(rest of date) as the date format in the log at the bottom.


<!-- Instructions for testing. -->

Fixes #26495 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
