### PR TITLE
Move Zoom Monitor 4 rel. to self

### DIFF
--- a/docs/source/release/v4.2.0/sans.rst
+++ b/docs/source/release/v4.2.0/sans.rst
@@ -13,7 +13,7 @@ New
 ###
 - Support for shifting both monitor 4 and 5 on Zoom including a new setting in the 
   ISIS SANS GUI. A new user file command has also been added to
-  perform monitor shifts without changing the selected tranmission spectrum.
+  perform monitor shifts without changing the selected transmission spectrum.
 
 Improved
 ########

--- a/scripts/SANS/sans/algorithm_detail/move_workspaces.py
+++ b/scripts/SANS/sans/algorithm_detail/move_workspaces.py
@@ -78,6 +78,62 @@ def rotate_component(workspace, angle, direction, component_to_rotate):
     alg.execute()
 
 
+def move_monitor(ws, move_info, monitor_offset, monitor_spectrum_number):
+    """
+    Moves a monitor relative to it's original position
+    :param ws: The workspace to move the monitor in
+    :param move_info: A dictionary containing various move details
+    :param monitor_offset: Offset to shift by (m)
+    :param monitor_spectrum_number: The spectrum number of the monitor to shift
+    """
+    monitor_n_name = move_info.monitor_names[str(monitor_spectrum_number)]
+
+    z_move = monitor_offset
+    offset = {CanonicalCoordinates.Z: z_move}
+
+    move_component(ws, offset, monitor_n_name)
+
+
+def move_backstop_monitor(ws, move_info, monitor_offset, monitor_spectrum_number):
+    """
+    Moves the monitor attached to the backstop (rear-detector) relative to
+    the rear detector
+    :param ws: The workspace to move the monitor in
+    :param move_info: A dictionary containing various move details
+    :param monitor_offset: Offset to shift by (m)
+    :param monitor_spectrum_number: The spectrum number of the monitor to shift
+    """
+    # Back out early so we don't shift the monitor from the IDF position to the
+    # rear detector position by accident
+    if monitor_offset == 0.0:
+        return
+
+    monitor_spectrum_number_as_string = str(monitor_spectrum_number)
+    # TODO we should pass the detector ID through, not the spec num
+    monitor_n_name = move_info.monitor_names[monitor_spectrum_number_as_string]
+
+    comp_info = ws.componentInfo()
+    monitor_n = comp_info.indexOfAny(monitor_n_name)
+
+    # Get position of monitor n
+    monitor_position = comp_info.position(monitor_n)
+
+    # The location is relative to the rear-detector, get this position
+    lab_detector = move_info.detectors[DetectorType.to_string(DetectorType.LAB)]
+    detector_name = lab_detector.detector_name
+    lab_detector_index = comp_info.indexOfAny(detector_name)
+    detector_position = comp_info.position(lab_detector_index)
+
+    z_position_detector = detector_position.getZ()
+    z_position_monitor = monitor_position.getZ()
+
+    z_new = z_position_detector + monitor_offset
+    z_move = z_new - z_position_monitor
+    offset = {CanonicalCoordinates.Z: z_move}
+
+    move_component(ws, offset, monitor_n_name)
+
+
 def move_sample_holder(workspace, sample_offset, sample_offset_direction):
     """
     Moves the sample holder by specified amount.
@@ -463,33 +519,11 @@ class SANSMoveSANS2D(SANSMove):
     def _move_monitor_n(workspace, move_info, monitor_spectrum_number):
         # Only monitor 4 can be moved for SANS2D
         assert(monitor_spectrum_number == 4)
-        monitor_offset = move_info.monitor_4_offset
 
-        if monitor_offset != 0.0:
-            monitor_spectrum_number_as_string = str(monitor_spectrum_number)
+        move_backstop_monitor(ws=workspace, move_info=move_info,
+                              monitor_spectrum_number=monitor_spectrum_number,
+                              monitor_offset=move_info.monitor_4_offset)
 
-            monitor_n_name = move_info.monitor_names[monitor_spectrum_number_as_string]
-
-            comp_info = workspace.componentInfo()
-            monitor_n = comp_info.indexOfAny(monitor_n_name)
-
-            # Get position of monitor n
-            monitor_position = comp_info.position(monitor_n)
-
-            # The location is relative to the rear-detector, get this position
-            lab_detector = move_info.detectors[DetectorType.to_string(DetectorType.LAB)]
-            detector_name = lab_detector.detector_name
-            lab_detector_index = comp_info.indexOfAny(detector_name)
-            detector_position =  comp_info.position(lab_detector_index)
-
-            z_position_detector = detector_position.getZ()
-            z_position_monitor = monitor_position.getZ()
-
-            z_new = z_position_detector + monitor_offset
-            z_move = z_new - z_position_monitor
-            offset = {CanonicalCoordinates.Z: z_move}
-
-            move_component(workspace, offset, monitor_n_name)
 
     def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
         # For LOQ we only have to coordinates
@@ -700,36 +734,17 @@ class SANSMoveZOOM(SANSMove):
         Moves n monitors in the workspace
         :param workspace: The associated workspace
         :param move_info: A move info object containing this instruments details
-        :return: None
         """
-        monitor_offset_dict = { 4 : move_info.monitor_4_offset,
-                                5 : move_info.monitor_5_offset }
 
-        comp_info = workspace.componentInfo()
+        # Apply monitor 4 offset
+        move_monitor(ws=workspace, move_info=move_info,
+                     monitor_offset=move_info.monitor_4_offset,
+                     monitor_spectrum_number=4)
 
-        for monitor_spec_num, offset in monitor_offset_dict.items():
-            if offset == 0.0:
-                continue
-
-            monitor_n_name = move_info.monitor_names[str(monitor_spec_num)]
-            monitor_index = comp_info.indexOfAny(monitor_n_name)
-
-            # Get position of monitor n
-            monitor_position = comp_info.position(monitor_index)
-            z_position_monitor = monitor_position.getZ()
-
-            # The location is relative to the rear-detector, get this position
-            lab_detector = move_info.detectors[DetectorType.to_string(DetectorType.LAB)]
-            detector_name = lab_detector.detector_name
-            lab_detector_index = comp_info.indexOfAny(detector_name)
-            detector_position = comp_info.position(lab_detector_index)
-            z_position_detector = detector_position.getZ()
-
-            z_new = z_position_detector + offset
-            z_move = z_new - z_position_monitor
-            offset = {CanonicalCoordinates.Z: z_move}
-
-            move_component(workspace, offset, monitor_n_name)
+        # Apply monitor 5 offset
+        move_backstop_monitor(ws=workspace, move_info=move_info,
+                              monitor_offset=move_info.monitor_5_offset,
+                              monitor_spectrum_number=5)
 
     def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
         # For ZOOM we only have to coordinates

--- a/scripts/SANS/sans/algorithm_detail/move_workspaces.py
+++ b/scripts/SANS/sans/algorithm_detail/move_workspaces.py
@@ -524,7 +524,6 @@ class SANSMoveSANS2D(SANSMove):
                               monitor_spectrum_number=monitor_spectrum_number,
                               monitor_offset=move_info.monitor_4_offset)
 
-
     def do_move_initial(self, move_info, workspace, coordinates, component, is_transmission_workspace):
         # For LOQ we only have to coordinates
         assert len(coordinates) == 2

--- a/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
+++ b/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
@@ -12,7 +12,7 @@ import mantid.simpleapi
 from sans.algorithm_detail.move_workspaces import SANSMoveZOOM, SANSMoveSANS2D
 from sans.common.enums import SANSFacility, SANSInstrument, DetectorType
 from sans.state.data import get_data_builder
-from sans.state.move import StateMoveZOOM, get_move_builder
+from sans.state.move import get_move_builder
 from sans.test_helper.file_information_mock import SANSFileInformationMock
 
 
@@ -30,7 +30,8 @@ def get_monitor_pos(ws, monitor_spectrum_no, move_info):
     return monitor_z_pos
 
 
-def calculate_new_pos(ws, move_info, offset):
+def calculate_new_pos_rel_to_rear(ws, move_info, offset):
+    # Calculates the new position relative to the rear detector offset
     rear_detector_z = get_rear_detector_pos(move_info=move_info, ws=ws)
     expected_pos = rear_detector_z + offset
     return expected_pos
@@ -46,7 +47,7 @@ def get_rear_detector_pos(move_info, ws):
     return detector_position
 
 
-class MoveSansMonitor(unittest.TestCase):
+class MoveSans2DMonitor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         sans_ws = mantid.simpleapi.LoadEmptyInstrument(InstrumentName="SANS2D")
@@ -102,7 +103,7 @@ class MoveSansMonitor(unittest.TestCase):
 
         z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
 
-        self.assertAlmostEqual(calculate_new_pos(ws=workspace, move_info=move_info, offset=mon_4_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_4_dist),
                                z_pos_mon_4_after)
 
     def test_not_moving_monitors(self):
@@ -187,12 +188,12 @@ class MoveZoomMonitors(unittest.TestCase):
         zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
+        # Monitor 4 shifts relative to itself rather than the rear detector on ZOOM
         z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
         z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
 
-        self.assertAlmostEqual(calculate_new_pos(ws=workspace, move_info=move_info, offset=mon_4_dist),
-                               z_pos_mon_4_after)
-        self.assertAlmostEqual(calculate_new_pos(ws=workspace, move_info=move_info, offset=mon_5_dist),
+        self.assertAlmostEqual(z_pos_mon_4_before + mon_4_dist, z_pos_mon_4_after)
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
                                z_pos_mon_5_after)
 
     def test_moving_only_monitor_4(self):
@@ -217,11 +218,11 @@ class MoveZoomMonitors(unittest.TestCase):
         zoom_class.move_initial(move_info=move_info, workspace=workspace, coordinates=coordinates,
                                 component=component, is_transmission_workspace=is_transmission_workspace)
 
+        # Monitor 4 shifts relative to itself rather than the rear detector on ZOOM
         z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
         z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
 
-        self.assertAlmostEqual(calculate_new_pos(ws=workspace, move_info=move_info, offset=mon_4_dist),
-                               z_pos_mon_4_after)
+        self.assertAlmostEqual(z_pos_mon_4_before + mon_4_dist, z_pos_mon_4_after)
         self.assertAlmostEqual(z_pos_mon_5_before, z_pos_mon_5_after)
 
     def test_moving_only_monitor_5(self):
@@ -250,7 +251,7 @@ class MoveZoomMonitors(unittest.TestCase):
         z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
 
         self.assertAlmostEqual(z_pos_mon_4_before, z_pos_mon_4_after)
-        self.assertAlmostEqual(calculate_new_pos(ws=workspace, move_info=move_info, offset=mon_5_dist),
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
                                z_pos_mon_5_after)
 
 


### PR DESCRIPTION
**Description of work.**
Moves Zoom's monitor 4 relative to itself, rather than the rear
detector.
Additionally, refactors the common 'backstop' monitor moving
code into its own function to remove duplication and make future
instruments easier.

**Report to:** ISIS/Diego

**To test:**
- Run updated unit tests
- Scientific validation (will be completed with user)

Fixes #26947 


*This does not require release notes* because these changes are already included

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
