### PR TITLE
Fix comment in history

### DIFF
--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -161,7 +161,7 @@ ScriptBuilder::buildCommentString(const AlgorithmHistory &algHistory) {
   if (name == COMMENT_ALG) {
     auto props = algHistory.getProperties();
     for (auto &prop : props) {
-      if (prop->name() == "Note") {
+      if (prop->name() == "Text") {
         comment << "# " << prop->value();
       }
     }


### PR DESCRIPTION
**Description of work.**

If one adds comments using `Comment` algorithm, one expects them to see it in the history. It turns out that the name of the property changed.

**To test:**

```
w=CreateSingleValuedWorkspace()
Comment(w,'text')
w+=w
```
Show the history, then generate the script to clipboard or to file, and check that there is a comment `# text`

*There is no associated issue.*

*This does not require release notes* because **minor bug**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
