### PR TITLE
EQSANSCorrectTofStructure: Use either path to individual pixel or to the center of the detector

### DIFF
--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -71,7 +71,9 @@ void EQSANSCorrectFrame::exec() {
   const auto &spectrumInfo = inputWS->spectrumInfo();
   const auto msd = spectrumInfo.l1(); // moderator-sample-distance
   auto ins = inputWS->getInstrument();
-  auto mdd = msd + ins->getComponentByName(detectorName)->getDistance(*(ins->getSample()));
+  auto mdd =
+      msd +
+      ins->getComponentByName(detectorName)->getDistance(*(ins->getSample()));
 
   // Creates a function that correct TOF values
   struct correctTofFactory {

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -66,10 +66,12 @@ void EQSANSCorrectFrame::exec() {
   const bool pathToPixel = getProperty("PathToPixel");
   const auto &spectrumInfo = inputWS->spectrumInfo();
 
-  const auto ins = inputWS->getInstrument();
-  const auto msd = ins->getSample()->getDistance(ins->getSource());
+  auto ins = inputWS->getInstrument();
+  auto sam = ins->getSample();
+  auto mod = ins->getSource():
+  const auto msd = mod->getDistance(*sam);
   const auto det = ins->getComponentyByName("detector1");
-  const auto mdd = det->getDistance(ins->getSource());
+  const auto mdd = mod->getDistance(*det);
 
   // Creates a function that correct TOF values
   struct correctTofFactory {

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -69,12 +69,10 @@ void EQSANSCorrectFrame::exec() {
   const std::string detectorName = getProperty("DetectorName");
 
   const auto &spectrumInfo = inputWS->spectrumInfo();
+  const auto msd = spectrumInfo.l1(); // moderator-sample-distance
   auto ins = inputWS->getInstrument();
-  auto sam = ins->getSample();
-  auto mod = ins->getSource();
-  const auto msd = mod->getDistance(*sam);
-  const auto det = ins->getComponentByName(detectorName);
-  const auto mdd = mod->getDistance(*det);
+  auto mdd = msd + ins->getComponentByName(detectorName)->getDistance(*(ins->getSample()));
+
   // Creates a function that correct TOF values
   struct correctTofFactory {
 

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -13,6 +13,7 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/EmptyValues.h"
 
+#include <functional>
 #include <vector>
 
 namespace Mantid {
@@ -47,6 +48,10 @@ void EQSANSCorrectFrame::init() {
   declareProperty("FrameSkipping", false,
                   "If True, the data was taken in frame skipping mode",
                   Direction::Input);
+  declareProperty("PathToPixel", true,
+                  "If True, use path from moderator to individual pixel instead"
+                  "of to center of the detector panel",
+                  Direction::Input);
 }
 
 void EQSANSCorrectFrame::exec() {
@@ -58,7 +63,13 @@ void EQSANSCorrectFrame::exec() {
   const double minTOF = getProperty("MinTOF");
   const double frameWidth = getProperty("FrameWidth");
   const bool isFrameSkipping = getProperty("FrameSkipping");
+  const bool pathToPixel = getProperty("PathToPixel");
   const auto &spectrumInfo = inputWS->spectrumInfo();
+
+  const auto &ins = inputWS->getInstrument();
+  const auto msd = ins.getSample().getDistance(ins.getSource());  // mod. to sample
+  const auto &det = ins.getComponentyByName("detector1"); // center of detector panel
+  const auto mdd = det.getDistance(ins.getSource());  // moderator to detector dist.
 
   // Creates a function that correct TOF values
   struct correctTofFactory {
@@ -66,8 +77,7 @@ void EQSANSCorrectFrame::exec() {
     explicit correctTofFactory(double pulsePeriod, double minTOF,
                                double frameWidth, bool isFrameSkipping)
         : m_pulsePeriod(pulsePeriod), m_minTOF(minTOF),
-          m_frameWidth(frameWidth), m_minTOF_delayed(minTOF + pulsePeriod),
-          m_isFrameSkipping(isFrameSkipping) {
+          m_frameWidth(frameWidth), m_isFrameSkipping(isFrameSkipping) {
       // Find how many frame widths elapsed from the time the neutrons of the
       // lead pulse were emitted and the time the neutrons arrived to the
       // detector bank. This time must be added to the stored TOF values
@@ -75,15 +85,16 @@ void EQSANSCorrectFrame::exec() {
       m_framesOffsetTime = frameWidth * nf;
     }
 
-    double operator()(const double tof) const {
+    double operator()(const double tof, const double pathToPixelFactor=1.0) const {
       // shift times to the correct frame
       double newTOF = tof + m_framesOffsetTime;
       // TOF values smaller than that of the fastest neutrons have been
       // 'folded' by the data acquisition system. They must be shifted
-      if (newTOF < m_minTOF)
+      double minTOF = m_minTOF * pathToPixelFactor;
+      if (newTOF < minTOF)
         newTOF += m_frameWidth;
       // Events from the skipped pulse are delayed by one pulse period
-      if (m_isFrameSkipping && newTOF > m_minTOF_delayed)
+      if (m_isFrameSkipping && newTOF > minTOF + m_pulsePeriod)
         newTOF += m_pulsePeriod;
       return newTOF;
     }
@@ -92,7 +103,6 @@ void EQSANSCorrectFrame::exec() {
     double m_minTOF;
     double m_frameWidth;
     double m_framesOffsetTime;
-    double m_minTOF_delayed;
     bool m_isFrameSkipping;
   };
 
@@ -111,7 +121,17 @@ void EQSANSCorrectFrame::exec() {
     EventList &evlist = inputWS->getSpectrum(ispec);
     if (evlist.getNumberEvents() == 0)
       continue; // no events recorded in this spectrum
-    evlist.convertTof(correctTof);
+
+    // Determine the factor by which to enlarge the minimum time-of-flight
+    // if considering the path to the pixel instead of to the detector center
+    double pathToPixelFactor(1.0);  // factor for path to detector center
+    if (pathToPixel) {
+      pathToPixelFactor = (msd + spectrumInfo.l2(ispec)) / mdd;
+    }
+    auto tofCorrector =
+        std::bind(correctTof, std::placeholders::_1, pathToPixelFactor);
+
+    evlist.convertTof(tofCorrector);
     progress.report("Correct TOF frame");
     PARALLEL_END_INTERUPT_REGION
   }

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -14,8 +14,8 @@
 #include "MantidKernel/EmptyValues.h"
 
 #include <functional>
-#include <vector>
 #include <string>
+#include <vector>
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -68,9 +68,9 @@ void EQSANSCorrectFrame::exec() {
 
   auto ins = inputWS->getInstrument();
   auto sam = ins->getSample();
-  auto mod = ins->getSource():
+  auto mod = ins->getSource();
   const auto msd = mod->getDistance(*sam);
-  const auto det = ins->getComponentyByName("detector1");
+  const auto det = ins->getComponentByName("detector1");
   const auto mdd = mod->getDistance(*det);
 
   // Creates a function that correct TOF values

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -67,9 +67,9 @@ void EQSANSCorrectFrame::exec() {
   const auto &spectrumInfo = inputWS->spectrumInfo();
 
   const auto &ins = inputWS->getInstrument();
-  const auto msd = ins.getSample().getDistance(ins.getSource());  // mod. to sample
-  const auto &det = ins.getComponentyByName("detector1"); // center of detector panel
-  const auto mdd = det.getDistance(ins.getSource());  // moderator to detector dist.
+  const auto msd = ins.getSample().getDistance(ins.getSource());
+  const auto &det = ins.getComponentyByName("detector1");
+  const auto mdd = det.getDistance(ins.getSource());
 
   // Creates a function that correct TOF values
   struct correctTofFactory {
@@ -85,7 +85,8 @@ void EQSANSCorrectFrame::exec() {
       m_framesOffsetTime = frameWidth * nf;
     }
 
-    double operator()(const double tof, const double pathToPixelFactor=1.0) const {
+    double operator()(const double tof,
+                      const double pathToPixelFactor = 1.0) const {
       // shift times to the correct frame
       double newTOF = tof + m_framesOffsetTime;
       // TOF values smaller than that of the fastest neutrons have been
@@ -124,7 +125,7 @@ void EQSANSCorrectFrame::exec() {
 
     // Determine the factor by which to enlarge the minimum time-of-flight
     // if considering the path to the pixel instead of to the detector center
-    double pathToPixelFactor(1.0);  // factor for path to detector center
+    double pathToPixelFactor(1.0); // factor for path to detector center
     if (pathToPixel) {
       pathToPixelFactor = (msd + spectrumInfo.l2(ispec)) / mdd;
     }

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include <vector>
+#include <string>
 
 namespace Mantid {
 namespace Algorithms {
@@ -52,6 +53,7 @@ void EQSANSCorrectFrame::init() {
                   "If True, use path from moderator to individual pixel instead"
                   "of to center of the detector panel",
                   Direction::Input);
+  declareProperty("DetectorName", "detector1", "Name of the double panel");
 }
 
 void EQSANSCorrectFrame::exec() {
@@ -64,15 +66,15 @@ void EQSANSCorrectFrame::exec() {
   const double frameWidth = getProperty("FrameWidth");
   const bool isFrameSkipping = getProperty("FrameSkipping");
   const bool pathToPixel = getProperty("PathToPixel");
-  const auto &spectrumInfo = inputWS->spectrumInfo();
+  const std::string detectorName = getProperty("DetectorName");
 
+  const auto &spectrumInfo = inputWS->spectrumInfo();
   auto ins = inputWS->getInstrument();
   auto sam = ins->getSample();
   auto mod = ins->getSource();
   const auto msd = mod->getDistance(*sam);
-  const auto det = ins->getComponentByName("detector1");
+  const auto det = ins->getComponentByName(detectorName);
   const auto mdd = mod->getDistance(*det);
-
   // Creates a function that correct TOF values
   struct correctTofFactory {
 

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -66,10 +66,10 @@ void EQSANSCorrectFrame::exec() {
   const bool pathToPixel = getProperty("PathToPixel");
   const auto &spectrumInfo = inputWS->spectrumInfo();
 
-  const auto &ins = inputWS->getInstrument();
-  const auto msd = ins.getSample().getDistance(ins.getSource());
-  const auto &det = ins.getComponentyByName("detector1");
-  const auto mdd = det.getDistance(ins.getSource());
+  const auto ins = inputWS->getInstrument();
+  const auto msd = ins->getSample()->getDistance(ins->getSource());
+  const auto det = ins->getComponentyByName("detector1");
+  const auto mdd = det->getDistance(ins->getSource());
 
   // Creates a function that correct TOF values
   struct correctTofFactory {

--- a/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
+++ b/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
@@ -32,7 +32,7 @@ public:
   // constructor
   EQSANSCorrectFrameTest()
       : m_pulseWidth(1.E6 / 60), m_frameWidth(2.E6 / 60), m_minTOF(4.1E6 / 60),
-        m_frameSkipping(true), m_bankSize(2){
+        m_frameSkipping(true), m_bankSize(2) {
 
     // bank contains m_bankSize^2 pixels
     const int numBanks = 1;
@@ -57,7 +57,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT(alg.isInitialized());
   }
-
 
   void testExec() {
     Mantid::Algorithms::EQSANSCorrectFrame alg;
@@ -84,14 +83,14 @@ public:
     }
   }
 
-private : EventWorkspace_sptr m_ews;
-double m_pulseWidth;
-double m_frameWidth;
-double m_minTOF;
-bool m_frameSkipping;
-int m_bankSize;
-void cleanup() { return; }
-}
-;
+private:
+  EventWorkspace_sptr m_ews;
+  double m_pulseWidth;
+  double m_frameWidth;
+  double m_minTOF;
+  bool m_frameSkipping;
+  int m_bankSize;
+  void cleanup() { return; }
+};
 
 #endif // MANTID_ALGORITHMS_EQSANSCORRECTFRAMETEST_H_

--- a/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
+++ b/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
@@ -79,20 +79,21 @@ public:
       TS_ASSERT_EQUALS(events.size(), 1);
       TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
     }
-  }
 
-  // Path to each pixel
-  alg.setProperty("PathToPixel", true);
-  alg.execute();
-  std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
-  const double pulseWidth(m_pulseWidth);
-  std::transform(tofs.begin(), tofs.end(), tofs.begin(),
-                 [&pulseWidth](double tof) { return tof * pulseWidth; });
-  const int numPixels(m_bankSize *m_bankSize);
-  for (int i = 0; i < numPixels; i++) {
-    std::vector<TofEvent> &events = m_ews->getSpectrum(i).getEvents();
-    TS_ASSERT_EQUALS(events.size(), 1);
-    TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
+
+    // Path to each pixel
+    alg.setProperty("PathToPixel", true);
+    alg.execute();
+    std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
+    const double pulseWidth(m_pulseWidth);
+    std::transform(tofs.begin(), tofs.end(), tofs.begin(),
+                  [&pulseWidth](double tof) { return tof * pulseWidth; });
+    const int numPixels(m_bankSize *m_bankSize);
+    for (int i = 0; i < numPixels; i++) {
+      std::vector<TofEvent> &events = m_ews->getSpectrum(i).getEvents();
+      TS_ASSERT_EQUALS(events.size(), 1);
+      TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
+    }
   }
 }
 

--- a/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
+++ b/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
@@ -40,10 +40,11 @@ public:
     m_ews->getAxis(0)->setUnit("TOF");
 
     // insert one event in each pixel
-    std::vector<double> tofs = {0.05, 0.15, 1.05, 1.15};  // in units of pulseWidth
+    std::vector<double> tofs = {0.05, 0.15, 1.05, 1.15};
     const double pulseWidth(m_pulseWidth);
-    std::transform(tofs.begin(), tofs.end(), tofs.begin(),
-                   [&pulseWidth](double tof) { return tof * pulseWidth; }); // in micro-sec
+    std::transform(
+        tofs.begin(), tofs.end(), tofs.begin(),
+        [&pulseWidth](double tof) { return tof * pulseWidth; });
     const int numPixels(m_bankSize * m_bankSize);
     for (int i = 0; i < numPixels; i++) {
       EventList &evlist = m_ews->getSpectrum(i);
@@ -82,29 +83,28 @@ public:
   }
 
   // Path to each pixel
-  alg.setProperty("PathToPixel", false);
+  alg.setProperty("PathToPixel", true);
   alg.execute();
-      std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
-    const double pulseWidth(m_pulseWidth);
-    std::transform(tofs.begin(), tofs.end(), tofs.begin(),
-                   [&pulseWidth](double tof) { return tof * pulseWidth; });
-    const int numPixels(m_bankSize * m_bankSize);
-    for (int i = 0; i < numPixels; i++) {
-      std::vector<TofEvent> &events = m_ews->getSpectrum(i).getEvents();
-      TS_ASSERT_EQUALS(events.size(), 1);
-      TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
-    }
+  std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
+  const double pulseWidth(m_pulseWidth);
+  std::transform(tofs.begin(), tofs.end(), tofs.begin(),
+                 [&pulseWidth](double tof) { return tof * pulseWidth; });
+  const int numPixels(m_bankSize *m_bankSize);
+  for (int i = 0; i < numPixels; i++) {
+    std::vector<TofEvent> &events = m_ews->getSpectrum(i).getEvents();
+    TS_ASSERT_EQUALS(events.size(), 1);
+    TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
   }
+}
 
-
-private:
-  EventWorkspace_sptr m_ews;
-  double m_pulseWidth;
-  double m_frameWidth;
-  double m_minTOF;
-  bool m_frameSkipping;
-  int m_bankSize;
-  void cleanup() { return; }
-};
+private : EventWorkspace_sptr m_ews;
+double m_pulseWidth;
+double m_frameWidth;
+double m_minTOF;
+bool m_frameSkipping;
+int m_bankSize;
+void cleanup() { return; }
+}
+;
 
 #endif // MANTID_ALGORITHMS_EQSANSCORRECTFRAMETEST_H_

--- a/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
+++ b/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
@@ -42,9 +42,8 @@ public:
     // insert one event in each pixel
     std::vector<double> tofs = {0.05, 0.15, 1.05, 1.15};
     const double pulseWidth(m_pulseWidth);
-    std::transform(
-        tofs.begin(), tofs.end(), tofs.begin(),
-        [&pulseWidth](double tof) { return tof * pulseWidth; });
+    std::transform(tofs.begin(), tofs.end(), tofs.begin(),
+                   [&pulseWidth](double tof) { return tof * pulseWidth; });
     const int numPixels(m_bankSize * m_bankSize);
     for (int i = 0; i < numPixels; i++) {
       EventList &evlist = m_ews->getSpectrum(i);

--- a/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
+++ b/Framework/Algorithms/test/EQSANSCorrectFrameTest.h
@@ -40,10 +40,10 @@ public:
     m_ews->getAxis(0)->setUnit("TOF");
 
     // insert one event in each pixel
-    std::vector<double> tofs = {0.05, 0.15, 1.05, 1.15};
+    std::vector<double> tofs = {0.05, 0.15, 1.05, 1.15};  // in units of pulseWidth
     const double pulseWidth(m_pulseWidth);
     std::transform(tofs.begin(), tofs.end(), tofs.begin(),
-                   [&pulseWidth](double tof) { return tof * pulseWidth; });
+                   [&pulseWidth](double tof) { return tof * pulseWidth; }); // in micro-sec
     const int numPixels(m_bankSize * m_bankSize);
     for (int i = 0; i < numPixels; i++) {
       EventList &evlist = m_ews->getSpectrum(i);
@@ -64,6 +64,9 @@ public:
     alg.setProperty("MinTOF", m_minTOF);
     alg.setProperty("FrameWidth", m_frameWidth);
     alg.setProperty("FrameSkipping", m_frameSkipping);
+
+    // Path to center of detector
+    alg.setProperty("PathToPixel", false);
     alg.execute();
 
     std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
@@ -77,6 +80,22 @@ public:
       TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
     }
   }
+
+  // Path to each pixel
+  alg.setProperty("PathToPixel", false);
+  alg.execute();
+      std::vector<double> tofs = {7.05, 4.15, 5.05, 6.15};
+    const double pulseWidth(m_pulseWidth);
+    std::transform(tofs.begin(), tofs.end(), tofs.begin(),
+                   [&pulseWidth](double tof) { return tof * pulseWidth; });
+    const int numPixels(m_bankSize * m_bankSize);
+    for (int i = 0; i < numPixels; i++) {
+      std::vector<TofEvent> &events = m_ews->getSpectrum(i).getEvents();
+      TS_ASSERT_EQUALS(events.size(), 1);
+      TS_ASSERT_DELTA(events[0].tof(), tofs[i], 1.0E-03 * m_pulseWidth);
+    }
+  }
+
 
 private:
   EventWorkspace_sptr m_ews;

--- a/docs/source/release/v4.2.0/sans.rst
+++ b/docs/source/release/v4.2.0/sans.rst
@@ -9,4 +9,9 @@ SANS Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Improved
+########
+
+- Option in :ref:`EQSANSCorrectFrame <algm-EQSANSCorrectFrame>` to correct TOF by path to individual pixel
+
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
**Description of work.**
- [x] add option to algorithm to select path
- [x] unit test with path-to-pixel enabled
- [x] updated [release notes](https://github.com/mantidproject/mantid/blob/7eebc59504a90b9662a65120817bf7c30970df20/docs/source/release/v4.2.0/sans.rst#improved)

**To test:**

Please review the code. Testing against the old correction (EQSANSLoad) is done in the integration tests of sans-rewrite's package ornl.sans.sns.eqsans.correct_frame.py

Fixes #26621
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
