### PR TITLE
Add reflectometry GUI runs presenter tests

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -122,9 +122,6 @@ protected:
   /// The algorithm used when the live data monitor is running
   Mantid::API::IAlgorithm_sptr m_monitorAlg;
 
-  std::string liveDataReductionOptions(const std::string &inputWorkspace,
-                                       const std::string &instrument);
-
 private:
   /// The main view we're managing
   IRunsView *m_view;
@@ -168,6 +165,9 @@ private:
   void stopMonitor();
   void startMonitorComplete();
   std::string liveDataReductionAlgorithm();
+  std::string liveDataReductionOptions(const std::string &inputWorkspace,
+                                       const std::string &instrument);
+
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 
   void handleError(const std::string &message, const std::exception &e);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -119,6 +119,8 @@ protected:
   std::unique_ptr<IRunNotifier> m_runNotifier;
   /// The search implementation
   std::unique_ptr<ISearcher> m_searcher;
+  /// The algorithm used when the live data monitor is running
+  Mantid::API::IAlgorithm_sptr m_monitorAlg;
 
   std::string liveDataReductionOptions(const std::string &inputWorkspace,
                                        const std::string &instrument);
@@ -136,8 +138,7 @@ private:
   std::vector<std::string> m_instruments;
   /// The default index in the instrument list
   int m_defaultInstrumentIndex;
-  /// The name to use for the live data workspace
-  Mantid::API::IAlgorithm_sptr m_monitorAlg;
+  /// The tolerance used when looking up settings by theta
   double m_thetaTolerance;
 
   bool isAnyBatchAutoreducing() const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidatePerThetaDefaults.cpp
@@ -7,7 +7,6 @@
 #include "ValidatePerThetaDefaults.h"
 #include "AllInitialized.h"
 #include "Common/Parse.h"
-#include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/variant.hpp>

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -491,19 +491,17 @@ public:
     expectGetLiveDataOptions(options);
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
-    assertPostProcessingPropertiesEqual(options, algRunner);
+    assertPostProcessingPropertiesContainOptions(options, algRunner);
     verifyAndClear();
   }
 
   void testStartMonitorSetsUserSpecifiedPostProcessingProperties() {
     auto presenter = makePresenter();
-    auto options = defaultLiveMonitorReductionOptions();
-    options["Prop1"] = "val1";
-    options["Prop2"] = "val2";
+    auto options = AlgorithmRuntimeProps{{"Prop1", "val1"}, {"Prop2", "val2"}};
     expectGetLiveDataOptions(options);
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
-    assertPostProcessingPropertiesEqual(options, algRunner);
+    assertPostProcessingPropertiesContainOptions(options, algRunner);
     verifyAndClear();
   }
 
@@ -865,13 +863,25 @@ private:
       TS_ASSERT_EQUALS(alg->getPropertyValue(kvp.first), kvp.second);
   }
 
-  void assertPostProcessingPropertiesEqual(
+  void assertStartMonitorPropertiesEqual(
       AlgorithmRuntimeProps const &expected,
       boost::shared_ptr<NiceMock<MockAlgorithmRunner>> &algRunner) {
     auto alg = algRunner->algorithm();
     auto result = alg->getPropertyValue("PostProcessingProperties");
     auto expectedString = optionsToString(expected, false, ";");
     TS_ASSERT_EQUALS(result, expectedString);
+  }
+
+  void assertPostProcessingPropertiesContainOptions(
+      AlgorithmRuntimeProps &expected,
+      boost::shared_ptr<NiceMock<MockAlgorithmRunner>> &algRunner) {
+    auto alg = algRunner->algorithm();
+    auto resultString = alg->getPropertyValue("PostProcessingProperties");
+    auto result = parseKeyValueString(resultString, ";");
+    for (auto const &kvp : expected) {
+      TS_ASSERT(result.find(kvp.first) != result.end());
+      TS_ASSERT_EQUALS(result[kvp.first], expected[kvp.first]);
+    }
   }
 
   double m_thetaTolerance;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -485,24 +485,21 @@ public:
     verifyAndClear();
   }
 
-  void testLiveDataReductionOptions() {
-    auto presenter = makePresenter();
-    auto props = AlgorithmRuntimeProps{{"Prop1", "val1"}, {"Prop2", "val2"}};
-    EXPECT_CALL(m_mainPresenter, rowProcessingProperties())
-        .Times(1)
-        .WillOnce(Return(props));
-    auto result =
-        presenter.liveDataReductionOptions("live_input_workspace", "INTER");
-    auto expected =
-        "GetLiveValueAlgorithm=GetLiveInstrumentValue;InputWorkspace="
-        "live_input_workspace;Instrument=INTER;Prop1=val1;Prop2="
-        "val2";
-    TS_ASSERT_EQUALS(result, expected);
-  }
-
-  void testStartMonitorSetsDefaultReductionAlgorithmProperties() {
+  void testStartMonitorSetsDefaultPostProcessingProperties() {
     auto presenter = makePresenter();
     auto options = defaultLiveMonitorReductionOptions();
+    expectGetLiveDataOptions(options);
+    auto algRunner = expectGetAlgorithmRunner();
+    presenter.notifyStartMonitor();
+    assertPostProcessingPropertiesEqual(options, algRunner);
+    verifyAndClear();
+  }
+
+  void testStartMonitorSetsUserSpecifiedPostProcessingProperties() {
+    auto presenter = makePresenter();
+    auto options = defaultLiveMonitorReductionOptions();
+    options["Prop1"] = "val1";
+    options["Prop2"] = "val2";
     expectGetLiveDataOptions(options);
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -489,7 +489,8 @@ public:
 
   void testStartMonitor() {
     auto presenter = makePresenter();
-    expectGetLiveDataOptions();
+    auto options = AlgorithmRuntimeProps();
+    expectGetLiveDataOptions(options);
     auto algRunner = expectGetAlgorithmRunner();
     EXPECT_CALL(*algRunner, startAlgorithm(_)).Times(1);
     expectUpdateViewWhenMonitorStarting();
@@ -812,15 +813,11 @@ private:
         .WillRepeatedly(Return(false));
   }
 
-  void expectGetLiveDataOptions() {
+  void expectGetLiveDataOptions(AlgorithmRuntimeProps const &options) {
     auto const instrument = std::string("OFFSPEC");
     EXPECT_CALL(m_view, getSearchInstrument())
         .Times(1)
         .WillOnce(Return(instrument));
-    auto options = AlgorithmRuntimeProps{
-        {"InputWorkspace", "TOF_live"},
-        {"Instrument", instrument},
-        {"GetLieValueAlgorithm", "GetLiveInstrumentValue"}};
     EXPECT_CALL(m_mainPresenter, rowProcessingProperties())
         .Times(1)
         .WillOnce(Return(options));

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -408,6 +408,30 @@ public:
     verifyAndClear();
   }
 
+  void testTransferUpdatesTablePresenter() {
+    auto presenter = makePresenter();
+    // Set up a valid search result with content
+    auto const rowIndex = 0;
+    auto const selectedRows = std::set<int>({rowIndex});
+    EXPECT_CALL(m_view, getSelectedSearchRows())
+        .Times(1)
+        .WillOnce(Return(selectedRows));
+    auto searchResult = SearchResult("12345", "Test group 1th=0.5", "");
+    EXPECT_CALL(*m_searcher, getSearchResult(rowIndex))
+        .Times(1)
+        .WillOnce(ReturnRef(searchResult));
+    // Check the runs table presenter is notified with the expected content
+    auto jobs = ReductionJobs();
+    auto group = Group("Test group 1");
+    group.appendRow(Row({"12345"}, 0.5, TransmissionRunPair(), RangeInQ(), boost::none,
+               ReductionOptionsMap(),
+               ReductionWorkspaces({"12345"}, TransmissionRunPair())));
+    jobs.appendGroup(group);
+    EXPECT_CALL(*m_runsTablePresenter, mergeAdditionalJobs(jobs)).Times(1);
+    presenter.notifyTransfer();
+    verifyAndClear();
+  }
+
   void testInstrumentChanged() {
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");

--- a/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Runs/RunsPresenterTest.h
@@ -487,18 +487,27 @@ public:
     TS_ASSERT_EQUALS(result, expected);
   }
 
-  void testStartMonitor() {
+  void testStartMonitorStartsAlgorithmRunner() {
     auto presenter = makePresenter();
     auto options = AlgorithmRuntimeProps();
     expectGetLiveDataOptions(options);
     auto algRunner = expectGetAlgorithmRunner();
     EXPECT_CALL(*algRunner, startAlgorithm(_)).Times(1);
+    presenter.notifyStartMonitor();
+    verifyAndClear();
+  }
+
+  void testStartMonitorUpdatesView() {
+    auto presenter = makePresenter();
+    auto options = AlgorithmRuntimeProps();
+    expectGetLiveDataOptions(options);
+    expectGetAlgorithmRunner();
     expectUpdateViewWhenMonitorStarting();
     presenter.notifyStartMonitor();
     verifyAndClear();
   }
 
-  void testStopMonitor() {
+  void testStopMonitorUpdatesView() {
     auto presenter = makePresenter();
     presenter.m_monitorAlg =
         AlgorithmManager::Instance().createUnmanaged("MonitorLiveData");

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -573,6 +573,7 @@ set(
   inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
   inc/MantidQtWidgets/Common/AlgorithmInputHistory.h
   inc/MantidQtWidgets/Common/AlgorithmRunner.h
+  inc/MantidQtWidgets/Common/MockAlgorithmRunner.h
   inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
   inc/MantidQtWidgets/Common/AlgorithmDialogFactory.h
   inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRunner.h
@@ -37,10 +37,10 @@ public:
   explicit AlgorithmRunner(QObject *parent = nullptr);
   ~AlgorithmRunner() override;
 
-  void cancelRunningAlgorithm();
+  virtual void cancelRunningAlgorithm();
 
-  void startAlgorithm(Mantid::API::IAlgorithm_sptr alg);
-  Mantid::API::IAlgorithm_sptr getAlgorithm() const;
+  virtual void startAlgorithm(Mantid::API::IAlgorithm_sptr alg);
+  virtual Mantid::API::IAlgorithm_sptr getAlgorithm() const;
 
 signals:
   /// Signal emitted when the algorithm has completed execution/encountered an

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockAlgorithmRunner.h
@@ -1,0 +1,30 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_MANTIDWIDGETS_MOCKALGORITHMRUNNER_H
+#define MANTIDQT_MANTIDWIDGETS_MOCKALGORITHMRUNNER_H
+
+#include "MantidAPI/IAlgorithm_fwd.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/AlgorithmRunner.h"
+
+#include <gmock/gmock.h>
+
+using namespace MantidQt::API;
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockAlgorithmRunner : public AlgorithmRunner {
+public:
+  MockAlgorithmRunner() = default;
+  MOCK_METHOD0(cancelRunningAlgorithm, void());
+  MOCK_METHOD1(startAlgorithm, void(Mantid::API::IAlgorithm_sptr));
+  MOCK_CONST_METHOD0(getAlgorithm, Mantid::API::IAlgorithm_sptr());
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+#endif

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockAlgorithmRunner.h
@@ -21,8 +21,20 @@ class MockAlgorithmRunner : public AlgorithmRunner {
 public:
   MockAlgorithmRunner() = default;
   MOCK_METHOD0(cancelRunningAlgorithm, void());
-  MOCK_METHOD1(startAlgorithm, void(Mantid::API::IAlgorithm_sptr));
+  MOCK_METHOD1(startAlgorithmImpl, void(Mantid::API::IAlgorithm_sptr));
   MOCK_CONST_METHOD0(getAlgorithm, Mantid::API::IAlgorithm_sptr());
+
+  // Wrapper around startAlgorithmImpl to allow us to record
+  // which algorithm was started
+  void startAlgorithm(Mantid::API::IAlgorithm_sptr alg) {
+    m_algorithm = alg;
+    startAlgorithmImpl(alg);
+  }
+
+  Mantid::API::IAlgorithm_sptr algorithm() const { return m_algorithm; }
+
+private:
+  Mantid::API::IAlgorithm_sptr m_algorithm;
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
@@ -39,8 +39,9 @@ convertMapToString(const std::map<QString, QString> &optionsMap,
 std::string EXPORT_OPT_MANTIDQT_COMMON
 convertMapToString(const std::map<std::string, std::string> &optionsMap,
                    const char separator, const bool quoteValues);
-std::string EXPORT_OPT_MANTIDQT_COMMON
-optionsToString(std::map<std::string, std::string> const &options);
+std::string EXPORT_OPT_MANTIDQT_COMMON optionsToString(
+    std::map<std::string, std::string> const &options,
+    const bool quoteValues = true, const std::string separator = ", ");
 } // namespace MantidWidgets
 } // namespace MantidQt
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
@@ -24,10 +24,10 @@ into a map of key/value pairs.
 namespace MantidQt {
 namespace MantidWidgets {
 
-std::map<std::string, std::string>
-    DLLExport parseKeyValueString(const std::string &str);
+std::map<std::string, std::string> DLLExport
+parseKeyValueString(const std::string &str, const std::string &separator = ",");
 MantidQt::MantidWidgets::DataProcessor::OptionsMap DLLExport
-parseKeyValueQString(const QString &str);
+parseKeyValueQString(const QString &str, const std::string &separator = ",");
 // Trim leading/trailing whitespace and quotes from a string
 void trimWhitespaceAndQuotes(const QString &valueIn);
 // Trim whitespace, quotes and empty values from a string list
@@ -41,7 +41,7 @@ convertMapToString(const std::map<std::string, std::string> &optionsMap,
                    const char separator, const bool quoteValues);
 std::string EXPORT_OPT_MANTIDQT_COMMON optionsToString(
     std::map<std::string, std::string> const &options,
-    const bool quoteValues = true, const std::string separator = ", ");
+    const bool quoteValues = true, const std::string &separator = ", ");
 } // namespace MantidWidgets
 } // namespace MantidQt
 

--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -13,6 +13,16 @@
 namespace MantidQt {
 namespace MantidWidgets {
 
+namespace {
+void appendKeyValuePair(const std::pair<std::string, std::string> &kvp,
+                        const bool quoteValues,
+                        std::ostringstream &resultStream) {
+  if (quoteValues)
+    resultStream << kvp.first << "='" << kvp.second << '\'';
+  else
+    resultStream << kvp.first << "=" << kvp.second;
+}
+
 /** Trim matching start/end quotes from the given string
  *
  * @param value [inout] : string to trim
@@ -39,6 +49,7 @@ void trimQuotes(QString &value, const char quote, const char escape) {
     }
   }
 }
+} // unnamed namespace
 
 /** Trim whitespace and quotes from the start/end of a string.
  * Edits the value in-place.
@@ -77,10 +88,12 @@ void trimWhitespaceQuotesAndEmptyValues(QStringList &values) {
    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'`
    into a map of key/value pairs
    @param str The input string
+   @param separator The character between each key=value pair
    @throws std::runtime_error on an invalid input string
    @returns : a map of key/value pairs as strings
 */
-std::map<std::string, std::string> parseKeyValueString(const std::string &str) {
+std::map<std::string, std::string>
+parseKeyValueString(const std::string &str, const std::string &separator) {
   /*
     This is a bad example of using a tokenizer, and
     Mantid::Kernel::StringTokenizer should
@@ -92,7 +105,7 @@ std::map<std::string, std::string> parseKeyValueString(const std::string &str) {
     yet possible with Mantid::Kernel::StringTokenizer.
   */
   boost::tokenizer<boost::escaped_list_separator<char>> tok(
-      str, boost::escaped_list_separator<char>("\\", ",", "\"'"));
+      str, boost::escaped_list_separator<char>("\\", separator, "\"'"));
   std::map<std::string, std::string> kvp;
 
   for (const auto &it : tok) {
@@ -127,10 +140,12 @@ std::map<std::string, std::string> parseKeyValueString(const std::string &str) {
    Parses a string in the format `a = 1,b=2, c = "1,2,3,4", d = 5.0, e='a,b,c'`
    into a map of key/value pairs
    @param qstr The input string
+   @param separator The character between each key=value pair
    @throws std::runtime_error on an invalid input string
    @returns : a map of key/value pairs as QStrings
 */
-std::map<QString, QString> parseKeyValueQString(const QString &qstr) {
+std::map<QString, QString> parseKeyValueQString(const QString &qstr,
+                                                const std::string &separator) {
   /*
     This is a bad example of using a tokenizer, and
     Mantid::Kernel::StringTokenizer should
@@ -143,7 +158,7 @@ std::map<QString, QString> parseKeyValueQString(const QString &qstr) {
   */
   auto str = qstr.toStdString();
   boost::tokenizer<boost::escaped_list_separator<char>> tok(
-      str, boost::escaped_list_separator<char>("\\", ",", "\"'"));
+      str, boost::escaped_list_separator<char>("\\", separator, "\"'"));
   std::map<QString, QString> kvp;
 
   for (const auto &it : tok) {
@@ -227,18 +242,9 @@ convertMapToString(const std::map<std::string, std::string> &optionsMap,
   return result;
 }
 
-void appendKeyValuePair(const std::pair<std::string, std::string> kvp,
-                        const bool quoteValues,
-                        std::ostringstream &resultStream) {
-  if (quoteValues)
-    resultStream << kvp.first << "='" << kvp.second << '\'';
-  else
-    resultStream << kvp.first << "=" << kvp.second;
-}
-
 std::string optionsToString(std::map<std::string, std::string> const &options,
                             const bool quoteValues,
-                            const std::string separator) {
+                            const std::string &separator) {
   if (!options.empty()) {
     std::ostringstream resultStream;
     auto optionsKvpIt = options.cbegin();

--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -227,18 +227,30 @@ convertMapToString(const std::map<std::string, std::string> &optionsMap,
   return result;
 }
 
-std::string optionsToString(std::map<std::string, std::string> const &options) {
+void appendKeyValuePair(const std::pair<std::string, std::string> kvp,
+                        const bool quoteValues,
+                        std::ostringstream &resultStream) {
+  if (quoteValues)
+    resultStream << kvp.first << "='" << kvp.second << '\'';
+  else
+    resultStream << kvp.first << "=" << kvp.second;
+}
+
+std::string optionsToString(std::map<std::string, std::string> const &options,
+                            const bool quoteValues,
+                            const std::string separator) {
   if (!options.empty()) {
     std::ostringstream resultStream;
     auto optionsKvpIt = options.cbegin();
 
     auto const &firstKvp = (*optionsKvpIt);
-    resultStream << firstKvp.first << "='" << firstKvp.second << '\'';
+    appendKeyValuePair(firstKvp, quoteValues, resultStream);
     ++optionsKvpIt;
 
     for (; optionsKvpIt != options.cend(); ++optionsKvpIt) {
       auto kvp = (*optionsKvpIt);
-      resultStream << ", " << kvp.first << "='" << kvp.second << '\'';
+      resultStream << separator;
+      appendKeyValuePair(kvp, quoteValues, resultStream);
     }
 
     return resultStream.str();

--- a/qt/widgets/common/test/ParseKeyValueStringTest.h
+++ b/qt/widgets/common/test/ParseKeyValueStringTest.h
@@ -14,34 +14,85 @@ using MantidQt::MantidWidgets::parseKeyValueQString;
 using MantidQt::MantidWidgets::parseKeyValueString;
 
 class ParseKeyValueStringTest : public CxxTest::TestSuite {
-
 public:
-  void testParseKeyValueString() {
-    std::map<std::string, std::string> kvp = parseKeyValueString(
-        R"(a = 1,b=2.0, c=3, d='1,2,3',e="4,5,6",f=1+1=2, g = '\'')");
+  using StdMap = std::map<std::string, std::string>;
+  using QtMap = std::map<QString, QString>;
+  static constexpr const char *TEST_STRING =
+      R"(a = 1,b=2.0, c=3, d='1,2,3',e="4,5,6",f=1+1=2, g = '\'')";
 
-    TS_ASSERT_EQUALS(kvp["a"], "1");
-    TS_ASSERT_EQUALS(kvp["b"], "2.0");
-    TS_ASSERT_EQUALS(kvp["c"], "3");
-    TS_ASSERT_EQUALS(kvp["d"], "1,2,3");
-    TS_ASSERT_EQUALS(kvp["e"], "4,5,6");
-    TS_ASSERT_EQUALS(kvp["f"], "1+1=2");
-    TS_ASSERT_EQUALS(kvp["g"], "'");
+  void testStdMapParsedOutputsAreCorrect() {
+    StdMap kvp = parseKeyValueString(TEST_STRING);
+    assertTestStringOutputsAreCorrect(kvp);
+  }
 
+  void testQtMapParsedOutputsAreCorrect() {
+    QtMap kvp = parseKeyValueQString(TEST_STRING);
+    assertTestStringOutputsAreCorrect(kvp);
+  }
+
+  void testStdMapParseKeyValueStringThrowsIfTrailingSeparator() {
     TS_ASSERT_THROWS(parseKeyValueString("a = 1, b = 2, c = 3,"),
                      const std::runtime_error &);
+  }
+
+  void testQtMapParseKeyValueStringThrowsIfTrailingSeparator() {
+    TS_ASSERT_THROWS(parseKeyValueQString("a = 1, b = 2, c = 3,"),
+                     const std::runtime_error &);
+  }
+
+  void testStdParseKeyValueStringThrowsIfNotKeyValuePair() {
     TS_ASSERT_THROWS(parseKeyValueString("a = 1, b = 2, c = 3,d"),
                      const std::runtime_error &);
+  }
+
+  void testQtParseKeyValueStringThrowsIfNotKeyValuePair() {
+    TS_ASSERT_THROWS(parseKeyValueQString("a = 1, b = 2, c = 3,d"),
+                     const std::runtime_error &);
+  }
+
+  void testStdParseKeyValueStringThrowsIfStartsWithSeparator() {
     TS_ASSERT_THROWS(parseKeyValueString(",a = 1"), const std::runtime_error &);
+  }
+
+  void testQtParseKeyValueStringThrowsIfStartsWithSeparator() {
+    TS_ASSERT_THROWS(parseKeyValueQString(",a = 1"),
+                     const std::runtime_error &);
+  }
+
+  void
+  testStdParseKeyValueStringThrowsIfStartsWithSeparatorAndEndsWithEquals() {
     TS_ASSERT_THROWS(parseKeyValueString(",a = 1 = 2,="),
                      const std::runtime_error &);
+  }
+
+  void testQtParseKeyValueStringThrowsIfStartsWithSeparatorAndEndsWithEquals() {
+    TS_ASSERT_THROWS(parseKeyValueQString(",a = 1 = 2,="),
+                     const std::runtime_error &);
+  }
+
+  void testStdParseKeyValueStringThrowsIfValuesOnlyContainEquals() {
     TS_ASSERT_THROWS(parseKeyValueString("=,=,="), const std::runtime_error &);
   }
 
-  void testParseKeyValueQString() {
-    std::map<QString, QString> kvp = parseKeyValueQString(
-        R"(a = 1,b=2.0, c=3, d='1,2,3',e="4,5,6",f=1+1=2, g = '\'')");
+  void testQtParseKeyValueStringThrowsIfValuesOnlyContainEquals() {
+    TS_ASSERT_THROWS(parseKeyValueQString("=,=,="), const std::runtime_error &);
+  }
 
+  void testStdParseKeyValueStringWithCustomSeparator() {
+    StdMap kvp = parseKeyValueString(R"(a=1;b=2)", ";");
+    TS_ASSERT_EQUALS(kvp["a"], "1");
+    TS_ASSERT_EQUALS(kvp["b"], "2");
+  }
+
+  void testQtParseKeyValueStringWithCustomSeparator() {
+    QtMap kvp = parseKeyValueQString(R"(a=1;b=2)", ";");
+    TS_ASSERT_EQUALS(kvp["a"], "1");
+    TS_ASSERT_EQUALS(kvp["b"], "2");
+  }
+
+private:
+  template <class StringType>
+  void assertTestStringOutputsAreCorrect(std::map<StringType, StringType> kvp) {
     TS_ASSERT_EQUALS(kvp["a"], "1");
     TS_ASSERT_EQUALS(kvp["b"], "2.0");
     TS_ASSERT_EQUALS(kvp["c"], "3");
@@ -49,29 +100,6 @@ public:
     TS_ASSERT_EQUALS(kvp["e"], "4,5,6");
     TS_ASSERT_EQUALS(kvp["f"], "1+1=2");
     TS_ASSERT_EQUALS(kvp["g"], "'");
-
-    TS_ASSERT_THROWS(parseKeyValueQString("a = 1, b = 2, c = 3,"),
-                     const std::runtime_error &);
-    TS_ASSERT_THROWS(parseKeyValueQString("a = 1, b = 2, c = 3,d"),
-                     const std::runtime_error &);
-    TS_ASSERT_THROWS(parseKeyValueQString(",a = 1"),
-                     const std::runtime_error &);
-    TS_ASSERT_THROWS(parseKeyValueQString(",a = 1 = 2,="),
-                     const std::runtime_error &);
-    TS_ASSERT_THROWS(parseKeyValueQString("=,=,="), const std::runtime_error &);
-  }
-
-  void testParseKeyValueStringWithCustomSeparator() {
-    std::map<std::string, std::string> kvp =
-        parseKeyValueString(R"(a=1;b=2)", ";");
-    TS_ASSERT_EQUALS(kvp["a"], "1");
-    TS_ASSERT_EQUALS(kvp["b"], "2");
-  }
-
-  void testParseKeyValueQStringWithCustomSeparator() {
-    std::map<QString, QString> kvp = parseKeyValueQString(R"(a=1;b=2)", ";");
-    TS_ASSERT_EQUALS(kvp["a"], "1");
-    TS_ASSERT_EQUALS(kvp["b"], "2");
   }
 };
 

--- a/qt/widgets/common/test/ParseKeyValueStringTest.h
+++ b/qt/widgets/common/test/ParseKeyValueStringTest.h
@@ -60,6 +60,19 @@ public:
                      const std::runtime_error &);
     TS_ASSERT_THROWS(parseKeyValueQString("=,=,="), const std::runtime_error &);
   }
+
+  void testParseKeyValueStringWithCustomSeparator() {
+    std::map<std::string, std::string> kvp =
+        parseKeyValueString(R"(a=1;b=2)", ";");
+    TS_ASSERT_EQUALS(kvp["a"], "1");
+    TS_ASSERT_EQUALS(kvp["b"], "2");
+  }
+
+  void testParseKeyValueQStringWithCustomSeparator() {
+    std::map<QString, QString> kvp = parseKeyValueQString(R"(a=1;b=2)", ";");
+    TS_ASSERT_EQUALS(kvp["a"], "1");
+    TS_ASSERT_EQUALS(kvp["b"], "2");
+  }
 };
 
 #endif // MANTID_MANTIDWIDGETS_PARSEKEYVALUESTRINGTEST_H


### PR DESCRIPTION
This PR adds missing unit tests for the Runs tab on the ISIS Reflectometry GUI. This includes the following main changes:

- Add a test to ensure the table presenter is updated when doing a transfer of runs from the search box.
- Add unit tests for the live data monitor and a `MockAlgorithmRunner` to support them.
- Generalise some supporting functions in `ParseKeyValueString` to help with converting between strings and maps when comparing results.
- Add unit tests for the new `ParseKeyValueString` behaviour and also split up the large existing tests for these functions into smaller units.

**To test:**

- Code review
- Ensure the parsing still works in the ISIS Reflectometry interface. This is used for the Options column and the stitch parameters:
  - Enter instrument `INTER`, run number `13460`, angle `0.5` and Options `ProcessingInstructions=4` on the Runs tab.
  - On the Experiment tab, enter the output stitch params as `Params=-0.02`
  - Back on the Runs tab, click Process.
- Ensure the live data monitor button still works on the interface:
  - Click Start Monitor and check that it attempts to start the live data monitor (it may not succeed if the instrument isn't currently running but should give a sensible error).

Refs #26512 	

*This does not require release notes* because **it concerns testing only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/IndividualTicketTesting/)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
