### PR TITLE
Add new InPlane option to MaskAngle

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -66,13 +66,16 @@ class MaskAngle(mantid.api.PythonAlgorithm):
 
         angleMin = self.getProperty('MinAngle').value
         angleMax = self.getProperty('MaxAngle').value
-        if self.getProperty('Angle').value != 'InPlane':
-            angleMin = numpy.fabs(angleMin)
-            angleMax = numpy.fabs(angleMax)
         if angleMin >= angleMax:
             msg = 'MinAngle ({}) must be less than MaxAngle ({})'.format(angleMin, angleMax)
             issues['MinAngle'] = msg
             issues['MaxAngle'] = msg
+
+        if self.getProperty('Angle').value != 'InPlane':
+            if angleMin < 0.:
+                issues['MinAngle'] = 'Must be positive'
+            if angleMax < 0.:
+                issues['MaxAngle'] = 'Must be positive'
 
         return issues
 
@@ -101,13 +104,6 @@ class MaskAngle(mantid.api.PythonAlgorithm):
 
         angle_phi = self.getProperty('Angle').value == 'Phi'
         angle_in_plane = self.getProperty('Angle').value == 'InPlane'
-        if not angle_in_plane:
-            if ttmin < 0.:
-                self.log().information('Using absolute value of MinAngle')
-                ttmin = numpy.fabs(ttmin)
-            if ttmax < 0.:
-                self.log().information('Using absolute value of MaxAngle')
-                ttmax = numpy.fabs(ttmax)
         spectrum_info = ws.spectrumInfo()
         detector_info = ws.detectorInfo()
         det_ids = detector_info.detectorIDs()

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -40,13 +40,13 @@ class MaskAngle(mantid.api.PythonAlgorithm):
                              "Input workspace")
 
         angleValidator=mantid.kernel.FloatBoundedValidator()
-        angleValidator.setBounds(0.,180.)
+        angleValidator.setBounds(-180.,180.)
         self.declareProperty(name="MinAngle", defaultValue=0.0, validator=angleValidator,
                              direction=mantid.kernel.Direction.Input, doc="Angles above MinAngle are going to be masked")
         self.declareProperty(name="MaxAngle", defaultValue=180.0, validator=angleValidator,
                              direction=mantid.kernel.Direction.Input, doc="Angles below MaxAngle are going to be masked")
         self.declareProperty('Angle', 'TwoTheta',
-                             mantid.kernel.StringListValidator(['TwoTheta', 'Phi']),
+                             mantid.kernel.StringListValidator(['TwoTheta', 'Phi', 'InPlane']),
                              'Which angle to use')
         self.declareProperty(mantid.kernel.IntArrayProperty(name="MaskedDetectors", direction=mantid.kernel.Direction.Output),
                              doc="List of detector masked, with scattering angles between MinAngle and MaxAngle")
@@ -60,8 +60,20 @@ class MaskAngle(mantid.api.PythonAlgorithm):
                 hasInstrument = hasInstrument and len(item.componentInfo()) > 0
         else:
             hasInstrument = len(ws.componentInfo()) > 0
+
         if not hasInstrument:
             issues["Workspace"] = "Workspace must have an associated instrument."
+
+        angleMin = self.getProperty('MinAngle').value
+        angleMax = self.getProperty('MaxAngle').value
+        if self.getProperty('Angle').value != 'InPlane':
+            angleMin = numpy.fabs(angleMin)
+            angleMax = numpy.fabs(angleMax)
+        if angleMin >= angleMax:
+            msg = 'MinAngle ({}) must be less than MaxAngle ({})'.format(angleMin, angleMax)
+            issues['MinAngle'] = msg
+            issues['MaxAngle'] = msg
+
         return issues
 
     def _get_phi(self, spectra_pos):
@@ -72,6 +84,14 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         '''
         return numpy.fabs(numpy.arctan2(spectra_pos.Y(), spectra_pos.X()))
 
+    def _get_in_plane(self, spectra_pos):
+        '''
+        The implementation here assumes that z is the beam direction and x is in plane.
+        That assumption is not universally true, it depends on the geometry configuration.
+        This returns the angle from the z-axis constrained in-plane
+        '''
+        return numpy.arctan2(spectra_pos.X(), spectra_pos.Z())
+
     def PyExec(self):
         ws = self.getProperty("Workspace").value
         ttmin = numpy.radians(self.getProperty("MinAngle").value)
@@ -80,6 +100,14 @@ class MaskAngle(mantid.api.PythonAlgorithm):
             raise ValueError("MinAngle > MaxAngle, please check angle range for masking")
 
         angle_phi = self.getProperty('Angle').value == 'Phi'
+        angle_in_plane = self.getProperty('Angle').value == 'InPlane'
+        if not angle_in_plane:
+            if ttmin < 0.:
+                self.log().information('Using absolute value of MinAngle')
+                ttmin = numpy.fabs(ttmin)
+            if ttmax < 0.:
+                self.log().information('Using absolute value of MaxAngle')
+                ttmax = numpy.fabs(ttmax)
         spectrum_info = ws.spectrumInfo()
         detector_info = ws.detectorInfo()
         det_ids = detector_info.detectorIDs()
@@ -89,9 +117,11 @@ class MaskAngle(mantid.api.PythonAlgorithm):
                 # Get the first detector of spectrum. Ignore time aspects.
                 if angle_phi:
                     val = self._get_phi(spectrum.position)
-                else:
-                    # Two theta
+                elif angle_in_plane:
+                    val = self._get_in_plane(spectrum.position)
+                else:  # Two theta
                     val =spectrum.twoTheta
+
                 if val>= ttmin and val<= ttmax:
                     detectors = spectrum.spectrumDefinition
                     for j in range(len(detectors)):

--- a/docs/source/algorithms/MaskAngle-v1.rst
+++ b/docs/source/algorithms/MaskAngle-v1.rst
@@ -16,6 +16,13 @@ that were masked
 
 When masking the phi angle the absolute value of phi is used.
 
+The three angle options are subtly different:
+* ``TwoTheta`` is the detector's :math:`2 \theta` value as calcualted from the downstream beam. This is the angle from the pole and not constrained to be in-plane.
+* ``Phi`` is the detector's angle with respect to the positive z-axis not constrained to be in-plane. For many geometries this will be the same as the ``TwoTheta`` option.
+* ``InPlane`` is the detector's angle with respect to the positive z-axis constrained within the x-z-plane.
+
+For the ``TwoTheta`` and ``Phi`` options, the absolute value of the min and max angles are used.
+
 Usage
 -----
 
@@ -27,11 +34,11 @@ Usage
 
     #Load a workspace
     ws = Load("CNCS_7860")
-    
+
     #Do the masking for direct beam
     mask = MaskAngle(ws, MinAngle=0, MaxAngle=10)
     print("The algorithm has masked {} detectors".format(mask.size))
-    
+
     #to test check a couple of detectors
     inst = ws.getInstrument()
     print("Is the minimum element in the mask list (detector {}) masked?  {}".format(mask.min(), inst.getDetector(int(mask.min())).isMasked()))
@@ -55,7 +62,7 @@ Output:
 The instrument view would look like:
 
 .. figure:: /images/MaskAngle.png
-   :alt: MaskAngle.png    
+   :alt: MaskAngle.png
 
 **Phi example**
 

--- a/docs/source/algorithms/MaskAngle-v1.rst
+++ b/docs/source/algorithms/MaskAngle-v1.rst
@@ -21,7 +21,7 @@ The three angle options are subtly different:
 * ``Phi`` is the detector's angle with respect to the positive z-axis not constrained to be in-plane. For many geometries this will be the same as the ``TwoTheta`` option.
 * ``InPlane`` is the detector's angle with respect to the positive z-axis constrained within the x-z-plane.
 
-For the ``TwoTheta`` and ``Phi`` options, the absolute value of the min and max angles are used.
+For the ``TwoTheta`` and ``Phi`` options, only positive angles are allowed.
 
 Usage
 -----

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -14,6 +14,7 @@ Concepts
 
 Algorithms
 ----------
+* ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
 
 Data Objects
 ------------


### PR DESCRIPTION
To help calculate information for a new magnet being designed, this adds a new option for using the in-plane angle for calculating the mask.

**Report to:** Qiang Zhang

**To test:**

Try running it on an instrument with out-of-plane detectors and see that only the in-plane angle matters.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
