### PR TITLE
Report usage statistics for ISIS Reflectometry GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/QtEventView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtEventView.h"
 #include "EventPresenter.h"
+#include "MantidKernel/UsageService.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -191,28 +192,45 @@ void QtEventView::enableSliceTypeSelection() {
 }
 
 void QtEventView::onToggleUniform(bool isChecked) {
-  if (isChecked)
+  if (isChecked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->EventTab->EnableUniformSlicing", false);
     m_notifyee->notifySliceTypeChanged(SliceType::Uniform);
+  }
 }
 
 void QtEventView::onToggleUniformEven(bool isChecked) {
-  if (isChecked)
+  if (isChecked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->EventTab->EnableUniformEvenSlicing",
+        false);
     m_notifyee->notifySliceTypeChanged(SliceType::UniformEven);
+  }
 }
 
 void QtEventView::onToggleCustom(bool isChecked) {
-  if (isChecked)
+  if (isChecked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->EventTab->EnableCustomSlicing", false);
     m_notifyee->notifySliceTypeChanged(SliceType::Custom);
+  }
 }
 
 void QtEventView::onToggleLogValue(bool isChecked) {
-  if (isChecked)
+  if (isChecked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->EventTab->EnableLogValueSlicing",
+        false);
     m_notifyee->notifySliceTypeChanged(SliceType::LogValue);
+  }
 }
 
 void QtEventView::onToggleDisabledSlicing(bool isChecked) {
-  if (isChecked)
+  if (isChecked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->EventTab->DisableSlicing", false);
     m_notifyee->notifySliceTypeChanged(SliceType::None);
+  }
 }
 
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -5,6 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtExperimentView.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/AlgorithmHintStrategy.h"
 #include <QMessageBox>
@@ -52,6 +53,9 @@ QtExperimentView::QtExperimentView(
 }
 
 void QtExperimentView::onRemovePerThetaDefaultsRequested() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->ExperimentTab->RemovePerThetaDefaultsRow",
+      false);
   auto index = m_ui.optionsTable->currentIndex();
   if (index.isValid()) {
     m_notifyee->notifyRemovePerAngleDefaultsRequested(index.row());
@@ -283,6 +287,8 @@ void QtExperimentView::disconnectExperimentSettingsWidgets() {
 }
 
 void QtExperimentView::onRestoreDefaultsRequested() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->ExperimentTab->RestoreDefaults", false);
   m_notifyee->notifyRestoreDefaultsRequested();
 }
 
@@ -442,6 +448,9 @@ void QtExperimentView::onPerAngleDefaultsChanged(int row, int column) {
 
 /** Add a new row to the transmission runs table **/
 void QtExperimentView::onNewPerThetaDefaultsRowRequested() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->ExperimentTab->AddPerThetaDefaultsRow",
+      false);
   m_notifyee->notifyNewPerAngleDefaultsRequested();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -5,6 +5,8 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtInstrumentView.h"
+#include "MantidKernel/UsageService.h"
+
 #include <QMessageBox>
 #include <QScrollBar>
 #include <boost/algorithm/string/join.hpp>
@@ -109,6 +111,8 @@ void QtInstrumentView::onSettingsChanged() {
 }
 
 void QtInstrumentView::onRestoreDefaultsRequested() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->InstrumentTab->RestoreDefaults", false);
   m_notifyee->notifyRestoreDefaultsRequested();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -11,6 +11,7 @@
 #include "GUI/Common/Decoder.h"
 #include "GUI/Common/Encoder.h"
 #include "GUI/Common/Plotter.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtWidgets/Common/SlitCalculator.h"
 #include <QMessageBox>
 #include <QToolButton>
@@ -107,26 +108,38 @@ void QtMainWindowView::initLayout() {
 }
 
 void QtMainWindowView::onTabCloseRequested(int tabIndex) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->CloseBatch", false);
   m_notifyee->notifyCloseBatchRequested(tabIndex);
 }
 
 void QtMainWindowView::onNewBatchRequested(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->NewBatch", false);
   m_notifyee->notifyNewBatchRequested();
 }
 
 void QtMainWindowView::onLoadBatchRequested(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->LoadBatch", false);
   m_notifyee->notifyLoadBatchRequested(m_ui.mainTabs->currentIndex());
 }
 
 void QtMainWindowView::onSaveBatchRequested(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->SaveBatch", false);
   m_notifyee->notifySaveBatchRequested(m_ui.mainTabs->currentIndex());
 }
 
 void QtMainWindowView::onShowOptionsRequested(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->ShowOptions", false);
   m_notifyee->notifyShowOptionsRequested();
 }
 
 void QtMainWindowView::onShowSlitCalculatorRequested(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->ShowSlitCalculator", false);
   m_notifyee->notifyShowSlitCalculatorRequested();
 }
 
@@ -134,7 +147,11 @@ void QtMainWindowView::subscribe(MainWindowSubscriber *notifyee) {
   m_notifyee = notifyee;
 }
 
-void QtMainWindowView::helpPressed() { m_notifyee->notifyHelpPressed(); }
+void QtMainWindowView::helpPressed() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->MainWindow->ShowHelp", false);
+  m_notifyee->notifyHelpPressed();
+}
 
 /**
 Runs python code

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtRunsView.h"
 #include "MantidAPI/ITableWorkspace.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtIcons/Icon.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/FileDialogHandler.h"
@@ -235,13 +236,19 @@ void QtRunsView::onSearchComplete() {
 /**
 This slot notifies the presenter that the "search" button has been pressed
 */
-void QtRunsView::on_actionSearch_triggered() { m_notifyee->notifySearch(); }
+void QtRunsView::on_actionSearch_triggered() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->Search", false);
+  m_notifyee->notifySearch();
+}
 
 /**
 This slot conducts a search operation before notifying the presenter that the
 "autoreduce" button has been pressed
 */
 void QtRunsView::on_actionAutoreduce_triggered() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->StartAutoprocessing", false);
   m_notifyee->notifyResumeAutoreductionRequested();
 }
 
@@ -250,19 +257,27 @@ This slot conducts a search operation before notifying the presenter that the
 "pause autoreduce" button has been pressed
 */
 void QtRunsView::on_actionAutoreducePause_triggered() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->PauseAutoprocessing", false);
   m_notifyee->notifyPauseAutoreductionRequested();
 }
 
 /**
 This slot notifies the presenter that the "transfer" button has been pressed
 */
-void QtRunsView::on_actionTransfer_triggered() { m_notifyee->notifyTransfer(); }
+void QtRunsView::on_actionTransfer_triggered() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->Transfer", false);
+  m_notifyee->notifyTransfer();
+}
 
 /**
 This slot is triggered when the user right clicks on the search results table
 @param pos : The position of the right click within the table
 */
 void QtRunsView::onShowSearchContextMenuRequested(const QPoint &pos) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->ShowSearchContextMenu", false);
   if (!m_ui.tableSearchResults->indexAt(pos).isValid())
     return;
 
@@ -278,6 +293,8 @@ void QtRunsView::onShowSearchContextMenuRequested(const QPoint &pos) {
  */
 void QtRunsView::onInstrumentChanged(int index) {
   UNUSED_ARG(index);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->InstrumentChanged", false);
   m_ui.textSearch->clear();
   m_notifyee->notifyChangeInstrumentRequested();
 }
@@ -349,9 +366,17 @@ int QtRunsView::getLiveDataUpdateInterval() const {
   return m_ui.spinBoxUpdateInterval->value();
 }
 
-void QtRunsView::on_buttonMonitor_clicked() { startMonitor(); }
+void QtRunsView::on_buttonMonitor_clicked() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->StartMonitor", false);
+  startMonitor();
+}
 
-void QtRunsView::on_buttonStopMonitor_clicked() { stopMonitor(); }
+void QtRunsView::on_buttonStopMonitor_clicked() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTab->StopMonitor", false);
+  stopMonitor();
+}
 
 /** Start live data monitoring
  */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -7,6 +7,7 @@
 #include "QtRunsTableView.h"
 #include "Common/IndexOf.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/UsageService.h"
 #include "MantidQtIcons/Icon.h"
 #include "MantidQtWidgets/Common/AlgorithmHintStrategy.h"
 #include <QMessageBox>
@@ -85,6 +86,8 @@ void QtRunsTableView::onFilterChanged(QString const &filter) {
 
 void QtRunsTableView::onInstrumentChanged(int index) {
   UNUSED_ARG(index);
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTable->InstrumentChanged", false);
   m_notifyee->notifyChangeInstrumentRequested();
 }
 
@@ -239,10 +242,14 @@ void QtRunsTableView::onCollapseAllGroupsPressed(bool) {
 }
 
 void QtRunsTableView::onProcessPressed(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTable->StartProcessing", false);
   m_notifyee->notifyResumeReductionRequested();
 }
 
 void QtRunsTableView::onPausePressed(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTable->PauseProcessing", false);
   m_notifyee->notifyPauseReductionRequested();
 }
 
@@ -275,10 +282,14 @@ void QtRunsTableView::onPastePressed(bool) {
 }
 
 void QtRunsTableView::onPlotSelectedPressed(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTable->PlotRows", false);
   m_notifyee->notifyPlotSelectedPressed();
 }
 
 void QtRunsTableView::onPlotSelectedStitchedOutputPressed(bool) {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->RunsTable->PlotGroups", false);
   m_notifyee->notifyPlotSelectedStitchedOutputPressed();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -21,7 +21,6 @@ public:
   virtual void notifyFilterWorkspaceList() = 0;
   virtual void notifyPopulateParametersList() = 0;
   virtual void notifySaveSelectedWorkspaces() = 0;
-  virtual void notifySuggestSaveDir() = 0;
   virtual void notifyAutosaveDisabled() = 0;
   virtual void notifyAutosaveEnabled() = 0;
   virtual void notifySavePathChanged() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -5,6 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtSaveView.h"
+#include "MantidKernel/UsageService.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -61,13 +62,22 @@ void QtSaveView::browseToSaveDirectory() {
   }
 }
 
-void QtSaveView::onSavePathChanged() { m_notifyee->notifySavePathChanged(); }
+void QtSaveView::onSavePathChanged() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->SaveTab->SavePathChanged", false);
+  m_notifyee->notifySavePathChanged();
+}
 
 void QtSaveView::onAutosaveChanged(int state) {
-  if (state == Qt::CheckState::Checked)
+  if (state == Qt::CheckState::Checked) {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->SaveTab->EnableAutosave", false);
     m_notifyee->notifyAutosaveEnabled();
-  else
+  } else {
+    Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+        "Feature", "ISIS Reflectometry->SaveTab->DisableAutosave", false);
     m_notifyee->notifyAutosaveDisabled();
+  }
 }
 
 void QtSaveView::disableAutosaveControls() {
@@ -219,6 +229,8 @@ void QtSaveView::setParametersList(const std::vector<std::string> &logs) const {
 /** Populate the 'List of workspaces' widget
  */
 void QtSaveView::populateListOfWorkspaces() const {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->SaveTab->PopulateWorkspaces", false);
   m_notifyee->notifyPopulateWorkspaceList();
 }
 
@@ -231,12 +243,16 @@ void QtSaveView::filterWorkspaceList() const {
 /** Request for the parameters of a workspace
  */
 void QtSaveView::requestWorkspaceParams() const {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->SaveTab->PopulateParameters", false);
   m_notifyee->notifyPopulateParametersList();
 }
 
 /** Save selected workspaces
  */
 void QtSaveView::saveWorkspaces() const {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
+      "Feature", "ISIS Reflectometry->SaveTab->SaveWorkspaces", false);
   m_notifyee->notifySaveSelectedWorkspaces();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -24,8 +24,6 @@ QtSaveView::QtSaveView(QWidget *parent) : QWidget(parent), m_notifyee(nullptr) {
 
 void QtSaveView::subscribe(SaveViewSubscriber *notifyee) {
   m_notifyee = notifyee;
-  populateListOfWorkspaces();
-  suggestSaveDir();
 }
 
 /** Destructor
@@ -255,10 +253,6 @@ void QtSaveView::saveWorkspaces() const {
       "Feature", "ISIS Reflectometry->SaveTab->SaveWorkspaces", false);
   m_notifyee->notifySaveSelectedWorkspaces();
 }
-
-/** Suggest a save directory
- */
-void QtSaveView::suggestSaveDir() const { m_notifyee->notifySuggestSaveDir(); }
 
 void QtSaveView::error(const std::string &title, const std::string &prompt) {
   QMessageBox::critical(this, QString::fromStdString(title),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -93,8 +93,6 @@ public slots:
   void requestWorkspaceParams() const;
   /// Save selected workspaces
   void saveWorkspaces() const;
-  /// Suggest a save directory
-  void suggestSaveDir() const;
   void browseToSaveDirectory();
 
   void onSavePathChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -34,6 +34,8 @@ SavePresenter::SavePresenter(ISaveView *view,
     : m_view(view), m_saver(std::move(saver)), m_shouldAutosave(false) {
 
   m_view->subscribe(this);
+  populateWorkspaceList();
+  suggestSaveDir();
 }
 
 void SavePresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) {
@@ -47,8 +49,6 @@ void SavePresenter::notifyFilterWorkspaceList() { filterWorkspaceNames(); }
 void SavePresenter::notifyPopulateParametersList() { populateParametersList(); }
 
 void SavePresenter::notifySaveSelectedWorkspaces() { saveSelectedWorkspaces(); }
-
-void SavePresenter::notifySuggestSaveDir() { suggestSaveDir(); }
 
 void SavePresenter::notifyAutosaveDisabled() { disableAutosave(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -45,7 +45,6 @@ public:
   void notifyFilterWorkspaceList() override;
   void notifyPopulateParametersList() override;
   void notifySaveSelectedWorkspaces() override;
-  void notifySuggestSaveDir() override;
   void notifyAutosaveDisabled() override;
   void notifyAutosaveEnabled() override;
   void notifySavePathChanged() override;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Save/SavePresenterTest.h
@@ -48,6 +48,21 @@ public:
     verifyAndClear();
   }
 
+  void testSetWorkspaceListOnConstruction() {
+    auto workspaceNames = createWorkspaces();
+    expectSetWorkspaceListFromADS(workspaceNames);
+    auto presenter = makePresenter();
+    verifyAndClear();
+  }
+
+  void testSetDefaultSavePathOnConstruction() {
+    auto const path = Mantid::Kernel::ConfigService::Instance().getString(
+        "defaultsave.directory");
+    EXPECT_CALL(m_view, setSavePath(path)).Times(1);
+    auto presenter = makePresenter();
+    verifyAndClear();
+  }
+
   void testNotifyPopulateWorkspaceList() {
     auto presenter = makePresenter();
     auto workspaceNames = createWorkspaces();
@@ -171,15 +186,6 @@ public:
         .WillOnce(Return(emptyWorkspaceList));
     EXPECT_CALL(m_view, noWorkspacesSelected()).Times(1);
     presenter.notifySaveSelectedWorkspaces();
-    verifyAndClear();
-  }
-
-  void testNotifySuggestSaveDir() {
-    auto presenter = makePresenter();
-    auto const path = Mantid::Kernel::ConfigService::Instance().getString(
-        "defaultsave.directory");
-    EXPECT_CALL(m_view, setSavePath(path)).Times(1);
-    presenter.notifySuggestSaveDir();
     verifyAndClear();
   }
 


### PR DESCRIPTION
This PR adds usage reporting for specific features to the ISIS Reflectometry interface. (Note that opening the GUI already reports usage via its inheritance of UserSubWindow.)

This PR also makes some minor adjustments to the save tab's presenter/view interactions so that we can report usage more helpfully - the logic to set the save path and update the workspaces list has been moved from `QtSaveView::subscribe` to the `SavePresenter` constructor.

Note that there is a spurious report for InstrumentChanged when the GUI is opened which is difficult to avoid because the `currentIndexChanged` signal gets sent when the combo box is set up. I don't think it's a big enough issue to worry about fixing.

**To test:**

Should be tested by someone at ISIS in MantidPlot or Workbench

- Tick `Report usage data` in the first time setup dialog
- Open the `ISIS Reflectometry` interface
- On the Save tab, check that the save directory matches your mantid default save directory and that the list of workspaces matches the workspaces that currently exist
- Load or remove some workspaces in the ADS and click `Refresh` on the save tab and check that the list of workspaces updates
- Try out various other interactions, e.g. 
  - the menu items (note that you can just cancel operations like Load Batch after selecting the menu item - its usage will still be reported)
  - clicking search, autoprocess (again you can cancel)
  - enter a run and angle (e.g. for instrument INTER, `13460`, `0.5`) and click process
  - click Start Monitor (it doesn't matter if it fails to start)
  - click Restore Defaults on the Instrument or Experiment tab
  - change the slicing type on the Event tab
- Check that some sensible usage reports have been produced (contact me for the results if you don't have access to the database)
- Ensure you untick `Report usage data` when you have finished

Fixes #27030 

*This does not require release notes* because **it is a developer feature**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
