### PR TITLE
Bump required memory for WISH SX peak system test

### DIFF
--- a/Testing/SystemTests/tests/analysis/ISIS_WISHSingleCrystalReduction.py
+++ b/Testing/SystemTests/tests/analysis/ISIS_WISHSingleCrystalReduction.py
@@ -29,7 +29,7 @@ class WISHSingleCrystalPeakPredictionTest(MantidSystemTest):
 
     def requiredMemoryMB(self):
         # Need lots of memory for full WISH dataset
-        return 16000
+        return 24000
 
     def cleanup(self):
         try:


### PR DESCRIPTION
**Description of work.**

When running this locally I found that the peak memory usage was ~23GB. This bumps the required memory for the test to 24GB.

**To test:**

System tests should pass.

*There is no associated issue.*

*This does not require release notes* because **it relates to internal testing.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
