### PR TITLE
Add option to specify reflection type to PredictFractionalPeaks

### DIFF
--- a/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
+++ b/Framework/API/inc/MantidAPI/IPeaksWorkspace.h
@@ -105,7 +105,7 @@ public:
    * detector. Calculated if not provided.
    * @return a pointer to a new Peak object.
    */
-  virtual Mantid::Geometry::IPeak *
+  virtual std::unique_ptr<Geometry::IPeak>
   createPeak(const Mantid::Kernel::V3D &QLabFrame,
              boost::optional<double> detectorDistance = boost::none) const = 0;
 
@@ -124,7 +124,7 @@ public:
    * @param HKL V3D
    * @return a pointer to a new Peak object.
    */
-  virtual Mantid::Geometry::IPeak *
+  virtual std::unique_ptr<Geometry::IPeak>
   createPeakHKL(const Mantid::Kernel::V3D &HKL) const = 0;
 
   //---------------------------------------------------------------------------------------------

--- a/Framework/Crystal/inc/MantidCrystal/PredictFractionalPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictFractionalPeaks.h
@@ -34,6 +34,8 @@ public:
 
   /// Algorithm's category for identification
   const std::string category() const override { return "Crystal\\Peaks"; }
+  /// Return any errors in cross-property validation
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   /// Initialise the properties

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -5,10 +5,12 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidCrystal/PredictFractionalPeaks.h"
+#include "MantidAPI/Run.h"
 #include "MantidAPI/Sample.h"
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidGeometry/Instrument/Goniometer.h"
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
 #include "MantidKernel/ArrayLengthValidator.h"
 #include "MantidKernel/ArrayProperty.h"
@@ -16,10 +18,207 @@
 
 #include <boost/math/special_functions/round.hpp>
 
-using namespace Mantid::API;
-using namespace Mantid::DataObjects;
-using namespace Mantid::Geometry;
-using namespace Mantid::Kernel;
+using Mantid::API::Algorithm;
+using Mantid::API::IPeaksWorkspace_sptr;
+using Mantid::API::Progress;
+using Mantid::DataObjects::PeaksWorkspace;
+using Mantid::DataObjects::PeaksWorkspace_sptr;
+using Mantid::Geometry::Instrument_const_sptr;
+using Mantid::Kernel::DblMatrix;
+using Mantid::Kernel::V3D;
+
+namespace {
+
+namespace PropertyNames {
+const std::string PEAKS{"Peaks"};
+const std::string HOFFSET{"Hoffset"};
+const std::string KOFFSET{"Koffset"};
+const std::string LOFFSET{"Loffset"};
+const std::string INCLUDEPEAKSINRANGE{"IncludeAllPeaksInRange"};
+const std::string HMIN{"Hmin"};
+const std::string HMAX{"Hmax"};
+const std::string KMIN{"Kmin"};
+const std::string KMAX{"Kmax"};
+const std::string LMIN{"Lmin"};
+const std::string LMAX{"Lmax"};
+const std::string FRACPEAKS{"FracPeaks"};
+} // namespace PropertyNames
+
+/**
+ * Defines a type to capture details required
+ * to perform a fractional peak search given a HKL range
+ */
+class PeaksInRangeStrategy {
+public:
+  PeaksInRangeStrategy(V3D hklMin, V3D hklMax,
+                       const PeaksWorkspace *const inputPeaks)
+      : m_hklMin{std::move(hklMin)}, m_hklMax{std::move(hklMax)},
+        m_inputPeaks{inputPeaks} {}
+
+  Progress createProgressReporter(Algorithm *const alg) const noexcept {
+    const int nHKLCombinations = boost::math::iround(
+        (m_hklMax[0] - m_hklMin[0] + 1) * (m_hklMax[1] - m_hklMin[1] + 1) *
+        (m_hklMax[2] - m_hklMin[2] + 1));
+    return Progress(alg, 0.0, 1.0, nHKLCombinations);
+  }
+
+  void initialHKL(V3D *hkl, DblMatrix *gonioMatrix, int *runNumber) const
+      noexcept {
+    *hkl = m_hklMin;
+    *gonioMatrix = m_inputPeaks->run().getGoniometer().getR();
+    *runNumber = m_inputPeaks->getPeak(0).getRunNumber();
+  }
+
+  /// Compute the next HKL value in the range
+  bool nextHKL(V3D *hkl, DblMatrix * /*gonioMatrix*/, int * /*runNumber*/) const
+      noexcept {
+    bool canContinue{true};
+
+    auto &currentHKL{*hkl};
+    currentHKL[0]++;
+    if (currentHKL[0] > m_hklMax[0]) {
+      currentHKL[0] = m_hklMin[0];
+      currentHKL[1]++;
+      if (currentHKL[1] > m_hklMax[1]) {
+        currentHKL[1] = m_hklMin[1];
+        currentHKL[2]++;
+        if (currentHKL[2] > m_hklMax[2])
+          canContinue = false;
+      }
+    }
+    return canContinue;
+  }
+
+private:
+  V3D m_hklMin, m_hklMax;
+  const PeaksWorkspace *const m_inputPeaks;
+};
+
+/**
+ * Defines a type to capture details required
+ * to perform a fractional peak search given an input
+ * peaks workspace with peaks already indexed.
+ */
+class PeaksFromIndexedStrategy {
+public:
+  explicit PeaksFromIndexedStrategy(const PeaksWorkspace *const inputPeaks)
+      : m_inputPeaks{inputPeaks}, m_currentPeak{0} {}
+
+  Progress createProgressReporter(Algorithm *const alg) const noexcept {
+    return Progress(alg, 0.0, 1.0, m_inputPeaks->getNumberPeaks());
+  }
+
+  void initialHKL(V3D *hkl, DblMatrix *gonioMatrix, int *runNumber) const
+      noexcept {
+    const auto &initialPeak = m_inputPeaks->getPeak(m_currentPeak);
+    *hkl = initialPeak.getHKL();
+    *gonioMatrix = initialPeak.getGoniometerMatrix();
+    *runNumber = initialPeak.getRunNumber();
+  }
+
+  /// Compute the next HKL value in the range
+  bool nextHKL(V3D *hkl, DblMatrix *gonioMatrix, int *runNumber) const
+      noexcept {
+    bool canContinue{true};
+    m_currentPeak++;
+    if (m_currentPeak < m_inputPeaks->getNumberPeaks()) {
+      const auto &initialPeak = m_inputPeaks->getPeak(m_currentPeak);
+      *hkl = initialPeak.getHKL();
+      *gonioMatrix = initialPeak.getGoniometerMatrix();
+      *runNumber = initialPeak.getRunNumber();
+    } else {
+      canContinue = false;
+    }
+
+    return canContinue;
+  }
+
+private:
+  const PeaksWorkspace *const m_inputPeaks;
+  mutable int m_currentPeak;
+};
+
+/**
+ * Predict fractional peaks in the range specified by [hklMin, hklMax] and
+ * add them to a new PeaksWorkspace
+ * @param alg The host algorithm pointer
+ * @param hOffsets Offsets to apply to HKL in H direction
+ * @param kOffsets Offsets to apply to HKL in K direction
+ * @param lOffsets Offsets to apply to HKL in L direction
+ * @param strategy An object defining wgere to start the search and how to
+ * advance to the next HKL
+ * @return A new PeaksWorkspace containing the predicted fractional peaks
+ */
+template <typename SearchStrategy>
+IPeaksWorkspace_sptr
+predictPeaks(Algorithm *const alg, const std::vector<double> &hOffsets,
+             const std::vector<double> &kOffsets,
+             const std::vector<double> &lOffsets,
+             const PeaksWorkspace &inputPeaks, const SearchStrategy &strategy) {
+  using Mantid::API::WorkspaceFactory;
+  auto outPeaks = WorkspaceFactory::Instance().createPeaks();
+  const auto instrument = inputPeaks.getInstrument();
+  outPeaks->setInstrument(instrument);
+
+  using Mantid::Geometry::InstrumentRayTracer;
+  const InstrumentRayTracer tracer(instrument);
+  const auto &UB = inputPeaks.sample().getOrientedLattice().getUB();
+  using PeakHash = std::array<int, 4>;
+  std::vector<PeakHash> alreadyDonePeaks;
+
+  V3D currentHKL;
+  DblMatrix gonioMatrix;
+  int runNumber{0};
+  strategy.initialHKL(&currentHKL, &gonioMatrix, &runNumber);
+  auto progressReporter = strategy.createProgressReporter(alg);
+  while (true) {
+    for (double hOffset : hOffsets) {
+      for (double kOffset : kOffsets) {
+        for (double lOffset : lOffsets) {
+          const V3D candidateHKL(currentHKL[0] + hOffset,
+                                 currentHKL[1] + kOffset,
+                                 currentHKL[2] + lOffset);
+          const V3D qSample = (gonioMatrix * UB * candidateHKL) * 2 * M_PI;
+          if (qSample[2] <= 0)
+            continue;
+
+          using Mantid::Geometry::IPeak;
+          std::unique_ptr<IPeak> peak;
+          try {
+            peak = inputPeaks.createPeak(qSample, 1);
+          } catch (std::invalid_argument &) {
+            continue;
+          }
+
+          peak->setGoniometerMatrix(gonioMatrix);
+          if (peak->findDetector(tracer)) {
+            PeakHash savedPeak{runNumber,
+                               boost::math::iround(1000.0 * candidateHKL[0]),
+                               boost::math::iround(1000.0 * candidateHKL[1]),
+                               boost::math::iround(1000.0 * candidateHKL[2])};
+            auto it = find(alreadyDonePeaks.begin(), alreadyDonePeaks.end(),
+                           savedPeak);
+            if (it == alreadyDonePeaks.end())
+              alreadyDonePeaks.push_back(savedPeak);
+            else
+              continue;
+
+            peak->setHKL(candidateHKL);
+            peak->setRunNumber(runNumber);
+            outPeaks->addPeak(*peak);
+          }
+        }
+      }
+    }
+    progressReporter.report();
+    if (!strategy.nextHKL(&currentHKL, &gonioMatrix, &runNumber))
+      break;
+  }
+
+  return outPeaks;
+}
+
+} // namespace
 
 namespace Mantid {
 namespace Crystal {
@@ -28,219 +227,111 @@ DECLARE_ALGORITHM(PredictFractionalPeaks)
 
 /// Initialise the properties
 void PredictFractionalPeaks::init() {
+  using API::WorkspaceProperty;
+  using Kernel::Direction;
   declareProperty(
-      std::make_unique<WorkspaceProperty<PeaksWorkspace>>("Peaks", "",
-                                                          Direction::Input),
+      std::make_unique<WorkspaceProperty<PeaksWorkspace_sptr::element_type>>(
+          PropertyNames::PEAKS, "", Direction::Input),
       "Workspace of Peaks with orientation matrix that indexed the peaks and "
       "instrument loaded");
 
-  declareProperty(
-      std::make_unique<WorkspaceProperty<PeaksWorkspace>>("FracPeaks", "",
-                                                          Direction::Output),
-      "Workspace of Peaks with peaks with fractional h,k, and/or l values");
   declareProperty(std::make_unique<Kernel::ArrayProperty<double>>(
-                      std::string("HOffset"), "-0.5,0.0,0.5"),
+                      PropertyNames::HOFFSET, "-0.5,0.0,0.5"),
                   "Offset in the h direction");
   declareProperty(std::make_unique<Kernel::ArrayProperty<double>>(
-                      std::string("KOffset"), "0"),
-                  "Offset in the h direction");
+                      PropertyNames::KOFFSET, "0"),
+                  "Offset in the k direction");
   declareProperty(std::make_unique<Kernel::ArrayProperty<double>>(
-                      std::string("LOffset"), "-0.5,0.5"),
+                      PropertyNames::LOFFSET, "-0.5,0.5"),
                   "Offset in the h direction");
-
-  declareProperty("IncludeAllPeaksInRange", false,
+  declareProperty(PropertyNames::INCLUDEPEAKSINRANGE, false,
                   "If false only offsets from peaks from Peaks are used");
+  declareProperty(PropertyNames::HMIN, -8.0,
+                  "Minimum H value to use during search", Direction::Input);
+  declareProperty(PropertyNames::HMAX, 8.0,
+                  "Maximum H value to use during search", Direction::Input);
+  declareProperty(PropertyNames::KMIN, -8.0,
+                  "Minimum K value to use during search", Direction::Input);
+  declareProperty(PropertyNames::KMAX, 8.0,
+                  "Maximum K value to use during search", Direction::Input);
+  declareProperty(PropertyNames::LMIN, -8.0,
+                  "Minimum L value to use during search", Direction::Input);
+  declareProperty(PropertyNames::LMAX, 8.0,
+                  "Maximum L value to use during search", Direction::Input);
 
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Hmin", -8.0,
-                                                              Direction::Input),
-                  "Minimum H value to use");
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Hmax", 8.0,
-                                                              Direction::Input),
-                  "Maximum H value to use");
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Kmin", -8.0,
-                                                              Direction::Input),
-                  "Minimum K value to use");
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Kmax", 8.0,
-                                                              Direction::Input),
-                  "Maximum K value to use");
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Lmin", -8.0,
-                                                              Direction::Input),
-                  "Minimum L value to use");
-  declareProperty(std::make_unique<PropertyWithValue<double>>("Lmax", 8.0,
-                                                              Direction::Input),
-                  "Maximum L value to use");
+  setPropertySettings(
+      PropertyNames::HMIN,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
 
-  setPropertySettings("Hmin", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
+  setPropertySettings(
+      PropertyNames::HMAX,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
+  setPropertySettings(
+      PropertyNames::KMIN,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
 
-  setPropertySettings("Hmax", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
-  setPropertySettings("Kmin", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
+  setPropertySettings(
+      PropertyNames::KMAX,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
+  setPropertySettings(
+      PropertyNames::KMAX,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
 
-  setPropertySettings("Kmax", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
-  setPropertySettings("Lmin", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
-
-  setPropertySettings("Lmax", std::make_unique<Kernel::EnabledWhenProperty>(
-                                  std::string("IncludeAllPeaksInRange"),
-                                  Kernel::IS_EQUAL_TO, "1"));
+  setPropertySettings(
+      PropertyNames::LMAX,
+      std::make_unique<Kernel::EnabledWhenProperty>(
+          std::string("IncludeAllPeaksInRange"), Kernel::IS_EQUAL_TO, "1"));
+  // Outputs
+  declareProperty(
+      std::make_unique<WorkspaceProperty<PeaksWorkspace_sptr::element_type>>(
+          PropertyNames::FRACPEAKS, "", Direction::Output),
+      "Workspace of Peaks with peaks with fractional h,k, and/or l values");
 }
 
-/// Run the algorithm
-void PredictFractionalPeaks::exec() {
-  PeaksWorkspace_sptr Peaks = getProperty("Peaks");
-  if (Peaks->getNumberPeaks() <= 0) {
-    g_log.error() << "There are no peaks in the input PeaksWorkspace\n";
+std::map<std::string, std::string> PredictFractionalPeaks::validateInputs() {
+  std::map<std::string, std::string> helpMessages;
+  PeaksWorkspace_sptr peaks = getProperty(PropertyNames::PEAKS);
+  if (peaks->getNumberPeaks() <= 0) {
+    helpMessages[PropertyNames::PEAKS] = "Input workspace has no peaks.";
   }
-  std::vector<double> hOffsets = getProperty("HOffset");
-  std::vector<double> kOffsets = getProperty("KOffset");
-  std::vector<double> lOffsets = getProperty("LOffset");
+  return helpMessages;
+}
+
+void PredictFractionalPeaks::exec() {
+  PeaksWorkspace_sptr inputPeaks = getProperty(PropertyNames::PEAKS);
+  std::vector<double> hOffsets = getProperty(PropertyNames::HOFFSET);
+  std::vector<double> kOffsets = getProperty(PropertyNames::KOFFSET);
+  std::vector<double> lOffsets = getProperty(PropertyNames::LOFFSET);
   if (hOffsets.empty())
     hOffsets.push_back(0.0);
   if (kOffsets.empty())
     kOffsets.push_back(0.0);
   if (lOffsets.empty())
     lOffsets.push_back(0.0);
-  bool includePeaksInRange = getProperty("IncludeAllPeaksInRange");
+  const bool includePeaksInRange = getProperty("IncludeAllPeaksInRange");
+  const V3D hklMin{getProperty(PropertyNames::HMIN),
+                   getProperty(PropertyNames::KMIN),
+                   getProperty(PropertyNames::LMIN)};
+  const V3D hklMax{getProperty(PropertyNames::HMAX),
+                   getProperty(PropertyNames::KMAX),
+                   getProperty(PropertyNames::LMAX)};
 
-  API::Sample samp = Peaks->sample();
-  Geometry::OrientedLattice &ol = samp.getOrientedLattice();
-  Geometry::Instrument_const_sptr Instr = Peaks->getInstrument();
-
-  auto OutPeaks = boost::dynamic_pointer_cast<IPeaksWorkspace>(
-      WorkspaceFactory::Instance().createPeaks());
-  OutPeaks->setInstrument(Instr);
-
-  V3D hkl;
-  int peakNum = 0;
-  const auto NPeaks = Peaks->getNumberPeaks();
-  Kernel::Matrix<double> Gon;
-  Gon.identityMatrix();
-
-  const double Hmin = getProperty("Hmin");
-  const double Hmax = getProperty("Hmax");
-  const double Kmin = getProperty("Kmin");
-  const double Kmax = getProperty("Kmax");
-  const double Lmin = getProperty("Lmin");
-  const double Lmax = getProperty("Lmax");
-
-  int N = NPeaks;
+  IPeaksWorkspace_sptr outPeaks;
   if (includePeaksInRange) {
-    N = boost::math::iround((Hmax - Hmin + 1) * (Kmax - Kmin + 1) *
-                            (Lmax - Lmin + 1));
-    N = std::max<int>(100, N);
-  }
-  auto &peak0 = Peaks->getPeak(0);
-  auto RunNumber = peak0.getRunNumber();
-  Gon = peak0.getGoniometerMatrix();
-  Progress prog(this, 0.0, 1.0, N);
-  if (includePeaksInRange) {
+    outPeaks =
+        predictPeaks(this, hOffsets, kOffsets, lOffsets, *inputPeaks,
+                     PeaksInRangeStrategy(hklMin, hklMax, inputPeaks.get()));
 
-    hkl[0] = Hmin;
-    hkl[1] = Kmin;
-    hkl[2] = Lmin;
   } else {
-    hkl[0] = peak0.getH();
-    hkl[1] = peak0.getK();
-    hkl[2] = peak0.getL();
+    outPeaks = predictPeaks(this, hOffsets, kOffsets, lOffsets, *inputPeaks,
+                            PeaksFromIndexedStrategy(inputPeaks.get()));
   }
-
-  const Kernel::DblMatrix &UB = ol.getUB();
-  std::vector<std::vector<int>> AlreadyDonePeaks;
-  bool done = false;
-  int ErrPos = 1; // Used to determine position in code of a throw
-  Geometry::InstrumentRayTracer tracer(Peaks->getInstrument());
-  while (!done) {
-    for (double hOffset : hOffsets) {
-      for (double kOffset : kOffsets) {
-        for (double lOffset : lOffsets) {
-          try {
-            V3D hkl1(hkl);
-            ErrPos = 0;
-
-            hkl1[0] += hOffset;
-            hkl1[1] += kOffset;
-            hkl1[2] += lOffset;
-
-            Kernel::V3D Qs = UB * hkl1;
-            Qs *= 2.0;
-            Qs *= M_PI;
-            Qs = Gon * Qs;
-            if (Qs[2] <= 0)
-              continue;
-
-            ErrPos = 1;
-
-            boost::shared_ptr<IPeak> peak(Peaks->createPeak(Qs, 1));
-
-            peak->setGoniometerMatrix(Gon);
-
-            if (Qs[2] > 0 && peak->findDetector(tracer)) {
-              ErrPos = 2;
-              std::vector<int> SavPk{RunNumber,
-                                     boost::math::iround(1000.0 * hkl1[0]),
-                                     boost::math::iround(1000.0 * hkl1[1]),
-                                     boost::math::iround(1000.0 * hkl1[2])};
-
-              // TODO keep list sorted so searching is faster?
-              auto it =
-                  find(AlreadyDonePeaks.begin(), AlreadyDonePeaks.end(), SavPk);
-
-              if (it == AlreadyDonePeaks.end())
-                AlreadyDonePeaks.push_back(SavPk);
-              else
-                continue;
-
-              peak->setHKL(hkl1);
-              peak->setRunNumber(RunNumber);
-              OutPeaks->addPeak(*peak);
-            }
-          } catch (...) {
-            if (ErrPos != 1) // setQLabFrame in createPeak throws exception
-              throw std::invalid_argument("Invalid data at this point");
-          }
-        }
-      }
-    }
-    if (includePeaksInRange) {
-      hkl[0]++;
-      if (hkl[0] > Hmax) {
-        hkl[0] = Hmin;
-        hkl[1]++;
-        if (hkl[1] > Kmax) {
-
-          hkl[1] = Kmin;
-          hkl[2]++;
-          if (hkl[2] > Lmax)
-            done = true;
-        }
-      }
-    } else {
-      peakNum++;
-      if (peakNum >= NPeaks)
-        done = true;
-      else { // peak0= Peaks->getPeak(peakNum);
-        IPeak &peak1 = Peaks->getPeak(peakNum);
-        //??? could not assign to peak0 above. Did not work
-        // the peak that peak0 was associated with did NOT change
-        hkl[0] = peak1.getH();
-        hkl[1] = peak1.getK();
-        hkl[2] = peak1.getL();
-        Gon = peak1.getGoniometerMatrix();
-        RunNumber = peak1.getRunNumber();
-      }
-    }
-    prog.report();
-  }
-
-  setProperty("FracPeaks", OutPeaks);
+  setProperty(PropertyNames::FRACPEAKS, outPeaks);
 }
 
 } // namespace Crystal

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -19,6 +19,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/math/special_functions/round.hpp>
 
@@ -209,10 +210,12 @@ predictPeaks(Algorithm *const alg, const std::vector<double> &hOffsets,
           peak->setGoniometerMatrix(gonioMatrix);
           if (requirePeaksOnDetector && peak->getDetectorID() < 0)
             continue;
+          GNU_DIAG_OFF("missing-braces")
           PeakHash savedPeak{runNumber,
                              boost::math::iround(1000.0 * candidateHKL[0]),
                              boost::math::iround(1000.0 * candidateHKL[1]),
                              boost::math::iround(1000.0 * candidateHKL[2])};
+          GNU_DIAG_ON("missing-braces")
           auto it =
               find(alreadyDonePeaks.begin(), alreadyDonePeaks.end(), savedPeak);
           if (it == alreadyDonePeaks.end())

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -295,10 +295,25 @@ void PredictFractionalPeaks::init() {
 
 std::map<std::string, std::string> PredictFractionalPeaks::validateInputs() {
   std::map<std::string, std::string> helpMessages;
-  PeaksWorkspace_sptr peaks = getProperty(PropertyNames::PEAKS);
-  if (peaks->getNumberPeaks() <= 0) {
+  const PeaksWorkspace_sptr peaks = getProperty(PropertyNames::PEAKS);
+  if (peaks && peaks->getNumberPeaks() <= 0) {
     helpMessages[PropertyNames::PEAKS] = "Input workspace has no peaks.";
   }
+
+  auto validateRange = [&helpMessages, this](const std::string &minName,
+                                             const std::string &maxName) {
+    const double min{getProperty(minName)}, max{getProperty(maxName)};
+    if (max < min) {
+      const std::string helpMsg = "Inconsistent " + minName + "/" + maxName +
+                                  ": " + maxName + " < " + minName;
+      helpMessages[minName] = helpMsg;
+      helpMessages[maxName] = helpMsg;
+    }
+  };
+  validateRange(PropertyNames::HMIN, PropertyNames::HMAX);
+  validateRange(PropertyNames::KMIN, PropertyNames::KMAX);
+  validateRange(PropertyNames::LMIN, PropertyNames::LMAX);
+
   return helpMessages;
 }
 

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -194,14 +194,14 @@ predictPeaks(Algorithm *const alg, const std::vector<double> &hOffsets,
           const V3D candidateHKL(currentHKL[0] + hOffset,
                                  currentHKL[1] + kOffset,
                                  currentHKL[2] + lOffset);
-          const V3D qSample = (gonioMatrix * UB * candidateHKL) * 2 * M_PI;
-          if (qSample[2] <= 0)
+          const V3D qLab = (gonioMatrix * UB * candidateHKL) * 2 * M_PI;
+          if (qLab[2] <= 0)
             continue;
 
           using Mantid::Geometry::IPeak;
           std::unique_ptr<IPeak> peak;
           try {
-            peak = inputPeaks.createPeak(qSample);
+            peak = inputPeaks.createPeak(qLab);
           } catch (std::invalid_argument &) {
             continue;
           }

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -203,7 +203,8 @@ predictPeaks(Algorithm *const alg, const std::vector<double> &hOffsets,
           std::unique_ptr<IPeak> peak;
           try {
             peak = inputPeaks.createPeak(qLab);
-          } catch (std::invalid_argument &) {
+          } catch (...) {
+            // If we can't create a valid peak we have no choice but to skip it
             continue;
           }
 

--- a/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
+++ b/Framework/Crystal/test/CombinePeaksWorkspacesTest.h
@@ -42,7 +42,8 @@ public:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
-    PeaksWorkspace_sptr lhsWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr lhsWS =
+        WorkspaceCreationHelper::createPeaksWorkspace(2);
     PeaksWorkspace_sptr rhsWS =
         WorkspaceCreationHelper::createPeaksWorkspace(3);
 
@@ -82,7 +83,7 @@ public:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     // Name of the output workspace.
     std::string outWSName("CombinePeaksWorkspacesTest_OutputWS");

--- a/Framework/Crystal/test/DiffPeaksWorkspacesTest.h
+++ b/Framework/Crystal/test/DiffPeaksWorkspacesTest.h
@@ -44,7 +44,7 @@ public:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     // Name of the output workspace.
     std::string outWSName("CombinePeaksWorkspacesTest_OutputWS");
@@ -76,7 +76,8 @@ public:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
-    PeaksWorkspace_sptr lhsWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr lhsWS =
+        WorkspaceCreationHelper::createPeaksWorkspace(2);
     PeaksWorkspace_sptr rhsWS =
         WorkspaceCreationHelper::createPeaksWorkspace(6);
 
@@ -109,8 +110,10 @@ public:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
 
-    PeaksWorkspace_sptr lhsWS = WorkspaceCreationHelper::createPeaksWorkspace();
-    PeaksWorkspace_sptr rhsWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr lhsWS =
+        WorkspaceCreationHelper::createPeaksWorkspace(2);
+    PeaksWorkspace_sptr rhsWS =
+        WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     // Shift the rhs peaks in Q
     auto &rhsPeaks = rhsWS->getPeaks();

--- a/Framework/Crystal/test/FilterPeaksTest.h
+++ b/Framework/Crystal/test/FilterPeaksTest.h
@@ -80,7 +80,7 @@ public:
     using namespace Mantid::DataObjects;
 
     PeaksWorkspace_sptr inputWS =
-        WorkspaceCreationHelper::createPeaksWorkspace();
+        WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     // Name of the output workspace.
     std::string outWSName("FilterPeaksTest_OutputWS");

--- a/Framework/Crystal/test/IntegratePeaksHybridTest.h
+++ b/Framework/Crystal/test/IntegratePeaksHybridTest.h
@@ -105,7 +105,7 @@ public:
   }
 
   void test_input_md_workspace_mandatory() {
-    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     IntegratePeaksHybrid alg;
     alg.setRethrows(true);
@@ -119,7 +119,7 @@ public:
   }
 
   void test_outer_radius_mandatory() {
-    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     IMDEventWorkspace_sptr mdws = boost::static_pointer_cast<IMDEventWorkspace>(
         MDEventsTestHelper::makeMDEW<3>(10, 0, 10));
@@ -136,7 +136,7 @@ public:
   }
 
   void test_throw_if_special_coordinates_unknown() {
-    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace(2);
     IMDEventWorkspace_sptr mdws = boost::static_pointer_cast<IMDEventWorkspace>(
         MDEventsTestHelper::makeMDEW<3>(10, 0, 10));
 

--- a/Framework/Crystal/test/IntegratePeaksUsingClustersTest.h
+++ b/Framework/Crystal/test/IntegratePeaksUsingClustersTest.h
@@ -81,7 +81,7 @@ public:
   }
 
   void test_input_md_workspace_mandatory() {
-    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     IntegratePeaksUsingClusters alg;
     alg.setRethrows(true);
@@ -95,7 +95,7 @@ public:
   }
 
   void test_throw_if_special_coordinates_unknown() {
-    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksws = WorkspaceCreationHelper::createPeaksWorkspace(2);
     IMDHistoWorkspace_sptr mdws =
         MDEventsTestHelper::makeFakeMDHistoWorkspace(1, 1);
 

--- a/Framework/Crystal/test/PeaksInRegionTest.h
+++ b/Framework/Crystal/test/PeaksInRegionTest.h
@@ -80,7 +80,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Extents", "-1,1,-1,1,-1,1");
     alg.setPropertyValue("OutputWorkspace", "OutWS");
@@ -93,7 +93,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Extents", extents);
     alg.setPropertyValue("OutputWorkspace", "OutWS");

--- a/Framework/Crystal/test/PeaksOnSurfaceTest.h
+++ b/Framework/Crystal/test/PeaksOnSurfaceTest.h
@@ -59,7 +59,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Vertex1", vertex1);
     alg.setPropertyValue("Vertex2", vertex2);
@@ -98,7 +98,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Vertex1", "0,0,0");
     alg.setPropertyValue("Vertex2", "0,1,0");
@@ -114,7 +114,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Vertex1", "0,0,0");
     alg.setPropertyValue("Vertex2", "0,1,0");
@@ -132,7 +132,7 @@ public:
     alg.initialize();
     TS_ASSERT(alg.isInitialized());
     alg.setProperty("InputWorkspace",
-                    WorkspaceCreationHelper::createPeaksWorkspace());
+                    WorkspaceCreationHelper::createPeaksWorkspace(2));
     alg.setPropertyValue("CoordinateFrame", "Q (lab frame)");
     alg.setPropertyValue("Vertex1", "0,0,0");
     alg.setPropertyValue("Vertex2", "0,1,0");

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -4,107 +4,168 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-/*
- * PredictFractionalPeaksTest.h
- *
- *  Created on: Dec 28, 2012
- *      Author: ruth
- */
-
 #ifndef PREDICTFRACTIONALPEAKSTEST_H_
 #define PREDICTFRACTIONALPEAKSTEST_H_
 
-#include "MantidKernel/System.h"
-#include "MantidKernel/Timer.h"
-#include <cxxtest/TestSuite.h>
-
-#include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/Sample.h"
 #include "MantidCrystal/IndexPeaks.h"
 #include "MantidCrystal/LoadIsawUB.h"
 #include "MantidCrystal/PredictFractionalPeaks.h"
+#include "MantidDataHandling/LoadInstrument.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
+#include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidKernel/OptionalBool.h"
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidTestHelpers/FacilityHelper.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
 
-using namespace Mantid::Crystal;
-using namespace Mantid::API;
-using namespace Mantid::DataObjects;
+using Mantid::API::Workspace_sptr;
+using Mantid::Crystal::PredictFractionalPeaks;
+using Mantid::DataObjects::PeaksWorkspace_sptr;
+using Mantid::Geometry::OrientedLattice;
+using Mantid::Kernel::V3D;
+
 using namespace Mantid::DataHandling;
-using namespace Mantid::Kernel;
+using namespace Mantid::Crystal;
+
+namespace {
+
+PeaksWorkspace_sptr createIndexedPeaksWorkspace() {
+  LoadNexusProcessed loader;
+  loader.setChild(true);
+  loader.initialize();
+  loader.isInitialized();
+  loader.setPropertyValue("Filename", "TOPAZ_3007.peaks.nxs");
+  loader.setPropertyValue("OutputWorkspace", "__unused__");
+  loader.execute();
+  Workspace_sptr loadedWS = loader.getProperty("OutputWorkspace");
+
+  LoadIsawUB ubLoader;
+  ubLoader.setChild(true);
+  ubLoader.initialize();
+  ubLoader.setProperty("InputWorkspace", loadedWS);
+  ubLoader.setProperty("FileName", "TOPAZ_3007.mat");
+  ubLoader.execute();
+
+  IndexPeaks indexer;
+  indexer.setChild(true);
+  indexer.setLogging(false);
+  indexer.initialize();
+  indexer.setProperty("PeaksWorkspace", loadedWS);
+  indexer.execute();
+
+  return boost::dynamic_pointer_cast<PeaksWorkspace_sptr::element_type>(
+      loadedWS);
+}
+
+PeaksWorkspace_sptr runPredictFractionalPeaks(
+    const PeaksWorkspace_sptr &inputPeaks,
+    const std::unordered_map<const char *, const char *> &args) {
+  PredictFractionalPeaks alg;
+  alg.setChild(true);
+  alg.initialize();
+  alg.setProperty("Peaks", inputPeaks);
+  alg.setPropertyValue("FracPeaks", "__unused__");
+  for (const auto &nameValue : args) {
+    alg.setProperty(nameValue.first, nameValue.second);
+  }
+  alg.execute();
+  TS_ASSERT(alg.isExecuted())
+
+  return alg.getProperty("FracPeaks");
+}
+
+} // namespace
 
 class PredictFractionalPeaksTest : public CxxTest::TestSuite {
 
 public:
   void test_Init() {
     PredictFractionalPeaks alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
   }
 
-  void test_exec() {
-    LoadNexusProcessed loader;
-    TS_ASSERT_THROWS_NOTHING(loader.initialize());
-    TS_ASSERT(loader.isInitialized());
+  void setUp() override {
+    if (!m_indexedPeaks) {
+      m_indexedPeaks = createIndexedPeaksWorkspace();
+    }
+  }
 
-    std::string WSName("peaks");
-    loader.setPropertyValue("Filename", "TOPAZ_3007.peaks.nxs");
-    loader.setPropertyValue("OutputWorkspace", WSName);
-    TS_ASSERT(loader.execute());
-    TS_ASSERT(loader.isExecuted());
+  void test_exec_without_hkl_range_uses_input_peaks() {
+    const auto fracPeaks = runPredictFractionalPeaks(
+        m_indexedPeaks,
+        {{"HOffset", "-0.5,0,0.5"}, {"KOffset", "0.0"}, {"LOffset", "0.2"}});
 
-    LoadIsawUB UBloader;
-    TS_ASSERT_THROWS_NOTHING(UBloader.initialize());
-    TS_ASSERT(UBloader.isInitialized());
+    TS_ASSERT_EQUALS(117, fracPeaks->getNumberPeaks())
+    const auto &peak0 = fracPeaks->getPeak(0);
+    TS_ASSERT_DELTA(peak0.getH(), -5.5, .0001)
+    TS_ASSERT_DELTA(peak0.getK(), 7.0, .0001)
+    TS_ASSERT_DELTA(peak0.getL(), -3.8, .0001)
 
-    UBloader.setPropertyValue("InputWorkspace", WSName);
+    const auto &peak3 = fracPeaks->getPeak(3);
+    TS_ASSERT_DELTA(peak3.getH(), -5.5, .0001)
+    TS_ASSERT_DELTA(peak3.getK(), 3.0, .0001)
+    TS_ASSERT_DELTA(peak3.getL(), -2.8, .0001)
 
-    UBloader.setProperty("FileName", "TOPAZ_3007.mat");
-    TS_ASSERT(UBloader.execute());
-    TS_ASSERT(UBloader.isExecuted());
+    const auto &peak6 = fracPeaks->getPeak(6);
+    TS_ASSERT_DELTA(peak6.getH(), -6.5, .0001)
+    TS_ASSERT_DELTA(peak6.getK(), 4.0, .0001)
+    TS_ASSERT_DELTA(peak6.getL(), -3.8, .0001)
+  }
 
-    IndexPeaks indexer;
-    TS_ASSERT_THROWS_NOTHING(indexer.initialize());
-    TS_ASSERT(indexer.isInitialized());
+  void test_exec_with_include_in_range() {
+    const auto fracPeaks = runPredictFractionalPeaks(
+        m_indexedPeaks, {{"HOffset", "-0.5,0,0.5"},
+                         {"KOffset", "0.0"},
+                         {"LOffset", "0.2"},
+                         {"IncludeAllPeaksInRange", "1"},
+                         {"Hmin", "-1"},
+                         {"Hmax", "1"},
+                         {"Kmin", "-2"},
+                         {"Kmax", "2"},
+                         {"Lmin", "-3"},
+                         {"Lmax", "3"}
 
-    indexer.setPropertyValue("PeaksWorkspace", WSName);
+                        });
+    TS_ASSERT_EQUALS(9, fracPeaks->getNumberPeaks())
+    const auto &peak0 = fracPeaks->getPeak(0);
+    TS_ASSERT_DELTA(peak0.getH(), -0.5, .0001)
+    TS_ASSERT_DELTA(peak0.getK(), -2.0, .0001)
+    TS_ASSERT_DELTA(peak0.getL(), -1.8, .0001)
 
-    TS_ASSERT(indexer.execute());
-    TS_ASSERT(indexer.isExecuted());
+    const auto &peak3 = fracPeaks->getPeak(3);
+    TS_ASSERT_DELTA(peak3.getH(), -1.0, .0001)
+    TS_ASSERT_DELTA(peak3.getK(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak3.getL(), -0.8, .0001)
 
+    const auto &peak6 = fracPeaks->getPeak(6);
+    TS_ASSERT_DELTA(peak6.getH(), -0.5, .0001)
+    TS_ASSERT_DELTA(peak6.getK(), 0.0, .0001)
+    TS_ASSERT_DELTA(peak6.getL(), 0.2, .0001)
+
+    const auto &peak8 = fracPeaks->getPeak(8);
+    TS_ASSERT_DELTA(peak8.getH(), -1.5, .0001)
+    TS_ASSERT_DELTA(peak8.getK(), 2.0, .0001)
+    TS_ASSERT_DELTA(peak8.getL(), 0.2, .0001)
+  }
+
+  // ---------------- Failure tests -----------------------------
+  void test_empty_peaks_workspace_is_not_allowed() {
     PredictFractionalPeaks alg;
-    TS_ASSERT_THROWS_NOTHING(alg.initialize());
-    TS_ASSERT(alg.isInitialized());
+    alg.initialize();
+    alg.setProperty("Peaks", WorkspaceCreationHelper::createPeaksWorkspace(0));
 
-    alg.setProperty("Peaks", WSName);
+    auto helpMsgs = alg.validateInputs();
 
-    alg.setProperty("FracPeaks", std::string("FracPeaks"));
-    alg.setProperty("HOffset", "-.5,0,.5");
-    alg.setProperty("KOffset", "0.0");
-    alg.setProperty("LOffset", ".2");
-    TS_ASSERT(alg.execute());
-    TS_ASSERT(alg.isExecuted());
-    alg.setPropertyValue("FracPeaks", "FracPeaks");
-    PeaksWorkspace_sptr FracPeaks = alg.getProperty("FracPeaks");
-
-    TS_ASSERT_EQUALS(FracPeaks->getNumberPeaks(), 117);
-
-    Peak &peakx = dynamic_cast<Peak &>(FracPeaks->getPeak(0));
-    Peak peak = peakx;
-    TS_ASSERT_DELTA(peak.getH(), -5.5, .0001);
-    TS_ASSERT_DELTA(peak.getK(), 7.0, .0001);
-    TS_ASSERT_DELTA(peak.getL(), -3.8, .0001);
-
-    peakx = dynamic_cast<Peak &>(FracPeaks->getPeak(3));
-    peak = peakx;
-    TS_ASSERT_DELTA(peak.getH(), -5.5, .0001);
-    TS_ASSERT_DELTA(peak.getK(), 3.0, .0001);
-    TS_ASSERT_DELTA(peak.getL(), -2.8, .0001);
-
-    peakx = dynamic_cast<Peak &>(FracPeaks->getPeak(6));
-    peak = peakx;
-    TS_ASSERT_DELTA(peak.getH(), -6.5, .0001);
-    TS_ASSERT_DELTA(peak.getK(), 4.0, .0001);
-    TS_ASSERT_DELTA(peak.getL(), -3.8, .0001);
+    const auto valueIter = helpMsgs.find("Peaks");
+    TS_ASSERT(valueIter != helpMsgs.cend())
   }
+
+private:
+  PeaksWorkspace_sptr m_indexedPeaks;
 };
 
 #endif /* PredictFRACTIONALPEAKSTEST_H_ */

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -136,15 +136,15 @@ public:
     TS_ASSERT_DELTA(peak0.getK(), -2.0, .0001)
     TS_ASSERT_DELTA(peak0.getL(), -1.8, .0001)
 
-    const auto &peak3 = fracPeaks->getPeak(3);
-    TS_ASSERT_DELTA(peak3.getH(), -1.0, .0001)
-    TS_ASSERT_DELTA(peak3.getK(), 1.0, .0001)
-    TS_ASSERT_DELTA(peak3.getL(), -0.8, .0001)
+    const auto &peak2 = fracPeaks->getPeak(2);
+    TS_ASSERT_DELTA(peak2.getH(), -0.5, .0001)
+    TS_ASSERT_DELTA(peak2.getK(), 0.0, .0001)
+    TS_ASSERT_DELTA(peak2.getL(), 0.2, .0001)
 
-    const auto &peak6 = fracPeaks->getPeak(6);
-    TS_ASSERT_DELTA(peak6.getH(), -0.5, .0001)
-    TS_ASSERT_DELTA(peak6.getK(), 0.0, .0001)
-    TS_ASSERT_DELTA(peak6.getL(), 0.2, .0001)
+    const auto &peak4 = fracPeaks->getPeak(4);
+    TS_ASSERT_DELTA(peak4.getH(), -1.0, .0001)
+    TS_ASSERT_DELTA(peak4.getK(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak4.getL(), -0.8, .0001)
 
     const auto &peak8 = fracPeaks->getPeak(8);
     TS_ASSERT_DELTA(peak8.getH(), -1.5, .0001)

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -164,7 +164,34 @@ public:
     TS_ASSERT(valueIter != helpMsgs.cend())
   }
 
+  void test_inconsistent_H_range_gives_validation_error() {
+    doInvalidRangeTest("H");
+  }
+
+  void test_inconsistent_K_range_gives_validation_error() {
+    doInvalidRangeTest("K");
+  }
+
+  void test_inconsistent_L_range_gives_validation_error() {
+    doInvalidRangeTest("L");
+  }
+
 private:
+  void doInvalidRangeTest(const std::string &dimension) {
+    PredictFractionalPeaks alg;
+    alg.initialize();
+    const std::string minName{dimension + "min"}, maxName{dimension + "max"};
+    alg.setProperty(minName, 8.0);
+    alg.setProperty(maxName, -8.0);
+
+    auto helpMsgs = alg.validateInputs();
+
+    const auto minError = helpMsgs.find(minName);
+    TS_ASSERT(minError != helpMsgs.cend())
+    const auto maxError = helpMsgs.find(maxName);
+    TS_ASSERT(maxError != helpMsgs.cend())
+  }
+
   PeaksWorkspace_sptr m_indexedPeaks;
 };
 

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -104,19 +104,22 @@ public:
     TS_ASSERT_DELTA(peak0.getH(), -5.5, .0001)
     TS_ASSERT_DELTA(peak0.getK(), 7.0, .0001)
     TS_ASSERT_DELTA(peak0.getL(), -3.8, .0001)
+    TS_ASSERT_EQUALS(peak0.getDetectorID(), 1146353)
 
     const auto &peak3 = fracPeaks->getPeak(3);
     TS_ASSERT_DELTA(peak3.getH(), -5.5, .0001)
     TS_ASSERT_DELTA(peak3.getK(), 3.0, .0001)
     TS_ASSERT_DELTA(peak3.getL(), -2.8, .0001)
+    TS_ASSERT_EQUALS(peak3.getDetectorID(), 1747163)
 
     const auto &peak6 = fracPeaks->getPeak(6);
     TS_ASSERT_DELTA(peak6.getH(), -6.5, .0001)
     TS_ASSERT_DELTA(peak6.getK(), 4.0, .0001)
     TS_ASSERT_DELTA(peak6.getL(), -3.8, .0001)
+    TS_ASSERT_EQUALS(peak6.getDetectorID(), 1737894)
   }
 
-  void test_exec_with_include_in_range() {
+  void test_exec_with_include_in_range_and_hit_detector() {
     const auto fracPeaks = runPredictFractionalPeaks(
         m_indexedPeaks, {{"HOffset", "-0.5,0,0.5"},
                          {"KOffset", "0.0"},
@@ -135,21 +138,95 @@ public:
     TS_ASSERT_DELTA(peak0.getH(), -0.5, .0001)
     TS_ASSERT_DELTA(peak0.getK(), -2.0, .0001)
     TS_ASSERT_DELTA(peak0.getL(), -1.8, .0001)
+    TS_ASSERT_EQUALS(peak0.getDetectorID(), 1517488)
 
     const auto &peak2 = fracPeaks->getPeak(2);
     TS_ASSERT_DELTA(peak2.getH(), -0.5, .0001)
     TS_ASSERT_DELTA(peak2.getK(), 0.0, .0001)
     TS_ASSERT_DELTA(peak2.getL(), 0.2, .0001)
+    TS_ASSERT_EQUALS(peak2.getDetectorID(), 3219638)
 
     const auto &peak4 = fracPeaks->getPeak(4);
     TS_ASSERT_DELTA(peak4.getH(), -1.0, .0001)
     TS_ASSERT_DELTA(peak4.getK(), 1.0, .0001)
     TS_ASSERT_DELTA(peak4.getL(), -0.8, .0001)
+    TS_ASSERT_EQUALS(peak4.getDetectorID(), 1176666)
 
     const auto &peak8 = fracPeaks->getPeak(8);
     TS_ASSERT_DELTA(peak8.getH(), -1.5, .0001)
     TS_ASSERT_DELTA(peak8.getK(), 2.0, .0001)
     TS_ASSERT_DELTA(peak8.getL(), 0.2, .0001)
+    TS_ASSERT_EQUALS(peak8.getDetectorID(), 2577373)
+  }
+
+  void test_exec_with_reflection_condition_and_hit_detector() {
+    const auto fracPeaks = runPredictFractionalPeaks(
+        m_indexedPeaks, {{"HOffset", "-0.5,0,0.5"},
+                         {"KOffset", "0.0"},
+                         {"LOffset", "0.2"},
+                         {"ReflectionCondition", "C-face centred"},
+                         {"Hmin", "-1"},
+                         {"Hmax", "1"},
+                         {"Kmin", "-2"},
+                         {"Kmax", "2"},
+                         {"Lmin", "-3"},
+                         {"Lmax", "3"}});
+    TS_ASSERT_EQUALS(5, fracPeaks->getNumberPeaks())
+    const auto &peak0 = fracPeaks->getPeak(0);
+    TS_ASSERT_DELTA(peak0.getH(), -1.5, .0001)
+    TS_ASSERT_DELTA(peak0.getK(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak0.getL(), -0.8, .0001)
+    TS_ASSERT_EQUALS(peak0.getDetectorID(), 1730014)
+
+    const auto &peak2 = fracPeaks->getPeak(2);
+    TS_ASSERT_DELTA(peak2.getH(), -1.5, .0001)
+    TS_ASSERT_DELTA(peak2.getK(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak2.getL(), 0.2, .0001)
+    TS_ASSERT_EQUALS(peak2.getDetectorID(), 3157981)
+
+    const auto &peak4 = fracPeaks->getPeak(4);
+    TS_ASSERT_DELTA(peak4.getH(), -0.5, .0001)
+    TS_ASSERT_DELTA(peak4.getK(), 0.0, .0001)
+    TS_ASSERT_DELTA(peak4.getL(), 0.2, .0001)
+    TS_ASSERT_EQUALS(peak4.getDetectorID(), 3219638)
+  }
+
+  void test_exec_with_reflection_condition_and_not_required_on_detector() {
+    const auto fracPeaks = runPredictFractionalPeaks(
+        m_indexedPeaks, {{"HOffset", "-0.5,0,0.5"},
+                         {"KOffset", "0.0"},
+                         {"LOffset", "0.2"},
+                         {"ReflectionCondition", "C-face centred"},
+                         {"RequirePeaksOnDetector", "0"},
+                         {"Hmin", "-1"},
+                         {"Hmax", "1"},
+                         {"Kmin", "-2"},
+                         {"Kmax", "2"},
+                         {"Lmin", "-3"},
+                         {"Lmax", "3"}});
+    TS_ASSERT_EQUALS(72, fracPeaks->getNumberPeaks())
+
+    const auto &peak0 = fracPeaks->getPeak(0);
+    TS_ASSERT_DELTA(peak0.getH(), -1.5, .0001)
+    TS_ASSERT_DELTA(peak0.getK(), -2.0, .0001)
+    TS_ASSERT_DELTA(peak0.getL(), -2.8, .0001)
+    TS_ASSERT_EQUALS(peak0.getDetectorID(), -1)
+
+    const auto &peak32 = fracPeaks->getPeak(32);
+    TS_ASSERT_DELTA(peak32.getH(), 0.0, .0001)
+    TS_ASSERT_DELTA(peak32.getK(), -2.0, .0001)
+    TS_ASSERT_DELTA(peak32.getL(), -0.8, .0001)
+    TS_ASSERT_EQUALS(peak32.getDetectorID(), -1)
+
+    const auto &peak71 = fracPeaks->getPeak(71);
+    TS_ASSERT_DELTA(peak71.getH(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak71.getK(), 1.0, .0001)
+    TS_ASSERT_DELTA(peak71.getL(), -0.8, .0001)
+    TS_ASSERT_EQUALS(peak71.getDetectorID(), -1)
+
+    // check a couple of peaks had detectors
+    TS_ASSERT_EQUALS(fracPeaks->getPeak(21).getDetectorID(), 1730014)
+    TS_ASSERT_EQUALS(fracPeaks->getPeak(24).getDetectorID(), 3157981)
   }
 
   // ---------------- Failure tests -----------------------------

--- a/Framework/Crystal/test/SortPeaksWorkspaceTest.h
+++ b/Framework/Crystal/test/SortPeaksWorkspaceTest.h
@@ -117,7 +117,7 @@ public:
     // Name of the output workspace.
     std::string outWSName("SortPeaksWorkspaceTest_OutputWS");
 
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     SortPeaksWorkspace alg;
     alg.setRethrows(true);
@@ -135,7 +135,7 @@ public:
     // Name of the output workspace.
     std::string outWSName("SortPeaksWorkspaceTest_OutputWS");
 
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     SortPeaksWorkspace alg;
     alg.setRethrows(true);
@@ -152,7 +152,7 @@ public:
     const std::string columnOfInterestName = "h";
 
     // Create a peaks workspace and add some peaks with unordered H values.
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
     Peak peak1;
     peak1.setH(1);
     Peak peak2;
@@ -170,7 +170,7 @@ public:
     const std::string columnOfInterestName = "h";
 
     // Create a peaks workspace and add some peaks with unordered H values.
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
     Peak peak1;
     peak1.setH(0);
     Peak peak2;
@@ -186,7 +186,7 @@ public:
   }
 
   void test_modify_workspace_in_place() {
-    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    PeaksWorkspace_sptr inWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     SortPeaksWorkspace alg;
     alg.setChild(true);

--- a/Framework/DataHandling/test/LoadNexusProcessedTest.h
+++ b/Framework/DataHandling/test/LoadNexusProcessedTest.h
@@ -722,7 +722,7 @@ public:
   }
 
   void test_coordinates_saved_and_loaded_on_peaks_workspace() {
-    auto peaksTestWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksTestWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
     // Loading a peaks workspace without a instrument from an IDF doesn't work
     // ...
     const std::string filename = FileFinder::Instance().getFullPath(
@@ -767,7 +767,7 @@ public:
 
   // backwards compatability check
   void test_coordinates_saved_and_loaded_on_peaks_workspace_from_expt_info() {
-    auto peaksTestWS = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto peaksTestWS = WorkspaceCreationHelper::createPeaksWorkspace(2);
     // Loading a peaks workspace without a instrument from an IDF doesn't work
     // ...
     const std::string filename = FileFinder::Instance().getFullPath(

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -125,7 +125,7 @@ public:
       const Mantid::Kernel::V3D &QSampleFrame,
       boost::optional<double> detectorDistance = boost::none) override;
   void
-  setQLabFrame(const Mantid::Kernel::V3D &QLabFrame,
+  setQLabFrame(const Mantid::Kernel::V3D &qLab,
                boost::optional<double> detectorDistance = boost::none) override;
 
   void setWavelength(double wavelength) override;

--- a/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeaksWorkspace.h
@@ -93,7 +93,7 @@ public:
   Peak &getPeak(int peakNum) override;
   const Peak &getPeak(int peakNum) const override;
 
-  Geometry::IPeak *createPeak(
+  std::unique_ptr<Geometry::IPeak> createPeak(
       const Kernel::V3D &QLabFrame,
       boost::optional<double> detectorDistance = boost::none) const override;
 
@@ -104,7 +104,8 @@ public:
   std::vector<std::pair<std::string, std::string>>
   peakInfo(const Kernel::V3D &qFrame, bool labCoords) const override;
 
-  Peak *createPeakHKL(const Kernel::V3D &HKL) const override;
+  std::unique_ptr<Geometry::IPeak>
+  createPeakHKL(const Kernel::V3D &HKL) const override;
 
   int peakInfoNumber(const Kernel::V3D &qFrame, bool labCoords) const override;
 
@@ -186,7 +187,8 @@ private:
   /// Adds a new PeakColumn of the given type
   void addPeakColumn(const std::string &name);
   /// Create a peak from a QSample position
-  Peak *createPeakQSample(const Kernel::V3D &position) const;
+  std::unique_ptr<Geometry::IPeak>
+  createPeakQSample(const Kernel::V3D &position) const;
 
   // ====================================== ITableWorkspace Methods
   // ==================================

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -9,6 +9,7 @@
 #include "MantidGeometry/Instrument/RectangularDetector.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include "MantidGeometry/Objects/InstrumentRayTracer.h"
+#include "MantidGeometry/Surfaces/LineIntersectVisit.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Strings.h"
@@ -629,12 +630,11 @@ V3D Peak::getVirtualDetectorPosition(const V3D &detectorDir) const {
   if (!component) {
     return detectorDir; // the best idea we have is just the direction
   }
-
   const auto object =
       boost::dynamic_pointer_cast<const ObjComponent>(component);
-  Geometry::Track track(samplePos, detectorDir);
-  object->shape()->interceptSurface(track);
-  return track.back().exitPoint;
+  const auto distance =
+      object->shape()->distance(Geometry::Track(samplePos, detectorDir));
+  return detectorDir * distance;
 }
 
 /** After creating a peak using the Q in the lab frame,

--- a/Framework/DataObjects/src/Peak.cpp
+++ b/Framework/DataObjects/src/Peak.cpp
@@ -699,15 +699,14 @@ bool Peak::findDetector(const Mantid::Kernel::V3D &beam,
         V3D gapDir;
         gapDir[i] = gap;
         V3D beam1 = beam + gapDir;
-        tracer.traceFromSample(beam1);
+        tracer.traceFromSample(normalize(beam1));
         IDetector_const_sptr det1 = tracer.getDetectorResult();
         V3D beam2 = beam - gapDir;
-        tracer.traceFromSample(beam2);
+        tracer.traceFromSample(normalize(beam2));
         IDetector_const_sptr det2 = tracer.getDetectorResult();
         if (det1 && det2) {
           // Set the detector ID to one of the neighboring pixels
           this->setDetectorID(static_cast<int>(det1->getID()));
-          ;
           detPos = det1->getPos();
           found = true;
           break;

--- a/Framework/DataObjects/test/PeaksWorkspaceTest.h
+++ b/Framework/DataObjects/test/PeaksWorkspaceTest.h
@@ -367,7 +367,7 @@ public:
     const auto params = makePeakParameters();
     auto ws = makeWorkspace(params);
     // Create the peak
-    Peak *peak = ws->createPeakHKL(params.hkl);
+    auto peak = ws->createPeakHKL(params.hkl);
 
     /*
      Now we check we have made a self - consistent peak
@@ -388,9 +388,6 @@ public:
                       params.detectorPosition, detector->getPos());
     TSM_ASSERT_EQUALS("Goniometer has not been set properly",
                       params.goniometer.getR(), peak->getGoniometerMatrix());
-
-    // Clean up.
-    delete peak;
   }
 
   void test_create_peak_with_position_hkl() {

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/BasicHKLFilters.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/BasicHKLFilters.h
@@ -54,10 +54,23 @@ namespace Geometry {
   Combining HKLGenerator and different HKLFilters provides a very flexible
   system for creating and processing specific sets of Miller indices that
   is easy to expand by adding other HKLFilters.
-
-      @author Michael Wedel, ESS
-      @date 23/09/2015
 */
+
+/**
+ * A class to do no filtering of HKL values.
+ *
+ * It implements the NULL-object pattern to avoid having generic code
+ * check if a filter is available. Instead use this if no filter is required.\
+ */
+class MANTID_GEOMETRY_DLL HKLFilterNone final : public HKLFilter {
+public:
+  inline std::string getDescription() const noexcept override {
+    return "Accepts all HKL values.";
+  }
+  inline bool isAllowed(const Kernel::V3D & /*hkl*/) const noexcept override {
+    return true;
+  }
+};
 
 /**
  * A class to filter HKLs by their d-values
@@ -70,13 +83,13 @@ namespace Geometry {
  * be the lattice parameter with the largest value. There can not be
  * a greater interplanar spacing than that value.
  */
-class MANTID_GEOMETRY_DLL HKLFilterDRange : public HKLFilter {
+class MANTID_GEOMETRY_DLL HKLFilterDRange final : public HKLFilter {
 public:
   HKLFilterDRange(const UnitCell &cell, double dMin);
   HKLFilterDRange(const UnitCell &cell, double dMin, double dMax);
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 
 private:
   void checkProperDRangeValues();
@@ -92,12 +105,12 @@ private:
  * reflections as allowed that are allowed according to the
  * reflection conditions of the space group.
  */
-class MANTID_GEOMETRY_DLL HKLFilterSpaceGroup : public HKLFilter {
+class MANTID_GEOMETRY_DLL HKLFilterSpaceGroup final : public HKLFilter {
 public:
   HKLFilterSpaceGroup(const SpaceGroup_const_sptr &spaceGroup);
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 
 protected:
   SpaceGroup_const_sptr m_spaceGroup;
@@ -111,13 +124,13 @@ protected:
  * minimum, the reflection is considered allowed. The default minimum
  * is 1e-6.
  */
-class MANTID_GEOMETRY_DLL HKLFilterStructureFactor : public HKLFilter {
+class MANTID_GEOMETRY_DLL HKLFilterStructureFactor final : public HKLFilter {
 public:
   HKLFilterStructureFactor(const StructureFactorCalculator_sptr &calculator,
                            double fSquaredMin = 1.0e-6);
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 
 protected:
   StructureFactorCalculator_sptr m_calculator;
@@ -130,12 +143,12 @@ protected:
  * HKLFilterCentering is a filter that stores a ReflectionCondition object
  * internally and filters the HKLs according to that.
  */
-class MANTID_GEOMETRY_DLL HKLFilterCentering : public HKLFilter {
+class MANTID_GEOMETRY_DLL HKLFilterCentering final : public HKLFilter {
 public:
   HKLFilterCentering(const ReflectionCondition_sptr &centering);
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 
 protected:
   ReflectionCondition_sptr m_centering;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/HKLFilter.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/HKLFilter.h
@@ -67,13 +67,15 @@ class MANTID_GEOMETRY_DLL HKLFilter {
 public:
   virtual ~HKLFilter() = default;
 
-  std::function<bool(const Kernel::V3D &)> fn() const;
+  std::function<bool(const Kernel::V3D &)> fn() const noexcept;
 
   virtual std::string getDescription() const = 0;
   virtual bool isAllowed(const Kernel::V3D &hkl) const = 0;
 };
 
+using HKLFilter_uptr = std::unique_ptr<HKLFilter>;
 using HKLFilter_const_sptr = boost::shared_ptr<const HKLFilter>;
+using HKLFilter_sptr = boost::shared_ptr<HKLFilter>;
 
 /// Base class for unary logic operations for HKLFilter.
 class MANTID_GEOMETRY_DLL HKLFilterUnaryLogicOperation : public HKLFilter {
@@ -81,22 +83,23 @@ public:
   HKLFilterUnaryLogicOperation(const HKLFilter_const_sptr &filter);
 
   /// Returns the operand of the function.
-  const HKLFilter_const_sptr &getOperand() const { return m_operand; }
+  const HKLFilter_const_sptr &getOperand() const noexcept { return m_operand; }
 
 protected:
   HKLFilter_const_sptr m_operand;
 };
 
 /// Logical "Not"-operation for HKLFilter.
-class MANTID_GEOMETRY_DLL HKLFilterNot : public HKLFilterUnaryLogicOperation {
+class MANTID_GEOMETRY_DLL HKLFilterNot final
+    : public HKLFilterUnaryLogicOperation {
 public:
   /// Constructor, calls base class constructor, throws exception if filter is a
   /// null pointer.
   HKLFilterNot(const HKLFilter_const_sptr &filter)
       : HKLFilterUnaryLogicOperation(filter) {}
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 };
 
 /// Base class for binary logic operations for HKLFilter.
@@ -106,10 +109,10 @@ public:
                                 const HKLFilter_const_sptr &rhs);
 
   /// Returns the left-hand side operand of the operation.
-  const HKLFilter_const_sptr &getLHS() const { return m_lhs; }
+  const HKLFilter_const_sptr &getLHS() const noexcept { return m_lhs; }
 
   /// Returns the right-hand side operand of the operation.
-  const HKLFilter_const_sptr &getRHS() const { return m_rhs; }
+  const HKLFilter_const_sptr &getRHS() const noexcept { return m_rhs; }
 
 protected:
   HKLFilter_const_sptr m_lhs;
@@ -117,27 +120,29 @@ protected:
 };
 
 /// Logical "And"-operation for HKLFilter.
-class MANTID_GEOMETRY_DLL HKLFilterAnd : public HKLFilterBinaryLogicOperation {
+class MANTID_GEOMETRY_DLL HKLFilterAnd final
+    : public HKLFilterBinaryLogicOperation {
 public:
   /// Constructor, calls base class constructor, throws exception if either of
   /// the operands is null.
   HKLFilterAnd(const HKLFilter_const_sptr &lhs, const HKLFilter_const_sptr &rhs)
       : HKLFilterBinaryLogicOperation(lhs, rhs) {}
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 };
 
 /// Logical "Or"-operation for HKLFilter.
-class MANTID_GEOMETRY_DLL HKLFilterOr : public HKLFilterBinaryLogicOperation {
+class MANTID_GEOMETRY_DLL HKLFilterOr final
+    : public HKLFilterBinaryLogicOperation {
 public:
   /// Constructor, calls base class constructor, throws exception if either of
   /// the operands is null.
   HKLFilterOr(const HKLFilter_const_sptr &lhs, const HKLFilter_const_sptr &rhs)
       : HKLFilterBinaryLogicOperation(lhs, rhs) {}
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 };
 
 MANTID_GEOMETRY_DLL const HKLFilter_const_sptr

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/HKLFilterWavelength.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/HKLFilterWavelength.h
@@ -23,13 +23,13 @@ namespace Geometry {
       @author Michael Wedel, ESS
       @date 23/10/2015
 */
-class MANTID_GEOMETRY_DLL HKLFilterWavelength : public HKLFilter {
+class MANTID_GEOMETRY_DLL HKLFilterWavelength final : public HKLFilter {
 public:
   HKLFilterWavelength(const Kernel::DblMatrix &ub, double lambdaMin,
                       double lambdaMax);
 
-  std::string getDescription() const override;
-  bool isAllowed(const Kernel::V3D &hkl) const override;
+  std::string getDescription() const noexcept override;
+  bool isAllowed(const Kernel::V3D &hkl) const noexcept override;
 
 protected:
   void checkProperLambdaRangeValues() const;

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionCondition.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionCondition.h
@@ -175,9 +175,10 @@ public:
 
 /// Shared pointer to a ReflectionCondition
 using ReflectionCondition_sptr = boost::shared_ptr<ReflectionCondition>;
+/// A collection of reflections
+using ReflectionConditions = std::vector<ReflectionCondition_sptr>;
 
-MANTID_GEOMETRY_DLL std::vector<ReflectionCondition_sptr>
-getAllReflectionConditions();
+MANTID_GEOMETRY_DLL const ReflectionConditions &getAllReflectionConditions();
 MANTID_GEOMETRY_DLL std::vector<std::string> getAllReflectionConditionNames();
 MANTID_GEOMETRY_DLL std::vector<std::string> getAllReflectionConditionSymbols();
 MANTID_GEOMETRY_DLL ReflectionCondition_sptr

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Container.h
@@ -57,6 +57,9 @@ public:
   int interceptSurface(Geometry::Track &t) const override {
     return m_shape->interceptSurface(t);
   }
+  double distance(const Geometry::Track &t) const override {
+    return m_shape->distance(t);
+  }
   double solidAngle(const Kernel::V3D &observer) const override {
     return m_shape->solidAngle(observer);
   }

--- a/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/CSGObject.h
@@ -129,7 +129,8 @@ public:
   void write(std::ostream &) const; ///< MCNPX output
 
   // INTERSECTION
-  int interceptSurface(Geometry::Track &) const override;
+  int interceptSurface(Geometry::Track &track) const override;
+  double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
   double solidAngle(const Kernel::V3D &observer) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/IObject.h
@@ -53,6 +53,7 @@ public:
   virtual int getName() const = 0;
 
   virtual int interceptSurface(Geometry::Track &) const = 0;
+  virtual double distance(const Geometry::Track &) const = 0;
   // Solid angle
   virtual double solidAngle(const Kernel::V3D &observer) const = 0;
   // Solid angle with a scaling of the object

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject.h
@@ -87,6 +87,7 @@ public:
 
   // INTERSECTION
   int interceptSurface(Geometry::Track &) const override;
+  double distance(const Track &track) const override;
 
   // Solid angle - uses triangleSolidAngle unless many (>30000) triangles
   double solidAngle(const Kernel::V3D &observer) const override;

--- a/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
+++ b/Framework/Geometry/inc/MantidGeometry/Objects/MeshObject2D.h
@@ -49,6 +49,7 @@ public:
       const Kernel::V3D &point) const override; ///< Check if a point is inside
   bool isOnSide(const Kernel::V3D &) const override;
   int interceptSurface(Geometry::Track &ut) const override;
+  double distance(const Geometry::Track &ut) const override;
   MeshObject2D *clone() const override;
   MeshObject2D *
   cloneWithMaterial(const Kernel::Material &material) const override;

--- a/Framework/Geometry/src/Crystal/BasicHKLFilters.cpp
+++ b/Framework/Geometry/src/Crystal/BasicHKLFilters.cpp
@@ -24,7 +24,7 @@ HKLFilterDRange::HKLFilterDRange(const UnitCell &cell, double dMin, double dMax)
 }
 
 /// Returns a description containing the parameters of the filter.
-std::string HKLFilterDRange::getDescription() const {
+std::string HKLFilterDRange::getDescription() const noexcept {
   std::ostringstream strm;
   strm << "(" << m_dmin << " <= d <= " << m_dmax << ")";
 
@@ -32,7 +32,7 @@ std::string HKLFilterDRange::getDescription() const {
 }
 
 /// Returns true if the d-value of the HKL is within the specified range.
-bool HKLFilterDRange::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterDRange::isAllowed(const Kernel::V3D &hkl) const noexcept {
   double d = m_cell.d(hkl);
 
   return d >= m_dmin && d <= m_dmax;
@@ -64,16 +64,13 @@ HKLFilterSpaceGroup::HKLFilterSpaceGroup(
 }
 
 /// Returns a description of the filter that contains the space group symbol.
-std::string HKLFilterSpaceGroup::getDescription() const {
-  std::ostringstream strm;
-  strm << "(Space group: " << m_spaceGroup->hmSymbol() << ")";
-
-  return strm.str();
+std::string HKLFilterSpaceGroup::getDescription() const noexcept {
+  return "(Space group: " + m_spaceGroup->hmSymbol() + ")";
 }
 
 /// Returns true if the reflection is allowed by the space group reflection
 /// conditions.
-bool HKLFilterSpaceGroup::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterSpaceGroup::isAllowed(const Kernel::V3D &hkl) const noexcept {
   return m_spaceGroup->isAllowedReflection(hkl);
 }
 
@@ -88,7 +85,7 @@ HKLFilterStructureFactor::HKLFilterStructureFactor(
 }
 
 /// Returns a description for the filter that contains the minimum F^2.
-std::string HKLFilterStructureFactor::getDescription() const {
+std::string HKLFilterStructureFactor::getDescription() const noexcept {
   std::ostringstream strm;
   strm << "(F^2 > " << m_fSquaredMin << ")";
 
@@ -96,7 +93,8 @@ std::string HKLFilterStructureFactor::getDescription() const {
 }
 
 /// Returns true if F^2(hkl) is larger than the stored minimum.
-bool HKLFilterStructureFactor::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterStructureFactor::isAllowed(const Kernel::V3D &hkl) const
+    noexcept {
   return m_calculator->getFSquared(hkl) > m_fSquaredMin;
 }
 
@@ -111,12 +109,12 @@ HKLFilterCentering::HKLFilterCentering(
 }
 
 /// Returns a description with the centering symbol.
-std::string HKLFilterCentering::getDescription() const {
+std::string HKLFilterCentering::getDescription() const noexcept {
   return "(Centering: " + m_centering->getSymbol() + ")";
 }
 
 /// Returns true if the HKL is allowed according to the lattice centering.
-bool HKLFilterCentering::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterCentering::isAllowed(const Kernel::V3D &hkl) const noexcept {
   return m_centering->isAllowed(static_cast<int>(hkl.X()),
                                 static_cast<int>(hkl.Y()),
                                 static_cast<int>(hkl.Z()));

--- a/Framework/Geometry/src/Crystal/CrystalStructure.cpp
+++ b/Framework/Geometry/src/Crystal/CrystalStructure.cpp
@@ -114,8 +114,7 @@ void CrystalStructure::setReflectionConditionFromSpaceGroup(
     centering = "Robv";
   }
 
-  std::vector<ReflectionCondition_sptr> reflectionConditions =
-      getAllReflectionConditions();
+  const auto &reflectionConditions = getAllReflectionConditions();
   for (auto &reflectionCondition : reflectionConditions) {
     if (reflectionCondition->getSymbol() == centering) {
       m_centering = reflectionCondition;

--- a/Framework/Geometry/src/Crystal/HKLFilter.cpp
+++ b/Framework/Geometry/src/Crystal/HKLFilter.cpp
@@ -67,7 +67,7 @@ bool HKLFilterAnd::isAllowed(const Kernel::V3D &hkl) const noexcept {
 }
 
 /// Returns a description of the HKLFilterOr.
-std::string HKLFilterOr::getDescription() const noexcept{
+std::string HKLFilterOr::getDescription() const noexcept {
   return "(" + m_lhs->getDescription() + " | " + m_rhs->getDescription() + ")";
 }
 

--- a/Framework/Geometry/src/Crystal/HKLFilter.cpp
+++ b/Framework/Geometry/src/Crystal/HKLFilter.cpp
@@ -21,7 +21,7 @@ namespace Geometry {
  *
  * @return Function object with filter function for V3D.s
  */
-std::function<bool(const Kernel::V3D &)> HKLFilter::fn() const {
+std::function<bool(const Kernel::V3D &)> HKLFilter::fn() const noexcept {
   return std::bind(&HKLFilter::isAllowed, this, std::placeholders::_1);
 }
 
@@ -36,12 +36,12 @@ HKLFilterUnaryLogicOperation::HKLFilterUnaryLogicOperation(
 }
 
 /// Returns a description of the HKLFilterNot.
-std::string HKLFilterNot::getDescription() const {
+std::string HKLFilterNot::getDescription() const noexcept {
   return "!" + m_operand->getDescription();
 }
 
 /// Returns true if the wrapped filter returns false and false otherwise.
-bool HKLFilterNot::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterNot::isAllowed(const Kernel::V3D &hkl) const noexcept {
   return !(m_operand->isAllowed(hkl));
 }
 
@@ -57,22 +57,22 @@ HKLFilterBinaryLogicOperation::HKLFilterBinaryLogicOperation(
 }
 
 /// Returns a description of the HKLFilterAnd.
-std::string HKLFilterAnd::getDescription() const {
+std::string HKLFilterAnd::getDescription() const noexcept {
   return "(" + m_lhs->getDescription() + " & " + m_rhs->getDescription() + ")";
 }
 
 /// Returns true if both wrapped filters return true.
-bool HKLFilterAnd::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterAnd::isAllowed(const Kernel::V3D &hkl) const noexcept {
   return m_lhs->isAllowed(hkl) && m_rhs->isAllowed(hkl);
 }
 
 /// Returns a description of the HKLFilterOr.
-std::string HKLFilterOr::getDescription() const {
+std::string HKLFilterOr::getDescription() const noexcept{
   return "(" + m_lhs->getDescription() + " | " + m_rhs->getDescription() + ")";
 }
 
 /// Returns true if either of the wrapped filters returns true.
-bool HKLFilterOr::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterOr::isAllowed(const Kernel::V3D &hkl) const noexcept {
   return m_lhs->isAllowed(hkl) || m_rhs->isAllowed(hkl);
 }
 

--- a/Framework/Geometry/src/Crystal/HKLFilterWavelength.cpp
+++ b/Framework/Geometry/src/Crystal/HKLFilterWavelength.cpp
@@ -21,7 +21,7 @@ HKLFilterWavelength::HKLFilterWavelength(const Kernel::DblMatrix &ub,
 }
 
 /// Returns a description for the filter.
-std::string HKLFilterWavelength::getDescription() const {
+std::string HKLFilterWavelength::getDescription() const noexcept {
   std::ostringstream strm;
   strm << "(" << m_lambdaMin << " <= lambda <= " << m_lambdaMax << ")";
 
@@ -29,7 +29,7 @@ std::string HKLFilterWavelength::getDescription() const {
 }
 
 /// Returns true if lambda of the reflection is within the limits.
-bool HKLFilterWavelength::isAllowed(const Kernel::V3D &hkl) const {
+bool HKLFilterWavelength::isAllowed(const Kernel::V3D &hkl) const noexcept {
   V3D q = m_ub * hkl;
   double lambda = (2.0 * q.Z()) / (q.norm2());
 

--- a/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
+++ b/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
@@ -5,41 +5,52 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidGeometry/Crystal/ReflectionCondition.h"
-#include "MantidKernel/System.h"
 #include <algorithm>
 #include <iterator>
+
+#include <boost/make_shared.hpp>
 
 namespace Mantid {
 namespace Geometry {
 
+// General template definition for RegisterConditions
+template <typename... Args> struct RegisterConditions;
+
+// Specialisation for recursive case
+template <typename R, typename... Args> struct RegisterConditions<R, Args...> {
+  static void run(ReflectionConditions &container) {
+    container.emplace_back(boost::make_shared<R>());
+    RegisterConditions<Args...>::run(container);
+  }
+};
+
+// Specialisation to end recursion
+template <> struct RegisterConditions<> {
+  static void run(ReflectionConditions &) {}
+};
+
 /** @return a vector with all possible ReflectionCondition objects */
-std::vector<ReflectionCondition_sptr> getAllReflectionConditions() {
-  std::vector<ReflectionCondition_sptr> out;
-  out.push_back(ReflectionCondition_sptr(new ReflectionConditionPrimitive()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionCFaceCentred()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionAFaceCentred()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionBFaceCentred()));
-  out.push_back(ReflectionCondition_sptr(new ReflectionConditionBodyCentred()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionAllFaceCentred()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionRhombohedrallyObverse()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionRhombohedrallyReverse()));
-  out.push_back(
-      ReflectionCondition_sptr(new ReflectionConditionHexagonallyReverse()));
-  return out;
+const ReflectionConditions &getAllReflectionConditions() {
+  static ReflectionConditions conditions;
+  if (conditions.empty()) {
+    RegisterConditions<
+        ReflectionConditionPrimitive, ReflectionConditionCFaceCentred,
+        ReflectionConditionAFaceCentred, ReflectionConditionBFaceCentred,
+        ReflectionConditionBodyCentred, ReflectionConditionAllFaceCentred,
+        ReflectionConditionRhombohedrallyObverse,
+        ReflectionConditionRhombohedrallyReverse,
+        ReflectionConditionHexagonallyReverse>::run(conditions);
+  }
+  return conditions;
 }
 
 /// Helper function that transforms all ReflectionConditions to strings.
 std::vector<std::string> transformReflectionConditions(
     const std::function<std::string(const ReflectionCondition_sptr &)> &fn) {
-  auto conditions = getAllReflectionConditions();
+  const auto &conditions = getAllReflectionConditions();
 
   std::vector<std::string> names;
+  names.reserve(conditions.size());
   std::transform(conditions.cbegin(), conditions.cend(),
                  std::back_inserter(names), fn);
 
@@ -78,7 +89,7 @@ std::vector<std::string> getAllReflectionConditionSymbols() {
 ReflectionCondition_sptr getReflectionConditionWhere(
     const std::function<bool(const ReflectionCondition_sptr &)> &fn,
     const std::string &hint) {
-  auto conditions = getAllReflectionConditions();
+  const auto & conditions = getAllReflectionConditions();
 
   auto it = std::find_if(conditions.cbegin(), conditions.cend(), fn);
 

--- a/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
+++ b/Framework/Geometry/src/Crystal/ReflectionCondition.cpp
@@ -89,7 +89,7 @@ std::vector<std::string> getAllReflectionConditionSymbols() {
 ReflectionCondition_sptr getReflectionConditionWhere(
     const std::function<bool(const ReflectionCondition_sptr &)> &fn,
     const std::string &hint) {
-  const auto & conditions = getAllReflectionConditions();
+  const auto &conditions = getAllReflectionConditions();
 
   auto it = std::find_if(conditions.cbegin(), conditions.cend(), fn);
 

--- a/Framework/Geometry/src/Objects/MeshObject.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject.cpp
@@ -143,7 +143,6 @@ bool MeshObject::isOnSide(const Kernel::V3D &point) const {
  * @return Number of segments added
  */
 int MeshObject::interceptSurface(Geometry::Track &UT) const {
-
   int originalCount = UT.count(); // Number of intersections original track
   BoundingBox bb = getBoundingBox();
   if (!bb.doesLineIntersect(UT)) {
@@ -165,6 +164,28 @@ int MeshObject::interceptSurface(Geometry::Track &UT) const {
   UT.buildLink();
 
   return UT.count() - originalCount;
+}
+
+/**
+ * Compute the distance to the first point of intersection with the surface
+ * @param track Track defining start/direction
+ * @return The distance to the object
+ * @throws std::runtime_error if no intersection was found
+ */
+double MeshObject::distance(const Track &track) const {
+  Kernel::V3D vertex1, vertex2, vertex3, intersection;
+  TrackDirection unused;
+  for (size_t i = 0; getTriangle(i, vertex1, vertex2, vertex3); ++i) {
+    if (MeshObjectCommon::rayIntersectsTriangle(
+            track.startPoint(), track.direction(), vertex1, vertex2, vertex3,
+            intersection, unused)) {
+      return track.startPoint().distance(intersection);
+    }
+  }
+  std::ostringstream os;
+  os << "Unable to find intersection with object with track starting at "
+     << track.startPoint() << " in direction " << track.direction() << "\n";
+  throw std::runtime_error(os.str());
 }
 
 /**

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -262,7 +262,7 @@ int MeshObject2D::interceptSurface(Geometry::Track &ut) const {
 
 /**
  * Compute the distance to the first point of intersection with the mesh
- * @param track Track defining start/direction
+ * @param ut Track defining start/direction
  * @return The distance to the object
  * @throws std::runtime_error if no intersection was found
  */

--- a/Framework/Geometry/src/Objects/MeshObject2D.cpp
+++ b/Framework/Geometry/src/Objects/MeshObject2D.cpp
@@ -232,13 +232,13 @@ bool MeshObject2D::isOnSide(const Kernel::V3D &point) const {
  * @return Number of segments added
  */
 int MeshObject2D::interceptSurface(Geometry::Track &ut) const {
-
-  int originalCount = ut.count(); // Number of intersections original track
+  const int originalCount =
+      ut.count(); // Number of intersections original track
 
   const auto &norm = m_planeParameters.normal;
-  auto t = -(ut.startPoint().scalar_prod(norm) +
-             m_planeParameters.p0.scalar_prod(norm)) /
-           ut.direction().scalar_prod(norm);
+  const auto t = -(ut.startPoint().scalar_prod(norm) +
+                   m_planeParameters.p0.scalar_prod(norm)) /
+                 ut.direction().scalar_prod(norm);
 
   // Intersects infinite plane. No point evaluating individual segements if this
   // fails
@@ -258,6 +258,38 @@ int MeshObject2D::interceptSurface(Geometry::Track &ut) const {
   }
 
   return ut.count() - originalCount;
+}
+
+/**
+ * Compute the distance to the first point of intersection with the mesh
+ * @param track Track defining start/direction
+ * @return The distance to the object
+ * @throws std::runtime_error if no intersection was found
+ */
+double MeshObject2D::distance(const Track &ut) const {
+  const auto &norm = m_planeParameters.normal;
+  const auto t = -(ut.startPoint().scalar_prod(norm) +
+                   m_planeParameters.p0.scalar_prod(norm)) /
+                 ut.direction().scalar_prod(norm);
+
+  // Intersects infinite plane. No point evaluating individual segements if this
+  // fails
+  if (t >= 0) {
+    Kernel::V3D intersection;
+    TrackDirection entryExit;
+    for (size_t i = 0; i < m_vertices.size(); i += 3) {
+      if (MeshObjectCommon::rayIntersectsTriangle(
+              ut.startPoint(), ut.direction(), m_vertices[i], m_vertices[i + 1],
+              m_vertices[i + 2], intersection, entryExit)) {
+        // All vertices on plane. So only one triangle intersection possible
+        return intersection.distance(ut.startPoint());
+      }
+    }
+  }
+  std::ostringstream os;
+  os << "Unable to find intersection with object with track starting at "
+     << ut.startPoint() << " in direction " << ut.direction() << "\n";
+  throw std::runtime_error(os.str());
 }
 
 MeshObject2D *MeshObject2D::clone() const {

--- a/Framework/Geometry/test/BasicHKLFiltersTest.h
+++ b/Framework/Geometry/test/BasicHKLFiltersTest.h
@@ -35,6 +35,15 @@ public:
   }
   static void destroySuite(BasicHKLFiltersTest *suite) { delete suite; }
 
+  void testHKLFilterNone() {
+    HKLFilterNone filter;
+
+    TS_ASSERT(filter.isAllowed(V3D(1, 2, 3)))
+    TS_ASSERT(filter.isAllowed(V3D(-1, -2, 3)))
+    TS_ASSERT(filter.isAllowed(V3D(-1, -2, -3)))
+    TS_ASSERT(filter.isAllowed(V3D(120380123, 4012983, -131233)))
+  }
+
   void testHKLFilterDRangeConstructors() {
     UnitCell cell(10., 10., 10.);
 

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -423,6 +423,24 @@ public:
     checkTrackIntercept(track, expectedResults);
   }
 
+  void testDistanceWithIntersectionReturnsResult() {
+    auto geom_obj = createCappedCylinder();
+    V3D dir(0., 1., 0.);
+    dir.normalize();
+    Track track(V3D(0, 0, 0), dir);
+
+    TS_ASSERT_DELTA(3.0, geom_obj->distance(track), 1e-08)
+  }
+
+  void testDistanceWithoutIntersectionThrows() {
+    auto geom_obj = createCappedCylinder();
+    V3D dir(-1., 0., 0.);
+    dir.normalize();
+    Track track(V3D(-10, 0, 0), dir);
+
+    TS_ASSERT_THROWS(geom_obj->distance(track), std::runtime_error)
+  }
+
   void testTrackTwoIsolatedCubes()
   /**
   Test a track going through an object

--- a/Framework/Geometry/test/HKLFilterTest.h
+++ b/Framework/Geometry/test/HKLFilterTest.h
@@ -192,7 +192,7 @@ public:
   }
   GNU_DIAG_OFF_SUGGEST_OVERRIDE
 private:
-  class MockHKLFilter : public HKLFilter {
+  class MockHKLFilter final : public HKLFilter {
   public:
     MOCK_CONST_METHOD0(getDescription, std::string());
     MOCK_CONST_METHOD1(isAllowed, bool(const V3D &));

--- a/Framework/Geometry/test/MeshObjectTest.h
+++ b/Framework/Geometry/test/MeshObjectTest.h
@@ -384,6 +384,24 @@ public:
     checkTrackIntercept(std::move(geom_obj), track, expectedResults);
   }
 
+  void testDistanceWithIntersectionReturnsResult() {
+    auto geom_obj = createCube(3);
+    V3D dir(0., 1., 0.);
+    dir.normalize();
+    Track track(V3D(0, 0, 0), dir);
+
+    TS_ASSERT_DELTA(3.0, geom_obj->distance(track), 1e-08)
+  }
+
+  void testDistanceWithoutIntersectionThrows() {
+    auto geom_obj = createCube(3);
+    V3D dir(-1., 0., 0.);
+    dir.normalize();
+    Track track(V3D(-10, 0, 0), dir);
+
+    TS_ASSERT_THROWS(geom_obj->distance(track), std::runtime_error)
+  }
+
   void testTrackTwoIsolatedCubes()
   /**
   Test a track going through two objects

--- a/Framework/Geometry/test/ReflectionConditionTest.h
+++ b/Framework/Geometry/test/ReflectionConditionTest.h
@@ -8,8 +8,6 @@
 #define MANTID_GEOMETRY_REFLECTIONCONDITIONTEST_H_
 
 #include "MantidGeometry/Crystal/ReflectionCondition.h"
-#include "MantidKernel/System.h"
-#include "MantidKernel/Timer.h"
 #include <cxxtest/TestSuite.h>
 #include <unordered_set>
 
@@ -21,7 +19,7 @@ public:
                size_t count) {
     for (size_t i = 0; i < count; i++) {
       bool v = rc.isAllowed(h[i], k[i], l[i]);
-      TS_ASSERT_EQUALS((valid[i] == 1), v);
+      TS_ASSERT_EQUALS((valid[i] == 1), v)
     }
   }
 
@@ -44,11 +42,11 @@ public:
   }
 
   void test_getAllReflectionConditions() {
-    std::vector<ReflectionCondition_sptr> refs = getAllReflectionConditions();
-    TS_ASSERT_EQUALS(refs.size(), 9);
-    TS_ASSERT(refs[0]);
-    TS_ASSERT_EQUALS(refs[0]->getName(), "Primitive");
-    TS_ASSERT(refs[8]);
+    const auto &refs = getAllReflectionConditions();
+    TS_ASSERT_EQUALS(refs.size(), 9)
+    TS_ASSERT(refs[0])
+    TS_ASSERT_EQUALS(refs[0]->getName(), "Primitive")
+    TS_ASSERT(refs[8])
   }
 
   void test_ReflectionConditionSymbols() {
@@ -63,23 +61,23 @@ public:
     centeringSymbols.insert("Rrev");
     centeringSymbols.insert("H");
 
-    std::vector<ReflectionCondition_sptr> refs = getAllReflectionConditions();
+    const auto &refs = getAllReflectionConditions();
     for (auto &ref : refs) {
       TSM_ASSERT_DIFFERS(ref->getSymbol(),
                          centeringSymbols.find(ref->getSymbol()),
-                         centeringSymbols.end());
+                         centeringSymbols.end())
       centeringSymbols.erase(ref->getSymbol());
     }
 
     // All centering symbols are present if the set is empty.
-    TS_ASSERT_EQUALS(centeringSymbols.size(), 0);
+    TS_ASSERT_EQUALS(centeringSymbols.size(), 0)
   }
 
   void test_getReflectionConditionNames() {
     auto conditions = getAllReflectionConditions();
     auto names = getAllReflectionConditionNames();
 
-    TS_ASSERT_EQUALS(conditions.size(), names.size());
+    TS_ASSERT_EQUALS(conditions.size(), names.size())
 
     // there should not be any duplicates in the names
     std::unordered_set<std::string> nameSet(names.begin(), names.end());
@@ -91,7 +89,7 @@ public:
     auto conditions = getAllReflectionConditions();
     auto symbols = getAllReflectionConditionSymbols();
 
-    TS_ASSERT_EQUALS(conditions.size(), symbols.size());
+    TS_ASSERT_EQUALS(conditions.size(), symbols.size())
 
     // there should not be any duplicates in the names
     std::unordered_set<std::string> symbolSet(symbols.begin(), symbols.end());
@@ -104,11 +102,11 @@ public:
 
     for (auto name : names) {
       TSM_ASSERT_THROWS_NOTHING("Problem with ReflectionCondition: " + name,
-                                getReflectionConditionByName(name));
+                                getReflectionConditionByName(name))
     }
 
     TS_ASSERT_THROWS(getReflectionConditionByName("invalid"),
-                     const std::invalid_argument &);
+                     const std::invalid_argument &)
   }
 
   void test_getReflectionConditionBySymbol() {
@@ -116,11 +114,11 @@ public:
 
     for (auto symbol : symbols) {
       TSM_ASSERT_THROWS_NOTHING("Problem with ReflectionCondition: " + symbol,
-                                getReflectionConditionBySymbol(symbol));
+                                getReflectionConditionBySymbol(symbol))
     }
 
     TS_ASSERT_THROWS(getReflectionConditionBySymbol("Q"),
-                     const std::invalid_argument &);
+                     const std::invalid_argument &)
   }
 };
 

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
@@ -33,11 +33,10 @@ void addFakeEllipsoid(const V3D &peakHKL, const int &totalNPixels,
                       EventWorkspace_sptr &eventWS,
                       PeaksWorkspace_sptr &peaksWS) {
   // Create the peak and add it to the peaks ws
-  Peak *peak = peaksWS->createPeakHKL(peakHKL);
+  auto peak = peaksWS->createPeakHKL(peakHKL);
   peaksWS->addPeak(*peak);
   const int detectorId = peak->getDetectorID();
   const double tofExact = peak->getTOF();
-  delete peak;
 
   EventList &el = eventWS->getSpectrum(detectorId - totalNPixels);
 

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsWithSatellitesTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsWithSatellitesTest.h
@@ -33,12 +33,11 @@ void addFakeEllipsoid(const V3D &peakHKL, const V3D &peakMNP,
                       const double tofGap, EventWorkspace_sptr &eventWS,
                       PeaksWorkspace_sptr &peaksWS) {
   // Create the peak and add it to the peaks ws
-  Peak *peak = peaksWS->createPeakHKL(peakHKL);
+  auto peak = peaksWS->createPeakHKL(peakHKL);
   peak->setIntMNP(peakMNP);
   peaksWS->addPeak(*peak);
   const int detectorId = peak->getDetectorID();
   const double tofExact = peak->getTOF();
-  delete peak;
 
   EventList &el = eventWS->getSpectrum(detectorId - totalNPixels);
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -29,22 +29,28 @@ namespace {
 
 /// Create a peak via it's HKL value from a list or numpy array
 IPeak *createPeakHKL(IPeaksWorkspace &self, const object &data) {
-  return self.createPeakHKL(
+  auto peak = self.createPeakHKL(
       Mantid::PythonInterface::Converters::PyObjectToV3D(data)());
+  // Python will manage it
+  return peak.release();
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
 IPeak *createPeakQLab(IPeaksWorkspace &self, const object &data) {
-  return self.createPeak(
+  auto peak = self.createPeak(
       Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), boost::none);
+  // Python will manage it
+  return peak.release();
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
 IPeak *createPeakQLabWithDistance(IPeaksWorkspace &self, const object &data,
                                   double detectorDistance) {
-  return self.createPeak(
+  auto peak = self.createPeak(
       Mantid::PythonInterface::Converters::PyObjectToV3D(data)(),
       detectorDistance);
+  // Python will manage the object
+  return peak.release();
 }
 /// Create a peak via it's QLab value from a list or numpy array
 void addPeak(IPeaksWorkspace &self, const IPeak &peak) { self.addPeak(peak); }

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -387,8 +387,13 @@ void populateWsWithInitList(T &destination, size_t startingIndex,
 
 /// Create a simple peaks workspace containing the given number of peaks
 boost::shared_ptr<Mantid::DataObjects::PeaksWorkspace>
-createPeaksWorkspace(const int numPeaks = 2,
+createPeaksWorkspace(const int numPeaks,
                      const bool createOrientedLattice = false);
+/// Create a simple peaks workspace containing the given number of peaks and UB
+/// matrix
+boost::shared_ptr<Mantid::DataObjects::PeaksWorkspace>
+createPeaksWorkspace(const int numPeaks,
+                     const Mantid::Kernel::DblMatrix &ubMat);
 /**Build table workspace with preprocessed detectors for existing workspace with
  * instrument */
 boost::shared_ptr<Mantid::DataObjects::TableWorkspace>

--- a/Framework/TestHelpers/src/SingleCrystalDiffractionTestHelper.cpp
+++ b/Framework/TestHelpers/src/SingleCrystalDiffractionTestHelper.cpp
@@ -162,7 +162,7 @@ void WorkspaceBuilder::createPeak(const HKLPeakDescriptor &descriptor) {
   const auto sigmas = std::get<2>(descriptor);
 
   // Create the peak and add it to the peaks ws
-  const auto peak = std::unique_ptr<Peak>(m_peaksWorkspace->createPeakHKL(hkl));
+  const auto peak = m_peaksWorkspace->createPeakHKL(hkl);
   m_peaksWorkspace->addPeak(*peak);
 
   // Get detector ID and TOF position of peak

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1330,6 +1330,18 @@ createPeaksWorkspace(const int numPeaks, const bool createOrientedLattice) {
   return peaksWS;
 }
 
+Mantid::DataObjects::PeaksWorkspace_sptr
+createPeaksWorkspace(const int numPeaks,
+                     const Mantid::Kernel::DblMatrix &ubMat) {
+  if (ubMat.numRows() != 3 || ubMat.numCols() != 3) {
+    throw std::invalid_argument("UB matrix is not 3x3");
+  }
+
+  auto peaksWS = createPeaksWorkspace(numPeaks, true);
+  peaksWS->mutableSample().getOrientedLattice().setUB(ubMat);
+  return peaksWS;
+}
+
 /** helper method to create preprocessed detector's table workspace */
 boost::shared_ptr<DataObjects::TableWorkspace>
 createTableWorkspace(const API::MatrixWorkspace_const_sptr &inputWS) {

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -38,6 +38,8 @@ Single Crystal Diffraction
 Improvements
 ############
 
+- :ref:`PredictFractionalPeaks <algm-PredictFractionalPeaks>` now has the option to specify a reflection condition to restrict the number of peaks predicted,
+  along with the option to not require a predicted peak to hit a detector.
 - :ref:`SaveHKL <algm-SaveHKL>` now saves the tbar and transmission values for shapes and materials provided by :ref:`SetSample <algm-SetSample>`.
 
 

--- a/qt/widgets/sliceviewer/test/ConcretePeaksPresenterTest.h
+++ b/qt/widgets/sliceviewer/test/ConcretePeaksPresenterTest.h
@@ -741,7 +741,8 @@ public:
   void test_contentsDifferent_same() {
     ConcretePeaksPresenterBuilder builder = createStandardBuild();
     // Set a common peaks workspace.
-    builder.withPeaksWorkspace(WorkspaceCreationHelper::createPeaksWorkspace());
+    builder.withPeaksWorkspace(
+        WorkspaceCreationHelper::createPeaksWorkspace(2));
 
     ConcretePeaksPresenter_sptr a = builder.create();
     ConcretePeaksPresenter_sptr b = builder.create();
@@ -753,9 +754,9 @@ public:
   }
 
   void test_contentsDifferent_mixed() {
-    auto a = WorkspaceCreationHelper::createPeaksWorkspace();
-    auto b = WorkspaceCreationHelper::createPeaksWorkspace();
-    auto c = WorkspaceCreationHelper::createPeaksWorkspace();
+    auto a = WorkspaceCreationHelper::createPeaksWorkspace(2);
+    auto b = WorkspaceCreationHelper::createPeaksWorkspace(2);
+    auto c = WorkspaceCreationHelper::createPeaksWorkspace(2);
 
     // We are creating another comparison peaks presenter, which will deliver a
     // set of peaks workspaces.


### PR DESCRIPTION
**Description of work.**



**To test:**

Download the data from #26910. You'll need to NeXus from the .zip file. The following script gives an idea of how to use the algorithm.

```python
Load(Filename='unindexed-peaks.nxs', OutputWorkspace='sx_peaks')
LoadIsawUB(InputWorkspace='sx_peaks', Filename='pr-26807.txt')
PredictFractionalPeaks(Peaks='sx_peaks', Hmin=-1, Hmax=1, Kmin=-1, Kmax=1, Lmin=-1, Lmax=1, ReflectionCondition='All-face centred', RequirePeaksOnDetector=False, FracPeaks='fractional')
LoadEmptyInstrument(InstrumentName='WISH', OutputWorkspace='wish')
```

Once the `fractional` workspace has been created open the instrument view on the `wish` workspace and drag the `fractional` workspace on to it. In this example, because `RequirePeaksOnDetector=False` then you should see peaks not on a detector bank. Flip this option to `True` and the peaks should all be on a detector.

Play with the ranges and if you expand them more peaks should be found and vice versa. Selecting the another reflection type should change the peaks found. 

Fixes #26690

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
