### PR TITLE
Recognise new SYSTEST_NPROCS variable in systemtest scripts

### DIFF
--- a/buildconfig/Jenkins/systemtests
+++ b/buildconfig/Jenkins/systemtests
@@ -98,11 +98,10 @@ echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 default_save_directory=${WORKSPACE}/build/Testing/SystemTests/scripts/
 find ${default_save_directory} -name "*-mismatch*" -delete
 
-# Run
-NTHREADS=${BUILD_THREADS:?}
-MAXTHREADS=12
-if [ ${NTHREADS} -gt ${MAXTHREADS} ]; then
-  NTHREADS=${MAXTHREADS}
-fi
+# Run. Use SYSTEST_NPROCS over BUILD_THREADS if defined
+BUILD_THREADS=${BUILD_THREADS:-1}
+SYSTEST_NPROCS=${SYSTEST_NPROCS:-$BUILD_THREADS}
+echo "Running system tests with ${SYSTEST_NPROCS} cores."
+
 PKGDIR=${WORKSPACE}/build
-${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${NTHREADS} $EXTRA_ARGS
+${X11_RUNNER} "${X11_RUNNER_ARGS}" python $WORKSPACE/Testing/SystemTests/scripts/InstallerTests.py -o -d $PKGDIR -j ${SYSTEST_NPROCS} $EXTRA_ARGS

--- a/buildconfig/Jenkins/systemtests.bat
+++ b/buildconfig/Jenkins/systemtests.bat
@@ -84,10 +84,18 @@ echo CheckMantidVersion.OnStartup = 0 >> %USERPROPS_NIGHTLY%
 
 :: Run
 set PKGDIR=%WORKSPACE%\build
-:: A completely clean build will not have Mantid installed but will need Python to
-:: run the testing setup scripts. Assume it is in the PATH
-set NTHREADS=%BUILD_THREADS%
-set MAXTHREADS=12
-if %NTHREADS% gtr %MAXTHREADS% set NTHREADS=%MAXTHREADS%
+if "%SYSTEST_NPROCS%"=="" (
+  if "%BUILD_THREADS%"=="" (
+    set NTHREADS=1
+  ) else (
+    set NTHREADS=%BUILD_THREADS%
+  )
+) else (
+  set NTHREADS=%SYSTEST_NPROCS%
+)
+@echo "Runing system tests with %NTHREADS% cores."
+
+:: A completely clean builder will not have Mantid installed but will need Python to
+:: run the testing setup scripts. Assume it is in the PATH.
 set PYTHON_EXE=python.exe
 %PYTHON_EXE% %WORKSPACE%\Testing\SystemTests\scripts\InstallerTests.py -o -d %PKGDIR% -j %NTHREADS% %EXTRA_ARGS%


### PR DESCRIPTION
**Description of work.**

See commit description for more detail. This should help build build stability.

**To test:**

Review the scripts.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
