### PR TITLE
Fix EventsFilter GUI crash

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -72,5 +72,6 @@ Bugfixes
 - Fixes an issue where subscribing a new algorithm duplicates the list of algorithms in the algorithm selector widget.
 - Plots are no longer zoomed out along their y-axis when you perform a fit or do a plot guess.
 - You can now save scripts that contain unicode characters.
+- A crash no longer occurs when the GenerateEventsFilter algorithm fails in the Filter Events Interface
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/scripts/FilterEvents/eventFilterGUI.py
+++ b/scripts/FilterEvents/eventFilterGUI.py
@@ -963,17 +963,15 @@ class MainWindow(QMainWindow):
         fastLog = self.ui.checkBox_fastLog.isChecked()
 
         title = str(self.ui.lineEdit_title.text())
-
-        splitws, infows = api.GenerateEventsFilter(InputWorkspace=self._dataWS,
-                                                   UnitOfTime="Seconds",
-                                                   TitleOfSplitters=title,
-                                                   OutputWorkspace=splitwsname,
-                                                   LogName=samplelog,
-                                                   FastLog=fastLog,
-                                                   InformationWorkspace=splitinfowsname,
-                                                   **kwargs)
-
         try:
+            splitws, infows = api.GenerateEventsFilter(InputWorkspace=self._dataWS,
+                                                       UnitOfTime="Seconds",
+                                                       TitleOfSplitters=title,
+                                                       OutputWorkspace=splitwsname,
+                                                       LogName=samplelog,
+                                                       FastLog=fastLog,
+                                                       InformationWorkspace=splitinfowsname,
+                                                       **kwargs)
             self.splitWksp(splitws, infows)
         except RuntimeError as e:
             self._setErrorMsg("Splitting Failed!\n %s" % (str(e)))


### PR DESCRIPTION
**Description of work:**

The call to the `GenerateEventsFilter` has now been moved into a try/catch, any failure info is output with an error message box rather than a crash. 

**To test:**
1. Load an event workspace (`EQSANS_6071_event` is in the training data).
2. Interfaces -> Utility -> FilterEvents
3. Select the workspace at the top and click use. 
4. In the "Filter By Log" tab change the Sample Log dropdown to "Phase 4"
5. Click plot. 
6. Move the left slider over to the changes in value. 
7. Click filter.
8. An error box should appear and Mantid should not handle a crash. 

Fixes #27179 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
