### PR TITLE
Fix LoadNexusMonitors2 bug

### DIFF
--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -188,6 +188,8 @@ void LoadNexusMonitors2::exec() {
       throw std::invalid_argument(
           m_filename + " does not contain an entry named " + m_top_entry_name);
     }
+    file.openGroup(m_top_entry_name, "NXentry"); // Open as will need to be
+    // open for subsequent operations
   }
   prog1.report();
 

--- a/Framework/DataHandling/test/LoadNexusMonitorsTest.h
+++ b/Framework/DataHandling/test/LoadNexusMonitorsTest.h
@@ -77,6 +77,20 @@ public:
                      WS->run().getProperty("Filename")->value());
   }
 
+  void test_with_custom_top_level_entry_name() {
+    LoadNexusMonitors2 alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.setProperty("Filename", "LARMOR00003368.nxs");
+    alg.setProperty(
+        "NXentryName",
+        "raw_data_1"); // Actual entry name, provided as custom entry
+    alg.setPropertyValue("OutputWorkspace", "dummy");
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+  }
+
   void testExecEvent() {
     Mantid::API::FrameworkManager::Instance();
     LoadNexusMonitors ld;

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -24,7 +24,7 @@ Python
 
 Bug Fixes
 ------
-* ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` bug fix for user provided top-level NXEntry name 
+* ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` bug fix for user provided top-level NXentry name 
 
 :ref:`Release 4.2.0 <v4.2.0>`
 

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -22,4 +22,9 @@ Data Objects
 Python
 ------
 
+Bug Fixes
+------
+* ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` bug fix for user provided top-level NXEntry name 
+
 :ref:`Release 4.2.0 <v4.2.0>`
+

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -23,7 +23,7 @@ Python
 ------
 
 Bug Fixes
-------
+---------
 * ref:`LoadNexusMonitors <algm-LoadNexusMonitors>` bug fix for user provided top-level NXentry name 
 
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
Fixes #26577 Reported by V20 user

**Tester**

Specifying the top level nx entry name should result in a successful load provided it matches what is in file. That is being exercised as part of regression test. So only really code review necessary.