### PR TITLE
Workbench: Move ProjectSave and ProjectLoad to a worker thread

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -14,7 +14,7 @@ User Interface
 Improvements
 ############
 - The keyboard shortcut Ctrl+N now opens a new tab in the script editor.
-
+- Project Save and Load will no longer freeze when saving and loading large amounts of workspaces and/or interfaces.
 - Attempting to save files that are larger than (by default) 10GB now results in a dialog box to inform the user that it may take a long time and gives them the opportunity to cancel.
 
 Bugfixes

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -520,6 +520,11 @@ class MainWindow(QMainWindow):
 
     # ----------------------- Events ---------------------------------
     def closeEvent(self, event):
+        if self.project.is_saving or self.project.is_loading:
+            event.ignore()
+            self.project.inform_user_not_possible()
+            return
+
         # Check whether or not to save project
         if not self.project.saved:
             # Offer save

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -9,7 +9,6 @@
 from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import os
-from threading import Thread
 
 from qtpy.QtWidgets import QFileDialog, QMessageBox
 from qtpy.QtWidgets import QApplication

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -32,6 +32,9 @@ class Project(AnalysisDataServiceObserver):
         # Has the project been saved, to Access this call .saved
         self.__saved = True
 
+        self.__is_saving = False
+        self.__is_loading = False
+
         # Last save locations
         self.last_project_location = None
 
@@ -52,7 +55,15 @@ class Project(AnalysisDataServiceObserver):
     def __get_saved(self):
         return self.__saved
 
+    def __get_is_saving(self):
+        return self.__is_saving
+
+    def __get_is_loading(self):
+        return self.__is_loading
+
     saved = property(__get_saved)
+    is_saving = property(__get_is_saving)
+    is_loading = property(__get_is_loading)
 
     def save(self):
         """
@@ -107,6 +118,7 @@ class Project(AnalysisDataServiceObserver):
                                   file_filter="Project files ( *" + self.project_file_ext + ")")
 
     def _save(self):
+        self.__is_saving = True
         workspaces_to_save = AnalysisDataService.getObjectNames()
         # Calculate the size of the workspaces in the project.
         project_size = self._get_project_size(workspaces_to_save)
@@ -122,6 +134,13 @@ class Project(AnalysisDataServiceObserver):
             project_saver.save_project(file_name=self.last_project_location, workspace_to_save=workspaces_to_save,
                                        plots_to_save=plots_to_save, interfaces_to_save=interfaces_to_save)
             self.__saved = True
+        self.__is_saving = False
+
+    @staticmethod
+    def inform_user_not_possible():
+        return QMessageBox().information(None, "That action is not possible!",
+                                         "You cannot at present exit workbench whilst it is saving or loading a "
+                                         "project")
 
     @staticmethod
     def _get_project_size(workspace_names):

--- a/qt/python/mantidqt/project/project.py
+++ b/qt/python/mantidqt/project/project.py
@@ -154,6 +154,7 @@ class Project(AnalysisDataServiceObserver):
         The event that is called when open project is clicked on the main window
         :return: None; if the user cancelled.
         """
+        self.__is_loading = True
         file_name = self._load_file_dialog()
         if file_name is None:
             # Cancel close dialogs
@@ -169,6 +170,7 @@ class Project(AnalysisDataServiceObserver):
 
         self.last_project_location = file_name
         self.__saved = True
+        self.__is_loading = False
 
     def _load(self, file_name):
         project_loader = ProjectLoader(self.project_file_ext)

--- a/qt/python/mantidqt/project/projectloader.py
+++ b/qt/python/mantidqt/project/projectloader.py
@@ -15,6 +15,7 @@ from mantidqt.project.workspaceloader import WorkspaceLoader
 from mantidqt.project.plotsloader import PlotsLoader
 from mantidqt.project.decoderfactory import DecoderFactory
 from mantid import AnalysisDataService as ADS, logger
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 def _confirm_all_workspaces_loaded(workspaces_to_confirm):
@@ -66,7 +67,7 @@ class ProjectLoader(object):
 
             # Load interfaces
             if self.project_reader.interface_list is not None:
-                self.load_interfaces(directory=directory)
+                QAppThreadCall(self.load_interfaces)(directory)
 
         return workspace_success
 

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -19,6 +19,7 @@ from mantid.kernel import ConfigService
 from mantid.simpleapi import CreateSampleWorkspace, GroupWorkspaces, RenameWorkspace, UnGroupWorkspace
 from mantid.py3compat import mock
 from mantidqt.project.project import Project
+from mantidqt.utils.qt.testing import start_qapplication
 
 
 class FakeGlobalFigureManager(object):
@@ -30,6 +31,7 @@ def fake_window_finding_function():
     return []
 
 
+@start_qapplication
 class ProjectTest(unittest.TestCase):
     def setUp(self):
         self.fgfm = FakeGlobalFigureManager()

--- a/qt/python/mantidqt/project/test/test_projectloader.py
+++ b/qt/python/mantidqt/project/test/test_projectloader.py
@@ -22,6 +22,7 @@ from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.simpleapi import CreateSampleWorkspace  # noqa
 from mantid.py3compat import mock  # noqa
 from mantidqt.project import projectloader, projectsaver  # noqa
+from mantidqt.utils.qt.testing import start_qapplication  # noqa
 
 
 project_file_ext = ".mtdproj"
@@ -29,6 +30,7 @@ working_directory = tempfile.mkdtemp()
 working_project_file = join(working_directory, "temp" + project_file_ext)
 
 
+@start_qapplication
 class ProjectLoaderTest(unittest.TestCase):
     def setUp(self):
         ws1_name = "ws1"


### PR DESCRIPTION
**Description of work.**
This work will stop Mantid Workbench from freezing when you attempt to save or load.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Workbench
- Load a workspace with data and an instrument
- Open the data display, a plot, and the instrument view for this workspace
- Save the project
- Close and Open Workbench
- Load the project
- Ensure all windows opened again

- Repeat without windows but with 100+ workspaces and ensure that it doesn't freeze or crash workbench.

<!-- Instructions for testing. -->

Fixes #25325 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
