### PR TITLE
Updated workspace selection on run change

### DIFF
--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -24,6 +24,7 @@ Muon Analysis 2
 ###############
 
 - When loading PSI data if the groups given are poorly stored in the file, it should now produce unique names in the grouping tab for groups.
+- When switching between data sets groups selected to fit are remembered.
 
 Algorithms
 ----------

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -618,6 +618,14 @@ class FittingTabPresenterTest(unittest.TestCase):
 
         self.view.parameter_display_combo.setCurrentIndex(1)
 
+    def test_get_selected_groups_and_pairs_returns_correct_list(self):
+        self.presenter.selected_data = ['MUSR22725; Group; top; Asymmetry', 'MUSR22725; Group; bottom; Asymmetry',
+                                        'MUSR22725; Group; fwd; Asymmetry']
+
+        result = self.presenter._get_selected_groups_and_pairs()
+
+        self.assertEqual(result.sort(), ['top', 'bottom', 'fwd'].sort())
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**

In Muon analysis the selection of workspaces to plot is reset whenever new data is loaded. This is not the desired behavior and instead the groups and pairs selected should be remembered when switching between data.

**Report to:**  Adrian Hillier

**To test:**

  * You will need access to the ISIS data Archive to test this PR
  * Open Muon Analysis 2 and load MUSR 62260, go to the fitting tab and add Guass Osc as a fit function.
  * Go to select data and select several different groups to fit
  * Do a fit
  * In the load bar type 62260-70 to load several runs, switch to sequential fit and check that the same work spaces are selected to be fit as previously.

<!-- Instructions for testing. -->

Fixes #26564  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
