### PR TITLE
Add constraint slots so signal is passed through

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
@@ -24,7 +24,8 @@ class FunctionMultiDomainPresenter;
  * Parameters can be set individually or all to the same value.
  * They also can be fixed and unfixed.
  */
-class EXPORT_OPT_MANTIDQT_COMMON EditLocalParameterDialog : public MantidQt::API::MantidDialog {
+class EXPORT_OPT_MANTIDQT_COMMON EditLocalParameterDialog
+    : public MantidQt::API::MantidDialog {
   Q_OBJECT
 public:
   EditLocalParameterDialog(QWidget *parent, const QString &parName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/EditLocalParameterDialog.h
@@ -9,6 +9,7 @@
 
 #include "DllOption.h"
 #include "MantidQtWidgets/Common/LogValueFinder.h"
+#include "MantidQtWidgets/Common/MantidDialog.h"
 #include "ui_EditLocalParameterDialog.h"
 #include <QDialog>
 #include <memory>
@@ -23,7 +24,7 @@ class FunctionMultiDomainPresenter;
  * Parameters can be set individually or all to the same value.
  * They also can be fixed and unfixed.
  */
-class EXPORT_OPT_MANTIDQT_COMMON EditLocalParameterDialog : public QDialog {
+class EXPORT_OPT_MANTIDQT_COMMON EditLocalParameterDialog : public MantidQt::API::MantidDialog {
   Q_OBJECT
 public:
   EditLocalParameterDialog(QWidget *parent, const QString &parName,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/LocalParameterItemDelegate.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/LocalParameterItemDelegate.h
@@ -42,6 +42,8 @@ signals:
   void setAllFixed(bool /*_t1*/);
   void setTie(int /*_t1*/, QString /*_t2*/);
   void setTieAll(QString /*_t1*/);
+  void setConstraint(int /*_t1*/, QString /*_t2*/);
+  void setConstraintAll(QString /*_t1*/);
   void setValueToLog(int /*_t1*/);
   void setAllValuesToLog();
 

--- a/qt/widgets/common/src/EditLocalParameterDialog.cpp
+++ b/qt/widgets/common/src/EditLocalParameterDialog.cpp
@@ -37,7 +37,7 @@ EditLocalParameterDialog::EditLocalParameterDialog(
     QWidget *parent, const QString &parName, const QStringList &wsNames,
     QList<double> values, QList<bool> fixes, QStringList ties,
     QStringList constraints)
-    : QDialog(parent), m_parName(parName), m_values(values), m_fixes(fixes),
+    : MantidDialog(parent), m_parName(parName), m_values(values), m_fixes(fixes),
       m_ties(ties), m_constraints(constraints) {
   assert(values.size() == wsNames.size());
   assert(fixes.size() == wsNames.size());

--- a/qt/widgets/common/src/EditLocalParameterDialog.cpp
+++ b/qt/widgets/common/src/EditLocalParameterDialog.cpp
@@ -37,8 +37,8 @@ EditLocalParameterDialog::EditLocalParameterDialog(
     QWidget *parent, const QString &parName, const QStringList &wsNames,
     QList<double> values, QList<bool> fixes, QStringList ties,
     QStringList constraints)
-    : MantidDialog(parent), m_parName(parName), m_values(values), m_fixes(fixes),
-      m_ties(ties), m_constraints(constraints) {
+    : MantidDialog(parent), m_parName(parName), m_values(values),
+      m_fixes(fixes), m_ties(ties), m_constraints(constraints) {
   assert(values.size() == wsNames.size());
   assert(fixes.size() == wsNames.size());
   assert(ties.size() == wsNames.size());

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -105,7 +105,12 @@ splitConstraintString(const QString &constraint) {
         lowerBoundStr = QString::fromStdString(expr[1].str());
       }
       paramName = QString::fromStdString(expr[0].str());
-    } else {           // parameter is second
+    } else { // parameter is second
+      try {
+        boost::lexical_cast<double>(expr[0].name());
+      } catch (...) { // error - neither terms are numbers
+        return error;
+      }
       if (op == "<") { // number < param
         lowerBoundStr = QString::fromStdString(expr[0].str());
       } else { // number > param

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -73,28 +73,25 @@ splitConstraintString(const QString &constraint) {
   if (expr.name() != "==") {
     return error;
   }
+  double temp;
   if (expr.size() == 3) { // lower < param < upper
-    try {
-      // check that the first and third terms are numbers
-      boost::lexical_cast<double>(expr[0].str());
-      boost::lexical_cast<double>(expr[2].str());
-      if (expr[1].operator_name() == "<" && expr[2].operator_name() == "<") {
-        lowerBoundStr = QString::fromStdString(expr[0].str());
-        upperBoundStr = QString::fromStdString(expr[2].str());
-      } else { // assume that the operators are ">"
-        lowerBoundStr = QString::fromStdString(expr[2].str());
-        upperBoundStr = QString::fromStdString(expr[0].str());
-      }
-      paramName = QString::fromStdString(expr[1].str());
-    } catch (...) { // error in constraint
+    // check that the first and third terms are numbers
+    if (!boost::conversion::try_lexical_convert(expr[0].str(), temp) ||
+        !boost::conversion::try_lexical_convert(expr[2].str(), temp)) {
       return error;
     }
+    if (expr[1].operator_name() == "<" && expr[2].operator_name() == "<") {
+      lowerBoundStr = QString::fromStdString(expr[0].str());
+      upperBoundStr = QString::fromStdString(expr[2].str());
+    } else { // assume that the operators are ">"
+      lowerBoundStr = QString::fromStdString(expr[2].str());
+      upperBoundStr = QString::fromStdString(expr[0].str());
+    }
+    paramName = QString::fromStdString(expr[1].str());
   } else if (expr.size() == 2) { // lower < param or param > lower etc
     size_t paramPos = 0;
-    try // find position of the parameter name in expression
-    {
-      boost::lexical_cast<double>(expr[1].name());
-    } catch (...) {
+    // find position of the parameter name in expression
+    if (!boost::conversion::try_lexical_convert(expr[1].name(), temp)) {
       paramPos = 1;
     }
     std::string op = expr[1].operator_name();
@@ -106,11 +103,10 @@ splitConstraintString(const QString &constraint) {
       }
       paramName = QString::fromStdString(expr[0].str());
     } else { // parameter is second
-      try {
-        boost::lexical_cast<double>(expr[0].name());
-      } catch (...) { // error - neither terms are numbers
-        return error;
+      if (!boost::conversion::try_lexical_convert(expr[0].name(), temp)) {
+        return error; // error - neither terms are numbers
       }
+
       if (op == "<") { // number < param
         lowerBoundStr = QString::fromStdString(expr[0].str());
       } else { // number > param

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -8,6 +8,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/Expression.h"
 #include <boost/lexical_cast.hpp>
+#include <boost/lexical_cast/try_lexical_convert.hpp>
 
 namespace MantidQt {
 namespace MantidWidgets {

--- a/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
+++ b/qt/widgets/common/src/FunctionBrowser/FunctionBrowserUtils.cpp
@@ -8,7 +8,6 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/Expression.h"
 #include <boost/lexical_cast.hpp>
-#include <boost/lexical_cast/try_lexical_convert.hpp>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -74,25 +73,28 @@ splitConstraintString(const QString &constraint) {
   if (expr.name() != "==") {
     return error;
   }
-  double temp;
   if (expr.size() == 3) { // lower < param < upper
-    // check that the first and third terms are numbers
-    if (!boost::conversion::try_lexical_convert(expr[0].str(), temp) ||
-        !boost::conversion::try_lexical_convert(expr[2].str(), temp)) {
+    try {
+      // check that the first and third terms are numbers
+      boost::lexical_cast<double>(expr[0].str());
+      boost::lexical_cast<double>(expr[2].str());
+      if (expr[1].operator_name() == "<" && expr[2].operator_name() == "<") {
+        lowerBoundStr = QString::fromStdString(expr[0].str());
+        upperBoundStr = QString::fromStdString(expr[2].str());
+      } else { // assume that the operators are ">"
+        lowerBoundStr = QString::fromStdString(expr[2].str());
+        upperBoundStr = QString::fromStdString(expr[0].str());
+      }
+      paramName = QString::fromStdString(expr[1].str());
+    } catch (...) { // error in constraint
       return error;
     }
-    if (expr[1].operator_name() == "<" && expr[2].operator_name() == "<") {
-      lowerBoundStr = QString::fromStdString(expr[0].str());
-      upperBoundStr = QString::fromStdString(expr[2].str());
-    } else { // assume that the operators are ">"
-      lowerBoundStr = QString::fromStdString(expr[2].str());
-      upperBoundStr = QString::fromStdString(expr[0].str());
-    }
-    paramName = QString::fromStdString(expr[1].str());
   } else if (expr.size() == 2) { // lower < param or param > lower etc
     size_t paramPos = 0;
-    // find position of the parameter name in expression
-    if (!boost::conversion::try_lexical_convert(expr[1].name(), temp)) {
+    try // find position of the parameter name in expression
+    {
+      boost::lexical_cast<double>(expr[1].name());
+    } catch (...) {
       paramPos = 1;
     }
     std::string op = expr[1].operator_name();
@@ -104,10 +106,11 @@ splitConstraintString(const QString &constraint) {
       }
       paramName = QString::fromStdString(expr[0].str());
     } else { // parameter is second
-      if (!boost::conversion::try_lexical_convert(expr[0].name(), temp)) {
-        return error; // error - neither terms are numbers
+      try {
+        boost::lexical_cast<double>(expr[0].name());
+      } catch (...) { // error - neither terms are numbers
+        return error;
       }
-
       if (op == "<") { // number < param
         lowerBoundStr = QString::fromStdString(expr[0].str());
       } else { // number > param

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -352,6 +352,12 @@ void FunctionModel::setLocalParameterTie(const QString &parName, int i,
 void FunctionModel::setLocalParameterConstraint(const QString &parName, int i,
                                                 const QString &constraint) {
   auto const parts = splitConstraintString(constraint);
+  if (constraint != "" && parts.second.first == "" &&
+      parts.second.second == "") {
+    g_log.error("Constraint " + parName.toStdString() + ": " +
+                constraint.toStdString() + " is not a valid constraint");
+    return;
+  }
   QString prefix, name;
   std::tie(prefix, name) = splitParameterName(parName);
   auto fun = getFunctionWithPrefix(prefix, getSingleFunction(i));

--- a/qt/widgets/common/src/LocalParameterEditor.cpp
+++ b/qt/widgets/common/src/LocalParameterEditor.cpp
@@ -226,7 +226,7 @@ void LocalParameterEditor::removeAllTies() {
 }
 
 void LocalParameterEditor::setConstraint() {
-  auto constraint = setTieDialog(m_constraint);
+  auto constraint = setConstraintDialog(m_constraint);
   if (!constraint.isEmpty()) {
     m_constraint = constraint;
     emit setConstraint(m_index, m_constraint);


### PR DESCRIPTION
**Description of work.**
This PR fixes the add and remove constraint button in simultaneous fitting when adding via the `...` button.

**To test:**
Follow instructions in #27180 
Do the fit and the value should be between the constraints.

Fixes #27180 

*This does not require release notes* because **the bug did not exist in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
