### PR TITLE
Add python2-sip/python3-sip to search directory for PyQt sip files

### DIFF
--- a/buildconfig/CMake/FindPyQt.py
+++ b/buildconfig/CMake/FindPyQt.py
@@ -45,7 +45,16 @@ class PyQtConfig(object):
               raise RuntimeError("Unknown Qt version ({}) found. Unable to determine location of PyQt sip files."
                                  "Please update FindPyQt accordingly.".format(self.version_str[0]))
       else:
-          self.sip_dir = os.path.join(sys.prefix, 'share', 'sip', name)
+          # RHEL has a separate python2-sip and python3-sip directory
+          prefix_share = os.path.join(sys.prefix, 'share')
+          possible_sip_dirs = (os.path.join(prefix_share, 'sip', name),
+                               os.path.join(prefix_share,
+                                           'python{}-sip'.format(sys.version_info.major),
+                                            name))
+          for sip_dir in possible_sip_dirs:
+              if os.path.exists(sip_dir):
+                  self.sip_dir = sip_dir
+
       # Assume uic script is in uic submodule
       uic = __import__(name + '.uic', globals(), locals(), ['uic'], 0)
       self.pyuic_path = os.path.join(os.path.dirname(uic.__file__), 'pyuic.py')


### PR DESCRIPTION
**Description of work.**

New RHEL packages use separate directories for python2 and python3 PyQt sip files. Also check these when configuring.

Needs to be in release for us to be able to update RHEL PyQt 5 packages

**To test:**

Do a clean cmake configure on RHEL with the new `python2-qt5` package from copr. It should succeed.

*There is no associated issue.*

*This does not require release notes* because **users don't care about this stuff.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
