### PR TITLE
Resolve Framework warnings on Linux Clang

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
@@ -40,7 +40,7 @@ private:
 
 protected:
   Cone(const Cone &) = default;
-  Cone &operator=(const Cone &) = default;
+  Cone &operator=(const Cone &) = delete;
 
 public:
   /// Public identifer

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Cylinder.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Cylinder.h
@@ -46,7 +46,7 @@ private:
 
 protected:
   Cylinder(const Cylinder &) = default;
-  Cylinder &operator=(const Cylinder &) = default;
+  Cylinder &operator=(const Cylinder &) = delete;
 
 public:
   /// Public identifer

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/General.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/General.h
@@ -32,7 +32,7 @@ private:
 
 protected:
   General(const General &) = default;
-  General &operator=(const General &) = default;
+  General &operator=(const General &) = delete;
 
 public:
   General();

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h
@@ -43,7 +43,7 @@ private:
 
 protected:
   Plane(const Plane &) = default;
-  Plane &operator=(const Plane &) = default;
+  Plane &operator=(const Plane &) = delete;
 
 public:
   /// Effective typename

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Quadratic.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Quadratic.h
@@ -35,7 +35,7 @@ private:
 protected:
   std::vector<double> BaseEqn; ///< Base equation (as a 10 point vector)
   Quadratic(const Quadratic &) = default;
-  Quadratic &operator=(const Quadratic &) = default;
+  Quadratic &operator=(const Quadratic &) = delete;
 
 public:
   static const int Nprecision = 10; ///< Precision of the output

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Sphere.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Sphere.h
@@ -39,7 +39,7 @@ private:
 
 protected:
   Sphere(const Sphere &) = default;
-  Sphere &operator=(const Sphere &) = default;
+  Sphere &operator=(const Sphere &) = delete;
 
 public:
   Sphere();

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Torus.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Torus.h
@@ -42,7 +42,7 @@ private:
 
 protected:
   Torus(const Torus &) = default;
-  Torus &operator=(const Torus &) = default;
+  Torus &operator=(const Torus &) = delete;
 
 public:
   /// Public identifier


### PR DESCRIPTION
**Description of work.**
Note: Clang on Linux is an unsupported configuration (and won't even build Mantid Qt targets locally for me). Whilst you can build with it, only GCC is officially supported.

Marks some default copy constructors deleted as their base classes were deleted copy. This resolves 60+ warnings Clang emits when building the Framework target.

To test:
- Build the Framework target using clang-8 on Linux 
- Ensure no warnings are emitted 

Fixes N/A

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
