### PR TITLE
Add unit tests for merging rows into the reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -9,6 +9,7 @@
 #include "CatalogSearcher.h"
 #include "GUI/Batch/IBatchPresenter.h"
 #include "GUI/Common/IMessageHandler.h"
+#include "GUI/Common/IPythonRunner.h"
 #include "GUI/RunsTable/RunsTablePresenter.h"
 #include "IRunsView.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -366,11 +367,8 @@ void RunsPresenter::transfer(const std::set<int> &rowsToTransfer,
       auto const &result = m_searcher->getSearchResult(rowIndex);
       auto row = validateRowFromRunAndTheta(result.runNumber(), result.theta());
       if (row.is_initialized()) {
-        auto rowChanged = [](Row const &rowA, Row const &rowB) -> bool {
-          return rowA.runNumbers() != rowB.runNumbers();
-        };
-        mergeRowIntoGroup(jobs, row.get(), m_thetaTolerance, result.groupName(),
-                          rowChanged);
+        mergeRowIntoGroup(jobs, row.get(), m_thetaTolerance,
+                          result.groupName());
       } else {
         m_searcher->setSearchResultError(
             rowIndex, "Theta was not specified in the description.");

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
@@ -162,8 +162,7 @@ void updateRow(ReductionJobs &jobs, int groupIndex, int rowIndex,
 }
 
 void mergeRowIntoGroup(ReductionJobs &jobs, Row const &row,
-                       double thetaTolerance, std::string const &groupName,
-                       bool (*rowChanged)(Row const &rowA, Row const &rowB)) {
+                       double thetaTolerance, std::string const &groupName) {
   auto &group = findOrMakeGroupWithName(jobs, groupName);
   auto indexOfRowToUpdate =
       group.indexOfRowWithTheta(row.theta(), thetaTolerance);
@@ -171,7 +170,7 @@ void mergeRowIntoGroup(ReductionJobs &jobs, Row const &row,
   if (indexOfRowToUpdate.is_initialized()) {
     auto rowToUpdate = group[indexOfRowToUpdate.get()].get();
     auto newRowValue = mergedRow(rowToUpdate, row);
-    if (rowChanged(newRowValue, rowToUpdate))
+    if (newRowValue.runNumbers() != rowToUpdate.runNumbers())
       group.updateRow(indexOfRowToUpdate.get(), newRowValue);
   } else {
     group.insertRowSortedByAngle(row);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
@@ -85,9 +85,9 @@ std::string groupName(ReductionJobs const &jobs, int groupIndex);
 
 int percentComplete(ReductionJobs const &jobs);
 
-void mergeRowIntoGroup(ReductionJobs &jobs, Row const &row,
-                       double thetaTolerance, std::string const &groupName,
-                       bool (*rowChanged)(Row const &rowA, Row const &rowB));
+MANTIDQT_ISISREFLECTOMETRY_DLL void
+mergeRowIntoGroup(ReductionJobs &jobs, Row const &row, double thetaTolerance,
+                  std::string const &groupName);
 
 template <typename ModificationListener>
 void mergeJobsInto(ReductionJobs &intoHere, ReductionJobs const &fromHere,

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
@@ -97,7 +97,7 @@ public:
   }
 
   void testMergeJobsIntoExistingWhenNameClashButNoRows() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(Group("A"));
     auto addition = ReductionJobs();
@@ -110,7 +110,7 @@ public:
   }
 
   void testMergeJobsIntoExistingWhenNameClashButRowsWithDifferentAngles() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(Group("A", {rowWithAngle(0.1)}));
     auto addition = ReductionJobs();
@@ -124,7 +124,7 @@ public:
   }
 
   void testCallsInsertWhenAddingRow() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(Group("A", {rowWithAngle(0.1)}));
     auto addition = ReductionJobs();
@@ -140,7 +140,7 @@ public:
   }
 
   void testMergeJobsIntoExistingWhenNameClashAndRowsHaveSameAngles() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(Group("A", {rowWithNameAndAngle("C", 0.1)}));
     auto addition = ReductionJobs();
@@ -156,7 +156,7 @@ public:
   }
 
   void testCallsModifiedWhenMergingRow() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(Group("A", {rowWithNameAndAngle("C", 0.1)}));
     auto addition = ReductionJobs();
@@ -201,7 +201,7 @@ public:
   }
 
   void testMergeIntoSelfResultsInNoChange() {
-    MockModificationListener listener;
+    NiceMock<MockModificationListener> listener;
     auto target = ReductionJobs();
     target.appendGroup(
         Group("S1 SI/ D20 ", {rowWithNameAndAngle("47450", 0.7),

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_CUSTOMINTERFACES_REDUCTIONJOBSMERGETEST_H_
 #define MANTID_CUSTOMINTERFACES_REDUCTIONJOBSMERGETEST_H_
-#include "../../../ISISReflectometry/Common/ModelCreationHelper.h"
+#include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "Common/ZipRange.h"
 #include "Reduction/ReductionJobs.h"
 #include <cxxtest/TestSuite.h>


### PR DESCRIPTION
This PR adds additional unit tests to do with merging rows into the ISIS Reflectometry GUI. In particular, it tests the `mergeRowIntoGroup` function, which updates the `ReductionJobs` model with the merged row (if a merge is applicable).

There is also some minor tidying to simplify the function interface and remove spurious warnings from existing tests.

**To test:**

- Code review and ensure unit tests pass.
- Ensure transferring rows still works in the ISIS Reflectometry interface: follow the same tests as on PR #26517

Refs #26512 	

*This does not require release notes* because **it concerns testing only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
