### PR TITLE
Fix failing system test scripts on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,8 +82,9 @@ if(ENABLE_MANTIDPLOT)
   include(ParaViewSetup)
 endif()
 
-# Set expected variables for OS X
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+if( MSVC )
+  include ( MSVCSetup )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   include(DarwinSetup)
 endif()
 

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -41,14 +41,18 @@ import time
 import unittest
 
 
+def santize_backslash(path):
+    """ Some windows paths can contain sequences such as \r, e.g. \release_systemtests
+        and need escaping to be able to add to the python path"""
+    return path.replace('\\', '\\\\')
+
+
 # Path to this file
-THIS_MODULE_DIR = os.path.dirname(os.path.realpath(__file__))
-# Some windows paths can contain sequences such as \r, e.g. \release_systemtests
-# and need escaping to be able to add to the python path
-TESTING_FRAMEWORK_DIR = THIS_MODULE_DIR.replace('\\', '\\\\')
+TESTING_FRAMEWORK_DIR = santize_backslash(os.path.dirname(os.path.realpath(__file__)))
 # Path to PythonInterface/test directory for testhelpers module
-FRAMEWORK_PYTHONINTERFACE_TEST_DIR = os.path.realpath(os.path.join(TESTING_FRAMEWORK_DIR, "..", "..", "..", "..",
-                                                                   "Framework", "PythonInterface", "test"))
+FRAMEWORK_PYTHONINTERFACE_TEST_DIR = santize_backslash(os.path.realpath(os.path.join(TESTING_FRAMEWORK_DIR,
+                                                                                     "..", "..", "..", "..",
+                                                                                     "Framework", "PythonInterface", "test")))
 
 if not os.path.exists(FRAMEWORK_PYTHONINTERFACE_TEST_DIR):
     raise ImportError("Expected 'Framework/PythonInterface/test' to be found at '{}' but it wasn'target. Has the directory moved?")

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -34,6 +34,8 @@ parser.add_argument('--archivesearch', dest='archivesearch', action='store_true'
                     help='Turn on archive search for file finder')
 parser.add_argument('--exclude-in-pull-requests', dest="exclude_in_pr_builds",action="store_true",
                     help="Skip tests that are not run in pull request builds")
+parser.add_argument('--ignore-failed-imports', dest="ignore_failed_imports", action="store_true",
+                    help="Skip tests that do not import correctly rather raising an error.")
 log_levels = ['error', 'warning', 'notice', 'information', 'debug']
 parser.add_argument('-l', dest='log_level', metavar='level', default='information',
                     choices=log_levels, help='Log level '+str(log_levels))
@@ -99,6 +101,8 @@ try:
         run_test_cmd += ' --archivesearch'
     if options.exclude_in_pr_builds:
         run_test_cmd += ' --exclude-in-pull-requests'
+    if options.ignore_failed_imports:
+        run_test_cmd += ' --ignore-failed-imports'
     if options.out2stdout:
         print("Executing command '{0}'".format(run_test_cmd))
         p = subprocess.Popen(run_test_cmd, shell=True) # no PIPE: print on screen for debugging

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -10,14 +10,14 @@ from __future__ import (absolute_import, division, print_function)
 
 import optparse
 import os
-# If any tests happen to hit a PyQt4 import make sure item uses version 2 of the api
-# Remove this when everything is switched to qtpy
-import sip
 import sys
 import time
 from multiprocessing import Process, Array, Manager, Value, Lock
 
 try:
+   # If any tests happen to hit a PyQt4 import make sure item uses version 2 of the api
+   # Remove this when everything is switched to qtpy
+    import sip
     sip.setapi('QString', 2)
     sip.setapi('QVariant', 2)
     sip.setapi('QDate', 2)
@@ -25,7 +25,7 @@ try:
     sip.setapi('QTextStream', 2)
     sip.setapi('QTime', 2)
     sip.setapi('QUrl', 2)
-except AttributeError:
+except (AttributeError, ImportError):
     # PyQt < v4.6
     pass
 
@@ -100,6 +100,8 @@ def main():
                       help="Turn on archive search for file finder.")
     parser.add_option("", "--exclude-in-pull-requests", dest="exclude_in_pr_builds", action="store_true",
                       help="Skip tests that are not run in pull request builds")
+    parser.add_option("", "--ignore-failed-imports", dest="ignore_failed_imports", action="store_true",
+                      help="Skip tests that do not import correctly rather raising an error.")
     parser.set_defaults(frameworkLoc=DEFAULT_FRAMEWORK_LOC, executable=sys.executable, makeprop=True,
                         loglevel="information", ncores=1, quiet=False, output_on_failure=False, clean=False)
     (options, args) = parser.parse_args()
@@ -147,7 +149,8 @@ def main():
                                      quiet=options.quiet,
                                      testsInclude=options.testsInclude,
                                      testsExclude=options.testsExclude,
-                                     exclude_in_pr_builds=options.exclude_in_pr_builds)
+                                     exclude_in_pr_builds=options.exclude_in_pr_builds,
+                                     ignore_failed_imports=options.ignore_failed_imports)
 
     test_counts, test_list, test_stats, files_required_by_test_module, data_file_lock_status = \
         tmgr.generateMasterTestList()

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -80,9 +80,6 @@ if( MSVC )
   set ( BOOST_INCLUDEDIR "${CMAKE_INCLUDE_PATH}" )
   set ( BOOST_LIBRARYDIR "${CMAKE_LIBRARY_PATH}" )
   set ( Boost_NO_SYSTEM_PATHS TRUE )
-
-  # Configure MSVC
-  include ( MSVCSetup )
 else()
   find_package ( Git )
 endif()

--- a/scripts/SANS/sans/gui_logic/models/diagnostics_page_model.py
+++ b/scripts/SANS/sans/gui_logic/models/diagnostics_page_model.py
@@ -13,19 +13,9 @@ from sans.common.enums import IntegralEnum, DetectorType, SANSDataType
 from sans.common.file_information import get_instrument_paths_for_sans_file
 from sans.common.general_functions import create_child_algorithm, parse_diagnostic_settings
 from sans.common.xml_parsing import get_named_elements_from_ipf_file
+from sans.gui_logic.plotting import get_plotting_module
 from sans.gui_logic.models.table_model import TableModel, TableIndexModel
 from sans.gui_logic.presenter.gui_state_director import (GuiStateDirector)
-
-from qtpy import PYQT4
-IN_MANTIDPLOT = False
-if PYQT4:
-    try:
-        import mantidplot
-        IN_MANTIDPLOT = True
-    except (Exception, Warning):
-        pass
-else:
-    from mantidqt.plotting.functions import plot
 
 
 def run_integral(integral_ranges, mask, integral, detector, state):
@@ -133,12 +123,13 @@ def generate_output_workspace_name(range, integral, mask, detector, input_worksp
 
 
 def plot_graph(workspace):
-    if IN_MANTIDPLOT:
-        return mantidplot.plotSpectrum(workspace, 0)
-    elif not PYQT4:
+    plotting_module = get_plotting_module()
+    if hasattr(plotting_module, 'plotSpectrum'):
+        return plotting_module.plotSpectrum(workspace, 0)
+    elif hasattr(plotting_module, 'plot'):
         if not isinstance(workspace, list):
             workspace = [workspace]
-        plot(workspace, wksp_indices=[0])
+        plotting_module.plot(workspace, wksp_indices=[0])
 
 
 def apply_mask(state, workspace, component):

--- a/scripts/SANS/sans/gui_logic/models/table_model.py
+++ b/scripts/SANS/sans/gui_logic/models/table_model.py
@@ -19,7 +19,6 @@ import re
 from sans.common.constants import ALL_PERIODS
 from sans.common.enums import RowState, SampleShape
 from sans.common.file_information import SANSFileInformationFactory
-from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
 from sans.gui_logic.presenter.create_file_information import create_file_information
 from ui.sans_isis.work_handler import WorkHandler
 
@@ -378,6 +377,8 @@ class OptionsColumnModel(object):
 
     @staticmethod
     def get_hint_strategy():
+        from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
+
         return BasicHintStrategy({"WavelengthMin": 'The min value of the wavelength when converting from TOF.',
                                   "WavelengthMax": 'The max value of the wavelength when converting from TOF.',
                                   "PhiMin": 'The min angle of the detector to accept.'
@@ -485,6 +486,8 @@ class SampleShapeColumnModel(object):
 
     @staticmethod
     def get_hint_strategy():
+        from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
+
         return BasicHintStrategy({"Cylinder": "",
                                   "Disc": "",
                                   "FlatPlate": ""})

--- a/scripts/SANS/sans/gui_logic/plotting.py
+++ b/scripts/SANS/sans/gui_logic/plotting.py
@@ -1,0 +1,25 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import)
+
+
+def get_plotting_module():
+    """
+    :returns: The plotting module to use. Can be None if Qt is not accessible.
+    """
+    plotting_module = None
+    try:
+        from qtpy import PYQT4
+        if PYQT4:
+            import mantidplot as plotting_module
+        else:
+            import mantidqt.plotting.functions as plotting_module
+    except ImportError as exc:
+        from mantid.kernel import logger
+        logger.debug("Unable to import plotting module {}".format(str(exc)))
+
+    return plotting_module


### PR DESCRIPTION
~~**MERGE AFTER: #26681**~~

**Description of work.**

The [system tests](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-windows/917/) on windows are failing to find the paths for ParaView and the internal `testhelpers`. This fixes the problems finding them.

**To test:**

This needs to run like the builders run the tests:

1. Make a temporary new build directory, called e.g. `systemtests`
1. Download the latest nightly from the `master_clean` job into the new `systemtests` directory
1. Install the nightly
1. Run cmake from the command line with only the data targets enabled:
```
cd systemtests
cmake -G "Visual Studio 16 2019" -A x64 -DDATA_TARGETS_ONLY=ON <mantid-src>
```
1. Run the systemtests as
```
python <mantid-src>\Testing\SystemTests\scripts\InstallerTests.py -n -d . -o -R PVPython
```

and the test should pass.

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal testing issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
