### PR TITLE
Mock matplotlib backend selection in workspace display tests

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_io.py
@@ -10,8 +10,9 @@ from __future__ import absolute_import
 
 import unittest
 
-from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import CreateSampleWorkspace
+from mantid.py3compat import mock
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.workspacedisplay.matrix.io import MatrixWorkspaceDisplayDecoder, MatrixWorkspaceDisplayEncoder
 from mantidqt.widgets.workspacedisplay.matrix import StatusBarView, MatrixWorkspaceDisplay
 
@@ -30,17 +31,19 @@ class MatrixWorkspaceDisplayEncoderTest(unittest.TestCase):
         self.assertEqual(MATRIXWORKSPACEDISPLAY_DICT, self.encoder.encode(self.view))
 
 
+# matplotlib is not used so patch it out to avoid tkinter errors on older matplotlib versions
+@mock.patch('matplotlib.pyplot._backend_selection')
 @start_qapplication
 class MatrixWorkspaceDisplayDecoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = CreateSampleWorkspace(OutputWorkspace="ws")
         self.decoder = MatrixWorkspaceDisplayDecoder()
 
-    def test_decoder_returns_view(self):
+    def test_decoder_returns_view(self, _):
         decoded_object = self.decoder.decode(MATRIXWORKSPACEDISPLAY_DICT)
         self.assertEqual(decoded_object.__class__, StatusBarView)
         self.assertEqual(decoded_object.presenter.__class__, MatrixWorkspaceDisplay)
 
-    def test_decoder_returns_workspace(self):
+    def test_decoder_returns_workspace(self, _):
         view = self.decoder.decode(MATRIXWORKSPACEDISPLAY_DICT)
         self.assertEqual(self.ws.name(), view.presenter.model._ws.name())

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
@@ -10,8 +10,9 @@ from __future__ import (absolute_import, print_function)
 
 import unittest
 
-from mantidqt.utils.qt.testing import start_qapplication
 from mantid.simpleapi import Load
+from mantid.py3compat import mock
+from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.workspacedisplay.table.io import TableWorkspaceDisplayDecoder, TableWorkspaceDisplayEncoder
 from mantidqt.widgets.workspacedisplay.table import StatusBarView
 
@@ -32,16 +33,18 @@ class TableWorkspaceDisplayEncoderTest(unittest.TestCase):
         self.assertEqual(TABLEWORKSPACEDISPLAY_DICT, self.encoder.encode(self.view))
 
 
+# matplotlib is not used so patch it out to avoid tkinter errors on older matplotlib versions
+@mock.patch('matplotlib.pyplot._backend_selection')
 @start_qapplication
 class TableWorkspaceDisplayDecoderTest(unittest.TestCase):
     def setUp(self):
         self.ws = Load("SavedTableWorkspace.nxs", OutputWorkspace="ws")
         self.decoder = TableWorkspaceDisplayDecoder()
 
-    def test_decoder_returns_view(self):
+    def test_decoder_returns_view(self, _):
         self.assertEqual(self.decoder.decode(TABLEWORKSPACEDISPLAY_DICT).__class__, StatusBarView)
 
-    def test_decoder_returns_custom_features(self):
+    def test_decoder_returns_custom_features(self, _):
         view = self.decoder.decode(TABLEWORKSPACEDISPLAY_DICT)
         self.assertEqual(self.ws.name(), view.presenter.model.ws.name())
         self.assertEqual(TABLEWORKSPACEDISPLAY_DICT["markedColumns"]["as_y"], view.presenter.model.marked_columns.as_y)


### PR DESCRIPTION
**Description of work.**

Remove matplotlib TKagg requirement from tests. Some [builds](https://builds.mantidproject.org/job/pull_requests-ubuntu-python3/19625/testReport/junit/projectroot.qt/python/mantidqt_qt5_test_tableworkspacedisplay_io_test_tableworkspacedisplay_io/) fall over when the machine doesn't have the `python-tk` installed

**To test:**

Check the tests pass on Python 3 builds.

*This does not require release notes* because **it is an internal testing issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
