### PR TITLE
Fix crash when fitting tablews with column of type float

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
@@ -83,7 +83,7 @@ public:
 
 private:
   /// Calculate size and starting iterator in the X array
-  std::pair<size_t, size_t> getXInterval() const;
+  std::pair<size_t, size_t> getXInterval(std::vector<double> XData) const;
   /// Set all parameters
   void setParameters() const;
   /// Set the names of the X, Y and Error columns

--- a/Framework/CurveFitting/src/TableWorkspaceDomainCreator.cpp
+++ b/Framework/CurveFitting/src/TableWorkspaceDomainCreator.cpp
@@ -213,16 +213,17 @@ void TableWorkspaceDomainCreator::createDomain(
   }
 
   auto X = m_tableWorkspace->getColumn(m_xColName);
-  std::vector<double> XData;
+  std::vector<double> xData;
+  xData.reserve(m_tableWorkspace->rowCount());
   for (size_t i = 0; i < m_tableWorkspace->rowCount(); ++i) {
-    XData.push_back(X->toDouble(i));
+    xData.push_back(X->toDouble(i));
   }
 
   // find the fitting interval: from -> to
   size_t endRowNo = 0;
-  std::tie(m_startRowNo, endRowNo) = getXInterval(XData);
-  auto from = XData.begin() + m_startRowNo;
-  auto to = XData.begin() + endRowNo;
+  std::tie(m_startRowNo, endRowNo) = getXInterval(xData);
+  auto from = xData.begin() + m_startRowNo;
+  auto to = xData.begin() + endRowNo;
   auto n = endRowNo - m_startRowNo;
 
   if (m_domainType != Simple) {
@@ -266,7 +267,7 @@ void TableWorkspaceDomainCreator::createDomain(
   }
 
   // Helps find points excluded form fit.
-  ExcludeRangeFinder excludeFinder(m_exclude, XData.front(), XData.back());
+  ExcludeRangeFinder excludeFinder(m_exclude, xData.front(), xData.back());
 
   auto errors = m_tableWorkspace->getColumn(m_errColName);
   for (size_t i = m_startRowNo; i < endRowNo; ++i) {
@@ -275,7 +276,7 @@ void TableWorkspaceDomainCreator::createDomain(
     auto error = errors->toDouble(i);
     double weight = 0.0;
 
-    if (excludeFinder.isExcluded(XData[i])) {
+    if (excludeFinder.isExcluded(xData[i])) {
       weight = 0.0;
     } else if (!std::isfinite(y)) {
       // nan or inf data
@@ -564,25 +565,29 @@ TableWorkspaceDomainCreator::createEmptyResultWS(const size_t nhistograms,
   auto inputY = m_tableWorkspace->getColumn(m_yColName);
   auto inputE = m_tableWorkspace->getColumn(m_errColName);
 
-  std::vector<double> XData;
-  std::vector<double> YData;
-  std::vector<double> EData;
+  std::vector<double> xData;
+  std::vector<double> yData;
+  std::vector<double> eData;
+  xData.reserve(m_tableWorkspace->rowCount());
+  yData.reserve(m_tableWorkspace->rowCount());
+  eData.reserve(m_tableWorkspace->rowCount());
+
   for (size_t i = 0; i < m_tableWorkspace->rowCount(); ++i) {
-    XData.push_back(inputX->toDouble(i));
-    YData.push_back(inputY->toDouble(i));
-    EData.push_back(inputE->toDouble(i));
+    xData.push_back(inputX->toDouble(i));
+    yData.push_back(inputY->toDouble(i));
+    eData.push_back(inputE->toDouble(i));
   }
 
   // X values for all
   for (size_t i = 0; i < nhistograms; i++) {
-    ws->mutableX(i).assign(XData.begin() + m_startRowNo,
-                           XData.begin() + m_startRowNo + nxvalues);
+    ws->mutableX(i).assign(xData.begin() + m_startRowNo,
+                           xData.begin() + m_startRowNo + nxvalues);
   }
   // Data values for the first histogram
-  ws->mutableY(0).assign(YData.begin() + m_startRowNo,
-                         YData.begin() + m_startRowNo + nyvalues);
-  ws->mutableE(0).assign(EData.begin() + m_startRowNo,
-                         EData.begin() + m_startRowNo + nyvalues);
+  ws->mutableY(0).assign(yData.begin() + m_startRowNo,
+                         yData.begin() + m_startRowNo + nyvalues);
+  ws->mutableE(0).assign(eData.begin() + m_startRowNo,
+                         eData.begin() + m_startRowNo + nyvalues);
 
   return ws;
 }
@@ -593,12 +598,13 @@ TableWorkspaceDomainCreator::createEmptyResultWS(const size_t nhistograms,
 size_t TableWorkspaceDomainCreator::getDomainSize() const {
   setParameters();
   auto X = m_tableWorkspace->getColumn(m_xColName);
-  std::vector<double> XData;
+  std::vector<double> xData;
+  xData.reserve(m_tableWorkspace->rowCount());
   for (size_t i = 0; i < m_tableWorkspace->rowCount(); ++i) {
-    XData.push_back(X->toDouble(i));
+    xData.push_back(X->toDouble(i));
   }
   size_t startIndex, endIndex;
-  std::tie(startIndex, endIndex) = getXInterval(XData);
+  std::tie(startIndex, endIndex) = getXInterval(xData);
   return endIndex - startIndex;
 }
 
@@ -632,8 +638,8 @@ void TableWorkspaceDomainCreator::setInitialValues(API::IFunction &function) {
  * @returns :: A pair of start iterator and size of the data.
  */
 std::pair<size_t, size_t>
-TableWorkspaceDomainCreator::getXInterval(std::vector<double> XData) const {
-  const auto sizeOfData = XData.size();
+TableWorkspaceDomainCreator::getXInterval(std::vector<double> xData) const {
+  const auto sizeOfData = xData.size();
   if (sizeOfData == 0) {
     throw std::runtime_error("Workspace contains no data.");
   }
@@ -646,13 +652,13 @@ TableWorkspaceDomainCreator::getXInterval(std::vector<double> XData) const {
   Mantid::MantidVec::iterator from;
   Mantid::MantidVec::iterator to;
 
-  bool isXAscending = XData.front() < XData.back();
+  bool isXAscending = xData.front() < xData.back();
 
   if (m_startX == EMPTY_DBL() && m_endX == EMPTY_DBL()) {
-    m_startX = XData.front();
-    from = XData.begin();
-    m_endX = XData.back();
-    to = XData.end();
+    m_startX = xData.front();
+    from = xData.begin();
+    m_endX = xData.back();
+    to = xData.end();
   } else if (m_startX == EMPTY_DBL() || m_endX == EMPTY_DBL()) {
     throw std::invalid_argument(
         "Both StartX and EndX must be given to set fitting interval.");
@@ -660,15 +666,15 @@ TableWorkspaceDomainCreator::getXInterval(std::vector<double> XData) const {
     if (m_startX > m_endX) {
       std::swap(m_startX, m_endX);
     }
-    from = std::lower_bound(XData.begin(), XData.end(), m_startX);
-    to = std::upper_bound(from, XData.end(), m_endX);
+    from = std::lower_bound(xData.begin(), xData.end(), m_startX);
+    to = std::upper_bound(from, xData.end(), m_endX);
   } else { // x is descending
     if (m_startX < m_endX) {
       std::swap(m_startX, m_endX);
     }
     from =
-        std::lower_bound(XData.begin(), XData.end(), m_startX, greaterIsLess);
-    to = std::upper_bound(from, XData.end(), m_endX, greaterIsLess);
+        std::lower_bound(xData.begin(), xData.end(), m_startX, greaterIsLess);
+    to = std::upper_bound(from, xData.end(), m_endX, greaterIsLess);
   }
 
   // Check whether the fitting interval defined by StartX and EndX is 0.
@@ -679,8 +685,8 @@ TableWorkspaceDomainCreator::getXInterval(std::vector<double> XData) const {
                                 "within the workspace interval.");
   }
 
-  return std::make_pair(std::distance(XData.begin(), from),
-                        std::distance(XData.begin(), to));
+  return std::make_pair(std::distance(xData.begin(), from),
+                        std::distance(xData.begin(), to));
 }
 
 /**

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -427,7 +427,7 @@ public:
     double endX() const;
     void setEndX(double end);
     void setXRange(double start, double end);
-    QVector<double> getXRange();
+    QVector<double> getXRange() throw(std::invalid_argument);
     QString getXColumnName() const;
     QString getYColumnName() const;
     QString getErrColumnName() const;

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -174,7 +174,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         try:
             x_data = self.getXRange()
             return x_data
-        except RuntimeError or IndexError:
+        except (RuntimeError, IndexError, ValueError):
             return None
 
     def set_fit_bounds(self, fit_bounds):
@@ -190,7 +190,8 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         Sets the range to fit in the FitPropertyBrowser
         :param fit_range: The new fit range
         """
-        self.setXRange(fit_range[0], fit_range[1])
+        if fit_range is not None:
+            self.setXRange(fit_range[0], fit_range[1])
 
     def hide(self):
         """

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1930,8 +1930,16 @@ QVector<double> FitPropertyBrowser::getXRange() {
   if (tbl) {
     auto xColumnIndex = m_columnManager->value(m_xColumn);
     std::vector<double> xColumnData;
-    for (size_t i = 0; i < tbl->rowCount(); ++i) {
-      xColumnData.push_back(tbl->Double(i, xColumnIndex));
+    auto col = tbl->getColumn(xColumnIndex);
+    try {
+      for (size_t i = 0; i < tbl->rowCount(); ++i) {
+        xColumnData.push_back(col->toDouble(i));
+      }
+    } catch (std::invalid_argument err) {
+			
+      QMessageBox::critical(this, "Mantid - Error",
+                            "The X column is not a number");
+			throw std::invalid_argument(err);
     }
     std::sort(xColumnData.begin(), xColumnData.end());
     range.push_back(xColumnData.front());

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1936,10 +1936,10 @@ QVector<double> FitPropertyBrowser::getXRange() {
         xColumnData.push_back(col->toDouble(i));
       }
     } catch (std::invalid_argument err) {
-			
+
       QMessageBox::critical(this, "Mantid - Error",
                             "The X column is not a number");
-			throw std::invalid_argument(err);
+      throw std::invalid_argument(err);
     }
     std::sort(xColumnData.begin(), xColumnData.end());
     range.push_back(xColumnData.front());

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1935,8 +1935,7 @@ QVector<double> FitPropertyBrowser::getXRange() {
       for (size_t i = 0; i < tbl->rowCount(); ++i) {
         xColumnData.push_back(col->toDouble(i));
       }
-    } catch (std::invalid_argument err) {
-
+    } catch (std::invalid_argument & err) {
       QMessageBox::critical(this, "Mantid - Error",
                             "The X column is not a number");
       throw std::invalid_argument(err);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1935,7 +1935,7 @@ QVector<double> FitPropertyBrowser::getXRange() {
       for (size_t i = 0; i < tbl->rowCount(); ++i) {
         xColumnData.push_back(col->toDouble(i));
       }
-    } catch (std::invalid_argument & err) {
+    } catch (std::invalid_argument &err) {
       QMessageBox::critical(this, "Mantid - Error",
                             "The X column is not a number");
       throw std::invalid_argument(err);


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug that when a table workspace contains numbers that aren't doubles the fit property browser crashes

**To test:**
1. Open a table workspace containing `floats` or `ints` or create one using the script below.
2. Plot the workspace
3. Open fit browser and add a suitable function 
4. Plot guess, `Display->Plot Guess`, this should plot a line (and not crash)
5. Fit the function, `Fit->Fit`, this should plot the calculated values and differences (and also not crash)
```
#creates an table workspace with a gaussian curve and a background 
import math

tableWS = CreateEmptyTableWorkspace()

tableWS.addColumn(type="float",name="X")
tableWS.addColumn(type="float",name="Y")
tableWS.addColumn(type="float",name="E")

for i in range(0,40):
      xValue = i * 0.05
      yValue = 10.0 * math.exp(-0.5*(xValue - 1.0)**2/0.05) + 2.0
      eValue = i%2*0.05
      tableWS.addRow ( { 'X': xValue, 'Y': yValue, 'E': eValue } )
```
Fixes #26922 

*This does not require release notes* because **it fixes a bug created during this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
