### PR TITLE
Fixed issue with WANDPowderReduction handling of event workspaces

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -154,6 +154,29 @@ class WANDPowderReductionTest(unittest.TestCase):
         self.assertAlmostEqual(y.max(), 20.72968357)
         self.assertAlmostEqual(x[0,y.argmax()], 45.008708196)
 
+    def test_event(self):
+        # check that the workflow runs with event workspaces as input, junk data
+
+        event_data = CreateSampleWorkspace(NumBanks=1,BinWidth=20000,PixelSpacing=0.1,BankPixelWidth=100,WorkspaceType='Event')
+        event_cal = CreateSampleWorkspace(NumBanks=1,BinWidth=20000,PixelSpacing=0.1,BankPixelWidth=100,WorkspaceType='Event',
+                                          Function='Flat background')
+        event_bkg = CreateSampleWorkspace(NumBanks=1,BinWidth=20000,PixelSpacing=0.1,BankPixelWidth=100,WorkspaceType='Event',
+                                          Function='Flat background')
+
+        pd_out=WANDPowderReduction(InputWorkspace=event_data,
+                                   CalibrationWorkspace=event_cal,
+                                   BackgroundWorkspace=event_bkg,
+                                   Target='Theta',
+                                   NumberBins=1000,
+                                   NormaliseBy='None')
+
+        x = pd_out.extractX()
+        y = pd_out.extractY()
+
+        self.assertAlmostEqual(x.min(), 0.03517355)
+        self.assertAlmostEqual(x.max(), 70.3119282)
+        self.assertAlmostEqual(y[0, 0], 0.)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v4.2.0/diffraction.rst
+++ b/docs/source/release/v4.2.0/diffraction.rst
@@ -29,6 +29,7 @@ Bug Fixes
 
 - The values used to mask the prompt pulse on HRPD have been fixed.
 - :ref:`AlignAndFocusPowderFromFiles <algm-AlignAndFocusPowderFromFiles-v1>` will reload the instrument if logs are skipped
+- Fixed issue with :ref:`WANDPowderReduction <algm-WANDPowderReduction-v1>` handling of event workspaces
 - Fixed issues with OptimizeLatticeForCellType, SelectCellOfType, SelectCellWithForm and TransformHKL when using modulated structures.
 
 Engineering Diffraction


### PR DESCRIPTION
Changes in #24814 caused ConvertSpectrumAxis to not histogram data in some cases causing WANDPowderReduction to fail


**To test:**

```python
ws = Load("HB2C_7000.nxs.h5")
out = WANDPowderReduction(ws, NumberBins=1000, Target='theta', NormaliseBy='None')
```

currently fails with

```
RuntimeError: Transpose: error (see log)
  at line 111 in '/opt/Mantid/plugins/python/algorithms/WorkflowAlgorithms/WANDPowderReduction.py'
  caused by line 1129 in '/opt/Mantid/bin/mantid/simpleapi.py'
```

but should now complete successfully.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
