### PR TITLE
Disallow opening multiple instances of an interface

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -43,6 +43,7 @@ Improvements
 - You can now zoom in/out on figures by scrolling and pan figures using the middle mouse button.
 - The keyboard shortcut Ctrl+D now aborts a running script.
 - Plot windows now stay on top of Workbench's main window, so you can easily drag and drop workspaces onto existing figures.
+- Opening more than one instance of an interface is now disallowed, as was the case in MantidPlot.
 
 Bugfixes
 ########

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -25,6 +25,7 @@ from mantid.py3compat import setswitchinterval
 from mantid.utils import is_required_version
 from workbench.app import MAIN_WINDOW_OBJECT_NAME, MAIN_WINDOW_TITLE
 from workbench.plugins.exception_handler import exception_logger
+from workbench.utils.windowfinder import find_window
 from workbench.widgets.settings.presenter import SettingsPresenter
 
 # -----------------------------------------------------------------------------
@@ -364,9 +365,14 @@ class MainWindow(QMainWindow):
         self.interface_executor.execute(open(filename).read(), filename)
 
     def launch_custom_cpp_gui(self, interface_name):
-        interface = self.interface_manager.createSubWindow(interface_name)
-        interface.setAttribute(Qt.WA_DeleteOnClose, True)
-        interface.show()
+        window = find_window(interface_name, QMainWindow)
+        if window is None:
+            interface = self.interface_manager.createSubWindow(interface_name)
+            interface.setObjectName(interface_name)
+            interface.setAttribute(Qt.WA_DeleteOnClose, True)
+            interface.show()
+        else:
+            window.raise_()
 
     def populate_interfaces_menu(self):
         """Populate then Interfaces menu with all Python and C++ interfaces"""

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -368,10 +368,11 @@ class MainWindow(QMainWindow):
     def launch_custom_cpp_gui(self, interface_name):
         """Create a new interface window if one does not already exist,
         else show existing window"""
-        window = find_window(interface_name, UserSubWindow)
+        object_name = 'custom-cpp-interface-' + interface_name
+        window = find_window(object_name, UserSubWindow)
         if window is None:
             interface = self.interface_manager.createSubWindow(interface_name)
-            interface.setObjectName(interface_name)
+            interface.setObjectName(object_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
             interface.show()
         else:

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -56,6 +56,7 @@ from mantidqt.utils.qt import (add_actions, create_action, plugins,
                                widget_updates_disabled)  # noqa
 from mantidqt.project.project import Project  # noqa
 from mantidqt.usersubwindowfactory import UserSubWindowFactory  # noqa
+from mantidqt.usersubwindow import UserSubWindow  # noqa
 
 # Pre-application setup
 plugins.setup_library_paths()
@@ -367,7 +368,7 @@ class MainWindow(QMainWindow):
     def launch_custom_cpp_gui(self, interface_name):
         """Create a new interface window if one does not already exist,
         else show existing window"""
-        window = find_window(interface_name, QMainWindow)
+        window = find_window(interface_name, UserSubWindow)
         if window is None:
             interface = self.interface_manager.createSubWindow(interface_name)
             interface.setObjectName(interface_name)

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -365,6 +365,8 @@ class MainWindow(QMainWindow):
         self.interface_executor.execute(open(filename).read(), filename)
 
     def launch_custom_cpp_gui(self, interface_name):
+        """Create a new interface window if one does not already exist,
+        else show existing window"""
         window = find_window(interface_name, QMainWindow)
         if window is None:
             interface = self.interface_manager.createSubWindow(interface_name)

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -14,8 +14,9 @@ from __future__ import (absolute_import, division, print_function, unicode_liter
 
 import unittest
 
-from mantid.py3compat.mock import Mock, patch
+from mantid.py3compat.mock import patch
 from workbench.app.mainwindow import MainWindow
+
 
 class MainWindowTest(unittest.TestCase):
     @classmethod

--- a/qt/applications/workbench/workbench/test/mainwindowtest.py
+++ b/qt/applications/workbench/workbench/test/mainwindowtest.py
@@ -1,0 +1,46 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+"""
+Defines the QMainWindow of the application and the main() entry point.
+"""
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
+import unittest
+
+from mantid.py3compat.mock import Mock, patch
+from workbench.app.mainwindow import MainWindow
+
+class MainWindowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main_window = MainWindow()
+
+    @patch("workbench.app.mainwindow.find_window")
+    def test_launch_custom_cpp_gui_creates_interface_if_not_already_open(self, mock_find_window):
+        mock_find_window.return_value = None
+        interface_name = 'ISIS Reflectometry'
+        with patch.object(self.main_window, 'interface_manager') as mock_interface_manager:
+            self.main_window.launch_custom_cpp_gui(interface_name)
+            mock_interface_manager.createSubWindow.assert_called_once_with(interface_name)
+
+    @patch("workbench.app.mainwindow.find_window")
+    def test_different_interfaces_simultaneously_created(self, mock_find_window):
+        mock_find_window.return_value = None
+        interface_name = 'Data Reduction'
+        second_interface_name = 'Settings'
+        with patch.object(self.main_window, 'interface_manager') as mock_interface_manager:
+            self.main_window.launch_custom_cpp_gui(interface_name)
+            mock_interface_manager.createSubWindow.assert_called_with(interface_name)
+            self.main_window.launch_custom_cpp_gui(second_interface_name)
+            mock_interface_manager.createSubWindow.assert_called_with(second_interface_name)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/applications/workbench/workbench/utils/test/windowfindertest.py
+++ b/qt/applications/workbench/workbench/utils/test/windowfindertest.py
@@ -31,8 +31,8 @@ class WindowFinderTest(unittest.TestCase):
         window = find_window(interface_name, QMainWindow)
         self.assertIs(top_level_widget, window, "Window found was not the widget supplied")
 
-
     def test_find_window_returns_none_if_no_widget_exists(self):
         interface_name = 'ISIS Reflectometry'
         window = find_window(interface_name, QMainWindow)
         self.assertIsNone(window, "Found a widget when none expected")
+        

--- a/qt/applications/workbench/workbench/utils/test/windowfindertest.py
+++ b/qt/applications/workbench/workbench/utils/test/windowfindertest.py
@@ -1,0 +1,38 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+#
+"""
+Defines the QMainWindow of the application and the main() entry point.
+"""
+from __future__ import (absolute_import, division, print_function, unicode_literals)
+
+import unittest
+
+from workbench.app.mainwindow import MainWindow
+from workbench.utils.windowfinder import find_window
+from qtpy.QtWidgets import QMainWindow
+
+
+class WindowFinderTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.main_window = MainWindow()
+
+    def test_find_window_finds_top_level_widget(self):
+        top_level_widget = QMainWindow()
+        interface_name = 'ISIS Reflectometry'
+        top_level_widget.setObjectName(interface_name)
+        window = find_window(interface_name, QMainWindow)
+        self.assertIs(top_level_widget, window, "Window found was not the widget supplied")
+
+
+    def test_find_window_returns_none_if_no_widget_exists(self):
+        interface_name = 'ISIS Reflectometry'
+        window = find_window(interface_name, QMainWindow)
+        self.assertIsNone(window, "Found a widget when none expected")

--- a/qt/applications/workbench/workbench/utils/test/windowfindertest.py
+++ b/qt/applications/workbench/workbench/utils/test/windowfindertest.py
@@ -35,4 +35,3 @@ class WindowFinderTest(unittest.TestCase):
         interface_name = 'ISIS Reflectometry'
         window = find_window(interface_name, QMainWindow)
         self.assertIsNone(window, "Found a widget when none expected")
-        

--- a/qt/applications/workbench/workbench/utils/windowfinder.py
+++ b/qt/applications/workbench/workbench/utils/windowfinder.py
@@ -27,9 +27,11 @@ def get_main_window_widget():
 
 def find_window(object_name, cls=None):
     """
-        Finds the currently open window
-        :return: window or None
-        """
+    Finds the currently open window
+    :param list: object name as a unicode list
+    :param cls: class type
+    :return QWidget: window or None
+    """
     windows = QApplication.topLevelWidgets()
     for window in windows:
         if window.objectName() == object_name and isinstance(window, cls):

--- a/qt/applications/workbench/workbench/utils/windowfinder.py
+++ b/qt/applications/workbench/workbench/utils/windowfinder.py
@@ -34,8 +34,12 @@ def find_window(object_name, cls=None):
     """
     windows = QApplication.topLevelWidgets()
     for window in windows:
-        if window.objectName() == object_name and isinstance(window, cls):
+        if cls is not None:
+            if window.objectName() == object_name and isinstance(window, cls):
+                return window
+        elif window.objectName() == object_name:
             return window
+        
 
 def find_plot_windows():
     """

--- a/qt/applications/workbench/workbench/utils/windowfinder.py
+++ b/qt/applications/workbench/workbench/utils/windowfinder.py
@@ -39,7 +39,7 @@ def find_window(object_name, cls=None):
                 return window
         elif window.objectName() == object_name:
             return window
-        
+
 
 def find_plot_windows():
     """

--- a/qt/applications/workbench/workbench/utils/windowfinder.py
+++ b/qt/applications/workbench/workbench/utils/windowfinder.py
@@ -25,6 +25,16 @@ def get_main_window_widget():
             return widget
 
 
+def find_window(object_name, cls=None):
+    """
+        Finds the currently open window
+        :return: window or None
+        """
+    windows = QApplication.topLevelWidgets()
+    for window in windows:
+        if window.objectName() == object_name and isinstance(window, cls):
+            return window
+
 def find_plot_windows():
     """
     Finds the currently open plot windows and returns them in a dict

--- a/qt/python/mantidqt/usersubwindow.py
+++ b/qt/python/mantidqt/usersubwindow.py
@@ -1,0 +1,15 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+#
+#
+from __future__ import (absolute_import)
+
+from mantidqt.utils.qt import import_qt
+
+
+UserSubWindow = import_qt('._common', 'mantidqt', 'UserSubWindow')


### PR DESCRIPTION
**Description of work.**
This PR disallows opening multiple instances of the same interface in workbench, as was the case in MantidPlot.

**To test:**
- Open workbench
- Open any C++ interface
- Attempt to open it again
- Observe original interface raise

Fixes #27112 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
