### PR TITLE
Revert changed input parameters

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/CalculateChiSquared.cpp
+++ b/Framework/CurveFitting/src/Algorithms/CalculateChiSquared.cpp
@@ -250,7 +250,7 @@ public:
                               bool &ok) {
 
     auto base = ChebfunBase::bestFitAnyTolerance(lBound, rBound, *this, P, A,
-                                                 1e-4, 129, 1.0);
+                                                 1.0, 1e-4, 129);
     ok = bool(base);
     if (!base) {
       base = boost::make_shared<ChebfunBase>(10, lBound, rBound, 1e-4);


### PR DESCRIPTION
**Description of work.**
A change was made in PR #26755 which swapped the order of the input parameters in the method `bestFitAnyTolerance` in `CalculateChiSquared`. This PR reverts this as it shouldn't have changed.

**To test:**
Check the last 3 parameters in the `bestFitAnyTolerance` are `1.0, 1e-4, 129` `(maxA, tolerance, maxSize)`, compare with PR 26755

*There is no associated issue.*

*This does not require release notes* because **it is reverting a change that has happened during this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
