### PR TITLE
Fix FDA error when no Im data and phaseQuad plot

### DIFF
--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -37,12 +37,14 @@ Improvements
 Interfaces
 ----------
 
-Muon Analysis 2
-###############
+Muon Analysis 2 and Frequency Domain Analysis
+#############################################
 
 - When loading PSI data if the groups given are poorly stored in the file, it should now produce unique names in the grouping tab for groups.
 - When switching between data sets groups selected to fit are remembered.
 - The FFT tab now uses the group pair selection to make a guess at the users selection for workspaces.
+- Can now plot FFT's of PhaseQuad data.
+- No longer produces an error if using multiple runs and the user plots all the FFT results when no imaginary data was used.
 
 Algorithms
 ----------

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
@@ -131,7 +131,6 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
         workspace_list = self.get_workspaces_to_plot(
             self.context.group_pair_context.selected, self._view.if_raw(),
             self._view.get_selected())
-            self._view.get_selected(), workspace_list)
         self._model.plot(workspace_list, self.get_plot_title(), self.get_domain(), self._force_redraw, self.context.window_title)
         self._force_redraw = False
 

--- a/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_plot_widget/home_plot_widget_presenter.py
@@ -131,6 +131,7 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
         workspace_list = self.get_workspaces_to_plot(
             self.context.group_pair_context.selected, self._view.if_raw(),
             self._view.get_selected())
+            self._view.get_selected(), workspace_list)
         self._model.plot(workspace_list, self.get_plot_title(), self.get_domain(), self._force_redraw, self.context.window_title)
         self._force_redraw = False
 
@@ -197,7 +198,7 @@ class HomePlotWidgetPresenter(HomeTabSubWidget):
             for run in self.context.data_context.current_runs:
                 runs += ", " + str(run[0])
             workspace_list = self.context.get_names_of_frequency_domain_workspaces_to_fit(
-                runs, current_group_pair, False, plot_type[len(FREQ_PLOT_TYPE):])
+                runs, current_group_pair, True, plot_type[len(FREQ_PLOT_TYPE):])
 
             return workspace_list
         except AttributeError:

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
@@ -22,10 +22,15 @@ class FFT(object):
 
     def __init__(self, ws_freq_name, Re_run, Re, Im_run, Im, phasequad):
         self.Re_run = Re_run
-        self.Im_run = Im_run
+
         self.ws_freq_name = ws_freq_name
         self.Re = Re
-        self.Im = Im
+        if Im == "" and Im_run == "":
+            self.Im = None
+            self.Im_run = None
+        else:
+            self.Im = Im
+            self.Im_run = Im_run
         self.phasequad = phasequad
 
 
@@ -75,11 +80,14 @@ class FrequencyContext(object):
         for name, fft in iteritems(self._FFT_freq):
             for runs in run_list:
                 for run in runs:
-                    if (int(run) == int(fft.Re_run) or int(run) == int(fft.Im_run)) and \
-                       (fft.Re in group or fft.Re in pair or fft.Im in group or fft.Im in pair) and name not in names:
+                    # check Re part
+                    if int(run) == int(fft.Re_run) and (fft.Re in group or fft.Re in pair) and name not in names:
                         names.append(name)
+                    # check Im part
+                    if fft.Im and int(run) == int(fft.Im_run) and (fft.Im in group or fft.Im in pair) and name not in names:
+                         names.append(name)
                     # do phaseQuad - will only have one run
-                    elif int(run) == int(fft.Re_run) and phasequad and fft.phasequad:
+                    if int(run) == int(fft.Re_run) and phasequad and fft.phasequad:
                         names.append(name)
         if frequency_type == "All":
             return names

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
@@ -85,7 +85,7 @@ class FrequencyContext(object):
                         names.append(name)
                     # check Im part
                     if fft.Im and int(run) == int(fft.Im_run) and (fft.Im in group or fft.Im in pair) and name not in names:
-                         names.append(name)
+                        names.append(name)
                     # do phaseQuad - will only have one run
                     if int(run) == int(fft.Re_run) and phasequad and fft.phasequad:
                         names.append(name)


### PR DESCRIPTION
The FDA GUI had a couple of bugs with plotting, this fixes them.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
test 1:
open workbench
open Frequency domian analysis
load runs 62260-62261
go to the transform tab.
turn off Imaginary Data and then calculate FFT
go to home tab, and change plot type to Frequency FFT All

test 2
Go to the phaseQuad tab and generate some data
Go to the transform tab and do some FFT's of phasequad
Go to home tab and try the various FFT plot options
The phaseQuad data should show up
<!-- Instructions for testing. -->

Fixes #26602 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---
In release notes
#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
