### PR TITLE
Remove group of groups from elemental analysis

### DIFF
--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -14,6 +14,9 @@ Improvements
   * Improved the speed of plotting during sequential fits.
 
 Removed
+  * Removed the creation of a group of groups from the elemental analysis GUI. The elemental analysis gui will now create a workspace for each detector, with each workspace containing three spectra corresponding to Total, Delayed and Prompt data
+  
+  
 #######
 
 

--- a/docs/source/release/v4.2.0/muon.rst
+++ b/docs/source/release/v4.2.0/muon.rst
@@ -16,7 +16,6 @@ Improvements
 Removed
   * Removed the creation of a group of groups from the elemental analysis GUI. The elemental analysis gui will now create a workspace for each detector, with each workspace containing three spectra corresponding to Total, Delayed and Prompt data
   
-  
 #######
 
 

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -8,9 +8,8 @@ from __future__ import (absolute_import, division, unicode_literals)
 
 import glob
 import os
-
+import numpy as np
 from six import iteritems
-
 from mantid import config
 import mantid.simpleapi as mantid
 
@@ -38,7 +37,7 @@ class LModel(object):
             for filename in to_load if get_filename(filename, self.run) is not None
         }
         self._load(workspaces)
-        self.loaded_runs[self.run] = group_by_detector(self.run, workspaces.values())
+        self.loaded_runs[self.run] = merge_ws(self.run, workspaces.values())
         self.last_loaded_runs.append(self.run)
         return self.loaded_runs[self.run]
 
@@ -68,28 +67,77 @@ def search_user_dirs(run):
     return files
 
 
-def group_by_detector(run, workspaces):
+# merge each detector workspace into one
+def merge_ws(run, workspaces):
     """ where workspaces is a tuple of form:
             (filepath, ws name)
     """
     d_string = "{}; Detector {}"
+    # detectors is a dictionary of {detector_name : [names_of_workspaces]}
     detectors = {d_string.format(run, x): [] for x in range(1, 5)}
+    # fill dictionary
     for workspace in workspaces:
         detector_number = get_detector_num_from_ws(workspace)
         detectors[d_string.format(run, detector_number)].append(workspace)
-    for detector, workspace_list in iteritems(detectors):
-        mantid.GroupWorkspaces(workspace_list, OutputWorkspace=str(detector))
-    detector_list = sorted(list(detectors))
-    group_grouped_workspaces(run, detector_list)
-    return detector_list
-
-
-def group_grouped_workspaces(name, workspaces):
+    # initialise a group workspace
     tmp = mantid.CreateSampleWorkspace()
-    overall = mantid.GroupWorkspaces(tmp, OutputWorkspace=str(name))
-    for workspace in workspaces:
-        overall.add(workspace)
+    overall_ws = mantid.GroupWorkspaces(tmp, OutputWorkspace=str(run))
+    # merge each workspace list in dectors into a single workspace
+    for detector, workspace_list in iteritems(detectors):
+        # number of workspaces for each detector
+        num_workspaces = len(workspace_list)
+        # sort workspace list
+        workspace_list = sorted(workspace_list)
+        # get max number of bins
+        max_num_bins = 0
+        max_x = 0
+        min_x = 0
+        for i in range(0, num_workspaces):
+            ws = mantid.mtd[workspace_list[i]]
+            max_num_bins = max(ws.blocksize(), max_num_bins)
+            max_x = max(np.max(ws.readX(0)), max_x)
+            min_x = min(np.min(ws.readX(0)), min_x)
+        # create merged workspace
+        if workspace_list:
+            merged_ws = create_merged_workspace(workspace_list, max_num_bins,
+                                                num_workspaces, max_x)
+        # add workspace to list of mantid workspaces
+        mantid.mtd.add(detector, merged_ws)
+        overall_ws.add(detector)
+
     mantid.AnalysisDataService.remove("tmp")
+    # return name of group storing this runs workspaces
+    return str(run)
+
+
+# creates merged workspace, based on workspaces from workspace list
+def create_merged_workspace(workspace_list, max_num_bins, num_workspaces, max_x):
+    # create single ws for the merged data, use original ws as a template
+    merged_ws = mantid.WorkspaceFactory.create(mantid.mtd[workspace_list[0]], NVectors=num_workspaces,
+                                               XLength=max_num_bins, YLength=max_num_bins,
+                                               )
+
+    # create a merged workspace based on every entry from workspace list
+    for i in range(0, num_workspaces):
+        # load in ws
+        ws = mantid.mtd[workspace_list[i]]
+        # get current number of bins
+        num_bins = ws.blocksize()
+        # pad bins
+        X_padded = np.full(max_num_bins, max_x + 1)
+        X_padded[:num_bins] = ws.readX(0)
+        Y_padded = np.full(max_num_bins, 0)
+        Y_padded[:num_bins] = ws.readY(0)
+        E_padded = np.zeros(max_num_bins)
+        E_padded[:num_bins] = ws.readE(0)
+
+        # set row of merged workspace
+        merged_ws.setX(i, X_padded)
+        merged_ws.setY(i, Y_padded)
+        merged_ws.setE(i, E_padded)
+        mantid.AnalysisDataService.remove(ws.getName())
+
+    return merged_ws
 
 
 def get_detector_num_from_ws(name):

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -144,6 +144,8 @@ def create_merged_workspace(workspace_list):
             merged_ws.setX(i, X_padded)
             merged_ws.setY(i, Y_padded)
             merged_ws.setE(i, E_padded)
+
+            # remove workspace from ADS
             mantid.AnalysisDataService.remove(ws.getName())
 
         return merged_ws

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -20,6 +20,8 @@ from MultiPlotting.multi_plotting_widget import MultiPlotWindow
 from MultiPlotting.label import Label
 
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
+from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
+
 from Muon.GUI.Common.load_widget.load_view import LoadView
 from Muon.GUI.Common.load_widget.load_presenter import LoadPresenter
 
@@ -39,8 +41,6 @@ from Muon.GUI.Common import message_box
 import mantid.simpleapi as mantid
 
 offset = 0.9
-# Dictionary to map data type into associated spectrum number within the workspace
-type_index = {"Delayed": 1, "Prompt": 2, "Total": 3}
 
 
 def is_string(value):
@@ -309,11 +309,11 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         ws.setYUnit('Counts')
         # find correct detector number from the workspace group run
         if self.lines.total.isChecked():
-            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Total"], color=self.BLUE)
+            self.plotting.plot(detector, ws.getName(), spec_num=spectrum_index["Total"], color=self.BLUE)
         if self.lines.prompt.isChecked():
-            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Prompt"],color=self.ORANGE)
+            self.plotting.plot(detector, ws.getName(), spec_num=spectrum_index["Prompt"], color=self.ORANGE)
         if self.lines.delayed.isChecked():
-            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Delayed"], color=self.GREEN)
+            self.plotting.plot(detector, ws.getName(), spec_num=spectrum_index["Delayed"], color=self.GREEN)
 
         # add current selection of lines
         for element in self.ptable.selection:
@@ -444,7 +444,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for subplot in self.plotting.get_subplots():
             name = '{}; Detector {}'.format(run, subplot[-1])
             ws = mantid.mtd[name]
-            self.plotting.plot(subplot, ws.getName(), spec_num=type_index[_type], color=color)
+            self.plotting.plot(subplot, ws.getName(), spec_num=spectrum_index[_type], color=color)
 
     def remove_line_type(self, run, _type):
         if self.plot_window is None:
@@ -455,7 +455,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         for subplot in self.plotting.get_subplots():
             name = '{}; Detector {}'.format(run, subplot[-1])
             ws = mantid.mtd[name]
-            self.plotting.remove_line(subplot, ws.getName(), spec=type_index[_type])
+            self.plotting.remove_line(subplot, ws.getName(), spec=spectrum_index[_type])
 
         # If no line type is selected do not allow plotting
         self.uncheck_detectors_if_no_line_plotted()

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -39,6 +39,7 @@ from Muon.GUI.Common import message_box
 import mantid.simpleapi as mantid
 
 offset = 0.9
+# Dictionary to map data type into associated spectrum number within the workspace
 type_index = {"Delayed": 1, "Prompt": 2, "Total": 3}
 
 

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -39,6 +39,7 @@ from Muon.GUI.Common import message_box
 import mantid.simpleapi as mantid
 
 offset = 0.9
+type_index = {"Delayed": 1, "Prompt": 2, "Total": 3}
 
 
 def is_string(value):
@@ -177,7 +178,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             self.plot_window.closeEvent(event)
         super(ElementalAnalysisGui, self).closeEvent(event)
 
-# general functions
+    # general functions
 
     def _gen_label(self, name, x_value_in, element=None):
         if element is None:
@@ -303,14 +304,16 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     # detectors
     def add_detector_to_plot(self, detector, name):
         self.plotting.add_subplot(detector)
-        for ws in mantid.mtd[name]:
-            ws.setYUnit('Counts')
-            if self.lines.total.isChecked() and 'Total' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color=self.BLUE)
-            if self.lines.prompt.isChecked() and 'Prompt' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color=self.ORANGE)
-            if self.lines.delayed.isChecked() and 'Delayed' in ws.getName():
-                self.plotting.plot(detector, ws.getName(), color=self.GREEN)
+        ws = mantid.mtd[name]
+        ws.setYUnit('Counts')
+        # find correct detector number from the workspace group run
+        if self.lines.total.isChecked():
+            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Total"], color=self.BLUE)
+        if self.lines.prompt.isChecked():
+            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Prompt"],color=self.ORANGE)
+        if self.lines.delayed.isChecked():
+            self.plotting.plot(detector, ws.getName(), spec_num=type_index["Delayed"], color=self.GREEN)
+
         # add current selection of lines
         for element in self.ptable.selection:
             self.add_peak_data(element.symbol, detector)
@@ -438,9 +441,9 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         else:
             color = self.GREEN
         for subplot in self.plotting.get_subplots():
-            for ws in mantid.mtd['{}; Detector {}'.format(run, subplot[-1])]:
-                if _type in ws.getName():
-                    self.plotting.plot(subplot, ws.getName(), color=color)
+            name = '{}; Detector {}'.format(run, subplot[-1])
+            ws = mantid.mtd[name]
+            self.plotting.plot(subplot, ws.getName(), spec_num=type_index[_type], color=color)
 
     def remove_line_type(self, run, _type):
         if self.plot_window is None:
@@ -449,18 +452,18 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
         # Remove the correct line type on all open subplots
         for subplot in self.plotting.get_subplots():
-            for ws in mantid.mtd['{}; Detector {}'.format(run, subplot[-1])]:
-                if _type in ws.getName():
-                    self.plotting.remove_line(subplot, ws.getName())
+            name = '{}; Detector {}'.format(run, subplot[-1])
+            ws = mantid.mtd[name]
+            self.plotting.remove_line(subplot, ws.getName(), spec=type_index[_type])
 
         # If no line type is selected do not allow plotting
         self.uncheck_detectors_if_no_line_plotted()
 
     def uncheck_detectors_if_no_line_plotted(self):
         if not any([
-                self.lines.total.isChecked(),
-                self.lines.prompt.isChecked(),
-                self.lines.delayed.isChecked()
+            self.lines.total.isChecked(),
+            self.lines.prompt.isChecked(),
+            self.lines.delayed.isChecked()
         ]):
             for detector in self.detectors.detectors:
                 detector.setEnabled(False)

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -17,11 +17,12 @@ from qtpy.QtGui import QCloseEvent
 
 import matplotlib
 from Muon.GUI.ElementalAnalysis.elemental_analysis import ElementalAnalysisGui
+from Muon.GUI.ElementalAnalysis.elemental_analysis import type_index
 from Muon.GUI.ElementalAnalysis.elemental_analysis import gen_name
 from MultiPlotting.multi_plotting_widget import MultiPlotWindow
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
 from MultiPlotting.label import Label
-type_index = {"Delayed": 1, "Prompt": 2, "Total": 3}
+
 
 
 @start_qapplication
@@ -304,9 +305,6 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.lines.prompt.isChecked.return_value = False
         self.gui.lines.delayed.isChecked.return_value = True
         mock_mantid.mtd['name1'].getName.return_value = 'Detector 1'
-        # mock_mantid.mtd['name1'][1].getName.return_value = 'ws with Delayed'
-        # mock_mantid.mtd['name1'][2].getName.return_value = 'ws with Prompt'
-
         self.gui.add_detector_to_plot('GE1', 'name1')
         self.assertEqual(self.gui.plotting.add_subplot.call_count, 1)
         self.assertEqual(self.gui.plotting.plot.call_count, 2)

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -17,7 +17,7 @@ from qtpy.QtGui import QCloseEvent
 
 import matplotlib
 from Muon.GUI.ElementalAnalysis.elemental_analysis import ElementalAnalysisGui
-from Muon.GUI.ElementalAnalysis.elemental_analysis import type_index
+from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
 from Muon.GUI.ElementalAnalysis.elemental_analysis import gen_name
 from MultiPlotting.multi_plotting_widget import MultiPlotWindow
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
@@ -560,8 +560,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         mock_mantid.mtd['2695; Detector 1'].getName.return_value = '2695; Detector 1'
         mock_mantid.mtd['2695; Detector 2'].getName.return_value = '2695; Detector 2'
         expected_calls = [
-            mock.call('1', '2695; Detector 1', color='C0',spec_num=type_index['Total']),
-            mock.call('2', '2695; Detector 2', color='C0',spec_num=type_index['Total'])
+            mock.call('1', '2695; Detector 1', color='C0',spec_num=spectrum_index['Total']),
+            mock.call('2', '2695; Detector 2', color='C0',spec_num=spectrum_index['Total'])
         ]
         self.gui.add_line_by_type(2695, 'Total')
 
@@ -587,8 +587,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         }
         mock_mantid.mtd['2695; Detector 1'].getName.return_value = '2695; Detector 1'
         mock_mantid.mtd['2695; Detector 2'].getName.return_value = '2695; Detector 2'
-        expected_calls = [mock.call('1', '2695; Detector 1', spec=type_index['Total']),
-                          mock.call('2', '2695; Detector 2', spec=type_index['Total'])]
+        expected_calls = [mock.call('1', '2695; Detector 1', spec=spectrum_index['Total']),
+                          mock.call('2', '2695; Detector 2', spec=spectrum_index['Total'])]
         self.gui.remove_line_type(2695, 'Total')
 
         self.assertEqual(1, self.gui.plotting.get_subplots.call_count)

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -21,6 +21,7 @@ from Muon.GUI.ElementalAnalysis.elemental_analysis import gen_name
 from MultiPlotting.multi_plotting_widget import MultiPlotWindow
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
 from MultiPlotting.label import Label
+type_index = {"Delayed": 1, "Prompt": 2, "Total": 3}
 
 
 @start_qapplication
@@ -294,17 +295,17 @@ class ElementalAnalysisTest(unittest.TestCase):
     def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(
             self, mock_mantid, mock_add_peak_data):
         mock_mantid.mtd = {
-            'name1': [mock.Mock(), mock.Mock(), mock.Mock()],
-            'name2': [mock.Mock(), mock.Mock(), mock.Mock()]
+            'name1': mock.Mock(),
+            'name2': mock.Mock(),
         }
         self.gui.plotting = mock.Mock()
         self.gui.lines = mock.Mock()
         self.gui.lines.total.isChecked.return_value = True
         self.gui.lines.prompt.isChecked.return_value = False
         self.gui.lines.delayed.isChecked.return_value = True
-        mock_mantid.mtd['name1'][0].getName.return_value = 'ws with Total'
-        mock_mantid.mtd['name1'][1].getName.return_value = 'ws with Delayed'
-        mock_mantid.mtd['name1'][2].getName.return_value = 'ws with Prompt'
+        mock_mantid.mtd['name1'].getName.return_value = 'Detector 1'
+        # mock_mantid.mtd['name1'][1].getName.return_value = 'ws with Delayed'
+        # mock_mantid.mtd['name1'][2].getName.return_value = 'ws with Prompt'
 
         self.gui.add_detector_to_plot('GE1', 'name1')
         self.assertEqual(self.gui.plotting.add_subplot.call_count, 1)
@@ -463,8 +464,8 @@ class ElementalAnalysisTest(unittest.TestCase):
         mock_get_open_file_name.return_value = 'filename'
         mock_generate_element_widgets.side_effect = self.raise_ValueError_once
         self.gui.select_data_file()
-        warning_text = 'The file does not contain correctly formatted data, resetting to default data file.'\
-                       'See "https://docs.mantidproject.org/nightly/interfaces/'\
+        warning_text = 'The file does not contain correctly formatted data, resetting to default data file.' \
+                       'See "https://docs.mantidproject.org/nightly/interfaces/' \
                        'Muon%20Elemental%20Analysis.html" for more information.'
         mock_warning.assert_called_with(warning_text)
 
@@ -554,17 +555,15 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.plot_window = mock.Mock()
         self.gui.plotting.get_subplots.return_value = ['1', '2']
         mock_mantid.mtd = {
-            '2695; Detector 1': [mock.Mock(), mock.Mock()],
-            '2695; Detector 2': [mock.Mock(), mock.Mock()],
-            '2695; Detector 3': [mock.Mock(), mock.Mock()]
+            '2695; Detector 1': mock.Mock(),
+            '2695; Detector 2': mock.Mock(),
+            '2695; Detector 3': mock.Mock()
         }
-        mock_mantid.mtd['2695; Detector 1'][0].getName.return_value = 'det1, ws1 Total'
-        mock_mantid.mtd['2695; Detector 1'][1].getName.return_value = 'det1, ws2'
-        mock_mantid.mtd['2695; Detector 2'][0].getName.return_value = 'det2, ws1'
-        mock_mantid.mtd['2695; Detector 2'][1].getName.return_value = 'det2, ws2 Total'
+        mock_mantid.mtd['2695; Detector 1'].getName.return_value = '2695; Detector 1'
+        mock_mantid.mtd['2695; Detector 2'].getName.return_value = '2695; Detector 2'
         expected_calls = [
-            mock.call('1', 'det1, ws1 Total', color='C0'),
-            mock.call('2', 'det2, ws2 Total', color='C0')
+            mock.call('1', '2695; Detector 1', color='C0',spec_num=type_index['Total']),
+            mock.call('2', '2695; Detector 2', color='C0',spec_num=type_index['Total'])
         ]
         self.gui.add_line_by_type(2695, 'Total')
 
@@ -584,15 +583,14 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.plotting = mock.Mock()
         self.gui.plotting.get_subplots.return_value = ['1', '2']
         mock_mantid.mtd = {
-            '2695; Detector 1': [mock.Mock(), mock.Mock()],
-            '2695; Detector 2': [mock.Mock(), mock.Mock()],
-            '2695; Detector 3': [mock.Mock(), mock.Mock()]
+            '2695; Detector 1': mock.Mock(),
+            '2695; Detector 2': mock.Mock(),
+            '2695; Detector 3': mock.Mock()
         }
-        mock_mantid.mtd['2695; Detector 1'][0].getName.return_value = 'det1, ws1 Total'
-        mock_mantid.mtd['2695; Detector 1'][1].getName.return_value = 'det1, ws2'
-        mock_mantid.mtd['2695; Detector 2'][0].getName.return_value = 'det2, ws1'
-        mock_mantid.mtd['2695; Detector 2'][1].getName.return_value = 'det2, ws2 Total'
-        expected_calls = [mock.call('1', 'det1, ws1 Total'), mock.call('2', 'det2, ws2 Total')]
+        mock_mantid.mtd['2695; Detector 1'].getName.return_value = '2695; Detector 1'
+        mock_mantid.mtd['2695; Detector 2'].getName.return_value = '2695; Detector 2'
+        expected_calls = [mock.call('1', '2695; Detector 1', spec=type_index['Total']),
+                          mock.call('2', '2695; Detector 2', spec=type_index['Total'])]
         self.gui.remove_line_type(2695, 'Total')
 
         self.assertEqual(1, self.gui.plotting.get_subplots.call_count)

--- a/scripts/test/Muon/elemental_analysis/lmodel_test.py
+++ b/scripts/test/Muon/elemental_analysis/lmodel_test.py
@@ -26,14 +26,14 @@ class LModelTest(unittest.TestCase):
         mock_mantid.LoadAscii.assert_has_calls(call_list, any_order=True)
         self.assertEqual(mock_mantid.LoadAscii.call_count, 2)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.LoadWidget.load_utils.group_by_detector')
+    @mock.patch('Muon.GUI.ElementalAnalysis.LoadWidget.load_utils.merge_workspaces')
     @mock.patch('Muon.GUI.ElementalAnalysis.LoadWidget.load_utils.search_user_dirs')
-    def test_load_run_calls_search_user_dirs(self, mock_search_user_dirs, mock_group):
+    def test_load_run_calls_search_user_dirs(self, mock_search_user_dirs, mock_merged):
         self.model.run = 1234
         self.model.load_run()
 
         self.assertEqual(mock_search_user_dirs.call_count, 1)
-        self.assertEqual(mock_group.call_count, 1)
+        self.assertEqual(mock_merged.call_count, 1)
         mock_search_user_dirs.assert_called_with(1234)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.LoadWidget.load_utils.search_user_dirs')

--- a/scripts/test/Muon/elemental_analysis/load_utils_test.py
+++ b/scripts/test/Muon/elemental_analysis/load_utils_test.py
@@ -70,7 +70,6 @@ class LoadUtilsTest(unittest.TestCase):
         for out, arg in iteritems(tests):
             self.assertEqual(lutils.hyphenise(arg), out)
 
-
     def test_merge_workspaces(self):
         expected_output, workspaces = [], []
         detectors = range(1, 5)
@@ -87,7 +86,6 @@ class LoadUtilsTest(unittest.TestCase):
     def test_create_merged_workspace(self):
         workspace_list = []
         num_workspaces = 5
-        spectra_to_test = 2
         workspace_names = []
         num_bins = 100
         X_data = np.linspace(0, 400, num_bins)
@@ -113,9 +111,10 @@ class LoadUtilsTest(unittest.TestCase):
         self.assertEqual(merged_ws.getNumberHistograms(), num_workspaces)
         self.assertEqual(merged_ws.blocksize(), num_bins)
         # check that data has been copied over correctly into the new merged workspace
-        self.assertTrue(np.array_equal(merged_ws.readX(spectra_to_test), X_data))
-        self.assertTrue(np.array_equal(merged_ws.readY(spectra_to_test), Yfunc(X_data, spectra_to_test)))
-        self.assertTrue(np.array_equal(merged_ws.readE(spectra_to_test), Efunc(X_data, spectra_to_test)))
+        for i in range(0, num_workspaces):
+            self.assertTrue(np.array_equal(merged_ws.readX(i), X_data))
+            self.assertTrue(np.array_equal(merged_ws.readY(i), Yfunc(X_data, i)))
+            self.assertTrue(np.array_equal(merged_ws.readE(i), Efunc(X_data, i)))
 
     def test_flatten_run_data(self):
         test_workspaces = [mantid.CreateSampleWorkspace(OutputWorkspace=name) for name in self.test_ws_names]

--- a/scripts/test/Muon/elemental_analysis/load_utils_test.py
+++ b/scripts/test/Muon/elemental_analysis/load_utils_test.py
@@ -70,12 +70,7 @@ class LoadUtilsTest(unittest.TestCase):
         for out, arg in iteritems(tests):
             self.assertEqual(lutils.hyphenise(arg), out)
 
-    # originally test_group_by detectors would:
-    # generate and output and workspaces
-    # generate 1-4 detectors
-    # for each detector generate a w
 
-    # test merge_workspaces
     def test_merge_workspaces(self):
         expected_output, workspaces = [], []
         detectors = range(1, 5)

--- a/scripts/test/Muon/elemental_analysis/load_utils_test.py
+++ b/scripts/test/Muon/elemental_analysis/load_utils_test.py
@@ -11,7 +11,7 @@ from Muon.GUI.ElementalAnalysis.LoadWidget import load_utils as lutils
 
 import mantid.simpleapi as mantid
 from mantid import config
-
+import numpy as np
 from six import iteritems
 
 
@@ -70,16 +70,57 @@ class LoadUtilsTest(unittest.TestCase):
         for out, arg in iteritems(tests):
             self.assertEqual(lutils.hyphenise(arg), out)
 
-    def test_group_by_detector(self):
-        output, workspaces = [], []
+    # originally test_group_by detectors would:
+    # generate and output and workspaces
+    # generate 1-4 detectors
+    # for each detector generate a w
+
+    # test merge_workspaces
+    def test_merge_workspaces(self):
+        expected_output, workspaces = [], []
         detectors = range(1, 5)
         for detector in detectors:
             workspace = self.var_ws_name.format(detector, self.test_run)
             workspaces.append(workspace)
-            mantid.CreateSampleWorkspace(OutputWorkspace=workspace).name()
-            output.append("{}; Detector {}".format(self.test_run, detector))
+            mantid.CreateSampleWorkspace(OutputWorkspace=workspace)
+            expected_output.append("{}; Detector {}".format(self.test_run, detector))
 
-        self.assertEquals(lutils.group_by_detector(self.test_run, workspaces), output)
+        self.assertEquals(lutils.merge_workspaces(self.test_run, workspaces), sorted(expected_output))
+        # check call works with empty workspace list
+        self.assertEqual(lutils.merge_workspaces(self.test_run, []), sorted(expected_output))
+
+    def test_create_merged_workspace(self):
+        workspace_list = []
+        num_workspaces = 5
+        spectra_to_test = 2
+        workspace_names = []
+        num_bins = 100
+        X_data = np.linspace(0, 400, num_bins)
+        # create data in each workspace based on y = mx + specNumber
+        m = 0.1
+        Yfunc = lambda x, specNo: m * x + specNo
+        Efunc = lambda x, specNo: 2 * m * x + specNo
+        for i in range(0, 5):
+            name = "test_" + str(i)
+            workspace_names.append(name)
+            ws = mantid.WorkspaceFactory.create("Workspace2D", NVectors=1,
+                                                XLength=num_bins, YLength=num_bins)
+            mantid.mtd.add(name, ws)
+            Y_data = Yfunc(X_data, i)
+            E_data = Efunc(X_data, i)
+            ws.setY(0, Y_data)
+            ws.setX(0, X_data)
+            ws.setE(0, E_data)
+            workspace_list.append(ws.name())
+
+        merged_ws = lutils.create_merged_workspace(workspace_list)
+        # check number of bins, and number of histograms is correct
+        self.assertEqual(merged_ws.getNumberHistograms(), num_workspaces)
+        self.assertEqual(merged_ws.blocksize(), num_bins)
+        # check that data has been copied over correctly into the new merged workspace
+        self.assertTrue(np.array_equal(merged_ws.readX(spectra_to_test), X_data))
+        self.assertTrue(np.array_equal(merged_ws.readY(spectra_to_test), Yfunc(X_data, spectra_to_test)))
+        self.assertTrue(np.array_equal(merged_ws.readE(spectra_to_test), Efunc(X_data, spectra_to_test)))
 
     def test_flatten_run_data(self):
         test_workspaces = [mantid.CreateSampleWorkspace(OutputWorkspace=name) for name in self.test_ws_names]


### PR DESCRIPTION
**Description of work.**

Removed the group of groups from the elemental analysis GUI. This was done by replacing the inner groups with workspaces, with labels to reflect the data (i.e. total, prompt and delayed).

**To test:**
Open the elemental anaylsis GUI within the muon interface, and load the run data 2695. Verify that all the checkboxes within the GUI work, and each detector plots as expected. Load in 2697 and do the same, verifying that the plots work. 

Fixes #26733  

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
