### PR TITLE
Make plot legend movable after removing plot guess

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -38,4 +38,7 @@ Bugfixes
 - A crash in the Fit Browser when the default peak was not a registered peak type has been fixed.
 - Fixed an issue where you could not edit table workspaces to enter negative numbers.
 
+
+- Fixed an issue where the plot legend would no longer be movable after removing a plot guess.
+
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -230,7 +230,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         axes = self.get_axes()
         if axes.legend_ is not None:
-            axes.legend()
+            axes.legend().draggable()
 
     def plot_guess(self):
         """


### PR DESCRIPTION
**Description of work.**
Fixes an issue where after selecting Plot Guess in the fit property browser and then Remove Guess, the legend would no longer be draggable.

**To test:**
1. Plot a figure.
2. Open the fit menu.
3. Add a peak.
4. Go to Display -> Plot Guess
5. Go to Display -> Remove Guess
6. Check that the legend can be moved around.

Fixes #26551 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
