### PR TITLE
Fix ISIS Reflectometry batch load crash

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -183,7 +183,10 @@ void MainWindowPresenter::showHelp() {
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
-  auto filename = QFileDialog::getSaveFileName();
+  const QString jsonFilter = QString("JSON (*.json)");
+  auto filename =
+      QFileDialog::getSaveFileName(nullptr, QString(), QString(), jsonFilter,
+                                   nullptr, QFileDialog::DontResolveSymlinks);
   if (filename == "")
     return;
   Encoder encoder;
@@ -193,7 +196,10 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
 }
 
 void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
-  auto filename = QFileDialog::getOpenFileName();
+  const QString jsonFilter = QString("JSON (*.json)");
+  auto filename =
+      QFileDialog::getOpenFileName(nullptr, QString(), QString(), jsonFilter,
+                                   nullptr, QFileDialog::DontResolveSymlinks);
   if (filename == "")
     return;
   QMap<QString, QVariant> map;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -200,10 +200,10 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   try {
     map = MantidQt::API::loadJSONFromFile(filename);
   } catch (const std::runtime_error &e) {
-    QMessageBox msgBox;
-    msgBox.setText("Unable to load requested file. Please load a file of "
-                   "appropriate format saved from the GUI.");
-    msgBox.exec();
+    QMessageBox::warning(
+        nullptr, QString(),
+        QString("Unable to load requested file. Please load a file of "
+                "appropriate format saved from the GUI."));
   }
   IBatchPresenter *batchPresenter = m_batchPresenters[tabIndex].get();
   Decoder decoder;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -200,10 +200,10 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   try {
     map = MantidQt::API::loadJSONFromFile(filename);
   } catch (const std::runtime_error &e) {
-    QMessageBox::warning(
-        nullptr, QString(),
-        QString("Unable to load requested file. Please load a file of "
-                "appropriate format saved from the GUI."));
+    m_messageHandler->giveUserCritical(
+        "Unable to load requested file. Please load a file of "
+        "appropriate format saved from the GUI.",
+        "Error:");
   }
   IBatchPresenter *batchPresenter = m_batchPresenters[tabIndex].get();
   Decoder decoder;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -20,6 +20,7 @@
 #include "Reduction/Batch.h"
 
 #include <QFileDialog>
+#include <QMessageBox>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -195,7 +196,15 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   auto filename = QFileDialog::getOpenFileName();
   if (filename == "")
     return;
-  auto map = MantidQt::API::loadJSONFromFile(filename);
+  QMap<QString, QVariant> map;
+  try {
+    map = MantidQt::API::loadJSONFromFile(filename);
+  } catch (const std::runtime_error &e) {
+    QMessageBox msgBox;
+    msgBox.setText("Unable to load requested file. Please load a file of "
+                   "appropriate format saved from the GUI.");
+    msgBox.exec();
+  }
   IBatchPresenter *batchPresenter = m_batchPresenters[tabIndex].get();
   Decoder decoder;
   decoder.decodeBatch(batchPresenter, m_view, map);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -20,7 +20,6 @@
 #include "Reduction/Batch.h"
 
 #include <QFileDialog>
-#include <QMessageBox>
 
 namespace MantidQt {
 namespace CustomInterfaces {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -198,7 +198,7 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   QMap<QString, QVariant> map;
   try {
     map = MantidQt::API::loadJSONFromFile(filename);
-  } catch (const std::runtime_error &e) {
+  } catch (const std::runtime_error) {
     m_messageHandler->giveUserCritical(
         "Unable to load requested file. Please load a file of "
         "appropriate format saved from the GUI.",

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
@@ -19,7 +19,7 @@ namespace MantidQt {
 namespace API {
 
 void EXPORT_OPT_MANTIDQT_COMMON
-saveJSONToFile(const QString &filename, const QMap<QString, QVariant> &map);
+saveJSONToFile(QString &filename, const QMap<QString, QVariant> &map);
 
 QMap<QString, QVariant>
     EXPORT_OPT_MANTIDQT_COMMON loadJSONFromFile(const QString &filename);

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -126,7 +126,7 @@ void saveJSONToFile(const QString &filename,
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  QFile jsonFile(filename);
+  QFile jsonFile(filename + ".json");
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());
 #endif

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -121,9 +121,7 @@ void saveJSONToFile(const QString &filename,
   JSON JSON;
   auto jsonString = JSON.encode(map);
   if (filename.find_last_of(".") == std::string::npos ||
-      (filename.find_last_of(".") != std::string::npos &&
-       filename.substr(filename.find_last_of(".") + 1) !=
-           std::string("json"))) {
+      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
     filename.append(".json")
   }
   QFile jsonFile(filename);
@@ -133,9 +131,7 @@ void saveJSONToFile(const QString &filename,
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
   if (filename.find_last_of(".") == std::string::npos ||
-      (filename.find_last_of(".") != std::string::npos &&
-       filename.substr(filename.find_last_of(".") + 1) !=
-           std::string("json"))) {
+      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
     filename.append(".json")
   }
   QFile jsonFile(filename);

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -120,13 +120,25 @@ void saveJSONToFile(const QString &filename,
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;
   auto jsonString = JSON.encode(map);
+  if (filename.find_last_of(".") == std::string::npos ||
+      (filename.find_last_of(".") != std::string::npos &&
+       filename.substr(filename.find_last_of(".") + 1) !=
+           std::string("json"))) {
+    filename.append(".json")
+  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   QByteArray jsonByteArray;
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  QFile jsonFile(filename + ".json");
+  if (filename.find_last_of(".") == std::string::npos ||
+      (filename.find_last_of(".") != std::string::npos &&
+       filename.substr(filename.find_last_of(".") + 1) !=
+           std::string("json"))) {
+    filename.append(".json")
+  }
+  QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());
 #endif

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -116,24 +116,21 @@ public:
 namespace MantidQt {
 namespace API {
 void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {
+                    const QMap<QString, QVariant> &map) {	
+auto filenameString = filename.toStdString();
+if (filenameString.find_last_of(".") == std::string::npos ||
+      filenameString.substr(filenameString.find_last_of(".") + 1) != std::string("json")) {
+    filename.append(".json")
+  }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;
   auto jsonString = JSON.encode(map);
-  if (filename.find_last_of(".") == std::string::npos ||
-      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
-    filename.append(".json")
-  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   QByteArray jsonByteArray;
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  if (filename.find_last_of(".") == std::string::npos ||
-      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
-    filename.append(".json")
-  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -116,10 +116,11 @@ public:
 namespace MantidQt {
 namespace API {
 void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {	
-auto filenameString = filename.toStdString();
-if (filenameString.find_last_of(".") == std::string::npos ||
-      filenameString.substr(filenameString.find_last_of(".") + 1) != std::string("json")) {
+                    const QMap<QString, QVariant> &map) {
+  auto filenameString = filename.toStdString();
+  if (filenameString.find_last_of(".") == std::string::npos ||
+      filenameString.substr(filenameString.find_last_of(".") + 1) !=
+          std::string("json")) {
     filename.append(".json")
   }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -115,13 +115,12 @@ public:
 #endif
 namespace MantidQt {
 namespace API {
-void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {
+void saveJSONToFile(QString &filename, const QMap<QString, QVariant> &map) {
   auto filenameString = filename.toStdString();
   if (filenameString.find_last_of(".") == std::string::npos ||
       filenameString.substr(filenameString.find_last_of(".") + 1) !=
           std::string("json")) {
-    filename.append(".json")
+    filename += ".json";
   }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;

--- a/qt/widgets/common/test/QtJSONUtilsTest.h
+++ b/qt/widgets/common/test/QtJSONUtilsTest.h
@@ -30,7 +30,7 @@ public:
   static void destroySuite(QtJSONUtilsTest *suite) { delete suite; }
 
   void test_saveJSONToFile_and_loadJSONFromFile() {
-    QString filename("/tmp/tempFile");
+    QString filename("/tmp/tempFile.json");
     auto map1 = constructJSONMap();
     MantidQt::API::saveJSONToFile(filename, map1);
 


### PR DESCRIPTION
~~Merge after #27233~~

**Description of work.**
This PR adds a try/catch block to handle runtime errors which result in a hard crash when attempting to load an unsupported file type/format into the ISIS Reflectometry GUI through Batch -> Load

**To test:**

<!-- Instructions for testing. -->
- Open ISIS Reflectometry GUI
- Load in any file from SampleData-ISIS
- Observe handled exception
----
- Reopen GUI
- Enter run number `13460`, angle `0.5`
- Batch -> Save
- Close/Reopen GUI
- Load saved file
----
- Close/Reopen GUI
- Edit saved file in text editor (mess with the formatting etc)
- Attempt to load file
- Observe handled exception

Fixes #27178

*This does not require release notes* because **it is a bug fix which is unlikely to have been seen by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
