### PR TITLE
Deadtime from table workspace not working

### DIFF
--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -19,9 +19,10 @@ Removed
 
 Bug Fixes
 #########
-  * Fixed an issue where changeing the normalisation on a plot with autoscale disabled throws an exception.
+  * Fixed an issue where changing the normalisation on a plot with auto-scale disabled throws an exception.
   * Fixed an issue where warnings about adding workspaces to workspace groups multiple times were appearing in the log.
-  * Fixed an issue where logs in TF asymmetry mode were not being propogated to the results tab.
+  * Fixed an issue where logs in TF asymmetry mode were not being propagated to the results tab.
+  * Fixed an issue where changing the dead time to from table workspace or other file did not work and reverted back to from data file.
 
 Known Issues
 ############

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_model.py
@@ -132,6 +132,7 @@ class InstrumentWidgetModel(object):
             self._context.gui_context.update_and_send_signal(DeadTimeTable=None)
             return
         dtc = api.AnalysisDataService.retrieve(str(name))
+        self._context.gui_context.update_and_send_non_calculation_signal(DeadTimeSource='FromADS')
         self._context.gui_context.update_and_send_signal(DeadTimeTable=dtc)
 
     def validate_variable_rebin_string(self, variable_rebin_string):

--- a/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/home_instrument_widget/home_instrument_widget_presenter.py
@@ -50,7 +50,7 @@ class InstrumentWidgetPresenter(HomeTabSubWidget):
         self.handle_loaded_time_zero_checkState_change()
         self.handle_loaded_first_good_data_checkState_change()
         self.handle_loaded_last_good_data_checkState_change()
-        #self.handle_user_selects_dead_time_from_data()
+        self.handle_user_selects_dead_time_from_data()
 
     def show(self):
         self._view.show()

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -7,10 +7,11 @@
 import unittest
 
 
-from mantid.api import FileFinder
+from mantid.api import FileFinder, AnalysisDataService
 from mantid.py3compat import mock
 from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QWidget
+from mantid.simpleapi import LoadMuonNexus, CompareWorkspaces
 
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_model import InstrumentWidgetModel
 from Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter import InstrumentWidgetPresenter
@@ -327,6 +328,16 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         result, message = self.model.validate_variable_rebin_string('1,-5,19')
 
         self.assertTrue(result)
+
+    def test_dead_time_workspace_specified_used_when_selecting_from_table_workspace(self):
+        LoadMuonNexus(Filename='MUSR00022725.nxs', OutputWorkspace='output_ws', DeadTimeTable='dead_time_table')
+        self.model.check_dead_time_file_selection = mock.MagicMock(return_value=True)
+
+        self.view.dead_time_selector.setCurrentIndex(1)
+        self.view.dead_time_file_selector.setCurrentIndex(1)
+
+        self.assertTrue(CompareWorkspaces(self.model._context.dead_time_table(62260),
+                                          AnalysisDataService.retrieve('dead_time_table')))
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/home_instrument_widget_test.py
+++ b/scripts/test/Muon/home_instrument_widget_test.py
@@ -196,10 +196,11 @@ class HomeTabInstrumentPresenterTest(unittest.TestCase):
         dead_time_data = mock.MagicMock()
         dead_time_data.toDict.return_value = {'dead-time': [0.001, 0.002, 0.003]}
         self.presenter._model.get_dead_time_table_from_data = mock.MagicMock(return_value=dead_time_data)
+        self.presenter.handle_dead_time_unselected()
         self.presenter.handle_user_selects_dead_time_from_data()
 
         self.assertEqual(self.view.dead_time_label_3.text(), 'From 0.001 to 0.003 (ave. 0.002)')
-        self.gui_variable_observer.update.assert_called_once_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'FromFile'})
+        self.gui_variable_observer.update.assert_called_with(self.gui_context.gui_variables_notifier, {'DeadTimeSource': 'FromFile'})
 
     @mock.patch(
         'Muon.GUI.Common.home_instrument_widget.home_instrument_widget_presenter.load_utils.get_table_workspace_names_from_ADS')


### PR DESCRIPTION
When selecting a table workspace or other file for the deadtime, the correction would not be correct and the GUI would revert back to from other file.

**To test:**
- Open the muon analysis 2 interface
- Select MUSR as your instrument 
- load run 62260
- change the deadtime combo box to from table workspace
- change the dead time workspace combo box that has appeared to the only valiable workspace
- check that the dead time combo box still shows from table workspace
- in the ads, expand the workspace 62260 and right click on the counts
- show the workspace history
- scroll to the bottom and click on the MuonPreProcess which is closest to the bottom
- check that the deadtimetable is the same as the one selected in the muon interface

Fixes #26899.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
