### PR TITLE
Restore functionality to the home button

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -404,7 +404,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             for ax in axes:
                 # We check for axes type below as a pseudo check for an axes being
                 # a colorbar. this is based on the same check in
-                # FigureManagerADSObserverdeleteHandle.deleteHandle.
+                # FigureManagerADSObserver.deleteHandle.
                 if type(ax) is not Axes:
                     ax.relim(visible_only=True)
                     ax.autoscale()

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -406,8 +406,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 # a colorbar. this is based on the same check in
                 # FigureManagerADSObserver.deleteHandle.
                 if type(ax) is not Axes:
-                    ax.relim(visible_only=True)
+                    if ax.lines:  # Relim causes issues with colour plots, which have no lines. 
+                        ax.relim()
                     ax.autoscale()
+
             self.canvas.draw()
 
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -209,6 +209,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 self.generate_plot_script_clipboard)
             self.toolbar.sig_generate_plot_script_file_triggered.connect(
                 self.generate_plot_script_file)
+            self.toolbar.sig_home_clicked.connect(self.set_figure_zoom_to_display_all)
             self.toolbar.setFloatable(False)
             tbs_height = self.toolbar.sizeHint().height()
         else:
@@ -396,6 +397,14 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         for i, toolbar_action in enumerate(self.toolbar.actions()):
             if toolbar_action == action:
                 self.toolbar.actions()[i+1].setVisible(enabled)
+
+    def set_figure_zoom_to_display_all(self):
+        axes = self.canvas.figure.get_axes()
+        if axes:
+            for ax in axes:
+                ax.relim(visible_only=True)
+                ax.autoscale()
+            self.canvas.draw()
 
 
 # -----------------------------------------------------------------------------

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -402,8 +402,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         axes = self.canvas.figure.get_axes()
         if axes:
             for ax in axes:
-                ax.relim(visible_only=True)
-                ax.autoscale()
+                # We check for axes type below as a pseudo check for an axes being
+                # a colorbar. this is based on the same check in
+                # FigureManagerADSObserverdeleteHandle.deleteHandle.
+                if type(ax) is not Axes:
+                    ax.relim(visible_only=True)
+                    ax.autoscale()
             self.canvas.draw()
 
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -406,7 +406,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 # a colorbar. this is based on the same check in
                 # FigureManagerADSObserver.deleteHandle.
                 if type(ax) is not Axes:
-                    if ax.lines:  # Relim causes issues with colour plots, which have no lines. 
+                    if ax.lines:  # Relim causes issues with colour plots, which have no lines.
                         ax.relim()
                     ax.autoscale()
 


### PR DESCRIPTION
The connection and function for the home button on plots had been removed by accident in a previous commit. This PR puts it back

**To test:**
Follow instructions in issue

Fixes #27203 

*This does not require release notes* because It fixes a bug on a new feature

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
