### PR TITLE
Reload instrument when chunking

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -11,8 +11,8 @@ from mantid.api import mtd, AlgorithmFactory, DistributedDataProcessorAlgorithm,
 from mantid.kernel import Direction, PropertyManagerDataService
 from mantid.simpleapi import AlignAndFocusPowder, CompressEvents, ConvertDiffCal, ConvertUnits, CopyLogs, \
     CreateCacheFilename, DeleteWorkspace, DetermineChunking, Divide, EditInstrumentGeometry, FilterBadPulses, \
-    LoadDiffCal, Load, LoadNexusProcessed, PDDetermineCharacterizations, Plus, RebinToWorkspace, RemoveLogs, \
-    RenameWorkspace, SaveNexusProcessed
+    LoadDiffCal, Load, LoadIDFFromNexus, LoadNexusProcessed, PDDetermineCharacterizations, Plus, \
+    RebinToWorkspace, RemoveLogs, RenameWorkspace, SaveNexusProcessed
 import os
 import numpy as np
 
@@ -366,8 +366,13 @@ class AlignAndFocusPowderFromFiles(DistributedDataProcessorAlgorithm):
                 self.__setupCalibration(chunkname)
 
             # copy the necessary logs onto the workspace
-            if haveAccumulationForFile and len(chunks) > 1 and canSkipLoadingLogs:
+            if len(chunks) > 1 and canSkipLoadingLogs and haveAccumulationForFile:
                 CopyLogs(InputWorkspace=wkspname, OutputWorkspace=chunkname, MergeStrategy='WipeExisting')
+                # re-load instrument so detector positions that depend on logs get initialized
+                try:
+                    LoadIDFFromNexus(Workspace=chunkname, Filename=filename, InstrumentParentPath='/entry')
+                except RuntimeError as e:
+                    self.log().warning('Reloading instrument using "LoadIDFFromNexus" failed: {}'.format(e))
 
             # get the underlying loader name if we used the generic one
             if self.__loaderName == 'Load':

--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -187,6 +187,9 @@ class SNAPReduce(DataProcessorAlgorithm):
                              + "All detectors as one group, Groups (East,West for "
                              + "SNAP), Columns for SNAP, detector banks")
 
+        self.declareProperty("MaxChunkSize", 16.,
+                             "Specify maximum Gbytes of file to read in one chunk. Zero reads the whole file at once.")
+
         mode = ["Set-Up", "Production"]
         self.declareProperty("ProcessingMode", mode[1], StringListValidator(mode),
                              "Set-Up Mode is used for establishing correct parameters. Production "
@@ -394,7 +397,7 @@ class SNAPReduce(DataProcessorAlgorithm):
             progEnd = progStart + .9 * progDelta
             # pass all of the work to the child algorithm
             AlignAndFocusPowderFromFiles(Filename=filename, OutputWorkspace=wkspname ,
-                                         MaxChunkSize=16,  # GiB
+                                         MaxChunkSize=self.chunksize,
                                          UnfocussedWorkspace=unfocussed,  # can be empty string
                                          startProgress=progStart,
                                          endProgress=progEnd,
@@ -412,6 +415,7 @@ class SNAPReduce(DataProcessorAlgorithm):
         in_Runs = self.getProperty("RunNumbers").value
         progress = Progress(self, 0., .25, 3)
         finalUnits = self.getPropertyValue("FinalUnits")
+        self.chunkSize = self.getProperty('MaxChunkSize').value
 
         # default arguments for AlignAndFocusPowder
         self.alignAndFocusArgs = {'Tmin': 0,

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -19,13 +19,13 @@ Improvements
 - The file-naming scheme for ISIS powder is now controlled by a string template
 - The file-naming of output on HRPD as been updated to closely match old script outputs
 - Geometry definition for LLB 5C1
-- :ref:`SNAPReduce <SNAPReduce-v1>` has an additional parameter ``MaxChunkSize`` for customizing the chunking behavior
+- :ref:`SNAPReduce <algm-SNAPReduce-v1>` has an additional parameter ``MaxChunkSize`` for customizing the chunking behavior
 
 Bug Fixes
 #########
 
 - The values used to mask the prompt pulse on HRPD have been fixed.
-- :ref:`AlignAndFocusPowderFromFiles <AlignAndFocusPowderFromFiles-v1>` will reload the instrument if logs are skipped
+- :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles-v1>` will reload the instrument if logs are skipped
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -24,7 +24,7 @@ Bug Fixes
 #########
 
 - The values used to mask the prompt pulse on HRPD have been fixed.
-
+- :ref:`AlignAndFocusPowderFromFiles <AlignAndFocusPowderFromFiles-v1>` will reload the instrument if logs are skipped
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -19,6 +19,7 @@ Improvements
 - The file-naming scheme for ISIS powder is now controlled by a string template
 - The file-naming of output on HRPD as been updated to closely match old script outputs
 - Geometry definition for LLB 5C1
+- :ref:`SNAPReduce <SNAPReduce-v1>` has an additional parameter ``MaxChunkSize`` for customizing the chunking behavior
 
 Bug Fixes
 #########


### PR DESCRIPTION
When skipping logs in chunking mode on SNAP, the instrument needs to be reloaded in order to take the logs into account for calculating TOF->d conversions. While the issue is actually in `AlignAndFocusPowderFromFiles`, it was observed via `SNAPReduce` and can be tested from there.

There is no additional test because the file that exercised the bug is 16GB.

**To test:**

```python
SNAPReduce(RunNumbers=(45745),
               Masking='None',
               Calibration=convertType,
               CalibrationFilename='/SNS/SNAP/IPTS-22258/shared/SNAP_calibrate_d45735_2019_08_21.h5',
               Binning=(0.5,0.003,7),
               Normalization='None',
               FinalUnits='dSpacing')
```
should produce reasonable results.

Fixes #26771

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
