### PR TITLE
Improved workspace grouping in ReflectometryISISLoadAndProcess

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -252,6 +252,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
                 if (ws.getAxis(0).getUnit().unitID()) == 'TOF':
                     ungrouped_workspaces.append(ws_name)
                 else:
+                    # Do not remove the workspace group from the ADS if a non-TOF workspace exists
                     delete_ws_group_flag = False
         return ungrouped_workspaces
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -241,13 +241,18 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         """Given a list of workspaces, which themselves could be groups of workspaces,
         return a new list of workspaces which are TOF"""
         ungrouped_workspaces = []
+        delete_ws_group_flag = True
         for ws_name in workspaces:
             ws = AnalysisDataService.retrieve(ws_name)
-            if (ws.getAxis(0).getUnit().caption()) == 'Time-of-flight':
-                ungrouped_workspaces.append(ws_name)
             if isinstance(ws, WorkspaceGroup):
                 ungrouped_workspaces += self._collapse_workspace_groups(ws.getNames())
-                AnalysisDataService.remove(ws_name)
+                if delete_ws_group_flag is True:
+                    AnalysisDataService.remove(ws_name)
+            else:
+                if (ws.getAxis(0).getUnit().unitID()) == 'TOF':
+                    ungrouped_workspaces.append(ws_name)
+                else:
+                    delete_ws_group_flag = False
         return ungrouped_workspaces
 
     def _group_workspaces(self, workspaces, output_ws_name):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -237,13 +237,13 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         # Not found
         return None
 
-    def collapseWorkspaceGroups(self, workspaces):
+    def _collapse_workspace_groups(self, workspaces):
         """Given a list of workspaces, which themselves could be groups of workspaces,
         return a new list of workspaces which are TOF"""
         output_ws = []
         for ws in workspaces:
             if isinstance(ws, WorkspaceGroup):
-                output_ws.append(self._collapseWorkspaceGroups(ws.getNames()))
+                self._collapse_workspace_groups(ws.getNames())
                 AnalysisDataService.remove(ws)
             else:
                 if ws.getAxis(0).unit() is "TOF":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -440,6 +440,11 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'GroupWorkspaces', 'GroupWorkspaces']
         self._check_history(mtd['IvsQ_binned_12345_1'], history, False)
 
+    def test_TOF_input_workspace_groups_collapsed(self):
+        workspaces = [self._create_workspace(12345, 'TOF_'), self._create_workspace_group(67890, 2, 'TOF_')]
+        output_workspaces = ['TOF_12345', 'TOF_67890_1', 'TOF_67890_2']
+        self.assertEqual(self._collape_workspace_groups(workspaces), output_workspaces)
+
     def _create_workspace(self, run_number, prefix='', suffix=''):
         name = prefix + str(run_number) + suffix
         ws = CreateSampleWorkspace(WorkspaceType='Histogram',NumBanks=1, NumMonitors=2,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -546,16 +546,15 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         if namesNotExpected is not None:
             self.assertNotEqual(set(actual), set(namesNotExpected))
 
-    def _assert_run_algorithm_throws(self, args = None):
+    def _assert_run_algorithm_throws(self, args = {}):
         """Run the algorithm with the given args and check it throws"""
         throws = False
-        if args is not None:
-          alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
-          alg.setRethrows(True)
-          try:
-              alg.execute()
-          except:
-              throws = True
+        alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+        alg.setRethrows(True)
+        try:
+            alg.execute()
+        except:
+            throws = True
         self.assertEqual(throws, True)
 
     def _assert_delta(self, value1, value2):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -450,7 +450,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
         self._assert_run_algorithm_succeeds(args, outputs)
 
-    def test_throws_with_mixed_unit_input_workspace_group(self):
+    def test_fails_with_mixed_unit_input_workspace_group(self):
         self._create_workspace(13460, 'TOF_')
         self._create_workspace(13463, 'TOF_')
         self._create_workspace_wavelength(12345)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -433,7 +433,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '12345'
         outputs = ['IvsQ_12345', 'IvsQ_12345_1', 'IvsQ_12345_2', 'IvsQ_binned_12345',
                    'IvsQ_binned_12345_2', 'IvsQ_binned_12345_1', 'IvsLam_12345',
-                   'IvsLam_12345_1', 'IvsLam_12345_2', 'TOF_12345_1', 'TOF_12345_2']
+                   'IvsLam_12345_1', 'IvsLam_12345_2', 'TOF', 'TOF_12345_1', 'TOF_12345_2']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['CreateSampleWorkspace', 'AddSampleLog',  'CreateSampleWorkspace', 'AddSampleLog',
                    'GroupWorkspaces', 'ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 from mantid import config
-from mantid.api import mtd, AnalysisDataService
+from mantid.api import AnalysisDataService
 from mantid.simpleapi import (AddSampleLog, AddTimeSeriesLog, CreateSampleWorkspace,
                               CropWorkspace, GroupWorkspaces, Rebin)
 from testhelpers import (assertRaisesNothing, create_algorithm)
@@ -68,7 +68,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
             'TOF_38415_sliced_420_610', 'TOF']
 
     def tearDown(self):
-        mtd.clear()
+        AnalysisDataService.clear()
         config['default.facility'] = self._oldFacility
         config['default.instrument'] = self._oldInstrument
 
@@ -81,7 +81,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_input_run_that_is_in_ADS_with_prefixed_name_is_not_reloaded(self):
         self._create_workspace(13460, 'TOF_')
@@ -90,7 +90,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_input_run_that_is_in_ADS_without_prefix_is_not_reloaded(self):
         self._create_workspace(13460)
@@ -99,7 +99,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', '13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_input_run_is_reloaded_if_in_ADS_with_unknown_prefix(self):
         self._create_workspace(13460, 'TEST_')
@@ -108,7 +108,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TEST_13460', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_existing_workspace_is_used_when_name_passed_in_input_list(self):
         self._create_workspace(13460, 'TEST_')
@@ -117,7 +117,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TEST_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_loading_run_with_instrument_prefix_in_name(self):
         args = self._default_options
@@ -125,7 +125,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'RenameWorkspace', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_overriding_output_names(self):
         self._create_workspace(13460, 'TOF_')
@@ -135,7 +135,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['testIvsQ', 'testIvsQBin', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['testIvsQBin'], history)
+        self._check_history(AnalysisDataService.retrieve('testIvsQBin'), history)
 
     def test_overriding_output_names_includes_all_specified_outputs(self):
         self._create_workspace(13460, 'TOF_')
@@ -147,7 +147,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['testIvsQ', 'testIvsQBin', 'testIvsLam', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['testIvsQBin'], history)
+        self._check_history(AnalysisDataService.retrieve('testIvsQBin'), history)
 
     def test_debug_option_outputs_extra_workspaces(self):
         self._create_workspace(13460, 'TOF_')
@@ -157,7 +157,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'IvsLam_13460', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_debug_option_outputs_extra_workspaces_with_overridden_names(self):
         self._create_workspace(13460, 'TOF_')
@@ -168,7 +168,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['testIvsQ', 'testIvsQBin', 'testIvsLam', 'TOF_13460', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['testIvsQBin'], history)
+        self._check_history(AnalysisDataService.retrieve('testIvsQBin'), history)
 
     def test_multiple_input_runs_are_summed(self):
         self._create_workspace(13461, 'TOF_')
@@ -179,7 +179,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_13461+13462', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['MergeRuns', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13461+13462'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13461+13462'), history)
 
     def test_trans_run_is_not_reloaded_if_in_ADS(self):
         self._create_workspace(13460, 'TOF_')
@@ -190,7 +190,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_trans_runs_are_loaded_if_not_in_ADS(self):
         self._create_workspace(13460, 'TOF_')
@@ -204,7 +204,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_trans_runs_are_not_loaded_if_in_ADS_without_prefix(self):
         self._create_workspace(13460, 'TOF_')
@@ -220,7 +220,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_trans_runs_are_reloaded_if_in_ADS_with_unknown_prefix(self):
         self._create_workspace(13460, 'TOF_')
@@ -236,7 +236,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_existing_workspace_is_used_for_trans_runs_when_name_passed_in_input_list(self):
         self._create_workspace(13460, 'TOF_')
@@ -250,7 +250,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_first_and_second_trans_runs_are_combined(self):
         self._create_workspace(13460, 'TOF_')
@@ -265,7 +265,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_first_and_second_trans_runs_are_combined_with_debug_output(self):
         self._create_workspace(13460, 'TOF_')
@@ -282,7 +282,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_multiple_trans_runs_are_summed(self):
         self._create_workspace(13460, 'TOF_')
@@ -295,7 +295,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TRANS_13463+13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['MergeRuns', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_13460'], history)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
 
     def test_slicing_is_disallowed_if_summing_input_runs(self):
         self._create_workspace(13460, 'TOF_')
@@ -315,7 +315,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # might be something we want to change in the underlying algorithms at some point
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_1200'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_1200'), history, False)
 
     def test_slicing_uses_run_in_ADS_with_no_prefix(self):
         self._create_event_workspace(38415)
@@ -332,7 +332,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_1'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_1'), history, False)
 
     def test_slicing_loads_input_run_if_not_in_ADS(self):
         args = self._default_options
@@ -342,7 +342,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_reloads_input_run_if_workspace_is_incorrect_type(self):
         self._create_workspace(38415, 'TOF_')
@@ -353,7 +353,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_loads_input_run_if_monitor_ws_not_in_ADS(self):
         self._create_event_workspace(38415, 'TOF_', False)
@@ -364,7 +364,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_210'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_210'), history, False)
 
     def test_slicing_with_no_interval_returns_single_slice(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -377,7 +377,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_38415_sliced', 'TOF_38415_sliced_0_4200', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_4200'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_4200'), history, False)
 
     def test_slicing_by_number_of_slices(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -389,7 +389,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415_sliced_0_1200'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415_sliced_0_1200'), history, False)
 
     def test_slicing_by_log_value(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -410,7 +410,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415'+slice1], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415'+slice1), history, False)
 
     def test_slicing_by_log_value_with_no_interval_returns_single_slice(self):
         self._create_event_workspace(38415, 'TOF_')
@@ -425,7 +425,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
                    'TOF_38415'+sliceName]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_38415'+sliceName], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_38415'+sliceName), history, False)
 
     def test_with_input_workspace_group(self):
         self._create_workspace_group(12345, 2, 'TOF_')
@@ -438,7 +438,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         history = ['CreateSampleWorkspace', 'AddSampleLog',  'CreateSampleWorkspace', 'AddSampleLog',
                    'GroupWorkspaces', 'ReflectometryReductionOneAuto', 'ReflectometryReductionOneAuto',
                    'GroupWorkspaces', 'GroupWorkspaces']
-        self._check_history(mtd['IvsQ_binned_12345_1'], history, False)
+        self._check_history(AnalysisDataService.retrieve('IvsQ_binned_12345_1'), history, False)
 
     def test_TOF_input_workspace_groups_collapsed(self):
         self._create_workspace_group(13460, 2, 'TOF_')
@@ -551,14 +551,14 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         Clear these additional workspaces from the ADS"""
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
         assertRaisesNothing(self, alg.execute)
-        actual = mtd.getObjectNames()
+        actual = AnalysisDataService.getObjectNames()
         self.assertEqual(set(actual), set(expected))
 
     def _assert_run_algorithm_fails(self, args):
         """Run the algorithm with the given args and check it fails to produce output"""
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
         assertRaisesNothing(self, alg.execute)
-        self.assertEqual(mtd.doesExist('output'), False)
+        self.assertEqual(AnalysisDataService.doesExist('output'), False)
 
     def _assert_run_algorithm_throws(self, args = {}):
         """Run the algorithm with the given args and check it throws"""
@@ -575,7 +575,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
     def _clear(self, expected):
         for workspace in expected:
-            mtd.remove(workspace)
+            AnalysisDataService.remove(workspace)
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -450,44 +450,27 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
         self._assert_run_algorithm_succeeds(args, outputs)
 
-        workspace_names = AnalysisDataService.getObjectNames()
-        self.assertNotIn('TOF_13460', workspace_names)
-        self.assertIn('TOF_13460_1', workspace_names)
-        self.assertIn('TOF_13460_2', workspace_names)
-        self.assertIn('TOF_13463', workspace_names)
-
-    def test_mixed_unit_input_workspace_groups_collapsed(self):
+    def test_throws_with_mixed_unit_input_workspace_group(self):
         self._create_workspace(13460, 'TOF_')
         self._create_workspace(13463, 'TOF_')
         self._create_workspace_wavelength(12345)
         GroupWorkspaces('TOF_13463, 12345', OutputWorkspace='mixed_unit_group')
         args = self._default_options
         args['InputRunList'] = '13460, mixed_unit_group'
-        outputs = ['IvsQ_13460+mixed_unit_group', 'IvsQ_binned_13460+mixed_unit_group', 'TOF', 'TOF_13460+13463', 'TOF_13460',
+        outputs = ['IvsQ_13460+13463', 'IvsQ_binned_13460+13463', 'TOF', 'TOF_13460+13463', 'TOF_13460',
                    'TOF_13463', '12345']
 
-        self._assert_run_algorithm_fails(args)
+        self._assert_run_algorithm_fails(args, outputs)
 
-        workspace_names = AnalysisDataService.getObjectNames()
-        self.assertIn('mixed_unit_group', workspace_names)
-        self.assertIn('12345', workspace_names)
-        self.assertIn('TOF_13460', workspace_names)
-        self.assertIn('TOF_13463', workspace_names)
-
-    def test_no_TOF_input_workspace_groups_collapsed(self):
-        self._create_workspace(12345)
-        self._create_workspace(67890)
+    def test_no_TOF_input_workspace_groups_remain_unchanged(self):
+        self._create_workspace_wavelength(12345)
+        self._create_workspace_wavelength(67890)
         GroupWorkspaces('12345, 67890', OutputWorkspace='no_TOF_group')
         args = self._default_options
         args['InputRunList'] = '12345, 67890'
-        outputs = ['IvsQ_no_TOF_group', 'IvsQ_binned_no_TOF_group', '12345', '67890']
+        outputs = ['no_TOF_group', 'TOF_12345+67890', '12345', '67890']
 
-        self._assert_run_algorithm_fails(args)
-
-        workspace_names = AnalysisDataService.getObjectNames()
-        self.assertIn('no_TOF_group', workspace_names)
-        self.assertIn('12345', workspace_names)
-        self.assertIn('67890', workspace_names)
+        self._assert_run_algorithm_succeeds(args, outputs)
 
     def _create_workspace(self, run_number, prefix='', suffix=''):
         name = prefix + str(run_number) + suffix
@@ -554,11 +537,12 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         actual = AnalysisDataService.getObjectNames()
         self.assertEqual(set(actual), set(expected))
 
-    def _assert_run_algorithm_fails(self, args):
+    def _assert_run_algorithm_fails(self, args, expected = []):
         """Run the algorithm with the given args and check it fails to produce output"""
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
         assertRaisesNothing(self, alg.execute)
-        self.assertEqual(AnalysisDataService.doesExist('output'), False)
+        actual = AnalysisDataService.getObjectNames()
+        self.assertNotEqual(set(actual), set(expected))
 
     def _assert_run_algorithm_throws(self, args = {}):
         """Run the algorithm with the given args and check it throws"""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -546,15 +546,16 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         if namesNotExpected is not None:
             self.assertNotEqual(set(actual), set(namesNotExpected))
 
-    def _assert_run_algorithm_throws(self, args):
+    def _assert_run_algorithm_throws(self, args = None):
         """Run the algorithm with the given args and check it throws"""
         throws = False
-        alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
-        alg.setRethrows(True)
-        try:
-            alg.execute()
-        except:
-            throws = True
+        if args is not None:
+          alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+          alg.setRethrows(True)
+          try:
+              alg.execute()
+          except:
+              throws = True
         self.assertEqual(throws, True)
 
     def _assert_delta(self, value1, value2):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -460,7 +460,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         outputs = ['IvsQ_13460+13463', 'IvsQ_binned_13460+13463', 'TOF', 'TOF_13460+13463', 'TOF_13460',
                    'TOF_13463', '12345']
 
-        self._assert_run_algorithm_fails(args, outputs)
+        self._assert_run_algorithm_throws(args)
 
     def test_no_TOF_input_workspace_groups_remain_unchanged(self):
         self._create_workspace_wavelength(12345)
@@ -470,7 +470,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '12345, 67890'
         outputs = ['no_TOF_group', 'TOF_12345+67890', '12345', '67890']
 
-        self._assert_run_algorithm_succeeds(args, outputs)
+        self._assert_run_algorithm_succeeds(args)
 
     def _create_workspace(self, run_number, prefix='', suffix=''):
         name = prefix + str(run_number) + suffix
@@ -528,26 +528,29 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
             algNames = [alg.name() for alg in history]
         self.assertEqual(algNames, expected)
 
-    def _assert_run_algorithm_succeeds(self, args, expected):
+    def _assert_run_algorithm_succeeds(self, args, expected = None):
         """Run the algorithm with the given args and check it succeeds,
         and that the additional workspaces produced match the expected list.
         Clear these additional workspaces from the ADS"""
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
         assertRaisesNothing(self, alg.execute)
         actual = AnalysisDataService.getObjectNames()
-        self.assertEqual(set(actual), set(expected))
+        if expected is not None:
+            self.assertEqual(set(actual), set(expected))
 
-    def _assert_run_algorithm_fails(self, args, expected = []):
+    def _assert_run_algorithm_fails(self, args, namesNotExpected = None):
         """Run the algorithm with the given args and check it fails to produce output"""
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
         assertRaisesNothing(self, alg.execute)
         actual = AnalysisDataService.getObjectNames()
-        self.assertNotEqual(set(actual), set(expected))
+        if namesNotExpected is not None:
+            self.assertNotEqual(set(actual), set(namesNotExpected))
 
-    def _assert_run_algorithm_throws(self, args = {}):
+    def _assert_run_algorithm_throws(self, args):
         """Run the algorithm with the given args and check it throws"""
         throws = False
         alg = create_algorithm('ReflectometryISISLoadAndProcess', **args)
+        alg.setRethrows(True)
         try:
             alg.execute()
         except:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -459,17 +459,18 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
     def test_mixed_unit_input_workspace_groups_collapsed(self):
         self._create_workspace(13460, 'TOF_')
         self._create_workspace(13463, 'TOF_')
-        self._create_workspace(12345)
+        self._create_workspace_wavelength(12345)
         GroupWorkspaces('TOF_13463, 12345', OutputWorkspace='mixed_unit_group')
         args = self._default_options
-        args['InputRunList'] = '13460, 13463, 12345'
-        outputs = ['IvsQ_13460+13463+12345', 'IvsQ_binned_13460+13463+12345', 'TOF', 'TOF_13460+13463', 'TOF_13460',
-                   'TOF_13463']
+        args['InputRunList'] = '13460, mixed_unit_group'
+        outputs = ['IvsQ_13460+mixed_unit_group', 'IvsQ_binned_13460+mixed_unit_group', 'TOF', 'TOF_13460+13463', 'TOF_13460',
+                   'TOF_13463', '12345']
 
-        self._assert_run_algorithm_succeeds(args, outputs)
+        self._assert_run_algorithm_fails(args)
 
         workspace_names = AnalysisDataService.getObjectNames()
-        self.assertNotIn('mixed_unit_group', workspace_names)
+        self.assertIn('mixed_unit_group', workspace_names)
+        self.assertIn('12345', workspace_names)
         self.assertIn('TOF_13460', workspace_names)
         self.assertIn('TOF_13463', workspace_names)
 
@@ -479,19 +480,25 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         GroupWorkspaces('12345, 67890', OutputWorkspace='no_TOF_group')
         args = self._default_options
         args['InputRunList'] = '12345, 67890'
-        outputs = []
+        outputs = ['IvsQ_no_TOF_group', 'IvsQ_binned_no_TOF_group', '12345', '67890']
 
-        self._assert_run_algorithm_succeeds(args, outputs)
+        self._assert_run_algorithm_fails(args)
 
         workspace_names = AnalysisDataService.getObjectNames()
-        self.assertNotIn('no_TOF_group', workspace_names)
-        self.assertNotIn('12345', workspace_names)
-        self.assertNotIn('67890', workspace_names)
+        self.assertIn('no_TOF_group', workspace_names)
+        self.assertIn('12345', workspace_names)
+        self.assertIn('67890', workspace_names)
 
     def _create_workspace(self, run_number, prefix='', suffix=''):
         name = prefix + str(run_number) + suffix
         ws = CreateSampleWorkspace(WorkspaceType='Histogram',NumBanks=1, NumMonitors=2,
                                    BankPixelWidth=2, XMin=200, OutputWorkspace=name)
+        AddSampleLog(Workspace=ws, LogName='run_number', LogText=str(run_number))
+
+    def _create_workspace_wavelength(self, run_number, prefix='', suffix=''):
+        name = prefix + str(run_number) + suffix
+        ws = CreateSampleWorkspace(WorkspaceType='Histogram',NumBanks=1, NumMonitors=2,
+                                   BankPixelWidth=2, XMin=200, XUnit="Wavelength", OutputWorkspace=name)
         AddSampleLog(Workspace=ws, LogName='run_number', LogText=str(run_number))
 
     def _create_event_workspace(self, run_number, prefix='', includeMonitors=True):

--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -28,6 +28,10 @@ New
 
 - :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto-v3>` has been rewritten and updated to version 3. In the new version the polarization correction properties have been removed from the algorithm input and are now taken from the parameter file. A checkbox has been added to indicate whether the corrections should be applied.
 
+Improved
+########
+
+- Grouping of groups has been avoided by adding individual workspaces from input group into the TOF group and removing the original group, ignoring any workspaces with x-axes that are not TOF.
 
 Bug fixes
 #########

--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -31,13 +31,12 @@ New
 Improved
 ########
 
-- Grouping of groups has been avoided by adding individual workspaces from input group into the TOF group and removing the original group, ignoring any workspaces with x-axes that are not TOF.
-
 Bug fixes
 #########
 
 The following bugs have been fixed since the last release:
 
 - The pause button is now disabled upon opening the interface and becomes enabled when a process starts.
+- Ensure that the TOF group cannot contain non-TOF workspaces or nested groups (nested groups are not supported so are now flattened into a single group instead).
 
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
**Description of work.**
   - Added check to group `TOF` workspaces and ignore those with x-axis in another unit.
   - Groups of groups avoided by adding individual workspaces from input group into the TOF group 
      and removing the original group.

**To test:**
1. Run `ReflectometryISISLoadAndProcess` with `TOF` workspaces
2. Repeat with other grouped/ungrouped workspaces
3. Check `TOF` workspaces grouped and non-`TOF` ignored

Fixes #26658 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
