### PR TITLE
Added log copying in TF asymmetry mode

### DIFF
--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -21,6 +21,7 @@ Bug Fixes
 #########
   * Fixed an issue where changeing the normalisation on a plot with autoscale disabled throws an exception.
   * Fixed an issue where warnings about adding workspaces to workspace groups multiple times were appearing in the log.
+  * Fixed an issue where logs in TF asymmetry mode were not being propogated to the results tab.
 
 Known Issues
 ############

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -38,7 +38,7 @@ class FittingTabModel(object):
         alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
         output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix =\
             run_CalculateMuonAsymmetry(parameter_dict, alg)
-
+        CopyLogs(InputWorkspace=parameter_dict['ReNormalizedWorkspaceList'], OutputWorkspace=output_workspace, StoreInADS=False)
         self._handle_single_fit_results(parameter_dict['ReNormalizedWorkspaceList'], function_object,
                                         fitting_parameters_table, output_workspace, output_workspace_group, covariance_matrix)
 
@@ -48,6 +48,11 @@ class FittingTabModel(object):
         alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
         output_workspace, fitting_parameters_table, function_object, output_status, output_chi_squared, covariance_matrix =\
             run_CalculateMuonAsymmetry(parameter_dict, alg)
+        if len(parameter_dict['ReNormalizedWorkspaceList']) > 1:
+            for input_workspace, output in zip(parameter_dict['ReNormalizedWorkspaceList'], output_workspace.getNames()):
+                CopyLogs(InputWorkspace=input_workspace, OutputWorkspace=output, StoreInADS=False)
+        else:
+            CopyLogs(InputWorkspace=parameter_dict['ReNormalizedWorkspaceList'][0], OutputWorkspace=output_workspace, StoreInADS=False)
 
         self._handle_simultaneous_fit_results(parameter_dict['ReNormalizedWorkspaceList'], function_object,
                                               fitting_parameters_table, output_workspace,


### PR DESCRIPTION
**Description of work.**

Currently the logs are not copied into the fitted workspace in TF asymmetry mode. This leads to the results tab not working for fits performed in TF asymmetry mode. This adds the required lines to copy these logs forward.


**To test:**

<!-- Instructions for testing. -->
These changes affect TF asymmetry mode fits and how they interact with the results table. IN addition to code review I would reccomend trying the following things. If the below doesn't make sense please come and talk to me.
  * Perform a single fit in TF asymmetry mode go to the results tab and try to produce a results table from this fit containing all the logs
  * Do the same for a sequential and simultaneous fit.


*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
