### PR TITLE
GPSANS: correct translation equation along X-axis

### DIFF
--- a/instrument/CG2_Definition.xml
+++ b/instrument/CG2_Definition.xml
@@ -433,7 +433,7 @@
   <component type="double-flat-panel" idlist="pixel_ids" name="detector1">
     <location>
       <parameter name="x">
-        <logfile id="detector-translation" eq="0.001*value"/>
+        <logfile id="detector-translation" eq="-0.001*value"/>
       </parameter>
       <parameter name="z">
         <logfile id="sdd" eq="0.001*value"/>


### PR DESCRIPTION
**Description of work.**
- [x] Inserted a minus sign :sweat_smile:
- No need for release notes.

**To test:**

Run the following code
```
data_dir = '/SNS/EQSANS/shared/sans-backend/data/new/ornl/sans/hfir/gpsans/'
w = LoadHFIRSANS(data_dir + 'CG2_exp206_scan0021_0001.xml')
```
Then  show the instrument in the "Full 3D" view with the "Z-" projection. The beam center should be close to the origin, like in the figure:

<img src="https://user-images.githubusercontent.com/1136006/64357799-57d2e980-cfd3-11e9-9448-c36627785d86.png" width="400">

Without importing the translation along the X-axis from the metadata, the beam center would be greatly displaced, like in the figure:

<img src="https://user-images.githubusercontent.com/1136006/64358038-b304dc00-cfd3-11e9-97ce-fcec5bf3e4a1.png" width="400">

Fixes #26760

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
