### PR TITLE
Add a namespace for the ISISReflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Clipboard::Clipboard() : m_subtrees(boost::none), m_subtreeRoots(boost::none) {}
 
@@ -156,5 +157,6 @@ Clipboard::mutableSubtreeRoots() {
 bool containsGroups(Clipboard const &clipboard) {
   return containsGroups(clipboard.subtreeRoots());
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
@@ -42,7 +42,8 @@ bool Clipboard::isGroupLocation(int rootIndex) const {
     throw std::runtime_error("Attempted to access invalid value in clipboard");
 
   // Check if the root is a group
-  if (!MantidQt::CustomInterfaces::isGroupLocation(subtreeRoots()[rootIndex]))
+  if (!MantidQt::CustomInterfaces::ISISReflectometry::isGroupLocation(
+          subtreeRoots()[rootIndex]))
     return false;
 
   // If so, check if the first selected item in this root is the root itself

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class Clipboard {
 public:
@@ -67,6 +68,7 @@ private:
 };
 
 bool containsGroups(Clipboard const &clipboard);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_CLIPBOARD_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Common/First.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/First.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename T> boost::optional<T> first(std::vector<T> const &values) {
   if (values.size() > 0)
@@ -39,6 +40,7 @@ public:
       return boost::none;
   }
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_FIRST_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.cpp
@@ -7,6 +7,7 @@
 #include "GetInstrumentParameter.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 std::vector<std::string> InstrumentParameter<std::string>::get(
     Mantid::Geometry::Instrument_const_sptr instrument,
@@ -69,5 +70,6 @@ std::string const &InstrumentParameterTypeMissmatch::expectedType() const {
 std::string const &InstrumentParameterTypeMissmatch::originalMessage() const {
   return m_originalMessage;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/GetInstrumentParameter.h
@@ -12,6 +12,7 @@
 #include <vector>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 template <typename T> class InstrumentParameter;
 
 template <> class InstrumentParameter<std::string> {
@@ -131,6 +132,7 @@ auto getInstrumentParameter(Mantid::Geometry::Instrument_const_sptr instrument,
         std::declval<std::string const &>())) {
   return InstrumentParameter<T>::get(instrument, parameterName);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_GETINSTRUMENTPARAMETER_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename Container, typename Predicate>
 boost::optional<int> indexOf(Container const &container, Predicate pred) {
@@ -30,6 +31,7 @@ boost::optional<int> indexOfValue(Container const &container, ValueType value) {
   else
     return boost::none;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INDEXOF_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.cpp
@@ -7,6 +7,7 @@
 #include "InstrumentParameters.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 InstrumentParameters::InstrumentParameters(
     Mantid::Geometry::Instrument_const_sptr instrument)
     : m_instrument(std::move(instrument)) {}
@@ -32,5 +33,6 @@ bool InstrumentParameters::hasMissingValues() const {
 std::string const &MissingInstrumentParameterValue::parameterName() const {
   return m_parameterName;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename T>
 boost::optional<T>
@@ -133,6 +134,7 @@ private:
   std::vector<InstrumentParameterTypeMissmatch> m_typeErrors;
   std::vector<MissingInstrumentParameterValue> m_missingValueErrors;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPARAMETERS_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename Container, typename Transform,
           typename Out = typename std::result_of<
@@ -42,6 +43,7 @@ std::string optionalToString(boost::optional<T> maybeValue) {
              })
       .get_value_or(std::string());
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_MAP_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 OptionDefaults::OptionDefaults(
     Mantid::Geometry::Instrument_const_sptr instrument)
@@ -57,5 +58,6 @@ std::string OptionDefaults::getString(std::string const &propertyName,
                                       std::string const &parameterName) const {
   return getValue<std::string>(propertyName, parameterName);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class OptionDefaults
 
@@ -78,6 +79,7 @@ T OptionDefaults::getValue(std::string const &propertyName,
   return Mantid::API::checkForMandatoryInstrumentDefault<T>(
       m_algorithm.get(), propertyName, m_instrument, parameterName);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_OPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 bool isEntirelyWhitespace(std::string const &string) {
   return std::all_of(string.cbegin(), string.cend(),
@@ -70,5 +71,6 @@ boost::optional<int> parseNonNegativeInt(std::string string) {
   else
     return boost::none;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double>
 parseDouble(std::string string);
@@ -56,6 +57,7 @@ parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
     return std::vector<ParsedItem>();
   }
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_PARSE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Common/QWidgetGroup.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/QWidgetGroup.h
@@ -11,6 +11,7 @@
 #include <cstddef>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 template <std::size_t N> class QWidgetGroup {
 public:
   QWidgetGroup() : m_widgets() {}
@@ -36,6 +37,7 @@ QWidgetGroup<sizeof...(Ts)> makeQWidgetGroup(Ts... widgets) {
   return QWidgetGroup<sizeof...(Ts)>(
       std::array<QWidget *, sizeof...(Ts)>({{widgets...}}));
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_QWIDGETGROUP_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename Validated, typename Error = boost::blank>
 class ValidationResult {
@@ -69,6 +70,7 @@ ValidationResult<Validated, Error>::validElseNone() const {
   else
     return boost::none;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_RESULT_H

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ZipRange.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ZipRange.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <class... Containers>
 auto zip_range(Containers &... containers)
@@ -20,6 +21,7 @@ auto zip_range(Containers &... containers)
   return {boost::make_zip_iterator(boost::make_tuple(containers.begin()...)),
           boost::make_zip_iterator(boost::make_tuple(containers.end()...))};
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_ZIPRANGE_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
@@ -11,12 +11,13 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
+namespace AlgorithmProperties {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
 using Mantid::API::Workspace_sptr;
 
-namespace AlgorithmProperties {
 std::string boolToString(bool value) { return value ? "1" : "0"; }
 
 void update(std::string const &property, std::string const &value,
@@ -77,5 +78,6 @@ std::string getOutputWorkspace(IAlgorithm_sptr algorithm,
   return workspaceName;
 }
 } // namespace AlgorithmProperties
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 namespace AlgorithmProperties {
 
 using AlgorithmRuntimeProps = std::map<std::string, std::string>;
@@ -61,6 +62,7 @@ void update(std::string const &property, std::vector<VALUE_TYPE> const &values,
   update(property, value, properties);
 }
 } // namespace AlgorithmProperties
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
@@ -26,5 +27,6 @@ void BatchJobAlgorithm::updateItem() {
   if (m_item)
     m_updateFunction(m_algorithm, *m_item);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /**
  * The BatchJobAlgorithm class overrides ConfiguredAlgorithm so that
@@ -41,6 +42,7 @@ private:
 };
 
 using BatchJobAlgorithm_sptr = boost::shared_ptr<BatchJobAlgorithm>;
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -61,7 +61,7 @@ int BatchJobRunner::itemsInSelection(
 int BatchJobRunner::percentComplete() const {
   // If processing everything, get the percent from the whole table
   if (m_processAll)
-    return MantidQt::CustomInterfaces::percentComplete(
+    return MantidQt::CustomInterfaces::ISISReflectometry::percentComplete(
         m_batch.runsTable().reductionJobs());
 
   // If processing a selection but there is nothing to process, return 100%

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace { // unnamed
 
@@ -294,5 +295,6 @@ void BatchJobRunner::notifyAllWorkspacesDeleted() {
   // All output workspaces will be deleted so reset all rows and groups
   m_batch.resetState();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /**
  * The BatchJobRunner class sets up algorithms to run based on the reduction
@@ -80,6 +81,7 @@ private:
       Row &row,
       std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> &algorithms);
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -21,6 +21,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::AlgorithmManager;
@@ -353,5 +354,6 @@ void BatchPresenter::clearADSHandle() {
   m_runsPresenter->notifyRowOutputsChanged();
   m_runsPresenter->notifyRowStateChanged();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -22,6 +22,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IBatchView;
 
@@ -108,6 +109,7 @@ private:
 protected:
   std::unique_ptr<IBatchJobRunner> m_jobRunner;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_BATCHPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
@@ -19,6 +19,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 class BatchPresenterFactory {
 public:
   BatchPresenterFactory(
@@ -60,6 +61,7 @@ private:
   InstrumentPresenterFactory m_instrumentPresenterFactory;
   SavePresenterFactory m_savePresenterFactory;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_BATCHPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
@@ -144,5 +145,6 @@ AlgorithmRuntimeProps createAlgorithmRuntimeProps(Batch const &model,
   updateStitchProperties(properties, model.experiment().stitchParameters());
   return properties;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 class Batch;
 class Group;
 class IConfiguredAlgorithm;
@@ -26,6 +27,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr
 createConfiguredAlgorithm(Batch const &model, Group &group);
 MANTIDQT_ISISREFLECTOMETRY_DLL AlgorithmRuntimeProps
 createAlgorithmRuntimeProps(Batch const &model, Group const &group);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobAlgorithm.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class Item;
 
@@ -26,6 +27,7 @@ public:
   virtual void updateItem() = 0;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobRunner.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IBatchJobRunner {
 public:
@@ -46,6 +47,7 @@ public:
   getAlgorithms() = 0;
   virtual AlgorithmRuntimeProps rowProcessingProperties() const = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IMainWindowPresenter;
 
@@ -53,6 +54,7 @@ public:
   virtual Mantid::Geometry::Instrument_const_sptr instrument() const = 0;
   virtual std::string instrumentName() const = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IBATCHPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
@@ -23,6 +23,7 @@ using IConfiguredAlgorithm_sptr = boost::shared_ptr<IConfiguredAlgorithm>;
 } // namespace API
 
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL BatchViewSubscriber {
 public:
@@ -57,6 +58,7 @@ public:
   virtual void executeAlgorithmQueue() = 0;
   virtual void cancelAlgorithmQueue() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IBATCHVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using API::BatchAlgorithmRunner;
 using Mantid::API::IAlgorithm_sptr;
@@ -135,5 +136,6 @@ IAlgorithm_sptr QtBatchView::createReductionAlg() {
 std::unique_ptr<QtSaveView> QtBatchView::createSaveTab() {
   return std::make_unique<QtSaveView>(this);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
@@ -22,6 +22,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class QtBatchView : public QWidget, public IBatchView {
   Q_OBJECT
@@ -66,6 +67,7 @@ private:
   std::unique_ptr<QtInstrumentView> m_instrument;
   API::BatchAlgorithmRunner m_batchAlgoRunner;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_QTBATCHVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
@@ -311,5 +312,6 @@ AlgorithmRuntimeProps createAlgorithmRuntimeProps(Batch const &model) {
   updatePerThetaDefaultProperties(properties, model.wildcardDefaults());
   return properties;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 class Batch;
 class Row;
 class IConfiguredAlgorithm;
@@ -29,6 +30,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL AlgorithmRuntimeProps
 createAlgorithmRuntimeProps(Batch const &model, Row const &row);
 MANTIDQT_ISISREFLECTOMETRY_DLL AlgorithmRuntimeProps
 createAlgorithmRuntimeProps(Batch const &model);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IMessageHandler.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IMessageHandler.h
@@ -10,6 +10,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** @class IMessageHandler
 
 IMessageHandler is an interface for passing messages to the user
@@ -24,6 +25,7 @@ public:
   virtual bool askUserYesNo(const std::string &prompt,
                             const std::string &title) = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPlotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPlotter.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IPlotter {
 public:
@@ -21,6 +22,7 @@ public:
   reflectometryPlot(const std::vector<std::string> &workspaces) const = 0;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPythonRunner.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IPythonRunner.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** @class IPythonRunner
 
 IPythonRunner is an interface for running python code
@@ -23,6 +24,7 @@ public:
   virtual ~IPythonRunner(){};
   virtual std::string runPythonAlgorithm(const std::string &pythonCode) = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -23,6 +23,7 @@ using namespace MantidQt::Widgets::MplCpp;
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 Plotter::Plotter(MantidQt::CustomInterfaces::IPythonRunner *pythonRunner)
@@ -90,5 +91,6 @@ void Plotter::runPython(const std::string &pythonCode) const {
 }
 #endif
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -26,8 +26,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-Plotter::Plotter(MantidQt::CustomInterfaces::IPythonRunner *pythonRunner)
-    : m_pythonRunner(pythonRunner) {}
+Plotter::Plotter(IPythonRunner *pythonRunner) : m_pythonRunner(pythonRunner) {}
 #endif
 
 void Plotter::reflectometryPlot(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
@@ -23,7 +23,7 @@ class IPythonRunner;
 class MANTIDQT_ISISREFLECTOMETRY_DLL Plotter : public IPlotter {
 public:
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  Plotter(MantidQt::CustomInterfaces::IPythonRunner *pythonRunner);
+  Plotter(IPythonRunner *pythonRunner);
   void runPython(const std::string &pythonCode) const;
 #endif
   void
@@ -33,7 +33,7 @@ private:
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   // Object only needed for MantidPlot implementation as it requires Python
   // execution
-  MantidQt::CustomInterfaces::IPythonRunner *m_pythonRunner;
+  IPythonRunner *m_pythonRunner;
 #endif
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 class IPythonRunner;
 #endif
@@ -36,6 +37,7 @@ private:
 #endif
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** Constructor
  * @param view :: The view we are handling
@@ -148,5 +149,6 @@ bool EventPresenter::isProcessing() const {
 bool EventPresenter::isAutoreducing() const {
   return m_mainPresenter->isAutoreducing();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class EventPresenter
 
@@ -58,6 +59,7 @@ private:
   IEventView *m_view;
   SliceType m_sliceType;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenterFactory.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class EventPresenterFactory {
 public:
@@ -21,6 +22,7 @@ public:
     return std::make_unique<EventPresenter>(view);
   }
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_REFLEVENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventPresenter.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class IEventPresenter
 
@@ -30,6 +31,7 @@ public:
   virtual void autoreductionResumed() = 0;
   virtual Slicing const &slicing() const = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IREFLEVENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/IEventView.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 enum class SliceType { None, UniformEven, Uniform, Custom, LogValue };
 
@@ -54,6 +55,7 @@ public:
   virtual void enableSliceTypeSelection() = 0;
   virtual void disableSliceTypeSelection() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_IREFLEVENTVIEW_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** Constructor
  * @param parent :: [input] The parent of this widget
@@ -214,5 +215,6 @@ void QtEventView::onToggleDisabledSlicing(bool isChecked) {
     m_notifyee->notifySliceTypeChanged(SliceType::None);
 }
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** QtEventView : Provides an interface for the "Event Handling" widget
 in
@@ -79,6 +80,7 @@ private:
   EventViewSubscriber *m_notifyee;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 // unnamed namespace
 namespace {
@@ -110,5 +111,6 @@ Experiment ExperimentOptionDefaults::get(
     Mantid::Geometry::Instrument_const_sptr instrument) {
   return getExperimentDefaults(instrument);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IExperimentOptionDefaults {
 public:
@@ -30,6 +31,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL ExperimentOptionDefaults
 public:
   Experiment get(Mantid::Geometry::Instrument_const_sptr instrument) override;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTOPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 // unnamed namespace
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
@@ -329,5 +330,6 @@ void ExperimentPresenter::updateViewFromModel() {
   // Reconnect settings change notifications
   m_view->connectExperimentSettingsWidgets();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -18,6 +18,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class ExperimentValidationErrors {
 public:
@@ -103,6 +104,7 @@ private:
   Experiment m_model;
   double m_thetaTolerance;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenterFactory.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class ExperimentPresenterFactory {
 public:
@@ -29,6 +30,7 @@ public:
 private:
   double m_thetaTolerance;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_EXPERIMENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 class Instrument_const_sptr;
 
 class IExperimentPresenter {
@@ -29,6 +30,7 @@ public:
   virtual void instrumentChanged(std::string const &instrumentName) = 0;
   virtual void restoreDefaults() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IEXPERIMENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -18,6 +18,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class IExperimentView
 
@@ -117,6 +118,7 @@ public:
 
   virtual ~IExperimentView() = default;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IEXPERIMENTVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 InvalidDefaultsError::InvalidDefaultsError( // cppcheck-suppress passedByValue
     int row, std::vector<int> invalidColumns)
@@ -28,5 +29,6 @@ bool operator!=(InvalidDefaultsError const &lhs,
                 InvalidDefaultsError const &rhs) {
   return !(lhs == rhs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/InvalidDefaultsError.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL InvalidDefaultsError {
 public:
@@ -27,6 +28,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(InvalidDefaultsError const &lhs,
                                                InvalidDefaultsError const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(InvalidDefaultsError const &lhs,
                                                InvalidDefaultsError const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INVALIDDEFAULTSERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.cpp
@@ -8,6 +8,7 @@
 #include "ThetaValuesValidationError.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 PerThetaDefaultsTableValidationError::PerThetaDefaultsTableValidationError(
     // cppcheck-suppress passedByValue
@@ -25,5 +26,6 @@ boost::optional<ThetaValuesValidationError>
 PerThetaDefaultsTableValidationError::fullTableError() const {
   return m_fullTableError;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidationError.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaultsTableValidationError {
 public:
@@ -28,6 +29,7 @@ private:
   boost::optional<ThetaValuesValidationError> m_fullTableError;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATIONERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.cpp
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 auto PerThetaDefaultsTableValidator::
 operator()(ContentType const &perThetaDefaultsContent,
@@ -124,5 +125,6 @@ void PerThetaDefaultsTableValidator::appendThetaErrorForAllRows(
   for (auto row = 0u; row < rowCount; ++row)
     validationErrors.emplace_back(row, std::vector<int>({0}));
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/PerThetaDefaultsTableValidator.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaultsTableValidator {
 public:
@@ -44,6 +45,7 @@ public:
       std::vector<InvalidDefaultsError> &validationErrors,
       std::size_t rowCount) const;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_PERTHETADEFAULTSTABLEVALIDATOR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 // Changing the palette for spin boxes doesn't work but we can
@@ -711,5 +712,6 @@ void showOptionLoadErrors(
     std::vector<InstrumentParameterTypeMissmatch> const &typeErrors,
     std::vector<MissingInstrumentParameterValue> const &missingValues);
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** ExperiementView : Provides an interface for the "Experiement" tab in the
 ISIS Reflectometry interface.
@@ -176,6 +177,7 @@ private:
   ExperimentViewSubscriber *m_notifyee;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ThetaValuesValidationError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ThetaValuesValidationError.h
@@ -8,8 +8,10 @@
 #define MANTID_ISISREFLECTOMETRY_THETAVALUESVALIDATIONERROR_H
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 enum class ThetaValuesValidationError { MultipleWildcards, NonUniqueTheta };
-}
+} // namespace ISISReflectometry
+} // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_THETAVALUESVALIDATIONERROR_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentPresenter.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IBatchPresenter;
 
@@ -34,6 +35,7 @@ public:
   virtual void instrumentChanged(std::string const &instrumentName) = 0;
   virtual void restoreDefaults() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IINSTRUMENTPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class IInstrumentView
 
@@ -71,6 +72,7 @@ public:
   virtual void enableDetectorCorrectionType() = 0;
   virtual void disableDetectorCorrectionType() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IINSTRUMENTVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 // unnamed namespace
 namespace {
@@ -66,5 +67,6 @@ Instrument InstrumentOptionDefaults::get(
     Mantid::Geometry::Instrument_const_sptr instrument) {
   return getInstrumentDefaults(instrument);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IInstrumentOptionDefaults {
 public:
@@ -32,6 +33,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL InstrumentOptionDefaults
 public:
   Instrument get(Mantid::Geometry::Instrument_const_sptr instrument) override;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTOPTIONDEFAULTS_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
@@ -230,5 +231,6 @@ void InstrumentPresenter::updateViewFromModel() {
   // Reconnect settings change notifications
   m_view->connectInstrumentSettingsWidgets();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class InstrumentPresenter
 
@@ -67,6 +68,7 @@ private:
   bool isProcessing() const;
   bool isAutoreducing() const;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class InstrumentPresenterFactory {
 public:
@@ -24,6 +25,7 @@ public:
     return std::make_unique<InstrumentPresenter>(view, Instrument());
   }
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_INSTRUMENTPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 // Changing the palette for spin boxes doesn't work but we can
@@ -382,5 +383,6 @@ std::string QtInstrumentView::getDetectorCorrectionType() const {
 void QtInstrumentView::setDetectorCorrectionType(std::string const &value) {
   setSelected(*m_ui.detectorCorrectionTypeComboBox, value);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** QtInstrumentView : Provides an interface for the "Instrument" tab in the
 ISIS Reflectometry interface.
@@ -111,6 +112,7 @@ private:
   InstrumentViewSubscriber *m_notifyee;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class IMainWindowPresenter
 
@@ -27,6 +28,7 @@ public:
   virtual void notifyAutoreductionPaused() = 0;
   virtual ~IMainWindowPresenter() = default;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IMAINWINDOWPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowView.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class IMainWindowView
 
@@ -38,6 +39,7 @@ public:
 
   virtual ~IMainWindowView() = default;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IREFLWINDOWVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** Constructor
  * @param view :: [input] The view we are managing
@@ -99,5 +100,6 @@ void MainWindowPresenter::showHelp() {
   MantidQt::API::HelpWindow::showCustomInterface(nullptr,
                                                  QString("ISIS Reflectometry"));
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IMainWindowView;
 class IMessageHandler;
@@ -52,6 +53,7 @@ private:
   BatchPresenterFactory m_batchPresenterFactory;
   std::vector<std::shared_ptr<IBatchPresenter>> m_batchPresenters;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_MAINWINDOWPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 
@@ -168,5 +169,6 @@ bool QtMainWindowView::askUserYesNo(const std::string &prompt,
 
   return false;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
@@ -19,6 +19,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class QtMainWindowView
 
@@ -70,6 +71,7 @@ private:
   std::unique_ptr<MainWindowPresenter> m_presenter;
   std::vector<IBatchView *> m_batchViews;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_QTMAINWINDOWVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 CatalogRunNotifier::CatalogRunNotifier(IRunsView *view) : m_view(view) {
   m_view->subscribeTimer(this);
@@ -27,5 +28,6 @@ void CatalogRunNotifier::notifyTimerEvent() {
   if (m_notifyee)
     m_notifyee->notifyCheckForNewRuns();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/CatalogRunNotifier.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** @class CatalogRunNotifier
 
 CatalogRunNotifier implements IRunNotifier to provide functionality to
@@ -39,6 +40,7 @@ private:
   IRunsView *m_view;
   RunNotifierSubscriber *m_notifyee;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunNotifier.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunNotifier.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class RunNotifierSubscriber {
 public:
@@ -29,6 +30,7 @@ public:
   virtual void startPolling() = 0;
   virtual void stopPolling() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IBatchPresenter;
 
@@ -51,6 +52,7 @@ public:
   virtual int percentComplete() const = 0;
   virtual void notifySearchComplete() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IREFLRUNSPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -23,6 +23,7 @@ class AlgorithmRunner;
 }
 
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /**
 IRunsView is the base view class for the Reflectometry "Runs"
@@ -107,6 +108,7 @@ public:
   virtual void startMonitor() = 0;
   virtual void stopMonitor() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IRUNSVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL ISearchModel {
 public:
@@ -27,6 +28,7 @@ public:
 
 /// Typedef for a shared pointer to \c SearchModel
 using ISearchModel_sptr = boost::shared_ptr<ISearchModel>;
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class SearcherSubscriber {
 public:
@@ -46,6 +47,7 @@ public:
                                      const std::string &instrument,
                                      SearchType searchType) const = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -18,6 +18,7 @@ using namespace Mantid::API;
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace { // unnamed
 void removeResultsWithoutFilenameExtension(ITableWorkspace_sptr results) {
@@ -204,5 +205,6 @@ QtCatalogSearcher::createSearchAlgorithm(const std::string &text) {
 ISearchModel &QtCatalogSearcher::results() const {
   return m_view->mutableSearchResults();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IMainWindowView;
 
@@ -75,6 +76,7 @@ private:
   void searchAsync();
 };
 bool hasActiveCatalogSession();
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_QTCATALOGSEARCHER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 using namespace MantidQt::Icons;
@@ -404,5 +405,6 @@ void QtRunsView::startTimer(const int millisecs) {
 /** stop
  */
 void QtRunsView::stopTimer() { m_timer.stop(); }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -348,13 +348,9 @@ std::string QtRunsView::getSearchString() const {
   return ui.textSearch->text().toStdString();
 }
 
-void MantidQt::CustomInterfaces::QtRunsView::on_buttonMonitor_clicked() {
-  startMonitor();
-}
+void QtRunsView::on_buttonMonitor_clicked() { startMonitor(); }
 
-void MantidQt::CustomInterfaces::QtRunsView::on_buttonStopMonitor_clicked() {
-  stopMonitor();
-}
+void QtRunsView::on_buttonStopMonitor_clicked() { stopMonitor(); }
 
 /** Start live data monitoring
  */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -27,6 +27,7 @@ class AlgorithmRunner;
 }
 
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using MantidWidgets::SlitCalculator;
 
@@ -129,6 +130,7 @@ private slots:
   void onShowSearchContextMenuRequested(const QPoint &pos);
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 using namespace Mantid::API;
 
 namespace { // unnamed
@@ -217,5 +218,6 @@ bool QtSearchModel::runHasError(const SearchResult &run) const {
 SearchResult const &QtSearchModel::getRowData(int index) const {
   return m_runDetails[index];
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -19,6 +19,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** QtSearchModel : Provides a QAbstractTableModel for a Mantid
 ITableWorkspace of Reflectometry search results.
@@ -59,6 +60,7 @@ private:
   bool runHasError(const SearchResult &run) const;
   void mergeNewResults(std::vector<SearchResult> const &source);
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -30,6 +30,7 @@ using namespace MantidQt::MantidWidgets;
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** Constructor
  * @param mainView :: [input] The view we're managing
@@ -528,5 +529,6 @@ void RunsPresenter::errorHandle(const IAlgorithm *alg,
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -29,6 +29,7 @@ class ProgressableView;
 } // namespace MantidWidgets
 
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 // Forward decs
 class IMessageHandler;
@@ -179,6 +180,7 @@ private:
   void updateViewWhenMonitorStarted();
   void updateViewWhenMonitorStopped();
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_RUNSPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class RunsPresenterFactory {
 public:
@@ -44,6 +45,7 @@ private:
   IMessageHandler *m_messageHandler;
   IPythonRunner *m_pythonRunner;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_RUNSPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 SearchResult::SearchResult(const std::string &runNumber,
                            const std::string &desc, const std::string &loc)
@@ -55,5 +56,6 @@ bool operator==(SearchResult const &lhs, SearchResult const &rhs) {
 bool operator!=(SearchResult const &lhs, SearchResult const &rhs) {
   return !(lhs == rhs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL SearchResult {
 public:
@@ -40,6 +41,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(SearchResult const &lhs,
                                                SearchResult const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(SearchResult const &lhs,
                                                SearchResult const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_SEARCHRESULT_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IRunsPresenter;
 class RunsTable;
@@ -45,6 +46,7 @@ public:
   virtual void instrumentChanged(std::string const &instrumentName) = 0;
   virtual void settingsChanged() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_IREFLRUNSTABLEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTableView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTableView.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class RunsTableViewSubscriber
     : public MantidQt::MantidWidgets::Batch::JobTreeViewSubscriber {
@@ -81,6 +82,7 @@ public:
   virtual void setProcessButtonEnabled(bool enable) = 0;
   virtual void setActionEnabled(Action action, bool enable) = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_IBATCHVIEW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace { // unnamed
 std::vector<MantidQt::MantidWidgets::Batch::Cell>
@@ -96,6 +97,7 @@ public:
 private:
   MantidQt::MantidWidgets::Batch::IJobTreeView &m_view;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_JOBVIEWUPDATER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 QtRunsTableView::QtRunsTableView(std::vector<std::string> const &instruments,
                                  int defaultInstrumentIndex)
@@ -314,5 +315,6 @@ int RunsTableViewFactory::defaultInstrumentFromConfig() const {
   return indexOfElseFirst(Mantid::Kernel::ConfigService::Instance().getString(
       "default.instrument"));
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL QtRunsTableView : public QWidget,
                                                        public IRunsTableView {
@@ -87,6 +88,7 @@ public:
 private:
   std::vector<std::string> m_instruments;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_QTRUNSTABLEVIEW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using MantidQt::MantidWidgets::Batch::IJobTreeView;
 using MantidQt::MantidWidgets::Batch::RowLocation;
@@ -36,5 +37,6 @@ std::unique_ptr<RegexFilter> filterFromRegexString(std::string const &regex,
                                                    ReductionJobs const &jobs) {
   return std::make_unique<RegexFilter>(boost::regex(regex), view, jobs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RegexRowFilter.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class RegexFilter : public MantidQt::MantidWidgets::Batch::RowPredicate {
 public:
@@ -37,6 +38,7 @@ std::unique_ptr<RegexFilter>
 filterFromRegexString(std::string const &regex,
                       MantidQt::MantidWidgets::Batch::IJobTreeView const &view,
                       ReductionJobs const &jobs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -18,6 +18,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 namespace Colour {
 constexpr const char *DEFAULT = "#ffffff"; // white
 constexpr const char *INVALID = "#dddddd"; // very pale grey
@@ -874,5 +875,6 @@ void RunsTablePresenter::notifyPlotSelectedStitchedOutputPressed() {
 
   m_plotter.reflectometryPlot(workspaces);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -20,6 +20,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL RunsTablePresenter
     : public IRunsTablePresenter,
@@ -163,6 +164,7 @@ private:
   IRunsPresenter *m_mainPresenter;
   const IPlotter &m_plotter;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTER_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 RunsTablePresenterFactory::RunsTablePresenterFactory(
     std::vector<std::string> const &instruments, double thetaTolerance,
@@ -21,5 +22,6 @@ operator()(IRunsTableView *view) const {
   return std::make_unique<RunsTablePresenter>(
       view, m_instruments, m_thetaTolerance, ReductionJobs(), m_plotter);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenterFactory.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IRunsTableView;
 
@@ -31,6 +32,7 @@ protected:
   double m_thetaTolerance;
   Plotter m_plotter;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_BATCHPRESENTERFACTORY_H_

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.cpp
@@ -13,6 +13,7 @@
 #include <Poco/Path.h>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Mantid::API::IAlgorithm_sptr
 AsciiSaver::algorithmForFormat(NamedFormat format) {
@@ -145,5 +146,6 @@ void AsciiSaver::save(std::string const &saveDirectory,
     throw InvalidSavePath(saveDirectory);
   }
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/AsciiSaver.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 class AsciiSaver : public IAsciiSaver {
 public:
   static Mantid::API::IAlgorithm_sptr algorithmForFormat(NamedFormat format);
@@ -43,6 +44,7 @@ private:
             std::vector<std::string> const &logParameters,
             FileFormatOptions const &fileFormat) const;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_ASCIISAVER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.cpp
@@ -7,6 +7,7 @@
 #include "IAsciiSaver.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 InvalidSavePath::InvalidSavePath(std::string const &path)
     : std::runtime_error("The path" + path +
                          "does not exist or is not a directory."),
@@ -34,5 +35,6 @@ bool FileFormatOptions::shouldIncludeQResolution() const {
 std::string const &FileFormatOptions::separator() const { return m_separator; }
 std::string const &FileFormatOptions::prefix() const { return m_prefix; }
 NamedFormat FileFormatOptions::format() const { return m_format; }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/IAsciiSaver.h
@@ -13,6 +13,7 @@
 #include <vector>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 enum class NamedFormat { Custom, ThreeColumn, ANSTO, ILLCosmos };
 
@@ -75,6 +76,7 @@ public:
                     FileFormatOptions const &inputParameters) const = 0;
   virtual ~IAsciiSaver() = default;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_IASCIISAVER_H

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class IBatchPresenter;
 
@@ -32,6 +33,7 @@ public:
   virtual void autoreductionPaused() = 0;
   virtual void autoreductionResumed() = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_ISAVEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL SaveViewSubscriber {
 public:
@@ -71,6 +72,7 @@ public:
   virtual void cannotSaveWorkspaces() = 0;
   virtual void cannotSaveWorkspaces(std::string const &fullError) = 0;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_ISISREFLECTOMETRY_ISAVEVIEW_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** Constructor
  * @param parent :: The parent of this view
@@ -288,5 +289,6 @@ void QtSaveView::cannotSaveWorkspaces() {
 void QtSaveView::cannotSaveWorkspaces(std::string const &fullError) {
   error("Error", fullError);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** QtSaveView : Provides an interface for the "Save ASCII" tab in the
 ISIS Reflectometry interface.
@@ -108,6 +109,7 @@ private:
   SaveViewSubscriber *m_notifyee;
 };
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -21,6 +21,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using namespace Mantid::API;
 
@@ -267,5 +268,6 @@ std::vector<std::string> SavePresenter::getAvailableWorkspaceNames() {
 
   return validNames;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -19,6 +19,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class SavePresenter
 
@@ -85,6 +86,7 @@ private:
   std::unique_ptr<IAsciiSaver> m_saver;
   bool m_shouldAutosave;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif /* MANTID_CUSTOMINTERFACES_SAVEPRESENTER_H */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenterFactory.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class SavePresenterFactory {
 public:
@@ -23,6 +24,7 @@ public:
                                            std::make_unique<AsciiSaver>());
   }
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_SAVEPRESENTERFACTORY_H

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
@@ -10,6 +10,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename Param>
 bool allInitialized(boost::optional<Param> const &param) {
@@ -32,6 +33,7 @@ makeIfAllInitialized(boost::optional<Params> const &... params) {
     return boost::none;
 }
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_ALLINITIALIZED_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/AnalysisMode.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/AnalysisMode.h
@@ -10,6 +10,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 enum class AnalysisMode { PointDetector, MultiDetector };
 
 inline AnalysisMode analysisModeFromString(std::string const &analysisMode) {
@@ -30,6 +31,7 @@ inline std::string analysisModeToString(AnalysisMode analysisMode) {
   }
   throw std::invalid_argument("Unexpected analysis mode");
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_ANALYSISMODE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -7,6 +7,7 @@
 #include "Batch.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Batch::Batch(Experiment const &experiment, Instrument const &instrument,
              RunsTable &runsTable, Slicing const &slicing)
@@ -45,5 +46,6 @@ boost::optional<Item &>
 Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_runsTable.getItemWithOutputWorkspaceOrNone(wsName);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Batch
 
@@ -57,6 +58,7 @@ bool Batch::isInSelection(T const &item,
                               &selectedRowLocations) const {
   return m_runsTable.isInSelection(item, selectedRowLocations);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_BATCH_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.cpp
@@ -7,6 +7,7 @@
 #include "DetectorCorrections.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 DetectorCorrections::DetectorCorrections(bool correctPositions,
                                          DetectorCorrectionType correctionType)
@@ -30,5 +31,6 @@ bool operator==(DetectorCorrections const &lhs,
   return lhs.correctPositions() == rhs.correctPositions() &&
          lhs.correctionType() == rhs.correctionType();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/DetectorCorrections.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class DetectorCorrectionType
 
@@ -60,6 +61,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(DetectorCorrections const &lhs,
                                                DetectorCorrections const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(DetectorCorrections const &lhs,
                                                DetectorCorrections const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_DETECTORCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -10,6 +10,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Experiment::Experiment()
     : m_analysisMode(AnalysisMode::PointDetector),
@@ -124,5 +125,6 @@ bool operator==(Experiment const &lhs, Experiment const &rhs) {
          lhs.stitchParameters() == rhs.stitchParameters() &&
          lhs.perThetaDefaults() == rhs.perThetaDefaults();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -21,6 +21,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Experiment
 
@@ -74,6 +75,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Experiment const &lhs,
                                                Experiment const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Experiment const &lhs,
                                                Experiment const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_EXPERIMENT_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
@@ -7,6 +7,7 @@
 #include "FloodCorrections.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 FloodCorrections::FloodCorrections(FloodCorrectionType correctionType,
                                    boost::optional<std::string> workspace)
@@ -28,5 +29,6 @@ bool operator==(FloodCorrections const &lhs, FloodCorrections const &rhs) {
   return lhs.correctionType() == rhs.correctionType() &&
          lhs.workspace() == rhs.workspace();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
@@ -11,6 +11,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 enum class FloodCorrectionType { Workspace, ParameterFile };
 
 inline FloodCorrectionType
@@ -60,6 +61,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(FloodCorrections const &lhs,
                                                FloodCorrections const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(FloodCorrections const &lhs,
                                                FloodCorrections const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_FLOODCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Group::Group( // cppcheck-suppress passedByValue
     std::string name, std::vector<boost::optional<Row>> rows)
@@ -227,5 +228,6 @@ bool operator==(Group const &lhs, Group const &rhs) {
          lhs.postprocessedWorkspaceName() == rhs.postprocessedWorkspaceName() &&
          lhs.rows() == rhs.rows();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Group
 
@@ -95,6 +96,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Group const &lhs,
                                                Group const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Group const &lhs,
                                                Group const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_GROUP_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -7,6 +7,7 @@
 #include "Instrument.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Instrument::Instrument()
     : m_wavelengthRange(RangeInLambda(0.0, 0.0)),
@@ -67,5 +68,6 @@ bool operator==(Instrument const &lhs, Instrument const &rhs) {
          lhs.monitorCorrections() == rhs.monitorCorrections() &&
          lhs.detectorCorrections() == rhs.detectorCorrections();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Instrument
 
@@ -48,6 +49,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Instrument const &lhs,
                                                Instrument const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Instrument const &lhs,
                                                Instrument const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_INSTRUMENT_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Item::Item() : m_itemState(), m_skipped(false) {}
 
@@ -66,5 +67,6 @@ bool Item::requiresProcessing(bool reprocessFailed) const {
   }
   return false;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Item.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Item
 
@@ -55,6 +56,7 @@ protected:
   ItemState m_itemState;
   bool m_skipped;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACE_ITEM_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 ItemState::ItemState()
     : m_state(State::ITEM_NOT_STARTED), m_message(boost::none),
@@ -48,5 +49,6 @@ void ItemState::reset() {
   m_state = State::ITEM_NOT_STARTED;
   m_message = std::string();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 enum class State {
   ITEM_NOT_STARTED,
@@ -51,6 +52,7 @@ private:
 
   bool requiresMessage() const;
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACE_STATE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
@@ -7,6 +7,7 @@
 #include "MonitorCorrections.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 MonitorCorrections::MonitorCorrections(
     size_t monitorIndex, bool integrate,
@@ -37,5 +38,6 @@ bool operator==(MonitorCorrections const &lhs, MonitorCorrections const &rhs) {
          lhs.backgroundRange() == rhs.backgroundRange() &&
          lhs.integralRange() == rhs.integralRange();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
@@ -11,6 +11,7 @@
 #include <boost/optional.hpp>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class MonitorCorrections
 
@@ -39,6 +40,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(MonitorCorrections const &lhs,
                                                MonitorCorrections const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(MonitorCorrections const &lhs,
                                                MonitorCorrections const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_MONITORCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -13,6 +13,7 @@
 #include <set>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace { // unnamed
 boost::optional<std::vector<std::string>>
@@ -194,5 +195,6 @@ parseTransmissionRuns(std::string const &firstTransmissionRun,
   }
 }
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<std::vector<std::string>>
 parseRunNumbers(std::string const &runNumbers);
@@ -52,6 +53,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL
 boost::optional<boost::optional<std::string>>
 parseProcessingInstructions(std::string const &instructions);
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_PARSEREFLECTOMETRYSTRINGS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 PerThetaDefaults::PerThetaDefaults(
     boost::optional<double> theta,
@@ -84,5 +85,6 @@ perThetaDefaultsToArray(PerThetaDefaults const &perThetaDefaults) {
     result[8] = *perThetaDefaults.processingInstructions();
   return result;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -15,6 +15,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class PerThetaDefaults
 
@@ -73,6 +74,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(PerThetaDefaults const &lhs,
                                                PerThetaDefaults const &rhs);
 PerThetaDefaults::ValueArray
 perThetaDefaultsToArray(PerThetaDefaults const &perThetaDefaults);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_PERTHETADEFAULTS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.cpp
@@ -7,6 +7,7 @@
 #include "PolarizationCorrections.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 PolarizationCorrections::PolarizationCorrections(
     PolarizationCorrectionType correctionType)
@@ -25,5 +26,6 @@ bool operator==(PolarizationCorrections const &lhs,
                 PolarizationCorrections const &rhs) {
   return lhs.correctionType() == rhs.correctionType();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
@@ -12,6 +12,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 enum class PolarizationCorrectionType { None, ParameterFile };
 
 inline PolarizationCorrectionType
@@ -58,6 +59,7 @@ operator==(PolarizationCorrections const &lhs,
 MANTIDQT_ISISREFLECTOMETRY_DLL bool
 operator!=(PolarizationCorrections const &lhs,
            PolarizationCorrections const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_POLARIZATIONCORRECTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
@@ -11,11 +11,13 @@
 #include <boost/optional.hpp>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** For now processing instructions are just a string but we expect them to
     become more complicated so this can be changed to a class in the future
 */
 using ProcessingInstructions = std::string;
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_PROCESSINGINSTRUCTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/Tolerance.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 RangeInLambda::RangeInLambda(double min, double max) : m_min(min), m_max(max) {}
 
@@ -39,5 +40,6 @@ bool operator==(RangeInLambda const &lhs, RangeInLambda const &rhs) {
 bool operator!=(RangeInLambda const &lhs, RangeInLambda const &rhs) {
   return !(lhs == rhs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInLambda.h
@@ -9,6 +9,7 @@
 #include "Common/DllConfig.h"
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda {
 public:
@@ -30,6 +31,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(RangeInLambda const &lhs,
                                                RangeInLambda const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(RangeInLambda const &lhs,
                                                RangeInLambda const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_RANGEINLAMBDA_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
@@ -8,6 +8,7 @@
 #include <cassert>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 RangeInQ::RangeInQ(boost::optional<double> min, boost::optional<double> step,
                    boost::optional<double> max)
@@ -29,5 +30,6 @@ bool operator==(RangeInQ const &lhs, RangeInQ const &rhs) {
 bool operator!=(RangeInQ const &lhs, RangeInQ const &rhs) {
   return !(lhs == rhs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
@@ -11,6 +11,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL RangeInQ {
 public:
@@ -32,6 +33,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(RangeInQ const &lhs,
                                                RangeInQ const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(RangeInQ const &lhs,
                                                RangeInQ const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_RANGEINQ_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.cpp
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 Group &findOrMakeGroupWithName(ReductionJobs &jobs,
@@ -331,5 +332,6 @@ bool operator!=(ReductionJobs const &lhs, ReductionJobs const &rhs) {
 bool operator==(ReductionJobs const &lhs, ReductionJobs const &rhs) {
   return lhs.groups() == rhs.groups();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class ReductionJobs
 
@@ -114,6 +115,7 @@ void mergeJobsInto(ReductionJobs &intoHere, ReductionJobs const &fromHere,
     listener.groupRemoved(0);
   }
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionOptionsMap.h
@@ -9,11 +9,13 @@
 #include <map>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** The ReductionOptionsMap holds information relating to the settings
  * in the Options column in the runs table. These are user-specified
  * options specified as key=value pairs.
  */
 using ReductionOptionsMap = std::map<std::string, std::string>;
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_REDUCTIONOPTIONSMAP_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
@@ -10,6 +10,7 @@
 #include <boost/optional.hpp>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** The ReductionType determines what type of reduction is to be performed
  * by the reduction algorithm
  */
@@ -37,6 +38,7 @@ inline std::string reductionTypeToString(ReductionType reductionType) {
   }
   throw std::invalid_argument("Unexpected reduction type");
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_REDUCTIONTYPE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 ReductionWorkspaces::ReductionWorkspaces(
     // cppcheck-suppress passedByValue
     std::vector<std::string> inputRunNumbers,
@@ -90,5 +91,6 @@ std::string postprocessedWorkspaceName(
           });
   return boost::algorithm::join(summedRunList, "_");
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
@@ -17,6 +17,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class ReductionWorkspaces
 
@@ -62,6 +63,7 @@ workspaceNames(std::vector<std::string> const &inputRunNumbers,
 
 MANTIDQT_ISISREFLECTOMETRY_DLL std::string postprocessedWorkspaceName(
     std::vector<std::vector<std::string> const *> const &summedRunNumbers);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_REDUCTIONWORKSPACES_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 Row::Row( // cppcheck-suppress passedByValue
     std::vector<std::string> runNumbers, double theta,
@@ -117,5 +118,6 @@ bool operator==(Row const &lhs, Row const &rhs) {
          lhs.reducedWorkspaceNames() == rhs.reducedWorkspaceNames() &&
          lhs.reductionOptions() == rhs.reductionOptions();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
@@ -20,6 +20,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class Row
 
@@ -69,6 +70,7 @@ private:
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(Row const &lhs, Row const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Row const &lhs, Row const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row mergedRow(Row const &rowA, Row const &rowB);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACE_RUN_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.cpp
@@ -10,6 +10,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename T>
 void sortAndRemoveDuplicatesInplace(std::vector<T> &items) {
@@ -68,5 +69,6 @@ bool containsPath(
       [&path](MantidQt::MantidWidgets::Batch::RowLocation const &location)
           -> bool { return location.path() == path; });
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RowLocation.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 std::vector<int> groupIndexesFromSelection(
     std::vector<MantidWidgets::Batch::RowLocation> const &selected);
@@ -28,6 +29,7 @@ int rowOf(MantidQt::MantidWidgets::Batch::RowLocation const &rowLocation);
 bool containsPath(
     std::vector<MantidQt::MantidWidgets::Batch::RowLocation> const &locations,
     MantidQt::MantidWidgets::Batch::RowPath const &path);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_ISISREFLECTOMETRY_ROWLOCATION_H

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 using MantidWidgets::Batch::RowLocation;
 
@@ -66,5 +67,6 @@ std::vector<Row> RunsTable::selectedRows() const {
   }
   return rows;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class RunsTable
 
@@ -60,6 +61,7 @@ bool RunsTable::isInSelection(
   auto const path = m_reductionJobs.getPath(item);
   return containsPath(selectedRowLocations, path);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_RUNSTABLE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 UniformSlicingByTime::UniformSlicingByTime(double secondsPerSlice)
     : m_secondsPerSlice(secondsPerSlice) {}
@@ -115,5 +116,6 @@ std::ostream &operator<<(std::ostream &os, SlicingByEventLog const &slicing) {
   }
   return os;
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Slicing.h
@@ -15,6 +15,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL UniformSlicingByTime {
 public:
@@ -97,6 +98,7 @@ using Slicing =
 MANTIDQT_ISISREFLECTOMETRY_DLL bool isInvalid(Slicing const &slicing);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool isValid(Slicing const &slicing);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool isNoSlicing(Slicing const &slicing);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
@@ -12,6 +12,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** SummationType holds information about what type of summation should be
  * done in the reduction
@@ -36,6 +37,7 @@ inline std::string summationTypeToString(SummationType summationType) {
   }
   throw std::invalid_argument("Unexpected summation type");
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_SUMMATIONTYPE_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 TransmissionRunPair::TransmissionRunPair()
     : m_firstTransmissionRunNumbers(), m_secondTransmissionRunNumbers() {}
@@ -58,5 +59,6 @@ bool operator!=(TransmissionRunPair const &lhs,
   return !(lhs == rhs);
 }
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionRunPair.h
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 /** @class TransmissionRunPair
 
     The TransmissionRunPair model holds information about the two possible
@@ -41,6 +42,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(TransmissionRunPair const &lhs,
                                                TransmissionRunPair const &rhs);
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(TransmissionRunPair const &lhs,
                                                TransmissionRunPair const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_TRANSMISSIONRUNPAIR_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
@@ -8,6 +8,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 TransmissionStitchOptions::TransmissionStitchOptions()
     : m_overlapRange(boost::none), m_rebinParameters(), m_scaleRHS(false) {}
@@ -39,5 +40,6 @@ bool operator!=(TransmissionStitchOptions const &lhs,
                 TransmissionStitchOptions const &rhs) {
   return !(lhs == rhs);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -13,6 +13,7 @@
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 // For now just pass rebin params as a string but in future we may want to
 // expand this
@@ -46,6 +47,7 @@ operator==(TransmissionStitchOptions const &lhs,
 MANTIDQT_ISISREFLECTOMETRY_DLL bool
 operator!=(TransmissionStitchOptions const &lhs,
            TransmissionStitchOptions const &rhs);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_TRANSMISSIONSTITCHOPTIONS_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 template <typename T>
 class AppendErrorIfNotType : public boost::static_visitor<boost::optional<T>> {
@@ -130,5 +131,6 @@ validatePerThetaDefaults(CellText const &cells) {
   auto validate = PerThetaDefaultsValidator();
   return validate(cells);
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
@@ -48,7 +48,8 @@ PerThetaDefaultsValidator::parseThetaOrWhitespace(CellText const &cellText) {
   if (isEntirelyWhitespace(cellText[0])) {
     return boost::optional<double>();
   } else {
-    auto theta = ::MantidQt::CustomInterfaces::parseTheta(cellText[0]);
+    auto theta = ::MantidQt::CustomInterfaces::ISISReflectometry::parseTheta(
+        cellText[0]);
     if (theta.is_initialized()) {
       return theta;
     }
@@ -60,8 +61,8 @@ PerThetaDefaultsValidator::parseThetaOrWhitespace(CellText const &cellText) {
 boost::optional<TransmissionRunPair>
 PerThetaDefaultsValidator::parseTransmissionRuns(CellText const &cellText) {
   auto transmissionRunsOrError =
-      ::MantidQt::CustomInterfaces::parseTransmissionRuns(cellText[1],
-                                                          cellText[2]);
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseTransmissionRuns(
+          cellText[1], cellText[2]);
   return boost::apply_visitor(
       AppendErrorIfNotType<TransmissionRunPair>(m_invalidColumns, 1),
       transmissionRunsOrError);
@@ -70,8 +71,8 @@ PerThetaDefaultsValidator::parseTransmissionRuns(CellText const &cellText) {
 boost::optional<boost::optional<std::string>>
 PerThetaDefaultsValidator::parseTransmissionProcessingInstructions(
     CellText const &cellText) {
-  auto optionalInstructionsOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseProcessingInstructions(cellText[3]);
+  auto optionalInstructionsOrNoneIfError = ::MantidQt::CustomInterfaces::
+      ISISReflectometry::parseProcessingInstructions(cellText[3]);
   if (!optionalInstructionsOrNoneIfError.is_initialized())
     m_invalidColumns.emplace_back(3);
   return optionalInstructionsOrNoneIfError;
@@ -79,8 +80,9 @@ PerThetaDefaultsValidator::parseTransmissionProcessingInstructions(
 
 boost::optional<RangeInQ>
 PerThetaDefaultsValidator::parseQRange(CellText const &cellText) {
-  auto qRangeOrError = ::MantidQt::CustomInterfaces::parseQRange(
-      cellText[4], cellText[5], cellText[6]);
+  auto qRangeOrError =
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseQRange(
+          cellText[4], cellText[5], cellText[6]);
   return boost::apply_visitor(
       AppendErrorIfNotType<RangeInQ>(m_invalidColumns, 4), qRangeOrError);
 }
@@ -88,7 +90,8 @@ PerThetaDefaultsValidator::parseQRange(CellText const &cellText) {
 boost::optional<boost::optional<double>>
 PerThetaDefaultsValidator::parseScaleFactor(CellText const &cellText) {
   auto optionalScaleFactorOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseScaleFactor(cellText[7]);
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseScaleFactor(
+          cellText[7]);
   if (!optionalScaleFactorOrNoneIfError.is_initialized())
     m_invalidColumns.emplace_back(7);
   return optionalScaleFactorOrNoneIfError;
@@ -97,8 +100,8 @@ PerThetaDefaultsValidator::parseScaleFactor(CellText const &cellText) {
 boost::optional<boost::optional<std::string>>
 PerThetaDefaultsValidator::parseProcessingInstructions(
     CellText const &cellText) {
-  auto optionalInstructionsOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseProcessingInstructions(cellText[8]);
+  auto optionalInstructionsOrNoneIfError = ::MantidQt::CustomInterfaces::
+      ISISReflectometry::parseProcessingInstructions(cellText[8]);
   if (!optionalInstructionsOrNoneIfError.is_initialized())
     m_invalidColumns.emplace_back(8);
   return optionalInstructionsOrNoneIfError;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.h
@@ -16,6 +16,7 @@
 #include <boost/optional.hpp>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class PerThetaDefaultsValidator
 
@@ -50,6 +51,7 @@ private:
 ValidationResult<PerThetaDefaults, std::vector<int>>
 validatePerThetaDefaults(PerThetaDefaults::ValueArray const &cellText);
 
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_PERTHETADEFAUTSVALIDATOR_H_

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
@@ -13,6 +13,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 namespace {
 enum ColumnNumber {
@@ -145,5 +146,6 @@ boost::optional<Row> validateRowFromRunAndTheta(std::string const &run,
   std::vector<std::string> cells = {run, theta, "", "", "", "", "", "", ""};
   return validateRow(cells).validElseNone();
 }
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
@@ -59,7 +59,8 @@ private:
 boost::optional<std::vector<std::string>>
 RowValidator::parseRunNumbers(std::vector<std::string> const &cellText) {
   auto runNumbers =
-      ::MantidQt::CustomInterfaces::parseRunNumbers(cellText[RUNS_COLUMN]);
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseRunNumbers(
+          cellText[RUNS_COLUMN]);
   if (!runNumbers.is_initialized())
     m_invalidColumns.emplace_back(RUNS_COLUMN);
   return runNumbers;
@@ -67,7 +68,8 @@ RowValidator::parseRunNumbers(std::vector<std::string> const &cellText) {
 
 boost::optional<double>
 RowValidator::parseTheta(std::vector<std::string> const &cellText) {
-  auto theta = ::MantidQt::CustomInterfaces::parseTheta(cellText[THETA_COLUMN]);
+  auto theta = ::MantidQt::CustomInterfaces::ISISReflectometry::parseTheta(
+      cellText[THETA_COLUMN]);
   if (!theta.is_initialized())
     m_invalidColumns.emplace_back(THETA_COLUMN);
   return theta;
@@ -76,7 +78,7 @@ RowValidator::parseTheta(std::vector<std::string> const &cellText) {
 boost::optional<TransmissionRunPair>
 RowValidator::parseTransmissionRuns(std::vector<std::string> const &cellText) {
   auto transmissionRunsOrError =
-      ::MantidQt::CustomInterfaces::parseTransmissionRuns(
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseTransmissionRuns(
           cellText[FIRST_TRANS_COLUMN], cellText[SECOND_TRANS_COLUMN]);
   return boost::apply_visitor(AppendErrorIfNotType<TransmissionRunPair>(
                                   m_invalidColumns, FIRST_TRANS_COLUMN),
@@ -85,8 +87,9 @@ RowValidator::parseTransmissionRuns(std::vector<std::string> const &cellText) {
 
 boost::optional<RangeInQ>
 RowValidator::parseQRange(std::vector<std::string> const &cellText) {
-  auto qRangeOrError = ::MantidQt::CustomInterfaces::parseQRange(
-      cellText[QMIN_COLUMN], cellText[QMAX_COLUMN], cellText[QSTEP_COLUMN]);
+  auto qRangeOrError =
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseQRange(
+          cellText[QMIN_COLUMN], cellText[QMAX_COLUMN], cellText[QSTEP_COLUMN]);
   return boost::apply_visitor(
       AppendErrorIfNotType<RangeInQ>(m_invalidColumns, QMIN_COLUMN),
       qRangeOrError);
@@ -95,7 +98,8 @@ RowValidator::parseQRange(std::vector<std::string> const &cellText) {
 boost::optional<boost::optional<double>>
 RowValidator::parseScaleFactor(std::vector<std::string> const &cellText) {
   auto optionalScaleFactorOrNoneIfError =
-      ::MantidQt::CustomInterfaces::parseScaleFactor(cellText[SCALE_COLUMN]);
+      ::MantidQt::CustomInterfaces::ISISReflectometry::parseScaleFactor(
+          cellText[SCALE_COLUMN]);
   if (!optionalScaleFactorOrNoneIfError.is_initialized())
     m_invalidColumns.emplace_back(SCALE_COLUMN);
   return optionalScaleFactorOrNoneIfError;
@@ -103,8 +107,8 @@ RowValidator::parseScaleFactor(std::vector<std::string> const &cellText) {
 
 boost::optional<std::map<std::string, std::string>>
 RowValidator::parseOptions(std::vector<std::string> const &cellText) {
-  auto options =
-      ::MantidQt::CustomInterfaces::parseOptions(cellText[OPTIONS_COLUMN]);
+  auto options = ::MantidQt::CustomInterfaces::ISISReflectometry::parseOptions(
+      cellText[OPTIONS_COLUMN]);
   if (!options.is_initialized())
     m_invalidColumns.emplace_back(OPTIONS_COLUMN);
   return options;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
@@ -16,6 +16,7 @@
 #include <boost/optional.hpp>
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 /** @class RowValidator
 
@@ -49,6 +50,7 @@ RowValidationResult validateRow(std::vector<std::string> const &cellText);
 
 boost::optional<Row> validateRowFromRunAndTheta(std::string const &run,
                                                 std::string const &theta);
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_VALIDATEROW_H_

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -9,6 +9,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 namespace ModelCreationHelper {
 
 namespace { // unnamed
@@ -381,5 +382,6 @@ Instrument makeEmptyInstrument() {
       DetectorCorrections(false, DetectorCorrectionType::VerticalShift));
 }
 } // namespace ModelCreationHelper
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -14,6 +14,7 @@
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 namespace ModelCreationHelper {
 
 /* Helper methods to create reduction configuration models for the
@@ -90,6 +91,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL DetectorCorrections makeDetectorCorrections();
 MANTIDQT_ISISREFLECTOMETRY_DLL Instrument makeInstrument();
 MANTIDQT_ISISREFLECTOMETRY_DLL Instrument makeEmptyInstrument();
 } // namespace ModelCreationHelper
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 #endif // MANTID_CUSTOMINTERFACES_MODELCREATIONHELPER_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProgressBarTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProgressBarTest.h
@@ -9,7 +9,8 @@
 
 #include "BatchJobRunnerTest.h"
 
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 
 class BatchJobRunnerProgressBarTest : public CxxTest::TestSuite,
                                       public BatchJobRunnerTest {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerTest.h
@@ -17,8 +17,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using Mantid::API::Workspace_sptr;
 using Mantid::DataObjects::Workspace2D_sptr;
 using MantidQt::API::IConfiguredAlgorithm;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchPresenterTest.h
@@ -17,8 +17,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 using testing::AtLeast;
 using testing::Mock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/GroupProcessingAlgorithmTest.h
@@ -12,8 +12,9 @@
 
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 
 class GroupProcessingAlgorithmTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/MockBatchView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/MockBatchView.h
@@ -12,6 +12,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockBatchView : public IBatchView {
 public:
@@ -27,6 +28,7 @@ public:
   MOCK_METHOD0(executeAlgorithmQueue, void());
   MOCK_METHOD0(cancelAlgorithmQueue, void());
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/RowProcessingAlgorithmTest.h
@@ -12,8 +12,9 @@
 
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 
 class RowProcessingAlgorithmTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/PlotterTestQt5.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/PlotterTestQt5.h
@@ -51,7 +51,7 @@ public:
     alg->setProperty("OutputWorkspace", "ws1");
     alg->execute();
 
-    MantidQt::CustomInterfaces::Plotter plotter;
+    MantidQt::CustomInterfaces::ISISReflectometry::Plotter plotter;
     plotter.reflectometryPlot({"ws1"});
   }
 };

--- a/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Event/EventPresenterTest.h
@@ -14,7 +14,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Event/MockEventView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Event/MockEventView.h
@@ -12,6 +12,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockEventView : public IEventView {
 public:
@@ -33,6 +34,7 @@ public:
   MOCK_METHOD0(enableSliceTypeSelection, void());
   MOCK_METHOD0(disableSliceTypeSelection, void());
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentOptionDefaultsTest.h
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/ExperimentPresenterTest.h
@@ -21,8 +21,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentOptionDefaults.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentOptionDefaults.h
@@ -12,12 +12,14 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockExperimentOptionDefaults : public IExperimentOptionDefaults {
 public:
   MOCK_METHOD1(get,
                Experiment(Mantid::Geometry::Instrument_const_sptr instrument));
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/MockExperimentView.h
@@ -12,6 +12,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockExperimentView : public IExperimentView {
 public:
@@ -90,6 +91,7 @@ public:
   MOCK_METHOD1(removePerThetaDefaultsRow, void(int));
   MOCK_METHOD1(showPerAngleThetasNonUnique, void(double));
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Experiment/PerThetaDefaultsTableValidatorTest.h
@@ -11,7 +11,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentOptionDefaultsTest.h
@@ -17,7 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/InstrumentPresenterTest.h
@@ -21,7 +21,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/MockInstrumentOptionDefaults.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/MockInstrumentOptionDefaults.h
@@ -12,12 +12,14 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockInstrumentOptionDefaults : public IInstrumentOptionDefaults {
 public:
   MOCK_METHOD1(get,
                Instrument(Mantid::Geometry::Instrument_const_sptr instrument));
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Instrument/MockInstrumentView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Instrument/MockInstrumentView.h
@@ -12,6 +12,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockInstrumentView : public IInstrumentView {
 public:
@@ -49,6 +50,7 @@ public:
   MOCK_METHOD0(enableDetectorCorrectionType, void());
   MOCK_METHOD0(disableDetectorCorrectionType, void());
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/GroupTest.h
@@ -10,7 +10,7 @@
 #include "../../../ISISReflectometry/Reduction/ReductionWorkspaces.h"
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 class GroupTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
@@ -9,7 +9,7 @@
 #include "../../../ISISReflectometry/Reduction/ParseReflectometryStrings.h"
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 class ParseReflectometryStringsTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
@@ -16,7 +16,7 @@ using testing::Mock;
 using testing::NiceMock;
 using testing::_;
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using namespace ModelCreationHelper;
 
 class MockModificationListener {

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
@@ -10,7 +10,7 @@
 #include "MantidKernel/WarningSuppressions.h"
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 // The missing braces warning is a false positive -
 // https://llvm.org/bugs/show_bug.cgi?id=21629

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ValidateRowTest.h
@@ -10,7 +10,7 @@
 #include "../../../ISISReflectometry/Reduction/ValidateRow.h"
 #include <cxxtest/TestSuite.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 class ValidateRowTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -35,7 +35,7 @@
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using namespace Mantid::API;
 
 GNU_DIAG_OFF_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/MockRunsView.h
@@ -15,6 +15,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockRunsView : public IRunsView {
 public:
@@ -57,6 +58,7 @@ public:
   MOCK_METHOD0(startMonitor, void());
   MOCK_METHOD0(stopMonitor, void());
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -22,8 +22,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using Mantid::DataObjects::TableWorkspace;
 using testing::AtLeast;
 using testing::Mock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/SearchResultTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/SearchResultTest.h
@@ -11,7 +11,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using MantidQt::CustomInterfaces::SearchResult;
+using MantidQt::CustomInterfaces::ISISReflectometry::SearchResult;
 
 class SearchResultTest : public CxxTest::TestSuite {
 public:

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTablePresenter.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTablePresenter.h
@@ -15,6 +15,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockRunsTablePresenter : public IRunsTablePresenter {
 public:
@@ -34,6 +35,7 @@ public:
   MOCK_METHOD1(instrumentChanged, void(std::string const &));
   MOCK_METHOD0(settingsChanged, void());
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTableView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/MockRunsTableView.h
@@ -14,6 +14,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockRunsTableView : public IRunsTableView {
 public:
@@ -38,6 +39,7 @@ public:
   MOCK_METHOD1(setProcessButtonEnabled, void(bool));
   MOCK_METHOD2(setActionEnabled, void(Action, bool));
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
@@ -15,8 +15,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
@@ -14,8 +14,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterMergeJobsTest.h
@@ -15,8 +15,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
@@ -15,8 +15,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using MantidQt::MantidWidgets::Batch::Cell;
 using MantidQt::MantidWidgets::Batch::RowLocation;
 using MantidQt::MantidWidgets::Batch::RowPath;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowDeletionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowDeletionTest.h
@@ -15,8 +15,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h
@@ -14,8 +14,9 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
-using namespace MantidQt::CustomInterfaces::ModelCreationHelper;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterTest.h
@@ -19,7 +19,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using testing::AtLeast;
 using testing::Mock;
 using testing::NiceMock;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/MockSaveView.h
@@ -12,6 +12,7 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 namespace MantidQt {
 namespace CustomInterfaces {
+namespace ISISReflectometry {
 
 class MockSaveView : public ISaveView {
 public:
@@ -49,6 +50,7 @@ public:
   MOCK_METHOD0(cannotSaveWorkspaces, void());
   MOCK_METHOD1(cannotSaveWorkspaces, void(std::string const &));
 };
+} // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -22,7 +22,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-using namespace MantidQt::CustomInterfaces;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using Mantid::API::AlgorithmManager;
 using Mantid::API::AnalysisDataService;
 using Mantid::DataObjects::Workspace2D_sptr;


### PR DESCRIPTION
This PR adds a namespace for the ISISReflectometry GUI. Recent changes mean the classes for this GUI now have short names, so this namespace will ensure we won't clash with other GUIs.

Refs #26535

**To test:**

- Code review and ensure tests till pass
- Check that the ISIS Reflectometry GUI still opens

*This does not require release notes* because **it concerns file tidying only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
