### PR TITLE
Workbench: add a keyboard shortcut to create a new tab in the script editor

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -13,6 +13,7 @@ User Interface
 
 Improvements
 ############
+- The keyboard shortcut Ctrl+N now opens a new tab in the script editor.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -46,6 +46,7 @@ class CodeEditorTabWidget(QTabWidget):
         plus_button = QPushButton(self)
         plus_button.setObjectName(self.NEW_EDITOR_PLUS_BTN_OBJECT_NAME)
         plus_button.clicked.connect(parent.plus_button_clicked)
+        plus_button.setShortcut('Ctrl+N')
         plus_button.setIcon(get_icon("mdi.plus", "black", 1.2))
         self.setCornerWidget(plus_button, Qt.TopLeftCorner)
 


### PR DESCRIPTION
**Description of work.**
Pressing Ctrl+N in Workbench now create a new tab in the script editor.

**To test:**
In Workbench, check that the keyboard shortcut Ctrl+N creates a new tab in the script editor (identical to clicking the + button).

Fixes #26300 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
