### PR TITLE
Mark masked spectra in plots as masked numpy arrays

### DIFF
--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -323,6 +323,12 @@ def get_spectrum(workspace, wkspIndex, normalize_by_bin_width, withDy=False, wit
             if dy is not None:
                 dy = dy / (x[1:] - x[0:-1])
         x = points_from_boundaries(x)
+    try:
+        specInfo = workspace.spectrumInfo()
+        if specInfo.isMasked(wkspIndex):
+            y[:] = np.nan
+    except:
+        pass
     y = np.ma.masked_invalid(y)
     if dy is not None:
         dy = np.ma.masked_invalid(dy)
@@ -464,6 +470,14 @@ def get_matrix_2d_data(workspace, distribution, histogram2D=False, transpose=Fal
     y = workspace.getAxis(1).extractValues()
     z = workspace.extractY()
 
+    try:
+        specInfo = workspace.spectrumInfo()
+        for index in range(workspace.getNumberHistograms()):
+            if specInfo.isMasked(index):
+                z[index,:] = np.nan
+    except:
+        pass
+
     if workspace.isHistogramData():
         if not distribution:
             z /= x[:, 1:] - x[:, 0:-1]
@@ -515,6 +529,10 @@ def get_uneven_data(workspace, distribution):
     yvals = workspace.getAxis(1).extractValues()
     if len(yvals) == nhist:
         yvals = boundaries_from_points(yvals)
+    try:
+        specInfo = workspace.spectrumInfo()
+    except:
+        specInfo = None
     for index in range(nhist):
         xvals = workspace.readX(index)
         zvals = workspace.readY(index)
@@ -523,6 +541,8 @@ def get_uneven_data(workspace, distribution):
                 zvals = zvals/(xvals[1:] - xvals[0:-1])
         else:
             xvals = boundaries_from_points(xvals)
+        if specInfo and specInfo.isMasked(index):
+            zvals[:] = np.nan
         zvals = np.ma.masked_invalid(zvals)
         z.append(zvals)
         x.append(xvals)

--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -541,7 +541,7 @@ def get_uneven_data(workspace, distribution):
                 zvals = zvals/(xvals[1:] - xvals[0:-1])
         else:
             xvals = boundaries_from_points(xvals)
-        if specInfo and specInfo.isMasked(index):
+        if specInfo and specInfo.hasDetectors(index) and specInfo.isMasked(index):
             zvals[:] = np.nan
         zvals = np.ma.masked_invalid(zvals)
         z.append(zvals)


### PR DESCRIPTION
**Description of work.**

In matplotlib used masked arrays where the spectra is masked

**To test:**
Produce a simple masked workspace:
```
Load(Filename='CNCS_7860_event.nxs', OutputWorkspace='ws')
Rebin(InputWorkspace='ws', OutputWorkspace='ws', Params='100')
MaskBTP(Workspace='ws', Bank='40-42')
```
Use colorfill plot to look at it. In master, the data is just zeroed. In the new version, the region is marked as masked in the array, and should show up as a white band


Fixes #26652. 


*This does not require release notes* because **minor cosmetic feature**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
