### PR TITLE
Abins documentation: update "concepts" documentation

### DIFF
--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -27,7 +27,7 @@ At this point, there should be no effective force on the atoms.
 For this "relaxed" structure the dynamical matrix is calculated, either by finite displacements or perturbation theory.
 The dynamical matrix is related to the Hessian (the second derivative of system Hamiltonian with respect to atomic displacements) by a Fourier transform;
 the eigenvectors obtained from diagonalisation of this matrix are atomic displacements
-and the eigenvalues are squared frequencies of vibrations.
+and the eigenvalues are the frequencies of the vibrations squared.
 These vibrational *modes* are related to the *fundamental* vibrational excitations of the system,
 and using this displacement and frequency information one can calculate theoretical :math:`S(\mathbf{Q}, \omega)`.
 In Abins :math:`S(\mathbf{Q}, \omega)` is calculated for each atom separately.

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -1,6 +1,6 @@
 .. _DynamicalStructureFactorFromAbInitio:
 
-Ab-initio calculation of dynamical structure factor (S)
+Ab initio calculation of dynamical structure factor (S)
 =======================================================
 
 
@@ -11,7 +11,7 @@ The purpose of this document is to explain the link between theoretical and expe
 describe in general how the theoretical :math:`S` is calculated from from *ab initio* data by plugins in Mantid.
 
 During an inelastic neutron scattering experiment, a sample is exposed to neutron flux and a response is recorded in the form of dynamical structure factor, :math:`S(\mathbf{Q}, \omega)`.
-In principle, one obtains a vibrational spectrum which can be quite difficult to analyse; in crystalline materials this
+In principle, one obtains a vibrational spectrum that can be quite difficult to analyse; in crystalline materials this is
 related to the wavevector-dependent *phonon* spectrum.
 In order to better understand experimental outputs, one can compare with results from modelling.
 *Ab initio* calculations, especially within density-functional theory (DFT) [#Kohn1964]_, have proven quite successful in predicting vibrational spectra.
@@ -25,13 +25,13 @@ The initial guess should be as close as possible to an experimental structure, a
 Then the structure parameters are locally optimised within DFT, finding the nearest structure that minimises the DFT energy.
 At this point, there should be no effective force on the atoms.
 For this "relaxed" structure the dynamical matrix is calculated, either by finite displacements or perturbation theory.
-The dynamical matrix is related to the Hessian (the second derivative of system Hamiltonian with respect to atomic displacements) by a Fourier transform;
+The dynamical matrix is related to the Hessian (the second derivative of the system Hamiltonian with respect to atomic displacements) by a Fourier transform:
 the eigenvectors obtained from diagonalisation of this matrix are atomic displacements
-and the eigenvalues are the frequencies of the vibrations squared.
-These vibrational *modes* are related to the *fundamental* vibrational excitations of the system,
-and using this displacement and frequency information one can calculate theoretical :math:`S(\mathbf{Q}, \omega)`.
-In Abins :math:`S(\mathbf{Q}, \omega)` is calculated for each atom separately.
-The total S is then obtained as a sum over all partial atomic contributions.
+and the eigenvalues are the squared frequencies of the corresponding movements.
+These vibrational *modes* are related to the *fundamental* vibrational excitations of the system;
+using this displacement and frequency information one can calculate theoretical :math:`S(\mathbf{Q}, \omega)`.
+In Abins this is calculated for each atom separately,
+then the total spectrum is obtained as a sum over all atomic contributions.
 
 
 Working equations
@@ -43,12 +43,12 @@ Powder
 .. image:: ../images/s_powder_scheme.png
     :align: center
 
-In DFT studies of solid materials, one usually applies periodic boundary conditions to represent an infinite single crystal.
-In order to compare such calculations with experiments in which the sample is in the form of powder, one has to perform
-powder averaging.
+In DFT studies of solid materials, the simulation region is generally a finite unit cell with periodic boundary conditions.
+This models an infinite perfect crystal;
+in order to compare such calculations with powder experiments, orientational averaging should be considered.
 Usually a semi-empirical model is applied [#Howard1983]_:sup:`,` [#Howard1983b]_:
 
-:math:`S^j (\mathbf{Q},\omega_i) = S^j (Q,\omega_i) = \frac{Q^2 TrB_{\omega_i}}{3} exp\left(-Q^2 \alpha^j_{\omega_i} coth^2\left(\frac{\hbar \omega_i}{2 k_B T}\right)  \right)\sigma^j`
+:math:`S^j (\mathbf{Q},\omega_i) = S^j (Q,\omega_i) = \frac{Q^2 \mathrm{Tr}B_{\omega_i}}{3} exp\left(-Q^2 \alpha^j_{\omega_i} coth^2\left(\frac{\hbar \omega_i}{2 k_B T}\right)  \right)\sigma^j`
 
 where :math:`B` and :math:`A` are tensors created from atomic displacements in the following way:
 
@@ -60,9 +60,9 @@ with
 
 :math:`Q` -- momentum transfer due to neutron scattering.  The momentum transfer :math:`\mathbf{Q}` is a technically a vector. However, the powder averaging of :math: `S` allows it to be represented as a scalar.
 
-:math:`\alpha^j_{\omega_i}` -- semi-empirical parameter calculated as: :math:`\alpha^j_{\omega_i} = \frac{1}{5} \left \lbrace Tr A^j  + \frac{2 B^j_{\omega_i}: A^j}{Tr B^j_{\omega_i}} \right\rbrace`
+:math:`\alpha^j_{\omega_i}` -- semi-empirical parameter calculated as: :math:`\alpha^j_{\omega_i} = \frac{1}{5} \left \lbrace \mathrm{Tr} A^j  + \frac{2 B^j_{\omega_i}: A^j}{\mathrm{Tr} B^j_{\omega_i}} \right\rbrace`
 
-:math:`Tr` -- trace operation
+:math:`\mathrm{Tr}` -- trace operation
 
 :math:`:` --  tensor contraction operation
 
@@ -93,10 +93,10 @@ Within the harmonic approximation all second-order transitions form the followin
 \omega_1, \omega_1 + \omega_2, \omega_1 + \omega_3, \ldots, \omega_p + \omega_p \rbrace`.
 The cardinality of this set is :math:`p^2`, where :math:`p` is a number of fundamentals.
 In practice one can reduce this number by taking into consideration a realistic energy window
-and neglecting those :math:`\omega_{ij}=\omega_i + \omega_j` for which :math:`S(Q, \omega_i)` is negligible.
-Within the harmonic approximation phonons are treated as independent harmonic quantum oscillators.  The formula for :math:`S(Q, \omega_{ik})` is as follows [#Mitchell]_:
+and neglecting those :math:`\omega_{ij}=\omega_i + \omega_j` for which :math:`S(Q, \omega_i)` or :math:`S(Q, \omega_j)` is negligible.
+Within the harmonic approximation each phonon is treated as independent harmonic quantum oscillator.  The formula for :math:`S(Q, \omega_{ik})` is as follows [#Mitchell]_:
 
-:math:`S^j(Q, \omega_{ik}) = \frac{Q^4}{15  C}\left( TrB^j_{\omega_i}TrB^j_{\omega_k} + B^j_{\omega_i}:B^j_{\omega_k} + B^j_{\omega_k}:B^j_{\omega_i} \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ik}}{2 k_B T} \right) \right)\sigma^j`
+:math:`S^j(Q, \omega_{ik}) = \frac{Q^4}{15  C}\left( \mathrm{Tr}B^j_{\omega_i}\mathrm{Tr}B^j_{\omega_k} + B^j_{\omega_i}:B^j_{\omega_k} + B^j_{\omega_k}:B^j_{\omega_i} \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ik}}{2 k_B T} \right) \right)\sigma^j`
 
 where
 
@@ -106,15 +106,16 @@ where
 
 Similarly, one can define the contribution for the third quantum order events (:math:`0 \rightarrow 3`, simultaneous  :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''` for different oscillators, etc.) [#Mitchell]_:
 
-:math:`S^j(Q, \omega_{ikl}) = \frac{9Q^6}{543}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}  \right)  exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ikl}}{2 k_B T}\right) \right)\sigma^j`.
+:math:`S^j(Q, \omega_{ikl}) = \frac{9Q^6}{543}\left( \mathrm{Tr}B^j_{\omega_i} \mathrm{Tr}B^j_{\omega_k} \mathrm{Tr}B^j_{\omega_l}  \right)  exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ikl}}{2 k_B T}\right) \right)\sigma^j`.
 
 Usually in order to reconstruct the experimental spectrum it is sufficient to include contributions up to the fourth order (:math:`0 \rightarrow 4` , simultaneous :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''`, :math:`0 \rightarrow 1'''` for different oscillators, etc.)
 
-:math:`S^j(Q, \omega_{iklm}) = \frac{27Q^8}{9850}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}TrB^j_{\omega_m}  \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{iklm}}{2 k_B T}\right) \right)\sigma^j`. [#Mitchell]_
+:math:`S^j(Q, \omega_{iklm}) = \frac{27Q^8}{9850}\left( \mathrm{Tr}B^j_{\omega_i} \mathrm{Tr}B^j_{\omega_k} \mathrm{Tr}B^j_{\omega_l}\mathrm{Tr}B^j_{\omega_m}  \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{iklm}}{2 k_B T}\right) \right)\sigma^j`. [#Mitchell]_
 
-In the same way as for the second quantum order events, one can reduce the number of energy transitions by imposing the appropriate energy window and neglecting small S.
+In the same way as for the second quantum order events, one can reduce the number of energy transitions by imposing the appropriate energy window and neglecting small :math:`S`.
 
-After evaluating the above equations one obtains the discrete S for each quantum order and for each atom: :math:`S_{discrete}`. In order to compare these functions with an experimental spectrum one has to convolve them with experimental resolution
+After evaluating the above equations one obtains the discrete :math:`S` for each quantum order and for each atom: :math:`S_\mathrm{discrete}`.
+In order to compare these functions with an experimental spectrum one has to convolve them with experimental resolution
 
 :math:`S_\mathrm{theory}^{nj}(Q, \omega) = S_\mathrm{discrete}^{nj}(Q, \omega) * f(\omega)`
 
@@ -126,7 +127,7 @@ where:
 
 :math:`f(\omega)` -- is a resolution function
 
-:math:`S_\mathrm{theory}` -- is *theoretical S* to be compared with experimental results.
+:math:`S_\mathrm{theory}` -- is *theoretical* :math:`S` to be compared with experimental results.
 
 For `TOSCA <http://www.isis.stfc.ac.uk/instruments/tosca/tosca4715.html>`_  and TOSCA-like instruments :math:`f(\omega)` has the following form:
 
@@ -158,7 +159,7 @@ with
 Current implementation
 ----------------------
 
-Calculation of theoretical S from ab-initio results is implemented in :ref:`Abins <algm-Abins>`. At the moment Abins supports phonon outputs from the
+Calculation of theoretical :math:`S` from *ab initio* results is implemented in :ref:`Abins <algm-Abins>`. At the moment Abins supports phonon outputs from the
 `CASTEP <http://www.castep.org/>`_, `CRYSTAL <http://www.crystal.unito.it/index.php>`_, Gaussian and DMOL3 *ab initio* codes.
 The Gamma-point frequencies are used and phonon bands are assumed to be flat throughout the Brillouin zone; this assumption is primarily applicable for incoherent scattering in molecular crystals.
 Instrument parameters are included for

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -87,14 +87,14 @@ with
 
 The formula above is valid for *first-order quantum events*, i.e. transitions :math:`0 \rightarrow 1` for each phonon. (We neglect events that transfer energy *to* the scattered neutron.)
 In order to reconstruct the full spectrum one has to also consider higher-order quantum events.
-For second-order quantum events one should
+For second-order quantum events one should not only
 consider transitions :math:`0 \rightarrow 2`, but also simultaneous transitions :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'` for different phonons.
 Within the harmonic approximation all second-order transitions form the following set: :math:`\lbrace \omega_1 +
 \omega_1, \omega_1 + \omega_2, \omega_1 + \omega_3, \ldots, \omega_p + \omega_p \rbrace`.
 The cardinality of this set is :math:`p^2`, where :math:`p` is a number of fundamentals.
 In practice one can reduce this number by taking into consideration a realistic energy window
 and neglecting those :math:`\omega_{ij}=\omega_i + \omega_j` for which :math:`S(Q, \omega_i)` is negligible.
-Within the harmonic approximation each phonon is treated as independent harmonic quantum oscillator.  The formula for :math:`S(Q, \omega_{ik})` is as follows [#Mitchell]_:
+Within the harmonic approximation phonons are treated as independent harmonic quantum oscillators.  The formula for :math:`S(Q, \omega_{ik})` is as follows [#Mitchell]_:
 
 :math:`S^j(Q, \omega_{ik}) = \frac{Q^4}{15  C}\left( TrB^j_{\omega_i}TrB^j_{\omega_k} + B^j_{\omega_i}:B^j_{\omega_k} + B^j_{\omega_k}:B^j_{\omega_i} \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ik}}{2 k_B T} \right) \right)\sigma^j`
 
@@ -138,7 +138,7 @@ where:
 
 with :math:`A`, :math:`B`, :math:`C` as constants.
 
-Moreover, in case of TOSCA and TOSCA-like instruments length of momentum transfer depends on frequency (*indirect geometry spectrometer*).
+Moreover, in case of TOSCA and TOSCA-like instruments, the length of momentum transfer depends on frequency (*indirect geometry spectrometer*).
 The formula for :math:`Q^2` is as follows:
 
 :math:`Q^2(\omega)=k^2_i(\omega) + k^2_f - 2  \sqrt{k^2_i(\omega)  k^2_f} cos(\theta)`

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -8,7 +8,7 @@ Introduction
 ------------
 
 The purpose of this document is to explain the link between theoretical and experimental :math:`S(\mathbf{Q}, \omega)` and to
-describe in general how theoretical S is calculated from from *ab initio* data by plugins in Mantid.
+describe in general how the theoretical :math:`S` is calculated from from *ab initio* data by plugins in Mantid.
 
 During an inelastic neutron scattering experiment, a sample is exposed to neutron flux and a response is recorded in the form of dynamical structure factor, :math:`S(\mathbf{Q}, \omega)`.
 In principle, one obtains a vibrational spectrum which can be quite difficult to analyse; in crystalline materials this
@@ -20,7 +20,7 @@ In order to better understand experimental outputs, one can compare with results
     :align: center
 
 The usual workfow for calculating phonon spectra within DFT is presented in the figure above. First, one defines an
-initial guess for the structure in interest.
+initial guess for the structure of interest.
 The initial guess should be as close as possible to an experimental structure, and is usually derived from elastic X-ray and/or neutron scattering measurements.
 Then the structure parameters are locally optimised within DFT, finding the nearest structure that minimises the DFT energy.
 At this point, there should be no effective force on the atoms.
@@ -43,7 +43,7 @@ Powder
 .. image:: ../images/s_powder_scheme.png
     :align: center
 
-In DFT studies of solid materials, one usually applies periodic boundary conditions representing an infinite single crystal.
+In DFT studies of solid materials, one usually applies periodic boundary conditions to represent an infinite single crystal.
 In order to compare such calculations with experiments in which the sample is in the form of powder, one has to perform
 powder averaging.
 Usually a semi-empirical model is applied [#Howard1983]_:sup:`,` [#Howard1983b]_:
@@ -58,7 +58,7 @@ where :math:`B` and :math:`A` are tensors created from atomic displacements in t
 
 with
 
-:math:`Q` -- momentum transfer which occurs during neutron scattering. In principle, momentum transfer :math:`\mathbf{Q}` is a vector but, due to powder averaging S depends only on the length of :math:`\mathbf{Q}`.
+:math:`Q` -- momentum transfer due to neutron scattering.  The momentum transfer :math:`\mathbf{Q}` is a technically a vector. However, the powder averaging of :math: `S` allows it to be represented as a scalar.
 
 :math:`\alpha^j_{\omega_i}` -- semi-empirical parameter calculated as: :math:`\alpha^j_{\omega_i} = \frac{1}{5} \left \lbrace Tr A^j  + \frac{2 B^j_{\omega_i}: A^j}{Tr B^j_{\omega_i}} \right\rbrace`
 

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -8,25 +8,30 @@ Introduction
 ------------
 
 The purpose of this document is to explain the link between theoretical and experimental :math:`S(\mathbf{Q}, \omega)` and to
-describe the general idea how theoretical S from ab-initio is calculated by available plugins in Mantid.
+describe in general how theoretical S is calculated from from *ab initio* data by plugins in Mantid.
 
-During an inelastic neutron scattering experiment sample is exposed to neutron flux and response of a sample in the
-form of dynamical structure factor  is recorded. In principle, one obtains phonon (vibrational) spectrum which is often
-quite  difficult to analyse. In order to better understand experimental results one can use modeling methods. One of the
-most successful theoretical method in predicting phonon spectrum is ab-initio method DFT [1]_.
+During an inelastic neutron scattering experiment, a sample is exposed to neutron flux and a response is recorded in the form of dynamical structure factor, :math:`S(\mathbf{Q}, \omega)`.
+In principle, one obtains a vibrational spectrum which can be quite difficult to analyse; in crystalline materials this
+related to the wavevector-dependent *phonon* spectrum.
+In order to better understand experimental outputs, one can compare with results from modelling.
+*Ab initio* calculations, especially within density-functional theory (DFT) [#Kohn1964]_, have proven quite successful in predicting vibrational spectra.
 
 .. image:: ../images/dft_phonon_scheme.png
     :align: center
 
-Usual approach in calculating phonon spectra within DFT is presented in the figure above. First, one defines initial
-guess for the structure in interest. The initial guess should be as close as possible to an experimental structure.
-Then, one optimise structure within DFT. By optimising structure one should understand finding the closest to the
-initial guess local minimum of energy within accuracy of DFT method. At the closest minimum there
-should be no effective force on atoms. For that structure the dynamical matrix, e.g, second derivative of system Hamiltonian with respect to
-atomic displacements is calculated. Eigenvectors obtained from diagonalisation of this matrix are atomic displacements
-and eigenvalues are squared frequencies of vibrations. Those vibrations are sometime called *modes* or *fundamentals*.
-Using atomic displacements and frequencies obtained by DFT method one can calculate theoretical :math:`S(\mathbf{Q}, \omega)`. :math:`S(\mathbf{Q}, \omega)`
-is calculated for each atom separately. Total S is sum over all partial atomic contributions.
+The usual workfow for calculating phonon spectra within DFT is presented in the figure above. First, one defines an
+initial guess for the structure in interest.
+The initial guess should be as close as possible to an experimental structure, and is usually derived from elastic X-ray and/or neutron scattering measurements.
+Then the structure parameters are locally optimised within DFT, finding the nearest structure that minimises the DFT energy.
+At this point, there should be no effective force on the atoms.
+For this "relaxed" structure the dynamical matrix is calculated, either by finite displacements or perturbation theory.
+The dynamical matrix is related to the Hessian (the second derivative of system Hamiltonian with respect to atomic displacements) by a Fourier transform;
+the eigenvectors obtained from diagonalisation of this matrix are atomic displacements
+and the eigenvalues are squared frequencies of vibrations.
+These vibrational *modes* are related to the *fundamental* vibrational excitations of the system,
+and using this displacement and frequency information one can calculate theoretical :math:`S(\mathbf{Q}, \omega)`.
+In Abins :math:`S(\mathbf{Q}, \omega)` is calculated for each atom separately.
+The total S is then obtained as a sum over all partial atomic contributions.
 
 
 Working equations
@@ -38,9 +43,10 @@ Powder
 .. image:: ../images/s_powder_scheme.png
     :align: center
 
-From DFT calculations one usually obtains phonon data for infinite single crystal (there are ways to perform
-calculations for molecule, e.g, gas phase). In order to compare it with experiment in which sample is in the form of
-powder one has to perform powder averaging. Usually semi-empirical formula is used [2]_, [3]_:
+In DFT studies of solid materials, one usually applies periodic boundary conditions representing an infinite single crystal.
+In order to compare such calculations with experiments in which the sample is in the form of powder, one has to perform
+powder averaging.
+Usually a semi-empirical model is applied [#Howard1983]_:sup:`,` [#Howard1983b]_:
 
 :math:`S^j (\mathbf{Q},\omega_i) = S^j (Q,\omega_i) = \frac{Q^2 TrB_{\omega_i}}{3} exp\left(-Q^2 \alpha^j_{\omega_i} coth^2\left(\frac{\hbar \omega_i}{2 k_B T}\right)  \right)\sigma^j`
 
@@ -52,7 +58,7 @@ where :math:`B` and :math:`A` are tensors created from atomic displacements in t
 
 with
 
-:math:`Q` -- momentum transfer which occurs during neutron scattering. In principle, momentum transfer :math:`\mathbf{Q}` is a vector but due to powder averaging S for the powder case depends on length of :math:`\mathbf{Q}`
+:math:`Q` -- momentum transfer which occurs during neutron scattering. In principle, momentum transfer :math:`\mathbf{Q}` is a vector but, due to powder averaging S depends only on the length of :math:`\mathbf{Q}`.
 
 :math:`\alpha^j_{\omega_i}` -- semi-empirical parameter calculated as: :math:`\alpha^j_{\omega_i} = \frac{1}{5} \left \lbrace Tr A^j  + \frac{2 B^j_{\omega_i}: A^j}{Tr B^j_{\omega_i}} \right\rbrace`
 
@@ -79,35 +85,38 @@ with
 :math:`\sigma_j` -- cross-section for :math:`j`-th atom
 
 
-The formula above is valid for *first order quantum events*, e. g., transitions :math:`0 \rightarrow 1` for each phonon. In order to
-reconstruct spectrum one has to also consider higher order quantum events. For second order quantum event one should
-consider transitions :math:`0 \rightarrow 2`, but also simultaneous transitions :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'` for different phonons. Within harmonic approximation all second
-order transitions form the following  set: :math:`\lbrace \omega_1 + \omega_1, \omega_1 + \omega_2, \omega_1 + \omega_3, \ldots,  \omega_p + \omega_p \rbrace`.
-Cardinality of this set is :math:`p^2`, where :math:`p` is a number of fundamentals. In practice one can reduce this number by taking into consideration realistic energy  window
+The formula above is valid for *first-order quantum events*, i.e. transitions :math:`0 \rightarrow 1` for each phonon. (We neglect events that transfer energy *to* the scattered neutron.)
+In order to reconstruct the full spectrum one has to also consider higher-order quantum events.
+For second-order quantum events one should
+consider transitions :math:`0 \rightarrow 2`, but also simultaneous transitions :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'` for different phonons.
+Within the harmonic approximation all second-order transitions form the following set: :math:`\lbrace \omega_1 +
+\omega_1, \omega_1 + \omega_2, \omega_1 + \omega_3, \ldots, \omega_p + \omega_p \rbrace`.
+The cardinality of this set is :math:`p^2`, where :math:`p` is a number of fundamentals.
+In practice one can reduce this number by taking into consideration a realistic energy window
 and neglecting those :math:`\omega_{ij}=\omega_i + \omega_j` for which :math:`S(Q, \omega_i)` is negligible.
-Within harmonic approximation each phonon is treated as independent harmonic quantum oscillator.  The formula for :math:`S(Q, \omega_{ik})` is as follows [4]_:
+Within the harmonic approximation each phonon is treated as independent harmonic quantum oscillator.  The formula for :math:`S(Q, \omega_{ik})` is as follows [#Mitchell]_:
 
 :math:`S^j(Q, \omega_{ik}) = \frac{Q^4}{15  C}\left( TrB^j_{\omega_i}TrB^j_{\omega_k} + B^j_{\omega_i}:B^j_{\omega_k} + B^j_{\omega_k}:B^j_{\omega_i} \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ik}}{2 k_B T} \right) \right)\sigma^j`
 
-where:
+where
 
-:math:`\beta^j = A^j / 3`
+:math:`\beta^j = A^j / 3`.
 
-:math:`C` -- is a constant,  :math:`C=2` if :math:`i=j` and :math:`C=1` otherwise
+:math:`C` is a constant: if :math:`i=j` then :math:`C=2`, otherwise :math:`C=1`.
 
-Similarly one can define contribution for the third quantum order event (:math:`0 \rightarrow 3`, simultaneous  :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''` for different oscillators ,etc.. ) [4]:
+Similarly, one can define the contribution for the third quantum order events (:math:`0 \rightarrow 3`, simultaneous  :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''` for different oscillators, etc.) [#Mitchell]_:
 
-:math:`S^j(Q, \omega_{ikl}) = \frac{9Q^6}{543}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}  \right)  exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ikl}}{2 k_B T}\right) \right)\sigma^j`
+:math:`S^j(Q, \omega_{ikl}) = \frac{9Q^6}{543}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}  \right)  exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{ikl}}{2 k_B T}\right) \right)\sigma^j`.
 
-Usually in order to reconstruct experimental spectrum it is enough to give contribution up to fourth order (:math:`0 \rightarrow 4` , simultaneous :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''`, :math:`0 \rightarrow 1'''` for different oscillators, etc.)  [4]:
+Usually in order to reconstruct the experimental spectrum it is sufficient to include contributions up to the fourth order (:math:`0 \rightarrow 4` , simultaneous :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'`, :math:`0 \rightarrow 1''`, :math:`0 \rightarrow 1'''` for different oscillators, etc.)
 
-:math:`S^j(Q, \omega_{iklm}) = \frac{27Q^8}{9850}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}TrB^j_{\omega_m}  \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{iklm}}{2 k_B T}\right) \right)\sigma^j`
+:math:`S^j(Q, \omega_{iklm}) = \frac{27Q^8}{9850}\left( TrB^j_{\omega_i} TrB^j_{\omega_k} TrB^j_{\omega_l}TrB^j_{\omega_m}  \right) exp\left(-Q^2 \beta^j coth^2\left(\frac{\hbar \omega_{iklm}}{2 k_B T}\right) \right)\sigma^j`. [#Mitchell]_
 
-In the similar way as for the second quantum order event one can reduce number of energy transitions by taking into account considered energy window and neglecting small S.
+In the same way as for the second quantum order events, one can reduce the number of energy transitions by imposing the appropriate energy window and neglecting small S.
 
-After evaluating equations above one obtains discrete S for each quantum order and for each atom: :math:`S_{discrete}`. In order to compare such a spectrum with an experimental spectrum one has to convolve it with experimental resolution:
+After evaluating the above equations one obtains the discrete S for each quantum order and for each atom: :math:`S_{discrete}`. In order to compare these functions with an experimental spectrum one has to convolve them with experimental resolution
 
-:math:`S_{theory}^{nj}(Q, \omega) = S_{discrete}^{nj}(Q, \omega) * f(\omega)`
+:math:`S_\mathrm{theory}^{nj}(Q, \omega) = S_\mathrm{discrete}^{nj}(Q, \omega) * f(\omega)`
 
 where:
 
@@ -115,11 +124,11 @@ where:
 
 :math:`n` -- indicates :math:`n`-order event
 
-:math:`f(\omega)` -- resolution function
+:math:`f(\omega)` -- is a resolution function
 
-:math:`S_{theory}` -- it is *theoretical S* which can be compared with experimental results
+:math:`S_\mathrm{theory}` -- is *theoretical S* to be compared with experimental results.
 
-For `Tosca <http://www.isis.stfc.ac.uk/instruments/tosca/tosca4715.html>`_  and Tosca-like instruments :math:`f(\omega)` has the following form:
+For `TOSCA <http://www.isis.stfc.ac.uk/instruments/tosca/tosca4715.html>`_  and TOSCA-like instruments :math:`f(\omega)` has the following form:
 
 :math:`f(\omega)=1.0 / \sqrt{\sigma(\omega)  \pi}  \exp(-(\omega)^2  / \sigma(\omega))`
 
@@ -129,7 +138,7 @@ where:
 
 with :math:`A`, :math:`B`, :math:`C` as constants.
 
-Moreover, in case of Tosca and Tosca-like instruments length of momentum transfer depends on frequency (*indirect geometry spectrometer*).
+Moreover, in case of TOSCA and TOSCA-like instruments length of momentum transfer depends on frequency (*indirect geometry spectrometer*).
 The formula for :math:`Q^2` is as follows:
 
 :math:`Q^2(\omega)=k^2_i(\omega) + k^2_f - 2  \sqrt{k^2_i(\omega)  k^2_f} cos(\theta)`
@@ -142,33 +151,35 @@ where:
 
 with
 
-:math:`E_{final}` -- final energy on the crystal analyser in :math:`cm^{-1}`
+:math:`E_{final}` -- being the final energy on the crystal analyser in :math:`cm^{-1}` and
 
-:math:`cos(\theta)` -- cosines of crystal analyser angle in radians
+:math:`\theta` -- is the crystal analyser angle in radians. (TOSCA has two angles to consider, corresponding to the forward- and back-scattering detectors).
 
 Current implementation
 ----------------------
 
-Calculation of theoretical S from ab-initio results is implemented in :ref:`Abins <algm-Abins>`. At the moment Abins supports
-`CASTEP <http://www.castep.org/>`_ and `CRYSTAL <http://www.crystal.unito.it/index.php>`_ DFT programs. As it comes to instruments,
-`Tosca <http://www.isis.stfc.ac.uk/instruments/tosca/tosca4715.html>`_ and Tosca-like instruments are supported.
+Calculation of theoretical S from ab-initio results is implemented in :ref:`Abins <algm-Abins>`. At the moment Abins supports phonon outputs from the
+`CASTEP <http://www.castep.org/>`_, `CRYSTAL <http://www.crystal.unito.it/index.php>`_, Gaussian and DMOL3 *ab initio* codes.
+The Gamma-point frequencies are used and phonon bands are assumed to be flat throughout the Brillouin zone; this assumption is primarily applicable for incoherent scattering in molecular crystals.
+Instrument parameters are included for
+`TOSCA <http://www.isis.stfc.ac.uk/instruments/tosca/tosca4715.html>`_ and should be useful for TOSCA-like instruments.
 
-Referencing Abins
------------------
+Citing Abins
+------------
 
-If Abins is used as part of your data analysis routines, please cite the relevant reference [5]_.
+If Abins is used as part of your data analysis routines, please cite the relevant reference [#Dymkowski2018]_.
 
 References
 ----------
 
-.. [1] W. Kohn et al., *Inhomogeneous Electron Gas*, Phys. Rev. B {\bf 136}, 864 (1964).
+.. [#Kohn1964] W. Kohn et al., *Inhomogeneous Electron Gas*, Phys. Rev. B {\bf 136}, 864 (1964).
 
-.. [2] J. Howard, B.C. Boland, J. Tomkinson, *Intensities in inelastic neutron scattering spectra: a test of recent theory*, Chem. Phys. 77 (1983).
+.. [#Howard1983] J. Howard, B.C. Boland, J. Tomkinson, *Intensities in inelastic neutron scattering spectra: a test of recent theory*, Chem. Phys. 77 (1983).
 
-.. [3] J. Howard and J. Tomkinson, *An analytical method for the calculation of the relative intensities of bending and stretching modes in inelastic neutron scattering spectra*, Chem. Phys. Letters 98 (1983).
+.. [#Howard1983b] J. Howard and J. Tomkinson, *An analytical method for the calculation of the relative intensities of bending and stretching modes in inelastic neutron scattering spectra*, Chem. Phys. Letters 98 (1983).
 
-.. [4] P. C H Mitchell, S. F. Parker, A. J. Ramirez-Cuesta, J. Tomkinson, *Vibrational Spectroscopy with Neutrons With Applications in Chemistry, Biology, Materials Science and Catalysis*, ISBN: 978-981-256-013-1
+.. [#Mitchell] P. C H Mitchell, S. F. Parker, A. J. Ramirez-Cuesta, J. Tomkinson, *Vibrational Spectroscopy with Neutrons With Applications in Chemistry, Biology, Materials Science and Catalysis*, ISBN: 978-981-256-013-1
 
-.. [5] K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
+.. [#Dymkowski2018] K. Dymkowski, S. F. Parker, F. Fernandez-Alonso and S. Mukhopadhyay,  “AbINS: The modern software for INS interpretation” , Physica B, doi:10.1016/j.physb.2018.02.034 (2018).
 
 .. categories:: Concepts

--- a/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
+++ b/docs/source/concepts/DynamicalStructureFactorFromAbInitio.rst
@@ -23,7 +23,7 @@ The usual workfow for calculating phonon spectra within DFT is presented in the 
 initial guess for the structure of interest.
 The initial guess should be as close as possible to an experimental structure, and is usually derived from elastic X-ray and/or neutron scattering measurements.
 Then the structure parameters are locally optimised within DFT, finding the nearest structure that minimises the DFT energy.
-At this point, there should be no effective force on the atoms.
+At this point, there should be no net force on the atoms.
 For this "relaxed" structure the dynamical matrix is calculated, either by finite displacements or perturbation theory.
 The dynamical matrix is related to the Hessian (the second derivative of the system Hamiltonian with respect to atomic displacements) by a Fourier transform:
 the eigenvectors obtained from diagonalisation of this matrix are atomic displacements
@@ -85,7 +85,8 @@ with
 :math:`\sigma_j` -- cross-section for :math:`j`-th atom
 
 
-The formula above is valid for *first-order quantum events*, i.e. transitions :math:`0 \rightarrow 1` for each phonon. (We neglect events that transfer energy *to* the scattered neutron.)
+The formula above covers the *first-order quantum events* -- specifically the transitions :math:`0 \rightarrow 1` for each phonon.
+The :math:`1 \rightarrow 0` events (i.e. energy *to* the scattered neutron) would be infrequent at experimental conditions and are neglected.
 In order to reconstruct the full spectrum one has to also consider higher-order quantum events.
 For second-order quantum events one should not only
 consider transitions :math:`0 \rightarrow 2`, but also simultaneous transitions :math:`0 \rightarrow 1`, :math:`0 \rightarrow 1'` for different phonons.


### PR DESCRIPTION
**Description of work.**

The main documentation for the Abins algorithm focuses on the user interface and how to run Abins. A more detailed overview of the approximations employed in Abins (DynamicalStructureFactorFromAbInitio.rst) is stored in the "concepts" section of the docs and linked to by the Algorithm docs.

This commit mostly tweaks the wording for improved clarity. An explicit mention is also added of the current restriction to Gamma-point data.


**To test:**

Build the user docs and take a look at concepts/DynamicalStructureFactorFromAbInitio in a web browser

I don't think this requires release notes? It's a little polish to existing docs.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
