### PR TITLE
MantidPlot fit window not showing correct workspace index

### DIFF
--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -61,7 +61,8 @@ PeakPickerTool::PeakPickerTool(
     return;
   }
 
-    // Show the fitPropertyBrowser if it isn't already. This sets the WorkspaceIndex to 0
+  // Show the fitPropertyBrowser if it isn't already. This sets the
+  // WorkspaceIndex to 0
   if (showFitPropertyBrowser)
     m_fitPropertyBrowser->show();
 

--- a/MantidPlot/src/Mantid/PeakPickerTool.cpp
+++ b/MantidPlot/src/Mantid/PeakPickerTool.cpp
@@ -60,6 +60,11 @@ PeakPickerTool::PeakPickerTool(
   } else {
     return;
   }
+
+    // Show the fitPropertyBrowser if it isn't already. This sets the WorkspaceIndex to 0
+  if (showFitPropertyBrowser)
+    m_fitPropertyBrowser->show();
+
   m_fitPropertyBrowser->normaliseData(m_shouldBeNormalised);
   m_fitPropertyBrowser->getHandler()->removeAllPlots();
   m_fitPropertyBrowser->setWorkspaceName(m_wsName);
@@ -100,9 +105,6 @@ PeakPickerTool::PeakPickerTool(
   connect(m_fitPropertyBrowser, SIGNAL(destroyed()), graph,
           SLOT(disableTools()));
 
-  // Show the fitPropertyBrowser if it isn't already.
-  if (showFitPropertyBrowser)
-    m_fitPropertyBrowser->show();
   connect(this, SIGNAL(isOn(bool)), m_fitPropertyBrowser,
           SLOT(setPeakToolOn(bool)));
   emit isOn(true);


### PR DESCRIPTION
Resolve problem with workspace index being set to 0 when fit window activated using icon on MantidPlot toolbar. The workspace index is the zero-based index of the spectrum that is going to be fitted

**Description of work.**

The fitbrowser->show() function sets the workspace index to zero as well as showing the fit properties window. I think it does this because the fit window can be displayed from the View menu without a plot window being active and zero is a sensible default.

I have moved the show() call earlier which means it happens before call to setWorkspaceIndex so the "setting to zero" isn't the final action

**To test:**

1. Plot a single spectrum from a workspace that contains multiple spectra (any spectrum except the first one)
2. Press the fit icon on the toolbar to bring up the fit properties window
3. Check that the workspace index property is set to the correct value and not zero

Fixes #27056 .

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
