### PR TITLE
Fix the difference still being plotted when Plot Difference is unticked

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -26,5 +26,6 @@ Bugfixes
 - Fit results on normalised plots are now also normalised to match the plot.
 - A crash in the Fit Browser when the default peak was not a registered peak type has been fixed.
 - Fixed an issue where you could not edit table workspaces to enter negative numbers.
+- Fixed an issue with fitting where the difference would be plotted even if the Plot Difference option in the fit property browser was not enabled.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -391,6 +391,7 @@ public:
     void fit();
     void addAllowedSpectra(const QString &wsName, const QList<int> &wsIndices);
     void setTextPlotGuess(const QString);
+    bool plotDiff() const;
 
     SIP_PYOBJECT defaultPeakType();
 %MethodCode

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -324,7 +324,12 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         original_lines = self.get_lines()
 
         self.clear_fit_result_lines()
-        plot([ws], wksp_indices=[1, 2], fig=self.canvas.figure, overplot=True)
+
+        if self.plotDiff():
+            plot([ws], wksp_indices=[1, 2], fig=self.canvas.figure, overplot=True)
+        else:
+            plot([ws], wksp_indices=[1], fig=self.canvas.figure, overplot=True)
+
         name += ':'
         for lin in self.get_lines():
             if lin.get_label().startswith(name):


### PR DESCRIPTION
**Description of work.**
The difference is now only plotted when the Plot Difference box is ticked.

**To test:**
1. Set up a fit and in the properties untick Plot Difference. Click fit and check that the difference is not plotted.
2. Check that the difference is plotted when Plot Difference is ticked.

Fixes #26550 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
