### PR TITLE
ISIS interfaces set default facility

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -222,9 +222,7 @@ std::string MainWindowPresenter::instrumentName() const {
 }
 
 void MainWindowPresenter::updateInstrument(const std::string &instrumentName) {
-  Mantid::Kernel::ConfigService::Instance().setString("default.instrument",
-                                                      instrumentName);
-  g_log.information() << "Instrument changed to " << instrumentName;
+  setDefaultInstrument(instrumentName);
 
   // Load a workspace for this instrument so we can get the actual instrument
   auto loadAlg =
@@ -245,6 +243,24 @@ void MainWindowPresenter::updateInstrument(const std::string &instrumentName) {
   // Notify the slit calculator
   m_slitCalculator->setCurrentInstrumentName(instrumentName);
   m_slitCalculator->processInstrumentHasBeenChanged();
+}
+
+void MainWindowPresenter::setDefaultInstrument(
+    const std::string &requiredInstrument) {
+  auto &config = Mantid::Kernel::ConfigService::Instance();
+
+  auto currentFacility = config.getString("default.facility");
+  auto requiredFacility = "ISIS";
+  if (currentFacility != requiredFacility) {
+    config.setString("default.facility", requiredFacility);
+    g_log.notice() << "Facility changed to " << requiredFacility;
+  }
+
+  auto currentInstrument = config.getString("default.instrument");
+  if (currentInstrument != requiredInstrument) {
+    config.setString("default.instrument", requiredInstrument);
+    g_log.notice() << "Instrument changed to " << requiredInstrument;
+  }
 }
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -83,6 +83,7 @@ private:
                     std::string const &instrument);
   void changeInstrument(std::string const &instrumentName);
   void updateInstrument(const std::string &instrumentName);
+  void setDefaultInstrument(const std::string &newInstrument);
 
   void disableSaveAndLoadBatch();
   void enableSaveAndLoadBatch();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "QtRunsTableView.h"
 #include "Common/IndexOf.h"
-#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/UsageService.h"
 #include "MantidQtIcons/Icon.h"
 #include "MantidQtWidgets/Common/AlgorithmHintStrategy.h"

--- a/scripts/SANS/sans/common/enums.py
+++ b/scripts/SANS/sans/common/enums.py
@@ -102,6 +102,7 @@ class SANSInstrument(object):
     pass
 
 
+@string_convertible
 @serializable_enum("ISIS", "NoFacility")
 class SANSFacility(object):
     pass

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -25,7 +25,7 @@ from mantid.py3compat import csv_open_type
 from sans.command_interface.batch_csv_file_parser import BatchCsvParser
 from sans.common.constants import ALL_PERIODS
 from sans.common.enums import (BatchReductionEntry, ISISReductionMode, RangeStepType, RowState, SampleShape,
-                               SaveType, SANSInstrument)
+                               SANSFacility, SaveType, SANSInstrument)
 from sans.gui_logic.gui_common import (add_dir_to_datasearch, get_reduction_mode_from_gui_selection,
                                        get_reduction_mode_strings_for_gui, get_string_for_gui_from_instrument,
                                        remove_dir_from_datasearch, SANSGuiPropertiesHandler)
@@ -1227,6 +1227,10 @@ class RunTabPresenter(PresenterCommon):
     # Settings
     # ------------------------------------------------------------------------------------------------------------------
     def _setup_instrument_specific_settings(self, instrument=None):
+        if ConfigService["default.facility"] != SANSFacility.to_string(self._facility):
+            ConfigService["default.facility"] = SANSFacility.to_string(self._facility)
+            self.sans_logger.notice("Facility changed to ISIS.")
+
         if not instrument:
             instrument = self._view.instrument
 
@@ -1235,6 +1239,7 @@ class RunTabPresenter(PresenterCommon):
         else:
             instrument_string = get_string_for_gui_from_instrument(instrument)
             ConfigService["default.instrument"] = instrument_string
+            self.sans_logger.notice("Instrument changed to {}.".format(instrument_string))
             self._view.enable_process_buttons()
 
         self._view.set_instrument_settings(instrument)

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -77,7 +77,13 @@ class MultiPeriodMock(object):
 
 class RunTabPresenterTest(unittest.TestCase):
     def setUp(self):
-        config.setFacility("ISIS")
+        # Backup properties that the tests or GUI may change
+        self._backup_facility = config["default.facility"]
+        self._backup_instrument = config["default.instrument"]
+        self._backup_datasearch_dirs = config["datasearch.directories"]
+        self._backup_save_dir = config["defaultsave.directory"]
+
+        config["default.facility"] = "ISIS"
 
         patcher = mock.patch('sans.gui_logic.presenter.run_tab_presenter.BatchCsvParser')
         self.addCleanup(patcher.stop)
@@ -86,6 +92,12 @@ class RunTabPresenterTest(unittest.TestCase):
         self.os_patcher = mock.patch('sans.gui_logic.presenter.run_tab_presenter.os')
         self.addCleanup(self.os_patcher.stop)
         self.osMock = self.os_patcher.start()
+
+    def tearDown(self):
+        config["default.facility"] = self._backup_facility
+        config["default.instrument"] = self._backup_instrument
+        config["datasearch.directories"] = self._backup_datasearch_dirs
+        config["defaultsave.directory2"] = self._backup_save_dir
 
     def test_that_will_load_user_file(self):
         # Setup presenter and mock view
@@ -610,6 +622,28 @@ class RunTabPresenterTest(unittest.TestCase):
         presenter._view.set_instrument_settings.called_once_with(instrument)
         presenter._beam_centre_presenter.on_update_instrument.called_once_with(instrument)
         presenter._workspace_diagnostic_presenter.called_once_with(instrument)
+
+    def test_setup_instrument_specific_settings_sets_facility_in_config(self):
+        config.setFacility('TEST_LIVE')
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        presenter.set_view(mock.MagicMock())
+        presenter._beam_centre_presenter = mock.MagicMock()
+        presenter._workspace_diagnostic_presenter = mock.MagicMock()
+        instrument = SANSInstrument.LOQ
+
+        presenter._setup_instrument_specific_settings(instrument)
+        self.assertEqual(config.getFacility().name(), 'ISIS')
+
+    def test_setup_instrument_specific_settings_sets_instrument_in_config(self):
+        config['default.instrument'] = 'ALF'
+        presenter = RunTabPresenter(SANSFacility.ISIS)
+        presenter.set_view(mock.MagicMock())
+        presenter._beam_centre_presenter = mock.MagicMock()
+        presenter._workspace_diagnostic_presenter = mock.MagicMock()
+        instrument = SANSInstrument.LOQ
+
+        presenter._setup_instrument_specific_settings(instrument)
+        self.assertEqual(config['default.instrument'], 'LOQ')
 
     def test_on_copy_rows_requested_adds_correct_rows_to_clipboard(self):
         presenter = RunTabPresenter(SANSFacility.ISIS)


### PR DESCRIPTION
The `ISIS SANS` and `ISIS Reflectometry` interfaces set the default instrument, but previously they did not check that the facility was sensible for that instrument. This PR changes the facility to ISIS before we set the instrument. This is hard coded for now because these interfaces are exclusively used at ISIS.

**To test:**

- Try changing the facility and instrument to something not at ISIS in the First Time Setup (MantidPlot) / Settings dialog (Workbench)
- Open `ISIS Reflectometry` and check that the instrument displays as INTER on the interface.
- Reopen the First Time Setup / Settings dialog and check that the facility is ISIS and the instrument is INTER.
- Change the facility and instrument back to something non-ISIS.
- Open the `ISIS SANS` interface and load the MaskFile.txt from the ISIS sample data (loqdemo subdirectory). Check that the instrument displays as LOQ on the interface.
- Reopen the First Time Setup / Settings dialog and check that the facility is ISIS and the instrument is LOQ.

Refs #27241

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
