### PR TITLE
New method to get azimuthal angle

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -67,6 +67,7 @@ public:
   double l2(const size_t index) const;
   double twoTheta(const size_t index) const;
   double signedTwoTheta(const size_t index) const;
+  double azimuthal(const size_t index) const;
   Kernel::V3D position(const size_t index) const;
   bool hasDetectors(const size_t index) const;
   bool hasUniqueDetector(const size_t index) const;

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -99,6 +99,18 @@ double SpectrumInfo::signedTwoTheta(const size_t index) const {
   return signedTwoTheta / static_cast<double>(spectrumDefinition(index).size());
 }
 
+/** Returns the out-of-plane angle in radians (angle w.r.t. to vecPointingHorizontal
+ * direction).
+ *
+ * Throws an exception if the spectrum is a monitor.
+ */ double
+SpectrumInfo::azimuthal(const size_t index) const {
+  double phi{0.0};
+  for (const auto &detIndex : checkAndGetSpectrumDefinition(index))
+    phi += m_detectorInfo.azimuthal(detIndex);
+  return phi / static_cast<double>(spectrumDefinition(index).size());
+}
+
 /// Returns the position of the spectrum with given index.
 Kernel::V3D SpectrumInfo::position(const size_t index) const {
   Kernel::V3D newPos;

--- a/Framework/API/test/SpectrumInfoTest.h
+++ b/Framework/API/test/SpectrumInfoTest.h
@@ -251,6 +251,16 @@ public:
                      m_grouped.detectorSignedTwoTheta(*det));
   }
 
+  void test_azimuthal() {
+    const auto &spectrumInfo = m_workspace.spectrumInfo();
+    TS_ASSERT_DELTA(spectrumInfo.azimuthal(0), -1.570796, 1e-6);
+    TS_ASSERT_DELTA(spectrumInfo.azimuthal(1), 0.0, 1e-6);
+    TS_ASSERT_DELTA(spectrumInfo.azimuthal(2), 1.570796, 1e-6);
+    // Monitors
+    TS_ASSERT_THROWS(spectrumInfo.azimuthal(3), const std::logic_error &);
+    TS_ASSERT_THROWS(spectrumInfo.azimuthal(4), const std::logic_error &);
+  }
+
   void test_position() {
     const auto &spectrumInfo = m_workspace.spectrumInfo();
     TS_ASSERT_EQUALS(spectrumInfo.position(0), V3D(0.0, -0.1, 5.0));

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/DetectorInfo.h
@@ -74,6 +74,8 @@ public:
   double twoTheta(const std::pair<size_t, size_t> &index) const;
   double signedTwoTheta(const size_t index) const;
   double signedTwoTheta(const std::pair<size_t, size_t> &index) const;
+  double azimuthal(const size_t index) const;
+  double azimuthal(const std::pair<size_t, size_t> &index) const;
   Kernel::V3D position(const size_t index) const;
   Kernel::V3D position(const std::pair<size_t, size_t> &index) const;
   Kernel::Quat rotation(const size_t index) const;

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -228,6 +228,48 @@ DetectorInfo::signedTwoTheta(const std::pair<size_t, size_t> &index) const {
   return angle;
 }
 
+double DetectorInfo::azimuthal(const size_t index) const {
+  if (isMonitor(index))
+    throw std::logic_error("Azimuthal angle is not defined for monitors");
+
+  const auto samplePos = samplePosition();
+  const auto beamLine = samplePos - sourcePosition();
+
+  if (beamLine.nullVector()) {
+    throw Kernel::Exception::InstrumentDefinitionError(
+        "Source and sample are at same position!");
+  }
+
+  const auto sampleDetVec = position(index) - samplePos;
+  const double dotHorizontal = sampleDetVec.scalar_prod(
+      m_instrument->getReferenceFrame()->vecPointingHorizontal());
+  const double dotVertical = sampleDetVec.scalar_prod(
+      m_instrument->getReferenceFrame()->vecPointingUp());
+
+  return atan2(dotVertical, dotHorizontal);
+}
+
+double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
+  if (isMonitor(index))
+    throw std::logic_error("Azimuthal angle is not defined for monitors");
+
+  const auto samplePos = samplePosition();
+  const auto beamLine = samplePos - sourcePosition();
+
+  if (beamLine.nullVector()) {
+    throw Kernel::Exception::InstrumentDefinitionError(
+        "Source and sample are at same position!");
+  }
+
+  const auto sampleDetVec = position(index) - samplePos;
+  const double dotHorizontal = sampleDetVec.scalar_prod(
+      m_instrument->getReferenceFrame()->vecPointingHorizontal());
+  const double dotVertical = sampleDetVec.scalar_prod(
+      m_instrument->getReferenceFrame()->vecPointingUp());
+
+  return atan2(dotVertical, dotHorizontal);
+}
+
 /// Returns the position of the detector with given index.
 Kernel::V3D DetectorInfo::position(const size_t index) const {
   return Kernel::toV3D(m_detectorInfo->position(index));

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -241,10 +241,12 @@ double DetectorInfo::azimuthal(const size_t index) const {
   }
 
   const auto sampleDetVec = position(index) - samplePos;
-  const double dotHorizontal = sampleDetVec.scalar_prod(
-      m_instrument->getReferenceFrame()->vecPointingHorizontal());
-  const double dotVertical = sampleDetVec.scalar_prod(
-      m_instrument->getReferenceFrame()->vecPointingUp());
+  const auto horizontal =
+      m_instrument->getReferenceFrame()->vecPointingHorizontal();
+
+  const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
+  const auto vertical = Kernel::normalize(beamLine).cross_prod(horizontal);
+  const double dotVertical = sampleDetVec.scalar_prod(vertical);
 
   return atan2(dotVertical, dotHorizontal);
 }
@@ -262,10 +264,12 @@ double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
   }
 
   const auto sampleDetVec = position(index) - samplePos;
-  const double dotHorizontal = sampleDetVec.scalar_prod(
-      m_instrument->getReferenceFrame()->vecPointingHorizontal());
-  const double dotVertical = sampleDetVec.scalar_prod(
-      m_instrument->getReferenceFrame()->vecPointingUp());
+  const auto horizontal =
+      m_instrument->getReferenceFrame()->vecPointingHorizontal();
+
+  const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
+  const auto vertical = Kernel::normalize(beamLine).cross_prod(horizontal);
+  const double dotVertical = sampleDetVec.scalar_prod(vertical);
 
   return atan2(dotVertical, dotHorizontal);
 }

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -247,9 +247,16 @@ double DetectorInfo::azimuthal(const size_t index) const {
   const auto origHorizontal =
       m_instrument->getReferenceFrame()->vecPointingHorizontal();
   const auto vertical = beamLineNormalized.cross_prod(origHorizontal);
+  if (vertical.scalar_prod(
+          m_instrument->getReferenceFrame()->vecPointingUp()) <= 0.)
+    throw std::runtime_error(
+        "Failed to create up axis orthogonal to the beam direction");
 
   // generate the horizontal axis perpendicular to the other two
   const auto horizontal = vertical.cross_prod(beamLineNormalized);
+  if (origHorizontal.scalar_prod(horizontal) <= 0.)
+    throw std::runtime_error(
+        "Failed to create horizontal axis orthogonal to the beam direction");
 
   const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
   const double dotVertical = sampleDetVec.scalar_prod(vertical);

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -278,7 +278,7 @@ double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
 
   const auto sampleDetVec = position(index) - samplePos;
   const auto beamLineNormalized = Kernel::normalize(beamLine);
-  
+
   // generate the vertical axis
   const auto origHorizontal =
       m_instrument->getReferenceFrame()->vecPointingHorizontal();

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -241,11 +241,17 @@ double DetectorInfo::azimuthal(const size_t index) const {
   }
 
   const auto sampleDetVec = position(index) - samplePos;
-  const auto horizontal =
+  const auto beamLineNormalized = Kernel::normalize(beamLine);
+
+  // generate the vertical axis
+  const auto origHorizontal =
       m_instrument->getReferenceFrame()->vecPointingHorizontal();
+  const auto vertical = beamLineNormalized.cross_prod(origHorizontal);
+
+  // generate the horizontal axis perpendicular to the other two
+  const auto horizontal = vertical.cross_prod(beamLineNormalized);
 
   const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
-  const auto vertical = Kernel::normalize(beamLine).cross_prod(horizontal);
   const double dotVertical = sampleDetVec.scalar_prod(vertical);
 
   return atan2(dotVertical, dotHorizontal);
@@ -264,11 +270,17 @@ double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
   }
 
   const auto sampleDetVec = position(index) - samplePos;
-  const auto horizontal =
+  const auto beamLineNormalized = Kernel::normalize(beamLine);
+
+  // generate the vertical axis
+  const auto origHorizontal =
       m_instrument->getReferenceFrame()->vecPointingHorizontal();
+  const auto vertical = beamLineNormalized.cross_prod(origHorizontal);
+
+  // generate the horizontal axis perpendicular to the other two
+  const auto horizontal = vertical.cross_prod(beamLineNormalized);
 
   const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
-  const auto vertical = Kernel::normalize(beamLine).cross_prod(horizontal);
   const double dotVertical = sampleDetVec.scalar_prod(vertical);
 
   return atan2(dotVertical, dotHorizontal);

--- a/Framework/Geometry/src/Instrument/DetectorInfo.cpp
+++ b/Framework/Geometry/src/Instrument/DetectorInfo.cpp
@@ -278,14 +278,21 @@ double DetectorInfo::azimuthal(const std::pair<size_t, size_t> &index) const {
 
   const auto sampleDetVec = position(index) - samplePos;
   const auto beamLineNormalized = Kernel::normalize(beamLine);
-
+  
   // generate the vertical axis
   const auto origHorizontal =
       m_instrument->getReferenceFrame()->vecPointingHorizontal();
   const auto vertical = beamLineNormalized.cross_prod(origHorizontal);
+  if (vertical.scalar_prod(
+          m_instrument->getReferenceFrame()->vecPointingUp()) <= 0.)
+    throw std::runtime_error(
+        "Failed to create up axis orthogonal to the beam direction");
 
   // generate the horizontal axis perpendicular to the other two
   const auto horizontal = vertical.cross_prod(beamLineNormalized);
+  if (origHorizontal.scalar_prod(horizontal) <= 0.)
+    throw std::runtime_error(
+        "Failed to create horizontal axis orthogonal to the beam direction");
 
   const double dotHorizontal = sampleDetVec.scalar_prod(horizontal);
   const double dotVertical = sampleDetVec.scalar_prod(vertical);

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -31,59 +31,48 @@ SpectrumInfoPythonIterator make_pyiterator(SpectrumInfo &spectrumInfo) {
 void export_SpectrumInfo() {
   class_<SpectrumInfo, boost::noncopyable>("SpectrumInfo", no_init)
       .def("__iter__", make_pyiterator)
-
       .def("__len__", &SpectrumInfo::size, arg("self"),
            "Returns the number of spectra.")
-
       .def("size", &SpectrumInfo::size, arg("self"),
            "Returns the number of spectra.")
-
       .def("isMonitor", &SpectrumInfo::isMonitor, (arg("self"), arg("index")),
            "Returns True if the detector(s) associated with the spectrum are "
            "monitors.")
-
       .def("isMasked", &SpectrumInfo::isMasked, (arg("self"), arg("index")),
            "Returns True if the detector(s) associated with the spectrum are "
            "masked.")
-
       .def("setMasked", &SpectrumInfo::setMasked,
            (arg("self"), arg("index"), arg("masked")),
            "Set the mask flag of the spectrum with the given index.")
-
       .def("twoTheta", &SpectrumInfo::twoTheta, (arg("self"), arg("index")),
            "Returns the scattering angle 2 theta in radians w.r.t. beam "
            "direction.")
-
       .def("signedTwoTheta", &SpectrumInfo::signedTwoTheta,
            (arg("self"), arg("index")),
            "Returns the signed scattering angle 2 theta in radians w.r.t. beam "
            "direction.")
-
+      .def("azimuthal", &SpectrumInfo::azimuthal, (arg("self"), arg("index")),
+           "Returns the out-of-plane angle in radians angle w.r.t. to "
+           "vecPointingHorizontal "
+           "direction.")
       .def("l1", &SpectrumInfo::l1, arg("self"),
            "Returns the distance from the source to the sample.")
-
       .def("l2", &SpectrumInfo::l2, (arg("self"), arg("index")),
            "Returns the distance from the sample to the spectrum.")
-
       .def("hasDetectors", &SpectrumInfo::hasDetectors, (arg("self")),
            "Returns True if the spectrum is associated with detectors in the "
            "instrument.")
-
       .def("hasUniqueDetector", &SpectrumInfo::hasUniqueDetector,
            (arg("self"), arg("index")),
            "Returns True if the spectrum is associated with exactly one "
            "detector.")
-
       .def("position", &SpectrumInfo::position, (arg("self"), arg("index")),
            "Returns the absolute position of the spectrum with the given "
            "index.")
-
       .def("sourcePosition", &SpectrumInfo::sourcePosition, arg("self"),
            "Returns the absolute source position.")
-
       .def("samplePosition", &SpectrumInfo::samplePosition, arg("self"),
            "Returns the absolute sample position.")
-
       .def("getSpectrumDefinition", &SpectrumInfo::spectrumDefinition,
            return_value_policy<return_by_value>(), (arg("self"), arg("index")),
            "Returns the SpectrumDefinition of the spectrum with the given "

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/DetectorInfo.cpp
@@ -53,6 +53,9 @@ void export_DetectorInfo() {
   double (DetectorInfo::*twoTheta)(const size_t) const =
       &DetectorInfo::twoTheta;
 
+  double (DetectorInfo::*azimuthal)(const size_t) const =
+      &DetectorInfo::azimuthal;
+
   Mantid::Kernel::V3D (DetectorInfo::*position)(const size_t) const =
       &DetectorInfo::position;
 
@@ -101,7 +104,9 @@ void export_DetectorInfo() {
 
       .def("twoTheta", twoTheta, (arg("self"), arg("index")),
            "Returns 2 theta (scattering angle w.r.t beam direction).")
-
+      .def("azimuthal", azimuthal, (arg("self"), arg("index")),
+           "Returns the out-of-plane angle in radians angle w.r.t. to "
+           "vecPointingHorizontal")
       .def("position", position, (arg("self"), arg("index")),
            "Returns the absolute position of the detector where the detector "
            "is identified by 'index'.")

--- a/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
@@ -12,6 +12,7 @@ from testhelpers import WorkspaceCreationHelper
 from mantid.kernel import V3D
 from mantid.kernel import Quat
 from mantid.simpleapi import *
+import numpy as np
 
 
 class DetectorInfoTest(unittest.TestCase):
@@ -88,6 +89,13 @@ class DetectorInfoTest(unittest.TestCase):
         """ See if the returned value is a double (float in Python). """
         info = self._ws.detectorInfo()
         self.assertEqual(type(info.twoTheta(0)), float)
+
+    def test_azimuthal(self):
+        """ See if the returned value is a double (float in Python). """
+        info = self._ws.detectorInfo()
+        self.assertEqual(type(info.azimuthal(0)), float)
+        x, y, _ = info.position(0)
+        self.assertEqual(np.arctan2(y, x), info.azimuthal(0))
 
     def test_createWorkspaceAndDetectorInfo(self):
     	""" Try to create a workspace and see if DetectorInfo object

--- a/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/DetectorInfoTest.py
@@ -94,8 +94,9 @@ class DetectorInfoTest(unittest.TestCase):
         """ See if the returned value is a double (float in Python). """
         info = self._ws.detectorInfo()
         self.assertEqual(type(info.azimuthal(0)), float)
-        x, y, _ = info.position(0)
-        self.assertEqual(np.arctan2(y, x), info.azimuthal(0))
+        for i in range(info.size()):
+            x, y, _ = info.position(i)
+            self.assertEqual(np.arctan2(y, x), info.azimuthal(i))
 
     def test_createWorkspaceAndDetectorInfo(self):
     	""" Try to create a workspace and see if DetectorInfo object

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -18,6 +18,7 @@ Algorithms
 
 Data Objects
 ------------
+* New methods :py:obj:`mantid.api.SpectrumInfo.azimuthal` and :py:obj:`mantid.geometry.DetectorInfo.azimuthal`  which returns the out-of-plane angle for a spectrum
 
 Python
 ------


### PR DESCRIPTION
This adds methods on `SpectrumInfo` and `DetectorInfo` to get the azimuthal angle. This should avoid the pitfalls which caused #19019 to revert #18962.

**To test:**

Check out the new unit test in `DetectorInfo`. If you agree with that identity, then it works.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
