### PR TITLE
Workbench fixing table validation

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -25,5 +25,6 @@ Bugfixes
 - Fixes an issue where choosing to not overwrite an existing project when attempting to save upon closing would cause Workbench to close without saving.
 - Fit results on normalised plots are now also normalised to match the plot.
 - A crash in the Fit Browser when the default peak was not a registered peak type has been fixed.
+- Fixed an issue where you could not edit table workspaces to enter negative numbers.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
@@ -30,7 +30,7 @@ class PreciseDoubleFactory(QItemEditorFactory):
         if user_type == QVariant.Double:
             widget.setFrame(True)
             widget.setDecimals(16)
-            widget.setRange(sys.float_info.min, sys.float_info.max)
+            widget.setRange(-sys.float_info.max, sys.float_info.max)
 
         return widget
 


### PR DESCRIPTION
**Description of work.**

Currently if you try to manually edit a table workspace in workbench you are unable to enter negative numbers. This updates the range validation so that negative numbers are allowed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * Create a Table workspace

```
my_table = CreateEmptyTableWorkspace()

my_table.setTitle("My Data List")

my_table.addColumn("str", "Instrument Name")
my_table.addColumn("int", "Run Number")

my_table.addRow(["MUSR", 10245])
my_table.addRow(["IRIS", 8465])
my_table.addRow(["SANS2D", 20462])
```

Open it and try to change one of the numbers to a negative number.

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
