### PR TITLE
LoadEventNexus clean-up

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -56,6 +56,9 @@ public:
 
 private:
   size_t getWorkspaceIndexFromPixelID(const detid_t pixID);
+  size_t getFirstEventIndex(const size_t pulseIndex) const;
+  size_t getLastEventIndex(const size_t pulseIndex,
+                           const size_t numPulses) const;
 
   /// Algorithm being run
   DefaultEventLoader &m_loader;

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -10,6 +10,7 @@
 #include "MantidDataHandling/LoadEventNexus.h"
 #include "MantidDataHandling/ProcessBankData.h"
 #include "MantidKernel/Unit.h"
+#include <algorithm>
 
 #include "MantidNexus/NexusIOHelper.h"
 
@@ -216,13 +217,8 @@ LoadBankFromDiskTask::loadEventId(::NeXus::File &file) {
     file.closeData();
 
     // determine the range of pixel ids
-    for (int64_t i = 0; i < m_loadSize[0]; ++i) {
-      const auto id = event_id[i];
-      if (id < m_min_id)
-        m_min_id = id;
-      if (id > m_max_id)
-        m_max_id = id;
-    }
+    m_min_id = *(std::min_element(event_id.get(), event_id.get() + m_loadSize[0]));
+    m_max_id = *(std::max_element(event_id.get(), event_id.get() + m_loadSize[0]));
 
     if (m_min_id > static_cast<uint32_t>(m_loader.eventid_max)) {
       // All the detector IDs in the bank are higher than the highest 'known'

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -217,8 +217,10 @@ LoadBankFromDiskTask::loadEventId(::NeXus::File &file) {
     file.closeData();
 
     // determine the range of pixel ids
-    m_min_id = *(std::min_element(event_id.get(), event_id.get() + m_loadSize[0]));
-    m_max_id = *(std::max_element(event_id.get(), event_id.get() + m_loadSize[0]));
+    m_min_id =
+        *(std::min_element(event_id.get(), event_id.get() + m_loadSize[0]));
+    m_max_id =
+        *(std::max_element(event_id.get(), event_id.get() + m_loadSize[0]));
 
     if (m_min_id > static_cast<uint32_t>(m_loader.eventid_max)) {
       // All the detector IDs in the bank are higher than the highest 'known'

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -34,33 +34,6 @@ ProcessBankData::ProcessBankData(
 }
 
 namespace {
-inline size_t getFirstPulseIndex(
-    const size_t event_index,
-    const boost::shared_ptr<std::vector<uint64_t>> &event_index_vec) {
-  const auto event_index_begin = event_index_vec->cbegin();
-
-  if ((event_index >= *event_index_begin) &&
-      (event_index < *(event_index_begin + 1)))
-    return 0;
-
-  const auto event_index_end = event_index_vec->cend();
-  const auto event_index_iter =
-      std::lower_bound(event_index_begin, event_index_end, event_index);
-  if (event_index_iter == event_index_end) {
-    return event_index_vec->size() - 1;
-  } else {
-    const auto new_pulse_index =
-        std::distance(event_index_vec->cbegin(),
-                      event_index_iter); // TODO may need to subtract one
-    if (new_pulse_index != 0) {
-      // lower_bound returns the element greater than what we were looking for
-      return new_pulse_index - 1;
-    } else {
-      return new_pulse_index;
-    }
-  }
-}
-
 // this assumes that last_pulse_index is already to the point of including this
 // one so we only need to search forward
 inline size_t
@@ -165,7 +138,7 @@ void ProcessBankData::run() { // override {
   if (compress)
     usedDetIds.assign(m_max_id - m_min_id + 1, false);
 
-  size_t pulse_last = getFirstPulseIndex(startAt, event_index);
+  size_t pulse_last = getPulseIndex(startAt, pulse_i, event_index);
   // Go through all events in the list
   for (std::size_t index_in_tof_array = startAt; index_in_tof_array < numEvents;
        index_in_tof_array++) {

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -39,8 +39,7 @@ namespace {
 inline size_t
 getPulseIndex(const size_t event_index, const size_t last_pulse_index,
               const boost::shared_ptr<std::vector<uint64_t>> &event_index_vec) {
-  const auto numPulses = event_index_vec->size();
-  if (last_pulse_index >= numPulses - 1)
+  if (last_pulse_index + 1 >= event_index_vec->size())
     return last_pulse_index;
 
   // linear search is used because it is more likely that the next pulse index
@@ -112,25 +111,11 @@ void ProcessBankData::run() { // override {
   const bool pulsetimesincreasing = std::is_sorted(
       thisBankPulseTimes->pulseTimes,
       thisBankPulseTimes->pulseTimes + thisBankPulseTimes->numPulses);
-  Mantid::Types::Core::DateAndTime pulsetime;
-  int periodIndex = 0;
-  Mantid::Types::Core::DateAndTime lastpulsetime(0);
-
-  // Index into the pulse array
-  size_t pulseIndex = 0;
+  if (!std::is_sorted(event_index->cbegin(), event_index->cend()))
+    throw std::runtime_error("Event index is not sorted");
 
   // And there are this many pulses
-  const auto numPulses = thisBankPulseTimes->numPulses;
-  if (numPulses > event_index->size()) {
-    alg->getLogger().warning()
-        << "Entry " << entry_name
-        << "'s event_index vector is smaller than the event_time_zero field. "
-           "This is inconsistent, so we cannot find pulse times for this "
-           "entry.\n";
-    // This'll make the code skip looking for any pulse times.
-    pulseIndex = numPulses + 1;
-  }
-
+  const auto NUM_PULSES = thisBankPulseTimes->numPulses;
   prog->report(entry_name + ": filling events");
 
   // Will we need to compress?
@@ -141,75 +126,96 @@ void ProcessBankData::run() { // override {
   if (compress)
     usedDetIds.assign(m_max_id - m_min_id + 1, false);
 
-  // Go through all events in the list
-  for (std::size_t eventIndex = 0; eventIndex < numEvents; eventIndex++) {
-    //------ Find the pulse time for this event index ---------
-    if (pulseIndex < numPulses - 1) {
-      pulseIndex = getPulseIndex(eventIndex + startAt, pulseIndex, event_index);
+  const double TOF_MIN = alg->filter_tof_min;
+  const double TOF_MAX = alg->filter_tof_max;
 
-      // Save the pulse time at this index for creating those events
-      pulsetime = thisBankPulseTimes->pulseTimes[pulseIndex];
-      const int logPeriodNumber = thisBankPulseTimes->periodNumbers[pulseIndex];
-      periodIndex = logPeriodNumber - 1;
+  for (std::size_t pulseIndex = getPulseIndex(startAt, 0, event_index);
+       pulseIndex < NUM_PULSES; pulseIndex++) {
+    // Save the pulse time at this index for creating those events
+    const auto pulsetime = thisBankPulseTimes->pulseTimes[pulseIndex];
+    const int logPeriodNumber = thisBankPulseTimes->periodNumbers[pulseIndex];
+    const int periodIndex = logPeriodNumber - 1;
 
-      // Determine if pulse times continue to increase
-      if (pulsetime >= lastpulsetime) {
-        lastpulsetime = pulsetime;
-        if (alg->getCancel())
-          break;
-      }
+    const auto firstEventIndex = getFirstEventIndex(pulseIndex);
+    if (firstEventIndex > numEvents)
+      break;
+
+    const auto lastEventIndex = getLastEventIndex(pulseIndex, NUM_PULSES);
+    if (firstEventIndex == lastEventIndex)
+      continue;
+    else if (firstEventIndex > lastEventIndex) {
+      std::stringstream msg;
+      msg << "Something went really wrong: " << firstEventIndex << " > "
+          << lastEventIndex << "| " << entry_name << " startAt=" << startAt
+          << " numEvents=" << event_index->size() << " RAWINDICES=["
+          << firstEventIndex + startAt << ",?)"
+          << " pulseIndex=" << pulseIndex << " of " << event_index->size();
+      throw std::runtime_error(msg.str());
     }
 
-    // We cached a pointer to the vector<tofEvent> -> so retrieve it and add
-    // the event
-    const detid_t detId = event_id[eventIndex];
-    if (detId >= m_min_id && detId <= m_max_id) {
-      // Create the tofevent
-      const auto tof = static_cast<double>(event_time_of_flight[eventIndex]);
-      if ((tof >= alg->filter_tof_min) && (tof <= alg->filter_tof_max)) {
-        // Handle simulated data if present
-        if (have_weight) {
-          auto *eventVector = m_loader.weightedEventVectors[periodIndex][detId];
-          // NULL eventVector indicates a bad spectrum lookup
-          if (eventVector) {
-            const auto weight = static_cast<double>(event_weight[eventIndex]);
-            const double errorSq = weight * weight;
-            eventVector->emplace_back(tof, pulsetime, weight, errorSq);
+    for (std::size_t eventIndex = firstEventIndex; eventIndex < lastEventIndex;
+         ++eventIndex) {
+      // We cached a pointer to the vector<tofEvent> -> so retrieve it and add
+      // the event
+      const detid_t detId = event_id[eventIndex];
+      if (detId >= m_min_id && detId <= m_max_id) {
+        // Create the tofevent
+        const auto tof = static_cast<double>(event_time_of_flight[eventIndex]);
+        // this is fancy for check if value is in range
+        if ((tof - TOF_MIN) * (tof - TOF_MAX) <= 0.) {
+          // Handle simulated data if present
+          if (have_weight) {
+            auto *eventVector =
+                m_loader.weightedEventVectors[periodIndex][detId];
+            // NULL eventVector indicates a bad spectrum lookup
+            if (eventVector) {
+              const auto weight = static_cast<double>(event_weight[eventIndex]);
+              const double errorSq = weight * weight;
+              eventVector->emplace_back(tof, pulsetime, weight, errorSq);
+            } else {
+              ++my_discarded_events;
+            }
           } else {
-            ++my_discarded_events;
+            // We have cached the vector of events for this detector ID
+            auto *eventVector = m_loader.eventVectors[periodIndex][detId];
+            // NULL eventVector indicates a bad spectrum lookup
+            if (eventVector) {
+              eventVector->emplace_back(tof, pulsetime);
+            } else {
+              ++my_discarded_events;
+            }
           }
-        } else {
-          // We have cached the vector of events for this detector ID
-          auto *eventVector = m_loader.eventVectors[periodIndex][detId];
-          // NULL eventVector indicates a bad spectrum lookup
-          if (eventVector) {
-            eventVector->emplace_back(tof, pulsetime);
-          } else {
-            ++my_discarded_events;
-          }
-        }
 
-        // Local tof limits
-        if (tof < my_shortest_tof) {
-          my_shortest_tof = tof;
-        }
-        // Skip any events that are the cause of bad DAS data (e.g. a negative
-        // number in uint32 -> 2.4 billion * 100 nanosec = 2.4e8 microsec)
-        if (tof < 2e8) {
-          if (tof > my_longest_tof) {
-            my_longest_tof = tof;
-          }
-        } else
-          badTofs++;
+          // Skip any events that are the cause of bad DAS data (e.g. a negative
+          // number in uint32 -> 2.4 billion * 100 nanosec = 2.4e8 microsec)
+          if (tof < 2e8) {
+            // tof limits from things observed here
+            if (tof > my_longest_tof) {
+              my_longest_tof = tof;
+            }
+            if (tof < my_shortest_tof) {
+              my_shortest_tof = tof;
+            }
+          } else
+            badTofs++;
 
-        // Track all the touched wi (only necessary when compressing events,
-        // for thread safety)
-        if (compress)
-          usedDetIds[detId - m_min_id] = true;
-      } // valid time-of-flight
+          // Track all the touched wi (only necessary when compressing events,
+          // for thread safety)
+          if (compress)
+            usedDetIds[detId - m_min_id] = true;
+        } // valid time-of-flight
 
-    } // valid detector IDs
-  }   //(for each event)
+      } // valid detector IDs
+    }   // for events in pulse
+    // check if cancelled after each pulse
+    if (alg->getCancel())
+      break;
+  } // for pulses
+
+  // Check for canceled algorithm
+  if (alg->getCancel()) {
+    return;
+  }
 
   //------------ Compress Events (or set sort order) ------------------
   // Do it on all the detector IDs we touched
@@ -256,6 +262,24 @@ void ProcessBankData::run() { // override {
                            << "\n";
 #endif
 } // END-OF-RUN()
+
+size_t ProcessBankData::getFirstEventIndex(const size_t pulseIndex) const {
+  const auto firstEventIndex = event_index->operator[](pulseIndex);
+  if (firstEventIndex >= startAt)
+    return firstEventIndex - startAt;
+  else
+    return 0;
+}
+
+size_t ProcessBankData::getLastEventIndex(const size_t pulseIndex,
+                                          const size_t numPulses) const {
+  if (pulseIndex + 1 >= numPulses)
+    return numEvents;
+
+  const auto lastEventIndex = event_index->operator[](pulseIndex + 1) - startAt;
+
+  return std::min(lastEventIndex, numEvents);
+}
 
 /**
  * Get the workspace index for a given pixel ID. Throws if the pixel ID is

--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -276,7 +276,8 @@ size_t ProcessBankData::getLastEventIndex(const size_t pulseIndex,
   if (pulseIndex + 1 >= numPulses)
     return numEvents;
 
-  const auto lastEventIndex = event_index->operator[](pulseIndex + 1) - startAt;
+  const size_t lastEventIndex =
+      event_index->operator[](pulseIndex + 1) - startAt;
 
   return std::min(lastEventIndex, numEvents);
 }

--- a/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
+++ b/Framework/Types/inc/MantidTypes/Core/DateAndTime.h
@@ -79,10 +79,14 @@ public:
   int nanoseconds() const;
   int64_t totalNanoseconds() const;
 
-  bool operator==(const DateAndTime &rhs) const;
+  inline bool operator==(const DateAndTime &rhs) const {
+    return _nanoseconds == rhs._nanoseconds;
+  }
   bool operator==(const boost::posix_time::ptime &rhs) const;
   bool operator!=(const DateAndTime &rhs) const;
-  bool operator<(const DateAndTime &rhs) const;
+  inline bool operator<(const DateAndTime &rhs) const {
+    return _nanoseconds < rhs._nanoseconds;
+  }
   bool operator<=(const DateAndTime &rhs) const;
   bool operator>(const DateAndTime &rhs) const;
   bool operator>=(const DateAndTime &rhs) const;

--- a/Framework/Types/src/Core/DateAndTime.cpp
+++ b/Framework/Types/src/Core/DateAndTime.cpp
@@ -516,13 +516,6 @@ int DateAndTime::nanoseconds() const {
 int64_t DateAndTime::totalNanoseconds() const { return this->_nanoseconds; }
 
 //------------------------------------------------------------------------------------------------
-/** == operator
- * @param rhs :: DateAndTime to compare
- * @return true if equals
- */
-bool DateAndTime::operator==(const DateAndTime &rhs) const {
-  return _nanoseconds == rhs._nanoseconds;
-}
 
 /** == operator for boost::posix_time::ptime
  * @param rhs :: boost::posix_time::ptime to compare
@@ -553,14 +546,6 @@ bool DateAndTime::equals(const DateAndTime &rhs, const int64_t tol) const {
  */
 bool DateAndTime::operator!=(const DateAndTime &rhs) const {
   return _nanoseconds != rhs._nanoseconds;
-}
-
-/** < operator
- * @param rhs :: DateAndTime to compare
- * @return true if less than
- */
-bool DateAndTime::operator<(const DateAndTime &rhs) const {
-  return _nanoseconds < rhs._nanoseconds;
 }
 
 /** <= operator


### PR DESCRIPTION
This was a `valgrind --tool=callgrind` guided optimization of `LoadEventNexus`. Unfortunately, it didn't create much of a net effect other than cleaning up the code some. The exact script used is
```python
from mantid.simpleapi import mtd, LoadEventNexus, FilterByTime, RebinToWorkspace
from collections import defaultdict 
import numpy as np
from os import path
import time

filenames = ['CNCS_7860_event.nxs', 
             '/SNS/EQSANS/IPTS-17292/0/68200/NeXus/EQSANS_68200_event.nxs', # 334MiB
             '/SNS/NOM/IPTS-23742/nexus/NOM_131564.nxs.h5', # 5.9GiB
             '/SNS/REF_L/IPTS-22484/nexus/REF_L_172383.nxs.h5'] 

results = defaultdict(lambda: list())
NUM_TRIES = 5
for filename in filenames:
    for i in range(NUM_TRIES):
        shortname = path.split(filename)[-1]
        tzero = time.time()
        print('ITERATION {}: {}'.format(i, filename))
        LoadEventNexus(Filename=filename, OutputWorkspace='wksp', LoadLogs=False)
        total_events=mtd['wksp'].getNumberEvents()
        print('total events: {}'.format(total_events))
        results[shortname].append(time.time() - tzero)

print('Results from {} tries'.format(NUM_TRIES))
for name, values in results.items():
    values = np.sort(values)[:-1] # drop slowest which is likely from cold cache
    print('{}: {:.1f} +/- {:.1f} seconds'.format(name, np.mean(values), np.std(values)))
```
with most of the development changes being driven by checks with the EQSANS file followed by the NOMAD file.

Results from 5 tries of `master` and 10 tries of new code (dropping slowest, times are in seconds)

| run        | size | num banks |  total events | `master` | branch |
|------------|------|---------------|-----------------|------------|----------|
| CNCS_7860       |  8.9MiB  | 44 | 112,266 | 1.3 +/- 0.0 | 1.4 +/- 0.0 |
| EQSANS_68200 | 334MiB | 48 | 76,862,885 | 9.8 +/- 0.1 | 9.6 +/- 0.2 |
| NOM_131564           | 5.9GiB   | 99 | 741,688,197 | 22.0 +/- 0.3 | 18.9 +/- 0.2 |
| REF_L_172383        | 21MiB    |   1 | 71,999 | 0.4 +/- 0.0 | 0.3 +/- 0.0 |\\


Things that were not properly explored were
1. Not using the threadpool for `LoadBankFromDisk`. Instead just do that in the main thread and spawn new threads for processing the data
2. Using a [profiler that understands disk access](http://www.linuxprogrammingblog.com/io-profiling) would give more concrete information on whether we have a IO-bottleneck

**To test:**

All of the existing tests were unchanged. Reviewing the code is all that is needed.

*There is no associated issue.*

*This does not require release notes* because this is an internal code refactor.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
