### PR TITLE
Add options to SaveMD for MDHistoWorkspace

### DIFF
--- a/Framework/API/inc/MantidAPI/ExperimentInfo.h
+++ b/Framework/API/inc/MantidAPI/ExperimentInfo.h
@@ -116,6 +116,9 @@ public:
 
   /// Saves this experiment description to the open NeXus file
   void saveExperimentInfoNexus(::NeXus::File *file) const;
+  /// Saves this experiment description to the open NeXus file
+  void saveExperimentInfoNexus(::NeXus::File *file, bool saveInstrument,
+                               bool saveSample, bool saveLogs) const;
   /// Loads an experiment description from the open NeXus file
   void loadExperimentInfoNexus(const std::string &nxFilename,
                                ::NeXus::File *file, std::string &parameterStr);

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -1156,6 +1156,26 @@ void ExperimentInfo::saveExperimentInfoNexus(::NeXus::File *file) const {
   run().saveNexus(file, "logs");
 }
 
+/** Save the object to an open NeXus file.
+ * @param file :: open NeXus file
+ * @param saveInstrument :: option to save Instrument
+ * @param saveSample :: option to save Sample
+ * @param saveLogs :: option to save Logs
+ */
+void ExperimentInfo::saveExperimentInfoNexus(::NeXus::File *file,
+                                             bool saveInstrument,
+                                             bool saveSample,
+                                             bool saveLogs) const {
+  Instrument_const_sptr instrument = getInstrument();
+
+  if (saveInstrument)
+    instrument->saveNexus(file, "instrument");
+  if (saveSample)
+    sample().saveNexus(file, "sample");
+  if (saveLogs)
+    run().saveNexus(file, "logs");
+}
+
 /** Load the sample and log info from an open NeXus file.
  * @param file :: open NeXus file
  */

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -16,6 +16,7 @@ Algorithms
 ----------
 * :ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
 * Whitespace is now ignored anywhere in the string when setting the Filename parameter in :ref:`Load <algm-Load>`.
+* Added options to :ref:`SaveMD <algm-SaveMD>` to allow selection of what will be saved. For MDHistoWorkspace only.
 
 Data Objects
 ------------


### PR DESCRIPTION
This adds options to `SaveMD` to set if saving History, Instrument, Sample and Logs for `MDHistoWorkspace`

**To test:**
Load an `MDHistoWorkspace` and save it with different options and compare the output. You should always be able to load it back into Mantid with `LoadMD`. _e.g_
```python
md = LoadMD("NaCl.nxs")
SaveMD(md, "NaCl_test1.nxs", SaveHistory=False, SaveInstrument=False, SaveSample=False, SaveLogs=False)
md1 = LoadMD("NaCl_test1.nxs")
```

`NaCl.nxs` can be found at https://github.com/neutrons/IPythonNotebookTutorial/raw/master/Data/Fitting/NaCl.nxs



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
