### PR TITLE
Fixing use of wrong unit in elemental analysis interface

### DIFF
--- a/scripts/MultiPlotting/subplot/subplot_context.py
+++ b/scripts/MultiPlotting/subplot/subplot_context.py
@@ -9,7 +9,6 @@ from copy import copy
 
 
 class subplotContext(object):
-
     def __init__(self, name, subplot):
         self.name = name
         self._subplot = subplot
@@ -34,11 +33,11 @@ class subplotContext(object):
         x_range = self._subplot.get_xlim()
         y_range = self._subplot.get_ylim()
         if label.in_x_range(x_range):
-            self._labels[label.text] = self._subplot.annotate(
-                label.text,
-                xy=(label.get_xval(x_range), label.get_yval(y_range)),
-                xycoords="axes fraction",
-                rotation=label.rotation)
+            self._labels[label.text] = self._subplot.annotate(label.text,
+                                                              xy=(label.get_xval(x_range),
+                                                                  label.get_yval(y_range)),
+                                                              xycoords="axes fraction",
+                                                              rotation=label.rotation)
 
     def redraw_annotations(self):
         for key in list(self._labels.keys()):
@@ -49,11 +48,16 @@ class subplotContext(object):
 
     def addLine(self, ws, specNum=1, distribution=True):
         # make plot/get label
-        line, = plots.plotfunctions.plot(self._subplot, ws, specNum=specNum, distribution=distribution)
+        line, = plots.plotfunctions.plot(self._subplot,
+                                         ws,
+                                         specNum=specNum,
+                                         distribution=distribution)
         label = line.get_label()
         if self._errors:
-            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(
-                self._subplot, ws, specNum=specNum, label=label)
+            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot,
+                                                                      ws,
+                                                                      specNum=specNum,
+                                                                      label=label)
             all_lines = [line]
             all_lines.extend(cap_lines)
             all_lines.extend(bar_lines)
@@ -78,15 +82,25 @@ class subplotContext(object):
         del self._lines[label]
         # replot the line
         if self._errors:
-            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot, self.get_ws(
-                label), specNum=self.specNum[label], color=colour, marker=marker, label=label)
+            line, cap_lines, bar_lines = plots.plotfunctions.errorbar(self._subplot,
+                                                                      self.get_ws(label),
+                                                                      specNum=self.specNum[label],
+                                                                      color=colour,
+                                                                      marker=marker,
+                                                                      label=label,
+                                                                      distribution=distribution)
             all_lines = [line]
             all_lines.extend(cap_lines)
             all_lines.extend(bar_lines)
             self._lines[label] = all_lines
         else:
-            line, = plots.plotfunctions.plot(self._subplot, self.get_ws(label), specNum=self.specNum[label],
-                                             color=colour, marker=marker, label=label, distribution=distribution)
+            line, = plots.plotfunctions.plot(self._subplot,
+                                             self.get_ws(label),
+                                             specNum=self.specNum[label],
+                                             color=colour,
+                                             marker=marker,
+                                             label=label,
+                                             distribution=distribution)
             self._lines[label] = [line]
 
     def replace_ws(self, ws):

--- a/scripts/test/MultiPlotting/SubPlotContext_test.py
+++ b/scripts/test/MultiPlotting/SubPlotContext_test.py
@@ -11,9 +11,7 @@ from MultiPlotting.subplot.subplot_context import subplotContext
 from mantid import plots
 
 
-
 class line(object):
-
     def __init__(self):
         self.label = "test"
 
@@ -31,7 +29,6 @@ class line(object):
 
 
 class label(object):
-
     def __init__(self, name, protected):
         self.text = name
         self.protected = protected
@@ -42,7 +39,6 @@ def errors():
 
 
 class SubPlotContextTest(unittest.TestCase):
-
     def setUp(self):
         name = "test"
         self.subplot = mock.MagicMock()
@@ -67,11 +63,7 @@ class SubPlotContextTest(unittest.TestCase):
                 self.context.addLine(ws, 3)
                 self.assertEqual(plot.call_count, 1)
                 self.assertEqual(patch.call_count, 1)
-                patch.assert_called_with(
-                    self.subplot,
-                    ws,
-                    specNum=3,
-                    label=lines.get_label())
+                patch.assert_called_with(self.subplot, ws, specNum=3, label=lines.get_label())
 
     def test_redraw_errors(self):
         ws = mock.MagicMock()
@@ -88,13 +80,13 @@ class SubPlotContextTest(unittest.TestCase):
                 # redraw
                 self.context.redraw(lines.get_label())
                 self.assertEqual(patch.call_count, 2)
-                patch.assert_called_with(
-                    self.subplot,
-                    ws,
-                    specNum=3,
-                    color=lines.get_color(),
-                    marker=lines.get_marker(),
-                    label=lines.get_label())
+                patch.assert_called_with(self.subplot,
+                                         ws,
+                                         specNum=3,
+                                         color=lines.get_color(),
+                                         marker=lines.get_marker(),
+                                         label=lines.get_label(),
+                                         distribution=True)
 
     def test_redraw_no_errors(self):
         ws = mock.MagicMock()
@@ -107,14 +99,13 @@ class SubPlotContextTest(unittest.TestCase):
             # redraw
             self.context.redraw(lines.get_label())
             self.assertEqual(patch.call_count, 2)
-            patch.assert_called_with(
-                self.subplot,
-                ws,
-                specNum=3,
-                color=lines.get_color(),
-                marker=lines.get_marker(),
-                label=lines.get_label(),
-                distribution=True)
+            patch.assert_called_with(self.subplot,
+                                     ws,
+                                     specNum=3,
+                                     color=lines.get_color(),
+                                     marker=lines.get_marker(),
+                                     label=lines.get_label(),
+                                     distribution=True)
 
     def test_change_errors(self):
         self.context._lines = {"one": 1, "two": 2, "three": 3}
@@ -130,16 +121,16 @@ class SubPlotContextTest(unittest.TestCase):
 
     def test_vlines(self):
         self.context._labelObjects = {
-            "one": label("one", True), "two": label("two", False), "three": label("three", False)}
-        self.context._vLines = {
-            "two": mock.MagicMock(), "four": mock.MagicMock()}
+            "one": label("one", True),
+            "two": label("two", False),
+            "three": label("three", False)
+        }
+        self.context._vLines = {"two": mock.MagicMock(), "four": mock.MagicMock()}
         result = self.context.vlines
-        expect = ["two", "three","four"] 
+        expect = ["two", "three", "four"]
         for key in expect:
             self.assertIn(key, result)
         self.assertEqual(len(result), len(expect))
-
-
 
     def test_replaceWS(self):
         ws = mock.Mock()
@@ -154,19 +145,19 @@ class SubPlotContextTest(unittest.TestCase):
             self.context.addLine(ws2, 3)
         # check inital set up
         keys = self.context.ws.keys()
-        expect = [ws,ws2]
+        expect = [ws, ws2]
         for key in expect:
             self.assertIn(key, keys)
-        self.assertEqual(len(keys),len(expect))
+        self.assertEqual(len(keys), len(expect))
 
         # do the method
         redraw = self.context.replace_ws(ws)
-        self.assertEqual(redraw,True)
+        self.assertEqual(redraw, True)
         new_keys = self.context.ws.keys()
         for key in expect:
             self.assertIn(key, new_keys)
-        self.assertEqual(len(new_keys),len(expect))
-        self.assertEqual(self.context.ws[ws],["test"])
+        self.assertEqual(len(new_keys), len(expect))
+        self.assertEqual(self.context.ws[ws], ["test"])
 
     def test_getLinesFromWSName(self):
         ws = mock.Mock()
@@ -184,8 +175,6 @@ class SubPlotContextTest(unittest.TestCase):
         expect = ["test"]
         for key in expect:
             self.assertIn(key, "test")
- 
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**
The label used by elemental analysis is `counts` instead of `counts (keV)^-1` even when plotting with errors.

**To test:**
1.    `Interfaces->Muon->Elemental Analysis`
2.    Load and plot a run (eg. `2695`)
3.    Tick the Error bar checkbox
3.    The y-axis label will be `counts`


Fixes #26603.
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
