### PR TITLE
Add error setting states as a known issue for SANS GUI

### DIFF
--- a/docs/source/release/v4.2.0/sans.rst
+++ b/docs/source/release/v4.2.0/sans.rst
@@ -16,13 +16,23 @@ SANS Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Caveats
+#######
+- Attempting to load or process data in the SANS GUI will initially inform
+  the user that their file is not found. Pressing load or process again will
+  correctly load or process data if the user directories is setup.
+
+  This is a side-effect of the SANS usability improvements, specifically the
+  one that avoids users having to re-enter their run number when the row turns
+  blue. It will be resolved for the next release.
+
 New
 ###
-- Support for shifting both monitor 4 and 5 on Zoom including a new setting in the 
-  ISIS SANS GUI. A new user file command has also been added to
+- Support for shifting both monitor 4 and 5 on Zoom including a new setting in
+  the ISIS SANS GUI. A new user file command has also been added to
   perform monitor shifts without changing the selected transmission spectrum.
-- New :ref:`HFIRSANS2Wavelength <algm-HFIRSANS2Wavelength-v1>` algorithm to "convert" CG2 event files
-  to histograms in wavelength.
+- New :ref:`HFIRSANS2Wavelength <algm-HFIRSANS2Wavelength-v1>` algorithm to
+  "convert" CG2 event files to histograms in wavelength.
 
 Improved
 ########
@@ -41,6 +51,10 @@ Improved
 
 Multiple ISIS SANS GUI usability fixes including:
 
+- Numbers do not need to be re-entered if a file is not found, additionally
+  Mantid will not attempt to find data until Load or Process is selected, so
+  users can setup their data directories beforehand. However, this
+  comes with the caveat above.
 - Clicking on a cell in the table and typing will automatically start editing
   the cell without having to double click it.
 - Sample thickness is set when a user presses load or process selected,


### PR DESCRIPTION
**Description of work.**
Adds a note to the release notes about each time a user clicks process a
warning about error setting states being emitted. This cannot be fixed
in time for the release, as it involves changing how states are
generated within the SANS GUI

I'm working on this at the moment, however it has the potential to break more as SANS State is very intertwined. Therefore I'd like to put this caveat in now in case it doesn't make the release, and remove it later otherwise.

**To test:**
- Read the documentation
- Build


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
