### PR TITLE
Fix HRPD file naming bugs

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_PowderHRPDTest.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_PowderHRPDTest.py
@@ -96,13 +96,30 @@ class FocusTest(systemtesting.MantidSystemTest):
             self.assertTrue(os.path.isfile(os.path.join(directory, filename)),
                             msg=generate_error_message(filename, directory))
 
+        def first_x_value(filepath):
+            with open(filepath) as dat:
+                line = dat.readline().strip()
+                columns = line.split()
+                return float(columns[0])
+
         user_output = os.path.join(output_dir, cycle_number, user_name)
         assert_output_file_exists(user_output, 'hrpd66063.nxs')
         assert_output_file_exists(user_output, 'hrpd66063.gss')
         output_dat_dir = os.path.join(user_output, 'dat_files')
         for bankno in range(1, 4):
-            assert_output_file_exists(output_dat_dir, 'hrpd66063_b{}_D.dat'.format(bankno))
-            assert_output_file_exists(output_dat_dir, 'hrpd66063_b{}_TOF.dat'.format(bankno))
+            d_filename = 'hrpd66063_b{}_D.dat'.format(bankno)
+            assert_output_file_exists(output_dat_dir, d_filename)
+            # looks like dSpacing data
+            self.assertTrue(0.20 < first_x_value(os.path.join(output_dat_dir, d_filename)) < 0.8,
+                            msg="First D value={}".format(
+                                first_x_value(os.path.join(output_dat_dir, d_filename))))
+            tof_filename = 'hrpd66063_b{}_TOF.dat'.format(bankno)
+            assert_output_file_exists(output_dat_dir, tof_filename)
+            # looks like TOF data
+            self.assertTrue(
+                9800 < first_x_value(os.path.join(output_dat_dir, tof_filename)) < 10500,
+                msg="First TOF value={}".format(
+                    first_x_value(os.path.join(output_dat_dir, tof_filename))))
 
         if platform.system() == "Darwin":  # OSX requires higher tolerance for splines
             self.tolerance = 0.47

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -337,10 +337,7 @@ class AbstractInst(object):
             return [self._generate_inst_filename(run, file_ext) for run in run_number]
         else:
             # Individual entry
-            runfile = self._inst_prefix + str(run_number)
-            if file_ext is not None:
-                runfile += file_ext
-            return runfile
+            return self._inst_prefix + str(run_number) + file_ext
 
     def _add_formatting_options(self, format_options):
         """

--- a/scripts/Diffraction/isis_powder/gem.py
+++ b/scripts/Diffraction/isis_powder/gem.py
@@ -179,8 +179,8 @@ class Gem(AbstractInst):
                                 raise_warning=raise_warning)
 
     @staticmethod
-    def _generate_input_file_name(run_number):
-        return _gem_generate_inst_name(run_number=run_number)
+    def _generate_input_file_name(run_number, file_ext=""):
+        return _gem_generate_inst_name(run_number=run_number) + file_ext
 
     def _apply_absorb_corrections(self, run_details, ws_to_correct):
         if self._is_vanadium:

--- a/scripts/Diffraction/isis_powder/hrpd.py
+++ b/scripts/Diffraction/isis_powder/hrpd.py
@@ -14,10 +14,10 @@ from isis_powder.hrpd_routines import hrpd_advanced_config, hrpd_algs, hrpd_para
 
 import mantid.simpleapi as mantid
 
-# Force using raw files
-# A bug in loading old NeXus files prevents using NeXus.
+# A bug on the instrument when recording historic NeXus files (< 2015) caused
+# corrupted data. Use raw files for now until sufficient time has past and old
+# data is unlikely to be reanalysed.
 RAW_DATA_EXT = '.raw'
-
 
 # Constants
 PROMPT_PULSE_INTERVAL = 20000.0
@@ -106,14 +106,16 @@ class HRPD(AbstractInst):
             raise RuntimeError("Could not find " + os.path.join(path, name)+" please run create_vanadium with "
                                                                             "\"do_solid_angle_corrections=True\"")
 
-    def _generate_input_file_name(self, run_number, file_ext=None):
+    def _generate_input_file_name(self, run_number, file_ext=""):
         """
         Generates a name which Mantid uses within Load to find the file.
         :param run_number: The run number to convert into a valid format for Mantid
         :param file_ext: An optional file extension to add to force a particular format
         :return: A filename that will allow Mantid to find the correct run for that instrument.
         """
-        return self._generate_inst_filename(run_number=run_number, file_ext=RAW_DATA_EXT)
+        if not file_ext:
+            file_ext = RAW_DATA_EXT
+        return self._generate_inst_filename(run_number=run_number, file_ext=file_ext)
 
     def _apply_absorb_corrections(self, run_details, ws_to_correct):
         if self._is_vanadium:

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_advanced_config.py
@@ -65,8 +65,8 @@ window_180_280_params = {
 file_names = {
     "vanadium_peaks_masking_file": "VanaPeaks.dat",
     "grouping_file_name": "hrpd_new_072_01_corr.cal",
-    "nxs_filename": "{instlow}{runno}{suffix}.nxs",
-    "gss_filename": "{instlow}{runno}{suffix}.gss",
+    "nxs_filename": "{instlow}{runno}{_fileext}{suffix}.nxs",
+    "gss_filename": "{instlow}{runno}{_fileext}{suffix}.gss",
     "dat_files_directory": "dat_files",
     "tof_xye_filename": "{instlow}{runno}{_fileext}{suffix}_b{{bankno}}_TOF.dat",
     "dspacing_xye_filename": "{instlow}{runno}{_fileext}{suffix}_b{{bankno}}_D.dat",

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -92,7 +92,7 @@ class Polaris(AbstractInst):
         return cropped_ws
 
     @staticmethod
-    def _generate_input_file_name(run_number):
+    def _generate_input_file_name(run_number, file_ext=""):
         polaris_old_name = "POL"
         polaris_new_name = "POLARIS"
         first_run_new_name = 96912
@@ -114,7 +114,7 @@ class Polaris(AbstractInst):
 
             prefix = polaris_new_name if use_new_name else polaris_old_name
 
-            return prefix + str(run_number)
+            return prefix + str(run_number) + file_ext
 
     def _get_input_batching_mode(self):
         return self._inst_settings.input_mode

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -596,6 +596,7 @@ def _load_raw_files(run_number_string, instrument, file_ext=None):
     :return: A list of loaded workspaces
     """
     run_number_list = generate_run_numbers(run_number_string=run_number_string)
+    file_ext = "" if file_ext is None else file_ext
     load_raw_ws = _load_list_of_files(run_number_list, instrument, file_ext=file_ext)
     return load_raw_ws
 
@@ -613,8 +614,7 @@ def _load_list_of_files(run_numbers_list, instrument, file_ext=None):
     _check_load_range(list_of_runs_to_load=run_numbers_list)
 
     for run_number in run_numbers_list:
-        file_name = instrument._generate_input_file_name(run_number=run_number)
-        file_name = file_name + str(file_ext) if file_ext else file_name
+        file_name = instrument._generate_input_file_name(run_number=run_number, file_ext=file_ext)
         read_ws = mantid.Load(Filename=file_name)
         read_ws_list.append(mantid.RenameWorkspace(InputWorkspace=read_ws, OutputWorkspace=file_name))
 

--- a/scripts/Diffraction/isis_powder/routines/common_output.py
+++ b/scripts/Diffraction/isis_powder/routines/common_output.py
@@ -70,9 +70,9 @@ def save_focused_data(d_spacing_group, tof_group, output_paths):
                               Append=False)
 
     _save_xye(ws_group=d_spacing_group,
-              filename_template=ensure_dir_exists(output_paths["tof_xye_filename"]))
-    _save_xye(ws_group=tof_group,
               filename_template=ensure_dir_exists(output_paths["dspacing_xye_filename"]))
+    _save_xye(ws_group=tof_group,
+              filename_template=ensure_dir_exists(output_paths["tof_xye_filename"]))
 
 
 def _save_xye(ws_group, filename_template):

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -571,9 +571,9 @@ class ISISPowderMockInst(object):
         return ISISPowderMockRunDetails(file_ext=self._file_ext)
 
     @staticmethod
-    def _generate_input_file_name(run_number):
+    def _generate_input_file_name(run_number, file_ext=""):
         # Mantid will automatically convert this into either POL or POLARIS
-        return "POL" + str(run_number)
+        return "POL" + str(run_number) + file_ext
 
     @staticmethod
     def _normalise_ws_current(ws_to_correct, **_):


### PR DESCRIPTION
**Description of work.**


**Report to:** ISIS/Alex Gibbs

**To test:**

Run the tests in #26758 

The output files in `output/18_4/test/dat_files` that say `_D`/`_TOF` should now contain dSpacing/TOF respectively. They previously were swapped by accident.

Re-run the final focus command adding the argument `file_ext=".s01"` and observe that the output `.nxs` and `.gss` files are named `hrpd77265_s01.nxs` and `hrpd77265_s01.gss` respectively.

Fixes #26801

*This does not require release notes* because **it fixes a bug with work introduced this cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
