### PR TITLE
Fix source location of NonOrthogonalSourcePlugin on Windows

### DIFF
--- a/qt/paraview_ext/PVPlugins/CMakeLists.txt
+++ b/qt/paraview_ext/PVPlugins/CMakeLists.txt
@@ -56,5 +56,10 @@ add_custom_target(copy_nonorthogonal_plugin
                   DEPENDS ${_plugin_library_output}/qt4/${_plugin_filename})
 add_dependencies(MantidParaViewMDEWSourceSMPlugin copy_nonorthogonal_plugin)
 
-install(FILES ${_pv_library_output_dir}/${_plugin_filename} ${SYSTEM_PACKAGE_TARGET}
-        DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt4)
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+  install(FILES ${_pv_library_output_dir}/$<CONFIG>/${_plugin_filename}
+          DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt4)
+else()
+  install(FILES ${_pv_library_output_dir}/${_plugin_filename}
+          DESTINATION ${PLUGINS_DIR}/${PVPLUGINS_SUBDIR}/qt4)
+endif()


### PR DESCRIPTION
**Description of work.**

In #26866 there was a tweak to the source location for the install of the `NonOrthogonalSourcePlugin.dll` that missed out the configuration subdirectory for MSVC builds. This fixes the source path. 

**To test:**

Build a package - it's probably easiest to ask the builder to do it. Check the `NonOrthogonalSource.dll` is installed in `<prefix>/plugins/paraview/qt4`

*There is no associated issue.*

*This does not require release notes* because **it is a development regression in this dev cycle.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
