### PR TITLE
Resize the remove curve button in figure options

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -12,6 +12,7 @@ User Interface
 - The zoom icon in the SliceViewer and plot toolbars have been replaced with clearer icons.
 - Plots now allow the insertion of draggable horizontal and vertical markers.
 - Marker label, color and line style can be edited on a per-marker basis.
+- The button to remove a curve in the figure options is now the same size as the drop-down list of curves.
 
 New
 ###

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/curves_tab.ui
@@ -95,7 +95,7 @@
        <property name="maximumSize">
         <size>
          <width>1500000</width>
-         <height>16777215</height>
+         <height>22</height>
         </size>
        </property>
        <property name="text">


### PR DESCRIPTION
**Description of work.**
The button in the curves tab of the figure options menu to remove a curve is now the same size as the drop-down list of curves next to it.

**To test:**
1. Plot a figure, open figure options, go to curves tab.
2. Check that the remove button is the correct size.

Fixes #26592 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
