### PR TITLE
Hide PeakParameterFunction from gui dialogs 

### DIFF
--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -122,7 +122,7 @@ curvefitting.defaultPeak=Gaussian
 curvefitting.findPeaksFWHM=7
 curvefitting.findPeaksTolerance=4
 # Functions excluded from use by the guis
-curvefitting.guiExclude=CrystalFieldFunction;CrystalFieldHeatCapacity;CrystalFieldMagnetisation;CrystalFieldMoment;CrystalFieldMultiSpectrum;CrystalFieldPeaks;CrystalFieldSpectrum;CrystalFieldSusceptibility
+curvefitting.guiExclude=CrystalFieldFunction;CrystalFieldHeatCapacity;CrystalFieldMagnetisation;CrystalFieldMoment;CrystalFieldMultiSpectrum;CrystalFieldPeaks;CrystalFieldSpectrum;CrystalFieldSusceptibility;PeakParameterFunction;
 
 #Defines whether or not the sliceViewer will show NonOrthogonal view as a default
 sliceviewer.nonorthogonal=false

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -30,20 +30,23 @@ The Properties
 General properties
 ******************
 
-+----------------------------------+--------------------------------------------------+-------------------+
-|Property                          |Description                                       | Example value     |
-+==================================+==================================================+===================+
-| ``algorithms.categories.hidden`` | A comma separated list of any categories of      | ``Muons,Testing`` |
-|                                  | algorithms that should be hidden in Mantid.      |                   |
-+----------------------------------+--------------------------------------------------+-------------------+
-| ``algorithms.retained``          | The Number of algorithms properties to retain in | ``50``            |
-|                                  | memory for reference in scripts.                   |                 |
-+----------------------------------+--------------------------------------------------+-------------------+
-| ``MultiThreaded.MaxCores``       | Sets the maximum number of cores available to be | ``0``             |
-|                                  | used for threads for                             |                   |
-|                                  | `OpenMP <http://www.openmp.org/>`_. If zero it   |                   |
-|                                  | will use one thread per logical core available.  |                   |
-+----------------------------------+--------------------------------------------------+-------------------+
++----------------------------------+--------------------------------------------------+------------------------+
+|Property                          |Description                                       | Example value          |
++==================================+==================================================+========================+
+| ``algorithms.categories.hidden`` | A comma separated list of any categories of      | ``Muons,Testing``      |
+|                                  | algorithms that should be hidden in Mantid.      |                        |
++----------------------------------+--------------------------------------------------+------------------------+
+| ``algorithms.retained``          | The Number of algorithms properties to retain in | ``50``                 |
+|                                  | memory for reference in scripts.                 |                        |
++----------------------------------+--------------------------------------------------+------------------------+
+| ``curvefitting.guiExclude``      | A semicolon separated list of function names     | ``ExpDecay;Gaussian;`` |
+|                                  | that should be hidden in Mantid.                 |                        |
++----------------------------------+--------------------------------------------------+------------------------+
+| ``MultiThreaded.MaxCores``       | Sets the maximum number of cores available to be | ``0``                  |
+|                                  | used for threads for                             |                        |
+|                                  | `OpenMP <http://www.openmp.org/>`_. If zero it   |                        |
+|                                  | will use one thread per logical core available.  |                        |
++----------------------------------+--------------------------------------------------+------------------------+
 
 Facility and instrument properties
 **********************************
@@ -52,7 +55,7 @@ Facility and instrument properties
 |Property                      |Description                                         |Example value        |
 +==============================+====================================================+=====================+
 | ``default.facility``         | The name of the default facility. The facility     | ``ISIS``            |
-|                              | must be defined within the facilities.xml file to   |                    |
+|                              | must be defined within the facilities.xml file to  |                     |
 |                              | be considered valid. The file is described         |                     |
 |                              | :ref:`here <Facilities file>`.                     |                     |
 +------------------------------+----------------------------------------------------+---------------------+
@@ -181,7 +184,7 @@ Network Properties
 |                                           |operations (in seconds).                           |                                 |
 +-------------------------------------------+---------------------------------------------------+---------------------------------+
 | ``network.scriptrepo.timeout``            |The timeout for network operations in the script   | ``5``                           |
-|                                           |repository, this overrides the default timeout.   |                                  |
+|                                           |repository, this overrides the default timeout.    |                                 |
 +-------------------------------------------+---------------------------------------------------+---------------------------------+
 | ``proxy.host``                            | Allows the system proxy to be overridden, if not  | ``http://www.proxy.org``        |
 |                                           | set mantid will use the system proxy              |                                 |


### PR DESCRIPTION
**Description of work.**
This PR hides the function `PeakParameterFunction` from gui dialogs as it is only used internally and crashes mantid if it is selected.

**To test:**
Check that there are no `PeakParameterFunction` function in the Add Function dialog.

Fixes #26398 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
