### PR TITLE
Plotting of specific lines in elemental analysis

### DIFF
--- a/scripts/MultiPlotting/edit_windows/remove_plot_window.py
+++ b/scripts/MultiPlotting/edit_windows/remove_plot_window.py
@@ -26,19 +26,17 @@ class RemovePlotWindow(QtWidgets.QDialog):
         self.table.setColumnWidth(1, 50)
         self.table.verticalHeader().setVisible(False)
         self.table.horizontalHeader().setStretchLastSection(True)
-        self.table.setHorizontalHeaderLabels(
-            ("Line name;Remove").split(";"))
+        self.table.setHorizontalHeaderLabels("Line name;Remove".split(";"))
         table_utils.setTableHeaders(self.table)
 
         self.widgets = {}
         for index, line in enumerate(all_lines):
             table_utils.setRowName(self.table, index, line)
-            tmp = {
-                "line": line,
-                "box": table_utils.addCheckBoxToTable(
-                    self.table,
-                    False,
-                    index)}
+            tmp = {"line": line,
+                   "box": table_utils.addCheckBoxToTable(
+                       self.table,
+                       False,
+                       index)}
             self.widgets[line] = tmp
 
         self.grid.addWidget(self.table)

--- a/scripts/MultiPlotting/edit_windows/remove_plot_window.py
+++ b/scripts/MultiPlotting/edit_windows/remove_plot_window.py
@@ -32,11 +32,7 @@ class RemovePlotWindow(QtWidgets.QDialog):
         self.widgets = {}
         for index, line in enumerate(all_lines):
             table_utils.setRowName(self.table, index, line)
-            tmp = {"line": line,
-                   "box": table_utils.addCheckBoxToTable(
-                       self.table,
-                       False,
-                       index)}
+            tmp = {"line": line, "box": table_utils.addCheckBoxToTable(self.table, False, index)}
             self.widgets[line] = tmp
 
         self.grid.addWidget(self.table)

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -9,16 +9,13 @@ from __future__ import absolute_import, print_function
 from MultiPlotting.gridspec_engine import gridspecEngine
 from MultiPlotting.subplot.subplot_context import subplotContext
 
-
 import mantid.simpleapi as mantid
-
 
 xBounds = "xBounds"
 yBounds = "yBounds"
 
 
 class PlottingContext(object):
-
     def __init__(self, gridspec_engine=gridspecEngine()):
         self.context = {}
         self.subplots = {}
@@ -111,4 +108,7 @@ class PlottingContext(object):
         return self.subplots[subplot].size == 0
 
     def get_lines(self, subplot_name):
-        return self.subplots[subplot_name].lines
+        try:
+            return self.subplots[subplot_name].lines
+        except KeyError:
+            return []

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -51,25 +51,24 @@ class PlottingContext(object):
     def remove_line(self, subplot_name, name):
         try:
             self.subplots[subplot_name].removeLine(name)
-            self.subplots[subplot_name].redraw_annotations()
         except KeyError:
             return
 
-    def removePlotLine(self, subplotName, name):
+    def removePlotLine(self, subplot_name, name):
         try:
-            self.subplots[subplotName].removePlotLine(name)
+            self.subplots[subplot_name].removePlotLine(name)
         except KeyError:
             return
 
-    def removeLabel(self, subplotName, name):
+    def removeLabel(self, subplot_name, name):
         try:
-            self.subplots[subplotName].removeLabel(name)
+            self.subplots[subplot_name].removeLabel(name)
         except KeyError:
             return
 
-    def removeVLine(self, subplotName, name):
+    def removeVLine(self, subplot_name, name):
         try:
-            self.subplots[subplotName].removeVLine(name)
+            self.subplots[subplot_name].removeVLine(name)
         except KeyError:
             return
 

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -27,7 +27,7 @@ class PlottingContext(object):
     def addSubplot(self, name, subplot):
         self.subplots[name] = subplotContext(name, subplot)
 
-    def addLine(self, subplot_name, workspace, spec_num, color):
+    def addLine(self, subplot_name, workspace, spec_num, color=None):
         try:
             ws = None
             if isinstance(workspace, str):

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -27,7 +27,7 @@ class PlottingContext(object):
     def addSubplot(self, name, subplot):
         self.subplots[name] = subplotContext(name, subplot)
 
-    def addLine(self, subplotName, workspace, specNum):
+    def addLine(self, subplot_name, workspace, spec_num, color):
         try:
             ws = None
             if isinstance(workspace, str):
@@ -38,7 +38,7 @@ class PlottingContext(object):
                 ws = workspace
 
             if ws is not None:
-                self.subplots[subplotName].addLine(ws, specNum)
+                self.subplots[subplot_name].addLine(ws, spec_num, color=color)
         except:
             return
 

--- a/scripts/MultiPlotting/multi_plotting_context.py
+++ b/scripts/MultiPlotting/multi_plotting_context.py
@@ -45,11 +45,18 @@ class PlottingContext(object):
         except:
             return
 
-    def add_annotate(self, subplotName, label):
-        self.subplots[subplotName].add_annotate(label)
+    def add_annotate(self, subplot_name, label):
+        self.subplots[subplot_name].add_annotate(label)
 
-    def add_vline(self, subplotName, xvalue, name, color):
-        self.subplots[subplotName].add_vline(xvalue, name, color=color)
+    def add_vline(self, subplot_name, xvalue, name, color):
+        self.subplots[subplot_name].add_vline(xvalue, name, color=color)
+
+    def remove_line(self, subplot_name, name):
+        try:
+            self.subplots[subplot_name].removeLine(name)
+            self.subplots[subplot_name].redraw_annotations()
+        except KeyError:
+            return
 
     def removePlotLine(self, subplotName, name):
         try:
@@ -91,8 +98,7 @@ class PlottingContext(object):
     def update_layout(self, figure):
         keys = list(self.subplots.keys())
         for counter, name in zip(range(len(keys)), keys):
-            self.subplots[name].update_gridspec(
-                self._gridspec, figure, counter)
+            self.subplots[name].update_gridspec(self._gridspec, figure, counter)
 
     def delete(self, name):
         self.subplots[name].delete()
@@ -103,3 +109,6 @@ class PlottingContext(object):
 
     def is_subplot_empty(self, subplot):
         return self.subplots[subplot].size == 0
+
+    def get_lines(self, subplot_name):
+        return self.subplots[subplot_name].lines

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -64,7 +64,7 @@ class MultiPlotWidget(QtWidgets.QWidget):
 
         self.quickEdit.add_subplot(name)
 
-    def plot(self, subplot_name, ws, color, spec_num=1):
+    def plot(self, subplot_name, ws, color=None, spec_num=1):
         self.plots.plot(subplot_name, ws, color=color, spec_num=spec_num)
 
     def remove_subplot(self, name):

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -64,8 +64,8 @@ class MultiPlotWidget(QtWidgets.QWidget):
 
         self.quickEdit.add_subplot(name)
 
-    def plot(self, subplotName, ws, specNum=1):
-        self.plots.plot(subplotName, ws, specNum=specNum)
+    def plot(self, subplot_name, ws, color, spec_num=1):
+        self.plots.plot(subplot_name, ws, color=color, spec_num=spec_num)
 
     def remove_subplot(self, name):
         self.plots._remove_subplot(name)

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -94,6 +94,10 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def rm_vline(self, subplotName, name):
         self.plots.rm_vline(subplotName, name)
 
+    def remove_line(self, subplot_name, ws_name, spec=1):
+        name = '{}: spec {}'.format(ws_name, spec)
+        self.plots.remove_lines(subplot_name, [name])
+
     # gets initial values for quickEdit
     def set_all_values(self):
         names = self.quickEdit.get_selection()
@@ -122,8 +126,11 @@ class MultiPlotWidget(QtWidgets.QWidget):
     def connectCloseSignal(self, slot):
         self.closeSignal.connect(slot)
 
-    def removeSubplotConnection(self, slot):
+    def remove_subplot_connection(self, slot):
         self.plots.connect_rm_subplot_signal(slot)
+
+    def remove_line_connection(self, slot):
+        self.plots.connect_rm_line_signal(slot)
 
     def disconnectCloseSignal(self):
         self.closeSignal.disconnect()

--- a/scripts/MultiPlotting/multi_plotting_widget.py
+++ b/scripts/MultiPlotting/multi_plotting_widget.py
@@ -59,7 +59,6 @@ class MultiPlotWidget(QtWidgets.QWidget):
         self.setLayout(layout)
 
     """ plotting """
-
     def add_subplot(self, name):
         self.plots.add_subplot(name, len(self.quickEdit.get_subplots()))
 
@@ -139,7 +138,6 @@ class MultiPlotWidget(QtWidgets.QWidget):
         self.plots.disconnect_rm_subplot_signal()
 
     """ update GUI """
-
     def _if_empty_close(self):
         if not self._context.subplots:
             self.closeSignal.emit()

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -87,7 +87,7 @@ class subplot(QtWidgets.QWidget):
         self.canvas.draw()
 
     # plot a workspace, if a new subplot create it.
-    def plot(self, subplot_name, workspace, color, spec_num=1):
+    def plot(self, subplot_name, workspace, color=None, spec_num=1):
         new = False
         if subplot_name not in self._context.subplots.keys():
             self.add_subplot(subplot_name, len(list(self.plot_objects.keys())))
@@ -102,7 +102,7 @@ class subplot(QtWidgets.QWidget):
             self.canvas.draw()
 
     # adds plotted line to context and updates GUI
-    def _add_plotted_line(self, subplot_name, workspace, spec_num, color):
+    def _add_plotted_line(self, subplot_name, workspace, spec_num, color=None):
         """ Appends plotted lines to the related subplot list. """
         self._context.addLine(subplot_name, workspace, spec_num, color=color)
         self.canvas.draw()

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -223,13 +223,13 @@ class subplot(QtWidgets.QWidget):
         for name in line_names:
             self._context.subplots[subplot_name].removeLine(name)
 
+        self.rmLineSignal.emit([str(name) for name in line_names])
+
         # if all of the lines have been removed -> delete subplot
         if not self._context.get_lines(subplot_name):
             self._remove_subplot(subplot_name)
         else:
             self.canvas.draw()
-
-        self.rmLineSignal.emit([str(name) for name in line_names])
 
     def _apply_rm(self, line_names):
         to_close = []
@@ -238,13 +238,7 @@ class subplot(QtWidgets.QWidget):
                 to_close.append(name)
 
         self.remove_lines(self._rm_window.subplot, to_close)
-
-        # if no subplots then close plotting window
-        if len(self._context.subplots.keys()) == 0:
-            self._close_rm_window()
-            # close plot window once auto grid done
-        else:
-            self._close_rm_window()
+        self._close_rm_window()
 
     def _close_rm_window(self):
         self._rm_window.close

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -25,9 +25,9 @@ from MultiPlotting.subplot.subplot_ADS_observer import SubplotADSObserver
 
 
 class subplot(QtWidgets.QWidget):
-    quickEditSignal = QtCore.Signal(object)
-    rmSubplotSignal = QtCore.Signal(object)
-    rmLineSignal = QtCore.Signal(object)
+    sig_quick_edit = QtCore.Signal(object)
+    sig_rm_subplot = QtCore.Signal(object)
+    sig_rm_line = QtCore.Signal(object)
 
     def __init__(self, context):
         super(subplot, self).__init__()
@@ -50,7 +50,7 @@ class subplot(QtWidgets.QWidget):
         self.toolbar.setRmConnection(self._rm)
         self.toolbar.setRmSubplotConnection(self._rm_subplot)
         # add plot
-        self.plotObjects = {}
+        self.plot_objects = {}
         grid.addWidget(self.canvas, 1, 0)
         self.setLayout(grid)
 
@@ -59,7 +59,7 @@ class subplot(QtWidgets.QWidget):
     signal to update the axis ranges """
     def draw_event_callback(self, event):
         self.figure.tight_layout()
-        for subplot in self.plotObjects.keys():
+        for subplot in self.plot_objects.keys():
             self.emit_subplot_range(subplot)
 
     def add_annotate(self, subplotName, label):
@@ -68,96 +68,96 @@ class subplot(QtWidgets.QWidget):
         self._context.add_annotate(subplotName, label)
         self.canvas.draw()
 
-    def add_vline(self, subplotName, xvalue, name, color):
-        if subplotName not in self._context.subplots.keys():
+    def add_vline(self, subplot_name, xvalue, name, color):
+        if subplot_name not in self._context.subplots.keys():
             return
-        self._context.add_vline(subplotName, xvalue, name, color)
+        self._context.add_vline(subplot_name, xvalue, name, color)
         self.canvas.draw()
 
-    def rm_annotate(self, subplotName, name):
-        if subplotName not in self._context.subplots.keys():
+    def rm_annotate(self, subplot_name, name):
+        if subplot_name not in self._context.subplots.keys():
             return
-        self._context.removeLabel(subplotName, name)
+        self._context.removeLabel(subplot_name, name)
         self.canvas.draw()
 
-    def rm_vline(self, subplotName, name):
-        if subplotName not in self._context.subplots.keys():
+    def rm_vline(self, subplot_name, name):
+        if subplot_name not in self._context.subplots.keys():
             return
-        self._context.removeVLine(subplotName, name)
+        self._context.removeVLine(subplot_name, name)
         self.canvas.draw()
 
     # plot a workspace, if a new subplot create it.
-    def plot(self, subplotName, workspace, specNum=1):
+    def plot(self, subplot_name, workspace, color, spec_num=1):
         new = False
-        if subplotName not in self._context.subplots.keys():
-            self.add_subplot(subplotName, len(list(self.plotObjects.keys())))
+        if subplot_name not in self._context.subplots.keys():
+            self.add_subplot(subplot_name, len(list(self.plot_objects.keys())))
             new = True
-        self._add_plotted_line(subplotName, workspace, specNum=specNum)
+        self._add_plotted_line(subplot_name, workspace, spec_num=spec_num, color=color)
         if new:
-            self.emit_subplot_range(subplotName)
+            self.emit_subplot_range(subplot_name)
 
-    def change_errors(self, state, subplotNames):
-        for subplotName in subplotNames:
+    def change_errors(self, state, subplot_names):
+        for subplotName in subplot_names:
             self._context.subplots[subplotName].change_errors(state)
             self.canvas.draw()
 
     # adds plotted line to context and updates GUI
-    def _add_plotted_line(self, subplotName, workspace, specNum):
+    def _add_plotted_line(self, subplot_name, workspace, spec_num, color):
         """ Appends plotted lines to the related subplot list. """
-        self._context.addLine(subplotName, workspace, specNum)
+        self._context.addLine(subplot_name, workspace, spec_num, color=color)
         self.canvas.draw()
 
-    def add_subplot(self, subplotName, number):
+    def add_subplot(self, subplot_name, number):
         self._context.update_gridspec(number + 1)
         gridspec = self._context.gridspec
-        self.plotObjects[subplotName] = self.figure.add_subplot(gridspec[number],
-                                                                label=subplotName,
-                                                                projection='mantid')
-        self.plotObjects[subplotName].set_title(subplotName)
-        self._context.addSubplot(subplotName, self.plotObjects[subplotName])
+        self.plot_objects[subplot_name] = self.figure.add_subplot(gridspec[number],
+                                                                  label=subplot_name,
+                                                                  projection='mantid')
+        self.plot_objects[subplot_name].set_title(subplot_name)
+        self._context.addSubplot(subplot_name, self.plot_objects[subplot_name])
         self._update()
 
     def _update(self):
         self._context.update_layout(self.figure)
         self.canvas.draw()
 
-    def emit_subplot_range(self, subplotName):
-        self.quickEditSignal.emit(subplotName)
-        self._context.subplots[subplotName].redraw_annotations()
+    def emit_subplot_range(self, subplot_name):
+        self.sig_quick_edit.emit(subplot_name)
+        self._context.subplots[subplot_name].redraw_annotations()
 
-    def set_plot_x_range(self, subplotNames, range):
-        for subplotName in subplotNames:
+    def set_plot_x_range(self, subplot_names, range):
+        for subplotName in subplot_names:
             # make a set method in context and set it there
-            self.plotObjects[subplotName].set_xlim(range)
+            self.plot_objects[subplotName].set_xlim(range)
             self._context.subplots[subplotName].redraw_annotations()
             self.canvas.draw()
 
-    def set_plot_y_range(self, subplotNames, y_range):
-        for subplotName in subplotNames:
-            self.plotObjects[subplotName].set_ylim(y_range)
+    def set_plot_y_range(self, subplot_names, y_range):
+        for subplotName in subplot_names:
+            self.plot_objects[subplotName].set_ylim(y_range)
             self._context.subplots[subplotName].redraw_annotations()
             self.canvas.draw()
 
     def connect_quick_edit_signal(self, slot):
-        self.quickEditSignal.connect(slot)
+        self.sig_quick_edit.connect(slot)
 
     def disconnect_quick_edit_signal(self):
-        self.quickEditSignal.disconnect()
+        self.sig_quick_edit.disconnect()
 
     def connect_rm_subplot_signal(self, slot):
-        self.rmSubplotSignal.connect(slot)
+        self.sig_rm_subplot.connect(slot)
 
     def disconnect_rm_subplot_signal(self):
-        self.rmSubplotSignal.disconnect()
+        self.sig_rm_subplot.disconnect()
 
     def connect_rm_line_signal(self, slot):
-        self.rmLineSignal.connect(slot)
+        self.sig_rm_line.connect(slot)
 
     def disconnect_rm_line_signal(self):
-        self.rmLineSignal.disconnect()
+        self.sig_rm_line.disconnect()
 
-    def set_y_autoscale(self, subplotNames, state):
-        for subplotName in subplotNames:
+    def set_y_autoscale(self, subplot_names, state):
+        for subplotName in subplot_names:
             self._context.subplots[subplotName].change_auto(state)
             self.canvas.draw()
 
@@ -174,7 +174,7 @@ class subplot(QtWidgets.QWidget):
                 self._rm_window = None
             self._close_selector_window()
 
-            self._selector_window = self._createSelectWindow(names)
+            self._selector_window = self._create_select_window(names)
             self._selector_window.subplotSelectorSignal.connect(self._get_rm_window)
             self._selector_window.closeEventSignal.connect(self._close_selector_window)
             self._selector_window.setMinimumSize(300, 100)
@@ -185,14 +185,14 @@ class subplot(QtWidgets.QWidget):
         # If the selector is hidden then close it
         self._close_selector_window()
 
-        self._selector_window = self._createSelectWindow(names)
+        self._selector_window = self._create_select_window(names)
         self._selector_window.subplotSelectorSignal.connect(self._remove_subplot)
         self._selector_window.subplotSelectorSignal.connect(self._close_selector_window)
         self._selector_window.closeEventSignal.connect(self._close_selector_window)
         self._selector_window.setMinimumSize(300, 100)
         self._selector_window.show()
 
-    def _createSelectWindow(self, names):
+    def _create_select_window(self, names):
         return SelectSubplot(names)
 
     def _close_selector_window(self):
@@ -200,19 +200,19 @@ class subplot(QtWidgets.QWidget):
             self._selector_window.close()
             self._selector_window = None
 
-    def _create_rm_window(self, subplotName):
-        line_names = list(self._context.subplots[subplotName].lines.keys())
-        vline_names = self._context.subplots[subplotName].vlines
+    def _create_rm_window(self, subplot_name):
+        line_names = list(self._context.subplots[subplot_name].lines.keys())
+        vline_names = self._context.subplots[subplot_name].vlines
         return RemovePlotWindow(lines=line_names,
                                 vlines=vline_names,
-                                subplot=subplotName,
+                                subplot=subplot_name,
                                 parent=self)
 
-    def _get_rm_window(self, subplotName):
+    def _get_rm_window(self, subplot_name):
         # always close selector after making a selection
         self._close_selector_window()
         # create the remove window
-        self._rm_window = self._create_rm_window(subplotName=subplotName)
+        self._rm_window = self._create_rm_window(subplot_name=subplot_name)
         self._rm_window.applyRemoveSignal.connect(self._apply_rm)
         self._rm_window.closeEventSignal.connect(self._close_rm_window)
         self._rm_window.setMinimumSize(200, 200)
@@ -223,7 +223,7 @@ class subplot(QtWidgets.QWidget):
         for name in line_names:
             self._context.subplots[subplot_name].removeLine(name)
 
-        self.rmLineSignal.emit([str(name) for name in line_names])
+        self.sig_rm_line.emit([str(name) for name in line_names])
 
         # if all of the lines have been removed -> delete subplot
         if not self._context.get_lines(subplot_name):
@@ -244,13 +244,13 @@ class subplot(QtWidgets.QWidget):
         self._rm_window.close
         self._rm_window = None
 
-    def _remove_subplot(self, subplotName):
-        self.figure.delaxes(self.plotObjects[subplotName])
-        del self.plotObjects[subplotName]
-        self._context.delete(subplotName)
-        self._context.update_gridspec(len(list(self.plotObjects.keys())))
+    def _remove_subplot(self, subplot_name):
+        self.figure.delaxes(self.plot_objects[subplot_name])
+        del self.plot_objects[subplot_name]
+        self._context.delete(subplot_name)
+        self._context.update_gridspec(len(list(self.plot_objects.keys())))
         self._update()
-        self.rmSubplotSignal.emit(subplotName)
+        self.sig_rm_subplot.emit(subplot_name)
 
     def _rm_ws_from_plots(self, workspace_name):
         keys = deepcopy(self._context.subplots.keys())

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -57,7 +57,6 @@ class subplot(QtWidgets.QWidget):
     """ this is called when the zoom
     or pan are used. We want to send a
     signal to update the axis ranges """
-
     def draw_event_callback(self, event):
         self.figure.tight_layout()
         for subplot in self.plotObjects.keys():
@@ -111,8 +110,9 @@ class subplot(QtWidgets.QWidget):
     def add_subplot(self, subplotName, number):
         self._context.update_gridspec(number + 1)
         gridspec = self._context.gridspec
-        self.plotObjects[subplotName] = self.figure.add_subplot(
-            gridspec[number], label=subplotName, projection='mantid')
+        self.plotObjects[subplotName] = self.figure.add_subplot(gridspec[number],
+                                                                label=subplotName,
+                                                                projection='mantid')
         self.plotObjects[subplotName].set_title(subplotName)
         self._context.addSubplot(subplotName, self.plotObjects[subplotName])
         self._update()
@@ -203,7 +203,10 @@ class subplot(QtWidgets.QWidget):
     def _create_rm_window(self, subplotName):
         line_names = list(self._context.subplots[subplotName].lines.keys())
         vline_names = self._context.subplots[subplotName].vlines
-        return RemovePlotWindow(lines=line_names, vlines=vline_names, subplot=subplotName, parent=self)
+        return RemovePlotWindow(lines=line_names,
+                                vlines=vline_names,
+                                subplot=subplotName,
+                                parent=self)
 
     def _get_rm_window(self, subplotName):
         # always close selector after making a selection

--- a/scripts/MultiPlotting/subplot/subplot.py
+++ b/scripts/MultiPlotting/subplot/subplot.py
@@ -25,9 +25,9 @@ from MultiPlotting.subplot.subplot_ADS_observer import SubplotADSObserver
 
 
 class subplot(QtWidgets.QWidget):
-    sig_quick_edit = QtCore.Signal(object)
-    sig_rm_subplot = QtCore.Signal(object)
-    sig_rm_line = QtCore.Signal(object)
+    signal_quick_edit = QtCore.Signal(object)
+    signal_rm_subplot = QtCore.Signal(object)
+    signal_rm_line = QtCore.Signal(object)
 
     def __init__(self, context):
         super(subplot, self).__init__()
@@ -122,7 +122,7 @@ class subplot(QtWidgets.QWidget):
         self.canvas.draw()
 
     def emit_subplot_range(self, subplot_name):
-        self.sig_quick_edit.emit(subplot_name)
+        self.signal_quick_edit.emit(subplot_name)
         self._context.subplots[subplot_name].redraw_annotations()
 
     def set_plot_x_range(self, subplot_names, range):
@@ -139,22 +139,22 @@ class subplot(QtWidgets.QWidget):
             self.canvas.draw()
 
     def connect_quick_edit_signal(self, slot):
-        self.sig_quick_edit.connect(slot)
+        self.signal_quick_edit.connect(slot)
 
     def disconnect_quick_edit_signal(self):
-        self.sig_quick_edit.disconnect()
+        self.signal_quick_edit.disconnect()
 
     def connect_rm_subplot_signal(self, slot):
-        self.sig_rm_subplot.connect(slot)
+        self.signal_rm_subplot.connect(slot)
 
     def disconnect_rm_subplot_signal(self):
-        self.sig_rm_subplot.disconnect()
+        self.signal_rm_subplot.disconnect()
 
     def connect_rm_line_signal(self, slot):
-        self.sig_rm_line.connect(slot)
+        self.signal_rm_line.connect(slot)
 
     def disconnect_rm_line_signal(self):
-        self.sig_rm_line.disconnect()
+        self.signal_rm_line.disconnect()
 
     def set_y_autoscale(self, subplot_names, state):
         for subplotName in subplot_names:
@@ -223,7 +223,7 @@ class subplot(QtWidgets.QWidget):
         for name in line_names:
             self._context.subplots[subplot_name].removeLine(name)
 
-        self.sig_rm_line.emit([str(name) for name in line_names])
+        self.signal_rm_line.emit([str(name) for name in line_names])
 
         # if all of the lines have been removed -> delete subplot
         if not self._context.get_lines(subplot_name):
@@ -250,7 +250,7 @@ class subplot(QtWidgets.QWidget):
         self._context.delete(subplot_name)
         self._context.update_gridspec(len(list(self.plot_objects.keys())))
         self._update()
-        self.sig_rm_subplot.emit(subplot_name)
+        self.signal_rm_subplot.emit(subplot_name)
 
     def _rm_ws_from_plots(self, workspace_name):
         keys = deepcopy(self._context.subplots.keys())

--- a/scripts/MultiPlotting/subplot/subplot_ADS_observer.py
+++ b/scripts/MultiPlotting/subplot/subplot_ADS_observer.py
@@ -11,7 +11,6 @@ from mantid.api import AnalysisDataServiceObserver
 
 
 class SubplotADSObserver(AnalysisDataServiceObserver):
-
     def __init__(self, subplot):
         super(SubplotADSObserver, self).__init__()
         self._subplot = subplot

--- a/scripts/MultiPlotting/subplot/subplot_context.py
+++ b/scripts/MultiPlotting/subplot/subplot_context.py
@@ -46,13 +46,14 @@ class subplotContext(object):
         for label in list(self._labelObjects.keys()):
             self.add_annotate(self._labelObjects[label])
 
-    def addLine(self, ws, spec_num=1, distribution=True, color='C0'):
+    def addLine(self, ws, spec_num=1, distribution=True, color=None):
+        if color is None:
+            plot_kwargs = {'specNum': spec_num, 'distribution': distribution, 'color': color}
+        else:
+            plot_kwargs = {'specNum': spec_num, 'distribution': distribution, 'color': color}
+
         # make plot/get label
-        line, = plots.plotfunctions.plot(self._subplot,
-                                         ws,
-                                         specNum=spec_num,
-                                         distribution=distribution,
-                                         color=color)
+        line, = plots.plotfunctions.plot(self._subplot, ws, kwargs=plot_kwargs)
         label = line.get_label()
         if self._errors:
             line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot,

--- a/scripts/MultiPlotting/subplot/subplot_context.py
+++ b/scripts/MultiPlotting/subplot/subplot_context.py
@@ -46,18 +46,20 @@ class subplotContext(object):
         for label in list(self._labelObjects.keys()):
             self.add_annotate(self._labelObjects[label])
 
-    def addLine(self, ws, specNum=1, distribution=True):
+    def addLine(self, ws, spec_num=1, distribution=True, color='C0'):
         # make plot/get label
         line, = plots.plotfunctions.plot(self._subplot,
                                          ws,
-                                         specNum=specNum,
-                                         distribution=distribution)
+                                         specNum=spec_num,
+                                         distribution=distribution,
+                                         color=color)
         label = line.get_label()
         if self._errors:
             line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot,
                                                                       ws,
-                                                                      specNum=specNum,
-                                                                      label=label)
+                                                                      specNum=spec_num,
+                                                                      label=label,
+                                                                      color=color)
             all_lines = [line]
             all_lines.extend(cap_lines)
             all_lines.extend(bar_lines)
@@ -65,7 +67,7 @@ class subplotContext(object):
         else:
             # line will be a list - will include error bars
             self._lines[label] = [line]
-        self._specNum[label] = specNum
+        self._specNum[label] = spec_num
         # store the ws as the key and have a list of labels that use that ws
         if ws not in self._ws.keys():
             self._ws[ws] = [label]

--- a/scripts/MultiPlotting/subplot/subplot_context.py
+++ b/scripts/MultiPlotting/subplot/subplot_context.py
@@ -48,19 +48,15 @@ class subplotContext(object):
 
     def addLine(self, ws, spec_num=1, distribution=True, color=None):
         if color is None:
-            plot_kwargs = {'specNum': spec_num, 'distribution': distribution, 'color': color}
+            plot_kwargs = {'specNum': spec_num, 'distribution': distribution}
         else:
             plot_kwargs = {'specNum': spec_num, 'distribution': distribution, 'color': color}
 
         # make plot/get label
-        line, = plots.plotfunctions.plot(self._subplot, ws, kwargs=plot_kwargs)
+        line, = plots.plotfunctions.plot(self._subplot, ws, **plot_kwargs)
         label = line.get_label()
         if self._errors:
-            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot,
-                                                                      ws,
-                                                                      specNum=spec_num,
-                                                                      label=label,
-                                                                      color=color)
+            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot, ws, **plot_kwargs)
             all_lines = [line]
             all_lines.extend(cap_lines)
             all_lines.extend(bar_lines)

--- a/scripts/Muon/GUI/ElementalAnalysis/Detectors/detectors_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/Detectors/detectors_presenter.py
@@ -8,7 +8,6 @@ from __future__ import (absolute_import, division, unicode_literals)
 
 
 class DetectorsPresenter(object):
-
     def __init__(self, view):
         self.view = view
         self.detectors = []

--- a/scripts/Muon/GUI/ElementalAnalysis/Detectors/detectors_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/Detectors/detectors_view.py
@@ -10,12 +10,10 @@ from qtpy import QtWidgets
 
 from collections import OrderedDict
 
-
 from Muon.GUI.Common.checkbox import Checkbox
 
 
 class DetectorsView(QtWidgets.QWidget):
-
     def __init__(self, parent=None):
         super(DetectorsView, self).__init__(parent)
 

--- a/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorPresenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorPresenter.py
@@ -1,0 +1,16 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, unicode_literals)
+
+
+class LineSelectorPresenter(object):
+    def __init__(self, view):
+        self.view = view
+        self.total = self.view.total
+        self.prompt = self.view.prompt
+        self.delayed = self.view.delayed
+        self.line_checkboxes = self.view.line_checkboxes

--- a/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorView.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorView.py
@@ -1,0 +1,29 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, unicode_literals)
+
+from qtpy import QtWidgets
+
+from Muon.GUI.Common.checkbox import Checkbox
+
+
+class LineSelectorView(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super(LineSelectorView, self).__init__(parent)
+
+        self.list = QtWidgets.QVBoxLayout()
+
+        self.total = Checkbox("Plot Total")
+        self.prompt = Checkbox("Plot Prompt")
+        self.delayed = Checkbox("Plot Delayed")
+
+        self.line_checkboxes = [self.total,
+                                self.prompt,
+                                self.delayed]
+        for line_type in self.line_checkboxes:
+            self.list.addWidget(line_type)
+        self.setLayout(self.list)

--- a/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorView.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LineSelector/LineSelectorView.py
@@ -21,9 +21,7 @@ class LineSelectorView(QtWidgets.QWidget):
         self.prompt = Checkbox("Plot Prompt")
         self.delayed = Checkbox("Plot Delayed")
 
-        self.line_checkboxes = [self.total,
-                                self.prompt,
-                                self.delayed]
+        self.line_checkboxes = [self.total, self.prompt, self.delayed]
         for line_type in self.line_checkboxes:
             self.list.addWidget(line_type)
         self.setLayout(self.list)

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_model.py
@@ -47,17 +47,17 @@ class CoLoadModel(lutils.LModel):
             else:
                 self.workspace = self.loaded_runs[self.run]
 
-    def add_runs(self, l, r, suffix):
+    def add_runs(self, run1, run2, suffix):
         # prevent new suffix being appended to old one
-        out = lutils.replace_workspace_name_suffix(l, suffix)
-        mantid.Plus(l, r, OutputWorkspace=out)
+        out = lutils.replace_workspace_name_suffix(run1, suffix)
+        mantid.Plus(run1, run2, OutputWorkspace=out)
         return out
 
     def co_load_run(self, workspace):
         run = lutils.hyphenise(self.co_runs)
         self.last_loaded_runs.append(run)
         to_add = [
-            self.add_runs(l, r, run)
-            for l, r in zip(*lutils.flatten_run_data(self.workspace, workspace))
+            self.add_runs(run1, run2, run)
+            for run1, run2 in zip(*lutils.flatten_run_data(self.workspace, workspace))
         ]
         self.workspace = lutils.group_by_detector(run, to_add)

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_model.py
@@ -56,6 +56,8 @@ class CoLoadModel(lutils.LModel):
     def co_load_run(self, workspace):
         run = lutils.hyphenise(self.co_runs)
         self.last_loaded_runs.append(run)
-        to_add = [self.add_runs(l, r, run) for l, r in zip(*lutils.flatten_run_data(
-            self.workspace, workspace))]
+        to_add = [
+            self.add_runs(l, r, run)
+            for l, r in zip(*lutils.flatten_run_data(self.workspace, workspace))
+        ]
         self.workspace = lutils.group_by_detector(run, to_add)

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -33,8 +33,10 @@ class LModel(object):
         to_load = search_user_dirs(self.run)
         if not to_load:
             return None
-        workspaces = {filename: get_filename(
-            filename, self.run) for filename in to_load if get_filename(filename, self.run) is not None}
+        workspaces = {
+            filename: get_filename(filename, self.run)
+            for filename in to_load if get_filename(filename, self.run) is not None
+        }
         self._load(workspaces)
         self.loaded_runs[self.run] = group_by_detector(self.run, workspaces.values())
         self.last_loaded_runs.append(self.run)

--- a/scripts/Muon/GUI/ElementalAnalysis/Peaks/peaks_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/Peaks/peaks_view.py
@@ -22,11 +22,7 @@ class PeaksView(QtWidgets.QWidget):
         self.gamma = Checkbox("Gamma Peaks")
         self.electron = Checkbox("Electron Peaks")
 
-        self.peak_checkboxes = [
-            self.major,
-            self.minor,
-            self.gamma,
-            self.electron]
+        self.peak_checkboxes = [self.major, self.minor, self.gamma, self.electron]
         for peak_type in self.peak_checkboxes:
             self.list.addWidget(peak_type)
         self.setLayout(self.list)

--- a/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/PeriodicTable/PeakSelector/peak_selector_view.py
@@ -15,10 +15,10 @@ from Muon.GUI.Common.checkbox import Checkbox
 # Check that the new data format contains at least A, Z, primary (they can be empty)
 def valid_data(peak_data):
     data_label = peak_data.keys()
-    if any(['Z' not in data_label,
-            'A' not in data_label,
-            'Primary' not in data_label,
-            'Secondary' not in data_label]):
+    if any([
+            'Z' not in data_label, 'A' not in data_label, 'Primary' not in data_label,
+            'Secondary' not in data_label
+    ]):
         return False
 
     return True
@@ -44,7 +44,9 @@ class PeakSelectorView(QtWidgets.QListWidget):
         primary = peak_data["Primary"]
         self.primary_checkboxes = self._create_checkbox_list("Primary", primary)
         secondary = peak_data["Secondary"]
-        self.secondary_checkboxes = self._create_checkbox_list("Secondary", secondary, checked=False)
+        self.secondary_checkboxes = self._create_checkbox_list("Secondary",
+                                                               secondary,
+                                                               checked=False)
         try:
             gammas = peak_data["Gammas"]
             self.gamma_checkboxes = self._create_checkbox_list("Gammas", gammas, checked=False)
@@ -57,7 +59,9 @@ class PeakSelectorView(QtWidgets.QListWidget):
             for xpos, int in electrons.items():
                 name = '$e^-\quad$  {}'.format(xpos)
                 electron_data[name] = float(xpos)
-            self.electron_checkboxes = self._create_checkbox_list("Electrons", electron_data, checked=False)
+            self.electron_checkboxes = self._create_checkbox_list("Electrons",
+                                                                  electron_data,
+                                                                  checked=False)
         except KeyError:
             self.electron_checkboxes = []
 

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -170,7 +170,8 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             self.plot_window.closeEvent(event)
         super(ElementalAnalysisGui, self).closeEvent(event)
 
-    # general functions
+# general functions
+
     def _gen_label(self, name, x_value_in, element=None):
         if element is None:
             return
@@ -461,18 +462,13 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
                 if _type in ws.getName():
                     self.plotting.plot(subplot, ws.getName())
 
-    def is_any_line_checked(self):
-        if self.lines.total.isChecked():
-            return True
-        if self.lines.prompt.isChecked():
-            return True
-        if self.lines.delayed.isChecked():
-            return True
-        return False
-
     def remove_line_type(self, run, _type):
         # If no line type is selected do not allow plotting
-        if not self.is_any_line_checked():
+        if not any([
+                self.lines.total.isChecked(),
+                self.lines.prompt.isChecked(),
+                self.lines.delayed.isChecked()
+        ]):
             for detector in self.detectors.detectors:
                 detector.setEnabled(False)
 

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -299,11 +299,11 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for ws in mantid.mtd[name]:
             ws.setYUnit('Counts')
             if self.lines.total.isChecked() and 'Total' in ws.getName():
-                self.plotting.plot(detector, ws.getName())
+                self.plotting.plot(detector, ws.getName(), color='C0')
             if self.lines.prompt.isChecked() and 'Prompt' in ws.getName():
-                self.plotting.plot(detector, ws.getName())
+                self.plotting.plot(detector, ws.getName(), color='C1')
             if self.lines.delayed.isChecked() and 'Delayed' in ws.getName():
-                self.plotting.plot(detector, ws.getName())
+                self.plotting.plot(detector, ws.getName(), color='C2')
         # add current selection of lines
         for element in self.ptable.selection:
             self.add_peak_data(element.symbol, detector)
@@ -457,15 +457,19 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             return
 
         # Plot the correct line type on all open subplots
+        color = 'C3'
+        if _type == 'Total':
+            color = 'C0'
+        elif _type == 'Prompt':
+            color = 'C1'
+        elif _type == 'Delayed':
+            color = 'C2'
         for subplot in self.plotting.get_subplots():
             for ws in mantid.mtd['{}; Detector {}'.format(run, subplot[-1])]:
                 if _type in ws.getName():
-                    self.plotting.plot(subplot, ws.getName())
+                    self.plotting.plot(subplot, ws.getName(), color=color)
 
     def remove_line_type(self, run, _type):
-        # If no line type is selected do not allow plotting
-        self.uncheck_detectors_if_no_line_plotted()
-
         if self.plot_window is None:
             return
 
@@ -474,6 +478,9 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             for ws in mantid.mtd['{}; Detector {}'.format(run, subplot[-1])]:
                 if _type in ws.getName():
                     self.plotting.remove_line(subplot, ws.getName())
+
+        # If no line type is selected do not allow plotting
+        self.uncheck_detectors_if_no_line_plotted()
 
     def uncheck_detectors_if_no_line_plotted(self):
         if not any([

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -321,7 +321,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             data = self.element_widgets[element].get_checked()
         color = self.get_color(element)
         for name, x_value in iteritems(data):
-            if isinstance(float, x_value):
+            if isinstance(x_value, float):
                 full_name = gen_name(element, name)
                 label = self._gen_label(full_name, x_value, element)
                 self._plot_line_once(subplot, x_value, label, color)
@@ -464,13 +464,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
     def remove_line_type(self, run, _type):
         # If no line type is selected do not allow plotting
-        if not any([
-                self.lines.total.isChecked(),
-                self.lines.prompt.isChecked(),
-                self.lines.delayed.isChecked()
-        ]):
-            for detector in self.detectors.detectors:
-                detector.setEnabled(False)
+        self.uncheck_detectors_if_no_line_plotted()
 
         if self.plot_window is None:
             return
@@ -481,15 +475,31 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
                 if _type in ws.getName():
                     self.plotting.remove_line(subplot, ws.getName())
 
+    def uncheck_detectors_if_no_line_plotted(self):
+        if not any([
+                self.lines.total.isChecked(),
+                self.lines.prompt.isChecked(),
+                self.lines.delayed.isChecked()
+        ]):
+            for detector in self.detectors.detectors:
+                detector.setEnabled(False)
+
     # When removing a line with the remove window uncheck the line here
     def uncheck_on_removed(self, removed_lines):
         for line in removed_lines:
             if 'Total' in line:
+                self.lines.total.blockSignals(True)
                 self.lines.total.setChecked(False)
+                self.lines.total.blockSignals(False)
             if 'Prompt' in line:
+                self.lines.prompt.blockSignals(True)
                 self.lines.prompt.setChecked(False)
+                self.lines.prompt.blockSignals(False)
             if 'Delayed' in line:
+                self.lines.delayed.blockSignals(True)
                 self.lines.delayed.setChecked(False)
+                self.lines.delayed.blockSignals(False)
+        self.uncheck_detectors_if_no_line_plotted()
 
     # Line total
     def line_total_checked(self):

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -394,25 +394,10 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self._update_checked_data()
 
     def _update_checked_data(self):
-        if self.peaks.major.isChecked():
-            self.major_peaks_checked()
-        else:
-            self.major_peaks_unchecked()
-
-        if self.peaks.minor.isChecked():
-            self.minor_peaks_checked()
-        else:
-            self.minor_peaks_unchecked()
-
-        if self.peaks.gamma.isChecked():
-            self.gammas_checked()
-        else:
-            self.gammas_unchecked()
-
-        if self.peaks.electron.isChecked():
-            self.electrons_checked()
-        else:
-            self.electrons_unchecked()
+        self.major_peaks_changed(self.peaks.major)
+        self.minor_peaks_changed(self.peaks.minor)
+        self.gammas_changed(self.peaks.gamma)
+        self.electrons_changed(self.peaks.electron)
 
     # general checked data
     def checked_data(self, element, selection, state):

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -31,6 +31,9 @@ from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_presenter import PeakSelectorPresenter
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_view import PeakSelectorView
 
+from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorPresenter import LineSelectorPresenter
+from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorView import LineSelectorView
+
 from Muon.GUI.Common import message_box
 
 import mantid.simpleapi as mantid
@@ -101,9 +104,20 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.peaks.electron.on_checkbox_checked(self.electrons_checked)
         self.peaks.electron.on_checkbox_unchecked(self.electrons_unchecked)
 
+        # Line type boxes
+        self.lines = LineSelectorPresenter(LineSelectorView())
+        self.lines.total.setChecked(True)
+        self.lines.total.on_checkbox_checked(self.line_total_checked)
+        self.lines.total.on_checkbox_unchecked(self.line_total_unchecked)
+        self.lines.prompt.on_checkbox_checked(self.line_prompt_checked)
+        self.lines.prompt.on_checkbox_unchecked(self.line_prompt_unchecked)
+        self.lines.delayed.on_checkbox_checked(self.line_delayed_checked)
+        self.lines.delayed.on_checkbox_unchecked(self.line_delayed_unchecked)
+
         # set up
         self.widget_list = QtWidgets.QVBoxLayout()
         self.widget_list.addWidget(self.peaks.view)
+        self.widget_list.addWidget(self.lines.view)
         self.widget_list.addWidget(self.detectors.view)
         self.widget_list.addWidget(self.load_widget.view)
 
@@ -282,7 +296,12 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.plotting.add_subplot(detector)
         for ws in mantid.mtd[name]:
             ws.setYUnit('Counts')
-            self.plotting.plot(detector, ws.getName())
+            if self.lines.total.isChecked() and 'Total' in ws.getName():
+                self.plotting.plot(detector, ws.getName())
+            if self.lines.prompt.isChecked() and 'Prompt' in ws.getName():
+                self.plotting.plot(detector, ws.getName())
+            if self.lines.delayed.isChecked() and 'Delayed' in ws.getName():
+                self.plotting.plot(detector, ws.getName())
         # add current selection of lines
         for element in self.ptable.selection:
             self.add_peak_data(element.symbol, detector)
@@ -428,3 +447,24 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     def minor_peaks_unchecked(self):
         for element, selector in iteritems(self.element_widgets):
             self.checked_data(element, selector.secondary_checkboxes, False)
+
+    # Line total
+    def line_total_checked(self):
+        pass
+
+    def line_total_unchecked(self):
+        pass
+
+    # Line prompt
+    def line_prompt_checked(self):
+        pass
+
+    def line_prompt_unchecked(self):
+        pass
+
+    # Line delayed
+    def line_delayed_checked(self):
+        pass
+
+    def line_delayed_unchecked(self):
+        pass

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -67,6 +67,10 @@ def gen_name(element, name):
 
 
 class ElementalAnalysisGui(QtWidgets.QMainWindow):
+    BLUE = 'C0'
+    ORANGE = 'C1'
+    GREEN = 'C2'
+
     def __init__(self, parent=None):
         super(ElementalAnalysisGui, self).__init__(parent)
         # set menu
@@ -107,12 +111,12 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # Line type boxes
         self.lines = LineSelectorPresenter(LineSelectorView())
         self.lines.total.setChecked(True)
-        self.lines.total.on_checkbox_checked(self.line_total_checked)
-        self.lines.total.on_checkbox_unchecked(self.line_total_unchecked)
-        self.lines.prompt.on_checkbox_checked(self.line_prompt_checked)
-        self.lines.prompt.on_checkbox_unchecked(self.line_prompt_unchecked)
-        self.lines.delayed.on_checkbox_checked(self.line_delayed_checked)
-        self.lines.delayed.on_checkbox_unchecked(self.line_delayed_unchecked)
+        self.lines.total.on_checkbox_checked(self.line_total_changed)
+        self.lines.total.on_checkbox_unchecked(self.line_total_changed)
+        self.lines.prompt.on_checkbox_checked(self.line_prompt_changed)
+        self.lines.prompt.on_checkbox_unchecked(self.line_prompt_changed)
+        self.lines.delayed.on_checkbox_checked(self.line_delayed_changed)
+        self.lines.delayed.on_checkbox_unchecked(self.line_delayed_changed)
 
         # set up
         self.widget_list = QtWidgets.QVBoxLayout()
@@ -299,11 +303,11 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for ws in mantid.mtd[name]:
             ws.setYUnit('Counts')
             if self.lines.total.isChecked() and 'Total' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color='C0')
+                self.plotting.plot(detector, ws.getName(), color=self.BLUE)
             if self.lines.prompt.isChecked() and 'Prompt' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color='C1')
+                self.plotting.plot(detector, ws.getName(), color=self.ORANGE)
             if self.lines.delayed.isChecked() and 'Delayed' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color='C2')
+                self.plotting.plot(detector, ws.getName(), color=self.GREEN)
         # add current selection of lines
         for element in self.ptable.selection:
             self.add_peak_data(element.symbol, detector)
@@ -457,13 +461,12 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             return
 
         # Plot the correct line type on all open subplots
-        color = 'C3'
         if _type == 'Total':
-            color = 'C0'
+            color = self.BLUE
         elif _type == 'Prompt':
-            color = 'C1'
-        elif _type == 'Delayed':
-            color = 'C2'
+            color = self.ORANGE
+        else:
+            color = self.GREEN
         for subplot in self.plotting.get_subplots():
             for ws in mantid.mtd['{}; Detector {}'.format(run, subplot[-1])]:
                 if _type in ws.getName():
@@ -509,28 +512,25 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.uncheck_detectors_if_no_line_plotted()
 
     # Line total
-    def line_total_checked(self):
-        self.lines.total.setChecked(True)
-        self.add_line_by_type(self.load_widget.last_loaded_run(), 'Total')
-
-    def line_total_unchecked(self):
-        self.lines.total.setChecked(False)
-        self.remove_line_type(self.load_widget.last_loaded_run(), 'Total')
+    def line_total_changed(self, line_total):
+        self.lines.total.setChecked(line_total.isChecked())
+        if line_total.isChecked():
+            self.add_line_by_type(self.load_widget.last_loaded_run(), 'Total')
+        else:
+            self.remove_line_type(self.load_widget.last_loaded_run(), 'Total')
 
     # Line prompt
-    def line_prompt_checked(self):
-        self.lines.prompt.setChecked(True)
-        self.add_line_by_type(self.load_widget.last_loaded_run(), 'Prompt')
-
-    def line_prompt_unchecked(self):
-        self.lines.prompt.setChecked(False)
-        self.remove_line_type(self.load_widget.last_loaded_run(), 'Prompt')
+    def line_prompt_changed(self, line_prompt):
+        self.lines.prompt.setChecked(line_prompt.isChecked())
+        if line_prompt.isChecked():
+            self.add_line_by_type(self.load_widget.last_loaded_run(), 'Prompt')
+        else:
+            self.remove_line_type(self.load_widget.last_loaded_run(), 'Prompt')
 
     # Line delayed
-    def line_delayed_checked(self):
-        self.lines.delayed.setChecked(True)
-        self.add_line_by_type(self.load_widget.last_loaded_run(), 'Delayed')
-
-    def line_delayed_unchecked(self):
-        self.lines.delayed.setChecked(False)
-        self.remove_line_type(self.load_widget.last_loaded_run(), 'Delayed')
+    def line_delayed_changed(self, line_delayed):
+        self.lines.delayed.setChecked(line_delayed.isChecked())
+        if line_delayed.isChecked():
+            self.add_line_by_type(self.load_widget.last_loaded_run(), 'Delayed')
+        else:
+            self.remove_line_type(self.load_widget.last_loaded_run(), 'Delayed')

--- a/scripts/plotting_test.py
+++ b/scripts/plotting_test.py
@@ -32,9 +32,9 @@ class plotTestGui(QtGui.QMainWindow):
         self.test.add_subplot("baa")
         self.test.add_subplot("EXTRA")
 
-        self.test.plot("test", ws, specNum=26)
-        self.test.plot("test", ws, specNum=21)
-        self.test.plot("test", ws, specNum=22)
+        self.test.plot("test", ws, spec_num=26)
+        self.test.plot("test", ws, spec_num=21)
+        self.test.plot("test", ws, spec_num=22)
         # defines position of label
         dummy = Label("dummy", 10.1, False, 0.9, True, rotation=-90)
         dummy2 = Label(
@@ -57,10 +57,10 @@ class plotTestGui(QtGui.QMainWindow):
         self.test.add_annotate("bob", dummy3)
         self.test.add_vline("bob", 1.2, "just a line")
 
-        self.test.plot("bob", ws, specNum=1)
-        self.test.plot("EXTRA", ws, specNum=42)
-        self.test.plot("moo", ws, specNum=42)
-        self.test.plot("baa", ws, specNum=2)
+        self.test.plot("bob", ws, spec_num=1)
+        self.test.plot("EXTRA", ws, spec_num=42)
+        self.test.plot("moo", ws, spec_num=42)
+        self.test.plot("baa", ws, spec_num=2)
         self.test.set_all_values()
 
         self.test.connectCloseSignal(self.close)
@@ -82,7 +82,7 @@ class plotTestGui(QtGui.QMainWindow):
     def add(self):
         self.n += 1
         self.test.add_subplot(str(self.n))
-        self.test.plot(str(self.n), self.ws, specNum=self.n)
+        self.test.plot(str(self.n), self.ws, spec_num=self.n)
 
 
 def setUpSubplot():

--- a/scripts/test/MultiPlotting/MultiPlotWidget_test.py
+++ b/scripts/test/MultiPlotting/MultiPlotWidget_test.py
@@ -33,11 +33,10 @@ class bounds(object):
 
 
 def data():
-    values = {}
-    values["one"] = bounds([5, 20], [5, 10])
-    values["two"] = bounds([6, 10], [0, 9])
-    values["three"] = bounds([-1, 11], [7, 8])
-    values["four"] = bounds([4, 12], [4, 50])
+    values = {"one": bounds([5, 20], [5, 10]),
+              "two": bounds([6, 10], [0, 9]),
+              "three": bounds([-1, 11], [7, 8]),
+              "four": bounds([4, 12], [4, 50])}
     return values
 
 
@@ -48,8 +47,7 @@ class MultiPlotWidgetTest(unittest.TestCase):
         self.widget = MultiPlotWidget(context)
 
     def test_add_subplot(self):
-        with mock.patch(
-                "MultiPlotting.QuickEdit.quickEdit_widget.QuickEditWidget.add_subplot") as qe_patch:
+        with mock.patch("MultiPlotting.QuickEdit.quickEdit_widget.QuickEditWidget.add_subplot") as qe_patch:
             self.widget.add_subplot("test")
             self.assertEqual(qe_patch.call_count, 1)
 

--- a/scripts/test/MultiPlotting/MultiPlotWidget_test.py
+++ b/scripts/test/MultiPlotting/MultiPlotWidget_test.py
@@ -56,10 +56,10 @@ class MultiPlotWidgetTest(unittest.TestCase):
     def test_plot(self):
         with mock.patch("MultiPlotting.subplot.subplot.subplot.plot") as patch:
             ws = mock.MagicMock()
-            subplotName = "test"
-            specNum = 4
-            self.widget.plot(subplotName, ws, specNum)
-            patch.assert_called_with(subplotName, ws, specNum=specNum)
+            subplot_name = "test"
+            spec_num = 4
+            self.widget.plot(subplot_name, ws, color='C0', spec_num=spec_num)
+            patch.assert_called_with(subplot_name, ws, color='C0', spec_num=spec_num)
             self.assertEqual(patch.call_count, 1)
 
     def test_set_all_values(self):

--- a/scripts/test/MultiPlotting/MultiPlotWidget_test.py
+++ b/scripts/test/MultiPlotting/MultiPlotWidget_test.py
@@ -14,18 +14,18 @@ from MultiPlotting.multi_plotting_widget import MultiPlotWidget
 
 
 class bounds(object):
-    def __init__(self,x,y):
+    def __init__(self, x, y):
         self.x = x
-        self.y =y
+        self.y = y
         self.error = False
 
     @property
     def xbounds(self):
-       return self.x
+        return self.x
 
     @property
     def ybounds(self):
-       return self.y
+        return self.y
 
     @property
     def errors(self):
@@ -34,112 +34,112 @@ class bounds(object):
 
 def data():
     values = {}
-    values["one"] = bounds([5,20],[5,10])
-    values["two"] = bounds([6,10],[0,9])
-    values["three"] = bounds([-1,11],[7,8])
-    values["four"] = bounds([4,12],[4,50])
+    values["one"] = bounds([5, 20], [5, 10])
+    values["two"] = bounds([6, 10], [0, 9])
+    values["three"] = bounds([-1, 11], [7, 8])
+    values["four"] = bounds([4, 12], [4, 50])
     return values
 
 
 @start_qapplication
 class MultiPlotWidgetTest(unittest.TestCase):
-
     def setUp(self):
         context = PlottingContext()
         self.widget = MultiPlotWidget(context)
 
     def test_add_subplot(self):
-        with mock.patch("MultiPlotting.QuickEdit.quickEdit_widget.QuickEditWidget.add_subplot") as qe_patch:
+        with mock.patch(
+                "MultiPlotting.QuickEdit.quickEdit_widget.QuickEditWidget.add_subplot") as qe_patch:
             self.widget.add_subplot("test")
-            self.assertEqual(qe_patch.call_count,1)
+            self.assertEqual(qe_patch.call_count, 1)
 
     def test_plot(self):
         with mock.patch("MultiPlotting.subplot.subplot.subplot.plot") as patch:
-             ws = mock.MagicMock()
-             subplotName = "test"
-             specNum = 4
-             self.widget.plot(subplotName, ws, specNum)
-             patch.assert_called_with(subplotName, ws, specNum=specNum)
-             self.assertEqual(patch.call_count,1)
+            ws = mock.MagicMock()
+            subplotName = "test"
+            specNum = 4
+            self.widget.plot(subplotName, ws, specNum)
+            patch.assert_called_with(subplotName, ws, specNum=specNum)
+            self.assertEqual(patch.call_count, 1)
 
-    def test_setAllValues(self):
+    def test_set_all_values(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value = list(data().keys()))
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=list(data().keys()))
         self.widget._x_range_changed = mock.MagicMock()
         self.widget._y_range_changed = mock.MagicMock()
-        self.widget._check_all_errors = mock.MagicMock(return_value = False)
+        self.widget._check_all_errors = mock.MagicMock(return_value=False)
         self.widget._change_errors = mock.MagicMock()
 
         self.widget.set_all_values()
-        self.widget._x_range_changed.assert_called_with([-1,20])
-        self.widget._y_range_changed.assert_called_with([0,50])
+        self.widget._x_range_changed.assert_called_with([-1, 20])
+        self.widget._y_range_changed.assert_called_with([0, 50])
 
-    def test_updateQuickEditNoMatch(self):
+    def test_update_quick_edit_no_match(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value = data())
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=data())
         self.widget.quickEdit.rm_subplot = mock.Mock()
         self.widget.quickEdit._if_empty_close = mock.Mock()
 
         self.widget._update_quick_edit("no match")
         self.assertEqual(self.widget.quickEdit.rm_subplot.call_count, 1)
 
-    def test_updateQuickEdit1Match(self):
+    def test_update_quick_edit1_match(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =["two"])
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=["two"])
         self.widget.quickEdit.set_plot_x_range = mock.MagicMock()
         self.widget.quickEdit.set_plot_y_range = mock.MagicMock()
 
         self.widget._update_quick_edit("two")
-        self.widget.quickEdit.set_plot_x_range.assert_called_with([6,10])
-        self.widget.quickEdit.set_plot_y_range.assert_called_with([0,9])
+        self.widget.quickEdit.set_plot_x_range.assert_called_with([6, 10])
+        self.widget.quickEdit.set_plot_y_range.assert_called_with([0, 9])
 
-    def test_updateQuickEdit1NoMatch(self):
+    def test_update_quick_edit1_no_match(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =["two"])
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=["two"])
         self.widget.quickEdit.set_plot_x_range = mock.MagicMock()
         self.widget.quickEdit.set_plot_y_range = mock.MagicMock()
 
         self.widget._update_quick_edit("three")
-        self.assertEqual(self.widget.quickEdit.set_plot_x_range.call_count,0)
-        self.assertEqual(self.widget.quickEdit.set_plot_y_range.call_count,0)
+        self.assertEqual(self.widget.quickEdit.set_plot_x_range.call_count, 0)
+        self.assertEqual(self.widget.quickEdit.set_plot_y_range.call_count, 0)
 
-    def test_updateQuickEditMany(self):
+    def test_update_quick_edit_many(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =["two","three"])
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=["two", "three"])
         self.widget.quickEdit.set_plot_x_range = mock.MagicMock()
         self.widget.quickEdit.set_plot_y_range = mock.MagicMock()
 
         self.widget._update_quick_edit("two")
-        self.widget.quickEdit.set_plot_x_range.assert_called_with([6,10])
-        self.widget.quickEdit.set_plot_y_range.assert_called_with([0,9])
+        self.widget.quickEdit.set_plot_x_range.assert_called_with([6, 10])
+        self.widget.quickEdit.set_plot_y_range.assert_called_with([0, 9])
 
-    def test_selectionChanged(self):
+    def test_selection_changed(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =["two"])
-        self.widget._check_all_errors = mock.MagicMock(return_value = False)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=["two"])
+        self.widget._check_all_errors = mock.MagicMock(return_value=False)
         self.widget._change_errors = mock.MagicMock()
         self.widget.quickEdit.set_plot_x_range = mock.MagicMock()
         self.widget.quickEdit.set_plot_y_range = mock.MagicMock()
 
         self.widget._selection_changed(1)
-        self.widget.quickEdit.set_plot_x_range.assert_called_with([6,10])
-        self.widget.quickEdit.set_plot_y_range.assert_called_with([0,9])
+        self.widget.quickEdit.set_plot_x_range.assert_called_with([6, 10])
+        self.widget.quickEdit.set_plot_y_range.assert_called_with([0, 9])
 
-    def test_selectionChangedAll(self):
+    def test_selection_changed_all(self):
         self.widget._context.subplots = data()
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =["two","three"])
-        xbounds = [-1,2]
-        ybounds = [-10,20]
-        self.widget._context.get_xBounds = mock.MagicMock(return_value = xbounds)
-        self.widget._context.get_yBounds = mock.MagicMock(return_value = ybounds)
-        self.widget._check_all_errors = mock.MagicMock(return_value = False)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=["two", "three"])
+        xbounds = [-1, 2]
+        ybounds = [-10, 20]
+        self.widget._context.get_xBounds = mock.MagicMock(return_value=xbounds)
+        self.widget._context.get_yBounds = mock.MagicMock(return_value=ybounds)
+        self.widget._check_all_errors = mock.MagicMock(return_value=False)
         self.widget._change_errors = mock.MagicMock()
         self.widget.quickEdit.set_plot_x_range = mock.MagicMock()
         self.widget.quickEdit.set_plot_y_range = mock.MagicMock()
@@ -152,67 +152,78 @@ class MultiPlotWidgetTest(unittest.TestCase):
         self.widget._x_range_changed.assert_called_with(xbounds)
         self.widget._y_range_changed.assert_called_with(ybounds)
 
-    def test_xRangeChanged(self):
-        names = ["two","three"]
-        xbounds = [9,18]
+    def test_x_range_changed(self):
+        names = ["two", "three"]
+        xbounds = [9, 18]
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =names)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=names)
         self.widget._context.set_xBounds = mock.MagicMock()
         self.widget.plots.set_plot_x_range = mock.MagicMock()
         self.widget._x_range_changed(xbounds)
         self.widget._context.set_xBounds.assert_called_with(xbounds)
-        self.widget.plots.set_plot_x_range.assert_called_with(names,xbounds)
+        self.widget.plots.set_plot_x_range.assert_called_with(names, xbounds)
 
-    def test_xRangeChanged1(self):
+    def test_x_range_changed1(self):
         names = ["two"]
-        xbounds = [9,18]
+        xbounds = [9, 18]
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =names)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=names)
         self.widget._context.set_xBounds = mock.MagicMock()
         self.widget.plots.set_plot_x_range = mock.MagicMock()
         self.widget._x_range_changed(xbounds)
         self.assertEqual(self.widget._context.set_xBounds.call_count, 0)
-        self.widget.plots.set_plot_x_range.assert_called_with(names,xbounds)
+        self.widget.plots.set_plot_x_range.assert_called_with(names, xbounds)
 
-    def test_yRangeChanged(self):
-        names = ["two","three"]
-        ybounds = [9,18]
+    def test_y_range_changed(self):
+        names = ["two", "three"]
+        ybounds = [9, 18]
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =names)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=names)
         self.widget._context.set_yBounds = mock.MagicMock()
         self.widget.plots.set_plot_y_range = mock.MagicMock()
         self.widget._y_range_changed(ybounds)
         self.widget._context.set_yBounds.assert_called_with(ybounds)
-        self.widget.plots.set_plot_y_range.assert_called_with(names,ybounds)
+        self.widget.plots.set_plot_y_range.assert_called_with(names, ybounds)
 
-    def test_yRangeChanged1(self):
+    def test_y_range_changed1(self):
         names = ["two"]
-        ybounds = [9,18]
+        ybounds = [9, 18]
         # mocks as we only want to test logic
-        self.widget.quickEdit.get_selection = mock.MagicMock(return_value =names)
+        self.widget.quickEdit.get_selection = mock.MagicMock(return_value=names)
         self.widget._context.set_yBounds = mock.MagicMock()
         self.widget.plots.set_plot_y_range = mock.MagicMock()
         self.widget._y_range_changed(ybounds)
         self.assertEqual(self.widget._context.set_yBounds.call_count, 0)
-        self.widget.plots.set_plot_y_range.assert_called_with(names,ybounds)
+        self.widget.plots.set_plot_y_range.assert_called_with(names, ybounds)
 
-    def test_checkAllErrorsFalse(self):
+    def test_check_all_errors_false(self):
         context = data()
         self.widget._context.subplots = context
-        self.assertEqual(self.widget._check_all_errors(context.keys()),False)
+        self.assertEqual(self.widget._check_all_errors(context.keys()), False)
 
-    def test_checkAllErrorsTrue(self):
+    def test_check_all_errors_true(self):
         context = data()
         for name in context.keys():
             context[name].error = True
         self.widget._context.subplots = context
-        self.assertEqual(self.widget._check_all_errors(context.keys()),True)
+        self.assertEqual(self.widget._check_all_errors(context.keys()), True)
 
-    def test_checkAllErrors1True(self):
+    def test_check_all_errors1_true(self):
         context = data()
         context["two"].error = True
         self.widget._context.subplots = context
-        self.assertEqual(self.widget._check_all_errors(context.keys()),False)
+        self.assertEqual(self.widget._check_all_errors(context.keys()), False)
+
+    def test_that_remove_line_connection_connects_to_correct_signal(self):
+        self.widget.plots = mock.Mock()
+        self.widget.remove_line_connection("slot parameter")
+        self.widget.plots.connect_rm_line_signal.assert_called_with("slot parameter")
+
+    def test_that_remove_line_calls_correct_function(self):
+        self.widget.plots = mock.Mock()
+        self.widget.remove_line("subplot", 'ws_name')
+
+        self.widget.plots.remove_lines.assert_called_with("subplot", ["ws_name: spec 1"])
 
 
 if __name__ == "__main__":

--- a/scripts/test/MultiPlotting/MultiPlottingContext_test.py
+++ b/scripts/test/MultiPlotting/MultiPlottingContext_test.py
@@ -110,9 +110,9 @@ class MultiPlottingContextTest(unittest.TestCase):
 
         self.context.remove_line("plot", "line name")
 
-        self.assertEqual(self.context.subplots["plot"].remove_line.call_count, 1)
-        self.assertEqual(self.context.subplots["plot"].redraw_annotations.call_count, 1)
-        self.context.subplots["plot"].remove_line.assert_called_with("line name")
+        self.assertEqual(1, self.context.subplots["plot"].removeLine.call_count)
+        self.assertEqual(1, self.context.subplots["plot"].redraw_annotations.call_count)
+        self.context.subplots["plot"].removeLine.assert_called_with("line name")
 
     def test_that_get_lines_returns_empty_list_if_given_bad_name(self):
         self.context.subplots = {"plot": mock.Mock()}

--- a/scripts/test/MultiPlotting/MultiPlottingContext_test.py
+++ b/scripts/test/MultiPlotting/MultiPlottingContext_test.py
@@ -11,10 +11,11 @@ from MultiPlotting.multi_plotting_context import PlottingContext
 from MultiPlotting.subplot.subplot_context import subplotContext
 from line_helper import line
 
+
 class gen_ws(object):
-    def __init__(self,mock):
-       self._input = "in"
-       self._OutputWorkspace = mock
+    def __init__(self, mock):
+        self._input = "in"
+        self._OutputWorkspace = mock
 
     def __len__(self):
         return 2
@@ -27,7 +28,7 @@ class gen_ws(object):
 class MultiPlottingContextTest(unittest.TestCase):
     def setUp(self):
         self.context = PlottingContext()
- 
+
     def test_add_line_1(self):
         specNum = 4
         ws = mock.MagicMock()
@@ -35,10 +36,10 @@ class MultiPlottingContextTest(unittest.TestCase):
         subplot = mock.MagicMock()
         self.subplot = mock.create_autospec(subplotContext)
         with mock.patch("MultiPlotting.subplot.subplot_context.subplotContext.addLine") as patch:
-            self.context.addSubplot("one",subplot) 
-            self.context.addLine("one",ws,specNum)
-            self.assertEqual(patch.call_count,1)
-            patch.assert_called_with(ws,specNum)
+            self.context.addSubplot("one", subplot)
+            self.context.addLine("one", ws, specNum)
+            self.assertEqual(patch.call_count, 1)
+            patch.assert_called_with(ws, specNum)
 
     def test_add_line_2(self):
         specNum = 4
@@ -48,53 +49,86 @@ class MultiPlottingContextTest(unittest.TestCase):
         subplot = mock.MagicMock()
         self.subplot = mock.create_autospec(subplotContext)
         with mock.patch("MultiPlotting.subplot.subplot_context.subplotContext.addLine") as patch:
-            self.context.addSubplot("one",subplot) 
-            self.context.addLine("one",ws,specNum)
-            self.assertEqual(patch.call_count,1)
-            patch.assert_called_with(mockWS,specNum)
+            self.context.addSubplot("one", subplot)
+            self.context.addLine("one", ws, specNum)
+            self.assertEqual(patch.call_count, 1)
+            patch.assert_called_with(mockWS, specNum)
 
-    def test_updateLayout(self):
+    def test_update_layout(self):
         # add mocks
         figure = mock.Mock()
         self.subplot = mock.create_autospec(subplotContext)
-        names = ["one","two","three"]
+        names = ["one", "two", "three"]
         for name in names:
             self.context.addSubplot(name, mock.Mock())
 
         gridspec = mock.Mock()
         self.context._gridspec = gridspec
-        with mock.patch("MultiPlotting.subplot.subplot_context.subplotContext.update_gridspec") as patch:
+        with mock.patch(
+                "MultiPlotting.subplot.subplot_context.subplotContext.update_gridspec") as patch:
             self.context.update_layout(figure)
-            self.assertEqual(patch.call_count,3)
+            self.assertEqual(patch.call_count, 3)
             # only last iteration survives
-            patch.assert_called_with(gridspec,figure,2)
+            patch.assert_called_with(gridspec, figure, 2)
 
-
-    def test_subplotEmptyTrue(self):
-        names = ["one","two","three"]
+    def test_subplot_empty_true(self):
+        names = ["one", "two", "three"]
         for name in names:
             self.context.addSubplot(name, mock.Mock())
 
         for name in names:
-             self.assertEqual(self.context.is_subplot_empty(name),True)
- 
-    def test_subplotEmptyFalse(self):
-        names = ["one","two","three"]
+            self.assertEqual(self.context.is_subplot_empty(name), True)
+
+    def test_subplot_empty_false(self):
+        names = ["one", "two", "three"]
 
         no_lines = 1
 
         ws = mock.MagicMock()
         with mock.patch("mantid.plots.plotfunctions.plot") as patch:
             patch.return_value = tuple([line()])
- 
+
             for name in names:
                 self.context.addSubplot(name, mock.Mock())
-                for k in range(0,no_lines):
-                    self.context.addLine(name, ws,1)
-                no_lines +=1
+                for k in range(0, no_lines):
+                    self.context.addLine(name, ws, 1)
+                no_lines += 1
 
         for name in names:
-             self.assertEqual(self.context.is_subplot_empty(name),False)
-        
+            self.assertEqual(self.context.is_subplot_empty(name), False)
+
+    def test_that_remove_line_does_nothing_if_given_bad_subplot_name(self):
+        self.context.subplots = {"plot": mock.Mock()}
+
+        self.context.remove_line("plot that does not exist", "one")
+
+        self.assertEqual(self.context.subplots["plot"].remove_line.call_count, 0)
+        self.assertEqual(self.context.subplots["plot"].redraw_annotations.call_count, 0)
+
+    def test_that_remove_line_calls_the_correct_functions(self):
+        self.context.subplots = {"plot": mock.Mock()}
+
+        self.context.remove_line("plot", "line name")
+
+        self.assertEqual(self.context.subplots["plot"].remove_line.call_count, 1)
+        self.assertEqual(self.context.subplots["plot"].redraw_annotations.call_count, 1)
+        self.context.subplots["plot"].remove_line.assert_called_with("line name")
+
+    def test_that_get_lines_returns_empty_list_if_given_bad_name(self):
+        self.context.subplots = {"plot": mock.Mock()}
+
+        lines = self.context.get_lines("not a valid plot")
+
+        self.assertEqual(lines, [])
+
+    def test_that_get_lines_returns_correct_lines(self):
+        self.context.subplots = {"plot": mock.Mock()}
+        self.context.subplots["plot"].lines = ["one", "two", "three"]
+
+        lines = self.context.get_lines("plot")
+
+        self.assertEqual(["one", "two", "three"], lines)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/MultiPlotting/MultiPlottingContext_test.py
+++ b/scripts/test/MultiPlotting/MultiPlottingContext_test.py
@@ -30,29 +30,29 @@ class MultiPlottingContextTest(unittest.TestCase):
         self.context = PlottingContext()
 
     def test_add_line_1(self):
-        specNum = 4
+        spec_num = 4
         ws = mock.MagicMock()
         # add mock subplot
         subplot = mock.MagicMock()
         self.subplot = mock.create_autospec(subplotContext)
         with mock.patch("MultiPlotting.subplot.subplot_context.subplotContext.addLine") as patch:
             self.context.addSubplot("one", subplot)
-            self.context.addLine("one", ws, specNum)
+            self.context.addLine("one", ws, spec_num, 'C0')
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(ws, specNum)
+            patch.assert_called_with(ws, spec_num, color='C0')
 
     def test_add_line_2(self):
-        specNum = 4
-        mockWS = mock.MagicMock()
-        ws = gen_ws(mockWS)
+        spec_num = 4
+        mock_ws = mock.MagicMock()
+        ws = gen_ws(mock_ws)
         # add mock subplot
         subplot = mock.MagicMock()
         self.subplot = mock.create_autospec(subplotContext)
         with mock.patch("MultiPlotting.subplot.subplot_context.subplotContext.addLine") as patch:
             self.context.addSubplot("one", subplot)
-            self.context.addLine("one", ws, specNum)
+            self.context.addLine("one", ws, spec_num, 'C0')
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(mockWS, specNum)
+            patch.assert_called_with(mock_ws, spec_num, color='C0')
 
     def test_update_layout(self):
         # add mocks
@@ -91,7 +91,7 @@ class MultiPlottingContextTest(unittest.TestCase):
             for name in names:
                 self.context.addSubplot(name, mock.Mock())
                 for k in range(0, no_lines):
-                    self.context.addLine(name, ws, 1)
+                    self.context.addLine(name, ws, 1, 'C0')
                 no_lines += 1
 
         for name in names:

--- a/scripts/test/MultiPlotting/MultiPlottingContext_test.py
+++ b/scripts/test/MultiPlotting/MultiPlottingContext_test.py
@@ -111,7 +111,7 @@ class MultiPlottingContextTest(unittest.TestCase):
         self.context.remove_line("plot", "line name")
 
         self.assertEqual(1, self.context.subplots["plot"].removeLine.call_count)
-        self.assertEqual(1, self.context.subplots["plot"].redraw_annotations.call_count)
+        self.assertEqual(0, self.context.subplots["plot"].redraw_annotations.call_count)
         self.context.subplots["plot"].removeLine.assert_called_with("line name")
 
     def test_that_get_lines_returns_empty_list_if_given_bad_name(self):

--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -50,7 +50,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([line()])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True, color='C0')
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
 
     def test_add_line_errors(self):
         ws = mock.MagicMock()
@@ -66,8 +66,7 @@ class SubPlotContextTest(unittest.TestCase):
                 patch.assert_called_with(self.subplot,
                                          ws,
                                          specNum=3,
-                                         label=lines.get_label(),
-                                         color='C0')
+                                         distribution=True)
 
     def test_redraw_errors(self):
         ws = mock.MagicMock()
@@ -99,7 +98,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([lines])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True, color='C0')
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
             # redraw
             self.context.redraw(lines.get_label())
             self.assertEqual(patch.call_count, 2)

--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -50,7 +50,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([line()])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True, color='C0')
 
     def test_add_line_errors(self):
         ws = mock.MagicMock()
@@ -63,7 +63,11 @@ class SubPlotContextTest(unittest.TestCase):
                 self.context.addLine(ws, 3)
                 self.assertEqual(plot.call_count, 1)
                 self.assertEqual(patch.call_count, 1)
-                patch.assert_called_with(self.subplot, ws, specNum=3, label=lines.get_label())
+                patch.assert_called_with(self.subplot,
+                                         ws,
+                                         specNum=3,
+                                         label=lines.get_label(),
+                                         color='C0')
 
     def test_redraw_errors(self):
         ws = mock.MagicMock()
@@ -95,7 +99,7 @@ class SubPlotContextTest(unittest.TestCase):
             patch.return_value = tuple([lines])
             self.context.addLine(ws, 3)
             self.assertEqual(patch.call_count, 1)
-            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True)
+            patch.assert_called_with(self.subplot, ws, specNum=3, distribution=True, color='C0')
             # redraw
             self.context.redraw(lines.get_label())
             self.assertEqual(patch.call_count, 2)

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -14,7 +14,6 @@ from MultiPlotting.multi_plotting_context import PlottingContext
 from MultiPlotting.subplot.subplot import subplot
 
 
-
 def rm_logic(name):
     if name == "two":
         return False
@@ -23,7 +22,6 @@ def rm_logic(name):
 
 @start_qapplication
 class SubplotTest(unittest.TestCase):
-
     def setUp(self):
         context = PlottingContext()
         self.subplot = subplot(context)
@@ -35,7 +33,7 @@ class SubplotTest(unittest.TestCase):
         self.subplot._get_rm_window = mock.Mock()
         self.subplot._createSelectWindow = mock.MagicMock()
 
-    def test_rmOnePlotNewWindow(self):
+    def test_rm_one_plot_new_window(self):
         self.subplot._rm_window = None
         self.subplot._selector_window = None
 
@@ -48,7 +46,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._get_rm_window.call_count, 1)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
 
-    def test_rmOnePlotOldWindow(self):
+    def test_rm_one_plot_old_window(self):
         self.subplot._rm_window = mock.Mock()
         self.subplot._selector_window = None
 
@@ -61,7 +59,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
 
-    def test_rmTwoPlotsNewWindow(self):
+    def test_rm_two_plots_new_window(self):
         self.subplot._rm_window = None
         self.subplot._selector_window = None
 
@@ -75,7 +73,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
 
-    def test_rmTwoPlotsOldSelectWindow(self):
+    def test_rm_two_plots_old_select_window(self):
         self.subplot._rm_window = None
         self.subplot._selector_window = mock.Mock()
 
@@ -89,7 +87,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
 
-    def test_rmTwoPlotsoldRmWindow(self):
+    def test_rm_two_plots_old_rm_window(self):
         self.subplot._rm_window = mock.Mock()
         self.subplot._selector_window = None
 
@@ -117,10 +115,7 @@ class SubplotTest(unittest.TestCase):
 
         self.subplot._apply_rm(names)
 
-        self.assertEqual(
-            self.subplot._context.subplots[
-                "test"].removeLine.call_count,
-            3)
+        self.assertEqual(self.subplot._context.subplots["test"].removeLine.call_count, 3)
         self.assertEqual(self.subplot._close_rm_window.call_count, 1)
 
     def test_apply_rmNone(self):
@@ -130,10 +125,7 @@ class SubplotTest(unittest.TestCase):
 
         self.subplot._apply_rm(names)
 
-        self.assertEqual(
-            self.subplot._context.subplots[
-                "test"].removeLine.call_count,
-            0)
+        self.assertEqual(self.subplot._context.subplots["test"].removeLine.call_count, 0)
         self.assertEqual(self.subplot._close_rm_window.call_count, 1)
 
     def test_apply_rmSome(self):
@@ -143,21 +135,18 @@ class SubplotTest(unittest.TestCase):
 
         self.subplot._apply_rm(names)
 
-        self.assertEqual(
-            self.subplot._context.subplots[
-                "test"].removeLine.call_count,
-            2)
+        self.assertEqual(self.subplot._context.subplots["test"].removeLine.call_count, 2)
         self.assertEqual(self.subplot._close_rm_window.call_count, 1)
 
     def test_addSubplot(self):
-         self.subplot._update = mock.Mock()
-         gridspec = GridSpec(2,2)
-         self.subplot._context.update_gridspec = mock.Mock()
-         self.subplot._context._gridspec = gridspec
+        self.subplot._update = mock.Mock()
+        gridspec = GridSpec(2, 2)
+        self.subplot._context.update_gridspec = mock.Mock()
+        self.subplot._context._gridspec = gridspec
 
-         self.subplot.add_subplot("test",3)
-         self.subplot._context.update_gridspec.assert_called_with(4)
-         self.assertEqual(self.subplot._update.call_count,1)
+        self.subplot.add_subplot("test", 3)
+        self.subplot._context.update_gridspec.assert_called_with(4)
+        self.assertEqual(self.subplot._update.call_count, 1)
 
     def test_replaced_ws_false(self):
         one = mock.Mock()
@@ -166,13 +155,11 @@ class SubplotTest(unittest.TestCase):
         self.subplot._context.subplots["two"] = two
         self.subplot.canvas.draw = mock.Mock()
         ws = mock.Mock()
-        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value = False)
-        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = False)
+        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value=False)
+        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value=False)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,0)
-
-
+        self.assertEqual(self.subplot.canvas.draw.call_count, 0)
 
     def test_replaced_ws(self):
         one = mock.Mock()
@@ -181,13 +168,11 @@ class SubplotTest(unittest.TestCase):
         self.subplot._context.subplots["two"] = two
         self.subplot.canvas.draw = mock.Mock()
         ws = mock.Mock()
-        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value = False)
-        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = True)
+        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value=False)
+        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value=True)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,1)
-
-
+        self.assertEqual(self.subplot.canvas.draw.call_count, 1)
 
     def test_replaced_ws_true(self):
         one = mock.Mock()
@@ -196,11 +181,23 @@ class SubplotTest(unittest.TestCase):
         self.subplot._context.subplots["two"] = two
         self.subplot.canvas.draw = mock.Mock()
         ws = mock.Mock()
-        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value = True)
-        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value = True)
+        self.subplot._context.subplots["one"].replace_ws = mock.Mock(return_value=True)
+        self.subplot._context.subplots["two"].replace_ws = mock.Mock(return_value=True)
 
         self.subplot._replaced_ws(ws)
-        self.assertEqual(self.subplot.canvas.draw.call_count,2)
+        self.assertEqual(self.subplot.canvas.draw.call_count, 2)
+
+    def test_that_connect_rm_signal_calls_the_correct_function(self):
+        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.connect_rm_line_signal("slot value")
+
+        self.subplot.rmLineSignal.connect.assert_called_with("slot value")
+
+    def test_that_disconnect_rm_signal_calls_the_correct_function(self):
+        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.disconnect_rm_line_signal()
+
+        self.assertEqual(1, self.subplot.rmLineSignal.disconnect.call_count)
 
 
 if __name__ == "__main__":

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -247,7 +247,7 @@ class SubplotTest(unittest.TestCase):
         self.subplot.remove_lines(subplot_name, ["one"])
 
         self.assertEqual(1, self.subplot.rmLineSignal.emit.call_count)
-        
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -188,16 +188,16 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot.canvas.draw.call_count, 2)
 
     def test_that_connect_rm_signal_calls_the_correct_function(self):
-        self.subplot.sig_rm_line = mock.Mock()
+        self.subplot.signal_rm_line = mock.Mock()
         self.subplot.connect_rm_line_signal("slot value")
 
-        self.subplot.sig_rm_line.connect.assert_called_with("slot value")
+        self.subplot.signal_rm_line.connect.assert_called_with("slot value")
 
     def test_that_disconnect_rm_signal_calls_the_correct_function(self):
-        self.subplot.sig_rm_line = mock.Mock()
+        self.subplot.signal_rm_line = mock.Mock()
         self.subplot.disconnect_rm_line_signal()
 
-        self.assertEqual(1, self.subplot.sig_rm_line.disconnect.call_count)
+        self.assertEqual(1, self.subplot.signal_rm_line.disconnect.call_count)
 
     @staticmethod
     def rm_window_side_effect(name):
@@ -241,12 +241,12 @@ class SubplotTest(unittest.TestCase):
         subplot_name = "subplot"
         self.subplot._context.get_lines = mock.Mock(return_value=["not empty"])
         self.subplot._context.subplots = {subplot_name: mock.Mock()}
-        self.subplot.sig_rm_line = mock.Mock()
+        self.subplot.signal_rm_line = mock.Mock()
         self.subplot.canvas = mock.Mock()
 
         self.subplot.remove_lines(subplot_name, ["one"])
 
-        self.assertEqual(1, self.subplot.sig_rm_line.emit.call_count)
+        self.assertEqual(1, self.subplot.signal_rm_line.emit.call_count)
 
 
 if __name__ == "__main__":

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -103,19 +103,19 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
         self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
 
-    def setup_applyRm(self):
+    def setup_apply_rm(self):
         self.subplot._rm_window = mock.Mock()
         self.subplot._rm_window.subplot = "test"
         self.subplot._context.subplots["test"] = mock.MagicMock()
         self.subplot._remove_subplot = mock.Mock()
         self.subplot._close_rm_window = mock.Mock()
 
-    def test_applyRmAll(self):
+    def test_apply_rmAll(self):
         names = ["one", "two", "three"]
-        self.setup_applyRm()
+        self.setup_apply_rm()
         self.subplot._rm_window.getState = mock.Mock(return_value=True)
 
-        self.subplot._applyRm(names)
+        self.subplot._apply_rm(names)
 
         self.assertEqual(
             self.subplot._context.subplots[
@@ -123,12 +123,12 @@ class SubplotTest(unittest.TestCase):
             3)
         self.assertEqual(self.subplot._close_rm_window.call_count, 1)
 
-    def test_applyRmNone(self):
+    def test_apply_rmNone(self):
         names = ["one", "two", "three"]
-        self.setup_applyRm()
+        self.setup_apply_rm()
         self.subplot._rm_window.getState = mock.Mock(return_value=False)
 
-        self.subplot._applyRm(names)
+        self.subplot._apply_rm(names)
 
         self.assertEqual(
             self.subplot._context.subplots[
@@ -136,12 +136,12 @@ class SubplotTest(unittest.TestCase):
             0)
         self.assertEqual(self.subplot._close_rm_window.call_count, 1)
 
-    def test_applyRmSome(self):
+    def test_apply_rmSome(self):
         names = ["one", "two", "three"]
-        self.setup_applyRm()
+        self.setup_apply_rm()
         self.subplot._rm_window.getState = mock.Mock(side_effect=rm_logic)
 
-        self.subplot._applyRm(names)
+        self.subplot._apply_rm(names)
 
         self.assertEqual(
             self.subplot._context.subplots[

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -199,6 +199,55 @@ class SubplotTest(unittest.TestCase):
 
         self.assertEqual(1, self.subplot.rmLineSignal.disconnect.call_count)
 
+    @staticmethod
+    def rm_window_side_effect(name):
+        return True
+
+    def test_that_remove_line_calls_removeLine_the_correct_number_of_times(self):
+        subplot_name = "subplot"
+        lines = ["one", "two", "three"]
+        calls = [mock.call("one"), mock.call("two"), mock.call("three")]
+        self.subplot._context.subplots = {subplot_name: mock.Mock()}
+
+        self.subplot.remove_lines(subplot_name, lines)
+
+        self.subplot._context.subplots[subplot_name].removeLine.assert_has_calls(calls)
+
+    def test_that_remove_lines_removes_subplot_is_no_line_is_present(self):
+        subplot_name = "subplot"
+        self.subplot._context.get_lines = mock.Mock(return_value=[])
+        self.subplot._context.subplots = {subplot_name: mock.Mock()}
+        self.subplot._remove_subplot = mock.Mock()
+        self.subplot.canvas = mock.Mock()
+
+        self.subplot.remove_lines(subplot_name, ["one"])
+
+        self.assertEqual(1, self.subplot._remove_subplot.call_count)
+        self.assertEqual(0, self.subplot.canvas.draw.call_count)
+
+    def test_that_remove_lines_updates_canvas_without_closing_plot_if_lines_are_present(self):
+        subplot_name = "subplot"
+        self.subplot._context.get_lines = mock.Mock(return_value=["not empty"])
+        self.subplot._context.subplots = {subplot_name: mock.Mock()}
+        self.subplot._remove_subplot = mock.Mock()
+        self.subplot.canvas = mock.Mock()
+
+        self.subplot.remove_lines(subplot_name, ["one"])
+
+        self.assertEqual(0, self.subplot._remove_subplot.call_count)
+        self.assertEqual(1, self.subplot.canvas.draw.call_count)
+
+    def test_that_remove_lines_emits_signal(self):
+        subplot_name = "subplot"
+        self.subplot._context.get_lines = mock.Mock(return_value=["not empty"])
+        self.subplot._context.subplots = {subplot_name: mock.Mock()}
+        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.canvas = mock.Mock()
+
+        self.subplot.remove_lines(subplot_name, ["one"])
+
+        self.assertEqual(1, self.subplot.rmLineSignal.emit.call_count)
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/MultiPlotting/Subplot_test.py
+++ b/scripts/test/MultiPlotting/Subplot_test.py
@@ -31,7 +31,7 @@ class SubplotTest(unittest.TestCase):
         self.subplot._raise_rm_window = mock.Mock()
         self.subplot._raise_selector_window = mock.Mock()
         self.subplot._get_rm_window = mock.Mock()
-        self.subplot._createSelectWindow = mock.MagicMock()
+        self.subplot._create_select_window = mock.MagicMock()
 
     def test_rm_one_plot_new_window(self):
         self.subplot._rm_window = None
@@ -44,7 +44,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 1)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
+        self.assertEqual(self.subplot._create_select_window.call_count, 0)
 
     def test_rm_one_plot_old_window(self):
         self.subplot._rm_window = mock.Mock()
@@ -57,7 +57,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 0)
+        self.assertEqual(self.subplot._create_select_window.call_count, 0)
 
     def test_rm_two_plots_new_window(self):
         self.subplot._rm_window = None
@@ -71,7 +71,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
+        self.assertEqual(self.subplot._create_select_window.call_count, 1)
 
     def test_rm_two_plots_old_select_window(self):
         self.subplot._rm_window = None
@@ -85,7 +85,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
+        self.assertEqual(self.subplot._create_select_window.call_count, 1)
 
     def test_rm_two_plots_old_rm_window(self):
         self.subplot._rm_window = mock.Mock()
@@ -99,7 +99,7 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot._raise_rm_window.call_count, 0)
         self.assertEqual(self.subplot._raise_selector_window.call_count, 0)
         self.assertEqual(self.subplot._get_rm_window.call_count, 0)
-        self.assertEqual(self.subplot._createSelectWindow.call_count, 1)
+        self.assertEqual(self.subplot._create_select_window.call_count, 1)
 
     def setup_apply_rm(self):
         self.subplot._rm_window = mock.Mock()
@@ -188,16 +188,16 @@ class SubplotTest(unittest.TestCase):
         self.assertEqual(self.subplot.canvas.draw.call_count, 2)
 
     def test_that_connect_rm_signal_calls_the_correct_function(self):
-        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.sig_rm_line = mock.Mock()
         self.subplot.connect_rm_line_signal("slot value")
 
-        self.subplot.rmLineSignal.connect.assert_called_with("slot value")
+        self.subplot.sig_rm_line.connect.assert_called_with("slot value")
 
     def test_that_disconnect_rm_signal_calls_the_correct_function(self):
-        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.sig_rm_line = mock.Mock()
         self.subplot.disconnect_rm_line_signal()
 
-        self.assertEqual(1, self.subplot.rmLineSignal.disconnect.call_count)
+        self.assertEqual(1, self.subplot.sig_rm_line.disconnect.call_count)
 
     @staticmethod
     def rm_window_side_effect(name):
@@ -241,12 +241,12 @@ class SubplotTest(unittest.TestCase):
         subplot_name = "subplot"
         self.subplot._context.get_lines = mock.Mock(return_value=["not empty"])
         self.subplot._context.subplots = {subplot_name: mock.Mock()}
-        self.subplot.rmLineSignal = mock.Mock()
+        self.subplot.sig_rm_line = mock.Mock()
         self.subplot.canvas = mock.Mock()
 
         self.subplot.remove_lines(subplot_name, ["one"])
 
-        self.assertEqual(1, self.subplot.rmLineSignal.emit.call_count)
+        self.assertEqual(1, self.subplot.sig_rm_line.emit.call_count)
 
 
 if __name__ == "__main__":

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -503,7 +503,7 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_gamms_checked_calls_checked_data_for_each_element(self):
         elem = len(self.gui.ptable.peak_data)
         self.gui.checked_data = mock.Mock()
-        self.gui.gammas_checked()
+        self.gui.gammas_changed()
         self.assertEqual(self.gui.checked_data.call_count, elem)
 
     def test_gamms_unchecked_calls_checked_data_for_each_element(self):
@@ -515,7 +515,7 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_major_checked_calls_checked_data_for_each_element(self):
         elem = len(self.gui.ptable.peak_data)
         self.gui.checked_data = mock.Mock()
-        self.gui.major_peaks_checked()
+        self.gui.major_peaks_changed()
         self.assertEqual(self.gui.checked_data.call_count, elem)
 
     def test_major_unchecked_calls_checked_data_for_each_element(self):
@@ -527,7 +527,7 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_minor_checked_calls_checked_data_for_each_element(self):
         elem = len(self.gui.ptable.peak_data)
         self.gui.checked_data = mock.Mock()
-        self.gui.minor_peaks_checked()
+        self.gui.minor_peaks_changed()
         self.assertEqual(self.gui.checked_data.call_count, elem)
 
     def test_minor_unchecked_calls_checked_data_for_each_element(self):

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -288,10 +288,17 @@ class ElementalAnalysisTest(unittest.TestCase):
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_peak_data')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
-    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(
-            self, mock_mantid, mock_add_peak_data):
-        mock_mantid.mtd = {'name1': [mock.Mock(), mock.Mock()], 'name2': [mock.Mock(), mock.Mock()]}
+    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(self, mock_mantid, mock_add_peak_data):
+        mock_mantid.mtd = {'name1': [mock.Mock(), mock.Mock(), mock.Mock()],
+                           'name2': [mock.Mock(), mock.Mock(), mock.Mock()]}
         self.gui.plotting = mock.Mock()
+        self.gui.lines = mock.Mock()
+        self.gui.lines.total.isChecked.return_value = True
+        self.gui.lines.prompt.isChecked.return_value = False
+        self.gui.lines.delayed.isChecked.return_value = True
+        mock_mantid.mtd['name1'][0].getName.return_value = 'ws with Total'
+        mock_mantid.mtd['name1'][1].getName.return_value = 'ws with Delayed'
+        mock_mantid.mtd['name1'][2].getName.return_value = 'ws with Prompt'
 
         self.gui.add_detector_to_plot('GE1', 'name1')
         self.assertEqual(self.gui.plotting.add_subplot.call_count, 1)
@@ -400,7 +407,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.plotting.remove_subplot.call_count, 1)
         self.assertEqual(self.gui.plot_window, None)
 
-    def test_subplotRemoved_changes_state_only_if_other_subplots_exist(self):
+    def test_subplot_removed_changes_state_only_if_other_subplots_exist(self):
         self.gui.detectors.setStateQuietly = mock.Mock()
         self.gui.plotting.get_subplots = mock.Mock(return_value=True)
         self.gui.plot_window = 'plot_window'
@@ -410,7 +417,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.detectors.setStateQuietly.call_count, 1)
         self.assertEqual(self.gui.plot_window, 'plot_window')
 
-    def test_subplotRemoved_closes_plot_if_no_other_subplots_exist(self):
+    def test_subplot_removed_closes_plot_if_no_other_subplots_exist(self):
         self.gui.detectors.setStateQuietly = mock.Mock()
         self.gui.plotting.get_subplots = mock.Mock(return_value=False)
         self.gui.plot_window = mock.Mock()

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -146,8 +146,7 @@ class ElementalAnalysisTest(unittest.TestCase):
                                       protected=True)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
-                )
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
     def test_that_plot_line_returns_if_plot_window_is_none(self, mock_plot_line_once,
                                                            mock_gen_label):
         self.gui.plot_window = None
@@ -157,8 +156,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(mock_plot_line_once.call_count, 0)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
-                )
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
     def test_that_plot_line_calls_plot_line_once_if_window_not_none(self, mock_plot_line_once,
                                                                     mock_gen_label):
         self.gui.plot_window = mock.create_autospec(MultiPlotWindow)
@@ -200,15 +198,13 @@ class ElementalAnalysisTest(unittest.TestCase):
         elem = len(self.gui.ptable.peak_data)
         self.assertEqual(len(self.gui.element_widgets), elem)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
     def test_table_left_clicked_adds_lines_if_element_selected(self, mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=True)
         self.gui._add_element_lines(mock.Mock())
         self.assertEqual(mock_add_element_lines.call_count, 1)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
     def test_table_left_clicked_removed_lines_if_element_not_selected(self,
                                                                       mock_remove_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=False)
@@ -324,8 +320,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.plot_window, None)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
-                )
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
     def test_add_peak_data_plot_line_called_with_correct_terms(self, mock_plot_line_once,
                                                                mock_gen_label):
         mock_subplot = mock.Mock()
@@ -334,10 +329,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.add_peak_data('H', mock_subplot, data=test_data)
         mock_plot_line_once.assert_called_with(mock_subplot, 1.0, 'label', 'C0')
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
     def test_update_peak_data_element_is_selected(self, mock_remove_element_lines,
                                                   mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=True)
@@ -345,10 +338,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         mock_remove_element_lines.assert_called_with('test_element')
         mock_add_element_lines.assert_called_with('test_element')
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
     def test_update_peak_data_element_is_not_selected(self, mock_remove_element_lines,
                                                       mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=False)
@@ -441,20 +432,17 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.detectors.setStateQuietly.call_count, 1)
         self.assertEqual(self.gui.plot_window, None)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_set_peak_datafile_is_called_with_select_data_file(self, mock_getOpenFileName,
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_set_peak_datafile_is_called_with_select_data_file(self,
+                                                                    mock_getOpenFileName,
                                                                     mock_set_peak_datafile):
         mock_getOpenFileName.return_value = 'filename'
         self.gui.select_data_file()
         mock_set_peak_datafile.assert_called_with('filename')
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
     def test_that_select_data_file_uses_the_first_element_of_a_tuple_when_given_as_a_filename(
             self, mock_getOpenFileName, mock_set_peak_datafile):
         mock_getOpenFileName.return_value = ('string1', 'string2')
@@ -462,12 +450,10 @@ class ElementalAnalysisTest(unittest.TestCase):
         mock_set_peak_datafile.assert_called_with('string1')
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.message_box.warning')
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._generate_element_widgets'
-    )
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_select_data_file_raises_warning_with_correct_text(self, mock_getOpenFileName,
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._generate_element_widgets')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_select_data_file_raises_warning_with_correct_text(self,
+                                                                    mock_getOpenFileName,
                                                                     mock_generate_element_widgets,
                                                                     mock_warning):
         mock_getOpenFileName.return_value = 'filename'
@@ -550,8 +536,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.minor_peaks_unchecked()
         self.assertEqual(self.gui.checked_data.call_count, elem)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._update_peak_data')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._update_peak_data')
     def test_checked_data_changes_all_states_in_list(self, mock_update_peak_data):
         selection = [mock.Mock() for i in range(10)]
         self.gui.checked_data('Cu', selection, True)
@@ -670,8 +655,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.delayed.blockSignals.assert_has_calls([])
         self.assertEqual(1, self.gui.uncheck_detectors_if_no_line_plotted.call_count)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
     def test_line_total_checked_checks_line_and_calls_add_line_by_type(self, mock_add_line_by_type):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
         self.gui.line_total_checked()
@@ -679,8 +663,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.total.setChecked.assert_called_with(True)
         self.assertEqual(1, mock_add_line_by_type.call_count)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
     def test_line_total_unchecked_unchecks_line_and_calls_add_line_by_type(
             self, mock_remove_line_type):
         self.gui.line_total_unchecked()
@@ -698,8 +681,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.prompt.setChecked.assert_called_with(True)
         self.assertEqual(1, mock_add_line_by_type.call_count)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
     def test_line_prompt_unchecked_unchecks_line_and_calls_add_line_by_type(
             self, mock_remove_line_type):
         self.gui.line_prompt_unchecked()
@@ -707,8 +689,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.prompt.setChecked.assert_called_with(False)
         self.assertEqual(1, mock_remove_line_type.call_count)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
     def test_line_delayed_checked_checks_line_and_calls_add_line_by_type(
             self, mock_add_line_by_type):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
@@ -717,8 +698,7 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.delayed.setChecked.assert_called_with(True)
         self.assertEqual(1, mock_add_line_by_type.call_count)
 
-    @mock.patch(
-        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
     def test_line_delayed_unchecked_unchecks_line_and_calls_add_line_by_type(
             self, mock_remove_line_type):
         self.gui.line_delayed_unchecked()

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -477,43 +477,23 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui._update_checked_data = tmp
 
     def test_update_checked_data_calls_the_right_functions(self):
-        self.gui.peaks.major.isChecked = mock.Mock(return_value=True)
-        self.gui.peaks.minor.isChecked = mock.Mock(return_value=True)
-        self.gui.peaks.gamma.isChecked = mock.Mock(return_value=False)
-        self.gui.peaks.electron.isChecked = mock.Mock(return_value=True)
-        self.gui.major_peaks_checked = mock.Mock()
-        self.gui.major_peaks_unchecked = mock.Mock()
-        self.gui.minor_peaks_checked = mock.Mock()
-        self.gui.minor_peaks_unchecked = mock.Mock()
-        self.gui.gammas_checked = mock.Mock()
-        self.gui.gammas_unchecked = mock.Mock()
-        self.gui.electrons_checked = mock.Mock()
-        self.gui.electrons_unchecked = mock.Mock()
+        self.gui.major_peaks_changed = mock.Mock()
+        self.gui.minor_peaks_changed = mock.Mock()
+        self.gui.gammas_changed = mock.Mock()
+        self.gui.electrons_changed = mock.Mock()
 
         self.gui._update_checked_data()
 
-        self.assertEqual(1, self.gui.major_peaks_checked.call_count)
-        self.assertEqual(0, self.gui.major_peaks_unchecked.call_count)
-        self.assertEqual(1, self.gui.minor_peaks_checked.call_count)
-        self.assertEqual(0, self.gui.minor_peaks_unchecked.call_count)
-        self.assertEqual(0, self.gui.gammas_checked.call_count)
-        self.assertEqual(1, self.gui.gammas_unchecked.call_count)
-        self.assertEqual(1, self.gui.electrons_checked.call_count)
-        self.assertEqual(0, self.gui.electrons_unchecked.call_count)
+        self.assertEqual(1, self.gui.major_peaks_changed.call_count)
+        self.assertEqual(1, self.gui.minor_peaks_changed.call_count)
+        self.assertEqual(1, self.gui.gammas_changed.call_count)
+        self.assertEqual(1, self.gui.electrons_changed.call_count)
+        self.gui.major_peaks_changed.assert_called_with(self.gui.peaks.major)
+        self.gui.minor_peaks_changed.assert_called_with(self.gui.peaks.minor)
+        self.gui.gammas_changed.assert_called_with(self.gui.peaks.gamma)
+        self.gui.electrons_changed.assert_called_with(self.gui.peaks.electron)
 
-    def test_gamms_checked_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.gammas_changed()
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    def test_gamms_unchecked_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.gammas_unchecked()
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    def test_major_checked_calls_checked_data_for_each_element(self):
+    def test_major_changed_calls_checked_data_for_each_element(self):
         elem = len(self.gui.ptable.peak_data)
         self.gui.checked_data = mock.Mock()
         self.gui.major_peaks_changed(self.gui.peaks.major)

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -38,6 +38,9 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.used_colors = {}
         self.gui.element_lines = {}
         self.has_raise_ValueError_been_called_once = False
+        self.gui.detectors = mock.Mock()
+        self.gui.detectors.detectors = [mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
+        self.gui.lines = mock.Mock()
 
     def raise_ValueError_once(self):
         if not self.has_raise_ValueError_been_called_once:
@@ -143,8 +146,10 @@ class ElementalAnalysisTest(unittest.TestCase):
                                       protected=True)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_that_plot_line_returns_if_plot_window_is_none(self, mock_plot_line_once, mock_gen_label):
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
+                )
+    def test_that_plot_line_returns_if_plot_window_is_none(self, mock_plot_line_once,
+                                                           mock_gen_label):
         self.gui.plot_window = None
         mock_gen_label.return_value = 'name of the label'
         self.gui._plot_line('name', 1.0, 'C0', None)
@@ -152,8 +157,10 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(mock_plot_line_once.call_count, 0)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_that_plot_line_calls_plot_line_once_if_window_not_none(self, mock_plot_line_once, mock_gen_label):
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
+                )
+    def test_that_plot_line_calls_plot_line_once_if_window_not_none(self, mock_plot_line_once,
+                                                                    mock_gen_label):
         self.gui.plot_window = mock.create_autospec(MultiPlotWindow)
         self.gui.plotting = MultiPlotWidget(mock.Mock())
         self.gui.plotting.get_subplots = mock.Mock(return_value=['plot1'])
@@ -193,14 +200,17 @@ class ElementalAnalysisTest(unittest.TestCase):
         elem = len(self.gui.ptable.peak_data)
         self.assertEqual(len(self.gui.element_widgets), elem)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
     def test_table_left_clicked_adds_lines_if_element_selected(self, mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=True)
         self.gui._add_element_lines(mock.Mock())
         self.assertEqual(mock_add_element_lines.call_count, 1)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_table_left_clicked_removed_lines_if_element_not_selected(self, mock_remove_element_lines):
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    def test_table_left_clicked_removed_lines_if_element_not_selected(self,
+                                                                      mock_remove_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=False)
         self.gui.table_left_clicked(mock.Mock())
         self.assertEqual(mock_remove_element_lines.call_count, 1)
@@ -258,11 +268,10 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.plotting.remove_subplot.call_count, 0)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.Detectors.detectors_view.QtWidgets.QWidget')
-    def test_loading_finished_returns_correctly_if_no_plot_window_but_has_to_plot(self, mock_QWidget):
+    def test_loading_finished_returns_correctly_if_no_plot_window_but_has_to_plot(
+            self, mock_QWidget):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=['run1', 'run2', 'run3'])
-        self.gui.detectors = mock.Mock()
         self.gui.detectors.getNames.return_value = ['1', '2', '3']
-        self.gui.detectors.detectors = [mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
         self.gui.plot_window = None
         self.gui.plotting = mock.Mock()
         self.gui.plotting.get_subplots.return_value = ['1', '2', '3']
@@ -277,9 +286,7 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_loading_finished_returns_correctly_if_no_to_plot_but_has_plot_window(
             self, mock_QWidget):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=['run1', 'run2', 'run3'])
-        self.gui.detectors = mock.Mock()
         self.gui.detectors.getNames.return_value = ['1', '2', '3']
-        self.gui.detectors.detectors = [mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
         mock_QWidget.return_value = True
         self.gui.plot_window = mock.Mock()
 
@@ -288,9 +295,12 @@ class ElementalAnalysisTest(unittest.TestCase):
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_peak_data')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
-    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(self, mock_mantid, mock_add_peak_data):
-        mock_mantid.mtd = {'name1': [mock.Mock(), mock.Mock(), mock.Mock()],
-                           'name2': [mock.Mock(), mock.Mock(), mock.Mock()]}
+    def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(
+            self, mock_mantid, mock_add_peak_data):
+        mock_mantid.mtd = {
+            'name1': [mock.Mock(), mock.Mock(), mock.Mock()],
+            'name2': [mock.Mock(), mock.Mock(), mock.Mock()]
+        }
         self.gui.plotting = mock.Mock()
         self.gui.lines = mock.Mock()
         self.gui.lines.total.isChecked.return_value = True
@@ -314,28 +324,32 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.plot_window, None)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_add_peak_data_plot_line_called_with_correct_terms(self, mock_plot_line_once, mock_gen_label):
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once'
+                )
+    def test_add_peak_data_plot_line_called_with_correct_terms(self, mock_plot_line_once,
+                                                               mock_gen_label):
         mock_subplot = mock.Mock()
         mock_gen_label.return_value = 'label'
         test_data = {'name1': 1.0}
         self.gui.add_peak_data('H', mock_subplot, data=test_data)
         mock_plot_line_once.assert_called_with(mock_subplot, 1.0, 'label', 'C0')
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_update_peak_data_element_is_selected(self,
-                                                  mock_remove_element_lines,
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    def test_update_peak_data_element_is_selected(self, mock_remove_element_lines,
                                                   mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=True)
         self.gui._update_peak_data('test_element')
         mock_remove_element_lines.assert_called_with('test_element')
         mock_add_element_lines.assert_called_with('test_element')
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_update_peak_data_element_is_not_selected(self,
-                                                      mock_remove_element_lines,
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
+    def test_update_peak_data_element_is_not_selected(self, mock_remove_element_lines,
                                                       mock_add_element_lines):
         self.gui.ptable.is_selected = mock.Mock(return_value=False)
         self.gui._update_peak_data('test_element')
@@ -427,27 +441,33 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.detectors.setStateQuietly.call_count, 1)
         self.assertEqual(self.gui.plot_window, None)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_set_peak_datafile_is_called_with_select_data_file(self, mock_getOpenFileName, mock_set_peak_datafile):
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_set_peak_datafile_is_called_with_select_data_file(self, mock_getOpenFileName,
+                                                                    mock_set_peak_datafile):
         mock_getOpenFileName.return_value = 'filename'
         self.gui.select_data_file()
         mock_set_peak_datafile.assert_called_with('filename')
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_select_data_file_uses_the_first_element_of_a_tuple_when_given_as_a_filename(self,
-                                                                                              mock_getOpenFileName,
-                                                                                              mock_set_peak_datafile):
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_select_data_file_uses_the_first_element_of_a_tuple_when_given_as_a_filename(
+            self, mock_getOpenFileName, mock_set_peak_datafile):
         mock_getOpenFileName.return_value = ('string1', 'string2')
         self.gui.select_data_file()
         mock_set_peak_datafile.assert_called_with('string1')
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.message_box.warning')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._generate_element_widgets')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_select_data_file_raises_warning_with_correct_text(self,
-                                                                    mock_getOpenFileName,
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._generate_element_widgets'
+    )
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_select_data_file_raises_warning_with_correct_text(self, mock_getOpenFileName,
                                                                     mock_generate_element_widgets,
                                                                     mock_warning):
         mock_getOpenFileName.return_value = 'filename'
@@ -530,7 +550,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.minor_peaks_unchecked()
         self.assertEqual(self.gui.checked_data.call_count, elem)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._update_peak_data')
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._update_peak_data')
     def test_checked_data_changes_all_states_in_list(self, mock_update_peak_data):
         selection = [mock.Mock() for i in range(10)]
         self.gui.checked_data('Cu', selection, True)
@@ -541,6 +562,169 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_that_ptable_contains_no_peak_not_part_of_an_element(self):
         self.assertTrue('Electrons' not in self.gui.ptable.peak_data)
         self.assertTrue('Gammas' not in self.gui.ptable.peak_data)
+
+    def test_that_add_line_by_type_enables_all_detectors(self):
+        self.gui.detectors.detectors = [mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
+        for detector in self.gui.detectors.detectors:
+            detector.isEnabled.return_value = False
+
+        self.gui.add_line_by_type(2695, 'Total')
+
+        for detector in self.gui.detectors.detectors:
+            detector.setEnabled.assert_called_with(True)
+
+    def texst_that_add_line_by_type_returns_is_plot_window_is_none(self):
+        self.gui.plotting = mock.Mock()
+        self.gui.add_line_by_type(2695, 'Total')
+
+        self.assertEqual(0, self.gui.plotting.get_subplots.call_count)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
+    def test_that_add_line_by_type_plots_correct_lines_with_correct_colour(self, mock_mantid):
+        self.gui.plotting = mock.Mock()
+        self.gui.plot_window = mock.Mock()
+        self.gui.plotting.get_subplots.return_value = ['1', '2']
+        mock_mantid.mtd = {
+            '2695; Detector 1': [mock.Mock(), mock.Mock()],
+            '2695; Detector 2': [mock.Mock(), mock.Mock()],
+            '2695; Detector 3': [mock.Mock(), mock.Mock()]
+        }
+        mock_mantid.mtd['2695; Detector 1'][0].getName.return_value = 'det1, ws1 Total'
+        mock_mantid.mtd['2695; Detector 1'][1].getName.return_value = 'det1, ws2'
+        mock_mantid.mtd['2695; Detector 2'][0].getName.return_value = 'det2, ws1'
+        mock_mantid.mtd['2695; Detector 2'][1].getName.return_value = 'det2, ws2 Total'
+        expected_calls = [
+            mock.call('1', 'det1, ws1 Total', color='C0'),
+            mock.call('2', 'det2, ws2 Total', color='C0')
+        ]
+        self.gui.add_line_by_type(2695, 'Total')
+
+        self.assertEqual(1, self.gui.plotting.get_subplots.call_count)
+        self.gui.plotting.plot.assert_has_calls(expected_calls)
+
+    def test_remove_line_type_returns_if_no_plot_open(self):
+        self.gui.plot_window = None
+        self.gui.plotting = mock.Mock()
+        self.gui.remove_line_type(2695, 'Total')
+
+        self.assertEqual(0, self.gui.plotting.get_subplots.call_count)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
+    def test_remove_line_type_calls_remove_line(self, mock_mantid):
+        self.gui.plot_window = mock.Mock()
+        self.gui.plotting = mock.Mock()
+        self.gui.plotting.get_subplots.return_value = ['1', '2']
+        mock_mantid.mtd = {
+            '2695; Detector 1': [mock.Mock(), mock.Mock()],
+            '2695; Detector 2': [mock.Mock(), mock.Mock()],
+            '2695; Detector 3': [mock.Mock(), mock.Mock()]
+        }
+        mock_mantid.mtd['2695; Detector 1'][0].getName.return_value = 'det1, ws1 Total'
+        mock_mantid.mtd['2695; Detector 1'][1].getName.return_value = 'det1, ws2'
+        mock_mantid.mtd['2695; Detector 2'][0].getName.return_value = 'det2, ws1'
+        mock_mantid.mtd['2695; Detector 2'][1].getName.return_value = 'det2, ws2 Total'
+        expected_calls = [mock.call('1', 'det1, ws1 Total'), mock.call('2', 'det2, ws2 Total')]
+        self.gui.remove_line_type(2695, 'Total')
+
+        self.assertEqual(1, self.gui.plotting.get_subplots.call_count)
+        self.gui.plotting.remove_line.assert_has_calls(expected_calls)
+
+    def test_that_uncheck_detectors_if_no_line_plotted_unchecks_all_detectors(self):
+        self.gui.lines.total.isChecked.return_value = False
+        self.gui.lines.prompt.isChecked.return_value = False
+        self.gui.lines.delayed.isChecked.return_value = False
+
+        self.gui.uncheck_detectors_if_no_line_plotted()
+
+        for detector in self.gui.detectors.detectors:
+            detector.setEnabled.assert_called_with(False)
+            self.assertEqual(1, detector.setEnabled.call_count)
+
+    def test_that_uncheck_detectors_if_no_line_plotted_does_not_uncheck_if_plotting_some_lines(
+            self):
+        self.gui.lines.total.isChecked.return_value = False
+        self.gui.lines.prompt.isChecked.return_value = True
+        self.gui.lines.delayed.isChecked.return_value = False
+
+        self.gui.uncheck_detectors_if_no_line_plotted()
+
+        for detector in self.gui.detectors.detectors:
+            self.assertEqual(0, detector.setEnabled.call_count)
+
+    def test_that_uncheck_on_removed_uncheck_correct_lines(self):
+        rem_lines = ['line Total', 'line Prompt', 'line 3']
+        self.gui.uncheck_on_removed(rem_lines)
+        self.gui.lines.total.setChecked.assert_called_with(False)
+        self.gui.lines.prompt.setChecked.assert_called_with(False)
+        self.assertEqual(0, self.gui.lines.delayed.setChecked.call_count)
+
+    def test_that_uncheck_on_removed_blocks_signals_and_calls_right_function(self):
+        rem_lines = ['line Total', 'line Prompt', 'line 3']
+        calls = [mock.call(True), mock.call(False)]
+        self.gui.uncheck_detectors_if_no_line_plotted = mock.Mock()
+
+        self.gui.uncheck_on_removed(rem_lines)
+
+        self.gui.lines.total.blockSignals.assert_has_calls(calls)
+        self.gui.lines.prompt.blockSignals.assert_has_calls(calls)
+        self.gui.lines.delayed.blockSignals.assert_has_calls([])
+        self.assertEqual(1, self.gui.uncheck_detectors_if_no_line_plotted.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
+    def test_line_total_checked_checks_line_and_calls_add_line_by_type(self, mock_add_line_by_type):
+        self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
+        self.gui.line_total_checked()
+
+        self.gui.lines.total.setChecked.assert_called_with(True)
+        self.assertEqual(1, mock_add_line_by_type.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    def test_line_total_unchecked_unchecks_line_and_calls_add_line_by_type(
+            self, mock_remove_line_type):
+        self.gui.line_total_unchecked()
+
+        self.gui.lines.total.setChecked.assert_called_with(False)
+        self.assertEqual(1, mock_remove_line_type.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
+    def test_line_prompt_checked_checks_line_and_calls_add_line_by_type(
+            self, mock_add_line_by_type):
+        self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
+        self.gui.line_prompt_checked()
+
+        self.gui.lines.prompt.setChecked.assert_called_with(True)
+        self.assertEqual(1, mock_add_line_by_type.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    def test_line_prompt_unchecked_unchecks_line_and_calls_add_line_by_type(
+            self, mock_remove_line_type):
+        self.gui.line_prompt_unchecked()
+
+        self.gui.lines.prompt.setChecked.assert_called_with(False)
+        self.assertEqual(1, mock_remove_line_type.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_line_by_type')
+    def test_line_delayed_checked_checks_line_and_calls_add_line_by_type(
+            self, mock_add_line_by_type):
+        self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
+        self.gui.line_delayed_checked()
+
+        self.gui.lines.delayed.setChecked.assert_called_with(True)
+        self.assertEqual(1, mock_add_line_by_type.call_count)
+
+    @mock.patch(
+        'Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.remove_line_type')
+    def test_line_delayed_unchecked_unchecks_line_and_calls_add_line_by_type(
+            self, mock_remove_line_type):
+        self.gui.line_delayed_unchecked()
+
+        self.gui.lines.delayed.setChecked.assert_called_with(False)
+        self.assertEqual(1, mock_remove_line_type.call_count)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR allows the user to select which lines to plot when visualizing a spectra in the `Elemental Analysis` interface (choice between `Total`, `Prompt`, `Delayed`).

**To test:**
 - `Interfaces->Muon->Elemental Analysis`
 - There should be three checkboxes, one for each line type
 - Load a run (eg `2695`)
 - Select different checkboxes and make sure the correct lines are plotted
 - Deselect them and ensure the correct lines are deleted
 - Delete lines from the remove line window and make sure the corresponding checkbox is unselected
 - When no box is selected you should not be able to plot anything


Fixes #26432.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
