### PR TITLE
Create 1:1 spec-det map when message is missing

### DIFF
--- a/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventStreamDecoder.cpp
@@ -206,7 +206,9 @@ void KafkaEventStreamDecoder::captureImplExcept() {
   int64_t offset;
   int32_t partition;
   std::string topicName;
-  m_spDetStream->consumeMessage(&buffer, offset, partition, topicName);
+  if (m_spDetStream) {
+    m_spDetStream->consumeMessage(&buffer, offset, partition, topicName);
+  }
   auto runStartStruct = getRunStartMessage(runBuffer);
   initLocalCaches(buffer, runStartStruct);
 
@@ -530,40 +532,60 @@ void KafkaEventStreamDecoder::sampleDataFromMessage(const std::string &buffer) {
  */
 void KafkaEventStreamDecoder::initLocalCaches(
     const std::string &rawMsgBuffer, const RunStartStruct &runStartData) {
-  if (rawMsgBuffer.empty()) {
-    throw std::runtime_error("KafkaEventStreamDecoder::initLocalCaches() - "
-                             "Empty message received from spectrum-detector "
-                             "topic. Unable to continue");
-  }
-  auto spDetMsg = GetSpectraDetectorMapping(
-      reinterpret_cast<const uint8_t *>(rawMsgBuffer.c_str()));
-  auto nspec = static_cast<uint32_t>(spDetMsg->n_spectra());
-  auto nudet = spDetMsg->detector_id()->size();
-  if (nudet != nspec) {
-    std::ostringstream os;
-    os << "KafkaEventStreamDecoder::initLocalEventBuffer() - Invalid "
-          "spectra/detector mapping. Expected matched length arrays but "
-          "found nspec="
-       << nspec << ", ndet=" << nudet;
-    throw std::runtime_error(os.str());
-  }
-
   m_runId = runStartData.runId;
 
-  // Create buffer
-  auto eventBuffer = createBufferWorkspace<DataObjects::EventWorkspace>(
-      "EventWorkspace", static_cast<size_t>(spDetMsg->n_spectra()),
-      spDetMsg->spectrum()->data(), spDetMsg->detector_id()->data(), nudet);
+  const auto jsonGeometry = runStartData.nexusStructure;
+  const auto instName = runStartData.instrumentName;
 
-  // Load the instrument if possible but continue if we can't
-  auto jsonGeometry = runStartData.nexusStructure;
-  auto instName = runStartData.instrumentName;
-  if (!instName.empty())
-    loadInstrument<DataObjects::EventWorkspace>(instName, eventBuffer,
-                                                jsonGeometry);
-  else
-    g_log.warning(
-        "Empty instrument name received. Continuing without instrument");
+  DataObjects::EventWorkspace_sptr eventBuffer;
+  if (rawMsgBuffer.empty()) {
+    /* Load the instrument to get the number of spectra :c */
+    auto ws =
+        API::WorkspaceFactory::Instance().create("EventWorkspace", 1, 2, 1);
+    loadInstrument<API::MatrixWorkspace>(instName, ws, jsonGeometry);
+    const auto nspec = ws->getInstrument()->getNumberDetectors();
+
+    // Create buffer
+    eventBuffer = boost::static_pointer_cast<DataObjects::EventWorkspace>(
+        API::WorkspaceFactory::Instance().create("EventWorkspace", nspec, 2,
+                                                 1));
+    eventBuffer->setInstrument(ws->getInstrument());
+    eventBuffer->rebuildSpectraMapping();
+    eventBuffer->getAxis(0)->unit() =
+        Kernel::UnitFactory::Instance().create("TOF");
+    eventBuffer->setYUnit("Counts");
+  } else {
+    /* Parse mapping from stream */
+    auto spDetMsg = GetSpectraDetectorMapping(
+        reinterpret_cast<const uint8_t *>(rawMsgBuffer.c_str()));
+    auto nspec = static_cast<uint32_t>(spDetMsg->n_spectra());
+    auto nudet = spDetMsg->detector_id()->size();
+    if (nudet != nspec) {
+      std::ostringstream os;
+      os << "KafkaEventStreamDecoder::initLocalEventBuffer() - Invalid "
+            "spectra/detector mapping. Expected matched length arrays but "
+            "found nspec="
+         << nspec << ", ndet=" << nudet;
+      throw std::runtime_error(os.str());
+    }
+
+    // Create buffer
+    eventBuffer = createBufferWorkspace<DataObjects::EventWorkspace>(
+        "EventWorkspace", static_cast<size_t>(spDetMsg->n_spectra()),
+        spDetMsg->spectrum()->data(), spDetMsg->detector_id()->data(), nudet);
+
+    // Load the instrument if possible but continue if we can't
+    if (!instName.empty()) {
+      loadInstrument<DataObjects::EventWorkspace>(instName, eventBuffer,
+                                                  jsonGeometry);
+      if (rawMsgBuffer.empty()) {
+        eventBuffer->rebuildSpectraMapping();
+      }
+    } else {
+      g_log.warning(
+          "Empty instrument name received. Continuing without instrument");
+    }
+  }
 
   auto &mutableRun = eventBuffer->mutableRun();
   // Run start. Cache locally for computing frame times

--- a/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
+++ b/Framework/LiveData/test/KafkaEventStreamDecoderTest.h
@@ -443,24 +443,6 @@ public:
     TS_ASSERT(!decoder->isCapturing());
   }
 
-  void test_Empty_SpDet_Stream_Throws_Error_On_ExtractData() {
-    using namespace ::testing;
-    using namespace KafkaTesting;
-
-    auto mockBroker = std::make_shared<MockKafkaBroker>();
-    EXPECT_CALL(*mockBroker, subscribe_(_, _))
-        .Times(Exactly(3))
-        .WillOnce(Return(new FakeISISEventSubscriber(1)))
-        .WillOnce(Return(new FakeRunInfoStreamSubscriber(1)))
-        .WillOnce(Return(new FakeEmptyStreamSubscriber));
-    auto decoder = createTestDecoder(mockBroker);
-    startCapturing(*decoder, 1);
-
-    TS_ASSERT_THROWS(decoder->extractData(), const std::runtime_error &);
-    TS_ASSERT_THROWS_NOTHING(decoder->stopCapture());
-    TS_ASSERT(!decoder->isCapturing());
-  }
-
   void test_Empty_RunInfo_Stream_Throws_Error_On_ExtractData() {
     using namespace ::testing;
     using namespace KafkaTesting;


### PR DESCRIPTION
**Description of work.**

See commit messages.

**To test:**

- Stream some data without publishing the spec-det mapping topic
- See that spectrum numbers and detector IDs are populated and sensible in the created workspace

This can be placed in `Facilities.xml` a source of test data:
```xml
  <instrument name="V20_no_det_spec">
    <technique>Test Listener</technique>
    <livedata>
      <connection name="kafka_event" address="sakura.isis.cclrc.ac.uk:9092" listener="KafkaEventListener" />
    </livedata>
  </instrument>
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
