### PR TITLE
ma2 load multi period current run good frames

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonNexus1.h
@@ -93,7 +93,8 @@ private:
                     int64_t period);
   void addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
                      int64_t period, int nperiods);
-
+	///Returns the current date and time
+  Mantid::Types::Core::DateAndTime currentDateAndTime() const;
   /// Loads dead time table for the detector
   void loadDeadTimes(Mantid::NeXus::NXRoot &root);
 

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -870,7 +870,7 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
         run.addProperty("goodfrm", dataVals[0]);
         if (run.getProperty("goodfrm")->value() == "0") {
           run.removeLogData("goodfrm");
-          run.addProperty("goodfrm", 100);
+          run.addProperty("goodfrm", 47340);
 				}
 
       } else {

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -868,18 +868,25 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
         // If this is the first period
         // localWorkspace will not contain goodfrm
         run.addProperty("goodfrm", dataVals[0]);
+        if (run.getProperty("goodfrm")->value() == "0") {
+          run.removeLogData("goodfrm");
+          run.addProperty("goodfrm", 100);
+				}
 
       } else {
         // If period > 0, we need to remove
         // previous goodfrm log value
         run.removeLogData("goodfrm");
         run.addProperty("goodfrm", dataVals[period]);
+        if (run.getProperty("goodfrm")->value() == "0") {
+          run.removeLogData("goodfrm");
+          run.addProperty("goodfrm", 100);
+        }
       }
     } catch (::NeXus::Exception &) {
       g_log.warning("Could not read /run/instrument/beam/frames_period_daq");
     }
   } // else
-
   handle.close();
 }
 

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -47,7 +47,7 @@
 using Mantid::Types::Core::DateAndTime;
 namespace {
 const std::string GOODFRM = "goodfrm";
-double estimateGoodFrames(Mantid::Types::Core::DateAndTime start_time, Mantid::Types::Core::DateAndTime current_time) {
+int estimateGoodFrames(Mantid::Types::Core::DateAndTime start_time, Mantid::Types::Core::DateAndTime current_time) {
   Mantid::Types::Core::time_duration freq =
       DateAndTime::durationFromSeconds(40);
   //DateAndTime::durationFromSeconds(40)
@@ -878,7 +878,7 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
       auto &run = localWorkspace->mutableRun();
       auto temp = run.getLogData();
       auto start_time = DateAndTime(run.getProperty("run_start")->value());
-      auto current_time = DateAndTime::getCurrentTime();
+      auto current_time = currentDateAndTime();
       if (period == 0) {
         // If this is the first period
         // localWorkspace will not contain goodfrm
@@ -903,8 +903,13 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
   } // else
   handle.close();
 }
-
-/**
+/*
+* @return the current date and time
+*/
+DateAndTime LoadMuonNexus1::currentDateAndTime() const {
+  return DateAndTime::getCurrentTime();
+}
+    /**
  * Return the confidence with with this algorithm can load the file
  * @param descriptor A descriptor for the file
  * @returns An integer specifying the confidence level. 0 indicates it will not
@@ -949,6 +954,7 @@ int LoadMuonNexus1::confidence(Kernel::NexusDescriptor &descriptor) const {
   }
   return 0;
 }
+
 
 } // namespace DataHandling
 } // namespace Mantid

--- a/Framework/DataHandling/src/LoadMuonNexus1.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexus1.cpp
@@ -886,6 +886,8 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
         if (run.getProperty(GOODFRM)->value() == "0") {
           run.removeLogData(GOODFRM);
           run.addProperty(GOODFRM, estimateGoodFrames(start_time, current_time));
+          g_log.warning("The number of good frames is an estimate");
+
         }
       } else {
         // If period > 0, we need to remove
@@ -895,6 +897,7 @@ void LoadMuonNexus1::addGoodFrames(DataObjects::Workspace2D_sptr localWorkspace,
         if (run.getProperty(GOODFRM)->value() == "0") {
           run.removeLogData(GOODFRM);
           run.addProperty(GOODFRM, estimateGoodFrames(start_time, current_time));
+          g_log.warning("The number of good frames is an estimate");
         }
       }
     } catch (::NeXus::Exception &) {

--- a/Framework/Muon/src/AsymmetryCalc.cpp
+++ b/Framework/Muon/src/AsymmetryCalc.cpp
@@ -158,7 +158,7 @@ void AsymmetryCalc::exec() {
     if (denominator != 0.0) {
       double q1 = tmpWS->y(forward)[j] + alpha * alpha * tmpWS->y(backward)[j];
       double q2 = 1 + numerator * numerator / (denominator * denominator);
-      error = sqrt(abs(q1) * abs(q2))/ denominator;
+      error = sqrt(q1 * q2)/ denominator;
     }
     outputWS->mutableE(0)[j] = error;
 

--- a/Framework/Muon/src/AsymmetryCalc.cpp
+++ b/Framework/Muon/src/AsymmetryCalc.cpp
@@ -158,7 +158,7 @@ void AsymmetryCalc::exec() {
     if (denominator != 0.0) {
       double q1 = tmpWS->y(forward)[j] + alpha * alpha * tmpWS->y(backward)[j];
       double q2 = 1 + numerator * numerator / (denominator * denominator);
-      error = sqrt(q1 * q2) / denominator;
+      error = sqrt(abs(q1) * abs(q2))/ denominator;
     }
     outputWS->mutableE(0)[j] = error;
 


### PR DESCRIPTION
**Description of work.**
When multi period data is loaded when the second period has not finished, the number of good frames is not yet available. The number of good frames now defaults to 100 (this will be changed to something reasonable soon). The errors were also being calculated wrong in the asymmetry calculation.

**To test:**

- Load some data with no good frames 
- Check for errors such as Warning:converting masked element to Nan in the log 
- Check in the instrument details that the number of good frames is 47340
- In the ADS , expand the workspace and then right click on the counts and select show sample logs
- in the sample logs check the goodfrm and check that it is equal to the duration of the run* 40.


Fixes #26843 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
