### PR TITLE
Fix SANS MUD crash on changing save dir

### DIFF
--- a/docs/source/release/v4.2.0/sans.rst
+++ b/docs/source/release/v4.2.0/sans.rst
@@ -38,6 +38,8 @@ Improved
 - :ref:`ApplyTransmissionCorrection <algm-ApplyTransmissionCorrection-v1>` now
   can be supplied any transmission workspace that is supported
   by :ref:`Divide <algm-Divide-v1>` .
+- Fixed a bug where Mantid would crash when a user went to change their default
+  save directory if no instrument was selected.
 
 Multiple ISIS SANS GUI usability fixes including:
 

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -249,6 +249,7 @@ class SANSDataProcessorGui(QMainWindow,
         self._attach_validators()
 
         self._setup_progress_bar()
+        self._setup_add_runs_page()
 
         # At a later date we can drop new once we confirm the old GUI is not using "ISIS SANS"
         UsageService.registerFeatureUsage("Interface", "ISIS SANS (new)", False)
@@ -949,9 +950,6 @@ class SANSDataProcessorGui(QMainWindow,
         if instrument:
             reduction_mode_list = get_reduction_mode_strings_for_gui(instrument)
             self.set_reduction_modes(reduction_mode_list)
-
-            if instrument != SANSInstrument.NoInstrument:
-                self._setup_add_runs_page()
 
     def update_gui_combo_box(self, value, expected_type, combo_box):
         # There are three types of values that can be passed:

--- a/scripts/SANS/sans/gui_logic/models/create_state.py
+++ b/scripts/SANS/sans/gui_logic/models/create_state.py
@@ -46,9 +46,10 @@ def create_states(state_model, table_model, instrument, facility, row_index=None
 
 def _create_row_state(row, table_model, state_model, facility, instrument, file_lookup,
                       gui_state_director, user_file):
+    sans_logger.information("Generating state for row {}".format(row))
+    state = None
+
     try:
-        sans_logger.information("Generating state for row {}".format(row))
-        state = None
 
         table_entry = table_model.get_table_entry(row)
         if not table_entry.file_information and file_lookup:


### PR DESCRIPTION
**Description of work.**
Fixes a crash when a user does not have an instrument selected, then
goes to change their default save directory.

**To test:**
- Open the ISIS SANS GUI
- Click Load Mask and point to any file (that isn't a mask)
- It should say invalid, and reset to no instrument
- Close and open Mantid
- Re-open the SANS GUI
- Change the default save directory using the manage user directory button in the GUI
- Click okay to close the MUD interface, if it does not crash the bug is fixed

Fixes #27222 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
