### PR TITLE
Fix error thrown when toggling errorbars on line plot

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import QMenu
 from mantid.plots import MantidAxes
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter import CurvesTabWidgetPresenter
+from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
 
 class FigureErrorsManager(object):
@@ -90,6 +91,10 @@ class FigureErrorsManager(object):
 
     @staticmethod
     def toggle_error_bars_for(ax, curve, make_visible=None):
+        # get legend properties
+        if ax.legend_:
+            legend_props = LegendProperties.from_legend(ax.legend_)
+
         # get all curve properties
         curve_props = CurveProperties.from_curve(curve)
         # and remove the ones that matplotlib doesn't recognise
@@ -103,7 +108,7 @@ class FigureErrorsManager(object):
         curve_props.hide_errors = not curve_props.hide_errors if make_visible is None else not make_visible
 
         CurvesTabWidgetPresenter.toggle_errors(new_curve, curve_props)
-        CurvesTabWidgetPresenter.update_limits_and_legend(ax)
+        CurvesTabWidgetPresenter.update_limits_and_legend(ax, legend_props)
 
     def _update_plot_after(self, func, *args, **kwargs):
         """

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -94,6 +94,8 @@ class FigureErrorsManager(object):
         # get legend properties
         if ax.legend_:
             legend_props = LegendProperties.from_legend(ax.legend_)
+        else:
+            legend_props = None
 
         # get all curve properties
         curve_props = CurveProperties.from_curve(curve)

--- a/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
@@ -107,6 +107,26 @@ class FigureErrorsManagerTest(unittest.TestCase):
         # they are just invisible
         self.assertFalse(self.ax.containers[0][2][0].get_visible())
 
+    @plot_things(make_them_errors=True)
+    def test_hide_all_errors_retains_legend_properties(self):
+        # create a legend with a title
+        self.ax.legend(title="Test")
+
+        self.errors_manager._toggle_all_errors(self.ax, make_visible=False)
+
+        # check that the legend still has a title
+        self.assertEqual(self.ax.get_legend().get_title().get_text(), "Test")
+
+    @plot_things(make_them_errors=False)
+    def test_show_all_errors_retains_legend_properties(self):
+        # create a legend with a title
+        self.ax.legend(title="Test")
+
+        self.errors_manager._toggle_all_errors(self.ax, make_visible=True)
+
+        # check that the legend still has a title
+        self.assertEqual(self.ax.get_legend().get_title().get_text(), "Test")
+
 
 @start_qapplication
 class ScriptedPlotFigureErrorsManagerTest(unittest.TestCase):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -83,7 +83,7 @@ class CurvesTabWidgetPresenter:
     def update_limits_and_legend(ax, legend_props=None):
         ax.relim()
         ax.autoscale()
-        if ax.legend_:
+        if legend_props:
             LegendProperties.create_legend(legend_props, ax)
 
     @staticmethod


### PR DESCRIPTION
**Description of work.**
This PR makes it so that right clicking a plot and showing all error bars no longer throws an error.

**To test:**
Follow the steps in the associated issue and check that an error is no longer thrown.

Fixes #26895 

No release notes needed because this is bug isn't present in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
