### PR TITLE
Workaround a bug in argparse with arguments starting with a dash

### DIFF
--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -119,9 +119,15 @@ if not os.environ.get('MANTID_FRAMEWORK_CONDA_SYSTEMTEST'):
 
 log("Running system tests. Log files are: '%s' and '%s'" % (testRunLogPath, testRunErrPath))
 try:
-    run_test_cmd = '%s %s %s/runSystemTests.py --loglevel=%s --executable="%s" --exec-args="%s"' % \
-                (installer.python_cmd, installer.python_args, THIS_MODULE_DIR,
-                options.log_level, installer.python_cmd, installer.python_args)
+    # There is a long-standing bug in argparse surrounding processing options starting with a dash.
+    # See https://bugs.python.org/issue9334. The suggestion is to use the `=` as we do here but the
+    # windows bat file used to start python then swallows these and the `=` is converted to a space
+    # and this produces the error: argument -a/--exec-args: expected one argument from runSystemTests.
+    # The workaround places a space in the --exec-args parameter that is then stripped off inside
+    # runSystemTests.
+    run_test_cmd = '{} {} {}/runSystemTests.py --loglevel={} --executable="{}" --exec-args=" {}"'.format(
+        installer.python_cmd, installer.python_args, THIS_MODULE_DIR,
+        options.log_level, installer.python_cmd, installer.python_args)
     run_test_cmd += " -j%i --quiet --output-on-failure" % options.ncores
     if options.test_regex is not None:
         run_test_cmd += " -R " + options.test_regex

--- a/Testing/SystemTests/scripts/runSystemTests.py
+++ b/Testing/SystemTests/scripts/runSystemTests.py
@@ -196,7 +196,8 @@ def main():
     #########################################################################
 
     runner = systemtesting.TestRunner(executable=options.executable,
-                                      exec_args=options.execargs,
+                                      # see InstallerTests.py for why lstrip is required
+                                      exec_args=options.execargs.lstrip(),
                                       escape_quotes=True)
 
     tmgr = systemtesting.TestManager(test_loc=mtdconf.testDir,


### PR DESCRIPTION
**Description of work.**

The nightly system tests on [windows](https://builds.mantidproject.org/job/master_systemtests-windows/923/console) are failing after switching to `argparse` for command-line argument parsing.

The error `runSystemTests.py: error: argument -a/--exec-args: expected one argument` appears due to a "bug" in [argparse](https://bugs.python.org/issue9334). 

**To test:**

This needs to run like the builders run the tests:

1. Make a temporary new build directory, called e.g. `systemtests`
1. Download the latest nightly from the [`master_clean`](https://builds.mantidproject.org/job/master_clean-windows/) job into the new `systemtests` directory
1. Install the nightly
1. Run cmake from the command line with only the data targets enabled:
```
cd systemtests
cmake -G "Visual Studio 16 2019" -A x64 -DDATA_TARGETS_ONLY=ON <mantid-src>
```
1. Run the systemtests as
```
python <mantid-src>\Testing\SystemTests\scripts\InstallerTests.py -n -d . -o -R PVPython
```

and the test should pass.



*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
