### PR TITLE
Correct run numbers in Kafka event stream

### DIFF
--- a/Framework/LiveData/src/Kafka/IKafkaStreamDecoder.cpp
+++ b/Framework/LiveData/src/Kafka/IKafkaStreamDecoder.cpp
@@ -527,10 +527,11 @@ void IKafkaStreamDecoder::checkRunEnd(
 }
 
 int IKafkaStreamDecoder::runNumber() const noexcept {
+  /* If the run ID is empty or if any non-digit char was found in the string */
   if (m_runId.empty() ||
       (std::find_if_not(m_runId.cbegin(), m_runId.cend(), [](const char c) {
          return std::isdigit(c);
-       }) == m_runId.end()))
+       }) != m_runId.end()))
     return -1;
 
   return std::atoi(m_runId.c_str());


### PR DESCRIPTION
To test:

- Code inspection and read [this](https://github.com/mantidproject/mantid/pull/26656/files#r327094653) should be enough