### PR TITLE
Remove seeAlso list containing only an empty string

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/FitIncidentSpectrum.py
+++ b/Framework/PythonInterface/plugins/algorithms/FitIncidentSpectrum.py
@@ -30,9 +30,6 @@ class FitIncidentSpectrum(PythonAlgorithm):
                'Outputs a workspace containing the functionalized fit and its first ' \
                'derivative.'
 
-    def seeAlso(self):
-        return [""]
-
     def version(self):
         return 1
 


### PR DESCRIPTION
**Description of work.**

A help warning has crept on to [master](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_clean-windows/1067/consoleText) - `CUSTOMBUILD : warning : relatedalgorithms - Could not find algorithm "" listed in the seeAlso for FitIncidentSpectrum.v1 [C:\Jenkins\workspace\master_clean-windows\build\docs\docs-qthelp.vcxproj]`

This fixes the warning.

**To test:**

Builds should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal bug fix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
