### PR TITLE
Use vector::emplace_back to avoid a false positive warning

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
@@ -127,9 +127,9 @@ std::vector<boost::optional<Row>> Clipboard::createRowsForSubtree(
                    });
     auto validationResult = validateRow(cells);
     if (validationResult.isValid())
-      result.push_back(validationResult.assertValid());
+      result.emplace_back(validationResult.assertValid());
     else
-      result.push_back(boost::none);
+      result.emplace_back(boost::none);
   }
 
   return result;


### PR DESCRIPTION
**Description of work.**

[Clean builds](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-ubuntu-18.04/347/consoleFull) have picked up a warning. It is unclear where this has come from but using `emplace_back` over `push_back` seems to help the heuristics to not flag this as a false positive. 

**To test:**

Ubuntu builds should be clean.

*There is no associated issue.*

*This does not require release notes* because **it fixes a build issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
