### PR TITLE
Fix Monitor Number Bug

### DIFF
--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -546,7 +546,6 @@ size_t LoadNexusMonitors2::getMonitorInfo(::NeXus::File &file,
           throw std::runtime_error("Monitor number too larger to represent");
         }
         info.detNum = static_cast<detid_t>(detNum);
-        file.closeData();
       } else {
         // default creates it from monitor name
         Poco::Path monPath(entry_name);

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -540,9 +540,8 @@ size_t LoadNexusMonitors2::getMonitorInfo(::NeXus::File &file,
       string_map_t inner_entries = file.getEntries(); // get list of entries
       if (inner_entries.find("monitor_number") != inner_entries.end()) {
         // get monitor number from field in file
-        file.openData("monitor_number");
-        int64_t detNum;
-        file.getData(&detNum);
+        const auto detNum = NeXus::NeXusIOHelper::readNexusValue<int64_t>(
+            file, "monitor_number");
         if (detNum > std::numeric_limits<detid_t>::max()) {
           throw std::runtime_error("Monitor number too larger to represent");
         }

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -541,7 +541,12 @@ size_t LoadNexusMonitors2::getMonitorInfo(::NeXus::File &file,
       if (inner_entries.find("monitor_number") != inner_entries.end()) {
         // get monitor number from field in file
         file.openData("monitor_number");
-        file.getData(&info.detNum);
+        int64_t detNum;
+        file.getData(&detNum);
+        if (detNum > std::numeric_limits<detid_t>::max()) {
+          throw std::runtime_error("Monitor number too larger to represent");
+        }
+        info.detNum = static_cast<detid_t>(detNum);
         file.closeData();
       } else {
         // default creates it from monitor name

--- a/Framework/Nexus/test/NexusIOHelperTest.h
+++ b/Framework/Nexus/test/NexusIOHelperTest.h
@@ -157,6 +157,20 @@ public:
     file.closeGroup();
     file.closeGroup();
   }
+
+  void test_nexus_io_helper_readNexusValue() {
+    const std::string filename =
+        Mantid::API::FileFinder::Instance().getFullPath("V20_ESS_example.nxs");
+    ::NeXus::File file(filename);
+    file.openGroup("entry", "NXentry");
+    file.openGroup("instrument", "NXinstrument");
+    file.openGroup("monitor_1", "NXmonitor");
+    auto monitor_number = Nioh::readNexusValue<int64_t>(file, "detector_id");
+    TS_ASSERT_EQUALS(monitor_number, 22500);
+    TS_ASSERT_THROWS(Nioh::readNexusValue<int32_t>(file, "detector_id"),
+                     std::runtime_error &); // Downcasting forbidden
+    file.close();
+  }
 };
 
 #endif /*NEXUSIOHELPERTEST_H_*/

--- a/Framework/Nexus/test/NexusIOHelperTest.h
+++ b/Framework/Nexus/test/NexusIOHelperTest.h
@@ -168,7 +168,8 @@ public:
     TS_ASSERT_EQUALS(monitor_number, 1);
     TS_ASSERT_THROWS(Nioh::readNexusValue<int16_t>(file, "monitor_number"),
                      std::runtime_error &); // Downcasting forbidden
-    TS_ASSERT_THROWS_NOTHING(Nioh::readNexusValue<int64_t>(file, "monitor_number")); // Larger OK
+    TS_ASSERT_THROWS_NOTHING(
+        Nioh::readNexusValue<int64_t>(file, "monitor_number")); // Larger OK
     file.close();
   }
 };

--- a/Framework/Nexus/test/NexusIOHelperTest.h
+++ b/Framework/Nexus/test/NexusIOHelperTest.h
@@ -160,15 +160,15 @@ public:
 
   void test_nexus_io_helper_readNexusValue() {
     const std::string filename =
-        Mantid::API::FileFinder::Instance().getFullPath("V20_ESS_example.nxs");
+        Mantid::API::FileFinder::Instance().getFullPath("LARMOR00003368.nxs");
     ::NeXus::File file(filename);
-    file.openGroup("entry", "NXentry");
-    file.openGroup("instrument", "NXinstrument");
+    file.openGroup("raw_data_1", "NXentry");
     file.openGroup("monitor_1", "NXmonitor");
-    auto monitor_number = Nioh::readNexusValue<int64_t>(file, "detector_id");
-    TS_ASSERT_EQUALS(monitor_number, 22500);
-    TS_ASSERT_THROWS(Nioh::readNexusValue<int32_t>(file, "detector_id"),
+    auto monitor_number = Nioh::readNexusValue<int32_t>(file, "monitor_number");
+    TS_ASSERT_EQUALS(monitor_number, 1);
+    TS_ASSERT_THROWS(Nioh::readNexusValue<int16_t>(file, "monitor_number"),
                      std::runtime_error &); // Downcasting forbidden
+    TS_ASSERT_THROWS_NOTHING(Nioh::readNexusValue<int64_t>(file, "monitor_number")); // Larger OK
     file.close();
   }
 };


### PR DESCRIPTION
Usually stored as *NX_INT* which does not specify size, so 64bit reasonable valid value for the format.

Fixes #26578. 