### PR TITLE
Fix system tests on macOS

### DIFF
--- a/MantidPlot/make_package.rb.in
+++ b/MantidPlot/make_package.rb.in
@@ -210,11 +210,16 @@ if( "@MAKE_VATES@" == "ON" )
   `install_name_tool -id @rpath/libNonOrthogonalSource.dylib plugins/paraview/qt4/libNonOrthogonalSource.dylib`
 end
 
-# use install_tool_name to add an @rpath for the libraries
+# use install_tool_name to add an @rpath for the python dynamic libraries
 Dir["Contents/MacOS/*.so"].each do |library|
-  dependencies = `otool -L #{library}`
   print library, "\n"
   `install_name_tool -add_rpath @loader_path/../MacOS #{library} > /dev/null 2>&1`
+end
+
+# use install_tool_name to add an @rpath for the ParaView python dynamic libraries
+Dir["Contents/Libraries/*.so"].each do |library|
+  print library, "\n"
+  `install_name_tool -add_rpath @loader_path/../Libraries #{library} > /dev/null 2>&1`
 end
 
 #use install_name_tool to change dependencies from /usr/local to libraries in the package.

--- a/Testing/SystemTests/scripts/InstallerTests.py
+++ b/Testing/SystemTests/scripts/InstallerTests.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 import argparse
 import os
 import subprocess
+import sys
 
 from mantidinstaller import (createScriptLog, log, stop, failure, scriptfailure, get_installer, run)
 
@@ -125,9 +126,12 @@ try:
     # and this produces the error: argument -a/--exec-args: expected one argument from runSystemTests.
     # The workaround places a space in the --exec-args parameter that is then stripped off inside
     # runSystemTests.
-    run_test_cmd = '{} {} {}/runSystemTests.py --loglevel={} --executable="{}" --exec-args=" {}"'.format(
+    executor_args = installer.python_args
+    if sys.platform == 'win32':
+        executor_args = ' ' + executor_args
+    run_test_cmd = '{} {} {}/runSystemTests.py --loglevel={} --executable="{}" --exec-args="{}"'.format(
         installer.python_cmd, installer.python_args, THIS_MODULE_DIR,
-        options.log_level, installer.python_cmd, installer.python_args)
+        options.log_level, installer.python_cmd, executor_args)
     run_test_cmd += " -j%i --quiet --output-on-failure" % options.ncores
     if options.test_regex is not None:
         run_test_cmd += " -R " + options.test_regex

--- a/qt/paraview_ext/VatesAlgorithms/CMakeLists.txt
+++ b/qt/paraview_ext/VatesAlgorithms/CMakeLists.txt
@@ -51,7 +51,7 @@ if(OSX_VERSION VERSION_GREATER 10.8)
   set_target_properties(
     VatesAlgorithms
     PROPERTIES INSTALL_RPATH
-               "@loader_path/../Contents/MacOS;@loader_path/../Libraries")
+               "@loader_path/../Contents/MacOS;@loader_path/../Contents/Libraries")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set_target_properties(
     VatesAlgorithms


### PR DESCRIPTION
**Description of work.**

The system tests currently do not start on [macOS](https://builds.mantidproject.org/view/Master%20Pipeline/job/master_systemtests-osx/842/console). This fixes both the startup issue and an issue with the internal `RPATH` settings for the ParaView Python libraries that were causing the `PVPythonTest` to fail.  

**To test:**

* Build a package (or download one from Jenkins and place it in you build directory)
* Drag the `MantidPlot.app` bundle to `/Applications`
* In your build directory run:
```
python <mantid-src>/Testing/SystemTests/scripts/InstallerTests.py -o -d . -R "CodeConventions\|PVPython"
```
and all of the tests should complete.

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal bug.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
