### PR TITLE
Load current run in muon analysis

### DIFF
--- a/scripts/Muon/GUI/Common/utilities/load_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/load_utils.py
@@ -261,7 +261,7 @@ def create_load_algorithm(filename, property_dictionary):
     alg.initialize()
     alg.setAlwaysStoreInADS(True)
     alg.setProperty("OutputWorkspace", output_filename)
-    alg.setProperty("Filename", output_filename)
+    alg.setProperty("Filename", filename)
     return alg, psi_data
 
 

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -75,6 +75,15 @@ class MuonFileUtilsTest(unittest.TestCase):
         self.assertAlmostEqual(load_result['TimeZero'], 0.55000, 5)
         self.assertEqual(run, 22725)
 
+    def test_load_workspace_from_filename_for_file_path(self):
+        filename = 'test'+os.sep 'MUSR00022725.nsx'
+        load_result, run, filename, _ = utils.load_workspace_from_filename(filename)
+
+        self.assertEqual(load_result['DeadTimeTable'], None)
+        self.assertEqual(load_result['FirstGoodData'], 0.11)
+        self.assertEqual(load_result['MainFieldDirection'], 'Transverse')
+        self.assertAlmostEqual(load_result['TimeZero'], 0.55000, 5)
+        self.assertEqual(run, 22725)
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -78,10 +78,13 @@ class MuonFileUtilsTest(unittest.TestCase):
 
     def test_load_workspace_from_filename_for_file_path(self):
         mock_alg = mock.MagicMock()
-        filename = 'test'+os.sep 'MUSR00022725.nsx'
+        filename = 'PSI'+os.sep + 'run_1529_templs0.mon'
+        inputs = {
+              "DeadTimeTable": "__notUsed",
+              "DetectorGroupingTable": "__notUsed"}
 
-        alg, _ = utils.create_load_algorithm(filename,{})
-        self.assertEqual(alg.getProperty("Filename"), filename)
+        alg, _ = utils.create_load_algorithm(filename,inputs)
+        self.assertTrue(filename in alg.getProperty("Filename").value)
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -10,6 +10,7 @@ import unittest
 
 from mantid import simpleapi, ConfigService
 from mantid.api import AnalysisDataService, ITableWorkspace
+from mantid.py3compat import mock
 
 
 def create_simple_workspace(data_x, data_y, run_number=0):
@@ -76,14 +77,11 @@ class MuonFileUtilsTest(unittest.TestCase):
         self.assertEqual(run, 22725)
 
     def test_load_workspace_from_filename_for_file_path(self):
+        mock_alg = mock.MagicMock()
         filename = 'test'+os.sep 'MUSR00022725.nsx'
-        load_result, run, filename, _ = utils.load_workspace_from_filename(filename)
 
-        self.assertEqual(load_result['DeadTimeTable'], None)
-        self.assertEqual(load_result['FirstGoodData'], 0.11)
-        self.assertEqual(load_result['MainFieldDirection'], 'Transverse')
-        self.assertAlmostEqual(load_result['TimeZero'], 0.55000, 5)
-        self.assertEqual(run, 22725)
+        alg, _ = utils.create_load_algorithm(filename,{})
+        self.assertEqual(alg.getProperty("Filename"), filename)
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/scripts/test/Muon/utilities/load_utils_test.py
+++ b/scripts/test/Muon/utilities/load_utils_test.py
@@ -78,7 +78,7 @@ class MuonFileUtilsTest(unittest.TestCase):
 
     def test_load_workspace_from_filename_for_file_path(self):
         mock_alg = mock.MagicMock()
-        filename = 'PSI'+os.sep + 'run_1529_templs0.mon'
+        filename = 'PSI'+ os.sep + 'run_1529_templs0.mon'
         inputs = {
               "DeadTimeTable": "__notUsed",
               "DetectorGroupingTable": "__notUsed"}


### PR DESCRIPTION
**Description of work.**
The load current run button in (new) muon analysis should work. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open muon analysis 2
Click load current run
Should load some data (for ISIS instruments)
<!-- Instructions for testing. -->

No associated issue <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
