### PR TITLE
Add Pair from Context Menu Allows Name Allocation

### DIFF
--- a/docs/source/interfaces/muon_grouping_tab.rst
+++ b/docs/source/interfaces/muon_grouping_tab.rst
@@ -20,7 +20,7 @@ Grouping Table
 
 **Plus and Minus** Add or remove groups
 
-**Context Menu Pair Selection** Right clicking over the grouping table when two groups are selected allows a pair to be created.
+**Context Menu Pair Selection** Right clicking over the grouping table, when two groups are selected, allows a pair to be created with a specified name.
 
 **Group Asymmetry Range** Controls the range to use when estimating the group asymmetry. The values are used as ``StartX`` and ``EndX`` in :ref:`EstimateMuonAsymmetryFromCounts <algm-EstimateMuonAsymmetryFromCounts>`. By default this range is the first good data and end time value from the file
 but may be overridden here if required.

--- a/docs/source/interfaces/muon_grouping_tab.rst
+++ b/docs/source/interfaces/muon_grouping_tab.rst
@@ -20,6 +20,8 @@ Grouping Table
 
 **Plus and Minus** Add or remove groups
 
+**Context Menu Pair Selection** Right clicking over the grouping table when two groups are selected allows a pair to be created.
+
 **Group Asymmetry Range** Controls the range to use when estimating the group asymmetry. The values are used as ``StartX`` and ``EndX`` in :ref:`EstimateMuonAsymmetryFromCounts <algm-EstimateMuonAsymmetryFromCounts>`. By default this range is the first good data and end time value from the file
 but may be overridden here if required.
 

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -34,6 +34,7 @@ Improvements
 
 - Improve the handling of :ref:`LoadPSIMuonBin<algm-LoadPSIMuonBin-v1>` where a poor date is provided.
 - In TF asymmetry mode now rescales the fit to match the rescaled data.
+- Adding a pair by right clicking now allows a name to be specified.
 
 Interfaces
 ----------

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -85,7 +85,8 @@ class GroupingTabPresenter(object):
             description_text = self.text_for_description()
         self._view.set_description_text(description_text)
 
-    def add_pair_from_grouping_table(self, group_name1, group_name2):
+    def add_pair_from_grouping_table(self, group_name1="", group_name2=""):
+
         """
         If user requests to add a pair from the grouping table.
         """

--- a/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/grouping_tab_widget/grouping_tab_widget_presenter.py
@@ -89,9 +89,7 @@ class GroupingTabPresenter(object):
         """
         If user requests to add a pair from the grouping table.
         """
-        pair = self._model.construct_empty_pair_with_group_names(group_name1, group_name2)
-        self._model.add_pair(pair)
-        self.pairing_table_widget.update_view_from_model()
+        self.pairing_table_widget.handle_add_pair_button_clicked(group_name1, group_name2)
 
     def handle_guess_alpha(self, pair_name, group1_name, group2_name):
         """

--- a/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/pairing_table_widget/pairing_table_widget_presenter.py
@@ -131,7 +131,7 @@ class PairingTablePresenter(object):
         self._view.add_entry_to_table(entry)
         self._view.enable_updates()
 
-    def handle_add_pair_button_clicked(self):
+    def handle_add_pair_button_clicked(self, group_1='', group_2=''):
         if len(self._model.group_names) == 0 or len(self._model.group_names) == 1:
             self._view.warning_popup("At least two groups are required to create a pair")
         else:
@@ -141,8 +141,8 @@ class PairingTablePresenter(object):
             elif new_pair_name in self._model.group_and_pair_names:
                 self._view.warning_popup("Groups and pairs must have unique names")
             elif self.validate_pair_name(new_pair_name):
-                group1 = self._model.group_names[0]
-                group2 = self._model.group_names[1]
+                group1 = self._model.group_names[0] if not group_1 else group_1
+                group2 = self._model.group_names[1] if not group_2 else group_2
                 pair = MuonPair(pair_name=str(new_pair_name),
                                 forward_group_name=group1, backward_group_name=group2, alpha=1.0)
                 self.add_pair(pair)

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -20,6 +20,13 @@ from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import Pairi
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
+def pair_name():
+    name = []
+    for i in range(21):
+        name.append("pair_" + str(i+1))
+    return name
+
+
 @start_qapplication
 class GroupingTabPresenterTest(unittest.TestCase):
     def setUp(self):
@@ -31,7 +38,6 @@ class GroupingTabPresenterTest(unittest.TestCase):
         self.gui_context = self.context.gui_context
         self.group_context=self.context.group_pair_context  
 
- 
         self.model = GroupingTabModel(context=self.context)
 
         self.grouping_table_view = GroupingTableView()
@@ -52,6 +58,7 @@ class GroupingTabPresenterTest(unittest.TestCase):
                                               self.pairing_table_widget)
 
         self.presenter.create_update_thread = mock.MagicMock(return_value=mock.MagicMock())
+        self.presenter.pairing_table_widget.handle_add_pair_button_clicked = mock.MagicMock()
         self.view.display_warning_box = mock.MagicMock()
         self.grouping_table_view.warning_popup = mock.MagicMock()
         self.pairing_table_view.warning_popup = mock.MagicMock()
@@ -79,14 +86,14 @@ class GroupingTabPresenterTest(unittest.TestCase):
     def test_context_menu_add_pair_adds_pair_if_two_groups_selected(self):
         self.assertEqual(self.pairing_table_view.num_rows(), 2)
         self.grouping_table_view._get_selected_row_indices = mock.Mock(return_value=[0, 1])
-        self.grouping_table_view.contextMenuEvent(0)
+        self.grouping_table_view.contextMenuEvent(2)
         self.grouping_table_view.add_pair_action.triggered.emit(True)
 
         self.assertEqual(self.pairing_table_view.num_rows(), 3)
 
     def test_context_menu_add_pair_adds_correct_pair_if_two_groups_selected(self):
         self.grouping_table_view._get_selected_row_indices = mock.Mock(return_value=[0, 1])
-        self.grouping_table_view.contextMenuEvent(0)
+        self.grouping_table_view.contextMenuEvent(2)
         self.grouping_table_view.add_pair_action.triggered.emit(True)
 
         pair_name = "pair_0"
@@ -179,6 +186,10 @@ class GroupingTabPresenterTest(unittest.TestCase):
         self.presenter.grouping_table_widget.remove_last_row_in_view_and_model()
 
         self.assertEqual(self.model.pair_names, ['long1'])
+
+    def test_that_adding_pair_with_context_menu_allows_for_name_specification(self):
+        self.presenter.add_pair_from_grouping_table("first", "second")
+        self.pairing_table_widget.handle_add_pair_button_clicked.assert_called_once_with("first", "second")
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/grouping_tab_presenter_test.py
@@ -86,20 +86,10 @@ class GroupingTabPresenterTest(unittest.TestCase):
     def test_context_menu_add_pair_adds_pair_if_two_groups_selected(self):
         self.assertEqual(self.pairing_table_view.num_rows(), 2)
         self.grouping_table_view._get_selected_row_indices = mock.Mock(return_value=[0, 1])
-        self.grouping_table_view.contextMenuEvent(2)
+        self.grouping_table_view.contextMenuEvent(0)
         self.grouping_table_view.add_pair_action.triggered.emit(True)
 
-        self.assertEqual(self.pairing_table_view.num_rows(), 3)
-
-    def test_context_menu_add_pair_adds_correct_pair_if_two_groups_selected(self):
-        self.grouping_table_view._get_selected_row_indices = mock.Mock(return_value=[0, 1])
-        self.grouping_table_view.contextMenuEvent(2)
-        self.grouping_table_view.add_pair_action.triggered.emit(True)
-
-        pair_name = "pair_0"
-
-        self.assertEqual(self.group_context[pair_name].forward_group, "fwd")
-        self.assertEqual(self.group_context[pair_name].backward_group, "bwd")
+        self.presenter.pairing_table_widget.handle_add_pair_button_clicked.assert_called_once_with('fwd', 'bwd')
 
     def test_that_clear_button_clears_model_and_view(self):
         self.view.clear_grouping_button.clicked.emit(True)

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -14,6 +14,7 @@ from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import Groupi
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter
+from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_presenter import GroupingTabPresenter
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
@@ -38,6 +39,7 @@ class PairingTablePresenterTest(unittest.TestCase):
         self.model = GroupingTabModel(context=self.context)
         self.view = PairingTableView(parent=self.obj)
         self.presenter = PairingTablePresenter(self.view, self.model)
+        self.presenter_grouping_table = GroupingTabPresenter(self.view, self.model)
 
         self.view.warning_popup = mock.Mock()
         self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
@@ -259,7 +261,7 @@ class PairingTablePresenterTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.pair_names, ["pair_1", "pair_2", "pair_3"])
 
     def test_that_adding_pair_with_context_menu_allows_for_name_specification(self):
-        self.GroupingTabPresenter(self.model, self.view).add_pair_from_grouping_table(MuonPair(pair_name="new"))
+        GroupingTabPresenter(self.model, self.view).add_pair_from_grouping_table("my_group_1", "my_group_2")
 
         self.assertEqual(self.view.get_table_item_text(0, 0), "new")
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -25,6 +25,7 @@ def pair_name():
         name.append("pair_" + str(i+1))
     return name
 
+
 @start_qapplication
 class PairingTablePresenterTest(unittest.TestCase):
 

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -258,6 +258,11 @@ class PairingTablePresenterTest(unittest.TestCase):
         self.assertEqual(str(self.view.get_table_item_text(2, 0)), "pair_3")
         six.assertCountEqual(self, self.model.pair_names, ["pair_1", "pair_2", "pair_3"])
 
+    def test_that_adding_pair_with_context_menu_allows_for_name_specification(self):
+        self.add_pair_from_grouping_table(MuonPair(pair_name="new"))
+
+        self.assertEqual(self.view.get_table_item_text(0, 0), "new")
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -14,7 +14,6 @@ from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_model import Groupi
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_presenter import PairingTablePresenter
-from Muon.GUI.Common.grouping_tab_widget.grouping_tab_widget_presenter import GroupingTabPresenter
 from Muon.GUI.Common.pairing_table_widget.pairing_table_widget_view import PairingTableView
 from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_tests
 
@@ -40,7 +39,6 @@ class PairingTablePresenterTest(unittest.TestCase):
         self.model = GroupingTabModel(context=self.context)
         self.view = PairingTableView(parent=self.obj)
         self.presenter = PairingTablePresenter(self.view, self.model)
-        self.presenter_grouping_table = GroupingTabPresenter(self.view, self.model)
 
         self.view.warning_popup = mock.Mock()
         self.view.enter_pair_name = mock.Mock(side_effect=pair_name())
@@ -260,11 +258,6 @@ class PairingTablePresenterTest(unittest.TestCase):
         self.assertEqual(str(self.view.get_table_item_text(1, 0)), "pair_2")
         self.assertEqual(str(self.view.get_table_item_text(2, 0)), "pair_3")
         six.assertCountEqual(self, self.model.pair_names, ["pair_1", "pair_2", "pair_3"])
-
-    def test_that_adding_pair_with_context_menu_allows_for_name_specification(self):
-        GroupingTabPresenter(self.model, self.view).add_pair_from_grouping_table("my_group_1", "my_group_2")
-
-        self.assertEqual(self.view.get_table_item_text(0, 0), "new")
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
+++ b/scripts/test/Muon/grouping_tab/pairing_table_presenter_test.py
@@ -259,7 +259,7 @@ class PairingTablePresenterTest(unittest.TestCase):
         six.assertCountEqual(self, self.model.pair_names, ["pair_1", "pair_2", "pair_3"])
 
     def test_that_adding_pair_with_context_menu_allows_for_name_specification(self):
-        self.add_pair_from_grouping_table(MuonPair(pair_name="new"))
+        self.GroupingTabPresenter(self.model, self.view).add_pair_from_grouping_table(MuonPair(pair_name="new"))
 
         self.assertEqual(self.view.get_table_item_text(0, 0), "new")
 


### PR DESCRIPTION
When adding a pair via the context menu, a window pops up asking the user to input a name of the pair created. 

**To test:**

- Load some data into the MA2 GUI (run 62260)
- Navigate to the grouping tab
- hold shift and select two groups from the grouping table
- right click and select add pair
- enter a name for your group when prompted
- check that the pair is added to the pairing table with the correct name and including the correct groups

Fixes #25341 .
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
