### PR TITLE
Fix the axis quick editor tab order

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -19,6 +19,7 @@ Improvements
 
 Bugfixes
 ########
+- Pressing the tab key while in the axis quick editor now selects each input field in the correct order.
 - Clicking Cancel after attempting to save a project upon closing now keeps Workbench open instead of closing without saving.
 - Dialog windows no longer contain a useless ? button in their title bar.
 - Instrument view now keeps the saved rendering option when loading projects. 

--- a/qt/applications/workbench/workbench/plotting/axiseditor.ui
+++ b/qt/applications/workbench/workbench/plotting/axiseditor.ui
@@ -89,6 +89,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>editor_min</tabstop>
+  <tabstop>editor_max</tabstop>
+  <tabstop>logBox</tabstop>
+  <tabstop>gridBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
**Description of work.**
Pressing the tab key to move between input fields in the axis quick editor now correctly changes the current field from min to max.

**To test:**
1. Plot a figure.
2. Double click one of the axes.
3. Press the tab key and check that the input fields are selected in the correct order.

Fixes #26677 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
