### PR TITLE
Fix Engineering Diffraction Calibration Output Files

### DIFF
--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -398,7 +398,7 @@ def write_ENGINX_GSAS_iparam_file(output_file, difc, tzero, bank_names=None, cer
         bank_names = ["North", "South"]
 
     with open(template_file) as tf:
-        temp_lines = tf.readlines()
+        output_lines = tf.readlines()
 
     def replace_patterns(line, patterns, replacements):
         """
@@ -414,7 +414,6 @@ def write_ENGINX_GSAS_iparam_file(output_file, difc, tzero, bank_names=None, cer
     # need to replace two types of lines/patterns:
     # - instrument constants/parameters (ICONS)
     # - instrument calibration comment with run numbers (CALIB)
-    output_lines = []
     for b_idx, _bank_name in enumerate(bank_names):
         patterns = ["INS  %d ICONS" % (b_idx + 1),  # bank calibration parameters: DIFC, DIFA, TZERO
                     "INS    CALIB",  # calibration run numbers (Vanadium and Ceria)
@@ -429,7 +428,7 @@ def write_ENGINX_GSAS_iparam_file(output_file, difc, tzero, bank_names=None, cer
                         ("INS    INCBM  ob+mon_{0}_North_and_South_banks.his".
                          format(ceria_run)).ljust(80) + '\n']
 
-        output_lines = [replace_patterns(line, patterns, replacements) for line in temp_lines]
+        output_lines = [replace_patterns(line, patterns, replacements) for line in output_lines]
 
     with open(output_file, 'w') as of:
         of.writelines(output_lines)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_model.py
@@ -30,31 +30,35 @@ class CalibrationModelTest(unittest.TestCase):
         self.assertRaises(RuntimeError, self.model.create_new_calibration, "307521", "FAIL", True,
                           "ENGINX")
 
+    @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
     @patch(class_path + '.run_calibration')
     @patch(class_path + '.load_ceria')
     @patch(class_path + '.calculate_vanadium_correction')
-    def test_EnggVanadiumCorrections_algorithm_is_called(self, alg, load_ceria, calib,
-                                                         output_files):
+    def test_EnggVanadiumCorrections_algorithm_is_called(self, alg, load_ceria, calib, output_files,
+                                                         update_table):
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
         alg.assert_called_once()
 
+    @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
     @patch(class_path + '.load_ceria')
     @patch(class_path + '.calculate_vanadium_correction')
     @patch(class_path + '.run_calibration')
     def test_EnggCalibrate_algorithm_is_called(self, calibrate_alg, vanadium_alg, load_ceria,
-                                               output_files):
+                                               output_files, update_table):
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
         self.assertEqual(calibrate_alg.call_count, 1)
 
+    @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
     @patch(class_path + '.load_ceria')
     @patch(class_path + '.calculate_vanadium_correction')
     @patch(class_path + '._plot_vanadium_curves')
     @patch(class_path + '._plot_difc_zero')
     @patch(class_path + '.run_calibration')
-    def test_plotting_check(self, calib, plot_difc_zero, plot_van, van, ceria, output_files):
+    def test_plotting_check(self, calib, plot_difc_zero, plot_van, van, ceria, output_files,
+                            update_table):
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
         plot_van.assert_not_called()
         plot_difc_zero.assert_not_called()
@@ -62,6 +66,7 @@ class CalibrationModelTest(unittest.TestCase):
         plot_van.assert_called_once()
         self.assertEqual(plot_difc_zero.call_count, 2)
 
+    @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
     @patch(class_path + '.load_ceria')
     @patch(class_path + '.calculate_vanadium_correction')
@@ -69,7 +74,7 @@ class CalibrationModelTest(unittest.TestCase):
     @patch(class_path + '._plot_difc_zero')
     @patch(class_path + '.run_calibration')
     def test_present_RB_number_results_in_user_output_files(self, calib, plot_difc_zero, plot_van,
-                                                            van, ceria, output_files):
+                                                            van, ceria, output_files, update_table):
         self.model.create_new_calibration(VANADIUM_NUMBER,
                                           CERIUM_NUMBER,
                                           False,
@@ -77,6 +82,7 @@ class CalibrationModelTest(unittest.TestCase):
                                           rb_num="00110")
         self.assertEqual(output_files.call_count, 2)
 
+    @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
     @patch(class_path + '.load_ceria')
     @patch(class_path + '.calculate_vanadium_correction')
@@ -84,9 +90,20 @@ class CalibrationModelTest(unittest.TestCase):
     @patch(class_path + '._plot_difc_zero')
     @patch(class_path + '.run_calibration')
     def test_absent_run_number_results_in_no_user_output_files(self, calib, plot_difc_zero,
-                                                               plot_van, van, ceria, output_files):
+                                                               plot_van, van, ceria, output_files,
+                                                               update_table):
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
         self.assertEqual(output_files.call_count, 1)
+
+    @patch(class_path + '.update_calibration_params_table')
+    @patch(class_path + '.create_output_files')
+    @patch(class_path + '.load_ceria')
+    @patch(class_path + '.calculate_vanadium_correction')
+    @patch(class_path + '.run_calibration')
+    def test_calibration_params_table_is_updated(self, calibrate_alg, vanadium_alg, load_ceria,
+                                                 output_files, update_table):
+        self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
+        self.assertEqual(calibrate_alg.call_count, 1)
 
     @patch(class_path + '._generate_output_file_name')
     @patch('Engineering.gui.engineering_diffraction.tabs.calibration.model.makedirs')
@@ -149,6 +166,22 @@ class CalibrationModelTest(unittest.TestCase):
         self.assertEqual(filename, "ENGINX_20_10_bank_North.prm")
         self.assertEqual(vanadium, '20')
         self.assertEqual(ceria, '10')
+
+    @patch("Engineering.gui.engineering_diffraction.tabs.calibration.model.Ads")
+    def test_update_calibration_params_table_retrieves_workspace(self, ads):
+        table = [[0, 18414.900000000001, 0.0, -11.82], [1, 18497.75, 0.0, -26.5]]
+
+        self.model.update_calibration_params_table(table)
+
+        self.assertEqual(ads.retrieve.call_count, 1)
+
+    @patch("Engineering.gui.engineering_diffraction.tabs.calibration.model.Ads")
+    def test_update_calibration_params_table_stops_when_table_empty(self, ads):
+        table = []
+
+        self.model.update_calibration_params_table(table)
+
+        self.assertEqual(ads.retrieve.call_count, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Calibration output files now have the data from the calibration in the all_banks file rather than keeping the data from the template. The calibration process also outputs the parameters into a Mantid table workspace, functionality that was in the old GUI but missing from this one.

**To test:**
1. Open the Engineering Diffraction GUI (You may have to add 
`Diffraction/Engineering_Diffraction_2.py` to the `Mantid.properties.template` file).
2. Create a new calibration (Valid Run numbers: Ce: 305738 V: 307521)
3. Check that `engggui_calibration_banks_parameters` table workspace has been created. 
4. Check that in the "all_banks" file created in `User/Engineering_Mantid/Calibration/` the line beginning with `INS  1 ICONS` matches the first line in the table workspace. 


Fixes #27004

*This does not require release notes* because **the GUI is not yet in a state that would be useful for users.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
