### PR TITLE
Fix meaning of wavelength_spread in HFIRSANS2Wavelength

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/HFIRSANS2Wavelength.py
+++ b/Framework/PythonInterface/plugins/algorithms/HFIRSANS2Wavelength.py
@@ -32,6 +32,7 @@ class HFIRSANS2Wavelength(PythonAlgorithm):
         try:
             wavelength = runObj['wavelength'].getStatistics().mean
             wavelength_spread = runObj['wavelength_spread'].getStatistics().mean
+            wavelength_spread *= wavelength
         except:
             raise ValueError("Could not read wavelength and wavelength_spread logs from the workspace")
         progress = Progress(self, 0.0, 1.0, 4)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HFIRSANS2WavelengthTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HFIRSANS2WavelengthTest.py
@@ -18,7 +18,7 @@ class HFIRSANS2WavelengthTest(unittest.TestCase):
                              UnitX="TOF",
                              NSpec=2)
         AddSampleLog(ws, LogName='wavelength', LogText='6.5', LogType='Number Series')
-        AddSampleLog(ws, LogName='wavelength_spread', LogText='1.0', LogType='Number Series')
+        AddSampleLog(ws, LogName='wavelength_spread', LogText='0.1', LogType='Number Series')
 
     def tearDown(self):
         mtd.clear()
@@ -28,8 +28,8 @@ class HFIRSANS2WavelengthTest(unittest.TestCase):
         out = HFIRSANS2Wavelength(InputWorkspace="ws")
         self.assertTrue(out)
         self.assertEqual(out.blocksize(), 1)
-        self.assertEqual(out.readX(0)[0], 6)
-        self.assertEqual(out.readX(1)[1], 7)
+        self.assertEqual(out.readX(0)[0], 6.175)
+        self.assertEqual(out.readX(1)[1], 6.825)
         self.assertEqual(out.readY(0)[0], 24)
         self.assertAlmostEqual(out.readE(1)[0], 7.071067, 5)
         self.assertEqual(out.getAxis(0).getUnit().caption(), 'Wavelength')

--- a/docs/source/algorithms/HFIRSANS2Wavelength-v1.rst
+++ b/docs/source/algorithms/HFIRSANS2Wavelength-v1.rst
@@ -41,8 +41,8 @@ Output:
 .. testoutput:: HFIRSANS2Wavelength
 
   1
-  6.0
-  7.0
+  3.25
+  9.75
   Wavelength
 
 .. categories::


### PR DESCRIPTION
**Description of work.**
The `wavelength_spread` log is a fractional quantity, not an absolute value


*There is no associated issue.*


*This does not require release notes* because **algorithm introduced in this release**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
