### PR TITLE
Add missing kwarg for SANS GUI init

### DIFF
--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -54,7 +54,7 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
         self.Q_to.hide()
 
     def _setup_log_widget(self):
-        self.log_widget = messagedisplay.MessageDisplay(self.groupBox_2)
+        self.log_widget = messagedisplay.MessageDisplay(parent=self.groupBox_2)
         self.log_widget.setMinimumSize(QtCore.QSize(491, 371))
         self.log_widget.setObjectName(_fromUtf8("log_widget"))
         self.gridLayout.addWidget(self.log_widget, 0, 1, 4, 1)


### PR DESCRIPTION
**Description of work.**
Adds a missing kwarg to the MessageDisplay class used in the ISIS SANS GUI init. This is currently stopping the ISIS SANS GUI opening at all

**To test:**
Attempt to open the SANS GUI, if it opens the bug is fixed.

Fixes: No Associated Issues

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
