### PR TITLE
Output correct transmission workspaces for debug mode

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateTransmissionWorkspace2.h
@@ -39,13 +39,19 @@ private:
   normalizeDetectorsByMonitors(API::MatrixWorkspace_sptr IvsTOF);
   /// Get the run numbers of the input workspaces
   void getRunNumbers();
+  /// Get the run number of a given workspace
+  std::string getRunNumber(std::string const &propertyName);
   /// Store a transition run in ADS
   void storeTransitionRun(int which, API::MatrixWorkspace_sptr ws);
   /// Store the stitched transition workspace run in ADS
   void storeOutputWorkspace(API::MatrixWorkspace_sptr ws);
 
+  /// Run numbers for the first/second transmission run
   std::string m_firstTransmissionRunNumber;
   std::string m_secondTransmissionRunNumber;
+  /// Flag to indicate that one or both transmission workspace
+  /// does not have a run number set
+  bool m_missingRunNumber{false};
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -198,18 +198,28 @@ MatrixWorkspace_sptr CreateTransmissionWorkspace2::normalizeDetectorsByMonitors(
  * in class variables.
  */
 void CreateTransmissionWorkspace2::getRunNumbers() {
-  MatrixWorkspace_sptr firstTransWS = getProperty("FirstTransmissionRun");
-  auto const &run = firstTransWS->run();
-  if (run.hasProperty("run_number")) {
-    m_firstTransmissionRunNumber =
-        run.getPropertyValueAsType<std::string>("run_number");
-  }
+  m_firstTransmissionRunNumber = getRunNumber("FirstTransmissionRun");
+  m_secondTransmissionRunNumber = getRunNumber("SecondTransmissionRun");
+}
 
-  MatrixWorkspace_sptr secondTransWS = getProperty("SecondTransmissionRun");
-  if (secondTransWS && secondTransWS->run().hasProperty("run_number")) {
-    m_secondTransmissionRunNumber =
-        secondTransWS->run().getPropertyValueAsType<std::string>("run_number");
+/** Get the run number for a given workspace. Also sets the m_missingRunNumber
+ * flag if a required run number could not be found.
+ * @returns : the run number as a string, or an empty string if it was not
+ * fouind
+ */
+std::string
+CreateTransmissionWorkspace2::getRunNumber(std::string const &propertyName) {
+  auto runNumber = std::string();
+  MatrixWorkspace_sptr transWS = getProperty(propertyName);
+  if (transWS) {
+    auto const &run = transWS->run();
+    if (run.hasProperty("run_number")) {
+      runNumber = run.getPropertyValueAsType<std::string>("run_number");
+    } else {
+      m_missingRunNumber = true;
+    }
   }
+  return runNumber;
 }
 
 /** Store a transition run in ADS
@@ -239,12 +249,13 @@ void CreateTransmissionWorkspace2::storeTransitionRun(int which,
  */
 void CreateTransmissionWorkspace2::storeOutputWorkspace(
     API::MatrixWorkspace_sptr ws) {
-  if (isDefault("OutputWorkspace")) {
+  // If the output name is not set, attempt to set a sensible
+  // default based on the run number. If a required run number
+  // is missing, then there's not much we can do so leave it empty.
+  if (isDefault("OutputWorkspace") && !m_missingRunNumber) {
     std::string name = TRANS_LAM_PREFIX;
     if (!m_firstTransmissionRunNumber.empty()) {
       name.append(m_firstTransmissionRunNumber);
-    } else {
-      return;
     }
     if (!m_secondTransmissionRunNumber.empty()) {
       name.append("_");

--- a/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
+++ b/Framework/Algorithms/src/CreateTransmissionWorkspace2.cpp
@@ -218,6 +218,10 @@ void CreateTransmissionWorkspace2::getRunNumbers() {
  */
 void CreateTransmissionWorkspace2::storeTransitionRun(int which,
                                                       MatrixWorkspace_sptr ws) {
+  bool const isDebug = getProperty("Debug");
+  if (!isDebug)
+    return;
+
   if (which < 1 || which > 2) {
     throw std::logic_error("There are only two runs: 1 and 2.");
   }
@@ -235,8 +239,7 @@ void CreateTransmissionWorkspace2::storeTransitionRun(int which,
  */
 void CreateTransmissionWorkspace2::storeOutputWorkspace(
     API::MatrixWorkspace_sptr ws) {
-  bool const isDebug = getProperty("Debug");
-  if (isDefault("OutputWorkspace") && (!isChild() || isDebug)) {
+  if (isDefault("OutputWorkspace")) {
     std::string name = TRANS_LAM_PREFIX;
     if (!m_firstTransmissionRunNumber.empty()) {
       name.append(m_firstTransmissionRunNumber);
@@ -247,11 +250,7 @@ void CreateTransmissionWorkspace2::storeOutputWorkspace(
       name.append("_");
       name.append(m_secondTransmissionRunNumber);
     }
-    if (!isChild()) {
-      setPropertyValue("OutputWorkspace", name);
-    } else {
-      AnalysisDataService::Instance().addOrReplace(name, ws);
-    }
+    setPropertyValue("OutputWorkspace", name);
   }
   setProperty("OutputWorkspace", ws);
 }

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -538,6 +538,14 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     alg->setPropertyValue("Debug", getPropertyValue("Debug"));
     alg->execute();
     transmissionWS = alg->getProperty("OutputWorkspace");
+
+    // Add the output transmission workspace to the ADS otherwise it gets
+    // swallowed by this algorithm as it's not one of the output properties (it
+    // might be better to make it an output property but currently users always
+    // accept the default name so are unlikely to use it)
+    auto transmissionWSName = alg->getPropertyValue("OutputWorkspace");
+    AnalysisDataService::Instance().addOrReplace(transmissionWSName,
+                                                 transmissionWS);
   }
 
   // Rebin the transmission run to be the same as the input.

--- a/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
+++ b/Framework/Algorithms/src/ReflectometryReductionOne2.cpp
@@ -544,8 +544,9 @@ MatrixWorkspace_sptr ReflectometryReductionOne2::transmissionCorrection(
     // might be better to make it an output property but currently users always
     // accept the default name so are unlikely to use it)
     auto transmissionWSName = alg->getPropertyValue("OutputWorkspace");
-    AnalysisDataService::Instance().addOrReplace(transmissionWSName,
-                                                 transmissionWS);
+    if (!transmissionWSName.empty())
+      AnalysisDataService::Instance().addOrReplace(transmissionWSName,
+                                                   transmissionWS);
   }
 
   // Rebin the transmission run to be the same as the input.

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -399,157 +399,114 @@ public:
     }
   }
 
-  void test_one_run_store_in_ADS() {
-    AnalysisDataService::Instance().clear();
-    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
-
+  void test_one_run_stores_output_in_ADS() {
     CreateTransmissionWorkspace2 alg;
-    alg.initialize();
-    alg.setProperty("FirstTransmissionRun", inputWS);
-    alg.setProperty("WavelengthMin", 3.0);
-    alg.setProperty("WavelengthMax", 12.0);
-    alg.setPropertyValue("ProcessingInstructions", "2");
+    setup_test_to_check_stored_runs(alg);
     alg.setPropertyValue("OutputWorkspace", "outWS");
     alg.execute();
-
+    check_stored_lambda_workspace("outWS");
     TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("outWS"));
-
-    MatrixWorkspace_sptr firstLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("outWS");
-
-    TS_ASSERT(firstLam);
-    TS_ASSERT_EQUALS(firstLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(firstLam->x(0).front() >= 3.0);
-    TS_ASSERT(firstLam->x(0).back() <= 12.0);
   }
 
-  void test_one_run_store_in_ADS_default() {
-    AnalysisDataService::Instance().clear();
-    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
-
+  void test_one_run_stores_output_in_ADS_with_default_name() {
     CreateTransmissionWorkspace2 alg;
-    alg.initialize();
-    alg.setProperty("FirstTransmissionRun", inputWS);
-    alg.setProperty("WavelengthMin", 3.0);
-    alg.setProperty("WavelengthMax", 12.0);
-    alg.setPropertyValue("ProcessingInstructions", "2");
+    setup_test_to_check_stored_runs(alg);
     alg.execute();
-
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
-
-    MatrixWorkspace_sptr firstLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "TRANS_LAM_1234");
-
-    TS_ASSERT(firstLam);
-    TS_ASSERT_EQUALS(firstLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(firstLam->x(0).front() >= 3.0);
-    TS_ASSERT(firstLam->x(0).back() <= 12.0);
+    check_stored_lambda_workspace("TRANS_LAM_1234");
   }
 
-  void test_two_runs_store_in_ADS() {
-    AnalysisDataService::Instance().clear();
-    auto inputWS1 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS1->mutableRun().addProperty<std::string>("run_number", "1234");
-    auto inputWS2 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
-
+  void test_two_runs_stores_stitched_output_in_ADS() {
     CreateTransmissionWorkspace2 alg;
-    alg.initialize();
-    alg.setProperty("FirstTransmissionRun", inputWS1);
-    alg.setProperty("SecondTransmissionRun", inputWS2);
-    alg.setProperty("WavelengthMin", 3.0);
-    alg.setProperty("WavelengthMax", 12.0);
-    alg.setPropertyValue("ProcessingInstructions", "2");
+    setup_test_to_check_stored_runs_with_2_inputs(alg);
     alg.setPropertyValue("OutputWorkspace", "outWS");
     alg.execute();
-    MatrixWorkspace_sptr firstLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "TRANS_LAM_1234");
-    MatrixWorkspace_sptr secondLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "TRANS_LAM_4321");
-
-    TS_ASSERT(firstLam);
-    TS_ASSERT_EQUALS(firstLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(firstLam->x(0).front() >= 3.0);
-    TS_ASSERT(firstLam->x(0).back() <= 12.0);
-
-    TS_ASSERT(secondLam);
-    TS_ASSERT_EQUALS(secondLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(secondLam->x(0).front() >= 3.0);
-    TS_ASSERT(secondLam->x(0).back() <= 12.0);
-
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
-    TS_ASSERT(
-        !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("outWS"));
+    check_stored_lambda_workspace("outWS");
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
   }
 
-  void test_two_runs_store_in_ADS_default() {
-    AnalysisDataService::Instance().clear();
-    auto inputWS1 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS1->mutableRun().addProperty<std::string>("run_number", "1234");
-    auto inputWS2 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
-
+  void test_two_runs_stores_stitched_output_in_ADS_with_default_name() {
     CreateTransmissionWorkspace2 alg;
-    alg.initialize();
-    alg.setProperty("FirstTransmissionRun", inputWS1);
-    alg.setProperty("SecondTransmissionRun", inputWS2);
-    alg.setProperty("WavelengthMin", 3.0);
-    alg.setProperty("WavelengthMax", 12.0);
-    alg.setPropertyValue("ProcessingInstructions", "2");
+    setup_test_to_check_stored_runs_with_2_inputs(alg);
     alg.execute();
-    MatrixWorkspace_sptr firstLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "TRANS_LAM_1234");
-    MatrixWorkspace_sptr secondLam =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(
-            "TRANS_LAM_4321");
-
-    TS_ASSERT(firstLam);
-    TS_ASSERT_EQUALS(firstLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(firstLam->x(0).front() >= 3.0);
-    TS_ASSERT(firstLam->x(0).back() <= 12.0);
-
-    TS_ASSERT(secondLam);
-    TS_ASSERT_EQUALS(secondLam->getAxis(0)->unit()->unitID(), "Wavelength");
-    TS_ASSERT(secondLam->x(0).front() >= 3.0);
-    TS_ASSERT(secondLam->x(0).back() <= 12.0);
-
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
+    check_stored_lambda_workspace("TRANS_LAM_1234_4321");
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
   }
 
-  void test_two_runs_store_in_ADS_default_child() {
-    AnalysisDataService::Instance().clear();
-    auto inputWS1 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS1->mutableRun().addProperty<std::string>("run_number", "1234");
-    auto inputWS2 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
-
+  void test_two_runs_stores_all_lambda_workspaces_in_ADS_with_debug() {
     CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg);
+    alg.setProperty("Debug", true);
+    alg.execute();
+    check_stored_lambda_workspace("TRANS_LAM_1234");
+    check_stored_lambda_workspace("TRANS_LAM_4321");
+    check_stored_lambda_workspace("TRANS_LAM_1234_4321");
+  }
+
+  void test_two_runs_stores_no_lambda_workspaces_in_ADS_when_child() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg);
     alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("FirstTransmissionRun", inputWS1);
-    alg.setProperty("SecondTransmissionRun", inputWS2);
-    alg.setProperty("WavelengthMin", 3.0);
-    alg.setProperty("WavelengthMax", 12.0);
-    alg.setPropertyValue("ProcessingInstructions", "2");
     alg.execute();
     MatrixWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outWS);
-
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
+    check_lambda_workspace(outWS);
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
     TS_ASSERT(
         !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
+  }
+
+  void
+  test_two_runs_stores_interim_lambda_workspaces_in_ADS_when_child_with_debug() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg);
+    alg.setChild(true);
+    alg.setProperty("Debug", true);
+    alg.execute();
+    MatrixWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+    check_lambda_workspace(outWS);
+    check_stored_lambda_workspace("TRANS_LAM_1234");
+    check_stored_lambda_workspace("TRANS_LAM_4321");
+    TS_ASSERT(
+        !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
+  }
+
+private:
+  void setup_test_to_check_stored_runs(CreateTransmissionWorkspace2 &alg) {
+    AnalysisDataService::Instance().clear();
+    auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
+    inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
+
+    alg.initialize();
+    alg.setProperty("FirstTransmissionRun", inputWS);
+    alg.setProperty("WavelengthMin", 3.0);
+    alg.setProperty("WavelengthMax", 12.0);
+    alg.setPropertyValue("ProcessingInstructions", "2");
+  }
+
+  void setup_test_to_check_stored_runs_with_2_inputs(
+      CreateTransmissionWorkspace2 &alg) {
+    setup_test_to_check_stored_runs(alg);
+    auto inputWS2 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
+    inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
+    alg.setProperty("SecondTransmissionRun", inputWS2);
+  }
+
+  void check_stored_lambda_workspace(std::string const &name) {
+    TS_ASSERT(AnalysisDataService::Instance().doesExist(name));
+    MatrixWorkspace_sptr ws =
+        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
+    check_lambda_workspace(ws);
+  }
+
+  void check_lambda_workspace(MatrixWorkspace_sptr ws) {
+    TS_ASSERT(ws);
+    TS_ASSERT_EQUALS(ws->getAxis(0)->unit()->unitID(), "Wavelength");
+    TS_ASSERT(ws->x(0).front() >= 3.0);
+    TS_ASSERT(ws->x(0).back() <= 12.0);
   }
 };
 

--- a/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
+++ b/Framework/Algorithms/test/CreateTransmissionWorkspace2Test.h
@@ -474,11 +474,56 @@ public:
         !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
   }
 
+  void test_first_trans_run_not_stored_if_name_not_found() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg, false, true);
+    alg.setProperty("Debug", true);
+    alg.execute();
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
+    check_stored_lambda_workspace("TRANS_LAM_4321");
+  }
+
+  void test_second_trans_run_not_stored_if_name_not_found() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg, true, false);
+    alg.setProperty("Debug", true);
+    alg.execute();
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_4321"));
+    check_stored_lambda_workspace("TRANS_LAM_1234");
+  }
+
+  void test_stitched_trans_run_not_stored_if_first_name_not_found() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg, false, true);
+    alg.execute();
+    TS_ASSERT(
+        !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
+  }
+
+  void test_stitched_trans_run_not_stored_if_second_name_not_found() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg, true, false);
+    alg.execute();
+    TS_ASSERT(
+        !AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_4321"));
+  }
+
+  void test_output_workspace_is_still_returned_even_if_name_not_found() {
+    CreateTransmissionWorkspace2 alg;
+    setup_test_to_check_stored_runs_with_2_inputs(alg, false, true);
+    alg.execute();
+    MatrixWorkspace_sptr outWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outWS);
+    check_lambda_workspace(outWS);
+  }
+
 private:
-  void setup_test_to_check_stored_runs(CreateTransmissionWorkspace2 &alg) {
+  void setup_test_to_check_stored_runs(CreateTransmissionWorkspace2 &alg,
+                                       bool hasRunNumber = true) {
     AnalysisDataService::Instance().clear();
     auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
+    if (hasRunNumber)
+      inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
 
     alg.initialize();
     alg.setProperty("FirstTransmissionRun", inputWS);
@@ -488,10 +533,12 @@ private:
   }
 
   void setup_test_to_check_stored_runs_with_2_inputs(
-      CreateTransmissionWorkspace2 &alg) {
-    setup_test_to_check_stored_runs(alg);
+      CreateTransmissionWorkspace2 &alg, bool firstHasRunNumber = true,
+      bool secondHasRunNumber = true) {
+    setup_test_to_check_stored_runs(alg, firstHasRunNumber);
     auto inputWS2 = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
+    if (secondHasRunNumber)
+      inputWS2->mutableRun().addProperty<std::string>("run_number", "4321");
     alg.setProperty("SecondTransmissionRun", inputWS2);
   }
 

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -839,6 +839,31 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
+  void test_transmission_output_is_stored_when_one_transmission_input() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmTransmissionCorrection(alg, 1.5, 15.0, "2", m_multiDetectorWS,
+                                         false);
+    runAlgorithmLam(alg);
+
+    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
+
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_transmission_output_is_stored_when_two_transmission_inputs() {
+    ReflectometryReductionOne2 alg;
+    setupAlgorithmTransmissionCorrection(alg, 1.5, 15.0, "2", m_multiDetectorWS,
+                                         true);
+    runAlgorithmLam(alg);
+
+    // stitched output is stored
+    TS_ASSERT(AnalysisDataService::Instance().doesExist("TRANS_LAM_1234_1234"));
+    // interim outputs are not
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist("TRANS_LAM_1234"));
+
+    AnalysisDataService::Instance().clear();
+  }
+
 private:
   // Do standard algorithm setup
   void setupAlgorithm(ReflectometryReductionOne2 &alg,

--- a/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOne2Test.h
@@ -48,9 +48,13 @@ public:
     // A multi detector ws
     m_multiDetectorWS =
         create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    m_multiDetectorWS->mutableRun().addProperty<std::string>("run_number",
+                                                             "1234");
     // A transmission ws with different spectrum numbers to the run
     m_transmissionWS =
         create2DWorkspaceWithReflectometryInstrumentMultiDetector(0, 0.1);
+    m_transmissionWS->mutableRun().addProperty<std::string>("run_number",
+                                                            "4321");
     m_transmissionWS->getSpectrum(0).setSpectrumNo(2);
     m_transmissionWS->getSpectrum(1).setSpectrumNo(3);
     m_transmissionWS->getSpectrum(2).setSpectrumNo(4);
@@ -776,6 +780,7 @@ public:
   void test_debug_false_no_OutputWorkspace() {
     ReflectometryReductionOne2 alg;
     auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
+    inputWS->mutableRun().removeProperty("run_number");
     setYValuesToWorkspace(*inputWS);
 
     alg.initialize();
@@ -796,6 +801,7 @@ public:
   void test_debug_true_default_OutputWorkspace_no_run_number() {
     ReflectometryReductionOne2 alg;
     auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
+    inputWS->mutableRun().removeProperty("run_number");
     setYValuesToWorkspace(*inputWS);
 
     alg.initialize();
@@ -816,7 +822,6 @@ public:
   void test_debug_true_default_OutputWorkspace_with_run_number() {
     ReflectometryReductionOne2 alg;
     auto inputWS = MatrixWorkspace_sptr(m_multiDetectorWS->clone());
-    inputWS->mutableRun().addProperty<std::string>("run_number", "1234");
     setYValuesToWorkspace(*inputWS);
 
     alg.initialize();

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -187,7 +187,8 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args = self._default_options
         args['InputRunList'] = '13460'
         args['FirstTransmissionRunList'] = '13463'
-        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TOF']
+        outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463',
+                   'TRANS_LAM_13463', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -201,7 +202,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # Expect IvsQ outputs from the reduction, and intermediate LAM outputs from
         # creating the stitched transmission run
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
-                   'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
+                   'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -217,7 +218,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
         # creating the stitched transmission run
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', '13463', '13464',
-                   'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
+                   'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -233,7 +234,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         # Expect IvsQ outputs from the reduction, and initermediate LAM outputs from
         # creating the stitched transmission run
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
-                   'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
+                   'TEST_13463', 'TEST_13464', 'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['LoadNexus', 'LoadNexus', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -247,7 +248,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['FirstTransmissionRunList'] = 'TEST_13463'
         args['SecondTransmissionRunList'] = 'TEST_13464'
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TEST_13463', 'TEST_13464',
-                   'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
+                   'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -262,7 +263,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['SecondTransmissionRunList'] = '13464'
         # The intermediate LAM workspaces are output by the algorithm that combines the runs
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
-                   'TRANS_LAM_13463', 'TRANS_LAM_13464', 'TOF']
+                   'TRANS_LAM_13463_13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)
@@ -292,7 +293,7 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         args['InputRunList'] = '13460'
         args['FirstTransmissionRunList'] = '13463, 13464'
         outputs = ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF_13460', 'TRANS_13463', 'TRANS_13464',
-                   'TRANS_13463+13464', 'TOF']
+                   'TRANS_13463+13464', 'TRANS_LAM_13463+13464', 'TOF']
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ['MergeRuns', 'ReflectometryReductionOneAuto', 'GroupWorkspaces']
         self._check_history(AnalysisDataService.retrieve('IvsQ_binned_13460'), history)

--- a/Testing/SystemTests/tests/analysis/INTERReductionTest.py
+++ b/Testing/SystemTests/tests/analysis/INTERReductionTest.py
@@ -157,9 +157,6 @@ def createTransmissionWorkspaces(runs1, runs2, output_names):
             OutputWorkspace=name,
             StartOverlap=10,
             EndOverlap=12)
-        # Delete debug workspaces
-        DeleteWorkspace('TRANS_LAM_'+run1)
-        DeleteWorkspace('TRANS_LAM_'+run2)
 
 
 def eventRef(run_number, angle, start=0, stop=0, DB='TRANS'):

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -78,7 +78,7 @@ Output:
 
 .. testoutput:: ExSumTransmissionRuns
 
-	Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF', 'TOF_13460', 'TRANS_13463', 'TRANS_13463+13464', 'TRANS_13464']
+	Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF', 'TOF_13460', 'TRANS_13463', 'TRANS_13463+13464', 'TRANS_13464', 'TRANS_LAM_13463+13464']
 
 **Example: Two separate transmission run inputs**
 
@@ -94,7 +94,7 @@ Output:
 
 .. testoutput:: ExCombineTransmissionRuns
 
-   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF', 'TOF_13460', 'TRANS_13463', 'TRANS_13464', 'TRANS_LAM_13463', 'TRANS_LAM_13464']
+   Workspaces in the ADS after reduction: ['IvsQ_13460', 'IvsQ_binned_13460', 'TOF', 'TOF_13460', 'TRANS_13463', 'TRANS_13464', 'TRANS_LAM_13463_13464']
 
 **Example: Slice input run**
 

--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -45,5 +45,6 @@ The following bugs have been fixed since the last release:
 
 - The pause button is now disabled upon opening the interface and becomes enabled when a process starts.
 - Ensure that the TOF group cannot contain non-TOF workspaces or nested groups (nested groups are not supported so are now flattened into a single group instead).
+- An issue has been fixed where the incorrect transmission workspaces were being output when debug is on/off.
 
 :ref:`Release 4.2.0 <v4.2.0>`


### PR DESCRIPTION
**Report to:** Max at ISIS

This PR fixes a bug where the incorrect transmission workspaces were being output for debug/non-debug mode:
- The main output is now always output. This is the stitched workspace or, if only one input transmission run is provided, then it is the single input workspace converted to lambda.
- If two input transmission runs are provided, then the interim workspaces (i.e. both inputs converted to lambda) are only output if debug is true.

Some minor refactoring of the unit tests has been done to remove duplication and to make it easier to add the new tests for this PR.

Fixes #26896

### GUI tests

- Open the `ISIS Reflectometry` interface
- Set instrument to INTER and in the table enter run number `13460` and angle `0.5`
- Click Process. Outputs should be `TOF_13460`, `IvsQ_13460` and `IvsQ_binned_13460`
- Enter the first trans run in the table as `13463` and click Process. Additional outputs should be `TRANS_13463` and `TRANS_LAM_13463`.
- On the Experiment tab, tick `Debug` and reprocess. Additional output should be `IvsLam_13463`.
- Untick `Debug` and delete the IvsLam workspace and both the TRANS workspaces.
- Enter the second trans run in the table as `13464` and click Process. Additional workspaces now are `TRANS_13463`, `TRANS_13464` and `TRANS_LAM_13463_13464`.
- Tick `Debug` and reprocess. Additional workspaces now are `IvsLam_13460`, `TRANS_LAM_13463` and `TRANS_LAM_13464`

### Algorithm tests
The GUI is essentially a wrapper around `ReflectometryReductionOneAuto`. We should also test `CreateTransmissionWorkspace` directly as well as its wrapper, `CreateTransmissionWorkspaceAuto`, which uses it in a slightly different way. The following script has examples of running all of the affected algorithms in all combinations I can think of.

```
# The following line helps with future compatibility with Python 3
# print must now be used as a function, e.g print('Hello','World')
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

import matplotlib.pyplot as plt

import numpy as np

Load(Filename='INTER13460', OutputWorkspace='TOF_13460')
Load(Filename='INTER13463', OutputWorkspace='TRANS_13463')
Load(Filename='INTER13464', OutputWorkspace='TRANS_13464')

#
# Test CreateTransmissionWorkspace, and algorithms that call it,
# with 2 input transmission runs
#
def runCTW2(debug, output = None):
    CreateTransmissionWorkspace(FirstTransmissionRun='TRANS_13463', SecondTransmissionRun='TRANS_13464',
                            ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug,
                            OutputWorkspace=output)

def runCTWA2(output = None):
    CreateTransmissionWorkspaceAuto(FirstTransmissionRun='TRANS_13463', SecondTransmissionRun='TRANS_13464',
                            ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, 
                            OutputWorkspace=output)

def runRRO2(debug):
    ReflectometryReductionOne(InputWorkspace='TOF_13460',
                              FirstTransmissionRun='TRANS_13463', SecondTransmissionRun='TRANS_13464',
                              ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug)
                            
def runRROA2(debug):
    ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',
                              FirstTransmissionRun='TRANS_13463', SecondTransmissionRun='TRANS_13464',
                              ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug)


#
# Test CreateTransmissionWorkspace, and algorithms that call it,
# with 1 input transmission run
#
def runCTW1(debug, output = None):
    CreateTransmissionWorkspace(FirstTransmissionRun='TRANS_13463',
                            ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug,
                            OutputWorkspace=output)

def runCTWA1(output = None):
    CreateTransmissionWorkspaceAuto(FirstTransmissionRun='TRANS_13463',
                            ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, 
                            OutputWorkspace=output)

def runRRO1(debug):
    ReflectometryReductionOne(InputWorkspace='TOF_13460',
                              FirstTransmissionRun='TRANS_13463',
                              ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug)
                            
def runRROA1(debug):
    ReflectometryReductionOneAuto(InputWorkspace='TOF_13460',
                              FirstTransmissionRun='TRANS_13463',
                              ProcessingInstructions='4', WavelengthMin=1.5, WavelengthMax=17.0, Debug=debug)


#
# Run the tests with all combinations of inputs
#

runCTW1(debug = False) # output=TRANS_LAM_13463
runCTW1(debug = True) # output=TRANS_LAM_13463
runCTW1(debug = False, output='output') # output=output
runCTW1(debug = True, output='output') # output=output

runCTWA1(output='output') # output=output 

runRRO1(debug = False) # output trans=TRANS_LAM_13463, RRO output IvsQ
runRRO1(debug = True) # output trans=TRANS_LAM_13463, RRO outputs IvsQ and IvsLam

runRROA1(debug = False) # output trans=TRANS_LAM_13463, RROA outputs IvsQ, IvsQ_binned
runRROA1(debug = True) # output trans=TRANS_LAM_13463, RROA outputs IvsQ, IvsQ_binned and IvsLam


                            
runCTW2(debug = False) # stitched=TRANS_LAM_13463_13464
runCTW2(debug = True) # stitched=TRANS_LAM_13463_13464, interim = TRANS_LAM_13463, TRANS_LAM_13464
runCTW2(debug = False, output='output') # stitched=output 
runCTW2(debug = True, output='output') # stitched=output, interim = TRANS_LAM_13463, TRANS_LAM_13464

runCTWA2(output='output') # stitched=output 

runRRO2(debug = False) # stitched trans=TRANS_LAM_13463_13464, RRO output IvsQ
runRRO2(debug = True) # stitched trans=TRANS_LAM_13463_13464 + interim TRANS_LAM_13463/4, RRO outputs IvsQ and IvsLam

runRROA2(debug = False) # stitched trans=TRANS_LAM_13463_13464, RROA outputs IvsQ, IvsQ_binned
runRROA2(debug = True) # stitched trans=TRANS_LAM_13463_13464 + interim TRANS_LAM_13463/4, RROA outputs IvsQ, IvsQ_binned and IvsLam

```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
