### PR TITLE
Add a shortcut to abort a running script

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -41,6 +41,7 @@ Improvements
 - There are now forward and back buttons on figures to go back and forward through figure zoom states.
 - The home button on figures now always centres the figure's contents.
 - You can now zoom in/out on figures by scrolling and pan figures using the middle mouse button.
+- The keyboard shortcut Ctrl+D now aborts a running script.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -109,7 +109,7 @@ class CodeEditorTabWidget(QTabWidget):
                                        shortcut_context=Qt.ApplicationShortcut,
                                        shortcut_visible_in_context_menu=True)
 
-        abort_action = create_action(self, "Abort", on_triggered=parent.abort_current)
+        abort_action = create_action(self, "Abort", on_triggered=parent.abort_current, shortcut="Ctrl+D")
 
         # menu action to toggle the find/replace dialog
         toggle_find_replace = create_action(self, 'Find/Replace...', on_triggered=parent.toggle_find_replace_dialog,

--- a/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -109,7 +109,8 @@ class CodeEditorTabWidget(QTabWidget):
                                        shortcut_context=Qt.ApplicationShortcut,
                                        shortcut_visible_in_context_menu=True)
 
-        abort_action = create_action(self, "Abort", on_triggered=parent.abort_current, shortcut="Ctrl+D")
+        abort_action = create_action(self, "Abort", on_triggered=parent.abort_current, shortcut="Ctrl+D",
+                                     shortcut_context=Qt.ApplicationShortcut, shortcut_visible_in_context_menu=True)
 
         # menu action to toggle the find/replace dialog
         toggle_find_replace = create_action(self, 'Find/Replace...', on_triggered=parent.toggle_find_replace_dialog,


### PR DESCRIPTION
**Description of work.**
The keyboard shortcut Ctrl+D now aborts a script if there is one running in Workbench.

Report to: Duc Le

**To test:**
In Workbench, run the following script:
```
while True:
    continue
```

Press Ctrl+D and check that the script stops running.

Fixes #27076 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
