### PR TITLE
ISIS Reflectometry: Reset row state if the reduced workspace is renamed/replaced

### DIFF
--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -15,6 +15,7 @@ ISIS Reflectometry Interface
 Improved
 ########
 
+- Rows and Groups inside of the Runs table will now have their state reset when the underlying reduced workspace is replaced or renamed
 - The polarization correction inputs have been simplified to a single checkbox which when ticked will apply polarization corrections based on properties in the instrument parameters file.
 
 Algorithms

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -286,9 +286,14 @@ BatchJobRunner::notifyWorkspaceRenamed(std::string const &oldName,
   auto item = m_batch.getItemWithOutputWorkspaceOrNone(oldName);
   if (item.is_initialized()) {
     item->renameOutputWorkspace(oldName, newName);
-    item->resetState();
     return boost::optional<Item const &>(item.get());
   }
+  auto newItem = m_batch.getItemWithOutputWorkspaceOrNone(newName);
+  if (newItem.is_initialized()) {
+    newItem->resetState();
+    return boost::optional<Item const &>(newItem.get());
+  }
+
   return boost::none;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -286,6 +286,7 @@ BatchJobRunner::notifyWorkspaceRenamed(std::string const &oldName,
   auto item = m_batch.getItemWithOutputWorkspaceOrNone(oldName);
   if (item.is_initialized()) {
     item->renameOutputWorkspace(oldName, newName);
+    item->resetState();
     return boost::optional<Item const &>(item.get());
   }
   return boost::none;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerWorkspacesTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerWorkspacesTest.h
@@ -131,6 +131,17 @@ public:
     verifyAndClear();
   }
 
+  void testRenameWorkspaceDoesResetStateForRowWhenOldNameIsSameAsCurrent() {
+    auto jobRunner = makeJobRunner(oneGroupWithTwoRowsModel());
+    auto *row = getRow(jobRunner, 0, 1);
+    row->setSuccess();
+    row->setOutputNames({"", "IvsQ_test", "IvsQBin_test"});
+
+    jobRunner.notifyWorkspaceRenamed("IvsQBin_new", "IvsQBin_test");
+    TS_ASSERT_DIFFERS(row->state(), State::ITEM_COMPLETE)
+    verifyAndClear();
+  }
+
   void testRenameWorkspaceUpdatesCorrectWorkspaceForRow() {
     auto jobRunner = makeJobRunner(oneGroupWithTwoRowsModel());
     auto *row = getRow(jobRunner, 0, 1);


### PR DESCRIPTION
**Description of work.**
The aim of this is to reset row state if the reduced workspace is renamed/replaced
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Open Workbench
- Open Interfaces->Reflectometry->ISIS Reflectometry
- Add run 13460, and angle 0.5 to the table
- Hit process
- Run Rename workspace on Any workspace but rename it to IvsQ_binned_13460

<!-- Instructions for testing. -->

Fixes #26537. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
