### PR TITLE
Fix Duplication of Workspaces in GroupWorkspaces when Saving Projects

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -74,5 +74,6 @@ Bugfixes
 - Plots are no longer zoomed out along their y-axis when you perform a fit or do a plot guess.
 - You can now save scripts that contain unicode characters.
 - A crash no longer occurs when the GenerateEventsFilter algorithm fails in the Filter Events Interface
+- Workspaces contained within groups are no longer duplicated when saving a project.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -228,7 +228,10 @@ class ProjectTest(unittest.TestCase):
         self.project.interface_populating_function = mock.MagicMock(return_value="mocked_interfaces")
 
         self.project._save()
-        saver.assert_called_with(file_name=self.project.last_project_location, workspace_to_save=['newGroup', 'ws3'], plots_to_save="mocked_figs", interfaces_to_save="mocked_interfaces")
+        saver.assert_called_with(file_name=self.project.last_project_location,
+                                 workspace_to_save=['newGroup', 'ws3'],
+                                 plots_to_save="mocked_figs",
+                                 interfaces_to_save="mocked_interfaces")
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/project/test/test_project.py
+++ b/qt/python/mantidqt/project/test/test_project.py
@@ -218,6 +218,18 @@ class ProjectTest(unittest.TestCase):
                 pass
         self.assertFalse(self.project.is_saving)
 
+    @mock.patch('mantidqt.project.project.ProjectSaver.save_project')
+    def test_workspace_groups_are_not_duplicated_when_saving(self, saver):
+        CreateSampleWorkspace(OutputWorkspace="ws1")
+        CreateSampleWorkspace(OutputWorkspace="ws2")
+        GroupWorkspaces(InputWorkspaces="ws1,ws2", OutputWorkspace="newGroup")
+        CreateSampleWorkspace(OutputWorkspace="ws3")
+        self.project.plot_gfm.figs = "mocked_figs"
+        self.project.interface_populating_function = mock.MagicMock(return_value="mocked_interfaces")
+
+        self.project._save()
+        saver.assert_called_with(file_name=self.project.last_project_location, workspace_to_save=['newGroup', 'ws3'], plots_to_save="mocked_figs", interfaces_to_save="mocked_interfaces")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work.**

Instead of saving all of the workspaces that the ADS is tracking, only the top level workspaces are saved. 
As a result, when the project is reloaded, the workspaces that were in groups are no longer loaded twice.

**To test:**

1. Open workbench
2. Create/load some workspaces
3. Create some groups, leaving some workspaces not in groups
4. Save the project.
5. Clear the ADS or close and reopen workbench
6. Load the project.

The loaded project should be in the same state as the one that was saved.

<!-- Instructions for testing. -->

Fixes #27206 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
