### PR TITLE
import nxs not working on Windows

### DIFF
--- a/buildconfig/CMake/TargetFunctions.cmake
+++ b/buildconfig/CMake/TargetFunctions.cmake
@@ -40,6 +40,9 @@ function (mtd_install_files)
      list(REMOVE_DUPLICATES PARSED_INSTALL_DIRS)
 
      foreach( _dir ${PARSED_INSTALL_DIRS})
+         # install (FILES ) only overwrites file if timestamp is different. Touch files here to always overwrite
+         # Wrap call to execute_process in install (CODE ) so it runs at package time and not build time
+         install ( CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E touch \"${PARSED_FILES}\")")
          install ( FILES ${PARSED_FILES} DESTINATION ${_dir} RENAME ${PARSED_RENAME} )
      endforeach ()
 endfunction()


### PR DESCRIPTION
**Description of work.**

The "import nxs" command wasn't working due to the NEXUSLIB environment variable containing an absolute path that was specific to the build machine ( eg C:/Jenkins/workspace/release_clean-win7/external/src/ThirdParty/bin/libNeXus-0.dll) rather than a relative path

The cause of this is a file copy failing during the construction of the install package. A file called packagesetup.py is supposed to be overwritten by a different version of the same file containing a relative path for the library but this fails to happen.

The fix adds an additional step to the cpack process (that creates the installer) to update the datetime stamp on file before copying to target so overwrite always happens. This will ensure packagesetup.install.py successfully overwrites packagesetup.py during the process of creating the install package

**To test:**

Build the Windows installer using the command:

"C:\Program Files\CMake\bin\cpack.exe" -C Release --config CPackConfig.cmake

or by building the Package target in Visual Studio with release mode selected.

Run the resulting MantidPlot install and run the command "import nxs" in the script interpreter window. Also run a comment like:

f = nxs.open("test.h5",'w5')

...to double check the library works

Fixes #27018. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
