### PR TITLE
Disable fit button for tiled plots

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -278,7 +278,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         # Hack to ensure the canvas is up to date
         self.canvas.draw_idle()
-        if figure_type(self.canvas.figure) not in [FigureType.Line, FigureType.Errorbar]:
+        if figure_type(self.canvas.figure) not in [FigureType.Line, FigureType.Errorbar] \
+                or self.toolbar is not None and len(self.canvas.figure.get_axes()) > 1:
             self._set_fit_enabled(False)
 
         # For plot-to-script button to show, we must have a MantidAxes with lines in it

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -127,11 +127,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         Override the base class method. Initialise the peak editing tool.
         """
-        if len(self.canvas.figure.get_axes()) > 1:
-            self.toolbar_manager.toggle_fit_button_checked()
-            logger.warning("Cannot fit tiled plots.")
-            return
-
         allowed_spectra = self._get_allowed_spectra()
         table = self._get_table_workspace()
 

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -127,6 +127,11 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         Override the base class method. Initialise the peak editing tool.
         """
+        if len(self.canvas.figure.get_axes()) > 1:
+            self.toolbar_manager.toggle_fit_button_checked()
+            logger.warning("Cannot fit tiled plots.")
+            return
+
         allowed_spectra = self._get_allowed_spectra()
         table = self._get_table_workspace()
 


### PR DESCRIPTION
**Description of work.**
This PR disables the fit button for tiled plots in workbench as the fit property browser does not know how to handle them.

**To test:**
Load a workspace with more than one spectra
Plot a few spectra as a tiled plot
Press the fit button
The fit property browser should not appear and a message should be given

Fixes #26768 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
