### PR TITLE
Fix z-offsets check and monitor saving

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfoBankHelpers.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfoBankHelpers.h
@@ -8,11 +8,13 @@ namespace Mantid {
 namespace Geometry {
 
 class ComponentInfo;
+class DetectorInfo;
 namespace ComponentInfoBankHelpers {
 
 MANTID_GEOMETRY_DLL bool isDetectorFixedInBank(const ComponentInfo &compInfo,
                                                const size_t detIndex);
 MANTID_GEOMETRY_DLL bool isSaveableBank(const ComponentInfo &compInfo,
+                                        const DetectorInfo &detInfo,
                                         const size_t idx);
 
 MANTID_GEOMETRY_DLL bool isAncestorOf(const ComponentInfo &compInfo,

--- a/Framework/Geometry/test/ComponentInfoBankHelpersTest.h
+++ b/Framework/Geometry/test/ComponentInfoBankHelpersTest.h
@@ -73,16 +73,43 @@ public:
     TS_ASSERT(!isDetectorFixedInBank(componentInfo, componentInfo.root()));
   }
 
-  void test_any_non_detector_containing_detectors_considered_saveable() {
+  void test_any_non_root_assembly_containing_detectors_considered_saveable() {
     // test instrument with detector tubes.
     auto instr = ComponentCreationHelper::createInstrumentWithPSDTubes(
         2 /*number of tubes*/, 2 /*pixels per tube*/);
     auto wrappers = InstrumentVisitor::makeWrappers(*instr);
     const auto &compInfo = (*wrappers.first);
+    const auto &detInfo = (*wrappers.second);
     const size_t tubeIdx = 5; // index of a tube in component info
 
     // assert isSaveableBank returns false
-    TS_ASSERT(isSaveableBank(compInfo, tubeIdx));
+    TS_ASSERT(isSaveableBank(compInfo, detInfo, tubeIdx));
+  }
+
+  void test_monitors_in_bank_make_it_unsaveable() {
+    // Instrument which has NO monitors
+    auto instr = ComponentCreationHelper::createInstrumentWithPSDTubes(
+        2 /*number of tubes*/, 2 /*pixels per tube*/);
+    auto wrappers = InstrumentVisitor::makeWrappers(*instr);
+    {
+      const auto &compInfo = (*wrappers.first);
+      const auto &detInfo = (*wrappers.second);
+
+      // Root saveable as instrument has no monitors
+      TS_ASSERT(isSaveableBank(compInfo, detInfo, compInfo.root()));
+    }
+    // Instrument which has monitors
+    instr = ComponentCreationHelper::createMinimalInstrumentWithMonitor(
+        Mantid::Kernel::V3D{} /*monitor position, uninteresting*/,
+        Mantid::Kernel::Quat{} /*monitor rotation uninteresting*/);
+
+    wrappers = InstrumentVisitor::makeWrappers(*instr);
+    {
+      const auto &compInfo = (*wrappers.first);
+      const auto &detInfo = (*wrappers.second);
+      // In this case the root is NOT saveable due to monitors
+      TS_ASSERT(!isSaveableBank(compInfo, detInfo, compInfo.root()));
+    }
   }
 
   void test_isSaveableBank_false_for_detector() {
@@ -94,7 +121,8 @@ public:
     auto wrappers = InstrumentVisitor::makeWrappers(*instr);
     const auto &compInfo = (*wrappers.first);
 
-    TS_ASSERT(!isSaveableBank(compInfo, 0 /*index of detector*/));
+    const auto &detInfo = (*wrappers.second);
+    TS_ASSERT(!isSaveableBank(compInfo, detInfo, 0 /*index of detector*/));
   }
 
   void test_isSaveableBank_finds_rectangular() {
@@ -103,6 +131,7 @@ public:
         2 /*number of banks*/, 2 /*number of pixels*/);
     auto wrappers = InstrumentVisitor::makeWrappers(*instr);
     const auto &compInfo = (*wrappers.first);
+    const auto &detInfo = (*wrappers.second);
     // index of rectangular bank
     const size_t bankIdx = 13;
     // assert rectangular bank at bankIdx
@@ -110,7 +139,7 @@ public:
     TS_ASSERT(compInfo.componentType(bankIdx) ==
               Beamline::ComponentType::Rectangular);
     // assert isSaveableBank returns true
-    TS_ASSERT(isSaveableBank(compInfo, bankIdx))
+    TS_ASSERT(isSaveableBank(compInfo, detInfo, bankIdx))
   }
 
   void test_offsetFromAncestor_gets_expected_offset() {

--- a/Framework/NexusGeometry/src/NexusGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometryParser.cpp
@@ -360,6 +360,8 @@ private:
       rowLength = static_cast<int>(xValues.size());
     else if (!yEmpty)
       rowLength = static_cast<int>(yValues.size());
+    else if (!zEmpty)
+      rowLength = static_cast<int>(zValues.size());
     // Need at least 2 dimensions to define points
     else
       return offsetData;

--- a/Framework/NexusGeometry/src/NexusGeometrySave.cpp
+++ b/Framework/NexusGeometry/src/NexusGeometrySave.cpp
@@ -1069,7 +1069,8 @@ void saveInstrument(const Geometry::ComponentInfo &compInfo,
   std::list<size_t> saved_indices;
   // Looping from highest to lowest component index is critical
   for (size_t index = compInfo.root() - 1; index >= detInfo.size(); --index) {
-    if (Geometry::ComponentInfoBankHelpers::isSaveableBank(compInfo, index)) {
+    if (Geometry::ComponentInfoBankHelpers::isSaveableBank(compInfo, detInfo,
+                                                           index)) {
       if (isDesiredNXDetector(index, saved_indices, compInfo)) {
         if (reporter != nullptr)
           reporter->report();
@@ -1162,7 +1163,8 @@ void saveInstrument(const Mantid::API::MatrixWorkspace &ws,
   std::list<size_t> saved_indices;
   // Looping from highest to lowest component index is critical
   for (size_t index = compInfo.root() - 1; index >= detInfo.size(); --index) {
-    if (Geometry::ComponentInfoBankHelpers::isSaveableBank(compInfo, index)) {
+    if (Geometry::ComponentInfoBankHelpers::isSaveableBank(compInfo, detInfo,
+                                                           index)) {
 
       if (isDesiredNXDetector(index, saved_indices, compInfo)) {
         // Make spectra detector mappings that can be used


### PR DESCRIPTION
Fixes #27029

Main problem is failing to check for z-offsets for pixels. Monitor saving also corrected as identified by working with wish, which stores monitors in an assembly.

**Tester**

* Original script should now work
* Would also be a good idea to substitute a few other instruments in and check things work across a range of them*

*Note that the nexus format brings some additional restrictions, such as sample position must be (0,0,0) so some instruments will not automatically work (such as SANS2D_Definition_Tubes.xml). In these cases the error should be reported.

