### PR TITLE
Whitespace now ignored in MultiFile names

### DIFF
--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -650,6 +650,20 @@ public:
     TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
   }
 
+  void test_multipleFiles_ranges_without_spaces() {
+    MultipleFileProperty p("Filename");
+    p.setValue("1-5,3-4");
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("TSC00004.nxs"));
+  }
+
   void test_multipleFiles_ranges_with_spaces() {
     MultipleFileProperty p("Filename");
     p.setValue("1-5, 3-4");

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -611,6 +611,59 @@ public:
     TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.raw"));
   }
 
+  void test_multipleFiles_consistent_spaces() {
+    MultipleFileProperty p("Filename");
+    p.setValue("1, 2, 3, 4, 5");
+
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+  }
+
+  void test_multipleFiles_inconsistent_spaces() {
+    MultipleFileProperty p("Filename");
+    p.setValue("1,2, 3,4, 5");
+
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+  }
+
+  void test_multipleFiles_space_after_first() {
+    MultipleFileProperty p("Filename");
+    p.setValue("1, 2,3,4,5");
+
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00002.nxs"));
+    TS_ASSERT_EQUALS(fileNames[2][0], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[3][0], dummyFile("TSC00004.nxs"));
+    TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
+  }
+
+  void test_multipleFiles_ranges_with_spaces() {
+    MultipleFileProperty p("Filename");
+    p.setValue("1-5, 3-4");
+    std::vector<std::vector<std::string>> fileNames = p();
+
+    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.nxs"));
+    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00003.nxs"));
+    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("TSC00004.nxs"));
+  }
+
   //////////////////////////////////////////////////////////////////////////////////////////////
   // Testing of MultipleFileProperty objects when multiple file loading has been
   // switched OFF.

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -650,20 +650,6 @@ public:
     TS_ASSERT_EQUALS(fileNames[4][0], dummyFile("TSC00005.nxs"));
   }
 
-  void test_multipleFiles_ranges_without_spaces() {
-    MultipleFileProperty p("Filename");
-    p.setValue("1-5,3-4");
-    std::vector<std::vector<std::string>> fileNames = p();
-
-    TS_ASSERT_EQUALS(fileNames[0][0], dummyFile("TSC00001.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][1], dummyFile("TSC00002.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][2], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][3], dummyFile("TSC00004.nxs"));
-    TS_ASSERT_EQUALS(fileNames[0][4], dummyFile("TSC00005.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][0], dummyFile("TSC00003.nxs"));
-    TS_ASSERT_EQUALS(fileNames[1][1], dummyFile("TSC00004.nxs"));
-  }
-
   void test_multipleFiles_ranges_with_spaces() {
     MultipleFileProperty p("Filename");
     p.setValue("1-5, 3-4");

--- a/Framework/API/test/MultipleFilePropertyTest.h
+++ b/Framework/API/test/MultipleFilePropertyTest.h
@@ -626,7 +626,7 @@ public:
 
   void test_multipleFiles_inconsistent_spaces() {
     MultipleFileProperty p("Filename");
-    p.setValue("1,2, 3,4, 5");
+    p.setValue("1,2, 3  ,  4, 5");
 
     std::vector<std::vector<std::string>> fileNames = p();
 

--- a/Framework/Kernel/src/MultiFileNameParser.cpp
+++ b/Framework/Kernel/src/MultiFileNameParser.cpp
@@ -275,6 +275,12 @@ void Parser::split() {
   // (We shun the use of Poco::File here as it is unable to deal with certain
   // combinations of special characters, for example double commas.)
 
+  // Clear whitespace before getting extentions and directories.
+  m_multiFileName.erase(
+      std::remove_if( // ("Erase-remove" idiom.)
+          m_multiFileName.begin(), m_multiFileName.end(), isspace),
+      m_multiFileName.end());
+
   // Get the extension, if there is one.
   const size_t lastDot = m_multiFileName.find_last_of('.');
   if (lastDot != std::string::npos)

--- a/Framework/Kernel/test/MultiFileNameParserTest.h
+++ b/Framework/Kernel/test/MultiFileNameParserTest.h
@@ -394,7 +394,7 @@ public:
     TS_ASSERT_EQUALS(parser.dirString(), "");
     TS_ASSERT_EQUALS(parser.instString(), "TSC");
     TS_ASSERT_EQUALS(parser.underscoreString(), "");
-    TS_ASSERT_EQUALS(parser.runString(), "10-15, 30:40:2, 50+51+52");
+    TS_ASSERT_EQUALS(parser.runString(), "10-15,30:40:2,50+51+52");
     TS_ASSERT_EQUALS(parser.extString(), ".raw");
 
     std::vector<std::vector<std::string>> filenames = parser.fileNames();
@@ -454,7 +454,7 @@ public:
     TS_ASSERT_EQUALS(parser.dirString(), "");
     TS_ASSERT_EQUALS(parser.instString(), "CNCS");
     TS_ASSERT_EQUALS(parser.underscoreString(), "");
-    TS_ASSERT_EQUALS(parser.runString(), "10-15, 30:40:2, 50+51+52");
+    TS_ASSERT_EQUALS(parser.runString(), "10-15,30:40:2,50+51+52");
     TS_ASSERT_EQUALS(parser.extString(), ".nxs");
 
     std::vector<std::vector<std::string>> filenames = parser.fileNames();

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -15,6 +15,7 @@ Concepts
 Algorithms
 ----------
 * ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
+* Whitespace is now ignored when setting the Filename parameter in python scripts.
 
 Data Objects
 ------------

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -14,8 +14,8 @@ Concepts
 
 Algorithms
 ----------
-* ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
-* Whitespace is now ignored when setting the Filename parameter in python scripts.
+* :ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
+* Whitespace is now ignored anywhere in the string when setting the Filename parameter in :ref:`Load`.
 
 Data Objects
 ------------

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -15,7 +15,7 @@ Concepts
 Algorithms
 ----------
 * :ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
-* Whitespace is now ignored anywhere in the string when setting the Filename parameter in :ref:`Load`.
+* Whitespace is now ignored anywhere in the string when setting the Filename parameter in :ref:`Load <algm-Load>`.
 
 Data Objects
 ------------


### PR DESCRIPTION
**Description of work.**
When a MultiFile string is split into its components, whitespace is now removed to stop the checks for file types and instruments from throwing errors. 
**To test:**
1. Copy this code in both plot and workbench:
```
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

import matplotlib.pyplot as plt

import numpy as np


config['default.facility'] = 'ISIS' # or any other facility
config['default.instrument'] = 'IN6' # or any other instrument
config.appendDataSearchDir(r'REPLACE_WITH_LOCATION_OF_DATA_FILES')

wsLoadSuccessful_1 = Load(Filename='164198,    164199   ,      164200')
wsLoadSuccessful_2 = Load(Filename='164198:164199, 164200')
wsLoadSuccessful_3 = Load(Filename='164198-164199,164200-164201')
wsLoadSuccessful_4 = Load(Filename='164198, 164199, 164201') 
wsLoadSuccessful_5 = Load(Filename='164198-164199, 164200-164201') 
```
2. This code uses the IN6 data from the Training Course Data, replace the search directory value with an appropriate one.
3. Run the script.
4. Script should load all expected files in 5 groups.


Fixes #22564

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
