### PR TITLE
added support for lambda on two mode (no ticket)

### DIFF
--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -53,6 +53,7 @@ constexpr char FilterByTimeStopStr[] = "FilterByTimeStop";
 constexpr char PathToBinaryStr[] = "BinaryEventPath";
 constexpr char TOFBiasStr[] = "TimeOfFlightBias";
 constexpr char CalibrateTOFStr[] = "CalibrateTOFBias";
+constexpr char LambdaOnTwoStr[] = "LambdaOnTwoMode";
 
 // Common pairing of limits
 using TimeLimits = std::pair<double, double>;
@@ -501,6 +502,9 @@ void LoadPLN::init() {
   declareProperty(CalibrateTOFStr, false,
                   "Calibrate the TOF correction from the elastic pulse.");
 
+  declareProperty(LambdaOnTwoStr, false,
+      "Instrument is operating in Lambda on Two mode.");
+
   declareProperty(FilterByTimeStartStr, 0.0,
                   "Only include events after the provided start time, in "
                   "seconds (relative to the start of the run).");
@@ -807,6 +811,11 @@ void LoadPLN::loadParameters(const std::string &hdfFile,
     m_startRun = startTime.toISO8601String();
   }
 
+  // Add support for instrument running in lambda on two mode
+  bool const lambdaOnTwoMode = getProperty(LambdaOnTwoStr);
+  double lambdaFactor = (lambdaOnTwoMode ? 0.5 : 1.0);
+  logm.addProperty("LambdaOnTwoMode", (lambdaOnTwoMode ? 1 : 0));
+
   MapNeXusToSeries<double>(entry, "instrument/fermi_chopper/mchs", 0.0, logm,
                            m_startRun, "FermiChopperFreq", 1.0 / 60,
                            m_datasetIndex);
@@ -814,7 +823,7 @@ void LoadPLN::loadParameters(const std::string &hdfFile,
                            m_startRun, "OverlapChopperFreq", 1.0 / 60,
                            m_datasetIndex);
   MapNeXusToSeries<double>(entry, "instrument/crystal/wavelength", 0.0, logm,
-                           m_startRun, "Wavelength", 1.0, m_datasetIndex);
+                           m_startRun, "Wavelength", lambdaFactor, m_datasetIndex);
   MapNeXusToSeries<double>(entry, "instrument/detector/stth", 0.0, logm,
                            m_startRun, "DetectorTankAngle", 1.0,
                            m_datasetIndex);

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -811,7 +811,10 @@ void LoadPLN::loadParameters(const std::string &hdfFile,
     m_startRun = startTime.toISO8601String();
   }
 
-  // Add support for instrument running in lambda on two mode
+  // Add support for instrument running in lambda on two mode.
+  // Added as UI option as the available instrument parameters
+  // cannot be reliably interpreted to predict the mode (as
+  // advised by the instrument scientist).
   bool const lambdaOnTwoMode = getProperty(LambdaOnTwoStr);
   double lambdaFactor = (lambdaOnTwoMode ? 0.5 : 1.0);
   logm.addProperty("LambdaOnTwoMode", (lambdaOnTwoMode ? 1 : 0));

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -503,7 +503,7 @@ void LoadPLN::init() {
                   "Calibrate the TOF correction from the elastic pulse.");
 
   declareProperty(LambdaOnTwoStr, false,
-      "Instrument is operating in Lambda on Two mode.");
+                  "Instrument is operating in Lambda on Two mode.");
 
   declareProperty(FilterByTimeStartStr, 0.0,
                   "Only include events after the provided start time, in "
@@ -823,7 +823,8 @@ void LoadPLN::loadParameters(const std::string &hdfFile,
                            m_startRun, "OverlapChopperFreq", 1.0 / 60,
                            m_datasetIndex);
   MapNeXusToSeries<double>(entry, "instrument/crystal/wavelength", 0.0, logm,
-                           m_startRun, "Wavelength", lambdaFactor, m_datasetIndex);
+                           m_startRun, "Wavelength", lambdaFactor,
+                           m_datasetIndex);
   MapNeXusToSeries<double>(entry, "instrument/detector/stth", 0.0, logm,
                            m_startRun, "DetectorTankAngle", 1.0,
                            m_datasetIndex);

--- a/Framework/DataHandling/test/LoadPLNTest.h
+++ b/Framework/DataHandling/test/LoadPLNTest.h
@@ -79,6 +79,61 @@ public:
     TS_ASSERT_DELTA(logpm("Wavelength"), 4.6866, 1.0e-4);
     TS_ASSERT_DELTA(logpm("SampleRotation"), 13.001, 1.0e-3);
   }
+
+  void test_lambda_on_two_mode() {
+    LoadPLN algToBeTested;
+
+    if (!algToBeTested.isInitialized())
+      algToBeTested.initialize();
+
+    std::string outputSpace = "LoadPLNTest";
+    algToBeTested.setPropertyValue("OutputWorkspace", outputSpace);
+
+    // set lambda on two to confirm data is processed using half wavelength
+    // the file is not lambda on two data so the TOF calibration is not 
+    // meaningful
+    std::string inputFile = "PLN0044464.hdf";
+    algToBeTested.setPropertyValue("Filename", inputFile);
+    algToBeTested.setPropertyValue("BinaryEventPath", "./PLN0044464.bin");
+    algToBeTested.setPropertyValue("CalibrateTOFBias", "0");
+    algToBeTested.setPropertyValue("TimeOfFlightBias", "-258.0");
+    algToBeTested.setPropertyValue("LambdaOnTwoMode", "1");
+    TS_ASSERT_THROWS_NOTHING(algToBeTested.execute());
+    TS_ASSERT(algToBeTested.isExecuted());
+
+    // get workspace generated
+    MatrixWorkspace_sptr output =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
+            outputSpace);
+
+    // check number of histograms
+    TS_ASSERT_EQUALS(output->getNumberHistograms(), 12808);
+    double sum = 0.0;
+    for (size_t i = 0; i < output->getNumberHistograms(); i++)
+      sum += output->y(i)[0];
+    TS_ASSERT_EQUALS(sum, 163118);
+
+    // check that all required log values are there
+    auto run = output->run();
+
+    // test start and end time
+    TS_ASSERT(
+        run.getProperty("start_time")->value().compare("2018-11-12T10:45:06") ==
+        0)
+    TS_ASSERT(
+        run.getProperty("end_time")->value().find("2018-11-12T11:45:06.6") == 0)
+
+    // test some data properties
+    auto logpm = [&run](std::string tag) {
+      return dynamic_cast<TimeSeriesProperty<double> *>(run.getProperty(tag))
+          ->firstValue();
+    };
+    TS_ASSERT_DELTA(logpm("GatePeriod"), 5000.8, 1.0);
+    TS_ASSERT_DELTA(logpm("DetectorTankAngle"), 57.513, 1.0e-3);
+    TS_ASSERT_DELTA(logpm("TOFCorrection"), -258.0, 1.0e-3);
+    TS_ASSERT_DELTA(logpm("Wavelength"), 2.3433, 1.0e-4);
+    TS_ASSERT_DELTA(logpm("SampleRotation"), 13.001, 1.0e-3);
+  }
 };
 
 #endif /*LOADPLNTEST_H_*/

--- a/Framework/DataHandling/test/LoadPLNTest.h
+++ b/Framework/DataHandling/test/LoadPLNTest.h
@@ -90,7 +90,7 @@ public:
     algToBeTested.setPropertyValue("OutputWorkspace", outputSpace);
 
     // set lambda on two to confirm data is processed using half wavelength
-    // the file is not lambda on two data so the TOF calibration is not 
+    // the file is not lambda on two data so the TOF calibration is not
     // meaningful
     std::string inputFile = "PLN0044464.hdf";
     algToBeTested.setPropertyValue("Filename", inputFile);


### PR DESCRIPTION
**Description of work.**
The previous pelican loader could not handle data captured in lambda on two mode (halves the wavelength), this adds this capability. 

**To test:**
The loader test code has been updated. 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
