### PR TITLE
Fix a bug where the GUI could not be closed

### DIFF
--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -26,6 +26,11 @@ Improved
 - Batch names will now have a unique number assigned to it, and there will no longer be multiple batches of the same name.
 - The Instrument is now synchronised across all Batch tabs.
 
+Bug fixes
+#########
+
+- A bug has been fixed where the interface could sometimes not be closed after a failed attempt at starting Autoprocessing.
+  
 Algorithms
 ----------
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobRunner.cpp
@@ -102,7 +102,6 @@ void BatchJobRunner::notifyReductionPaused() {
 
 void BatchJobRunner::notifyAutoreductionResumed() {
   m_isAutoreducing = true;
-  m_isProcessing = true;
   m_reprocessFailed = true;
   m_processAll = true;
   m_batch.resetSkippedItems();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -153,12 +153,12 @@ Handles attempt to close main window
 * @param event : [input] The close event
 */
 void QtMainWindowView::closeEvent(QCloseEvent *event) {
-  // Close only if reduction has been paused
-  if (!m_presenter->isAnyBatchProcessing() ||
+  // Don't close if anything is running
+  if (m_presenter->isAnyBatchProcessing() ||
       m_presenter->isAnyBatchAutoreducing()) {
-    event->accept();
-  } else {
     event->ignore();
+  } else {
+    event->accept();
   }
 }
 

--- a/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProcessingTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Batch/BatchJobRunnerProcessingTest.h
@@ -49,7 +49,7 @@ public:
   void testAutoreductionResumed() {
     auto jobRunner = makeJobRunner();
     jobRunner.notifyAutoreductionResumed();
-    TS_ASSERT_EQUALS(jobRunner.isProcessing(), true);
+    TS_ASSERT_EQUALS(jobRunner.isProcessing(), false);
     TS_ASSERT_EQUALS(jobRunner.isAutoreducing(), true);
     TS_ASSERT_EQUALS(jobRunner.m_reprocessFailed, true);
     TS_ASSERT_EQUALS(jobRunner.m_processAll, true);


### PR DESCRIPTION
This PR fixes a couple of logic errors in handling the processing/autoprocessing state which was causing the GUI to be considered unclosable under certain situations, which in turn meant that MantidPlot/Workbench could not be closed.

The specific problems were:
- An incorrect logic check on whether a batch is processing or autoprocessing.
- Incorrectly setting the isProcessing flag when requesting to resume Autoprocessing. This has been removed so that it now only gets set when (and if) processing genuinely happens.

Fixes #26691

**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Should be tested by someone at ISIS

- Check that the bugs in #26691 and #26981 are fixed
- Enter instrument INTER and investigation `1120015` and click Search. 
- Select all of the results and click Transfer.
- Select some rows in the main table and click Process.
- Check that the GUI cannot be closed while processing continues but can be closed when processing finishes.
- Process some more rows and click the pause button on the toolbar. Check that the GUI can be closed.
- Enter the same instrument and investigation and click Autoprocess.
- Check that the GUI cannot be closed while processing continues but can be closed if it is paused.
- Leave autoprocessing to finish processing all of the runs for the investigation (this will take several minutes). Check that the GUI still cannot be closed unless you first click Pause. (This is because it is still polling for new runs in the background.)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
