### PR TITLE
Correct ToF calculation in Kafka event decoder

### DIFF
--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -397,7 +397,7 @@ void KafkaEventStreamDecoder::eventDataFromMessage(const std::string &buffer,
     m_receivedEventBuffer.reserve(oldBufferSize + nEvents);
 
     /* Store the buffered events */
-    std::transform(detData.begin(), detData.end(), detData.begin(),
+    std::transform(detData.begin(), detData.end(), tofData.begin(),
                    std::back_inserter(m_receivedEventBuffer),
                    [&](uint64_t detId, uint64_t tof) -> BufferedEvent {
                      const auto workspaceIndex =
@@ -452,7 +452,7 @@ void KafkaEventStreamDecoder::flushIntermediateBuffer() {
 
         // nanoseconds to microseconds
         spectrum->addEventQuickly(
-            TofEvent(static_cast<double>(event.tof) * 1e3, pulse.pulseTime));
+            TofEvent(static_cast<double>(event.tof) * 1e-3, pulse.pulseTime));
       }
     }
   }

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -93,6 +93,10 @@ public:
         eventWksp);
     checkWorkspaceMetadata(*eventWksp);
     checkWorkspaceEventData(*eventWksp);
+
+    /* Ensure ToF range is as expected */
+    TS_ASSERT_EQUALS(6.0, eventWksp->getTofMin());
+    TS_ASSERT_EQUALS(11.0, eventWksp->getTofMax());
   }
 
   void test_Multiple_Period_Event_Stream() {


### PR DESCRIPTION
**To test:**

- Stream some event data
- See that ToF in Mantid matches the streamed data

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
