### PR TITLE
Plotting of results for fitting table workspaces

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
@@ -152,8 +152,8 @@ private:
   /// Store the Y Error column name
   mutable std::string m_errColName;
 
-	/// Flag to indicate if no error column was found
-	mutable bool m_noErrCol;
+  /// Flag to indicate if no error column was found
+  mutable bool m_noErrCol;
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
@@ -151,6 +151,9 @@ private:
   mutable std::string m_yColName;
   /// Store the Y Error column name
   mutable std::string m_errColName;
+
+	/// Flag to indicate if no error column was found
+	mutable bool m_noErrCol;
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/src/TableWorkspaceDomainCreator.cpp
+++ b/Framework/CurveFitting/src/TableWorkspaceDomainCreator.cpp
@@ -123,7 +123,8 @@ TableWorkspaceDomainCreator::TableWorkspaceDomainCreator(
     TableWorkspaceDomainCreator::DomainType domainType)
     : IDomainCreator(fit, std::vector<std::string>(1, workspacePropertyName),
                      domainType),
-      m_startX(EMPTY_DBL()), m_endX(EMPTY_DBL()), m_maxSize(0) {
+      m_startX(EMPTY_DBL()), m_endX(EMPTY_DBL()), m_maxSize(0),
+      m_noErrCol(false) {
   if (m_workspacePropertyNames.empty()) {
     throw std::runtime_error("Cannot create FitMW: no workspace given");
   }
@@ -138,7 +139,8 @@ TableWorkspaceDomainCreator::TableWorkspaceDomainCreator(
 TableWorkspaceDomainCreator::TableWorkspaceDomainCreator(
     TableWorkspaceDomainCreator::DomainType domainType)
     : IDomainCreator(nullptr, std::vector<std::string>(), domainType),
-      m_startX(EMPTY_DBL()), m_endX(EMPTY_DBL()), m_maxSize(10) {}
+      m_startX(EMPTY_DBL()), m_endX(EMPTY_DBL()), m_maxSize(10),
+      m_noErrCol(false) {}
 
 /**
  * Declare properties that specify the dataset within the workspace to fit to.
@@ -278,6 +280,8 @@ void TableWorkspaceDomainCreator::createDomain(
       if (!m_ignoreInvalidData)
         throw std::runtime_error("Infinte number or NaN found in input data.");
       y = 0.0; // leaving inf or nan would break the fit
+    } else if (m_noErrCol) {
+      weight = 1.0;
     } else if (!std::isfinite(error)) {
       // nan or inf error
       if (!m_ignoreInvalidData)
@@ -779,6 +783,7 @@ void TableWorkspaceDomainCreator::setAndValidateWorkspace(
   // if no error column has been found a column is added with 0 errors
   if (columnNames.size() == 2) {
     m_errColName = "AddedErrorColumn";
+    m_noErrCol = true;
     auto columnAdded = m_tableWorkspace->addColumn("double", m_errColName);
     if (!columnAdded)
       throw std::invalid_argument("No error column provided.");

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -153,8 +153,8 @@ PeakPickerTool::PeakPickerTool(
         Mantid::API::AnalysisDataService::Instance().retrieve(
             m_wsName.toStdString()));
   } catch (...) { // or it can be a TableWorkspace
-    m_ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-        m_fitPropertyBrowser->createMatrixFromTableWorkspace());
+    m_ws = Mantid::API::AnalysisDataService::Instance().retrieve(
+        m_fitPropertyBrowser->workspaceName());
   }
 }
 

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -147,15 +147,6 @@ PeakPickerTool::PeakPickerTool(
 
   connect(d_graph, SIGNAL(curveRemoved()), this, SLOT(curveRemoved()));
   connect(d_graph, SIGNAL(modifiedGraph()), this, SLOT(modifiedGraph()));
-
-  try { // if it's a MatrixWorkspace in the ADS
-    m_ws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(
-        Mantid::API::AnalysisDataService::Instance().retrieve(
-            m_wsName.toStdString()));
-  } catch (...) { // or it can be a TableWorkspace
-    m_ws = Mantid::API::AnalysisDataService::Instance().retrieve(
-        m_fitPropertyBrowser->workspaceName());
-  }
 }
 
 PeakPickerTool::~PeakPickerTool() {

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -197,7 +197,7 @@ private:
   /// Workspace index
   int m_spec;
   /// Pointer to the workspace
-  boost::shared_ptr<Mantid::API::MatrixWorkspace> m_ws;
+  boost::shared_ptr<Mantid::API::Workspace> m_ws;
 
   bool m_init;         // Is the tool initialized?
   bool m_width_set;    // The width set flag

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -43,7 +43,7 @@ namespace Mantid {
 namespace API {
 class IFunction;
 class CompositeFunction;
-class MatrixWorkspace;
+class Workspace;
 } // namespace API
 } // namespace Mantid
 

--- a/MantidPlot/src/Mantid/PeakPickerTool.h
+++ b/MantidPlot/src/Mantid/PeakPickerTool.h
@@ -43,7 +43,6 @@ namespace Mantid {
 namespace API {
 class IFunction;
 class CompositeFunction;
-class Workspace;
 } // namespace API
 } // namespace Mantid
 
@@ -196,8 +195,6 @@ private:
   QString m_wsName;
   /// Workspace index
   int m_spec;
-  /// Pointer to the workspace
-  boost::shared_ptr<Mantid::API::Workspace> m_ws;
 
   bool m_init;         // Is the tool initialized?
   bool m_width_set;    // The width set flag

--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -31,6 +31,7 @@ Improvements
 - There are now icons alongside the colormap names in the plot options dialog.
 - Hex codes can now be inputted directly into the color selectors in figure options.
 - There is now a button on the plot window's toolbar to generate a script that will re-create the current figure.
+- It is now possible to fit table workspaces in the fit browser and in a script.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -415,9 +415,9 @@ public:
     void setEndX(double end);
     void setXRange(double start, double end);
     QVector<double> getXRange();
-	QString getXColumnName() const;
-	QString getYColumnName() const;
-	QString getErrColumnName() const;
+    QString getXColumnName() const;
+    QString getYColumnName() const;
+    QString getErrColumnName() const;
     int workspaceIndex() const;
     void setWorkspaceIndex(int i);
     QStringList getWorkspaceNames();

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -414,11 +414,16 @@ public:
     double endX() const;
     void setEndX(double end);
     void setXRange(double start, double end);
+    QVector<double> getXRange();
+	QString getXColumnName() const;
+	QString getYColumnName() const;
+	QString getErrColumnName() const;
     int workspaceIndex() const;
     void setWorkspaceIndex(int i);
     QStringList getWorkspaceNames();
     void fit();
     void addAllowedSpectra(const QString &wsName, const QList<int> &wsIndices);
+	void addAllowedTableWorkspace(const QString &wsName);
     void setTextPlotGuess(const QString);
     bool plotDiff() const;
 

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -11,8 +11,11 @@ from __future__ import (print_function, absolute_import, unicode_literals)
 
 from qtpy.QtCore import Qt, Signal, Slot
 
+from matplotlib.legend import Legend
+
 from mantid import logger
-from mantid.api import AlgorithmManager, AnalysisDataService
+from mantid.api import AlgorithmManager, AnalysisDataService, ITableWorkspace
+from mantid.plots import MantidAxes
 from mantid.simpleapi import mtd
 from mantidqt.utils.qt import import_qt
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
@@ -88,6 +91,19 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
                 pass
         return allowed_spectra
 
+    def _get_table_workspace(self):
+        """
+        Get the name of the table workspace if it exists
+        """
+        table_workspace = ""
+
+        for ax in self.canvas.figure.get_axes():
+            try:
+                table_workspace = ax.wsName
+            except AttributeError:  # only table workspaces have wsName
+                pass
+        return table_workspace
+
     def _get_selected_workspace_artist(self):
         ws_artists_list = self.get_axes().tracked_workspaces[self.workspaceName()]
         for ws_artists in ws_artists_list:
@@ -99,6 +115,9 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         Set if the data should be normalised before fitting using the
         normalisation state of the active workspace artist.
         """
+        if AnalysisDataService.doesExist(self.workspaceName()) \
+                and isinstance(AnalysisDataService.retrieve(self.workspaceName()), ITableWorkspace):
+            return
         ws_artist = self._get_selected_workspace_artist()
         self.normaliseData(ws_artist.is_normalized)
 
@@ -114,14 +133,19 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         Override the base class method. Initialise the peak editing tool.
         """
         allowed_spectra = self._get_allowed_spectra()
+        table = self._get_table_workspace()
+
         if allowed_spectra:
             self._add_spectra(allowed_spectra)
+        elif table != "":
+            self.addAllowedTableWorkspace(table)
         else:
             self.toolbar_manager.toggle_fit_button_checked()
             logger.warning("Cannot open fitting tool: No valid workspaces to "
                            "fit to.")
             return
 
+        super(FitPropertyBrowser, self).show()
         self.tool = FitInteractiveTool(self.canvas, self.toolbar_manager,
                                        current_peak_type=self.defaultPeakType())
         self.tool.fit_range_changed.connect(self.set_fit_range)
@@ -131,7 +155,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         self.tool.peak_type_changed.connect(self.setDefaultPeakType)
         self.tool.add_background_requested.connect(self.add_function_slot)
         self.tool.add_other_requested.connect(self.add_function_slot)
-        super(FitPropertyBrowser, self).show()
 
         self.set_fit_bounds(self.get_fit_bounds())
         self.set_fit_range(self.tool.fit_range.get_range())
@@ -150,12 +173,12 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
     def get_workspace_x_range(self, workspace):
         """
-        Gets the x limits of a matrix workspace
+        Gets the x limits of a workspace
         :param workspace: The workspace to get the limits from
         """
         try:
-            x_data = workspace.dataX(self.workspaceIndex())
-            return [x_data[0], x_data[-1]]
+            x_data = self.getXRange()
+            return x_data
         except RuntimeError or IndexError:
             return None
 
@@ -246,13 +269,20 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         startX = self.startX()
         endX = self.endX()
         out_ws_name = '{}_guess'.format(ws_name)
+        workspace = AnalysisDataService.retrieve(ws_name)
         try:
             alg = AlgorithmManager.createUnmanaged('EvaluateFunction')
             alg.setChild(True)
             alg.initialize()
             alg.setProperty('Function', fun)
             alg.setProperty('InputWorkspace', ws_name)
-            alg.setProperty('WorkspaceIndex', ws_index)
+            if isinstance(workspace, ITableWorkspace):
+                alg.setProperty('XColumn', self.getXColumnName())
+                alg.setProperty('YColumn', self.getYColumnName())
+                if self.getErrColumnName() != "":
+                    alg.setProperty('ErrColumn', self.getErrColumnName())
+            else:
+                alg.setProperty('WorkspaceIndex', ws_index)
             alg.setProperty('StartX', startX)
             alg.setProperty('EndX', endX)
             alg.setProperty('OutputWorkspace', out_ws_name)
@@ -261,11 +291,19 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             return
 
         out_ws = alg.getProperty('OutputWorkspace').value
+
+        # Convert to a MantidAxes if it is not already
+        MantidAxes.from_mpl_axes(self.get_axes(), ignore_artists=[Legend]) \
+            if not isinstance(self.get_axes(), MantidAxes) else self.get_axes()
+
         # Setting distribution=True prevents the guess being normalised
         self.guess_line = self.get_axes().plot(out_ws, wkspIndex=1,
                                                label=out_ws_name,
                                                distribution=True,
                                                update_axes_labels=False)[0]
+
+        self.get_axes().legend().draggable()
+
         if self.guess_line:
             self.setTextPlotGuess('Remove Guess')
         self.canvas.draw()
@@ -345,6 +383,8 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         new_lines = self.get_lines()
         for new_line, old_line in zip(new_lines, original_lines):
             new_line.update_from(old_line)
+
+        handles, labels = axes.get_legend_handles_labels()
 
         # Now update the legend to make sure it changes to the old properties
         LegendProperties.create_legend(props, axes)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -292,10 +292,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
         out_ws = alg.getProperty('OutputWorkspace').value
 
-        # Convert to a MantidAxes if it is not already
-        MantidAxes.from_mpl_axes(self.get_axes(), ignore_artists=[Legend]) \
-            if not isinstance(self.get_axes(), MantidAxes) else self.get_axes()
-
         # Setting distribution=True prevents the guess being normalised
         self.guess_line = self.get_axes().plot(out_ws, wkspIndex=1,
                                                label=out_ws_name,

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -95,14 +95,12 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         Get the name of the table workspace if it exists
         """
-        table_workspace = ""
-
         for ax in self.canvas.figure.get_axes():
             try:
-                table_workspace = ax.wsName
+                return ax.wsName
             except AttributeError:  # only table workspaces have wsName
                 pass
-        return table_workspace
+        return None
 
     def _get_selected_workspace_artist(self):
         ws_artists_list = self.get_axes().tracked_workspaces[self.workspaceName()]
@@ -137,7 +135,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
         if allowed_spectra:
             self._add_spectra(allowed_spectra)
-        elif table != "":
+        elif table:
             self.addAllowedTableWorkspace(table)
         else:
             self.toolbar_manager.toggle_fit_button_checked()
@@ -279,7 +277,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             if isinstance(workspace, ITableWorkspace):
                 alg.setProperty('XColumn', self.getXColumnName())
                 alg.setProperty('YColumn', self.getYColumnName())
-                if self.getErrColumnName() != "":
+                if self.getErrColumnName():
                     alg.setProperty('ErrColumn', self.getErrColumnName())
             else:
                 alg.setProperty('WorkspaceIndex', ws_index)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -11,11 +11,8 @@ from __future__ import (print_function, absolute_import, unicode_literals)
 
 from qtpy.QtCore import Qt, Signal, Slot
 
-from matplotlib.legend import Legend
-
 from mantid import logger
 from mantid.api import AlgorithmManager, AnalysisDataService, ITableWorkspace
-from mantid.plots import MantidAxes
 from mantid.simpleapi import mtd
 from mantidqt.utils.qt import import_qt
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -8,7 +8,8 @@
 
 import unittest
 
-from mantid.py3compat.mock import Mock, patch
+from mantid.api import AnalysisDataService, WorkspaceFactory
+from mantid.py3compat.mock import MagicMock, Mock, patch
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
 from testhelpers import assertRaisesNothing
@@ -32,8 +33,33 @@ class FitPropertyBrowserTest(unittest.TestCase):
             property_browser.normaliseData.assert_called_once_with(normalised)
             normaliseData_mock.reset_mock()
 
+    @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.show')
+    def test_fitpropertybrowser_is_shown_for_table_workspaces(self, mock):
+        axes_mock = Mock(wsName = "table")
+        property_browser = self._create_widget()
+        with patch.object(property_browser, 'get_axes', lambda: axes_mock):
+            property_browser.show()
+        self.assertEqual(1, mock.show().call_count)
+
+    def test_plot_guess_plots_for_table_workspaces(self):
+        table = WorkspaceFactory.createTable()
+        table.addColumn('double', 'X', 1)
+        table.addColumn('double', 'Y', 2)
+        for i in range(1,10):
+            table.addRow([0.1*i, 5])
+        name = "table_name"
+        AnalysisDataService.Instance().addOrReplace(name, table)
+        property_browser = self._create_widget()
+        property_browser.getFittingFunction = Mock(return_value='name=FlatBackground')
+        property_browser.workspaceName = Mock(return_value=name)
+        property_browser.startX = Mock(return_value=0.15)
+        property_browser.endX = Mock(return_value=0.95)
+        property_browser.plot_guess()
+
+        self.assertEqual(1, property_browser.get_axes().plot.call_count)
+
     # Private helper functions
-    def _create_widget(self, canvas=Mock(), toolbar_manager=Mock()):
+    def _create_widget(self, canvas=MagicMock(), toolbar_manager=Mock()):
         return FitPropertyBrowser(canvas, toolbar_manager)
 
 

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -33,14 +33,6 @@ class FitPropertyBrowserTest(unittest.TestCase):
             property_browser.normaliseData.assert_called_once_with(normalised)
             normaliseData_mock.reset_mock()
 
-    @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.show')
-    def test_fitpropertybrowser_is_shown_for_table_workspaces(self, mock):
-        axes_mock = Mock(wsName = "table")
-        property_browser = self._create_widget()
-        with patch.object(property_browser, 'get_axes', lambda: axes_mock):
-            property_browser.show()
-        self.assertEqual(1, mock.show().call_count)
-
     def test_plot_guess_plots_for_table_workspaces(self):
         table = WorkspaceFactory.createTable()
         table.addColumn('double', 'X', 1)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -234,7 +234,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         self._action_set_as(self.model.marked_columns.add_x, 1)
 
     def action_set_as_y(self):
-        self._action_set_as(self.model.marked_columns.add_y , 2)
+        self._action_set_as(self.model.marked_columns.add_y, 2)
 
     def action_set_as_y_err(self, related_y_column, label_index):
         """
@@ -336,6 +336,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         fig, ax = self.plot.subplots()
         fig.canvas.set_window_title(self.model.get_name())
         ax.set_xlabel(self.model.get_column_header(selected_x))
+        ax.wsName = self.model.get_name()
 
         plot_func = self._get_plot_function_from_type(ax, plot_type)
         kwargs = {}
@@ -357,7 +358,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
                 return
 
             ax.set_ylabel(column_label)
-        ax.legend()
+        ax.legend().draggable()
         fig.show()
 
     def _get_plot_function_from_type(self, ax, type):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -333,7 +333,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
                 return
         x = self.model.get_column(selected_x)
 
-        fig, ax = self.plot.subplots()
+        fig, ax = self.plot.subplots(subplot_kw={'projection': 'mantid'})
         fig.canvas.set_window_title(self.model.get_name())
         ax.set_xlabel(self.model.get_column_header(selected_x))
         ax.wsName = self.model.get_name()

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -462,7 +462,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y)]
         twd.action_plot(PlotType.LINEAR)
 
-        twd.plot.subplots.assert_called_once_with()
+        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
         col_y_name = twd.model.get_column_header(col_as_y)
@@ -489,7 +489,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
                                                                   MockQModelIndex(1, col_as_y2)]
         twd.action_plot(PlotType.LINEAR)
 
-        twd.plot.subplots.assert_called_once_with()
+        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
 
@@ -567,7 +567,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
 
         twd.action_plot(plot_type)
 
-        twd.plot.subplots.assert_called_once_with()
+        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
 
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
@@ -651,7 +651,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
                 [MockQModelIndex(1, col_as_y1_err), MockQModelIndex(1, col_as_y2_err)])
         twd.action_plot(plot_type)
 
-        twd.plot.subplots.assert_called_once_with()
+        twd.plot.subplots.assert_called_once_with(subplot_kw={'projection': 'mantid'})
         twd.plot.mock_fig.canvas.set_window_title.assert_called_once_with(twd.model.get_name())
         twd.plot.mock_ax.set_xlabel.assert_called_once_with(twd.model.get_column_header(col_as_x))
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -182,12 +182,12 @@ public:
   void setEndX(double end) override;
   /// Set both start and end X
   void setXRange(double start, double end);
-	/// Get the name of the X column 
-	QString getXColumnName() const;
-	/// Get the name of the Y column 
-	QString getYColumnName() const;
-	/// Get the name of the Error column 
-	QString getErrColumnName() const;
+  /// Get the name of the X column
+  QString getXColumnName() const;
+  /// Get the name of the Y column
+  QString getYColumnName() const;
+  /// Get the name of the Error column
+  QString getErrColumnName() const;
   /// Set LogValue for PlotPeakByLogValue
   void setLogValue(const QString &lv = "");
   /// Get LogValue
@@ -287,7 +287,7 @@ public:
   // Methods intended for interfacing with the workbench fitting tools
 
   void addAllowedSpectra(const QString &wsName, const QList<int> &wsIndices);
-	void addAllowedTableWorkspace(const QString& wsName);
+  void addAllowedTableWorkspace(const QString &wsName);
   QString addFunction(const QString &fnName);
   PropertyHandler *getPeakHandler(const QString &prefix);
   void setPeakCentreOf(const QString &prefix, double value);
@@ -665,8 +665,8 @@ private:
   ///   keys are workspace names,
   ///   values are lists of workspace indices
   QMap<QString, QList<int>> m_allowedSpectra;
-	/// If set it contains the table workspace name to be fitted in this browser:
-	QString m_allowedTableWorkspace;
+  /// If set it contains the table workspace name to be fitted in this browser:
+  QString m_allowedTableWorkspace;
   /// Store workspace index to revert to in case validation fails
   int m_oldWorkspaceIndex;
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -169,6 +169,8 @@ public:
   int maxIterations() const;
   /// Get the peak radius for peak functions
   int getPeakRadius() const;
+  /// Get the X limits of the workspace
+  QVector<double> getXRange();
 
   /// Get the start X
   double startX() const;
@@ -180,6 +182,12 @@ public:
   void setEndX(double end) override;
   /// Set both start and end X
   void setXRange(double start, double end);
+	/// Get the name of the X column 
+	QString getXColumnName() const;
+	/// Get the name of the Y column 
+	QString getYColumnName() const;
+	/// Get the name of the Error column 
+	QString getErrColumnName() const;
   /// Set LogValue for PlotPeakByLogValue
   void setLogValue(const QString &lv = "");
   /// Get LogValue
@@ -263,8 +271,6 @@ public:
   /// Returns the list of workspaces that are currently been worked on by the
   /// fit property browser.
   QStringList getWorkspaceNames();
-  /// Create a MatrixWorkspace from a TableWorkspace
-  Mantid::API::Workspace_sptr createMatrixFromTableWorkspace() const;
 
   /// Allow or disallow sequential fits (depending on whether other conditions
   /// are met)
@@ -281,6 +287,7 @@ public:
   // Methods intended for interfacing with the workbench fitting tools
 
   void addAllowedSpectra(const QString &wsName, const QList<int> &wsIndices);
+	void addAllowedTableWorkspace(const QString& wsName);
   QString addFunction(const QString &fnName);
   PropertyHandler *getPeakHandler(const QString &prefix);
   void setPeakCentreOf(const QString &prefix, double value);
@@ -658,6 +665,8 @@ private:
   ///   keys are workspace names,
   ///   values are lists of workspace indices
   QMap<QString, QList<int>> m_allowedSpectra;
+	/// If set it contains the table workspace name to be fitted in this browser:
+	QString m_allowedTableWorkspace;
   /// Store workspace index to revert to in case validation fails
   int m_oldWorkspaceIndex;
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1750,21 +1750,21 @@ void FitPropertyBrowser::populateWorkspaceNames() {
   m_workspaceNames.clear();
   if (m_allowedTableWorkspace.isEmpty()) {
     bool allAreAllowed = m_allowedSpectra.isEmpty();
-    QStringList tmp;
-    auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
-    for (const auto &it : sv) {
-      auto const &name = QString::fromStdString(it);
+    QStringList allowedNames;
+    auto wsList = Mantid::API::AnalysisDataService::Instance().getObjectNames();
+    for (const auto &wsName : wsList) {
+      auto const &name = QString::fromStdString(wsName);
       if (allAreAllowed || m_allowedSpectra.contains(name)) {
-        tmp << name;
+        allowedNames << name;
       }
     }
 
-    for (const auto &i : tmp) {
+    for (const auto &name : allowedNames) {
       Mantid::API::Workspace_sptr ws =
           Mantid::API::AnalysisDataService::Instance().retrieve(
-              i.toStdString());
+              name.toStdString());
       if (isWorkspaceValid(ws)) {
-        m_workspaceNames.append(i);
+        m_workspaceNames.append(name);
       }
     }
   } else {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -65,10 +65,6 @@ Mantid::Kernel::Logger g_log("FitPropertyBrowser");
 
 using namespace Mantid::API;
 
-Workspace_sptr getADSWorkspace(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().retrieve(workspaceName);
-}
-
 int getNumberOfSpectra(MatrixWorkspace_sptr workspace) {
   return static_cast<int>(workspace->getNumberHistograms());
 }
@@ -1934,7 +1930,7 @@ QVector<double> FitPropertyBrowser::getXRange() {
   if (tbl) {
     auto xColumnIndex = m_columnManager->value(m_xColumn);
     std::vector<double> xColumnData;
-    for (auto i = 0; i < tbl->rowCount(); ++i) {
+    for (size_t i = 0; i < tbl->rowCount(); ++i) {
       xColumnData.push_back(tbl->Double(i, xColumnIndex));
     }
     std::sort(xColumnData.begin(), xColumnData.end());

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1640,8 +1640,8 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     } else {
       alg->setPropertyValue("XColumn", getXColumnName().toStdString());
       alg->setPropertyValue("YColumn", getYColumnName().toStdString());
-			if(getErrColumnName().toStdString() != "")
-				alg->setPropertyValue("ErrColumn", getErrColumnName().toStdString());
+      if (getErrColumnName().toStdString() != "")
+        alg->setPropertyValue("ErrColumn", getErrColumnName().toStdString());
     }
     alg->setProperty("StartX", startX());
     alg->setProperty("EndX", endX());
@@ -1752,29 +1752,28 @@ void FitPropertyBrowser::clearFitResultStatus() {
 /// Get and store available workspace names
 void FitPropertyBrowser::populateWorkspaceNames() {
   m_workspaceNames.clear();
-	if (m_allowedTableWorkspace.isEmpty()) {
-		bool allAreAllowed = m_allowedSpectra.isEmpty();
-		QStringList tmp;
-		auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
-		for (auto& it : sv) {
-			auto const& name = QString::fromStdString(it);
-			if (allAreAllowed || m_allowedSpectra.contains(name)) {
-				tmp << name;
-			}
-		}
+  if (m_allowedTableWorkspace.isEmpty()) {
+    bool allAreAllowed = m_allowedSpectra.isEmpty();
+    QStringList tmp;
+    auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
+    for (auto &it : sv) {
+      auto const &name = QString::fromStdString(it);
+      if (allAreAllowed || m_allowedSpectra.contains(name)) {
+        tmp << name;
+      }
+    }
 
-		for (int i = 0; i < tmp.size(); i++) {
-			Mantid::API::Workspace_sptr ws =
-				Mantid::API::AnalysisDataService::Instance().retrieve(
-					tmp[i].toStdString());
-			if (isWorkspaceValid(ws)) {
-				m_workspaceNames.append(tmp[i]);
-			}
-		}
-	}
-	else {
-		m_workspaceNames.append(m_allowedTableWorkspace);
-	}
+    for (int i = 0; i < tmp.size(); i++) {
+      Mantid::API::Workspace_sptr ws =
+          Mantid::API::AnalysisDataService::Instance().retrieve(
+              tmp[i].toStdString());
+      if (isWorkspaceValid(ws)) {
+        m_workspaceNames.append(tmp[i]);
+      }
+    }
+  } else {
+    m_workspaceNames.append(m_allowedTableWorkspace);
+  }
   m_enumManager->setEnumNames(m_workspace, m_workspaceNames);
   setWorkspaceIndex(0);
 }
@@ -1810,7 +1809,8 @@ void FitPropertyBrowser::addHandle(
     const boost::shared_ptr<Mantid::API::Workspace> ws) {
   auto const qName = QString::fromStdString(wsName);
   if (!isWorkspaceValid(ws) ||
-      (!m_allowedSpectra.isEmpty() && !m_allowedSpectra.contains(qName) && m_allowedTableWorkspace.isEmpty()))
+      (!m_allowedSpectra.isEmpty() && !m_allowedSpectra.contains(qName) &&
+       m_allowedTableWorkspace.isEmpty()))
     return;
   QString oldName = QString::fromStdString(workspaceName());
   int i = m_workspaceNames.indexOf(qName);
@@ -1951,7 +1951,7 @@ QVector<double> FitPropertyBrowser::getXRange() {
 QString FitPropertyBrowser::getXColumnName() const {
   const auto ws = getWorkspace();
   auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
-	QString columnName = "";
+  QString columnName = "";
   if (tbl) {
     auto columns = tbl->getColumnNames();
     auto xIndex = m_columnManager->value(m_xColumn);
@@ -1967,7 +1967,7 @@ QString FitPropertyBrowser::getXColumnName() const {
 QString FitPropertyBrowser::getYColumnName() const {
   const auto ws = getWorkspace();
   auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
-	QString columnName = "";
+  QString columnName = "";
   if (tbl) {
     auto columns = tbl->getColumnNames();
     auto yIndex = m_columnManager->value(m_yColumn);
@@ -1983,7 +1983,7 @@ QString FitPropertyBrowser::getYColumnName() const {
 QString FitPropertyBrowser::getErrColumnName() const {
   const auto ws = getWorkspace();
   auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
-	QString columnName = "";
+  QString columnName = "";
   if (tbl) {
     auto columns = tbl->getColumnNames();
     // The error column has an empty first entry
@@ -3398,15 +3398,14 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName,
   }
 }
 
-void FitPropertyBrowser::addAllowedTableWorkspace(const QString& wsName) {
-	auto const name = wsName.toStdString();
-	auto ws = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(name);
-	if (ws) {
-		m_allowedTableWorkspace = wsName;
-	}
-	else {
-		throw std::runtime_error("Workspace " + name + " is not a TableWorkspace");
-	}
+void FitPropertyBrowser::addAllowedTableWorkspace(const QString &wsName) {
+  auto const name = wsName.toStdString();
+  auto ws = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(name);
+  if (ws) {
+    m_allowedTableWorkspace = wsName;
+  } else {
+    throw std::runtime_error("Workspace " + name + " is not a TableWorkspace");
+  }
 }
 
 /**

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1752,19 +1752,19 @@ void FitPropertyBrowser::populateWorkspaceNames() {
     bool allAreAllowed = m_allowedSpectra.isEmpty();
     QStringList tmp;
     auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
-    for (auto &it : sv) {
+    for (const auto &it : sv) {
       auto const &name = QString::fromStdString(it);
       if (allAreAllowed || m_allowedSpectra.contains(name)) {
         tmp << name;
       }
     }
 
-    for (int i = 0; i < tmp.size(); i++) {
+    for (const auto &i : tmp) {
       Mantid::API::Workspace_sptr ws =
           Mantid::API::AnalysisDataService::Instance().retrieve(
-              tmp[i].toStdString());
+              i.toStdString());
       if (isWorkspaceValid(ws)) {
-        m_workspaceNames.append(tmp[i]);
+        m_workspaceNames.append(i);
       }
     }
   } else {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -69,10 +69,6 @@ Workspace_sptr getADSWorkspace(std::string const &workspaceName) {
   return AnalysisDataService::Instance().retrieve(workspaceName);
 }
 
-MatrixWorkspace_sptr convertToMatrixWorkspace(Workspace_sptr workspace) {
-  return boost::dynamic_pointer_cast<MatrixWorkspace>(workspace);
-}
-
 int getNumberOfSpectra(MatrixWorkspace_sptr workspace) {
   return static_cast<int>(workspace->getNumberHistograms());
 }
@@ -1116,10 +1112,6 @@ FitPropertyBrowser::getWorkspace() const {
   if (wsName.empty())
     return boost::shared_ptr<Mantid::API::Workspace>();
   try {
-    if (m_settingsGroup->property()->subProperties().contains(m_xColumn)) {
-      return createMatrixFromTableWorkspace();
-    }
-
     return Mantid::API::AnalysisDataService::Instance().retrieve(wsName);
   } catch (...) {
     return boost::shared_ptr<Mantid::API::Workspace>();
@@ -1642,7 +1634,15 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     }
     alg->setPropertyValue("Function", funStr);
     alg->setProperty("InputWorkspace", ws);
-    alg->setProperty("WorkspaceIndex", workspaceIndex());
+    auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+    if (!tbl) {
+      alg->setProperty("WorkspaceIndex", workspaceIndex());
+    } else {
+      alg->setPropertyValue("XColumn", getXColumnName().toStdString());
+      alg->setPropertyValue("YColumn", getYColumnName().toStdString());
+			if(getErrColumnName().toStdString() != "")
+				alg->setPropertyValue("ErrColumn", getErrColumnName().toStdString());
+    }
     alg->setProperty("StartX", startX());
     alg->setProperty("EndX", endX());
     alg->setPropertyValue("Output", outputName());
@@ -1652,7 +1652,9 @@ void FitPropertyBrowser::doFit(int maxIterations) {
     alg->setProperty("MaxIterations", maxIterations);
     alg->setProperty("PeakRadius", getPeakRadius());
     if (!isHistogramFit()) {
-      alg->setProperty("Normalise", m_shouldBeNormalised);
+      if (!tbl) {
+        alg->setProperty("Normalise", m_shouldBeNormalised);
+      }
       // Always output each composite function but not necessarily plot it
       alg->setProperty("OutputCompositeMembers", true);
       if (alg->existsProperty("ConvolveMembers")) {
@@ -1750,25 +1752,29 @@ void FitPropertyBrowser::clearFitResultStatus() {
 /// Get and store available workspace names
 void FitPropertyBrowser::populateWorkspaceNames() {
   m_workspaceNames.clear();
-  bool allAreAllowed = m_allowedSpectra.isEmpty();
+	if (m_allowedTableWorkspace.isEmpty()) {
+		bool allAreAllowed = m_allowedSpectra.isEmpty();
+		QStringList tmp;
+		auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
+		for (auto& it : sv) {
+			auto const& name = QString::fromStdString(it);
+			if (allAreAllowed || m_allowedSpectra.contains(name)) {
+				tmp << name;
+			}
+		}
 
-  QStringList tmp;
-  auto sv = Mantid::API::AnalysisDataService::Instance().getObjectNames();
-  for (auto &it : sv) {
-    auto const &name = QString::fromStdString(it);
-    if (allAreAllowed || m_allowedSpectra.contains(name)) {
-      tmp << name;
-    }
-  }
-
-  for (int i = 0; i < tmp.size(); i++) {
-    Mantid::API::Workspace_sptr ws =
-        Mantid::API::AnalysisDataService::Instance().retrieve(
-            tmp[i].toStdString());
-    if (isWorkspaceValid(ws)) {
-      m_workspaceNames.append(tmp[i]);
-    }
-  }
+		for (int i = 0; i < tmp.size(); i++) {
+			Mantid::API::Workspace_sptr ws =
+				Mantid::API::AnalysisDataService::Instance().retrieve(
+					tmp[i].toStdString());
+			if (isWorkspaceValid(ws)) {
+				m_workspaceNames.append(tmp[i]);
+			}
+		}
+	}
+	else {
+		m_workspaceNames.append(m_allowedTableWorkspace);
+	}
   m_enumManager->setEnumNames(m_workspace, m_workspaceNames);
   setWorkspaceIndex(0);
 }
@@ -1804,7 +1810,7 @@ void FitPropertyBrowser::addHandle(
     const boost::shared_ptr<Mantid::API::Workspace> ws) {
   auto const qName = QString::fromStdString(wsName);
   if (!isWorkspaceValid(ws) ||
-      (!m_allowedSpectra.isEmpty() && !m_allowedSpectra.contains(qName)))
+      (!m_allowedSpectra.isEmpty() && !m_allowedSpectra.contains(qName) && m_allowedTableWorkspace.isEmpty()))
     return;
   QString oldName = QString::fromStdString(workspaceName());
   int i = m_workspaceNames.indexOf(qName);
@@ -1855,7 +1861,7 @@ void FitPropertyBrowser::postDeleteHandle(const std::string &wsName) {
 }
 
 /** Check if the workspace can be used in the fit. The accepted types are
- * MatrixWorkspaces same size
+ * MatrixWorkspaces or TableWorkspaces
  * @param ws :: The workspace
  */
 bool FitPropertyBrowser::isWorkspaceValid(
@@ -1918,6 +1924,78 @@ void FitPropertyBrowser::setXRange(double start, double end) {
   connect(m_doubleManager, SIGNAL(propertyChanged(QtProperty *)), this,
           SLOT(doubleChanged(QtProperty *)));
 #endif
+}
+
+QVector<double> FitPropertyBrowser::getXRange() {
+  auto ws = getWorkspace();
+  auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+  auto mws = boost::dynamic_pointer_cast<MatrixWorkspace>(ws);
+  QVector<double> range;
+  if (tbl) {
+    auto xColumnIndex = m_columnManager->value(m_xColumn);
+    std::vector<double> xColumnData;
+    for (auto i = 0; i < tbl->rowCount(); ++i) {
+      xColumnData.push_back(tbl->Double(i, xColumnIndex));
+    }
+    std::sort(xColumnData.begin(), xColumnData.end());
+    range.push_back(xColumnData.front());
+    range.push_back(xColumnData.back());
+  } else if (mws) {
+    auto xData = mws->mutableX(workspaceIndex());
+    range.push_back(xData.front());
+    range.push_back(xData.back());
+  }
+  return range;
+}
+
+QString FitPropertyBrowser::getXColumnName() const {
+  const auto ws = getWorkspace();
+  auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+	QString columnName = "";
+  if (tbl) {
+    auto columns = tbl->getColumnNames();
+    auto xIndex = m_columnManager->value(m_xColumn);
+    if (xIndex >= static_cast<int>(columns.size())) {
+      QMessageBox::critical(nullptr, "Mantid - Error",
+                            "X column was not found.");
+    }
+    columnName = QString::fromStdString(columns[xIndex]);
+  }
+  return columnName;
+}
+
+QString FitPropertyBrowser::getYColumnName() const {
+  const auto ws = getWorkspace();
+  auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+	QString columnName = "";
+  if (tbl) {
+    auto columns = tbl->getColumnNames();
+    auto yIndex = m_columnManager->value(m_yColumn);
+    if (yIndex >= static_cast<int>(columns.size())) {
+      QMessageBox::critical(nullptr, "Mantid - Error",
+                            "Y column was not found.");
+    }
+    columnName = QString::fromStdString(columns[yIndex]);
+  }
+  return columnName;
+}
+
+QString FitPropertyBrowser::getErrColumnName() const {
+  const auto ws = getWorkspace();
+  auto tbl = boost::dynamic_pointer_cast<ITableWorkspace>(ws);
+	QString columnName = "";
+  if (tbl) {
+    auto columns = tbl->getColumnNames();
+    // The error column has an empty first entry
+    auto errIndex = m_columnManager->value(m_errColumn) - 1;
+    if (errIndex >= static_cast<int>(columns.size())) {
+      QMessageBox::warning(nullptr, "Mantid - Warning",
+                           "Error column was not found.");
+    } else if (errIndex != -1) {
+      columnName = QString::fromStdString(columns[errIndex]);
+    }
+  }
+  return columnName;
 }
 
 ///
@@ -2461,7 +2539,7 @@ void FitPropertyBrowser::checkFunction() {}
  */
 int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {
   auto const workspace =
-      convertToMatrixWorkspace(getADSWorkspace(workspaceName()));
+      boost::dynamic_pointer_cast<MatrixWorkspace>(getWorkspace());
 
   if (!workspace) {
     return 0;
@@ -2588,16 +2666,17 @@ void FitPropertyBrowser::reset() {
   createCompositeFunction(str);
 }
 
-void FitPropertyBrowser::setWorkspace(Mantid::API::IFunction_sptr f) const {
+void FitPropertyBrowser::setWorkspace(
+    Mantid::API::IFunction_sptr function) const {
   std::string wsName = workspaceName();
   if (!wsName.empty()) {
     try {
       auto ws = Mantid::API::AnalysisDataService::Instance().retrieve(wsName);
       auto mws = boost::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(ws);
       if (mws) {
-        f->setMatrixWorkspace(mws, workspaceIndex(), startX(), endX());
+        function->setMatrixWorkspace(mws, workspaceIndex(), startX(), endX());
       } else {
-        f->setWorkspace(ws);
+        function->setWorkspace(ws);
       }
     } catch (...) {
     }
@@ -3107,6 +3186,8 @@ void FitPropertyBrowser::setWorkspaceProperties() {
     m_columnManager->setEnumNames(m_errColumn, columns);
     if (!errName.isEmpty()) {
       m_columnManager->setValue(m_errColumn, columns.indexOf(errName));
+    } else {
+      m_columnManager->setValue(m_errColumn, 0);
     }
     return;
   }
@@ -3119,78 +3200,6 @@ void FitPropertyBrowser::addWorkspaceIndexToBrowser() {
       m_settingsGroup->property()->insertSubProperty(m_workspaceIndex,
                                                      m_workspace);
     }
-  }
-}
-
-/**=================================================================================================
- * Create a MatrixWorkspace from a TableWorkspace. Name of the TableWorkspace
- * is in m_workspace property, column names to use are in m_xColumn,
- * m_yColumn, and m_errColumn.
- */
-Mantid::API::Workspace_sptr
-FitPropertyBrowser::createMatrixFromTableWorkspace() const {
-  std::string wsName = workspaceName();
-  try {
-    auto ws = Mantid::API::AnalysisDataService::Instance().retrieve(wsName);
-    auto tws = boost::dynamic_pointer_cast<Mantid::API::ITableWorkspace>(ws);
-    if (!tws)
-      return boost::shared_ptr<Mantid::API::Workspace>();
-    const size_t rowCount = tws->rowCount();
-    if (rowCount == 0) {
-      QMessageBox::critical(nullptr, "Mantid - Error",
-                            "TableWorkspace is empty.");
-      return boost::shared_ptr<Mantid::API::Workspace>();
-    }
-
-    auto columns = tws->getColumnNames();
-
-    // get the x column
-    int ix = m_columnManager->value(m_xColumn);
-    if (ix >= static_cast<int>(columns.size())) {
-      QMessageBox::critical(nullptr, "Mantid - Error",
-                            "X column was not found.");
-      return boost::shared_ptr<Mantid::API::Workspace>();
-    }
-    auto xcol = tws->getColumn(columns[ix]);
-
-    // get the y column
-    int iy = m_columnManager->value(m_yColumn);
-    if (iy >= static_cast<int>(columns.size())) {
-      QMessageBox::critical(nullptr, "Mantid - Error",
-                            "Y column was not found.");
-      return boost::shared_ptr<Mantid::API::Workspace>();
-    }
-    auto ycol = tws->getColumn(columns[iy]);
-
-    // get the err column
-    int ie =
-        m_columnManager->value(m_errColumn) - 1; // first entry is empty string
-    if (ie >= 0 && ie >= static_cast<int>(columns.size())) {
-      QMessageBox::critical(nullptr, "Mantid - Error",
-                            "Error column was not found.");
-      return boost::shared_ptr<Mantid::API::Workspace>();
-    }
-    auto ecol =
-        ie < 0 ? Mantid::API::Column_sptr() : tws->getColumn(columns[ie]);
-
-    // create the MatrixWorkspace
-    Mantid::API::MatrixWorkspace_sptr mws =
-        Mantid::API::WorkspaceFactory::Instance().create("Workspace2D", 1,
-                                                         rowCount, rowCount);
-    auto &X = mws->mutableX(0);
-    auto &Y = mws->mutableY(0);
-    auto &E = mws->mutableE(0);
-
-    for (size_t row = 0; row < rowCount; ++row) {
-      X[row] = xcol->toDouble(row);
-      Y[row] = ycol->toDouble(row);
-      E[row] = ecol ? ecol->toDouble(row) : 1.0;
-    }
-
-    return mws;
-  } catch (std::exception &e) {
-    QMessageBox::critical(nullptr, "Mantid - Error", e.what());
-    return boost::shared_ptr<Mantid::API::Workspace>();
   }
 }
 
@@ -3387,6 +3396,17 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName,
   } else {
     throw std::runtime_error("Workspace " + name + " is not a MatrixWorkspace");
   }
+}
+
+void FitPropertyBrowser::addAllowedTableWorkspace(const QString& wsName) {
+	auto const name = wsName.toStdString();
+	auto ws = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(name);
+	if (ws) {
+		m_allowedTableWorkspace = wsName;
+	}
+	else {
+		throw std::runtime_error("Workspace " + name + " is not a TableWorkspace");
+	}
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR adds the functionality to fit table workspaces through the fit property browser and plot a guess and the fit results.

**To test:**
1. Open a table workspace or create one using the script below.
2. Plot the workspace
3. Open fit browser and add a suitable function 
4. Plot a guess by going to `Displace -> Plot Guess`, check this looks as expected
4. Fit the function, this should plot the calculated fit and the difference. (if `plot difference` is set to false only the calculated values should be plottted). Check this looks as expected

```
#creates an table workspace with a gaussian curve and a background 
import math

tableWS = CreateEmptyTableWorkspace()

tableWS.addColumn(type="double",name="X")
tableWS.addColumn(type="double",name="Y")
tableWS.addColumn(type="double",name="E")

for i in range(0,40):
      xValue = i * 0.05
      yValue = 10.0 * math.exp(-0.5*(xValue - 1.0)**2/0.05) + 2.0
      eValue = i%2*0.05
      tableWS.addRow ( { 'X': xValue, 'Y': yValue, 'E': eValue } )

```
Fixes #26449.
Fixes #26450.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
