### PR TITLE
26919 load ngem compiler error

### DIFF
--- a/Framework/DataHandling/src/LoadNGEM.cpp
+++ b/Framework/DataHandling/src/LoadNGEM.cpp
@@ -112,11 +112,10 @@ void createEventWorkspace(const int &maxToF, const double &binWidth,
   dataWorkspace = DataObjects::create<DataObjects::EventWorkspace>(
       NUM_OF_SPECTRA, HistogramData::Histogram(HistogramData::BinEdges(xAxis)));
   PARALLEL_FOR_NO_WSP_CHECK()
-  for (size_t i = 0; i < events.size(); ++i) {
+  for (int i = 0; i < NUM_OF_SPECTRA; ++i) {
     dataWorkspace->getSpectrum(i) = events[i];
-    const int index = static_cast<int>(i + 1);
-    dataWorkspace->getSpectrum(i).setSpectrumNo(index);
-    dataWorkspace->getSpectrum(i).setDetectorID(index);
+    dataWorkspace->getSpectrum(i).setSpectrumNo(i + 1);
+    dataWorkspace->getSpectrum(i).setDetectorID(i + 1);
   }
   dataWorkspace->setAllX(HistogramData::BinEdges{xAxis});
   dataWorkspace->getAxis(0)->unit() =


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
Resolve issue with DataHandling.dll not compiling in Visual Studio 2019 - specific problem was an OpenMP for loop in LoadNGEM.cpp. Problem appears to have been arisen due to earlier versions of Visual Studio 2019 unintentionally accepting an unsigned int as the index of an OpenMP for loop. Microsoft have since fixed this problem which means an unsigned int now gives a compiler error. See:

https://developercommunity.visualstudio.com/content/problem/650998/incorrect-number-of-threads-spawned-in-openmp-for.html

This link suggests earlier VS 2019 versions didn't produce expected functionality with an OpenMP for loop that used an unsigned int as an index even though it compiled.

Unit test LoadNGEMTest (in DataHandlingTest) has been run successfully on fixed code - these tests execute createEventWorkspace which contains the fix

**To test:**

Load file GEM000005_00_000_short.edb into a workspace in MantidPlot. The file is in the unit testing file set (in mantid\build\ExternalData\Testing\Data\UnitTest\)

Fixes #26919. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
