### PR TITLE
output transformation matrix 

### DIFF
--- a/Framework/Crystal/src/SelectCellOfType.cpp
+++ b/Framework/Crystal/src/SelectCellOfType.cpp
@@ -12,6 +12,7 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ScalarUtils.h"
 #include "MantidKernel/ListValidator.h"
+#include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -68,6 +69,10 @@ void SelectCellOfType::init() {
 
   this->declareProperty("AllowPermutations", true,
                         "Allow permutations of conventional cells");
+
+  this->declareProperty(std::make_unique<ArrayProperty<double>>(
+                            "TransformationMatrix", Direction::Output ),
+                        "The transformation matrix");
 }
 
 /** Execute the algorithm.
@@ -106,6 +111,7 @@ void SelectCellOfType::exec() {
 
   DblMatrix T = info.GetHKL_Tran();
   g_log.notice() << "Transformation Matrix =  " << T.str() << '\n';
+  this->setProperty("TransformationMatrix", T.getVector());
 
   if (apply) {
     std::vector<double> sigabc(6);

--- a/Framework/Crystal/src/SelectCellOfType.cpp
+++ b/Framework/Crystal/src/SelectCellOfType.cpp
@@ -11,8 +11,8 @@
 #include "MantidGeometry/Crystal/IndexingUtils.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ScalarUtils.h"
-#include "MantidKernel/ListValidator.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/ListValidator.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -71,7 +71,7 @@ void SelectCellOfType::init() {
                         "Allow permutations of conventional cells");
 
   this->declareProperty(std::make_unique<ArrayProperty<double>>(
-                            "TransformationMatrix", Direction::Output ),
+                            "TransformationMatrix", Direction::Output),
                         "The transformation matrix");
 }
 

--- a/Framework/Crystal/src/SelectCellWithForm.cpp
+++ b/Framework/Crystal/src/SelectCellWithForm.cpp
@@ -9,8 +9,8 @@
 #include "MantidGeometry/Crystal/IndexingUtils.h"
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ScalarUtils.h"
-#include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/BoundedValidator.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -49,7 +49,7 @@ void SelectCellWithForm::init() {
   this->declareProperty("AllowPermutations", true,
                         "Allow permutations of conventional cells");
   this->declareProperty(std::make_unique<ArrayProperty<double>>(
-                            "TransformationMatrix", Direction::Output ),
+                            "TransformationMatrix", Direction::Output),
                         "The transformation matrix");
 }
 

--- a/Framework/Crystal/src/SelectCellWithForm.cpp
+++ b/Framework/Crystal/src/SelectCellWithForm.cpp
@@ -10,6 +10,7 @@
 #include "MantidGeometry/Crystal/OrientedLattice.h"
 #include "MantidGeometry/Crystal/ScalarUtils.h"
 #include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid {
 namespace Crystal {
@@ -47,6 +48,9 @@ void SelectCellWithForm::init() {
 
   this->declareProperty("AllowPermutations", true,
                         "Allow permutations of conventional cells");
+  this->declareProperty(std::make_unique<ArrayProperty<double>>(
+                            "TransformationMatrix", Direction::Output ),
+                        "The transformation matrix");
 }
 
 Kernel::Matrix<double> SelectCellWithForm::DetermineErrors(
@@ -134,6 +138,7 @@ void SelectCellWithForm::exec() {
 
   DblMatrix T = info.GetHKL_Tran();
   g_log.notice() << "Transformation Matrix =  " << T.str() << '\n';
+  this->setProperty("TransformationMatrix", T.getVector());
 
   if (apply) {
     //----------------------------------- Try to optimize(LSQ) to find lattice

--- a/docs/source/algorithms/SelectCellOfType-v1.rst
+++ b/docs/source/algorithms/SelectCellOfType-v1.rst
@@ -16,6 +16,9 @@ flag is not set, the information about the selected cell will just be
 displayed. If the apply flag is set, the :ref:`UB matrix <Lattice>` associated with the
 sample in the PeaksWorkspace will be updated to a :ref:`UB matrix <Lattice>` corresponding to
 the selected cell AND the peaks will be re-indexed using the new :ref:`UB matrix <Lattice>`.
+The output transformation matrix :math:`M` will change :math:`UB` to :math:`UBM^{-1}`
+and map each :math:`(HKL)` vector to :math:`M(HKL)`. It can be further
+used by the :ref:`TransformHKL <algm-TransformHKL>` algorithm.
 NOTE: The possible conventional cells, together with the corresponding errors in the cell
 scalars can be seen by running the :ref:`ShowPossibleCells <algm-ShowPossibleCells>`
 algorithm, provided the stored :ref:`UB matrix <Lattice>` corresponds to a Niggli reduced cell.

--- a/docs/source/algorithms/SelectCellWithForm-v1.rst
+++ b/docs/source/algorithms/SelectCellWithForm-v1.rst
@@ -17,6 +17,9 @@ selected cell will just be displayed. If the apply flag is set, the
 :ref:`UB matrix <Lattice>` associated with the sample in the PeaksWorkspace
 will be updated to a :ref:`UB matrix <Lattice>` corresponding to the selected
 cell AND the peaks will be re-indexed using the new :ref:`UB matrix <Lattice>`.
+The output transformation matrix :math:`M` will change :math:`UB` to :math:`UBM^{-1}`
+and map each :math:`(HKL)` vector to :math:`M(HKL)`. It can be further
+used by the :ref:`TransformHKL <algm-TransformHKL>` algorithm.
 NOTE: The possible conventional cells, together with the corresponding errors
 in the cell scalars can be seen by running the
 :ref:`ShowPossibleCells <algm-ShowPossibleCells>` algorithm, provided the

--- a/docs/source/algorithms/TransformHKL-v1.rst
+++ b/docs/source/algorithms/TransformHKL-v1.rst
@@ -10,10 +10,11 @@ Description
 -----------
 
 Given a PeaksWorkspace with a :ref:`UB matrix <Lattice>` stored with
-the sample, this algorithm will accept a 3x3 transformation matrix M,
-change UB to UB\*M-inverse and map each (HKL) vector to M\*(HKL). For
-example, the transformation with elements 0,1,0,1,0,0,0,0,-1 will
-interchange the H and K values and negate L. This algorithm should allow
+the sample, this algorithm will accept a 3x3 transformation matrix :math:`M`,
+change :math:`UB` to :math:`UBM^{-1}` and map each :math:`(HKL)` vector to :math:`M(HKL)`.
+For example, the transformation with elements 0,1,0,1,0,0,0,0,-1 will
+interchange the :math:`H` and :math:`K` values and negate :math:`L`.
+This algorithm should allow
 the usr to perform any required transformation of the Miller indices,
 provided that transformation has a positive determinant. If a transformation
 with a negative or zero determinant is entered, the algorithm with throw an

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -39,6 +39,7 @@ Improvements
 ############
 
 - :ref:`SaveHKL <algm-SaveHKL>` now saves the tbar and transmission values for shapes and materials provided by :ref:`SetSample <algm-SetSample>`.
+- :ref:`SelectCellOfType <algm-SelectCellOfType>` and :ref:`SelectCellWithForm <algm-SelectCellWithForm>` now return the transformation matrix
 
 
 Bug Fixes


### PR DESCRIPTION
**Description of work.**

Returned the transformation matrix from `SelectCellOfType` and `SelectCellWithForm`

**Report to:** Xiaoping


**To test:**
Set your default facility/instrument to SNS/TOPAZ, then run

```python
ws=LoadIsawPeaks("TOPAZ_3007.peaks")
FindUBUsingFFT(ws,MinD=8.0,MaxD=13.0)
r=SelectCellOfType(PeaksWorkspace=ws, CellType='Monoclinic', Centering='C', Apply=True)
print(r.TransformationMatrix)
```
It should output the same transformation matrix as you see in the mantid logs.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
