### PR TITLE
fix plotting multiple single spectra workspaces

### DIFF
--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -130,10 +130,9 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
             for sp_set in ws_spectra[1:]:
                 plottable = plottable.intersection(sp_set)
         plottable = sorted(plottable)
-        try:
-            spec_min, spec_max = min(plottable), max(plottable)
-        except ValueError:
-            print('Error: Workspaces have no common spectra')
+        if len(plottable) == 0:
+            raise Exception('Error: Workspaces have no common spectra.')
+        spec_min, spec_max = min(plottable), max(plottable)
         self._ui.specNums.setPlaceholderText(PLACEHOLDER_FORMAT.format(spec_min, spec_max))
         self.spec_min, self.spec_max = spec_min, spec_max
 

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -130,7 +130,10 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
             for sp_set in ws_spectra[1:]:
                 plottable = plottable.intersection(sp_set)
         plottable = sorted(plottable)
-        spec_min, spec_max = min(plottable), max(plottable)
+        try:
+            spec_min, spec_max = min(plottable), max(plottable)
+        except ValueError:
+            print('Error: Workspaces have no common spectra')
         self._ui.specNums.setPlaceholderText(PLACEHOLDER_FORMAT.format(spec_min, spec_max))
         self.spec_min, self.spec_max = spec_min, spec_max
 

--- a/qt/python/mantidqt/dialogs/spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/spectraselectorutils.py
@@ -24,9 +24,17 @@ def get_spectra_selection(workspaces, parent_widget=None, show_colorfill_btn=Fal
     """
     SpectraSelectionDialog.raise_error_if_workspaces_not_compatible(workspaces)
     single_spectra_ws = [wksp.getNumberHistograms() for wksp in workspaces if wksp.getNumberHistograms() == 1]
-    if len(single_spectra_ws) == len(workspaces) > 0:
-        # All workspaces contains only a single spectrum so this is all
-        # that is possible to plot for all of them
+
+    ws_spectra = [{ws.getSpectrum(i).getSpectrumNo() for i in range(ws.getNumberHistograms())} for ws in workspaces]
+    plottable = ws_spectra[0]
+    # check if there are no common spectra in workspaces
+    if len(ws_spectra) > 1:
+        for sp_set in ws_spectra[1:]:
+            plottable = plottable.intersection(sp_set)
+
+    if len(single_spectra_ws) > 0 and (len(workspaces) == 1 or len(plottable) == 0):
+        # At least 1 workspace contains only a single spectrum and these are no
+        # common spectra
         selection = SpectraSelection(workspaces)
         selection.wksp_indices = [0]
         return selection

--- a/qt/python/mantidqt/dialogs/spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/spectraselectorutils.py
@@ -24,8 +24,8 @@ def get_spectra_selection(workspaces, parent_widget=None, show_colorfill_btn=Fal
     """
     SpectraSelectionDialog.raise_error_if_workspaces_not_compatible(workspaces)
     single_spectra_ws = [wksp.getNumberHistograms() for wksp in workspaces if wksp.getNumberHistograms() == 1]
-    if len(single_spectra_ws) > 0 and len(workspaces) == 1:
-        # At least 1 workspace contains only a single spectrum so this is all
+    if len(single_spectra_ws) == len(workspaces) > 0:
+        # All workspaces contains only a single spectrum so this is all
         # that is possible to plot for all of them
         selection = SpectraSelection(workspaces)
         selection.wksp_indices = [0]

--- a/qt/python/mantidqt/dialogs/spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/spectraselectorutils.py
@@ -25,14 +25,17 @@ def get_spectra_selection(workspaces, parent_widget=None, show_colorfill_btn=Fal
     SpectraSelectionDialog.raise_error_if_workspaces_not_compatible(workspaces)
     single_spectra_ws = [wksp.getNumberHistograms() for wksp in workspaces if wksp.getNumberHistograms() == 1]
 
-    ws_spectra = [{ws.getSpectrum(i).getSpectrumNo() for i in range(ws.getNumberHistograms())} for ws in workspaces]
-    plottable = ws_spectra[0]
-    # check if there are no common spectra in workspaces
-    if len(ws_spectra) > 1:
-        for sp_set in ws_spectra[1:]:
-            plottable = plottable.intersection(sp_set)
+    if len(workspaces) == len(single_spectra_ws):
+        plottable = []
+    else:
+        ws_spectra = [{ws.getSpectrum(i).getSpectrumNo() for i in range(ws.getNumberHistograms())} for ws in workspaces]
+        plottable = ws_spectra[0]
+        # check if there are no common spectra in workspaces
+        if len(ws_spectra) > 1:
+            for sp_set in ws_spectra[1:]:
+                plottable = plottable.intersection(sp_set)
 
-    if len(single_spectra_ws) > 0 and (len(workspaces) == 1 or len(plottable) == 0):
+    if len(single_spectra_ws) == len(workspaces) or len(plottable) == 0:
         # At least 1 workspace contains only a single spectrum and these are no
         # common spectra
         selection = SpectraSelection(workspaces)

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QDialogButtonBox
 
 from mantid.api import WorkspaceFactory
 from mantid.py3compat import mock
+from mantid.simpleapi import ExtractSpectra
 from mantidqt.dialogs.spectraselectordialog import parse_selection_str, SpectraSelectionDialog
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
 from mantidqt.utils.qt.testing import start_qapplication
@@ -136,6 +137,12 @@ class SpectraSelectionDialogTest(unittest.TestCase):
     def test_get_spectra_selection_raises_error_with_wrong_workspace_type(self):
         table = WorkspaceFactory.Instance().createTable()
         self.assertRaises(ValueError, get_spectra_selection, [self._single_spec_ws, table])
+
+    def test_set_placeholder_text_raises_error_if_workspaces_have_no_common_spectra(self):
+        spectra_1 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=0, EndWorkspaceIndex=5)
+        spectra_2 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=6, EndWorkspaceIndex=10)
+        workspaces = [spectra_1, spectra_2]
+        self.assertRaises(Exception, 'Error: Workspaces have no common spectra.', SpectraSelectionDialog, workspaces)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
@@ -11,6 +11,7 @@ import unittest
 
 from mantid.api import WorkspaceFactory
 from mantid.py3compat import mock
+from mantid.simpleapi import ExtractSpectra
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
 from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtGui import QIcon
@@ -58,3 +59,17 @@ class SpectraSelectionUtilsTest(unittest.TestCase):
         dialog_mock.assert_not_called()
         self.assertEqual([0], selection.wksp_indices)
         self.assertEqual([self._single_spec_ws], selection.workspaces)
+
+    @mock.patch('mantidqt.dialogs.spectraselectorutils.SpectraSelectionDialog')
+    def test_get_spectra_selection_does_not_use_dialog_for_multiple__single_spectrum(self, dialog_mock):
+        spectra_1 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=0, EndWorkspaceIndex=0)
+        spectra_2 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=1, EndWorkspaceIndex=1)
+        selection = get_spectra_selection([spectra_1, spectra_2])
+
+        dialog_mock.assert_not_called()
+        self.assertEqual([0], selection.wksp_indices)
+        self.assertEqual([spectra_1, spectra_2], selection.workspaces)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes a bug that caused an error to be raised when trying to plot multiple single spectra workspaces with different spectra indexs. This fix works by adding a check in the function to check if there are no common spectra before attempting to open the `SpectraSelectionDialog`, if there are no common spectra it instead overplots all selected workspaces.

This fix is a simple fix but in future after the release sprint `SpectraSelectionDialog` should be modified to handle these cases. however that will be more complex than would be appropriate to include this late into the release. I will make an issue for that against the next release.

**To test:**
1. open workbench
1. open `GEM63437_focussed.nxs` from the tutorial date, this contains a group workspace of foccused data with different spectra numbers.
1. select seveal workspaces
1. right click, plot
1. an overplot of all selected workspaces should be produced

Fixes #27248

*This does not require release notes* because It is a new bug introduced in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
