### PR TITLE
Make the text box in the ColorSelector widget editable

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -28,6 +28,8 @@ Improvements
 
 - The dialog for selecting spectra to plot now has the spectrum number input field selected by default.
 
+- Hex codes can now be inputted directly into the color selectors in figure options.
+
 Bugfixes
 ########
 - Pressing the tab key while in the axis quick editor now selects each input field in the correct order.

--- a/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
@@ -14,6 +14,7 @@ from qtpy.QtGui import QColor, QPalette, QRegExpValidator
 from qtpy.QtWidgets import (QWidget, QLineEdit, QPushButton, QHBoxLayout,
                             QColorDialog)
 
+
 def convert_color_to_hex(color):
     """Convert a matplotlib color to its hex form"""
     try:

--- a/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
@@ -43,6 +43,8 @@ class ColorSelector(QWidget):
 
         self.line_edit.setText(self.initial_color.name())
         self.prev_color = self.initial_color.name()
+
+        # Color input only allows valid hex codes.
         re = QRegExp('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')
         validator = ColorValidator(re, self.line_edit, self)
         self.line_edit.setValidator(validator)
@@ -65,8 +67,14 @@ class ColorSelector(QWidget):
         color_dialog.colorSelected.connect(
             lambda: self.set_line_edit(color_dialog.selectedColor().name())
         )
+        color_dialog.accepted.connect(
+            lambda: self.set_prev_color(color_dialog.selectedColor().name())
+        )
         color_dialog.setModal(True)
         color_dialog.show()
+
+    def set_prev_color(self, color):
+        self.prev_color = color
 
     def set_color(self, color_hex):
         self.line_edit.setText(color_hex)
@@ -84,6 +92,8 @@ class ColorSelector(QWidget):
     def convert_three_digit_hex_to_six(self):
         color = self.get_color()
 
+        # If a 3-digit hex code is inputted, it is converted to 6 digits
+        # by duplicating each digit.
         if len(color) == 4:
             new = '#{}'.format(''.join(2 * c for c in color.lstrip('#')))
             self.set_color(new)
@@ -95,8 +105,9 @@ class ColorSelector(QWidget):
 class ColorValidator(QRegExpValidator):
     def __init__(self, regexp, widget, color_selector):
         QRegExpValidator.__init__(self, regexp, widget)
-        self.widget = widget
         self.color_selector = color_selector
 
     def fixup(self, text):
+        # If an invalid color is inputted, the field reverts back
+        # to the last valid color entered.
         self.color_selector.set_color(self.color_selector.prev_color)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/colorselector.py
@@ -9,10 +9,10 @@
 from __future__ import (absolute_import, unicode_literals)
 
 from matplotlib import colors, rcParams
-from qtpy.QtGui import QColor, QPalette
+from qtpy.QtCore import QRegExp
+from qtpy.QtGui import QColor, QPalette, QRegExpValidator
 from qtpy.QtWidgets import (QWidget, QLineEdit, QPushButton, QHBoxLayout,
                             QColorDialog)
-
 
 def convert_color_to_hex(color):
     """Convert a matplotlib color to its hex form"""
@@ -42,7 +42,11 @@ class ColorSelector(QWidget):
         self.h_layout.setContentsMargins(0, 0, 0, 0)
 
         self.line_edit.setText(self.initial_color.name())
-        self.line_edit.setReadOnly(True)
+        self.prev_color = self.initial_color.name()
+        re = QRegExp('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')
+        validator = ColorValidator(re, self.line_edit, self)
+        self.line_edit.setValidator(validator)
+
         self.button.setAutoFillBackground(True)
         self.button.setFlat(True)
         self.update_color_button()
@@ -50,6 +54,7 @@ class ColorSelector(QWidget):
         # Signals
         self.button.clicked.connect(self.launch_qcolor_dialog)
         self.line_edit.textChanged.connect(self.update_color_button)
+        self.line_edit.editingFinished.connect(self.convert_three_digit_hex_to_six)
 
     def get_color(self):
         return self.line_edit.text()
@@ -75,3 +80,23 @@ class ColorSelector(QWidget):
         palette.setColor(QPalette.Button, qcolor)
         self.button.setPalette(palette)
         self.button.update()
+
+    def convert_three_digit_hex_to_six(self):
+        color = self.get_color()
+
+        if len(color) == 4:
+            new = '#{}'.format(''.join(2 * c for c in color.lstrip('#')))
+            self.set_color(new)
+            color = new
+
+        self.prev_color = color
+
+
+class ColorValidator(QRegExpValidator):
+    def __init__(self, regexp, widget, color_selector):
+        QRegExpValidator.__init__(self, regexp, widget)
+        self.widget = widget
+        self.color_selector = color_selector
+
+    def fixup(self, text):
+        self.color_selector.set_color(self.color_selector.prev_color)


### PR DESCRIPTION
**Description of work.**
In the figure options dialog, the text boxes for inputting a colour are no longer read-only so you can input hex codes into them directly. The input must start with a #, followed by a maximum of 6 characters which consist of 0-9 and a-f. If a 3-digit hex code is inputted, it is converted into a 6-digit hex code, and if a code of length neither 3 nor 6 is entered, the text box reverts back to the last valid colour entered.

**To test:**
1. Plot a figure and open figure options (the cog icon).
2. Go to the curves tab and check that all of the functionality described above works as intended for the color input fields.

Fixes #26595 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
