### PR TITLE
Workbench: Make it possible to close an existing project and save it with a new name

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -17,5 +17,6 @@ Improvements
 Bugfixes
 ########
 - Dialog windows no longer contain a useless ? button in their title bar.
+- Fixes an issue where choosing to not overwrite an existing project when attempting to save upon closing would cause Workbench to close without saving.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -65,7 +65,9 @@ class Project(AnalysisDataServiceObserver):
             if answer == QMessageBox.Yes:
                 # Actually save
                 self._save()
-            # Else do nothing
+            elif answer == QMessageBox.No:
+                # Save with a new name
+                self.save_as()
 
     def save_as(self):
         """


### PR DESCRIPTION
**Description of work.**
When closing an existing project which has unsaved changes, a dialog box asks if you wish to save the changes and then if you wish to overwrite the existing project. Previously clicking No would close Workbench without saving, but now the user is able to save the project with a new name.

**To test:**
1. In Workbench, open an existing project.
2. Make a change to the project, e.g. load a new workspace.
3. Press the X in the corner to close Workbench.
4. Click Yes in the dialog box asking if you want to save.
5. In the next dialog box asking if you want to overwrite the existing project, check that clicking Yes still saves the project with the same name, and clicking No now causes a file window to appear where you can choose the name and location of the project.

Refs #26513 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
