### PR TITLE
Add catch for negative min x when plotting with a log scale

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -47,12 +47,18 @@ class AxesTabWidgetPresenter:
             self.view.error_occurred(str(e))
         else:
             self.set_ax_title(ax, new_props.title)
-            ax.set_xlim(new_props.xlim)
             ax.set_xlabel(new_props.xlabel)
             ax.set_xscale(new_props.xscale)
-            ax.set_ylim(new_props.ylim)
+            if new_props.xscale == 'Log' and new_props.xlim[0] < 0:
+                ax.set_xlim(new_props.xlim[1]*0.01, new_props.xlim[1])
+            else:
+                ax.set_xlim(new_props.xlim)
             ax.set_ylabel(new_props.ylabel)
             ax.set_yscale(new_props.yscale)
+            if new_props.yscale == 'Log' and new_props.ylim[0] < 0:
+                ax.set_ylim(new_props.ylim[1]*0.01, new_props.ylim[1])
+            else:
+                ax.set_ylim(new_props.ylim)
             self.update_view()
 
     def get_selected_ax(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -147,16 +147,27 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                 getattr(new_view_mock, setter).assert_called_once_with(value)
 
     def test_apply_properties_correctly_handles_negative_axis_when_changing_to_log_scale(self):
-        presenter = self._generate_presenter()
-        ax = self.fig.get_axes()[0]
+        fig = figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0, 1], [10, 12], 'rx')
+        ax.set_title("My Axes")
+        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)")
+        presenter = Presenter(fig, view=mock_view)
+
         ax_properties = AxProperties.from_ax_object(ax)
-        ax_properties.xscale = 'log'
-        ax_properties.xlim = (-10, 10)
-        ax_properties.yscale = 'log'
-        ax_properties.ylim = (-10, 10)
+        min_limit = -10
+        max_limit = 10
+        ax_properties.xscale = 'Log'
+        ax_properties.xlim = (min_limit, max_limit)
+        ax_properties.yscale = 'Log'
+        ax_properties.ylim = (min_limit, max_limit)
         presenter.view.get_properties.return_value = ax_properties
 
         presenter.apply_properties()
 
-        self.assertEqual(ax.get_xlim(), (0.01, 10))
-        self.assertEqual(ax.get_ylim(), (0.01, 10))
+        self.assertEqual(ax.get_xlim(), (0.01*max_limit, max_limit))
+        self.assertEqual(ax.get_ylim(), (0.01*max_limit, max_limit))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -145,3 +145,18 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
             presenter.update_view()
             for setter, value in zip(setters, expected_vals):
                 getattr(new_view_mock, setter).assert_called_once_with(value)
+
+    def test_apply_properties_correctly_handles_negative_axis_when_changing_to_log_scale(self):
+        presenter = self._generate_presenter()
+        ax = self.fig.get_axes()[0]
+        ax_properties = AxProperties.from_ax_object(ax)
+        ax_properties.xscale = 'log'
+        ax_properties.xlim = (-10, 10)
+        ax_properties.yscale = 'log'
+        ax_properties.ylim = (-10, 10)
+        presenter.view.get_properties.return_value = ax_properties
+
+        presenter.apply_properties()
+
+        self.assertEqual(ax.get_xlim(), (0.01, 10))
+        self.assertEqual(ax.get_ylim(), (0.01, 10))


### PR DESCRIPTION
Previously colourfill plots would run into trouble automaticaly setting axis limits when told to set a negative xmin on a log scale. This pr makes it so that if asked to set a negattive value limit on a log scale it decaults to 0.01 times the max value (a similar scale to what matplotlib should automaticaly set it to).

This also solves an issue where changing to a log scale on a plot with a range going into the negative would result in it trying to plot between -inf and xmax and the changes needed to be applied twice to set it propperly.

**To test:**
1. load from training data EMU00020884.
2. make a colorfill of the data.
3. open the plot setting
4. change the x scale to log.
5. Click Apply
6. The xmin should change to 0.33 and the plot should be readable.

Fixes #27152 #27202

*This does not require release notes* because This was a bug that was only introduced in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
