### PR TITLE
Add tests for parsing search results to reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -65,6 +65,7 @@ set(TEST_FILES
     test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
     test/ISISReflectometry/Runs/CatalogRunNotifierTest.h
     test/ISISReflectometry/Runs/RunsPresenterTest.h
+    test/ISISReflectometry/Runs/SearchResultTest.h
     test/ISISReflectometry/Save/SavePresenterTest.h
     test/ISISReflectometry/Common/PlotterTestQt4.h
 )

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -9,20 +9,13 @@
 #include "CatalogSearcher.h"
 #include "GUI/Batch/IBatchPresenter.h"
 #include "GUI/Common/IMessageHandler.h"
-#include "GUI/Common/IPythonRunner.h"
 #include "GUI/RunsTable/RunsTablePresenter.h"
 #include "IRunsView.h"
 #include "MantidAPI/AlgorithmManager.h"
-#include "MantidAPI/CatalogManager.h"
-#include "MantidAPI/ITableWorkspace.h"
-#include "MantidKernel/FacilityInfo.h"
-#include "MantidKernel/StringTokenizer.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
-#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include "MantidQtWidgets/Common/ProgressPresenter.h"
 
 #include <algorithm>
-#include <boost/tokenizer.hpp>
 #include <fstream>
 #include <iterator>
 #include <sstream>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchModel.cpp
@@ -57,7 +57,7 @@ std::vector<SearchResult> const &SearchModel::results() const {
 }
 
 void SearchModel::setError(int i, std::string const &error) {
-  m_runDetails[i].issues = error;
+  m_runDetails[i].setError(error);
   emit dataChanged(index(i, 0), index(i, 2));
 }
 
@@ -134,7 +134,7 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const {
     if (role == Qt::ToolTipRole) {
       // setting the tool tips for any unsuccessful transfers
       if (runHasError(run)) {
-        auto errorMessage = "Invalid transfer: " + run.issues;
+        auto errorMessage = "Invalid transfer: " + run.error();
         return QString::fromStdString(errorMessage);
       }
     } else if (role == Qt::BackgroundRole) {
@@ -148,13 +148,13 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const {
   }
   /*SETTING DATA FOR RUNS*/
   if (colNumber == 0)
-    return QString::fromStdString(run.runNumber);
+    return QString::fromStdString(run.runNumber());
 
   if (colNumber == 1)
-    return QString::fromStdString(run.description);
+    return QString::fromStdString(run.description());
 
   if (colNumber == 2)
-    return QString::fromStdString(run.location);
+    return QString::fromStdString(run.location());
 
   return QVariant();
 }
@@ -211,7 +211,7 @@ void SearchModel::clear() {
 @return : true if there is at least one error for this run
 */
 bool SearchModel::runHasError(const SearchResult &run) const {
-  return !(run.issues.empty());
+  return !(run.error().empty());
 }
 
 SearchResult const &SearchModel::getRowData(int index) const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -30,17 +30,17 @@ void SearchResult::parseMetadata() {
   }
 }
 
-std::string SearchResult::runNumber() const { return m_runNumber; }
+const std::string &SearchResult::runNumber() const { return m_runNumber; }
 
-std::string SearchResult::description() const { return m_description; }
+const std::string &SearchResult::description() const { return m_description; }
 
-std::string SearchResult::location() const { return m_location; }
+const std::string &SearchResult::location() const { return m_location; }
 
-std::string SearchResult::error() const { return m_error; }
+const std::string &SearchResult::error() const { return m_error; }
 
-std::string SearchResult::groupName() const { return m_groupName; }
+const std::string &SearchResult::groupName() const { return m_groupName; }
 
-std::string SearchResult::theta() const { return m_theta; }
+const std::string &SearchResult::theta() const { return m_theta; }
 
 void SearchResult::setError(std::string const &error) { m_error = error; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -5,14 +5,51 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "SearchResult.h"
+#include <boost/regex.hpp>
 
 namespace MantidQt {
 namespace CustomInterfaces {
+
+SearchResult::SearchResult(const std::string &runNumber,
+                           const std::string &desc, const std::string &loc)
+    : m_runNumber(runNumber), m_description(desc), m_location(loc),
+      m_groupName(), m_theta() {
+  parseMetadata();
+}
+
+void SearchResult::parseMetadata() {
+  static boost::regex descriptionFormatRegex("(.*)(th[:=]([0-9.]+))(.*)");
+  boost::smatch matches;
+  if (boost::regex_search(m_description, matches, descriptionFormatRegex)) {
+    constexpr auto preThetaGroup = 1;
+    constexpr auto thetaValueGroup = 3;
+    m_theta = matches[thetaValueGroup].str();
+    m_groupName = matches[preThetaGroup].str();
+  } else {
+    m_groupName = m_description;
+  }
+}
+
+std::string SearchResult::runNumber() const { return m_runNumber; }
+
+std::string SearchResult::description() const { return m_description; }
+
+std::string SearchResult::location() const { return m_location; }
+
+std::string SearchResult::error() const { return m_error; }
+
+std::string SearchResult::groupName() const { return m_groupName; }
+
+std::string SearchResult::theta() const { return m_theta; }
+
+void SearchResult::setError(std::string const &error) { m_error = error; }
+
 bool operator==(SearchResult const &lhs, SearchResult const &rhs) {
-  // Ignore the issues field in the comparison because this represents the
+  // Ignore the error field in the comparison because this represents the
   // state of the item and is not a unique identifier
-  return lhs.runNumber == rhs.runNumber && lhs.description == rhs.description &&
-         lhs.location == rhs.location;
+  return lhs.runNumber() == rhs.runNumber() &&
+         lhs.description() == rhs.description() &&
+         lhs.location() == rhs.location();
 }
 
 bool operator!=(SearchResult const &lhs, SearchResult const &rhs) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -36,8 +36,10 @@ private:
   void parseMetadata();
 };
 
-bool operator==(SearchResult const &lhs, SearchResult const &rhs);
-bool operator!=(SearchResult const &lhs, SearchResult const &rhs);
+MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(SearchResult const &lhs,
+                                               SearchResult const &rhs);
+MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(SearchResult const &lhs,
+                                               SearchResult const &rhs);
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -17,12 +17,12 @@ public:
   SearchResult(const std::string &runNumber, const std::string &desc,
                const std::string &loc);
 
-  std::string runNumber() const;
-  std::string description() const;
-  std::string location() const;
-  std::string error() const;
-  std::string groupName() const;
-  std::string theta() const;
+  const std::string &runNumber() const;
+  const std::string &description() const;
+  const std::string &location() const;
+  const std::string &error() const;
+  const std::string &groupName() const;
+  const std::string &theta() const;
   void setError(std::string const &error);
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -6,20 +6,34 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H
 #define MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H
+#include "Common/DllConfig.h"
 #include <string>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
-struct SearchResult {
-  SearchResult() {}
+class MANTIDQT_ISISREFLECTOMETRY_DLL SearchResult {
+public:
   SearchResult(const std::string &runNumber, const std::string &desc,
-               const std::string &loc)
-      : runNumber(runNumber), description(desc), location(loc) {}
-  std::string runNumber;
-  std::string description;
-  std::string location;
-  std::string issues;
+               const std::string &loc);
+
+  std::string runNumber() const;
+  std::string description() const;
+  std::string location() const;
+  std::string error() const;
+  std::string groupName() const;
+  std::string theta() const;
+  void setError(std::string const &error);
+
+private:
+  std::string m_runNumber;
+  std::string m_description;
+  std::string m_location;
+  std::string m_error;
+  std::string m_groupName;
+  std::string m_theta;
+
+  void parseMetadata();
 };
 
 bool operator==(SearchResult const &lhs, SearchResult const &rhs);

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -48,7 +48,7 @@ public:
         m_view(), m_runsTableView(), m_progressView(), m_messageHandler(),
         m_searcher(nullptr), m_pythonRunner(), m_runNotifier(nullptr),
         m_runsTable(m_instruments, m_thetaTolerance, ReductionJobs()),
-        m_searchString("test search string") {
+        m_searchString("test search string"), m_searchResult("", "", "") {
     ON_CALL(m_view, table()).WillByDefault(Return(&m_runsTableView));
     ON_CALL(m_runsTableView, jobs()).WillByDefault(ReturnRef(m_jobs));
   }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/SearchResultTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/SearchResultTest.h
@@ -1,0 +1,149 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "../../../ISISReflectometry/GUI/Runs/SearchResult.h"
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using MantidQt::CustomInterfaces::SearchResult;
+
+class SearchResultTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SearchResultTest *createSuite() { return new SearchResultTest(); }
+  static void destroySuite(SearchResultTest *suite) { delete suite; }
+
+  void testConstructorSetsRunNumber() {
+    auto result = SearchResult("test run", "", "");
+    TS_ASSERT_EQUALS(result.runNumber(), "test run");
+  }
+
+  void testConstructorSetsLocation() {
+    auto result = SearchResult("", "", "test location");
+    TS_ASSERT_EQUALS(result.location(), "test location");
+  }
+
+  void testSetError() {
+    auto result = SearchResult("", "", "");
+    result.setError("test error");
+    TS_ASSERT_EQUALS(result.error(), "test error");
+  }
+
+  void testGroupNameAndThetaAreEmptyIfDescriptionEmpty() {
+    auto result = SearchResult("", "", "");
+    TS_ASSERT_EQUALS(result.groupName(), "");
+    TS_ASSERT_EQUALS(result.theta(), "");
+  }
+
+  void testGroupNameSetFromDescriptionIfThetaNotGiven() {
+    auto result = SearchResult("", "test description", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test description");
+  }
+
+  void testThetaIsEmptyIfNotIncludedInDescription() {
+    auto result = SearchResult("", "test description", "");
+    TS_ASSERT_EQUALS(result.theta(), "");
+  }
+
+  void testGroupNameAndThetaParsedFromDescription() {
+    auto result = SearchResult("", "test descriptionth=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test description");
+    TS_ASSERT_EQUALS(result.theta(), "1.5");
+  }
+
+  void testTextAfterThetaIsIgnoredInParsing() {
+    auto result =
+        SearchResult("", "test descriptionth=1.5 <this is ignored>", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test description");
+    TS_ASSERT_EQUALS(result.theta(), "1.5");
+  }
+
+  void testGroupNameContainsOnlyWhitespaceWithThetaSpecified() {
+    auto result = SearchResult("", "  th=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "  ");
+    TS_ASSERT_EQUALS(result.theta(), "1.5");
+  }
+
+  void testGroupNameAndThetaEmptyIfDescriptionContainsOnlyWhitespace() {
+    auto result = SearchResult("", "  ", "");
+    TS_ASSERT_EQUALS(result.groupName(), "  ");
+    TS_ASSERT_EQUALS(result.theta(), "");
+  }
+
+  void testThetaIsSetAndGroupNameIsEmptyIfDescriptionOnlyContainsTheta() {
+    auto result = SearchResult("", "th=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "");
+    TS_ASSERT_EQUALS(result.theta(), "1.5");
+  }
+
+  void testWhitespaceOutsideGroupNameIsNotClippedIfThetaIsFound() {
+    auto result = SearchResult("", "   test description  th=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "   test description  ");
+  }
+
+  void testWhitespaceOutsideGroupNameIsNotClippedIfThetaIsNotFound() {
+    auto result = SearchResult("", "   test description  ", "");
+    TS_ASSERT_EQUALS(result.groupName(), "   test description  ");
+  }
+
+  void testWhitespaceInsideGroupNameIsNotClippedIfThetaIsFound() {
+    auto result = SearchResult("", "test   descriptionth=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test   description");
+  }
+
+  void testWhitespaceInsideGroupNameIsNotClippedIfThetaIsNotFound() {
+    auto result = SearchResult("", "test   description", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test   description");
+  }
+
+  void testSpecialCharactersInDescription() {
+    auto result = SearchResult("", "test*+.descriptionth=1.5", "");
+    TS_ASSERT_EQUALS(result.groupName(), "test*+.description");
+    TS_ASSERT_EQUALS(result.theta(), "1.5");
+  }
+
+  void testSearchResultsWithSameRunDescriptionAndLocationAreEqual() {
+    auto result1 = SearchResult("run1", "desc1", "locn1");
+    auto result2 = SearchResult("run1", "desc1", "locn1");
+    TS_ASSERT(result1 == result2);
+  }
+
+  void testSearchResultsDifferringOnlyByErrorsAreEqual() {
+    auto result1 = SearchResult("run1", "desc1", "locn1");
+    auto result2 = SearchResult("run1", "desc1", "locn1");
+    result1.setError("error1");
+    result2.setError("error2");
+    TS_ASSERT(result1 == result2);
+  }
+
+  void testSearchResultsWithSameGroupNameButDifferentDescriptionsAreNotEqual() {
+    auto result1 = SearchResult("", "group-title th=1.5<ignored text>", "");
+    auto result2 = SearchResult("", "group-title th=1.5", "");
+    TS_ASSERT(result1 != result2);
+  }
+
+  void testSearchResultsWithDifferentRunAreNotEqual() {
+    auto result1 = SearchResult("run1", "desc1", "locn1");
+    auto result2 = SearchResult("run2", "desc1", "locn1");
+    TS_ASSERT(result1 != result2);
+  }
+
+  void testSearchResultsWithDifferentDescriptionAreNotEqual() {
+    auto result1 = SearchResult("run1", "desc1", "locn1");
+    auto result2 = SearchResult("run1", "desc2", "locn1");
+    TS_ASSERT(result1 != result2);
+  }
+
+  void testSearchResultsWithDifferentLocationAreNotEqual() {
+    auto result1 = SearchResult("run1", "desc1", "locn1");
+    auto result2 = SearchResult("run1", "desc1", "locn2");
+    TS_ASSERT(result1 != result2);
+  }
+};


### PR DESCRIPTION
This PR adds unit tests for constructing and parsing the search results for the ISIS Reflectometry GUI. It moves the code to do the parsing into the `SearchResult` class from the `RunsPresenter`.

**To test:**

- Code review and ensure unit tests pass
- Open the ISIS Reflectometry interface
- Set the instrument to INTER and enter investigation ID `1120015` and click Search. Log in to ICat if prompted.
- Select some of the results e.g. the first 7 rows and click transfer. They should either be transferred to the table or highlighted in blue to indicate an error. Hover over the blue rows to see a tooltip of the error message.
- Delete all rows in the table and add the same (valid) ones again but in reverse order. They should be sorted so that you get the same result as before.
- Try transferring the same row twice. It should only be added once.

![image](https://user-images.githubusercontent.com/12895056/62287914-176fd100-b453-11e9-8d23-0bbe7ff81304.png)

Refs #26512

*This does not require release notes* because **it concerns testing only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
