### PR TITLE
Avoid systemtest bat script eating --classic

### DIFF
--- a/Testing/SystemTests/scripts/systemtest.bat.in
+++ b/Testing/SystemTests/scripts/systemtest.bat.in
@@ -48,7 +48,7 @@ if ERRORLEVEL 1 exit /b %ERRORLEVEL%
 :: Execute
 echo.
 echo Running tests...
-%MANTIDPYTHON% %MANTIDPYTHON_ARGS% %RUNNER_SCRIPT% --executable="%MANTIDPYTHON%" --exec-args="--classic" %3 %4 %5 %6 %7 %8 %9
+%MANTIDPYTHON% %MANTIDPYTHON_ARGS% %RUNNER_SCRIPT% --executable="%MANTIDPYTHON%" --exec-args=" --classic" %3 %4 %5 %6 %7 %8 %9
 goto end
 
 :: -------- Functions  ---------


### PR DESCRIPTION
**Description of work.**

Fixes an issue with running the system tests from a developer build on Windows. The fix had already been applied [InstallerTests.py](https://github.com/mantidproject/mantid/blob/master/Testing/SystemTests/scripts/InstallerTests.py#L123) in the scripts that run the automated tests. This applies it to the bat script that developers run.

**To test:**

Try and execute a system test on windows and it should run and not fail with an error:

```
Running tests...
usage: runSystemTests.py [-h] [--email] [-x EXECUTABLE] [-a EXECARGS]
                         [--frameworkLoc FRAMEWORKLOC] [--disablepropmake]
                         [-R TESTSINCLUDE] [-E TESTSEXCLUDE]
                         [-l {error,warning,notice,information,debug}]
                         [-j NCORES] [-q] [-c] [--output-on-failure] [-N]
                         [--showskipped] [-d DATAPATHS] [-s SAVEDIR]
                         [--archivesearch] [--exclude-in-pull-requests]
                         [--ignore-failed-imports]
runSystemTests.py: error: argument -a/--exec-args: expected one argument
```

*This does not require release notes* because **it is a internal change**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
