### PR TITLE
Overlay plots in tf asymmetry mode

### DIFF
--- a/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
@@ -73,6 +73,9 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   double getNormValue(API::CompositeFunction_sptr &func);
   void addNormalizedFits(size_t numberOfFits, const std::vector<double>);
+  void normalizeWorkspace(const API::MatrixWorkspace_sptr &normalizedWorkspace,
+                          const API::MatrixWorkspace_const_sptr &unnormalizedWorkspace,
+                          size_t workspaceIndex, double N0);
 };
 
 } // namespace Algorithms

--- a/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
@@ -73,9 +73,10 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   double getNormValue(API::CompositeFunction_sptr &func);
   void addNormalizedFits(size_t numberOfFits, const std::vector<double>);
-  void normalizeWorkspace(const API::MatrixWorkspace_sptr &normalizedWorkspace,
-                          const API::MatrixWorkspace_const_sptr &unnormalizedWorkspace,
-                          size_t workspaceIndex, double N0);
+  void normalizeWorkspace(
+      const API::MatrixWorkspace_sptr &normalizedWorkspace,
+      const API::MatrixWorkspace_const_sptr &unnormalizedWorkspace,
+      size_t workspaceIndex, double N0);
 };
 
 } // namespace Algorithms

--- a/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
+++ b/Framework/Muon/inc/MantidMuon/CalculateMuonAsymmetry.h
@@ -72,6 +72,7 @@ private:
   std::vector<double> getNormConstants(std::vector<std::string> wsNames);
   std::map<std::string, std::string> validateInputs() override;
   double getNormValue(API::CompositeFunction_sptr &func);
+  void addNormalizedFits(size_t numberOfFits, const std::vector<double>);
 };
 
 } // namespace Algorithms

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -205,18 +205,23 @@ void CalculateMuonAsymmetry::exec() {
             wsNames[j]);
     API::Workspace_sptr fitWorkspace = getProperty("OutputWorkspace");
     API::MatrixWorkspace_sptr fitWorkspaceActual;
-    if (fitWorkspace->isGroup()){
-        fitWorkspaceActual = boost::dynamic_pointer_cast<API::MatrixWorkspace>(boost::static_pointer_cast<API::WorkspaceGroup>(fitWorkspace)->getItem(0));
+    if (fitWorkspace->isGroup()) {
+      fitWorkspaceActual = boost::dynamic_pointer_cast<API::MatrixWorkspace>(
+          boost::static_pointer_cast<API::WorkspaceGroup>(fitWorkspace)
+              ->getItem(0));
     } else {
-        fitWorkspaceActual = boost::dynamic_pointer_cast<API::MatrixWorkspace>(fitWorkspace);
+      fitWorkspaceActual =
+          boost::dynamic_pointer_cast<API::MatrixWorkspace>(fitWorkspace);
     }
-    API::IAlgorithm_sptr extractSpectra = createChildAlgorithm("ExtractSingleSpectrum");
+    API::IAlgorithm_sptr extractSpectra =
+        createChildAlgorithm("ExtractSingleSpectrum");
     API::IAlgorithm_sptr appendSpectra = createChildAlgorithm("AppendSpectra");
 
     extractSpectra->setProperty("InputWorkspace", fitWorkspaceActual);
     extractSpectra->setProperty("WorkspaceIndex", 2);
     extractSpectra->execute();
-    API::MatrixWorkspace_sptr unnormalisedFit = extractSpectra->getProperty("OutputWorkspace");
+    API::MatrixWorkspace_sptr unnormalisedFit =
+        extractSpectra->getProperty("OutputWorkspace");
 
     normWS->mutableY(0) = ws->y(0) / norms[j];
     normWS->mutableY(0) -= 1.0;
@@ -229,16 +234,19 @@ void CalculateMuonAsymmetry::exec() {
     appendSpectra->setProperty("InputWorkspace1", fitWorkspaceActual);
     appendSpectra->setProperty("InputWorkspace2", unnormalisedFit);
     appendSpectra->execute();
-    API::MatrixWorkspace_sptr appendedFitWorkspace = appendSpectra->getProperty("OutputWorkspace");
+    API::MatrixWorkspace_sptr appendedFitWorkspace =
+        appendSpectra->getProperty("OutputWorkspace");
 
-    if (fitWorkspace->isGroup()){
+    if (fitWorkspace->isGroup()) {
       std::string workspaceName = fitWorkspaceActual->getName();
-      auto fitWorkspaceGroupPointer = boost::static_pointer_cast<API::WorkspaceGroup>(fitWorkspace);
+      auto fitWorkspaceGroupPointer =
+          boost::static_pointer_cast<API::WorkspaceGroup>(fitWorkspace);
       fitWorkspaceGroupPointer->removeItem(0);
-      API::AnalysisDataService::Instance().addOrReplace(workspaceName, appendedFitWorkspace);
+      API::AnalysisDataService::Instance().addOrReplace(workspaceName,
+                                                        appendedFitWorkspace);
       fitWorkspaceGroupPointer->addWorkspace(appendedFitWorkspace);
     } else {
-        setProperty("OutputWorkspace", appendedFitWorkspace);
+      setProperty("OutputWorkspace", appendedFitWorkspace);
     }
 
     MuonAlgorithmHelper::addSampleLog(normWS, "analysis_asymmetry_norm",

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -222,7 +222,7 @@ void CalculateMuonAsymmetry::exec() {
 }
 
 /**
- * Adds a normalised fit asthe last spectra in the fitted workspace.
+ * Adds a normalised fit as the last spectra in the fitted workspace.
  * @param numberOfFits ::  The number of simultaneous fits performed
  * @param norms :: a vector of normalisation values
  * @return normalization constants

--- a/Framework/Muon/src/CalculateMuonAsymmetry.cpp
+++ b/Framework/Muon/src/CalculateMuonAsymmetry.cpp
@@ -205,7 +205,8 @@ void CalculateMuonAsymmetry::exec() {
             wsNames[j]);
 
     normalizeWorkspace(normWS, ws, 0, norms[j]);
-    API::AnalysisDataService::Instance().addOrReplace(normWS->getName(), normWS);
+    API::AnalysisDataService::Instance().addOrReplace(normWS->getName(),
+                                                      normWS);
 
     MuonAlgorithmHelper::addSampleLog(normWS, "analysis_asymmetry_norm",
                                       std::to_string(norms[j]));
@@ -226,7 +227,8 @@ void CalculateMuonAsymmetry::exec() {
  * @param norms :: a vector of normalisation values
  * @return normalization constants
  */
-void CalculateMuonAsymmetry::addNormalizedFits(size_t numberOfFits, const std::vector<double> norms){
+void CalculateMuonAsymmetry::addNormalizedFits(
+    size_t numberOfFits, const std::vector<double> norms) {
   for (size_t j = 0; j < numberOfFits; j++) {
     API::Workspace_sptr fitWorkspace = getProperty("OutputWorkspace");
     API::MatrixWorkspace_sptr fitWorkspaceActual;
@@ -268,7 +270,6 @@ void CalculateMuonAsymmetry::addNormalizedFits(size_t numberOfFits, const std::v
       setProperty("OutputWorkspace", appendedFitWorkspace);
     }
   }
-
 }
 
 /**
@@ -412,20 +413,24 @@ double CalculateMuonAsymmetry::getNormValue(API::CompositeFunction_sptr &func) {
   return flat->getParameter("A0");
 }
 /**
- * Normalize a single spectrum workpace based on a specified index from another workspace and a N0 value. The unormalized
- * from here is N0(1+f) where f is the desired normalized function.
+ * Normalize a single spectrum workpace based on a specified index from another
+ * workspace and a N0 value. The unormalized from here is N0(1+f) where f is the
+ * desired normalized function.
  * @param normalizedWorkspace :: workspace to store normalised data
  * @param unormalizedWorkspace :: workspace to normalise from
  * @param workspaceIndex :: index of raw data in unormalizedWorkspace
  * @param N0 :: normalization value
  * @return normalization constant
  */
-void CalculateMuonAsymmetry::normalizeWorkspace(const API::MatrixWorkspace_sptr &normalizedWorkspace,
-                                                const API::MatrixWorkspace_const_sptr &unnormalizedWorkspace,
-                                                size_t workspaceIndex, double N0){
-                        normalizedWorkspace->mutableY(0) = unnormalizedWorkspace->y(workspaceIndex) / N0;
-                        normalizedWorkspace->mutableY(0) -= 1.0;
-                        normalizedWorkspace->mutableE(0) = unnormalizedWorkspace->e(workspaceIndex) / N0;
-                        }
+void CalculateMuonAsymmetry::normalizeWorkspace(
+    const API::MatrixWorkspace_sptr &normalizedWorkspace,
+    const API::MatrixWorkspace_const_sptr &unnormalizedWorkspace,
+    size_t workspaceIndex, double N0) {
+  normalizedWorkspace->mutableY(0) =
+      unnormalizedWorkspace->y(workspaceIndex) / N0;
+  normalizedWorkspace->mutableY(0) -= 1.0;
+  normalizedWorkspace->mutableE(0) =
+      unnormalizedWorkspace->e(workspaceIndex) / N0;
+}
 } // namespace Algorithms
 } // namespace Mantid

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -32,6 +32,7 @@ Improvements
 ############
 
 - Improve the handling of :ref:`LoadPSIMuonBin<algm-LoadPSIMuonBin-v1>` where a poor date is provided.
+- In TF asymmetry mode now rescales the fit to match the rescaled data.
 
 Interfaces
 ----------

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_model.py
@@ -120,22 +120,26 @@ class HomePlotWidgetModel(object):
             self.autoscale_y_to_data_in_view()
             self.plot_figure.canvas.draw()
 
-    def add_workspace_to_plot(self, workspace, specNum, label):
+    def add_workspace_to_plot(self, workspace_name, workspace_index, label):
         """
         Adds a plot line to the specified subplot
         :param workspace: Name of workspace to get plot data from
-        :param specNum: Spectrum number to plot from workspace
+        :param workspace_index: workspace index to plot from workspace
         :return:
         """
         try:
-            workspaces = AnalysisDataService.Instance().retrieveWorkspaces([workspace], unrollGroups=True)
+            workspaces = AnalysisDataService.Instance().retrieveWorkspaces([workspace_name], unrollGroups=True)
         except RuntimeError:
             return
 
-        self.plot_figure = plot(workspaces, spectrum_nums=[specNum], fig=self.plot_figure, overplot=True,
+        if all([workspace.getNumberHistograms() == 4 for workspace in workspaces]) and workspace_index == 1:
+            workspace_index = 3
+
+        self.plot_figure = plot(workspaces, wksp_indices=[workspace_index], fig=self.plot_figure, overplot=True,
                                 plot_kwargs={'distribution': True, 'zorder': 4, 'autoscale_on_update': False, 'label': label})
 
-        self.plotted_fit_workspaces.append(workspace)
+        if workspace_name not in self._plotted_fit_workspaces:
+            self._plotted_fit_workspaces.append(workspace_name)
 
     def remove_workpace_from_plot(self, workspace_name):
         """

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
@@ -169,8 +169,8 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
             list_of_output_workspaces_to_plot = []
 
         for workspace_name in list_of_output_workspaces_to_plot:
-            self._model.add_workspace_to_plot(workspace_name, 2, workspace_name + ': Fit')
-            self._model.add_workspace_to_plot(workspace_name, 3, workspace_name + ': Diff')
+            self._model.add_workspace_to_plot(workspace_name, 1, workspace_name + ': Fit')
+            self._model.add_workspace_to_plot(workspace_name, 2, workspace_name + ': Diff')
 
         self._model.force_redraw()
 

--- a/scripts/test/Muon/home_plot_widget_test.py
+++ b/scripts/test/Muon/home_plot_widget_test.py
@@ -119,9 +119,9 @@ class HomeTabPlotPresenterTest(unittest.TestCase):
         self.presenter.handle_fit_completed()
 
         self.assertEqual(self.model.add_workspace_to_plot.call_count, 2)
-        self.model.add_workspace_to_plot.assert_any_call('MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', 2,
+        self.model.add_workspace_to_plot.assert_any_call('MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', 1,
                                                          'MUSR62260; Group; bottom; Asymmetry; MA; Fitted;: Fit')
-        self.model.add_workspace_to_plot.assert_called_with('MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', 3,
+        self.model.add_workspace_to_plot.assert_called_with('MUSR62260; Group; bottom; Asymmetry; MA; Fitted;', 2,
                                                             'MUSR62260; Group; bottom; Asymmetry; MA; Fitted;: Diff')
 
 


### PR DESCRIPTION
**Description of work.**

In Muon Analysis TF asymmetry mode the normalised data was being plotted on the same graph as the un-normalised fit. This leads to the fit and the data appearing to be offset. This PR adds a normalised fit spectra to the output of CalculateMuonAsymmetry and updates the plotting in the GUI to plot this normalised fit if it is available.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

  * In Muon Analysis 2 load MUSR62260, go to the fitting tab perform the following fits and check that they produce sensible plots.
  * Single fit in non tf mode
  * Single fit in tf mode
  * A simultaneous fit of all the groups in non tf mode
  * A simultaneous fit of all the groups in tf mode

<!-- Instructions for testing. -->

Fixes #26583 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
