### PR TITLE
Fix unhandled exceptions when pasting multiple groups

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -61,6 +61,11 @@ void applyWarningStateStyling(MantidWidgets::Batch::Cell &cell,
   cell.setToolTip(errorMessage);
 }
 
+/** Check if a group name exists in the given model.
+ * @param groupName : the name to check
+ * @param jobs : the model to compare against
+ * @rootsToIgnore : rows to ignore in the check
+ */
 bool groupNameExists(
     std::string const &groupName, ReductionJobs const &jobs,
     std::vector<MantidWidgets::Batch::RowLocation> const &rootsToIgnore) {
@@ -80,6 +85,22 @@ bool groupNameExists(
   return true;
 }
 
+/** Check if a group name exists in the clipboard.
+ * @param groupName : the name to check
+ * @param clipboard : the clipboard to compare against
+ * @indexToIgnore : the index of the original item which should be ignored
+ */
+bool groupNameExists(std::string const &groupName, Clipboard const &clipboard,
+                     int indexToIgnore) {
+  for (auto compareIndex = 0; compareIndex < clipboard.numberOfRoots();
+       ++compareIndex) {
+    if (compareIndex != indexToIgnore &&
+        groupName == clipboard.groupName(compareIndex))
+      return true;
+  }
+  return false;
+}
+
 void makePastedGroupNamesUnique(
     Clipboard &clipboard, int rootIndex,
     std::vector<MantidWidgets::Batch::RowLocation> const &replacementRoots,
@@ -88,9 +109,13 @@ void makePastedGroupNamesUnique(
   if (!clipboard.isGroupLocation(rootIndex))
     return;
 
-  // Recursively replace the group name until it is unique
   auto groupName = clipboard.groupName(rootIndex);
-  while (groupNameExists(groupName, jobs, replacementRoots))
+  if (groupName.empty())
+    return;
+
+  // Replace the group name until it is unique in the model and clipboard
+  while (groupNameExists(groupName, jobs, replacementRoots) ||
+         groupNameExists(groupName, clipboard, rootIndex))
     groupName.append(" (copy)");
 
   // Set the new name


### PR DESCRIPTION
This PR fixes a couple of potential unhandled exceptions when pasting multiple groups in the ISIS Reflectometry interface:
- When pasting an unnamed group, leave the name empty rather than appending the text " (copy)" because this doesn't make much sense and it means they become named groups, for which duplication then becomes an issue, whereas duplicate unnamed groups are fine.
- For named groups, check for duplicates in the clipboard as well as in the model.

Note that there are currently no unit tests for the copy/paste functionality and it is beyond the scope of this PR to add them. I've raised #27196 to deal with that along with some other missing tests.

Re #27193

**To test:**

See the instructions in the linked issue.

Fixes #27193

*This does not require release notes* because **this is an obscure edge case bug that users are unlikely to have noticed**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
