### PR TITLE
Fix Search Results List in Reflectometry not resizing

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>RunsWidget</class>
  <widget class="QWidget" name="RunsWidget">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>995</width>
-    <height>541</height>
-   </rect>
-  </property>
   <property name="windowTitle">
    <string>RunsTab</string>
   </property>
@@ -50,7 +42,7 @@
       <property name="title">
        <string>Search Runs</string>
       </property>
-      <layout class="QVBoxLayout" name="layoutSearchPane" stretch="2,2,0,1">
+      <layout class="QVBoxLayout" name="layoutSearchPane" stretch="0,1,0,0">
        <property name="spacing">
         <number>1</number>
        </property>
@@ -345,9 +337,6 @@
             </item>
             <item>
              <widget class="QSpinBox" name="spinBoxUpdateInterval">
-              <property name="suffix">
-               <string>s</string>
-              </property>
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -368,6 +357,9 @@
               </property>
               <property name="wrapping">
                <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string>s</string>
               </property>
               <property name="minimum">
                <number>1</number>


### PR DESCRIPTION
**Description of work.**
Fixes the search result list in reflectometry not resizing correctly.
Previously it would resize the other elements instead of the results
list.

**To test:**
- Open the Reflectometry GUI
- Drag the box down, check that search results resizes (see original issue)

Fixes #27177. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because it is a layout fix

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
