### PR TITLE
Plot legend shows label instead of spectrum number if the spectrum has a numeric label

### DIFF
--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -188,7 +188,7 @@ def get_wksp_index_dist_and_label(workspace, axis=MantidAxType.SPECTRUM, **kwarg
     if 'label' not in kwargs:
         ws_name = workspace.name()
         if axis == MantidAxType.SPECTRUM:
-            if workspace.getAxis(1).isText():
+            if workspace.getAxis(1).isText() or workspace.getAxis(1).isNumeric():
                 kwargs['label'] = '{0}: {1}'.format(ws_name, workspace.getAxis(1).label(workspace_index))
             else:
                 if ws_name:

--- a/Framework/PythonInterface/test/python/mantid/plots/helperfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/helperfunctionsTest.py
@@ -189,7 +189,7 @@ class HelperFunctionsTest(unittest.TestCase):
         index, dist, kwargs = funcs.get_wksp_index_dist_and_label(self.ws2d_histo, specNum=2)
         self.assertEqual(index, 1)
         self.assertTrue(dist)
-        self.assertEqual(kwargs['label'], 'ws2d_histo: spec 2')
+        self.assertEqual(kwargs['label'], 'ws2d_histo: 6')
         # get info from default spectrum in the 1d case
         index, dist, kwargs = funcs.get_wksp_index_dist_and_label(self.ws1d_point, wkspIndex=0)
         self.assertEqual(index, 0)
@@ -203,6 +203,14 @@ class HelperFunctionsTest(unittest.TestCase):
         ws.getAxis(1).setLabel(0, "test")
         index, dist, kwargs = funcs.get_wksp_index_dist_and_label(ws, specNum=1)
         self.assertEqual(kwargs['label'], 'ws: test')
+
+    def test_legend_uses_label_if_first_axis_is_numeric_axis(self):
+        ws = CreateWorkspace([1], [1], NSpec=1)
+        axis = mantid.api.NumericAxis.create(1)
+        ws.replaceAxis(1, axis)
+        ws.getAxis(1).setValue(0, 50)
+        index, dist, kwargs = funcs.get_wksp_index_dist_and_label(ws, specNum=1)
+        self.assertEqual(kwargs['label'], 'ws: 50')
 
     def test_get_axes_labels(self):
         axs = funcs.get_axes_labels(self.ws2d_histo)

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -98,7 +98,7 @@ class Plots__init__Test(unittest.TestCase):
         line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
         self.assertEqual(2, len(self.ax.lines))
 
-        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: spec 2')
+        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: 6')
         self.assertEqual(1, len(self.ax.lines))
         self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
         self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)
@@ -109,7 +109,7 @@ class Plots__init__Test(unittest.TestCase):
         self.assertEqual(2, len(self.ax.lines))
 
         is_empty = self.ax.remove_artists_if(
-            lambda artist: artist.get_label() in ['ws2d_histo: spec 2', 'ws2d_histo: spec 3'])
+            lambda artist: artist.get_label() in ['ws2d_histo: 6', 'ws2d_histo: 8'])
         self.assertEqual(0, len(self.ax.lines))
         self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
         self.assertTrue(line_ws2d_histo_spec_3 not in self.ax.lines)
@@ -121,7 +121,7 @@ class Plots__init__Test(unittest.TestCase):
         line_ws2d_histo_spec_3 = self.ax.plot(self.ws2d_histo, specNum=3, linewidth=6)[0]
         self.assertEqual(2, len(self.ax.lines))
 
-        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: spec 2')
+        self.ax.remove_artists_if(lambda artist: artist.get_label() == 'ws2d_histo: 6')
         self.assertEqual(1, len(self.ax.lines))
         self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
         self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)
@@ -147,7 +147,7 @@ class Plots__init__Test(unittest.TestCase):
         self.assertEqual(3, len(self.ax.lines))
 
         is_empty = self.ax.remove_artists_if(
-            lambda artist: artist.get_label() in ['ws2d_histo: spec 2', 'second_ws: spec 5'])
+            lambda artist: artist.get_label() in ['ws2d_histo: 6', 'second_ws: spec 5'])
         self.assertEqual(1, len(self.ax.lines))
         self.assertTrue(line_ws2d_histo_spec_2 not in self.ax.lines)
         self.assertTrue(line_ws2d_histo_spec_3 in self.ax.lines)


### PR DESCRIPTION
**Description of work.**
This PR makes it so that if the first axis in a workspace is a NumericAxis, when plotted the legend uses the number in the first axis as the label rather than the spectrum number.

**To test:**
1. In Workbench, load [Training_Exercise3a_SNS.zip](https://github.com/mantidproject/mantid/files/3713487/Training_Exercise3a_SNS.zip).
2. Show the workspace data and plot the workspace.
3. Check that the labels in the plot legend match the numbers in the first column of the workspace's data.

Fixes #27000 

This does not need release notes because it is an extension of #26716 which added release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
