### PR TITLE
Catch and fail system tests if the any error is detected

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -54,6 +54,8 @@ FRAMEWORK_PYTHONINTERFACE_TEST_DIR = santize_backslash(
     os.path.realpath(
         os.path.join(TESTING_FRAMEWORK_DIR, "..", "..", "..", "..", "Framework", "PythonInterface",
                      "test")))
+# Indicates the child process trying to run the tests had an error
+TESTING_PROC_FAILURE_CODE = 255
 
 if not os.path.exists(FRAMEWORK_PYTHONINTERFACE_TEST_DIR):
     raise ImportError(
@@ -1253,6 +1255,24 @@ def using_gsl_v1():
 def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict, tests_lock, tests_left,
                     res_array, stat_dict, total_number_of_tests, maximum_name_length, tests_done,
                     process_number, lock, required_files_dict, locked_files_dict):
+    try:
+        testThreadsLoopImpl(testDir, saveDir, dataDir, options, tests_dict, tests_lock, tests_left,
+                            res_array, stat_dict, total_number_of_tests, maximum_name_length,
+                            tests_done, process_number, lock, required_files_dict,
+                            locked_files_dict)
+        exit_code = 0
+    except Exception as exc:
+        import traceback
+        traceback.print_exc()
+        exit_code = TESTING_PROC_FAILURE_CODE
+
+    # exits the child process and not the whole program
+    sys.exit(exit_code)
+
+
+def testThreadsLoopImpl(testDir, saveDir, dataDir, options, tests_dict, tests_lock, tests_left,
+                        res_array, stat_dict, total_number_of_tests, maximum_name_length,
+                        tests_done, process_number, lock, required_files_dict, locked_files_dict):
     reporter = XmlResultReporter(showSkipped=options.showskipped,
                                  total_number_of_tests=total_number_of_tests,
                                  maximum_name_length=maximum_name_length)

--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -1319,8 +1319,6 @@ def testThreadsLoop(testDir, saveDir, dataDir, options, tests_dict, tests_lock, 
                               exclude_in_pr_builds=options.exclude_in_pr_builds,
                               showSkipped=options.showskipped,
                               output_on_failure=options.output_on_failure,
-                              process_number=process_number,
-                              ncores=options.ncores,
                               clean=options.clean,
                               list_of_tests=local_test_list)
 

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -122,7 +122,8 @@ def main():
                         dest="output_on_failure",
                         action="store_true",
                         help="Print full log for failed tests.")
-    parser.add_argument('-N', '--dry-run',
+    parser.add_argument('-N',
+                        '--dry-run',
                         dest='dry_run',
                         action='store_true',
                         help='Do not run tests just print what would be run.')
@@ -274,23 +275,30 @@ def main():
         for ip in range(options.ncores):
             processes.append(
                 Process(target=systemtesting.testThreadsLoop,
-                        args=(mtdconf.testDir, mtdconf.saveDir, mtdconf.dataDir, options, tests_dict,
-                              tests_lock, tests_left, results_array, status_dict, total_number_of_tests,
-                              maximum_name_length, tests_done, ip, lock, required_files_dict,
-                              locked_files_dict)))
+                        args=(mtdconf.testDir, mtdconf.saveDir, mtdconf.dataDir, options,
+                              tests_dict, tests_lock, tests_left, results_array, status_dict,
+                              total_number_of_tests, maximum_name_length, tests_done, ip, lock,
+                              required_files_dict, locked_files_dict)))
         # Start and join processes
+        exitcodes = []
         try:
             for p in processes:
                 p.start()
 
             for p in processes:
                 p.join()
+                exitcodes.append(p.exitcode)
+
         except KeyboardInterrupt:
             print("Killed via KeyboardInterrupt")
             kill_children(processes)
         except Exception as e:
             print("Unexpected exception occured: {}".format(e))
             kill_children(processes)
+
+        # test processes could have failed to even start the tests. In this case skip printing the results
+        if systemtesting.TESTING_PROC_FAILURE_CODE in exitcodes:
+            sys.exit("\nFailed to execute tests. See traceback for more details.")
 
         # Gather results
         skipped_tests = sum(results_array[:options.ncores]) + (test_stats[2] - test_stats[0])


### PR DESCRIPTION
**Description of work.**

#26705 accidentally introduced an error into the system test runner that causes all tests not to execute yet the pull request build was marked as passed. Looking at the [console log](https://builds.mantidproject.org/job/pull_requests-rhel7/31469/consoleText) it becomes readily apparent that there was an error but despite this the final process marked itself as successful. 

```
Process Process-2:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-3:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-4:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-5:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-6:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-7:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-8:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-9:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-10:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-11:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-12:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'
Process Process-13:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/builder/jenkins-linode/workspace/pull_requests-rhel7/Testing/SystemTests/lib/systemtests/systemtesting.py", line 1316, in testThreadsLoop
    list_of_tests=local_test_list)
TypeError: __init__() got an unexpected keyword argument 'ncores'

################################################################################
Total runtime: 00:00:07

100% tests passed, 0 tests failed out of 523 (0 skipped)
All tests passed? True
################################################################################
```

These changes add error catching around the test process for each child process and add a special exit code to indicate that there was some generic problem with setting up the tests and exits with a non-zero exit code if necessary.

**To test:**

Try to run a system test before merging this branch - it should fail similarly to the situation above. Merge this branch and see that the tests are fixed.

*There is no associated issue.*

*This does not require release notes* because **this fixes a regression that was introduced yesterday.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
