### PR TITLE
Load dialog asterisk position and window resizing fix

### DIFF
--- a/docs/source/release/v4.2.0/mantidplot.rst
+++ b/docs/source/release/v4.2.0/mantidplot.rst
@@ -11,5 +11,7 @@ Improvements
 Bugfixes
 ########
 - Algorithm progress bar now shows correct units for time remaining.
+- Fixes an issue where the * to indicate an invalid property would appear in the wrong place in the Load dialog.
+- Fixes an issue where the Load dialog would not resize correctly after clicking Run.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -25,6 +25,10 @@
 #include "MantidKernel/Property.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
 
+using namespace Mantid::API;
+using namespace Mantid::Kernel;
+using MantidQt::API::MWRunFiles;
+
 namespace MantidQt {
 namespace CustomDialogs {
 namespace {
@@ -147,6 +151,9 @@ void LoadDialog::accept() {
   while (m_form.fileWidget->isSearching() || m_populating)
     QApplication::instance()->processEvents();
 
+  // Makes it so the dialog is still resizable if it is kept open
+  m_form.propertyLayout->setEnabled(true);
+
   // Check that the file still exists just incase it somehow got removed
   std::string errMess =
       getAlgorithm()->getPointerToProperty("Filename")->isValid();
@@ -256,9 +263,6 @@ void LoadDialog::createDynamicLayout() {
   // be being deleted
   m_form.propertyLayout->setEnabled(false);
 
-  using namespace Mantid::API;
-  using namespace Mantid::Kernel;
-
   if (!m_form.fileWidget->isValid())
     return;
   // First step is the get the specific loader that is responsible
@@ -329,10 +333,6 @@ void LoadDialog::createDynamicLayout() {
 int LoadDialog::createWidgetsForProperty(const Mantid::Kernel::Property *prop,
                                          QVBoxLayout *propertyLayout,
                                          QWidget *parent) {
-  using namespace Mantid::API;
-  using namespace Mantid::Kernel;
-  using MantidQt::API::MWRunFiles;
-
   QString propName = QString::fromStdString(prop->name());
   QWidget *inputWidget(nullptr);
   QHBoxLayout *widgetLayout(nullptr);


### PR DESCRIPTION
**Description of work.**
Fixes an issue where for all properties except File in the Load dialog, the asterisk which appears to indicate an invalid input would be in the wrong place (in the top-left corner of the window instead of next to the property). Also fixes an issue where if the Load dialog remains open after clicking Run, the input boxes would not resize when the window is resized.

**To test:**
1. In MantidPlot, open the Load dialog.
2. Enter invalid values for all properties except for File.
3. Click run and check that the asterisks appear in the correct place.
4. Click and drag at the edge of the window to resize it and check that the dialog resizes correctly.
5. Do the same in Workbench.

Fixes #26387 
Fixes #26457 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
