### PR TITLE
Pass include directory via cmake argument

### DIFF
--- a/qt/icons/CMakeLists.txt
+++ b/qt/icons/CMakeLists.txt
@@ -68,7 +68,9 @@ set(
 mtd_add_qt_tests(
   TARGET_NAME MantidQtIconsTest
   SRC ${QT5_TEST_FILES}
-  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/inc
+  INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}/inc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../widgets/common/inc
   LINK_LIBS
     ${TARGET_LIBRARIES}
     ${Boost_LIBRARIES}
@@ -77,7 +79,3 @@ mtd_add_qt_tests(
   MTD_QT_LINK_LIBS MantidQtIcons
   PARENT_DEPENDENCIES GUITests
 )
-
-# Allow code to find the testing headers but don't link to the library
-target_include_directories(MantidQtIconsTestQt4 PRIVATE ../widgets/common/inc)
-target_include_directories(MantidQtIconsTestQt5 PRIVATE ../widgets/common/inc)


### PR DESCRIPTION
**Description of work.**

A [recent change](#27045) added include directories via separate `target_include_directories` calls but added no protection if the targets did not exist. This broke the build if one of `ENABLE_MANTIDPLOT` or `ENABLE_WORKBENCH` was set to `FALSE` but not both.


**To test:**

Code review. Builds/tests should pass.

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
