### PR TITLE
Make the spectrum selector dialog select the spectrum number input box by default

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -17,6 +17,8 @@ Improvements
 
 - Attempting to save files that are larger than (by default) 10GB now results in a dialog box to inform the user that it may take a long time and gives them the opportunity to cancel.
 
+- The dialog for selecting spectra to plot now has the spectrum number input field selected by default.
+
 Bugfixes
 ########
 - Clicking Cancel after attempting to save a project upon closing now keeps Workbench open instead of closing without saving.

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.ui
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.ui
@@ -7,58 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>481</width>
-    <height>186</height>
+    <height>187</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Plot 1D</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Plot type:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="specNums"/>
    </item>
-   <item row="5" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::YesToAll</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="specNums">
-     <property name="inputMask">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Workspace Indices:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="wkspIndices"/>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Spectrum Numbers:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="4" column="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QComboBox" name="plotType">
@@ -90,14 +49,14 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
+   <item row="1" column="2">
     <widget class="QLabel" name="label_4">
      <property name="text">
       <string>Or</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="2">
+   <item row="0" column="3">
     <widget class="QPushButton" name="specNumsValid">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -125,7 +84,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
+   <item row="2" column="3">
     <widget class="QPushButton" name="wkspIndicesValid">
      <property name="enabled">
       <bool>true</bool>
@@ -166,8 +125,56 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Workspace Indices:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::YesToAll</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Spectrum Numbers:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Plot type:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="wkspIndices"/>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>specNums</tabstop>
+  <tabstop>wkspIndices</tabstop>
+  <tabstop>specNumsValid</tabstop>
+  <tabstop>wkspIndicesValid</tabstop>
+  <tabstop>plotType</tabstop>
+  <tabstop>colorfillButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
**Description of work.**
When you open the spectrum selector dialog, you no longer have to click on the spectrum number input box because it is selected automatically.

**To test:**
1. Load a workspace, right-click it and select Plot -> Spectrum...
2. In the dialog window that opens, check that the Spectrum Numbers input box is selected, and you can enter input without clicking on it.

Fixes #26674 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
