### PR TITLE
Copyable Sample and Run

### DIFF
--- a/Framework/PythonInterface/core/CMakeLists.txt
+++ b/Framework/PythonInterface/core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(
 set(
   INC_FILES
   inc/MantidPythonInterface/core/CallMethod.h
+  inc/MantidPythonInterface/core/Copyable.h
   inc/MantidPythonInterface/core/DataServiceExporter.h
   inc/MantidPythonInterface/core/DllConfig.h
   inc/MantidPythonInterface/core/ErrorHandling.h

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
@@ -18,10 +18,18 @@ namespace PythonInterface {
 // Implementation based on
 // https://mail.python.org/pipermail/cplusplus-sig/2009-May/014505.html
 namespace bp = boost::python;
+
+/**
+ * Create a new object handle around arg. Caller is owner.
+ */
 template <typename T> inline PyObject *managingPyObject(T *p) {
   return typename bp::manage_new_object::apply<T *>::type()(p);
 }
 
+/**
+ * Create a shallow copy of type Copyable providing Copyable is newable and has
+ * a public copy constructor
+ */
 template <typename Copyable>
 boost::python::object generic__copy__(const bp::object &copyable) {
   Copyable *newCopyable(new Copyable(bp::extract<const Copyable &>(copyable)));
@@ -33,6 +41,10 @@ boost::python::object generic__copy__(const bp::object &copyable) {
   return result;
 }
 
+/**
+ * Create a deep copy of type Copyable providing Copyable is newable and has a
+ * public copy constructor
+ */
 template <typename Copyable>
 bp::object generic__deepcopy__(const bp::object &copyable, bp::dict &memo) {
   bp::object copyMod = bp::import("copy");

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
@@ -1,0 +1,55 @@
+
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_PYTHONINTERFACE_COPYABLE_H_
+#define MANTID_PYTHONINTERFACE_COPYABLE_H_
+#include <boost/python/class.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/extract.hpp>
+#include <boost/python/import.hpp>
+#include <boost/python/manage_new_object.hpp>
+namespace Mantid {
+namespace PythonInterface {
+
+// Implementation based on
+// https://mail.python.org/pipermail/cplusplus-sig/2009-May/014505.html
+namespace bp = boost::python;
+template <typename T> inline PyObject *managingPyObject(T *p) {
+  return typename bp::manage_new_object::apply<T *>::type()(p);
+}
+
+template <typename Copyable>
+boost::python::object generic__copy__(const bp::object &copyable) {
+  Copyable *newCopyable(new Copyable(bp::extract<const Copyable &>(copyable)));
+  bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
+
+  bp::extract<bp::dict>(result.attr("__dict__"))().update(
+      copyable.attr("__dict__"));
+
+  return result;
+}
+
+template <typename Copyable>
+bp::object generic__deepcopy__(const bp::object &copyable, bp::dict &memo) {
+  bp::object copyMod = bp::import("copy");
+  bp::object deepcopy = copyMod.attr("deepcopy");
+
+  Copyable *newCopyable(new Copyable(bp::extract<const Copyable &>(copyable)));
+  bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
+
+  // HACK: copyableId shall be the same as the result of id(copyable)
+  auto copyableId = (std::ptrdiff_t)(copyable.ptr());
+  memo[copyableId] = result;
+
+  bp::extract<bp::dict>(result.attr("__dict__"))().update(
+      deepcopy(bp::extract<bp::dict>(copyable.attr("__dict__"))(), memo));
+
+  return result;
+}
+} // namespace PythonInterface
+} // namespace Mantid
+#endif // MANTID_PYTHONINTERFACE_COPYABLE_H_

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,7 +18,6 @@
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
-#include <boost/python/copy_non_const_reference.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
@@ -78,12 +77,12 @@ void export_ExperimentInfo() {
       .staticmethod("getInstrumentFilename")
 
       .def("sample", &ExperimentInfo::sample,
-           return_value_policy<copy_const_reference>(), args("self"),
+           return_value_policy<reference_existing_object>(), args("self"),
            "Return the :class:`~mantid.api.Sample` object. This cannot be "
            "modified, use mutableSample to modify.")
 
       .def("mutableSample", &ExperimentInfo::mutableSample,
-           return_value_policy<copy_non_const_reference>(), args("self"),
+           return_value_policy<reference_existing_object>(), args("self"),
            "Return a modifiable :class:`~mantid.api.Sample` object.")
 
       .def("run", &ExperimentInfo::run,

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -18,6 +18,7 @@
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/copy_non_const_reference.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
@@ -77,12 +78,12 @@ void export_ExperimentInfo() {
       .staticmethod("getInstrumentFilename")
 
       .def("sample", &ExperimentInfo::sample,
-           return_value_policy<reference_existing_object>(), args("self"),
+           return_value_policy<copy_const_reference>(), args("self"),
            "Return the :class:`~mantid.api.Sample` object. This cannot be "
            "modified, use mutableSample to modify.")
 
       .def("mutableSample", &ExperimentInfo::mutableSample,
-           return_value_policy<reference_existing_object>(), args("self"),
+           return_value_policy<copy_non_const_reference>(), args("self"),
            "Return a modifiable :class:`~mantid.api.Sample` object.")
 
       .def("run", &ExperimentInfo::run,

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -7,6 +7,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidPythonInterface/core/Copyable.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h"
 
@@ -236,6 +237,6 @@ void export_Run() {
            return_value_policy<return_by_value>())
       .def("__setitem__", &addOrReplaceProperty,
            (arg("self"), arg("name"), arg("value")))
-
-      ;
+      .def("__copy__", &Mantid::PythonInterface::generic__copy__<Run>)
+      .def("__deepcopy__", &Mantid::PythonInterface::generic__deepcopy__<Run>);
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -153,7 +153,7 @@ void export_Run() {
   register_ptr_to_python<Run *>();
 
   // Run class
-  class_<Run, boost::noncopyable>("Run", no_init)
+  class_<Run, boost::noncopyable>("Run")
       .def("getProtonCharge", &Run::getProtonCharge, arg("self"),
            "Return the total good proton charge for the run")
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -29,7 +29,7 @@ void export_Sample() {
   register_ptr_to_python<Sample *>();
   register_ptr_to_python<boost::shared_ptr<Sample>>();
 
-  class_<Sample>("Sample", no_init)
+  class_<Sample, boost::noncopyable>("Sample", no_init)
       .def("getName", &Sample::getName,
            return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -29,7 +29,7 @@ void export_Sample() {
   register_ptr_to_python<Sample *>();
   register_ptr_to_python<boost::shared_ptr<Sample>>();
 
-  class_<Sample, boost::noncopyable>("Sample", no_init)
+  class_<Sample>("Sample", no_init)
       .def("getName", &Sample::getName,
            return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -9,58 +9,21 @@
 #include "MantidGeometry/Crystal/CrystalStructure.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidKernel/Material.h"
+#include "MantidPythonInterface/core/Copyable.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
-#include <boost/python/dict.hpp>
-#include <boost/python/import.hpp>
-#include <boost/python/manage_new_object.hpp>
-
 using Mantid::API::Sample;
 using Mantid::Geometry::OrientedLattice;
 using Mantid::Kernel::Material; // NOLINT
 using namespace boost::python;
-namespace bp = boost::python;
 
 GET_POINTER_SPECIALIZATION(Material)
 GET_POINTER_SPECIALIZATION(OrientedLattice)
 GET_POINTER_SPECIALIZATION(Sample)
-
-template <typename T> inline PyObject *managingPyObject(T *p) {
-  return typename bp::manage_new_object::apply<T *>::type()(p);
-}
-
-template <class Copyable>
-boost::python::object generic__copy__(const bp::object &copyable) {
-  Copyable *newCopyable(new Copyable(bp::extract<const Copyable &>(copyable)));
-  bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
-
-  bp::extract<bp::dict>(result.attr("__dict__"))().update(
-      copyable.attr("__dict__"));
-
-  return result;
-}
-
-template <class Copyable>
-bp::object generic__deepcopy__(const bp::object &copyable, bp::dict &memo) {
-  bp::object copyMod = bp::import("copy");
-  bp::object deepcopy = copyMod.attr("deepcopy");
-
-  Copyable *newCopyable(new Copyable(bp::extract<const Copyable &>(copyable)));
-  bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
-
-  // HACK: copyableId shall be the same as the result of id(copyable)
-  auto copyableId = (std::ptrdiff_t)(copyable.ptr());
-  memo[copyableId] = result;
-
-  bp::extract<bp::dict>(result.attr("__dict__"))().update(
-      deepcopy(bp::extract<bp::dict>(copyable.attr("__dict__"))(), memo));
-
-  return result;
-}
 
 void export_Sample() {
   register_ptr_to_python<Sample *>();
@@ -120,6 +83,7 @@ void export_Sample() {
            "Gets the number of samples in this collection")
       .def("__getitem__", &Sample::operator[],(arg("self"), arg("index")),
            return_internal_reference<>())
-      .def("__copy__", &generic__copy__<Sample>)
-      .def("__deepcopy__", &generic__deepcopy__<Sample>);
+      .def("__copy__", &Mantid::PythonInterface::generic__copy__<Sample>)
+      .def("__deepcopy__",
+           &Mantid::PythonInterface::generic__deepcopy__<Sample>);
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp
@@ -29,7 +29,7 @@ void export_Sample() {
   register_ptr_to_python<Sample *>();
   register_ptr_to_python<boost::shared_ptr<Sample>>();
 
-  class_<Sample, boost::noncopyable>("Sample", no_init)
+  class_<Sample, boost::noncopyable>("Sample")
       .def("getName", &Sample::getName,
            return_value_policy<copy_const_reference>(), arg("self"),
            "Returns the string name of the sample")

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+import copy
 from testhelpers import run_algorithm
 from mantid.geometry import Goniometer
 from mantid.kernel import DateAndTime
@@ -127,6 +128,22 @@ class RunTest(unittest.TestCase):
             runendstr, "2008-12-18T17:59:40 "
         )  # The space at the end is to get around an IPython bug (#8351)
         self.assertTrue(isinstance(runend, DateAndTime))
+
+    def do_test_copyable(self, copy_op):
+        original = self._expt_ws.run()
+        # make copy
+        cp = copy_op(original)
+        # Check identity different
+        self.assertNotEqual(id(original), id(cp))
+        # Simple tests that cp is equal to original
+        self.assertEqual(original.startTime(), cp.startTime())
+        self.assertEqual(original.endTime(), cp.endTime())
+
+    def test_shallow_copyable(self):
+        self.do_test_copyable(copy.copy)
+
+    def test_deep_copyable(self):
+        self.do_test_copyable(copy.deepcopy)
 
 
 if __name__ == '__main__':

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -8,10 +8,9 @@ from __future__ import (absolute_import, division, print_function)
 
 import unittest
 import copy
-from testhelpers import run_algorithm
 from mantid.geometry import Goniometer
 from mantid.kernel import DateAndTime
-
+from mantid.api import Run
 
 class RunTest(unittest.TestCase):
 
@@ -20,36 +19,31 @@ class RunTest(unittest.TestCase):
 
     def setUp(self):
         if self.__class__._expt_ws is None:
-            alg = run_algorithm('CreateWorkspace',
-                                DataX=[1, 2, 3, 4, 5],
-                                DataY=[1, 2, 3, 4, 5],
-                                NSpec=self._nspec,
-                                child=True)
-            ws = alg.getProperty("OutputWorkspace").value
-            ws.run().addProperty("gd_prtn_chrg", 10.05, True)
-            ws.run().addProperty("nspectra", self._nspec, True)
-            ws.run().setStartAndEndTime(DateAndTime("2008-12-18T17:58:38"),
+            run = Run()
+            run.addProperty("gd_prtn_chrg", 10.05, True)
+            run.addProperty("nspectra", self._nspec, True)
+            run.setStartAndEndTime(DateAndTime("2008-12-18T17:58:38"),
                                         DateAndTime("2008-12-18T17:59:40"))
-            self.__class__._expt_ws = ws
+            self.__class__._run = run
 
     def test_get_goniometer(self):
-        run = self._expt_ws.run()
+        run = Run()
         gm = run.getGoniometer()
         self.assertTrue(isinstance(gm, Goniometer))
 
     def test_proton_charge_returns_a_double(self):
-        run = self._expt_ws.run()
+        run = self._run
         charge = run.getProtonCharge()
         self.assertEqual(type(charge), float)
         self.assertAlmostEquals(charge, 10.05, 2)
 
     def test_run_hasProperty(self):
-        self.assertTrue(self._expt_ws.run().hasProperty('start_time'))
-        self.assertTrue('start_time' in self._expt_ws.run())
-        self.assertFalse('not a log' in self._expt_ws.run())
+        self.assertTrue(self._run.hasProperty('start_time'))
+        self.assertTrue('start_time' in self._run)
+        self.assertFalse('not a log' in self._run)
 
     def test_run_getProperty(self):
-        run_start = self._expt_ws.run().getProperty('start_time')
+        run_start = self._run.getProperty('start_time')
         self.assertEqual(type(run_start.value), str)
         self.assertEqual(run_start.value, "2008-12-18T17:58:38")
 
@@ -57,22 +51,22 @@ class RunTest(unittest.TestCase):
             self.assertEqual(type(nspectra.value), int)
             self.assertEqual(nspectra.value, self._nspec)
             self.assertRaises(RuntimeError,
-                              self._expt_ws.run().getProperty, 'not_a_log')
+                              self._run.getProperty, 'not_a_log')
 
-        do_spectra_check(self._expt_ws.run().getProperty('nspectra'))
-        do_spectra_check(self._expt_ws.run()['nspectra'])
-        do_spectra_check(self._expt_ws.run().get('nspectra'))
+        do_spectra_check(self._run.getProperty('nspectra'))
+        do_spectra_check(self._run['nspectra'])
+        do_spectra_check(self._run.get('nspectra'))
 
         # get returns the default if key does not exist, or None if no default
-        self.assertEqual(self._expt_ws.run().get('not_a_log'), None)
-        self.assertEqual(self._expt_ws.run().get('not_a_log', 5.), 5.)
+        self.assertEqual(self._run.get('not_a_log'), None)
+        self.assertEqual(self._run.get('not_a_log', 5.), 5.)
 
     def test_run_getPropertyAsSingleValue_with_number(self):
-        charge = self._expt_ws.run().getPropertyAsSingleValue('gd_prtn_chrg')
+        charge = self._run.getPropertyAsSingleValue('gd_prtn_chrg')
         self.assertAlmostEqual(10.05, charge)
 
     def test_add_property_with_known_type_succeeds(self):
-        run = self._expt_ws.run()
+        run = self._run
         nprops = len(run.getProperties())
         run.addProperty('int_t', 1, False)
         self.assertEqual(len(run.getProperties()), nprops + 1)
@@ -85,18 +79,18 @@ class RunTest(unittest.TestCase):
         self.assertEqual(run.getProperty('int_t').value, 6.5)
 
     def test_add_propgates_units_correctly(self):
-        run = self._expt_ws.run()
+        run = self._run
         run.addProperty('float_t', 2.4, 'metres', True)
         prop = run.getProperty('float_t')
         self.assertEqual(prop.units, 'metres')
 
     def test_add_property_with_unknown_type_raises_error(self):
-        run = self._expt_ws.run()
+        run = self._run
         # This used to test for dict, but we allow for dict now.
         self.assertRaises(ValueError, run.addProperty, 'set_t', set(), False)
 
     def test_keys_returns_a_list_of_the_property_names(self):
-        run = self._expt_ws.run()
+        run = self._run
         names = run.keys()
         self.assertEqual(type(names), list)
 
@@ -108,7 +102,7 @@ class RunTest(unittest.TestCase):
     def test_startime(self):
         """ Test exported function startTime()
         """
-        run = self._expt_ws.run()
+        run = self._run
 
         runstart = run.startTime()
         runstartstr = str(runstart)
@@ -120,7 +114,7 @@ class RunTest(unittest.TestCase):
     def test_endtime(self):
         """ Test exported function endTime()
         """
-        run = self._expt_ws.run()
+        run = self._run
 
         runend = run.endTime()
         runendstr = str(runend)
@@ -130,7 +124,7 @@ class RunTest(unittest.TestCase):
         self.assertTrue(isinstance(runend, DateAndTime))
 
     def do_test_copyable(self, copy_op):
-        original = self._expt_ws.run()
+        original = self._run
         # make copy
         cp = copy_op(original)
         # Check identity different

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -11,17 +11,14 @@ from mantid.simpleapi import CreateWorkspace
 from mantid.simpleapi import SetSampleMaterial
 from mantid.geometry import CrystalStructure
 from mantid.geometry import CSGObject
+from mantid.api import Sample
 from numpy import pi
 import copy
 
 class SampleTest(unittest.TestCase):
 
-    def setUp(self):
-        self._ws = CreateWorkspace(DataX=[1,2,3,4,5], DataY=[1,2,3,4,5], OutputWorkspace="dummy")
-
     def test_geometry_getters_and_setters(self):
-        sample = self._ws.sample()
-
+        sample = Sample()
         sample.setThickness(12.5)
         self.assertEqual(sample.getThickness(), 12.5)
         sample.setHeight(10.2)
@@ -30,7 +27,7 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(sample.getWidth(), 5.9)
 
     def test_crystal_structure_handling(self):
-        sample = self._ws.sample()
+        sample = Sample()
 
         self.assertEqual(sample.hasCrystalStructure(), False)
         self.assertRaises(RuntimeError, sample.getCrystalStructure)
@@ -57,8 +54,10 @@ class SampleTest(unittest.TestCase):
         self.assertRaises(RuntimeError, sample.getCrystalStructure)
 
     def test_material(self):
-        SetSampleMaterial(self._ws,"Al2 O3",SampleMassDensity=4)
-        material = self._ws.sample().getMaterial()
+        ws = CreateWorkspace(DataX=[1], DataY=[1], StoreInADS=False)
+        sample = ws.sample()
+        SetSampleMaterial(ws,"Al2 O3",SampleMassDensity=4, StoreInADS=False)
+        material = sample.getMaterial()
 
         self.assertAlmostEqual(material.numberDensity, 0.1181, places=4)
         self.assertAlmostEqual(material.relativeMolecularMass(), 101.961, places=3)
@@ -80,18 +79,17 @@ class SampleTest(unittest.TestCase):
         self.assertAlmostEquals(material.cohScatterXSection(), xs, places=4)
 
     def test_get_shape(self):
-        sample = self._ws.sample()
+        sample = Sample()
         self.assertEqual(type(sample.getShape()), CSGObject)
 
     def test_get_shape_xml(self):
-        sample = self._ws.sample()
+        sample = Sample()
         shape = sample.getShape()
         xml = shape.getShapeXML()
         self.assertEqual(type(xml), str)
 
     def do_test_copyable(self, copy_op):
-        ws = CreateWorkspace(DataX=[1], DataY=[1], StoreInADS=False)
-        original = self._ws.sample()
+        original = Sample() 
         width = 1.0
         height = 2.0
         thickness = 3.0
@@ -107,7 +105,6 @@ class SampleTest(unittest.TestCase):
         self.assertEqual(original.getWidth(), cp.getWidth())
         self.assertEqual(original.getThickness(), cp.getThickness())
         # Check really did succeed and is not tied in any way to original
-        del ws
         del original
         self.assertTrue(id(cp) > 0)
         self.assertEqual(height, cp.getHeight())

--- a/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SampleTest.py
@@ -12,6 +12,7 @@ from mantid.simpleapi import SetSampleMaterial
 from mantid.geometry import CrystalStructure
 from mantid.geometry import CSGObject
 from numpy import pi
+import copy
 
 class SampleTest(unittest.TestCase):
 
@@ -87,6 +88,37 @@ class SampleTest(unittest.TestCase):
         shape = sample.getShape()
         xml = shape.getShapeXML()
         self.assertEqual(type(xml), str)
+
+    def do_test_copyable(self, copy_op):
+        ws = CreateWorkspace(DataX=[1], DataY=[1], StoreInADS=False)
+        original = self._ws.sample()
+        width = 1.0
+        height = 2.0
+        thickness = 3.0
+        original.setThickness(thickness)
+        original.setHeight(height)
+        original.setWidth(width)
+        # make copy
+        cp = copy_op(original)
+        # Check identity different
+        self.assertNotEqual(id(original), id(cp))
+        # Simple tests that cp is equal to original
+        self.assertEqual(original.getHeight(), cp.getHeight())
+        self.assertEqual(original.getWidth(), cp.getWidth())
+        self.assertEqual(original.getThickness(), cp.getThickness())
+        # Check really did succeed and is not tied in any way to original
+        del ws
+        del original
+        self.assertTrue(id(cp) > 0)
+        self.assertEqual(height, cp.getHeight())
+        self.assertEqual(width, cp.getWidth())
+        self.assertEqual(thickness, cp.getThickness())
+
+    def test_shallow_copyable(self):
+        self.do_test_copyable(copy.copy)
+
+    def test_deep_copyable(self):
+        self.do_test_copyable(copy.deepcopy)
 
 
 


### PR DESCRIPTION
Sample and Run are useful concepts in Mantid and it would be good to be able to use these outside of Mantid directly. As it stands, it is not possible to make copies on the python side even though there is copy constructor and assignment support on the c++ side.

In this PR.

* Make `Sample` copyable, unit tests included.
* Same as above for `Run`
* Generic additions to `PythonInterface/core` should other developers want to follow the same strategy
