### PR TITLE
Powder diffraction Lorentz for POWGEN

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/LorentzCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/LorentzCorrection.h
@@ -25,10 +25,15 @@ public:
   }
   const std::string category() const override;
   const std::string summary() const override;
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   void init() override;
   void exec() override;
+  void processTOF_SCD(Mantid::API::MatrixWorkspace_sptr &wksp,
+                      Mantid::API::Progress &prog);
+  void processTOF_PD(Mantid::API::MatrixWorkspace_sptr &wksp,
+                     Mantid::API::Progress &prog);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/CloneWorkspace.cpp
+++ b/Framework/Algorithms/src/CloneWorkspace.cpp
@@ -34,6 +34,12 @@ void CloneWorkspace::init() {
 
 void CloneWorkspace::exec() {
   Workspace_sptr inputWorkspace = getProperty("InputWorkspace");
+  Workspace_const_sptr outputWorkspace = getProperty("OutputWorkspace");
+  if (inputWorkspace == outputWorkspace) {
+    g_log.information("Inplace operation requested, doing nothing");
+    return; // nothing to do
+  }
+
   MatrixWorkspace_const_sptr inputMatrix =
       boost::dynamic_pointer_cast<const MatrixWorkspace>(inputWorkspace);
   IMDWorkspace_sptr inputMD =

--- a/Framework/Algorithms/src/LorentzCorrection.cpp
+++ b/Framework/Algorithms/src/LorentzCorrection.cpp
@@ -5,11 +5,15 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/LorentzCorrection.h"
+#include "MantidAPI/Axis.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Progress.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidKernel/ListValidator.h"
 #include "MantidKernel/MultiThreaded.h"
+#include "MantidKernel/Unit.h"
 #include <boost/make_shared.hpp>
 #include <boost/shared_ptr.hpp>
 #include <cmath>
@@ -21,9 +25,28 @@ using namespace Mantid::API;
 using namespace Mantid::Geometry;
 using namespace Mantid::Kernel;
 using Mantid::API::WorkspaceProperty;
+using Mantid::DataObjects::EventWorkspace;
+using Mantid::DataObjects::EventWorkspace_sptr;
 
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(LorentzCorrection)
+
+namespace { // anonymous
+namespace PropertyNames {
+const std::string INPUT_WKSP("InputWorkspace");
+const std::string OUTPUT_WKSP("OutputWorkspace");
+const std::string TYPE("Type");
+}
+
+const std::string TOF_SCD("SingleCrystalTOF");
+const std::string TOF_PD("PowderTOF");
+
+inline double sinTheta(const API::SpectrumInfo &spectrumInfo, int64_t index) {
+  const double twoTheta =
+      spectrumInfo.isMonitor(index) ? 0.0 : spectrumInfo.twoTheta(index);
+  return std::sin(0.5 * twoTheta);
+}
+} // anonymous
 
 /// Algorithm's version for identification. @see Algorithm::version
 int LorentzCorrection::version() const { return 1; }
@@ -45,50 +68,89 @@ const std::string LorentzCorrection::name() const {
 /** Initialize the algorithm's properties.
  */
 void LorentzCorrection::init() {
-
+  declareProperty(
+      std::make_unique<WorkspaceProperty<MatrixWorkspace> >(
+          PropertyNames::INPUT_WKSP, "", Direction::Input, PropertyMode::Mandatory),
+      // boost::make_shared<WorkspaceUnitValidator>("Wavelength")),
+      "Input workspace to correct in Wavelength.");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input,
-                      PropertyMode::Mandatory,
-                      boost::make_shared<WorkspaceUnitValidator>("Wavelength")),
-                  "Input workspace to correct in Wavelength.");
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "OutputWorkspace", "", Direction::Output),
+                      PropertyNames::OUTPUT_WKSP, "", Direction::Output),
                   "An output workspace.");
+  const std::vector<std::string> correction_types{ TOF_SCD, TOF_PD };
+  declareProperty(PropertyNames::TYPE, correction_types[0],
+                  boost::make_shared<StringListValidator>(correction_types),
+                  "Type of Lorentz correction to do");
+}
+
+std::map<std::string, std::string> LorentzCorrection::validateInputs() {
+  std::map<std::string, std::string> result;
+
+  const auto processingType = this->getPropertyValue(PropertyNames::TYPE);
+  // check units if the SCD option is selected
+  if (processingType == TOF_SCD) {
+    MatrixWorkspace_const_sptr wksp = this->getProperty(PropertyNames::INPUT_WKSP);
+    // code is a variant of private method from WorkspaceUnitValidator
+    const auto unit = wksp->getAxis(0)->unit();
+    if ((!unit) || (unit->unitID().compare("Wavelength"))) {
+      result[PropertyNames::INPUT_WKSP] = "The workspace must have units of Wavelength";
+    }
+  }
+
+  return result;
 }
 
 /** Execute the algorithm.
  */
 void LorentzCorrection::exec() {
-  MatrixWorkspace_sptr inWS = this->getProperty("InputWorkspace");
+  MatrixWorkspace_sptr inWS = this->getProperty(PropertyNames::INPUT_WKSP);
 
+  // clone the workspace - does nothing for inplace operation
   auto cloneAlg = this->createChildAlgorithm("CloneWorkspace", 0, 0.1);
   cloneAlg->initialize();
   cloneAlg->setProperty("InputWorkspace", inWS);
+  cloneAlg->setPropertyValue("OutputWorkspace",
+                             this->getPropertyValue(PropertyNames::OUTPUT_WKSP));
   cloneAlg->execute();
   Workspace_sptr temp = cloneAlg->getProperty("OutputWorkspace");
   MatrixWorkspace_sptr outWS =
       boost::dynamic_pointer_cast<MatrixWorkspace>(temp);
 
-  const auto numHistos = inWS->getNumberHistograms();
-  const auto &spectrumInfo = inWS->spectrumInfo();
-  Progress prog(this, 0.0, 1.0, numHistos);
+  Progress prog(this, 0.1, 1.0, inWS->getNumberHistograms());
 
-  PARALLEL_FOR_IF(Kernel::threadSafe(*inWS))
-  for (int64_t i = 0; i < int64_t(numHistos); ++i) {
+  const auto processingType = this->getPropertyValue(PropertyNames::TYPE);
+  if (processingType == TOF_SCD)
+    processTOF_SCD(outWS, prog);
+  else if (processingType == TOF_PD)
+    processTOF_PD(outWS, prog);
+  else {
+    std::stringstream msg;
+    msg << "Do not understand know how to process Type=\"" << processingType
+        << "\" - developer forgot to fill in if/else tree";
+    throw std::runtime_error(msg.str());
+  }
+
+  this->setProperty(PropertyNames::OUTPUT_WKSP, outWS);
+}
+
+void LorentzCorrection::processTOF_SCD(MatrixWorkspace_sptr &wksp,
+                                       Progress &prog) {
+  const int64_t numHistos = static_cast<int64_t>(wksp->getNumberHistograms());
+  const auto &spectrumInfo = wksp->spectrumInfo();
+
+  PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
+  for (int64_t i = 0; i < numHistos; ++i) {
     PARALLEL_START_INTERUPT_REGION
 
     if (!spectrumInfo.hasDetectors(i))
       continue;
 
-    const double twoTheta =
-        spectrumInfo.isMonitor(i) ? 0.0 : spectrumInfo.twoTheta(i);
-    const double sinTheta = std::sin(twoTheta / 2);
-    double sinThetaSq = sinTheta * sinTheta;
+    const double sinTheta_v = sinTheta(spectrumInfo, i);
+    const double sinThetaSq = sinTheta_v * sinTheta_v;
 
-    auto &inY = inWS->y(i);
-    auto &outY = outWS->mutableY(i);
-    auto &outE = outWS->mutableE(i);
-    const auto points = inWS->points(i);
+    auto &outY = wksp->mutableY(i);
+    auto &outE = wksp->mutableE(i);
+    const auto points = wksp->points(i);
+    const auto num_points = points.size();
     const auto pos = std::find(cbegin(points), cend(points), 0.0);
     if (pos != cend(points)) {
       std::stringstream buffer;
@@ -96,7 +158,7 @@ void LorentzCorrection::exec() {
              << pos - cbegin(points);
       throw std::runtime_error(buffer.str());
     }
-    for (size_t j = 0; j < inY.size(); ++j) {
+    for (size_t j = 0; j < num_points; ++j) {
       double weight =
           sinThetaSq / (points[j] * points[j] * points[j] * points[j]);
       outY[j] *= weight;
@@ -108,8 +170,47 @@ void LorentzCorrection::exec() {
     PARALLEL_END_INTERUPT_REGION
   }
   PARALLEL_CHECK_INTERUPT_REGION
+}
 
-  this->setProperty("OutputWorkspace", outWS);
+void LorentzCorrection::processTOF_PD(MatrixWorkspace_sptr &wksp,
+                                      Progress &prog) {
+  const int64_t numHistos = static_cast<int64_t>(wksp->getNumberHistograms());
+  const auto &spectrumInfo = wksp->spectrumInfo();
+
+  EventWorkspace_sptr wkspEvent =
+      boost::dynamic_pointer_cast<EventWorkspace>(wksp);
+  bool isEvent = bool(wkspEvent);
+
+  PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
+  for (int64_t i = 0; i < numHistos; ++i) {
+    PARALLEL_START_INTERUPT_REGION
+
+    if (!spectrumInfo.hasDetectors(i))
+      continue;
+
+    const double sinTheta_v = sinTheta(spectrumInfo, i);
+
+    const auto points = wksp->points(i);
+    const auto pos = std::find(cbegin(points), cend(points), 0.0);
+    if (pos != cend(points)) {
+      std::stringstream buffer;
+      buffer << "Cannot have zero values Wavelength. At workspace index: "
+             << pos - cbegin(points);
+      throw std::runtime_error(buffer.str());
+    }
+
+    if (isEvent) {
+      wkspEvent->getSpectrum(i) *= sinTheta_v;
+    } else {
+      wksp->mutableY(i) *= sinTheta_v;
+      wksp->mutableE(i) *= sinTheta_v;
+    }
+
+    prog.report();
+
+    PARALLEL_END_INTERUPT_REGION
+  }
+  PARALLEL_CHECK_INTERUPT_REGION
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/LorentzCorrection.cpp
+++ b/Framework/Algorithms/src/LorentzCorrection.cpp
@@ -36,7 +36,7 @@ namespace PropertyNames {
 const std::string INPUT_WKSP("InputWorkspace");
 const std::string OUTPUT_WKSP("OutputWorkspace");
 const std::string TYPE("Type");
-}
+} // namespace PropertyNames
 
 const std::string TOF_SCD("SingleCrystalTOF");
 const std::string TOF_PD("PowderTOF");
@@ -46,7 +46,7 @@ inline double sinTheta(const API::SpectrumInfo &spectrumInfo, int64_t index) {
       spectrumInfo.isMonitor(index) ? 0.0 : spectrumInfo.twoTheta(index);
   return std::sin(0.5 * twoTheta);
 }
-} // anonymous
+} // namespace
 
 /// Algorithm's version for identification. @see Algorithm::version
 int LorentzCorrection::version() const { return 1; }
@@ -68,15 +68,15 @@ const std::string LorentzCorrection::name() const {
 /** Initialize the algorithm's properties.
  */
 void LorentzCorrection::init() {
-  declareProperty(
-      std::make_unique<WorkspaceProperty<MatrixWorkspace> >(
-          PropertyNames::INPUT_WKSP, "", Direction::Input, PropertyMode::Mandatory),
-      // boost::make_shared<WorkspaceUnitValidator>("Wavelength")),
-      "Input workspace to correct in Wavelength.");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
+                      PropertyNames::INPUT_WKSP, "", Direction::Input,
+                      PropertyMode::Mandatory),
+                  // boost::make_shared<WorkspaceUnitValidator>("Wavelength")),
+                  "Input workspace to correct in Wavelength.");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
                       PropertyNames::OUTPUT_WKSP, "", Direction::Output),
                   "An output workspace.");
-  const std::vector<std::string> correction_types{ TOF_SCD, TOF_PD };
+  const std::vector<std::string> correction_types{TOF_SCD, TOF_PD};
   declareProperty(PropertyNames::TYPE, correction_types[0],
                   boost::make_shared<StringListValidator>(correction_types),
                   "Type of Lorentz correction to do");
@@ -88,11 +88,13 @@ std::map<std::string, std::string> LorentzCorrection::validateInputs() {
   const auto processingType = this->getPropertyValue(PropertyNames::TYPE);
   // check units if the SCD option is selected
   if (processingType == TOF_SCD) {
-    MatrixWorkspace_const_sptr wksp = this->getProperty(PropertyNames::INPUT_WKSP);
+    MatrixWorkspace_const_sptr wksp =
+        this->getProperty(PropertyNames::INPUT_WKSP);
     // code is a variant of private method from WorkspaceUnitValidator
     const auto unit = wksp->getAxis(0)->unit();
     if ((!unit) || (unit->unitID().compare("Wavelength"))) {
-      result[PropertyNames::INPUT_WKSP] = "The workspace must have units of Wavelength";
+      result[PropertyNames::INPUT_WKSP] =
+          "The workspace must have units of Wavelength";
     }
   }
 
@@ -108,8 +110,8 @@ void LorentzCorrection::exec() {
   auto cloneAlg = this->createChildAlgorithm("CloneWorkspace", 0, 0.1);
   cloneAlg->initialize();
   cloneAlg->setProperty("InputWorkspace", inWS);
-  cloneAlg->setPropertyValue("OutputWorkspace",
-                             this->getPropertyValue(PropertyNames::OUTPUT_WKSP));
+  cloneAlg->setPropertyValue(
+      "OutputWorkspace", this->getPropertyValue(PropertyNames::OUTPUT_WKSP));
   cloneAlg->execute();
   Workspace_sptr temp = cloneAlg->getProperty("OutputWorkspace");
   MatrixWorkspace_sptr outWS =

--- a/Framework/Algorithms/test/LorentzCorrectionTest.h
+++ b/Framework/Algorithms/test/LorentzCorrectionTest.h
@@ -108,9 +108,10 @@ public:
     LorentzCorrection alg;
     alg.setChild(true);
     alg.initialize();
-    TSM_ASSERT_THROWS("Workspace must be in units of wavelength",
-                      alg.setProperty("InputWorkspace", ws_tof),
-                      std::invalid_argument &);
+    alg.setProperty("InputWorkspace", ws_tof);
+
+    TSM_ASSERT_THROWS("Workspace must be in units of wavelength", alg.execute(),
+                      std::runtime_error &);
   }
 
   void test_throws_if_wavelength_zero() {

--- a/Framework/Algorithms/test/LorentzCorrectionTest.h
+++ b/Framework/Algorithms/test/LorentzCorrectionTest.h
@@ -34,13 +34,17 @@ private:
   /*
    * Calculate what the weight should be.
    */
-  double calculate_weight_at(double xMin, double xMax, double twotheta) {
+  double calculate_scd_weight_at(double xMin, double xMax, double twotheta) {
 
     double lam = 0.5 * (xMin + xMax);
     double weight = std::sin(0.5 * twotheta);
     weight = weight * weight;
     weight = weight / (lam * lam * lam * lam);
     return weight;
+  }
+
+  double calculate_pd_weight_at(double twotheta) {
+    return std::sin(0.5 * twotheta);
   }
 
   /**
@@ -122,7 +126,7 @@ public:
                       alg.execute(), std::runtime_error &);
   }
 
-  void test_execute() {
+  void test_execute_scd() {
     auto ws_lam = this->create_workspace(2 /*nBins*/);
 
     LorentzCorrection alg;
@@ -142,17 +146,39 @@ public:
     const auto &eData = out_ws->e(0);
     const auto &spectrumInfo = out_ws->spectrumInfo();
 
-    int index = 0;
-    double weight = calculate_weight_at(xData[index], xData[index + 1],
-                                        spectrumInfo.twoTheta(0));
-    TS_ASSERT_EQUALS(yData[index], weight);
-    TS_ASSERT_EQUALS(eData[index], weight);
+    for (int index = 0; index < 2; ++index) {
+      const double weight = calculate_scd_weight_at(
+          xData[index], xData[index + 1], spectrumInfo.twoTheta(0));
+      TS_ASSERT_EQUALS(yData[index], weight);
+      TS_ASSERT_EQUALS(eData[index], weight);
+    }
+  }
 
-    index++; // go to 1
-    weight = calculate_weight_at(xData[index], xData[index + 1],
-                                 spectrumInfo.twoTheta(0));
-    TS_ASSERT_EQUALS(yData[index], weight);
-    TS_ASSERT_EQUALS(eData[index], weight);
+  void test_execute_pd() {
+    auto ws_lam = this->create_workspace(2 /*nBins*/);
+
+    LorentzCorrection alg;
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", ws_lam);
+    alg.setPropertyValue("OutputWorkspace", "temp");
+    alg.setPropertyValue("Type", "PowderTOF");
+    alg.execute();
+    MatrixWorkspace_sptr out_ws = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(out_ws != nullptr);
+
+    const std::string unitID = out_ws->getAxis(0)->unit()->unitID();
+    TS_ASSERT_EQUALS(unitID, "Wavelength");
+
+    const auto &yData = out_ws->y(0);
+    const auto &eData = out_ws->e(0);
+    const auto &spectrumInfo = out_ws->spectrumInfo();
+
+    for (int index = 0; index < 2; ++index) {
+      const double weight = calculate_pd_weight_at(spectrumInfo.twoTheta(0));
+      TS_ASSERT_EQUALS(yData[index], weight);
+      TS_ASSERT_EQUALS(eData[index], weight);
+    }
   }
 };
 

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -28,7 +28,7 @@ PROPS_FOR_ALIGN = [CAL_FILE, GROUP_FILE,
                    "Params", "ResampleX", "Dspacing",
                    "PreserveEvents",
                    "RemovePromptPulseWidth", "CompressTolerance", "CompressWallClockTolerance",
-                   "CompressStartTime", "UnwrapRef", "LowResRef",
+                   "CompressStartTime", "LorentzCorrection", "UnwrapRef", "LowResRef",
                    "LowResSpectrumOffset", "ReductionProperties"]
 PROPS_FOR_ALIGN.extend(PROPS_IN_PD_CHARACTER)
 PROPS_FOR_ALIGN.extend(PROPS_FOR_INSTR)

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -181,8 +181,8 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self.declareProperty(FileProperty(name="ExpIniFilename", defaultValue="", action=FileAction.OptionalLoad,
                                           extensions=[".ini"]))
         self.copyProperties('AlignAndFocusPowderFromFiles',
-                            ['UnwrapRef', 'LowResRef', 'CropWavelengthMin', 'CropWavelengthMax', 'RemovePromptPulseWidth',
-                             'MaxChunkSize'])
+                            ['LorentzCorrection', 'UnwrapRef', 'LowResRef', 'CropWavelengthMin', 'CropWavelengthMax',
+                             'RemovePromptPulseWidth', 'MaxChunkSize'])
         self.declareProperty(FloatArrayProperty("Binning", values=[0., 0., 0.],
                                                 direction=Direction.Input),
                              "Positive is linear bins, negative is logorithmic")  # Params
@@ -258,6 +258,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self._bin_in_dspace = self.getProperty("BinInDspace").value
         self._filterBadPulses = self.getProperty("FilterBadPulses").value
         self._removePromptPulseWidth = self.getProperty("RemovePromptPulseWidth").value
+        self._lorentz = self.getProperty("LorentzCorrection").value
         self._LRef = self.getProperty("UnwrapRef").value
         self._DIFCref = self.getProperty("LowResRef").value
         self._wavelengthMin = self.getProperty("CropWavelengthMin").value
@@ -712,6 +713,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                                          PreserveEvents=preserveEvents,
                                          RemovePromptPulseWidth=self._removePromptPulseWidth,
                                          CompressTolerance=self.COMPRESS_TOL_TOF,
+                                         LorentzCorrection=self._lorentz,
                                          UnwrapRef=self._LRef,
                                          LowResRef=self._DIFCref,
                                          LowResSpectrumOffset=self._lowResTOFoffset,
@@ -823,6 +825,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                                         PreserveEvents=preserveEvents,
                                         RemovePromptPulseWidth=self._removePromptPulseWidth,
                                         CompressTolerance=self.COMPRESS_TOL_TOF,
+                                        LorentzCorrection=self._lorentz,
                                         UnwrapRef=self._LRef,
                                         LowResRef=self._DIFCref,
                                         LowResSpectrumOffset=self._lowResTOFoffset,

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -9,8 +9,8 @@
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/SpectrumInfo.h"
+#include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
@@ -76,8 +76,8 @@ const std::string LORENTZ("LorentzCorrection");
 const std::string UNWRAP_REF("UnwrapRef");
 const std::string LOWRES_REF("LowResRef");
 const std::string LOWRES_SPEC_OFF("LowResSpectrumOffset");
-}
-}
+} // namespace PropertyNames
+} // namespace
 
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(AlignAndFocusPowder)
@@ -103,15 +103,14 @@ void AlignAndFocusPowder::init() {
   //   Direction::Output, PropertyMode::Optional),
   //   "The name of the workspace containing the filtered low resolution TOF
   //   data.");
-  declareProperty(
-      std::make_unique<FileProperty>(
-          PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad,
-          std::vector<std::string>{ ".h5", ".hd5", ".hdf", ".cal" }),
-      "The name of the calibration file with offset, masking, and "
-      "grouping data");
+  declareProperty(std::make_unique<FileProperty>(
+                      PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad,
+                      std::vector<std::string>{".h5", ".hd5", ".hdf", ".cal"}),
+                  "The name of the calibration file with offset, masking, and "
+                  "grouping data");
   declareProperty(std::make_unique<FileProperty>(
                       PropertyNames::GROUP_FILE, "", FileProperty::OptionalLoad,
-                      std::vector<std::string>{ ".xml", ".cal" }),
+                      std::vector<std::string>{".xml", ".cal"}),
                   "Overrides grouping from CalFileName");
   declareProperty(std::make_unique<WorkspaceProperty<GroupingWorkspace>>(
                       PropertyNames::GROUP_WKSP, "", Direction::InOut,
@@ -200,9 +199,10 @@ void AlignAndFocusPowder::init() {
       "starting filtering. Ignored if WallClockTolerance is not specified. "
       "Default is start of run",
       Direction::Input);
-  declareProperty(PropertyNames::LORENTZ, false, "Multiply each spectrum by "
-                                                 "sin(theta) where theta is "
-                                                 "half of the Bragg angle");
+  declareProperty(PropertyNames::LORENTZ, false,
+                  "Multiply each spectrum by "
+                  "sin(theta) where theta is "
+                  "half of the Bragg angle");
   declareProperty(PropertyNames::UNWRAP_REF, 0.,
                   "Reference total flight path for frame "
                   "unwrapping. Zero skips the correction");
@@ -225,9 +225,8 @@ void AlignAndFocusPowder::init() {
       "workspace indices).");
   declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::L2),
                   "Optional: Secondary flight (L2) paths for each detector");
-  declareProperty(
-      std::make_unique<ArrayProperty<double>>(PropertyNames::POLAR),
-      "Optional: Polar angles (two thetas) for detectors");
+  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::POLAR),
+                  "Optional: Polar angles (two thetas) for detectors");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::AZIMUTHAL),
       "Azimuthal angles (out-of-plain) for detectors");

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -602,13 +602,14 @@ void AlignAndFocusPowder::exec() {
   if (applyLorentz) {
     g_log.information() << "Applying Lorentz correction started at "
                         << Types::Core::DateAndTime::getCurrentTime() << "\n";
-    const size_t numHist = m_outputEW->getNumberHistograms();
+
+    API::IAlgorithm_sptr alg = createChildAlgorithm("LorentzCorrection");
+    alg->setProperty("InputWorkspace", m_outputW);
+    alg->setProperty("OutputWorkspace", m_outputW);
+    alg->setPropertyValue("Type", "PowderTOF");
+    alg->executeAsChildAlg();
+    m_outputW = alg->getProperty("OutputWorkspace");
     m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
-    const auto &specInfo = m_outputEW->spectrumInfo();
-    for (size_t i = 0; i < numHist; ++i) {
-      const double sin_theta = std::sin(.5 * specInfo.twoTheta(i));
-      m_outputEW->getSpectrum(i) *= sin_theta;
-    }
   }
 
   if (LRef > 0. || minwl > 0. || DIFCref > 0. || (!isEmpty(maxwl))) {

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -39,6 +39,44 @@ using API::MatrixWorkspace;
 using API::MatrixWorkspace_sptr;
 using API::WorkspaceProperty;
 
+namespace {
+namespace PropertyNames {
+const std::string INPUT_WKSP("InputWorkspace");
+const std::string OUTPUT_WKSP("OutputWorkspace");
+const std::string UNFOCUS_WKSP("UnfocussedWorkspace");
+const std::string CAL_FILE("CalFileName");
+const std::string GROUP_FILE("GroupFilename");
+const std::string GROUP_WKSP("GroupingWorkspace");
+const std::string CAL_WKSP("CalibrationWorkspace");
+const std::string OFFSET_WKSP("OffsetsWorkspace");
+const std::string MASK_WKSP("MaskWorkspace");
+const std::string MASK_TABLE("MaskBinTable");
+const std::string BINNING("Params");
+const std::string RESAMPLEX("ResampleX");
+const std::string BIN_IN_D("Dspacing");
+const std::string D_MINS("DMin");
+const std::string D_MAXS("DMax");
+const std::string TOF_MIN("TMin");
+const std::string TOF_MAX("TMax");
+const std::string WL_MIN("CropWavelengthMin");
+const std::string WL_MAX("CropWavelengthMax");
+const std::string PRESERVE_EVENTS("PreserveEvents");
+const std::string REMOVE_PROMPT_PULSE("RemovePromptPulseWidth");
+const std::string COMPRESS_TOF_TOL("CompressTolerance");
+const std::string COMPRESS_WALL_TOL("CompressWallClockTolerance");
+const std::string COMPRESS_WALL_START("CompressStartTime");
+const std::string L1("PrimaryFlightPath");
+const std::string SPEC_IDS("SpectrumIDs");
+const std::string L2("L2");
+const std::string POLAR("Polar");
+const std::string AZIMUTHAL("Azimuthal");
+const std::string PM_NAME("ReductionProperties");
+const std::string UNWRAP_REF("UnwrapRef");
+const std::string LOWRES_REF("LowResRef");
+const std::string LOWRES_SPEC_OFF("LowResSpectrumOffset");
+}
+}
+
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(AlignAndFocusPowder)
 
@@ -47,14 +85,15 @@ DECLARE_ALGORITHM(AlignAndFocusPowder)
  */
 void AlignAndFocusPowder::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input),
+                      PropertyNames::INPUT_WKSP, "", Direction::Input),
                   "The input workspace");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "OutputWorkspace", "", Direction::Output),
+                      PropertyNames::OUTPUT_WKSP, "", Direction::Output),
                   "The result of diffraction focussing of InputWorkspace");
   declareProperty(
       std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-          "UnfocussedWorkspace", "", Direction::Output, PropertyMode::Optional),
+          PropertyNames::UNFOCUS_WKSP, "", Direction::Output,
+          PropertyMode::Optional),
       "Treated data in d-spacing before focussing (optional). This will likely "
       "need rebinning.");
   // declareProperty(
@@ -62,85 +101,91 @@ void AlignAndFocusPowder::init() {
   //   Direction::Output, PropertyMode::Optional),
   //   "The name of the workspace containing the filtered low resolution TOF
   //   data.");
-  declareProperty(std::make_unique<FileProperty>(
-                      "CalFileName", "", FileProperty::OptionalLoad,
-                      std::vector<std::string>{".h5", ".hd5", ".hdf", ".cal"}),
-                  "The name of the calibration file with offset, masking, and "
-                  "grouping data");
-  declareProperty(std::make_unique<FileProperty>(
-                      "GroupFilename", "", FileProperty::OptionalLoad,
-                      std::vector<std::string>{".xml", ".cal"}),
-                  "Overrides grouping from CalFileName");
   declareProperty(
-      std::make_unique<WorkspaceProperty<GroupingWorkspace>>(
-          "GroupingWorkspace", "", Direction::InOut, PropertyMode::Optional),
-      "Optional: A GroupingWorkspace giving the grouping info.");
+      std::make_unique<FileProperty>(
+          PropertyNames::CAL_FILE, "", FileProperty::OptionalLoad,
+          std::vector<std::string>{ ".h5", ".hd5", ".hdf", ".cal" }),
+      "The name of the calibration file with offset, masking, and "
+      "grouping data");
+  declareProperty(std::make_unique<FileProperty>(
+                      PropertyNames::GROUP_FILE, "", FileProperty::OptionalLoad,
+                      std::vector<std::string>{ ".xml", ".cal" }),
+                  "Overrides grouping from CalFileName");
+  declareProperty(std::make_unique<WorkspaceProperty<GroupingWorkspace>>(
+                      PropertyNames::GROUP_WKSP, "", Direction::InOut,
+                      PropertyMode::Optional),
+                  "Optional: A GroupingWorkspace giving the grouping info.");
 
   declareProperty(
       std::make_unique<WorkspaceProperty<ITableWorkspace>>(
-          "CalibrationWorkspace", "", Direction::InOut, PropertyMode::Optional),
+          PropertyNames::CAL_WKSP, "", Direction::InOut,
+          PropertyMode::Optional),
       "Optional: A Workspace containing the calibration information. Either "
       "this or CalibrationFile needs to be specified.");
   declareProperty(
       std::make_unique<WorkspaceProperty<OffsetsWorkspace>>(
-          "OffsetsWorkspace", "", Direction::Input, PropertyMode::Optional),
+          PropertyNames::OFFSET_WKSP, "", Direction::Input,
+          PropertyMode::Optional),
       "Optional: An OffsetsWorkspace giving the detector calibration values.");
-  declareProperty(
-      std::make_unique<WorkspaceProperty<MaskWorkspace>>(
-          "MaskWorkspace", "", Direction::InOut, PropertyMode::Optional),
-      "Optional: A workspace giving which detectors are masked.");
+  declareProperty(std::make_unique<WorkspaceProperty<MaskWorkspace>>(
+                      PropertyNames::MASK_WKSP, "", Direction::InOut,
+                      PropertyMode::Optional),
+                  "Optional: A workspace giving which detectors are masked.");
   declareProperty(
       std::make_unique<WorkspaceProperty<TableWorkspace>>(
           "MaskBinTable", "", Direction::Input, PropertyMode::Optional),
       "Optional: A workspace giving pixels and bins to mask.");
-  declareProperty(
-      std::make_unique<ArrayProperty<double>>(
-          "Params" /*, boost::make_shared<RebinParamsValidator>()*/),
+  declareProperty( // intentionally not using the RebinParamsValidator
+      std::make_unique<ArrayProperty<double>>(PropertyNames::BINNING),
       "A comma separated list of first bin boundary, width, last bin boundary. "
       "Optionally\n"
       "this can be followed by a comma and more widths and last boundary "
       "pairs.\n"
       "Negative width values indicate logarithmic binning.");
-  declareProperty("ResampleX", 0,
+  declareProperty(PropertyNames::RESAMPLEX, 0,
                   "Number of bins in x-axis. Non-zero value "
                   "overrides \"Params\" property. Negative "
                   "value means logarithmic binning.");
-  setPropertySettings(
-      "Params", std::make_unique<EnabledWhenProperty>("ResampleX", IS_DEFAULT));
-  declareProperty("Dspacing", true,
+  setPropertySettings(PropertyNames::BINNING,
+                      std::make_unique<EnabledWhenProperty>(
+                          PropertyNames::RESAMPLEX, IS_DEFAULT));
+  declareProperty(PropertyNames::BIN_IN_D, true,
                   "Bin in Dspace. (True is Dspace; False is TOF)");
-  declareProperty(std::make_unique<ArrayProperty<double>>("DMin"),
-                  "Minimum for Dspace axis. (Default 0.) ");
-  mapPropertyName("DMin", "d_min");
-  declareProperty(std::make_unique<ArrayProperty<double>>("DMax"),
-                  "Maximum for Dspace axis. (Default 0.) ");
-  mapPropertyName("DMax", "d_max");
-  declareProperty("TMin", EMPTY_DBL(), "Minimum for TOF axis. Defaults to 0. ");
-  mapPropertyName("TMin", "tof_min");
-  declareProperty("TMax", EMPTY_DBL(),
+  declareProperty(
+      std::make_unique<ArrayProperty<double>>(PropertyNames::D_MINS),
+      "Minimum for Dspace axis. (Default 0.) ");
+  mapPropertyName(PropertyNames::D_MINS, "d_min");
+  declareProperty(
+      std::make_unique<ArrayProperty<double>>(PropertyNames::D_MAXS),
+      "Maximum for Dspace axis. (Default 0.) ");
+  mapPropertyName(PropertyNames::D_MAXS, "d_max");
+  declareProperty(PropertyNames::TOF_MIN, EMPTY_DBL(),
+                  "Minimum for TOF axis. Defaults to 0. ");
+  mapPropertyName(PropertyNames::TOF_MIN, "tof_min");
+  declareProperty(PropertyNames::TOF_MAX, EMPTY_DBL(),
                   "Maximum for TOF or dspace axis. Defaults to 0. ");
-  mapPropertyName("TMax", "tof_max");
-  declareProperty("PreserveEvents", true,
+  mapPropertyName(PropertyNames::TOF_MAX, "tof_max");
+  declareProperty(PropertyNames::PRESERVE_EVENTS, true,
                   "If the InputWorkspace is an "
                   "EventWorkspace, this will preserve "
                   "the full event list (warning: this "
                   "will use much more memory!).");
-  declareProperty("RemovePromptPulseWidth", 0.,
+  declareProperty(PropertyNames::REMOVE_PROMPT_PULSE, 0.,
                   "Width of events (in "
                   "microseconds) near the prompt "
                   "pulse to remove. 0 disables");
   auto mustBePositive = boost::make_shared<BoundedValidator<double>>();
   mustBePositive->setLower(0.0);
+  declareProperty(std::make_unique<PropertyWithValue<double>>(
+                      PropertyNames::COMPRESS_TOF_TOL, 1e-5, mustBePositive,
+                      Direction::Input),
+                  "Compress events (in "
+                  "microseconds) within this "
+                  "tolerance. (Default 1e-5)");
   declareProperty(
       std::make_unique<PropertyWithValue<double>>(
-          "CompressTolerance", 1e-5, mustBePositive, Direction::Input),
-      "Compress events (in "
-      "microseconds) within this "
-      "tolerance. (Default 1e-5)");
-  declareProperty(
-      std::make_unique<PropertyWithValue<double>>("CompressWallClockTolerance",
-                                                  EMPTY_DBL(), mustBePositive,
-                                                  Direction::Input),
+          PropertyNames::COMPRESS_WALL_TOL, EMPTY_DBL(), mustBePositive,
+          Direction::Input),
       "The tolerance (in seconds) on the wall-clock time for comparison. Unset "
       "means compressing all wall-clock times together disabling pulsetime "
       "resolution.");
@@ -148,38 +193,41 @@ void AlignAndFocusPowder::init() {
   auto dateValidator = boost::make_shared<DateTimeValidator>();
   dateValidator->allowEmpty(true);
   declareProperty(
-      "CompressStartTime", "", dateValidator,
+      PropertyNames::COMPRESS_WALL_START, "", dateValidator,
       "An ISO formatted date/time string specifying the timestamp for "
       "starting filtering. Ignored if WallClockTolerance is not specified. "
       "Default is start of run",
       Direction::Input);
-  declareProperty("UnwrapRef", 0.,
+  declareProperty(PropertyNames::UNWRAP_REF, 0.,
                   "Reference total flight path for frame "
                   "unwrapping. Zero skips the correction");
   declareProperty(
-      "LowResRef", 0.,
+      PropertyNames::LOWRES_REF, 0.,
       "Reference DIFC for resolution removal. Zero skips the correction");
   declareProperty(
       "CropWavelengthMin", 0.,
       "Crop the data at this minimum wavelength. Overrides LowResRef.");
-  mapPropertyName("CropWavelengthMin", "wavelength_min");
+  mapPropertyName(PropertyNames::WL_MIN, "wavelength_min");
   declareProperty("CropWavelengthMax", EMPTY_DBL(),
                   "Crop the data at this maximum wavelength. Forces use of "
                   "CropWavelengthMin.");
-  mapPropertyName("CropWavelengthMax", "wavelength_max");
-  declareProperty("PrimaryFlightPath", -1.0,
+  mapPropertyName(PropertyNames::WL_MAX, "wavelength_max");
+  declareProperty(PropertyNames::L1, -1.0,
                   "If positive, focus positions are changed.  (Default -1) ");
-  declareProperty(std::make_unique<ArrayProperty<int32_t>>("SpectrumIDs"),
-                  "Optional: Spectrum Nos (note that it is not detector ID or "
-                  "workspace indices).");
-  declareProperty(std::make_unique<ArrayProperty<double>>("L2"),
+  declareProperty(
+      std::make_unique<ArrayProperty<int32_t>>(PropertyNames::SPEC_IDS),
+      "Optional: Spectrum Nos (note that it is not detector ID or "
+      "workspace indices).");
+  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::L2),
                   "Optional: Secondary flight (L2) paths for each detector");
-  declareProperty(std::make_unique<ArrayProperty<double>>("Polar"),
-                  "Optional: Polar angles (two thetas) for detectors");
-  declareProperty(std::make_unique<ArrayProperty<double>>("Azimuthal"),
-                  "Azimuthal angles (out-of-plain) for detectors");
+  declareProperty(
+      std::make_unique<ArrayProperty<double>>(PropertyNames::POLAR),
+      "Optional: Polar angles (two thetas) for detectors");
+  declareProperty(
+      std::make_unique<ArrayProperty<double>>(PropertyNames::AZIMUTHAL),
+      "Azimuthal angles (out-of-plain) for detectors");
 
-  declareProperty("LowResSpectrumOffset", -1,
+  declareProperty(PropertyNames::LOWRES_SPEC_OFF, -1,
                   "Offset on spectrum No of low resolution spectra from high "
                   "resolution one. "
                   "If negative, then all the low resolution TOF will not be "
@@ -189,24 +237,26 @@ void AlignAndFocusPowder::init() {
                   "same spectrum Nos as the normal ones.  "
                   "Otherwise, the low resolution spectra will have spectrum "
                   "IDs offset from normal ones. ");
-  declareProperty("ReductionProperties", "__powdereduction", Direction::Input);
+  declareProperty(PropertyNames::PM_NAME, "__powdereduction", Direction::Input);
 }
 
 std::map<std::string, std::string> AlignAndFocusPowder::validateInputs() {
   std::map<std::string, std::string> result;
 
-  if (!isDefault("UnfocussedWorkspace")) {
-    if (getPropertyValue("OutputWorkspace") ==
-        getPropertyValue("UnfocussedWorkspace")) {
-      result["OutputWorkspace"] = "Cannot be the same as UnfocussedWorkspace";
-      result["UnfocussedWorkspace"] = "Cannot be the same as OutputWorkspace";
+  if (!isDefault(PropertyNames::UNFOCUS_WKSP)) {
+    if (getPropertyValue(PropertyNames::OUTPUT_WKSP) ==
+        getPropertyValue(PropertyNames::UNFOCUS_WKSP)) {
+      result[PropertyNames::OUTPUT_WKSP] =
+          "Cannot be the same as UnfocussedWorkspace";
+      result[PropertyNames::UNFOCUS_WKSP] =
+          "Cannot be the same as OutputWorkspace";
     }
   }
 
-  m_inputW = getProperty("InputWorkspace");
+  m_inputW = getProperty(PropertyNames::INPUT_WKSP);
   m_inputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_inputW);
   if (m_inputEW && m_inputEW->getNumberEvents() <= 0)
-    result["InputWorkspace"] = "Cannot process empty event workspace";
+    result[PropertyNames::INPUT_WKSP] = "Cannot process empty event workspace";
 
   return result;
 }
@@ -273,7 +323,7 @@ AlignAndFocusPowder::getVecPropertyFromPmOrSelf(const std::string &name,
  */
 void AlignAndFocusPowder::exec() {
   // retrieve the properties
-  m_inputW = getProperty("InputWorkspace");
+  m_inputW = getProperty(PropertyNames::INPUT_WKSP);
   m_inputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_inputW);
   m_instName = m_inputW->getInstrument()->getName();
   try {
@@ -282,33 +332,36 @@ void AlignAndFocusPowder::exec() {
   } catch (Exception::NotFoundError &) {
     ; // not noteworthy
   }
-  std::string calFilename = getPropertyValue("CalFileName");
-  std::string groupFilename = getPropertyValue("GroupFilename");
-  m_calibrationWS = getProperty("CalibrationWorkspace");
-  m_maskWS = getProperty("MaskWorkspace");
-  m_groupWS = getProperty("GroupingWorkspace");
-  DataObjects::TableWorkspace_sptr maskBinTableWS = getProperty("MaskBinTable");
-  m_l1 = getProperty("PrimaryFlightPath");
-  specids = getProperty("SpectrumIDs");
-  l2s = getProperty("L2");
-  tths = getProperty("Polar");
-  phis = getProperty("Azimuthal");
-  m_params = getProperty("Params");
-  dspace = getProperty("DSpacing");
-  auto dmin = getVecPropertyFromPmOrSelf("DMin", m_dmins);
-  auto dmax = getVecPropertyFromPmOrSelf("DMax", m_dmaxs);
-  LRef = getProperty("UnwrapRef");
-  DIFCref = getProperty("LowResRef");
-  minwl = getProperty("CropWavelengthMin");
-  maxwl = getProperty("CropWavelengthMax");
+  std::string calFilename = getPropertyValue(PropertyNames::CAL_FILE);
+  std::string groupFilename = getPropertyValue(PropertyNames::GROUP_FILE);
+  m_calibrationWS = getProperty(PropertyNames::CAL_WKSP);
+  m_maskWS = getProperty(PropertyNames::MASK_WKSP);
+  m_groupWS = getProperty(PropertyNames::GROUP_WKSP);
+  DataObjects::TableWorkspace_sptr maskBinTableWS =
+      getProperty(PropertyNames::MASK_TABLE);
+  m_l1 = getProperty(PropertyNames::L1);
+  specids = getProperty(PropertyNames::SPEC_IDS);
+  l2s = getProperty(PropertyNames::L2);
+  tths = getProperty(PropertyNames::POLAR);
+  phis = getProperty(PropertyNames::AZIMUTHAL);
+  m_params = getProperty(PropertyNames::BINNING);
+  dspace = getProperty(PropertyNames::BIN_IN_D);
+  auto dmin = getVecPropertyFromPmOrSelf(PropertyNames::D_MINS, m_dmins);
+  auto dmax = getVecPropertyFromPmOrSelf(PropertyNames::D_MAXS, m_dmaxs);
+  LRef = getProperty(PropertyNames::UNWRAP_REF);
+  DIFCref = getProperty(PropertyNames::LOWRES_REF);
+  minwl = getProperty(PropertyNames::WL_MIN);
+  maxwl = getProperty(PropertyNames::WL_MAX);
   if (maxwl == 0.)
     maxwl = EMPTY_DBL(); // python can only specify 0 for unused
-  tmin = getProperty("TMin");
-  tmax = getProperty("TMax");
-  m_preserveEvents = getProperty("PreserveEvents");
-  m_resampleX = getProperty("ResampleX");
-  const double compressEventsTolerance = getProperty("CompressTolerance");
-  const double wallClockTolerance = getProperty("CompressWallClockTolerance");
+  tmin = getProperty(PropertyNames::TOF_MIN);
+  tmax = getProperty(PropertyNames::TOF_MAX);
+  m_preserveEvents = getProperty(PropertyNames::PRESERVE_EVENTS);
+  m_resampleX = getProperty(PropertyNames::RESAMPLEX);
+  const double compressEventsTolerance =
+      getProperty(PropertyNames::COMPRESS_TOF_TOL);
+  const double wallClockTolerance =
+      getProperty(PropertyNames::COMPRESS_WALL_TOL);
   // determine some bits about d-space and binning
   if (m_resampleX != 0) {
     m_params.clear(); // ignore the normal rebin parameters
@@ -365,7 +418,7 @@ void AlignAndFocusPowder::exec() {
   }
 
   // Low resolution
-  int lowresoffset = getProperty("LowResSpectrumOffset");
+  int lowresoffset = getProperty(PropertyNames::LOWRES_SPEC_OFF);
   if (lowresoffset < 0) {
     m_processLowResTOF = false;
   } else {
@@ -376,7 +429,7 @@ void AlignAndFocusPowder::exec() {
   loadCalFile(calFilename, groupFilename);
 
   // Now setup the output workspace
-  m_outputW = getProperty("OutputWorkspace");
+  m_outputW = getProperty(PropertyNames::OUTPUT_WKSP);
   if (m_inputEW) {
     // event workspace
     if (m_outputW != m_inputW) {
@@ -428,8 +481,8 @@ void AlignAndFocusPowder::exec() {
       compressAlg->setProperty("Tolerance", compressEventsTolerance);
       if (!isEmpty(wallClockTolerance)) {
         compressAlg->setProperty("WallClockTolerance", wallClockTolerance);
-        compressAlg->setPropertyValue("StartTime",
-                                      getPropertyValue("CompressStartTime"));
+        compressAlg->setPropertyValue(
+            "StartTime", getPropertyValue(PropertyNames::COMPRESS_WALL_START));
       }
       compressAlg->executeAsChildAlg();
       m_outputEW = compressAlg->getProperty("OutputWorkspace");
@@ -463,7 +516,8 @@ void AlignAndFocusPowder::exec() {
   m_progress->report();
 
   // filter the input events if appropriate
-  double removePromptPulseWidth = getProperty("RemovePromptPulseWidth");
+  double removePromptPulseWidth =
+      getProperty(PropertyNames::REMOVE_PROMPT_PULSE);
   if (removePromptPulseWidth > 0.) {
     m_outputEW = boost::dynamic_pointer_cast<EventWorkspace>(m_outputW);
     if (m_outputEW->getNumberEvents() > 0) {
@@ -970,7 +1024,7 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename,
           m_instName + "_group");
   }
   if ((!m_calibrationWS) && (!calFilename.empty())) {
-    OffsetsWorkspace_sptr offsetsWS = getProperty("OffsetsWorkspace");
+    OffsetsWorkspace_sptr offsetsWS = getProperty(PropertyNames::OFFSET_WKSP);
     if (offsetsWS) {
       convertOffsetsToCal(offsetsWS);
     } else {
@@ -1031,21 +1085,21 @@ void AlignAndFocusPowder::loadCalFile(const std::string &calFilename,
 
     const std::string name = m_instName + "_group";
     AnalysisDataService::Instance().addOrReplace(name, m_groupWS);
-    this->setPropertyValue("GroupingWorkspace", name);
+    this->setPropertyValue(PropertyNames::GROUP_WKSP, name);
   }
   if (loadCalibration) {
     m_calibrationWS = alg->getProperty("OutputCalWorkspace");
 
     const std::string name = m_instName + "_cal";
     AnalysisDataService::Instance().addOrReplace(name, m_calibrationWS);
-    this->setPropertyValue("CalibrationWorkspace", name);
+    this->setPropertyValue(PropertyNames::CAL_WKSP, name);
   }
   if (loadMask) {
     m_maskWS = alg->getProperty("OutputMaskWorkspace");
 
     const std::string name = m_instName + "_mask";
     AnalysisDataService::Instance().addOrReplace(name, m_maskWS);
-    this->setPropertyValue("MaskWorkspace", name);
+    this->setPropertyValue(PropertyNames::MASK_WKSP, name);
   }
 }
 

--- a/docs/source/algorithms/CloneWorkspace-v1.rst
+++ b/docs/source/algorithms/CloneWorkspace-v1.rst
@@ -16,6 +16,8 @@ workspace. It maintains events if the input is an
 :ref:`MDHistoWorkspace <MDHistoWorkspace>`. It can also clone a
 :ref:`PeaksWorkspace <PeaksWorkspace>`.
 
+If in-place operation is requested (e.g. ``InputWorkspace==OutputWorkspace``) this algorithm does nothing.
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/LorentzCorrection-v1.rst
+++ b/docs/source/algorithms/LorentzCorrection-v1.rst
@@ -10,16 +10,18 @@
 Description
 -----------
 
-Calculates the Lorentz correction for time-of-flight diffraction and
-and multiplies the input workspace by it. The Lorentz correction,
-``L``, is calculated according to:
+Multiply the input workspace by the calculated Lorentz factor.
+The Lorentz correction for time-of-flight single crystal diffraction, ``L``, is calculated according to:
 
 .. math::
    L = \frac{\sin^{2}\theta}{\lambda^{4}}
 
-Where :math:`\theta` is the scattering angle.
+Where :math:`\theta` is the scattering angle. For time-of-flight powder diffraction it is calculated according to
 
-The calculations performed in this Algorithm are a subset of those performed by the :ref:`algm-AnvredCorrection`
+.. math::
+   L = \sin{theta}
+
+The calculations performed in this Algorithm are a subset of those performed by the :ref:`algm-AnvredCorrection` for single crystal measurements
 
 Usage
 -----

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -20,6 +20,7 @@ Improvements
 - The file-naming of output on HRPD as been updated to closely match old script outputs
 - Geometry definition for LLB 5C1
 - :ref:`SNAPReduce <algm-SNAPReduce-v1>` has an additional parameter ``MaxChunkSize`` for customizing the chunking behavior
+- :ref:`LorentzCorrection <algm-LorentzCorrection-v1>` has an additional option for single crystal (default) or powder operation
 
 Bug Fixes
 #########


### PR DESCRIPTION
Add an option to `LorentzCorrection` to calculate and apply the factor for time-of-flight powder diffraction as well. The instrument team is still exploring how effective the option is so the exact math may change over time.

**Report to:** Cheng Li

**To test:**

Run with and without the correction. It adds a theta-dependence to the data.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
