### PR TITLE
Add 0 scale validators to reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -100,11 +100,11 @@ boost::optional<boost::optional<double>>
 parseScaleFactor(std::string const &scaleFactor) {
   if (isEntirelyWhitespace(scaleFactor)) {
     return boost::optional<double>(boost::none);
-  } else {
-    auto value = parseDouble(scaleFactor);
-    if (value.is_initialized())
-      return value;
   }
+
+  auto value = parseDouble(scaleFactor);
+  if (value.is_initialized() && value != 0.0)
+    return value;
   return boost::none;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
@@ -102,6 +102,7 @@ RowValidator::parseScaleFactor(std::vector<std::string> const &cellText) {
           cellText[SCALE_COLUMN]);
   if (!optionalScaleFactorOrNoneIfError.is_initialized())
     m_invalidColumns.emplace_back(SCALE_COLUMN);
+
   return optionalScaleFactorOrNoneIfError;
 }
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
@@ -140,6 +140,17 @@ public:
     TS_ASSERT(!result.is_initialized());
   }
 
+  void testParseScaleFactorRejectsZero() {
+    auto result = parseScaleFactor("0.0");
+    TS_ASSERT(!result.is_initialized());
+  }
+
+  void testParseScaleFactorNegative() {
+    auto result = parseScaleFactor("-1.0");
+    TS_ASSERT(result.get().is_initialized());
+    TS_ASSERT_EQUALS(result.get().get(), -1.0);
+  }
+
   void testParseQRange() {
     auto result = parseQRange("0.05", "0.16", "0.02");
     TS_ASSERT_EQUALS(result.which(), VALUE);


### PR DESCRIPTION
**Description of work.**
Prevents users using a 0 scale factor in the reflectometry GUI. Previously, this would cause MantidPlot to crash, but now you just get empty plots.

Whilst the algorithms could be updated they were left as is as:
- There is a common property deceleration method, but not common validation method. So each reflectometry method would need this check adding
- These algorithms are called through the GUI and rarely if ever by users
- Setting a scale factor of 0 no longer crashes Mantid

**To test:**
- Open the reflectometry GUI
- Enter any random run number (e.g. 123) and a random angle
- Attempt to enter 0 - check it is no accepted
- Enter a positive and negative scale factor (whilst I can't think of a reason to scale negatively, there is no reason we shouldn't allow them to) check they are accepted

Fixes #24252 

This does not require release notes because it was only noticed through internal testing.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
