### PR TITLE
Removed FABADA minimizer from Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_view.py
@@ -14,7 +14,7 @@ from mantidqt.widgets.functionbrowser import FunctionBrowser
 
 ui_fitting_tab, _ = load_ui(__file__, "fitting_tab.ui")
 allowed_minimizers = ['Levenberg-Marquardt', 'BFGS', 'Conjugate gradient (Fletcher-Reeves imp.)', 'Conjugate gradient (Polak-Ribiere imp.)',
-                      'Damped GaussNewton', 'FABADA', 'Levenberg-MarquardtMD', 'Simplex',
+                      'Damped GaussNewton', 'Levenberg-MarquardtMD', 'Simplex',
                       'SteepestDescent', 'Trust Region']
 
 

--- a/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/fitting_tab_widget/fitting_tab_presenter_test.py
@@ -665,6 +665,12 @@ class FittingTabPresenterTest(unittest.TestCase):
         self.assertEquals(self.presenter.context.get_names_of_workspaces_to_fit.call_count,2)
         self.assertEquals(self.presenter.selected_data, "test")
 
+    def test_fabada_is_not_an_allowed_minimizer(self):
+        # In muon analysis FABADA minimizer cannot run as it requires a value of MaxIterations that is too high
+        # Furthermore it is not needed in this context (see issue #26478)
+        self.view.setup_fit_options_table()
+        self.assertEqual(-1, self.view.minimizer_combo.findText('FABADA'))
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**
The FABADA fit method requires a relatively high number of max iterations to run. In Muon Analysis this value cannot be changed by the user and the default value is too low for the minimizer to run.
In addition no muon scientist uses the minimizer, hence this PR removes it from the interface.

**To test:**
1. `Interfaces->Muon->Muon Analysis 2->Fitting`
2. Check that `FABADA` does not appear in the `Minimizer` list
3. Check that the interface works as expected with the other minimizers

Fixes #26478.
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
