### PR TITLE
Elemental Analysis color function now returns same color for same element

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -163,7 +163,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # check x value is a float
         try:
             x_value = float(x_value_in)
-        except ValueError:
+        except:
             return
         if name not in self.element_lines[element]:
             self.element_lines[element].append(name)

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -119,7 +119,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.electron_peaks = {}
         self._generate_element_widgets()
 
-    # Return the first unused colour, if all used then restart from the beginning of the cycle
     def get_color(self, element):
         """
         When requesting the colour for a new element, return the first unused colour of the matplotlib

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -121,15 +121,24 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
     # Return the first unused colour, if all used then restart from the beginning of the cycle
     def get_color(self, element):
+        """
+        When requesting the colour for a new element, return the first unused colour of the matplotlib
+        default colour cycle (i.e. mpl.rcParams['axes.prop_cycle']).
+        If all colours are used, return the first among the least used ones.
+        That is if C0-4 are all used twice and C5-9 are used once, C5 will be returned.
+
+        When requesting the colour for an element that is already plotted return the colour of that element.
+        This prevents the same element from being displayed in different colours in separate plots
+
+        :param element: Chemical symbol of the element that one wants the colour of
+        :return: Matplotlib colour string: C0, C1, ..., C9 to be used as plt.plot(..., color='C3')
+        """
         if element in self.used_colors:
             return self.used_colors[element]
 
-        occurrences = []
-        for i in range(self.num_colors):
-            occurrences.append(self.used_colors.values().count('C{}'.format(i)))
+        occurrences = [self.used_colors.values().count('C{}'.format(i)) for i in range(self.num_colors)]
 
-        color_list = ['C{}'.format(i) for i in range(self.num_colors) if occurrences[i] == min(occurrences)]
-        color_index = min([int(col[1:]) for col in color_list])
+        color_index = occurrences.index(min(occurrences))
 
         color = "C{}".format(color_index)
         self.used_colors[element] = color

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -38,17 +38,25 @@ import mantid.simpleapi as mantid
 offset = 0.9
 
 
+def is_string(value):
+    if isinstance(value, str):
+        return True
+    elif sys.version_info[:2] < (3, 0):
+        if isinstance(value, unicode):
+            return True
+
+    return False
+
+
 def gen_name(element, name):
-    if sys.version_info[:2] < (3, 0):
-        if (not isinstance(element, str)) and (not isinstance(element, unicode)):
-            raise TypeError("'%s' expected element to be 'str', found '%s' instead" % (str(element), type(element)))
-        if (not isinstance(name, str)) and (not isinstance(name, unicode)):
-            raise TypeError("'%s' expected name to be 'str', found '%s' instead" % (str(name), type(name)))
-    else:
-        if not isinstance(element, str):
-            raise TypeError("'%s' expected element to be 'str', found '%s' instead" % (str(element), type(element)))
-        if not isinstance(name, str):
-            raise TypeError("'%s' expected name to be 'str', found '%s' instead" % (str(name), type(name)))
+    msg = None
+    if not is_string(element):
+        msg = "'{}' expected element to be 'str', found '{}' instead".format(str(element), type(element))
+    if not is_string(name):
+        msg = "'{}' expected name to be 'str', found '{}' instead".format(str(name), type(name))
+
+    if msg is not None:
+        raise TypeError(msg)
 
     if element in name:
         return name
@@ -56,7 +64,6 @@ def gen_name(element, name):
 
 
 class ElementalAnalysisGui(QtWidgets.QMainWindow):
-
     def __init__(self, parent=None):
         super(ElementalAnalysisGui, self).__init__(parent)
         # set menu
@@ -156,7 +163,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # check x value is a float
         try:
             x_value = float(x_value_in)
-        except:
+        except ValueError:
             return
         if name not in self.element_lines[element]:
             self.element_lines[element].append(name)
@@ -210,7 +217,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for name, x_value in iteritems(data):
             try:
                 x_value = float(x_value)
-            except:
+            except ValueError:
                 continue
             full_name = gen_name(element, name)
             if full_name not in self.element_lines[element]:
@@ -292,7 +299,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for name, x_value in iteritems(data):
             try:
                 x_value = float(x_value)
-            except:
+            except ValueError:
                 continue
             full_name = gen_name(element, name)
             label = self._gen_label(full_name, x_value, element)
@@ -341,13 +348,14 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             self.ptable.set_peak_datafile(filename)
         # these are commneted out as they are a bug
         # see issue 25326
-        #self._clear_lines_after_data_file_selected()
+        # self._clear_lines_after_data_file_selected()
         try:
             self._generate_element_widgets()
         except ValueError:
-            message_box.warning('The file does not contain correctly formatted data, resetting to default data file.'
-                                'See "https://docs.mantidproject.org/nightly/interfaces/'
-                                'Muon%20Elemental%20Analysis.html" for more information.')
+            message_box.warning(
+                'The file does not contain correctly formatted data, resetting to default data file.'
+                'See "https://docs.mantidproject.org/nightly/interfaces/'
+                'Muon%20Elemental%20Analysis.html" for more information.')
             self.ptable.set_peak_datafile(None)
             self._generate_element_widgets()
 
@@ -356,7 +364,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
                 self.ptable.select_element(element)
             else:
                 self._remove_element_lines(element)
-        #self._generate_element_data()
+        # self._generate_element_data()
 
     # general checked data
     def checked_data(self, element, selection, state):

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -136,7 +136,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         if element in self.used_colors:
             return self.used_colors[element]
 
-        occurrences = [self.used_colors.values().count('C{}'.format(i)) for i in range(self.num_colors)]
+        occurrences = [list(self.used_colors.values()).count('C{}'.format(i)) for i in range(self.num_colors)]
 
         color_index = occurrences.index(min(occurrences))
 

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -25,13 +25,13 @@ from MultiPlotting.label import Label
 @start_qapplication
 class ElementalAnalysisTest(unittest.TestCase):
     @classmethod
-    def setUpClass(self):
-        super(ElementalAnalysisTest, self).setUpClass()
-        self.gui = ElementalAnalysisGui()
+    def setUpClass(cls):
+        super(ElementalAnalysisTest, cls).setUpClass()
+        cls.gui = ElementalAnalysisGui()
 
     @classmethod
-    def tearDownClass(self):
-        self.gui = None
+    def tearDownClass(cls):
+        cls.gui = None
 
     def setUp(self):
         self.gui.plot_window = None

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -203,9 +203,11 @@ class ElementalAnalysisTest(unittest.TestCase):
         data = {'line1': 10.0, 'line2': 20.0, 'line3': 30.0}
         self.gui._add_element_lines('Cu', data)
         self.assertEqual(mock_plot_line.call_count, 3)
-        call_list = [mock.call(gen_name('Cu', 'line3'), 30.0, 'C0', 'Cu'),
-                     mock.call(gen_name('Cu', 'line2'), 20.0, 'C0', 'Cu'),
-                     mock.call(gen_name('Cu', 'line1'), 10.0, 'C0', 'Cu')]
+        call_list = [
+            mock.call(gen_name('Cu', 'line3'), 30.0, 'C0', 'Cu'),
+            mock.call(gen_name('Cu', 'line2'), 20.0, 'C0', 'Cu'),
+            mock.call(gen_name('Cu', 'line1'), 10.0, 'C0', 'Cu')
+        ]
         mock_plot_line.assert_has_calls(call_list, any_order=True)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._rm_line')
@@ -260,7 +262,8 @@ class ElementalAnalysisTest(unittest.TestCase):
             self.assertEqual(detector.setChecked.call_count, 1)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.Detectors.detectors_view.QtWidgets.QWidget')
-    def test_loading_finished_returns_correctly_if_no_to_plot_but_has_plot_window(self, mock_QWidget):
+    def test_loading_finished_returns_correctly_if_no_to_plot_but_has_plot_window(
+            self, mock_QWidget):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=['run1', 'run2', 'run3'])
         self.gui.detectors = mock.Mock()
         self.gui.detectors.getNames.return_value = ['1', '2', '3']
@@ -273,9 +276,9 @@ class ElementalAnalysisTest(unittest.TestCase):
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_peak_data')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
-    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(self, mock_mantid, mock_add_peak_data):
-        mock_mantid.mtd = {'name1': [mock.Mock(), mock.Mock()],
-                           'name2': [mock.Mock(), mock.Mock()]}
+    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(
+            self, mock_mantid, mock_add_peak_data):
+        mock_mantid.mtd = {'name1': [mock.Mock(), mock.Mock()], 'name2': [mock.Mock(), mock.Mock()]}
         self.gui.plotting = mock.Mock()
 
         self.gui.add_detector_to_plot('GE1', 'name1')


### PR DESCRIPTION
Changed function `get_color` to always returned the first unused colour in matplotlib default colour cycle.
If all are used then it will return the least used one.
Every plotted element is assigned a colour and always plotted with it. This prevents the same element from having two colours in different plots.

**To test:**
1. `Interface->Muon->Elemental Analysis`
2. Load a run (eg `2695`)
3. Plot multiple elements on multiple plots

Fixes #26431.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
