### PR TITLE
Add missing unit tests for the Runs Table

### DIFF
--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -52,6 +52,7 @@ set(TEST_FILES
     test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
     test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
     test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+    test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h
@@ -122,6 +123,7 @@ set(QT5_TEST_FILES
     test/ISISReflectometry/Reduction/ParseReflectometryStringsTest.h
     test/ISISReflectometry/Reduction/ReductionJobsMergeTest.h
     test/ISISReflectometry/Reduction/ValidatePerThetaDefaultsTest.h
+    test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterGroupDeletionTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterGroupInsertionTest.h
     test/ISISReflectometry/RunsTable/RunsTablePresenterRowInsertionTest.h

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -43,6 +43,22 @@ Row makeRow(std::string const &run, double theta) {
       ReductionWorkspaces({run}, TransmissionRunPair({"Trans A", "Trans B"})));
 }
 
+Row makeSimpleRow(std::string const &run, double theta) {
+  return Row({run}, theta, TransmissionRunPair(), RangeInQ(), boost::none,
+             ReductionOptionsMap(),
+             ReductionWorkspaces({run}, TransmissionRunPair()));
+}
+
+Row makeRow(std::string const &run, double theta, std::string const &trans1,
+            std::string const &trans2, boost::optional<double> qMin,
+            boost::optional<double> qMax, boost::optional<double> qStep,
+            boost::optional<double> scale,
+            ReductionOptionsMap const &optionsMap) {
+  return Row({run}, theta, TransmissionRunPair({trans1, trans2}),
+             RangeInQ(qMin, qMax, qStep), scale, optionsMap,
+             ReductionWorkspaces({run}, TransmissionRunPair({trans1, trans2})));
+}
+
 Row makeRow(std::vector<std::string> const &runs, double theta) {
   return Row(
       runs, theta, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(),
@@ -213,6 +229,15 @@ ReductionJobs oneGroupWithTwoRowsModel() {
   return reductionJobs;
 }
 
+ReductionJobs oneGroupWithTwoSimpleRowsModel() {
+  auto reductionJobs = ReductionJobs();
+  auto group1 = Group("Test group 1");
+  group1.appendRow(makeSimpleRow("12345", 0.5));
+  group1.appendRow(makeSimpleRow("12346", 0.8));
+  reductionJobs.appendGroup(std::move(group1));
+  return reductionJobs;
+}
+
 ReductionJobs anotherGroupWithARowModel() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 2");
@@ -269,6 +294,14 @@ ReductionJobs emptyReductionJobs() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Group1");
   group1.appendRow(makeRow());
+  reductionJobs.appendGroup(std::move(group1));
+
+  return reductionJobs;
+}
+
+ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel() {
+  auto reductionJobs = ReductionJobs();
+  auto group1 = makeGroupWithTwoRows();
   reductionJobs.appendGroup(std::move(group1));
 
   return reductionJobs;

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -25,6 +25,15 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Row makeEmptyRow();
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::string const &run,
                                            double theta = 0.5);
+MANTIDQT_ISISREFLECTOMETRY_DLL Row makeSimpleRow(std::string const &run,
+                                                 double theta = 0.5);
+MANTIDQT_ISISREFLECTOMETRY_DLL Row
+makeRow(std::string const &run, double theta, std::string const &trans1,
+        std::string const &trans2, boost::optional<double> qMin = boost::none,
+        boost::optional<double> qMax = boost::none,
+        boost::optional<double> qStep = boost::none,
+        boost::optional<double> scale = boost::none,
+        ReductionOptionsMap const &optionsMap = ReductionOptionsMap());
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::vector<std::string> const &runs,
                                            double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row
@@ -56,11 +65,14 @@ MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs
 oneGroupWithAnotherRunWithSameAngleModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs oneGroupWithTwoRunsInARowModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs oneGroupWithTwoRowsModel();
+MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs oneGroupWithTwoSimpleRowsModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs anotherGroupWithARowModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithARowModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithTwoRowsModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs twoGroupsWithMixedRowsModel();
 MANTIDQT_ISISREFLECTOMETRY_DLL ReductionJobs emptyReductionJobs();
+MANTIDQT_ISISREFLECTOMETRY_DLL
+ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel();
 
 /* Experiment */
 MANTIDQT_ISISREFLECTOMETRY_DLL std::vector<PerThetaDefaults>

--- a/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/ReflMockObjects.h
@@ -12,6 +12,7 @@
 #include "GUI/Batch/IBatchPresenter.h"
 #include "GUI/Batch/IBatchPresenterFactory.h"
 #include "GUI/Common/IMessageHandler.h"
+#include "GUI/Common/IPlotter.h"
 #include "GUI/Common/IPythonRunner.h"
 #include "GUI/Event/IEventPresenter.h"
 #include "GUI/Experiment/IExperimentPresenter.h"
@@ -238,6 +239,11 @@ public:
 class MockPythonRunner : public IPythonRunner {
 public:
   MOCK_METHOD1(runPythonAlgorithm, std::string(const std::string &));
+};
+
+class MockPlotter : public IPlotter {
+public:
+  MOCK_CONST_METHOD1(reflectometryPlot, void(const std::vector<std::string> &));
 };
 
 /**** Saver ****/

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterDisplayTest.h
@@ -1,0 +1,271 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_
+#define MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_
+
+#include "../../../ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h"
+#include "RunsTablePresenterTest.h"
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::
+    ModelCreationHelper;
+using MantidQt::MantidWidgets::Batch::Cell;
+using testing::Mock;
+using testing::NiceMock;
+using testing::Return;
+
+class RunsTablePresenterDisplayTest : public CxxTest::TestSuite,
+                                      RunsTablePresenterTest {
+public:
+  static RunsTablePresenterDisplayTest *createSuite() {
+    return new RunsTablePresenterDisplayTest();
+  }
+
+  static void destroySuite(RunsTablePresenterDisplayTest *suite) {
+    delete suite;
+  }
+
+  void testExpandsAllGroupsWhenRequested() {
+    EXPECT_CALL(m_jobs, expandAll()).Times(2);
+
+    auto presenter = makePresenter(m_view);
+    presenter.notifyExpandAllRequested();
+
+    verifyAndClearExpectations();
+  }
+
+  void testCollapsesAllGroupsWhenRequested() {
+    EXPECT_CALL(m_jobs, collapseAll());
+
+    auto presenter = makePresenter(m_view);
+    presenter.notifyCollapseAllRequested();
+
+    verifyAndClearExpectations();
+  }
+
+  void testFilterChanged() {
+    EXPECT_CALL(m_jobs, filterRowsBy(_)).Times(1);
+
+    auto presenter = makePresenter(m_view, oneGroupWithARowModel());
+    presenter.notifyFilterChanged("test filter");
+
+    verifyAndClearExpectations();
+  }
+
+  void testFilterReset() {
+    EXPECT_CALL(m_view, resetFilterBox()).Times(1);
+
+    auto presenter = makePresenter(m_view, oneGroupWithARowModel());
+    presenter.notifyFilterReset();
+
+    verifyAndClearExpectations();
+  }
+
+  void testPlotSelected() {
+    auto presenter =
+        makePresenter(m_view, oneGroupWithTwoRowsWithOutputNamesModel());
+
+    // Set the second row as selected and complete
+    selectedRowLocationsAre(m_jobs, {location(0, 1)});
+    presenter.notifySelectionChanged();
+    getRow(presenter, 0, 1)->setSuccess();
+
+    auto const expected = std::vector<std::string>{"IvsQ_binned_2"};
+    EXPECT_CALL(m_plotter, reflectometryPlot(expected)).Times(1);
+
+    presenter.notifyPlotSelectedPressed();
+
+    verifyAndClearExpectations();
+  }
+
+  void testPlotSelectedStitchedOutputs() {
+    auto presenter =
+        makePresenter(m_view, oneGroupWithTwoRowsWithOutputNamesModel());
+
+    // Set the group as selected and complete
+    selectedRowLocationsAre(m_jobs, {location(0)});
+    presenter.notifySelectionChanged();
+    getGroup(presenter, 0).setSuccess();
+    getGroup(presenter, 0)
+        .setOutputNames(std::vector<std::string>{"stitched_group"});
+
+    auto const expected = std::vector<std::string>{"stitched_group"};
+    EXPECT_CALL(m_plotter, reflectometryPlot(expected)).Times(1);
+
+    presenter.notifyPlotSelectedStitchedOutputPressed();
+
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyFillDownRuns() {
+    auto presenter = makePresenter(m_view, oneGroupWithTwoSimpleRowsModel());
+
+    auto const column = 0;
+    selectedColumnIs(m_jobs, column);
+    auto const src = location(0, 0);
+    auto const dest = location(0, 1);
+    selectedRowLocationsAre(m_jobs, {src, dest});
+
+    auto const srcStr = std::string("12345");
+    expectCellThenDefault(src, column, Cell(srcStr), Cell(srcStr));
+    expectCellThenDefault(dest, column, Cell("12346"), Cell(srcStr));
+    updatedCellsAre(src, cellsArray(srcStr, "0.5"));
+    updatedCellsAre(dest, cellsArray(srcStr, "0.8"));
+
+    presenter.notifyFillDown();
+
+    TS_ASSERT_EQUALS(*getRow(presenter, src), makeSimpleRow(srcStr, 0.5));
+    TS_ASSERT_EQUALS(*getRow(presenter, dest), makeSimpleRow(srcStr, 0.8));
+
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyFillDownTheta() {
+    auto presenter = makePresenter(m_view, oneGroupWithTwoSimpleRowsModel());
+
+    auto const column = 1;
+    selectedColumnIs(m_jobs, column);
+    auto const src = location(0, 0);
+    auto const dest = location(0, 1);
+    selectedRowLocationsAre(m_jobs, {src, dest});
+
+    auto const srcValue = 0.5;
+    auto const srcStr = std::to_string(srcValue);
+    expectCellThenDefault(src, column, Cell(srcStr), Cell(srcStr));
+    expectCellThenDefault(dest, column, Cell("0.8"), Cell(srcStr));
+    updatedCellsAre(src, cellsArray("12345", srcStr));
+    updatedCellsAre(dest, cellsArray("12346", srcStr));
+
+    presenter.notifyFillDown();
+
+    TS_ASSERT_EQUALS(*getRow(presenter, src), makeSimpleRow("12345", srcValue));
+    TS_ASSERT_EQUALS(*getRow(presenter, dest),
+                     makeSimpleRow("12346", srcValue));
+
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyFillDownFirstTransmissionRun() {
+    auto presenter =
+        makePresenter(m_view, oneGroupWithTwoRowsWithSrcAndDestTransRuns());
+
+    auto const column = 2;
+    selectedColumnIs(m_jobs, column);
+    auto const src = location(0, 0);
+    auto const dest = location(0, 1);
+    selectedRowLocationsAre(m_jobs, {src, dest});
+
+    auto const srcStr = std::string("src trans A");
+    expectCellThenDefault(src, column, Cell(srcStr), Cell(srcStr));
+    expectCellThenDefault(dest, column, Cell("dest trans A"), Cell(srcStr));
+    updatedCellsAre(src, cellsArray("12345", "0.5", srcStr, "src trans B"));
+    updatedCellsAre(dest, cellsArray("12346", "0.8", srcStr, "dest trans B"));
+
+    presenter.notifyFillDown();
+
+    TS_ASSERT_EQUALS(*getRow(presenter, src),
+                     makeRow("12345", 0.5, srcStr, "src trans B"));
+    TS_ASSERT_EQUALS(*getRow(presenter, dest),
+                     makeRow("12346", 0.8, srcStr, "dest trans B"));
+
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyFillDownSecondTransmissionRun() {
+    auto presenter =
+        makePresenter(m_view, oneGroupWithTwoRowsWithSrcAndDestTransRuns());
+
+    auto const column = 3;
+    selectedColumnIs(m_jobs, column);
+    auto const src = location(0, 0);
+    auto const dest = location(0, 1);
+    selectedRowLocationsAre(m_jobs, {src, dest});
+
+    auto const srcStr = std::string("src trans B");
+    expectCellThenDefault(src, column, Cell(srcStr), Cell(srcStr));
+    expectCellThenDefault(dest, column, Cell("dest trans A"), Cell(srcStr));
+    updatedCellsAre(src, cellsArray("12345", "0.5", "src trans A", srcStr));
+    updatedCellsAre(dest, cellsArray("12346", "0.8", "dest trans A", srcStr));
+
+    presenter.notifyFillDown();
+
+    TS_ASSERT_EQUALS(*getRow(presenter, src),
+                     makeRow("12345", 0.5, "src trans A", srcStr));
+    TS_ASSERT_EQUALS(*getRow(presenter, dest),
+                     makeRow("12346", 0.8, "dest trans A", srcStr));
+
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyFillDownAcrossTwoGroupsWithMixedRows() {
+    auto presenter = makePresenter(m_view, twoGroupsWithMixedRowsModel());
+
+    auto const column = 1;
+    selectedColumnIs(m_jobs, column);
+    selectedRowLocationsAre(m_jobs, {location(0, 0), location(0, 1),
+                                     location(0, 2), location(1, 1)});
+
+    auto const srcValue = 0.5;
+    auto const srcStr = std::to_string(srcValue);
+    auto srcCell = Cell(srcStr);
+    expectCellThenDefault(location(0, 0), column, Cell(srcStr), Cell(srcStr));
+    expectCellThenDefault(location(0, 1), column, Cell(""), Cell(srcStr));
+    expectCellThenDefault(location(0, 2), column, Cell("0.8"), Cell(srcStr));
+    expectCellThenDefault(location(1, 1), column, Cell("0.9"), Cell(srcStr));
+
+    updatedCellsAre(location(0, 0), cellsArray("12345", srcStr));
+    updatedCellsAre(location(0, 1), cellsArray("", srcStr));
+    updatedCellsAre(location(0, 2), cellsArray("12346", srcStr));
+    updatedCellsAre(location(1, 1), cellsArray("22346", srcStr));
+
+    presenter.notifyFillDown();
+
+    // Check valid rows have been updated
+    TS_ASSERT_EQUALS(getRow(presenter, 0, 0)->theta(), srcValue);
+    TS_ASSERT_EQUALS(getRow(presenter, 0, 2)->theta(), srcValue);
+    TS_ASSERT_EQUALS(getRow(presenter, 1, 1)->theta(), srcValue);
+    // Check that the uninitialized row is still uninitialized
+    TS_ASSERT_EQUALS(
+        presenter.runsTable().reductionJobs()[0][1].is_initialized(), false);
+
+    verifyAndClearExpectations();
+  }
+
+private:
+  ReductionJobs oneGroupWithTwoRowsWithSrcAndDestTransRuns() {
+    auto reductionJobs = ReductionJobs();
+    auto group = Group("Test group 1");
+    group.appendRow(makeRow("12345", 0.5, "src trans A", "src trans B"));
+    group.appendRow(makeRow("12346", 0.8, "dest trans A", "dest trans B"));
+    reductionJobs.appendGroup(group);
+    return reductionJobs;
+  }
+
+  // This sets up calls to return the given "updated" cell values, which are
+  // used after a fill-down operation has been completed
+  void
+  updatedCellsAre(MantidQt::MantidWidgets::Batch::RowLocation const &location,
+                  std::vector<Cell> const &cells) {
+    ON_CALL(m_jobs, cellsAt(location)).WillByDefault(Return(cells));
+  }
+
+  // Expect the first cell value to be returned first for a particular location
+  // and subsequent calls to return the second cell value by default
+  void expectCellThenDefault(
+      MantidQt::MantidWidgets::Batch::RowLocation const &location, int column,
+      Cell const &firstCell, Cell const &defaultCell) {
+    EXPECT_CALL(m_jobs, cellAt(location, column))
+        .Times(AtLeast(1))
+        .WillOnce(Return(firstCell))
+        .WillRepeatedly(Return(defaultCell));
+  }
+};
+#endif // MANTID_CUSTOMINTERFACES_RUNSTABLEPRESENTERDISPLAYTEST_H_

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
@@ -131,6 +131,25 @@ public:
     verifyAndClearExpectations();
   }
 
+  void testSettingsChangedResetsStateInModel() {
+    auto presenter = makePresenter(m_view, oneGroupWithARowModel());
+    // Set success=true
+    getGroup(presenter, 0).setSuccess();
+    getRow(presenter, 0, 0)->setSuccess();
+    presenter.settingsChanged();
+    // Check success state is reset
+    TS_ASSERT_EQUALS(getGroup(presenter, 0).success(), false);
+    TS_ASSERT_EQUALS(getRow(presenter, 0, 0)->success(), false);
+  }
+
+  void testSettingsChangedResetsStateInView() {
+    auto presenter = makePresenter(m_view, oneGroupWithARowModel());
+    expectGroupStateCleared();
+    expectRowStateCleared();
+    presenter.settingsChanged();
+    verifyAndClearExpectations();
+  }
+
   void testRowStateChangedForDefaultRowAndGroup() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
     expectGroupStateCleared();

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
@@ -267,8 +267,9 @@ private:
   static constexpr const char *FAILURE = "#accbff"; // pale blue
 
   std::vector<Cell> rowCells(const char *colour) {
-    auto cells = std::vector<Cell>{Cell(""), Cell(""), Cell(""), Cell(""),
-                                   Cell(""), Cell(""), Cell(""), Cell("")};
+    auto cells =
+        std::vector<Cell>{Cell(""), Cell(""), Cell(""), Cell(""), Cell(""),
+                          Cell(""), Cell(""), Cell(""), Cell("")};
     for (auto &cell : cells)
       cell.setBackgroundColor(colour);
     return cells;
@@ -282,20 +283,6 @@ private:
     for (auto &cell : cells)
       cell.setBackgroundColor(colour);
     return cells;
-  }
-
-  Group &getGroup(RunsTablePresenter &presenter, int groupIndex) {
-    auto &reductionJobs = presenter.mutableRunsTable().mutableReductionJobs();
-    auto &group = reductionJobs.mutableGroups()[groupIndex];
-    return group;
-  }
-
-  Row *getRow(RunsTablePresenter &presenter, int groupIndex, int rowIndex) {
-    auto &reductionJobs = presenter.mutableRunsTable().mutableReductionJobs();
-    auto *row = &reductionJobs.mutableGroups()[groupIndex]
-                     .mutableRows()[rowIndex]
-                     .get();
-    return row;
   }
 
   void expectGroupStateCleared() {

--- a/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/RunsTable/RunsTablePresenterProcessingTest.h
@@ -111,7 +111,7 @@ public:
     verifyAndClearExpectations();
   }
 
-  void testNotifyInstrumentChanged() {
+  void testNotifyChangeInstrumentRequested() {
     auto presenter = makePresenter(m_view, ReductionJobs());
     auto const instrument = std::string("test_instrument");
     EXPECT_CALL(m_view, getInstrumentName())
@@ -120,6 +120,14 @@ public:
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument))
         .Times(1);
     presenter.notifyChangeInstrumentRequested();
+    verifyAndClearExpectations();
+  }
+
+  void testNotifyInstrumentChanged() {
+    auto presenter = makePresenter(m_view, ReductionJobs());
+    auto const instrument = std::string("test_instrument");
+    EXPECT_CALL(m_view, setInstrumentName(instrument)).Times(1);
+    presenter.notifyInstrumentChanged(instrument);
     verifyAndClearExpectations();
   }
 


### PR DESCRIPTION
This PR adds missing unit tests for the ISIS Reflectometry's RunsTable widget:
- New tests are mainly in the new file `RunsTablePresenterDisplayTest`
- A few have also been added to `RunsTablePresenterProcessingTest`
- Some existing tests have been moved to the new file as they relate more to how the table is displayed rather than processing
- Some supporting code has been moved into the base class so it can be used in both test suites.

**To test:**

Code review

Refs #26529 

*This does not require release notes* because **it concerns unit testing only**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
