### PR TITLE
Fix colorbar scale not updating in colorfill plot

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -41,7 +41,11 @@ class ImagesTabWidgetPresenter:
         if props.interpolation:
             image.set_interpolation(props.interpolation)
 
-        self.fig.gca().images[-1].colorbar.remove()
+        current_axis_images = self.fig.gca().images[-1]
+
+        if current_axis_images.colorbar:
+            current_axis_images.colorbar.remove()
+
         self.fig.colorbar(image)
 
     def get_selected_image(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -35,11 +35,14 @@ class ImagesTabWidgetPresenter:
         image = self.get_selected_image()
         self.set_selected_image_label(props.label)
         image.set_cmap(props.colormap)
-        if props.vmin == 0 and props.scale == "Logarithmic":
+        if props.vmin == 0:
             props.vmin += 1e-6  # Avoid 0 log scale error
         image.set_norm(SCALES[props.scale](vmin=props.vmin, vmax=props.vmax))
         if props.interpolation:
             image.set_interpolation(props.interpolation)
+
+        self.fig.gca().images[-1].colorbar.remove()
+        self.fig.colorbar(image)
 
     def get_selected_image(self):
         return self.image_names_dict[self.view.get_selected_image_name()]

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -120,7 +120,8 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
         presenter.apply_properties()
         self.assertEqual("New Label", img.get_label())
         self.assertEqual('jet', img.cmap.name)
-        self.assertEqual(0, img.norm.vmin)
+        # We should not get 0 as a log plot with a colour fill bar will attempt to scale to inf.
+        self.assertEqual(1e-6, img.norm.vmin)
         self.assertEqual(2, img.norm.vmax)
         self.assertTrue(isinstance(img.norm, Normalize))
 


### PR DESCRIPTION
**Description of work.**
Switching the scale of a colorfill plot to Logarithmic now also changes the colorbar scale.

**To test:**
1. In Workbench, load a workspace and go to Plot->Colorfill.
2. In the Images tab of the figure options, change the scale to Logarithmic and click Apply.
3. Check that the colorbar scale changes to logarithmic.

Fixes #27151 

No release notes because the bug wasn't present in a release.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
