### PR TITLE
ignore nan values in FindCenterOfMassPosition

### DIFF
--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -166,6 +166,10 @@ void FindCenterOfMassPosition2::exec() {
 
       // Get the current spectrum
       auto &YIn = inputWS->y(i);
+      // Skip if NaN
+      if (std::isnan(YIn[specID]))
+        continue;
+
       const V3D pos = spectrumInfo.position(i);
       double x = pos.X();
       double y = pos.Y();

--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -166,8 +166,8 @@ void FindCenterOfMassPosition2::exec() {
 
       // Get the current spectrum
       auto &YIn = inputWS->y(i);
-      // Skip if NaN
-      if (std::isnan(YIn[specID]))
+      // Skip if NaN of inf
+      if (std::isnan(YIn[specID]) || std::isinf(YIn[specID])
         continue;
 
       const V3D pos = spectrumInfo.position(i);

--- a/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
+++ b/Framework/Algorithms/src/FindCenterOfMassPosition2.cpp
@@ -167,9 +167,8 @@ void FindCenterOfMassPosition2::exec() {
       // Get the current spectrum
       auto &YIn = inputWS->y(i);
       // Skip if NaN of inf
-      if (std::isnan(YIn[specID]) || std::isinf(YIn[specID])
+      if (std::isnan(YIn[specID]) || std::isinf(YIn[specID]))
         continue;
-
       const V3D pos = spectrumInfo.position(i);
       double x = pos.X();
       double y = pos.Y();

--- a/Framework/Algorithms/test/FindCenterOfMassPosition2Test.h
+++ b/Framework/Algorithms/test/FindCenterOfMassPosition2Test.h
@@ -57,8 +57,9 @@ public:
         double dy = (center_y - (double)iy);
         Y[0] = exp(-(dx * dx + dy * dy));
         // Set tube extrema to special values
-        if (iy == 0 || iy == SANSInstrumentCreationHelper::nBins - 1 )
-          Y[0] = iy % 2 ? std::nan("") : std::numeric_limits<double>::infinity();
+        if (iy == 0 || iy == SANSInstrumentCreationHelper::nBins - 1)
+          Y[0] =
+              iy % 2 ? std::nan("") : std::numeric_limits<double>::infinity();
         E[0] = 1;
       }
     }

--- a/Framework/Algorithms/test/FindCenterOfMassPosition2Test.h
+++ b/Framework/Algorithms/test/FindCenterOfMassPosition2Test.h
@@ -56,6 +56,9 @@ public:
         double dx = (center_x - (double)ix);
         double dy = (center_y - (double)iy);
         Y[0] = exp(-(dx * dx + dy * dy));
+        // Set tube extrema to special values
+        if (iy == 0 || iy == SANSInstrumentCreationHelper::nBins - 1 )
+          Y[0] = iy % 2 ? std::nan("") : std::numeric_limits<double>::infinity();
         E[0] = 1;
       }
     }


### PR DESCRIPTION
**Description of work.**
- [x] Skip workspace if contains a nan value
- [x] Introduce `nan` and `inf` values in the unit tests

**To test:**

Download and unzip the data file [ref.nxs.zip](https://github.com/mantidproject/mantid/files/3570001/ref.nxs.zip) to directory `/tmp`, then run this script:

```
w = LoadNexus('/tmp/ref.nxs')
w2 = ReplaceSpecialValues(w, NaNValue=0)
FindCenterOfMassPosition(w, Output='table_w', DirectBeam=True)
FindCenterOfMassPosition(w2, Output='table_w2', DirectBeam=True)
```

Table `center_w` and `center_w2` should show the same (X, Y) coordinates.

Fixes #26736

This does not require release notes because it's a minor change not exposed to the public API

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
