### PR TITLE
Make python tests work in framework only build

### DIFF
--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -45,7 +45,10 @@ from mantid.kernel.funcinspect import customise_func as _customise_func, lhs_inf
 from mantid.kernel.packagesetup import update_sys_paths as _update_sys_paths
 
 # register matplotlib projection
-from mantid import plots  # noqa
+try:
+    from mantid import plots  # noqa
+except ImportError:
+    pass  # matplotlib is unavailable
 from mantid.kernel._aliases import *
 from mantid.api._aliases import *
 from mantid.fitfunctions import *

--- a/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
+++ b/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
@@ -7,7 +7,10 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from mantid.api import IFunction1D, FunctionFactory
-from matplotlib.mlab import bivariate_normal
+try:
+    from matplotlib.mlab import bivariate_normal
+except ImportError:
+    bivariate_normal = None  # mark that it doesn't exist
 
 
 class BivariateGaussian(IFunction1D):
@@ -225,4 +228,5 @@ class BivariateGaussian(IFunction1D):
                 jacobian.set(i,k,dF/dc[k])
 
 
-FunctionFactory.subscribe(BivariateGaussian)
+if bivariate_normal:
+    FunctionFactory.subscribe(BivariateGaussian)

--- a/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
+++ b/Framework/PythonInterface/plugins/functions/BivariateGaussian.py
@@ -7,10 +7,26 @@
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
 from mantid.api import IFunction1D, FunctionFactory
-try:
-    from matplotlib.mlab import bivariate_normal
-except ImportError:
-    bivariate_normal = None  # mark that it doesn't exist
+
+
+def bivariate_normal(X, Y, sigmax=1.0, sigmay=1.0,
+                     mux=0.0, muy=0.0, sigmaxy=0.0):
+    """
+    Bivariate Gaussian distribution for equal shape *X*, *Y*.
+
+    See `bivariate normal
+    <http://mathworld.wolfram.com/BivariateNormalDistribution.html>`_
+    at mathworld.
+
+    This was copied from https://matplotlib.org/2.2.4/_modules/matplotlib/mlab.html#bivariate_normal
+    """
+    Xmu = X-mux
+    Ymu = Y-muy
+
+    rho = sigmaxy/(sigmax*sigmay)
+    z = Xmu**2/sigmax**2 + Ymu**2/sigmay**2 - 2*rho*Xmu*Ymu/(sigmax*sigmay)
+    denom = 2*np.pi*sigmax*sigmay*np.sqrt(1-rho**2)
+    return np.exp(-z/(2*(1-rho**2))) / denom
 
 
 class BivariateGaussian(IFunction1D):
@@ -228,5 +244,4 @@ class BivariateGaussian(IFunction1D):
                 jacobian.set(i,k,dF/dc[k])
 
 
-if bivariate_normal:
-    FunctionFactory.subscribe(BivariateGaussian)
+FunctionFactory.subscribe(BivariateGaussian)

--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -20,8 +20,8 @@ import unittest
 
 # If any tests happen to hit a PyQt4 import make sure item uses version 2 of the api
 # Remove this when everything is switched to qtpy
-import sip
 try:
+    import sip
     sip.setapi('QString', 2)
     sip.setapi('QVariant', 2)
     sip.setapi('QDate', 2)
@@ -31,6 +31,9 @@ try:
     sip.setapi('QUrl', 2)
 except AttributeError:
     # PyQt < v4.6
+    pass
+except ImportError:
+    # sip is not available in Framework only builds
     pass
 
 


### PR DESCRIPTION
There were various bits importing SIP and matplotlib that were making framework only builds more difficult to use. This adds conditional imports to disable functionality in those cases.

**To test:**

A proper test is to build framework on an environment without matplotlib or sip available. Baring that, looking at the code should be sufficient.

*There is no associated issue.*

*This does not require release notes* because most users will not understand the change even if they were to notice it.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
