### PR TITLE
Removed abiliy to insert tabs via dropping in Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/scripts/Muon/GUI/Common/dock/dockable_tabs.py
@@ -28,7 +28,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
 
         self.tab_bar.onDetachTabSignal.connect(self.detach_tab)
         self.tab_bar.onMoveTabSignal.connect(self.move_tab)
-        self.tab_bar.detachedTabDropSignal.connect(self.detached_tab_drop)
+        # self.tab_bar.detachedTabDropSignal.connect(self.detached_tab_drop)
 
         self.setTabBar(self.tab_bar)
 


### PR DESCRIPTION
**Description of work.**

In the Muon Analysis GUI the functionality to reinsert popped out tabs via dropping them leads to an uncaught exception on OSX. On Linux and windows tabs cannot be inserted via dropping in the first place. As a quick fix this PR removes the ability to insert tabs via dropping at all (they must instead be closed). This is not an ideal long term solution but in the short term stops mantid crashing on OSX and brings the behavior on OSX in line with the other operating systems. I've added the issue #26613 to fix this properly.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * On Linux and windows check that the tabs still work as expected.
  * On OSX check that you cannot reinsert tabs by drag and drop which was leading to an error.

<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because **fill in an explanation of why** this is a very minor change


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
