### PR TITLE
Restrict ISIS Reflectometry batch save/load file extension

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -183,7 +183,10 @@ void MainWindowPresenter::showHelp() {
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
-  auto filename = QFileDialog::getSaveFileName();
+  const QString jsonFilter = QString("JSON (*.json)");
+  auto filename =
+      QFileDialog::getSaveFileName(nullptr, QString(), QString(), jsonFilter,
+                                   nullptr, QFileDialog::DontResolveSymlinks);
   if (filename == "")
     return;
   Encoder encoder;
@@ -193,7 +196,10 @@ void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {
 }
 
 void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
-  auto filename = QFileDialog::getOpenFileName();
+  const QString jsonFilter = QString("JSON (*.json)");
+  auto filename =
+      QFileDialog::getOpenFileName(nullptr, QString(), QString(), jsonFilter,
+                                   nullptr, QFileDialog::DontResolveSymlinks);
   if (filename == "")
     return;
   QMap<QString, QVariant> map;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJSONUtils.h
@@ -19,7 +19,7 @@ namespace MantidQt {
 namespace API {
 
 void EXPORT_OPT_MANTIDQT_COMMON
-saveJSONToFile(const QString &filename, const QMap<QString, QVariant> &map);
+saveJSONToFile(QString &filename, const QMap<QString, QVariant> &map);
 
 QMap<QString, QVariant>
     EXPORT_OPT_MANTIDQT_COMMON loadJSONFromFile(const QString &filename);

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -126,7 +126,7 @@ void saveJSONToFile(const QString &filename,
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  QFile jsonFile(filename);
+  QFile jsonFile(filename + ".json");
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());
 #endif

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -121,9 +121,7 @@ void saveJSONToFile(const QString &filename,
   JSON JSON;
   auto jsonString = JSON.encode(map);
   if (filename.find_last_of(".") == std::string::npos ||
-      (filename.find_last_of(".") != std::string::npos &&
-       filename.substr(filename.find_last_of(".") + 1) !=
-           std::string("json"))) {
+      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
     filename.append(".json")
   }
   QFile jsonFile(filename);
@@ -133,9 +131,7 @@ void saveJSONToFile(const QString &filename,
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
   if (filename.find_last_of(".") == std::string::npos ||
-      (filename.find_last_of(".") != std::string::npos &&
-       filename.substr(filename.find_last_of(".") + 1) !=
-           std::string("json"))) {
+      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
     filename.append(".json")
   }
   QFile jsonFile(filename);

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -120,13 +120,25 @@ void saveJSONToFile(const QString &filename,
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;
   auto jsonString = JSON.encode(map);
+  if (filename.find_last_of(".") == std::string::npos ||
+      (filename.find_last_of(".") != std::string::npos &&
+       filename.substr(filename.find_last_of(".") + 1) !=
+           std::string("json"))) {
+    filename.append(".json")
+  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   QByteArray jsonByteArray;
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  QFile jsonFile(filename + ".json");
+  if (filename.find_last_of(".") == std::string::npos ||
+      (filename.find_last_of(".") != std::string::npos &&
+       filename.substr(filename.find_last_of(".") + 1) !=
+           std::string("json"))) {
+    filename.append(".json")
+  }
+  QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());
 #endif

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -116,24 +116,21 @@ public:
 namespace MantidQt {
 namespace API {
 void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {
+                    const QMap<QString, QVariant> &map) {	
+auto filenameString = filename.toStdString();
+if (filenameString.find_last_of(".") == std::string::npos ||
+      filenameString.substr(filenameString.find_last_of(".") + 1) != std::string("json")) {
+    filename.append(".json")
+  }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;
   auto jsonString = JSON.encode(map);
-  if (filename.find_last_of(".") == std::string::npos ||
-      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
-    filename.append(".json")
-  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   QByteArray jsonByteArray;
   jsonFile.write(jsonByteArray.append(jsonString));
 #else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
-  if (filename.find_last_of(".") == std::string::npos ||
-      filename.substr(filename.find_last_of(".") + 1) != std::string("json")) {
-    filename.append(".json")
-  }
   QFile jsonFile(filename);
   jsonFile.open(QFile::WriteOnly);
   jsonFile.write(jsonDocument.toJson());

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -116,10 +116,11 @@ public:
 namespace MantidQt {
 namespace API {
 void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {	
-auto filenameString = filename.toStdString();
-if (filenameString.find_last_of(".") == std::string::npos ||
-      filenameString.substr(filenameString.find_last_of(".") + 1) != std::string("json")) {
+                    const QMap<QString, QVariant> &map) {
+  auto filenameString = filename.toStdString();
+  if (filenameString.find_last_of(".") == std::string::npos ||
+      filenameString.substr(filenameString.find_last_of(".") + 1) !=
+          std::string("json")) {
     filename.append(".json")
   }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -115,13 +115,12 @@ public:
 #endif
 namespace MantidQt {
 namespace API {
-void saveJSONToFile(const QString &filename,
-                    const QMap<QString, QVariant> &map) {
+void saveJSONToFile(QString &filename, const QMap<QString, QVariant> &map) {
   auto filenameString = filename.toStdString();
   if (filenameString.find_last_of(".") == std::string::npos ||
       filenameString.substr(filenameString.find_last_of(".") + 1) !=
           std::string("json")) {
-    filename.append(".json")
+    filename += ".json";
   }
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
   JSON JSON;

--- a/qt/widgets/common/test/QtJSONUtilsTest.h
+++ b/qt/widgets/common/test/QtJSONUtilsTest.h
@@ -30,7 +30,7 @@ public:
   static void destroySuite(QtJSONUtilsTest *suite) { delete suite; }
 
   void test_saveJSONToFile_and_loadJSONFromFile() {
-    QString filename("/tmp/tempFile");
+    QString filename("/tmp/tempFile.json");
     auto map1 = constructJSONMap();
     MantidQt::API::saveJSONToFile(filename, map1);
 


### PR DESCRIPTION
**Description of work.**
This PR restricts the ISIS Reflectometry GUI to only loading/saving .json files, reducing the likelihood of an exception (handled by #27227).

**To test:**
- Open ISIS Reflectometry
- Enter run number `13460`, angle `0.5`
- Batch -> Save
- Ensure it is saved with .json extension
- Close/Reopen GUI
- Load file
- Ensure you can only load .json files

Fixes #27224 
*This does not require release notes* because **it is part of a minor bug fix unlikely to be noticed by users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
