### PR TITLE
in line 400 `self.chunksize` has to be `self.chunkSize`

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -397,7 +397,7 @@ class SNAPReduce(DataProcessorAlgorithm):
             progEnd = progStart + .9 * progDelta
             # pass all of the work to the child algorithm
             AlignAndFocusPowderFromFiles(Filename=filename, OutputWorkspace=wkspname ,
-                                         MaxChunkSize=self.chunksize,
+                                         MaxChunkSize=self.chunkSize,
                                          UnfocussedWorkspace=unfocussed,  # can be empty string
                                          startProgress=progStart,
                                          endProgress=progEnd,


### PR DESCRIPTION
in line 400 `self.chunksize` has to be `self.chunkSize` in SNAPReduce algorithm



<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
```
SNAPReduce(RunNumbers=(45745),
               Masking='None',
               Calibration=convertType,
               CalibrationFilename='/SNS/SNAP/IPTS-22258/shared/SNAP_calibrate_d45735_2019_08_21.h5',
               Binning=(0.5,0.003,7),
               Normalization='None',
               FinalUnits='dSpacing')
```

*There is no associated issue.*


*This does not require release notes* because it is a bugfix to something already in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
