### PR TITLE
Plot: Save Dialog stops repeated calls to save

### DIFF
--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -265,13 +265,11 @@ void ProjectSaveView::save(bool checked) {
   auto filePath = m_ui.projectPath->text();
   auto compress = filePath.endsWith(".gz");
 
-  m_ui.btnSave->setEnabled(false);
-  m_ui.btnSave->setText("Saving");
+  close();
 
   m_serialiser.save(filePath, wsNames, windowNames, interfaces, compress);
   emit projectSaved();
 
-  close();
   // Set the result code after calling close() because
   // close() sets it to QDialog::Rejected
   setResult(QDialog::Accepted);

--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -266,6 +266,7 @@ void ProjectSaveView::save(bool checked) {
   auto compress = filePath.endsWith(".gz");
 
   m_ui.btnSave->setEnabled(false);
+  m_ui.btnCancel->setEnabled(false);
   m_ui.btnSave->setText("Saving");
 
   m_serialiser.save(filePath, wsNames, windowNames, interfaces, compress);

--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -265,11 +265,13 @@ void ProjectSaveView::save(bool checked) {
   auto filePath = m_ui.projectPath->text();
   auto compress = filePath.endsWith(".gz");
 
-  close();
+  m_ui.btnSave->setEnabled(false);
+  m_ui.btnSave->setText("Saving");
 
   m_serialiser.save(filePath, wsNames, windowNames, interfaces, compress);
   emit projectSaved();
 
+  close();
   // Set the result code after calling close() because
   // close() sets it to QDialog::Rejected
   setResult(QDialog::Accepted);

--- a/MantidPlot/src/ProjectSaveView.cpp
+++ b/MantidPlot/src/ProjectSaveView.cpp
@@ -265,6 +265,9 @@ void ProjectSaveView::save(bool checked) {
   auto filePath = m_ui.projectPath->text();
   auto compress = filePath.endsWith(".gz");
 
+  m_ui.btnSave->setEnabled(false);
+  m_ui.btnSave->setText("Saving");
+
   m_serialiser.save(filePath, wsNames, windowNames, interfaces, compress);
   emit projectSaved();
 

--- a/docs/source/release/v4.1.0/mantidplot.rst
+++ b/docs/source/release/v4.1.0/mantidplot.rst
@@ -21,5 +21,6 @@ Bugfixes
 * Help documentation for the manage user directories interface now correctly displays when launched from the interface.
 * Fix for the Instrument View pick tab miniplot where the x axis label was not updated when a new unit was selected.
 * The ErrorReporter window is now resizeable
+* Save button is now disabled while a project is being saved, stopping the same project being needlessly saved multiple times.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/docs/source/release/v4.1.0/mantidplot.rst
+++ b/docs/source/release/v4.1.0/mantidplot.rst
@@ -21,6 +21,6 @@ Bugfixes
 * Help documentation for the manage user directories interface now correctly displays when launched from the interface.
 * Fix for the Instrument View pick tab miniplot where the x axis label was not updated when a new unit was selected.
 * The ErrorReporter window is now resizeable
-* Save dialog is now closed while a project is being saved, stopping the same project being needlessly saved multiple times.
+* Save button is now disabled while a project is being saved, stopping the same project being needlessly saved multiple times.
 
 :ref:`Release 4.1.0 <v4.1.0>`

--- a/docs/source/release/v4.1.0/mantidplot.rst
+++ b/docs/source/release/v4.1.0/mantidplot.rst
@@ -21,6 +21,6 @@ Bugfixes
 * Help documentation for the manage user directories interface now correctly displays when launched from the interface.
 * Fix for the Instrument View pick tab miniplot where the x axis label was not updated when a new unit was selected.
 * The ErrorReporter window is now resizeable
-* Save button is now disabled while a project is being saved, stopping the same project being needlessly saved multiple times.
+* Save dialog is now closed while a project is being saved, stopping the same project being needlessly saved multiple times.
 
 :ref:`Release 4.1.0 <v4.1.0>`


### PR DESCRIPTION
**Description of work.**
Save dialog now greys out the button and gives the user feedback that the project is saving, so they do not hit the button multiple times and queue multiple save operations. 

**To test:**
1. Load some data.
2. Save a project.
3. Check that the save button is greyed out while the project is saving. 

Fixes #26572 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
