### PR TITLE
Keep interfaces above workbench when plot is loaded

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -40,13 +40,14 @@ class FigureWindow(QMainWindow, ObservingView):
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
 
-        # On Windows, setting the Workbench's main window as this window's
-        # parent always keeps this window on top, but still allows minimization.
-        # On Ubuntu the child is NOT kept above the parent, hence we use the
-        # focusWindowChanged event to bring this window back to the top when
-        # the main window gets focus. This does cause a slight flicker effect
-        # as the window is hidden and quickly brought back to the front. Using
-        # the parent-child method at least avoids this flicker on Windows.
+        # We use the focusWindowChanged event to bring this window back to the
+        # top when the main window gets focus. This does cause a slight flicker
+        # effect as the window is hidden and quickly brought back to the front.
+
+        # Using the parent-child method was tried. This worked on windows but
+        # not on Ubuntu as the child is NOT kept above the parent.
+        # However this is not used for windows as whenever a plot was done by
+        # an interface it moved behind workbench.
 
         # Using the Qt.WindowStaysOnTopFlag was tried, however this caused the
         # window to stay on top of all other windows, including external
@@ -57,11 +58,7 @@ class FigureWindow(QMainWindow, ObservingView):
         # Using the Qt.Tool flag, and setting the main window as this window's
         # parent, keeps this window on top. However it does not allow the
         # window to be minimized.
-        if platform.system() == "Windows":
-            from workbench.utils.windowfinder import get_main_window_widget
-            self.setParent(get_main_window_widget(), Qt.Window)
-        else:
-            QApplication.instance().focusWindowChanged.connect(self._on_focusWindowChanged)
+        QApplication.instance().focusWindowChanged.connect(self._on_focusWindowChanged)
         self.close_signal.connect(self._run_close)
         self.setAcceptDrops(True)
 

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -11,7 +11,6 @@
 from __future__ import absolute_import
 
 # std imports
-import platform
 import weakref
 
 # 3rdparty imports


### PR DESCRIPTION
This PR fixes an issue that when an interface does a plot or the user interacts with a plot the interface moves behind workbench. This was mainly an issue for the muon interfaces. This has been done by changing the way workbench keeps the plots on top in windows, this does mean there is a slight flicker but it is the same as the other operating systems.

**To test:**
Open Muon analysis:  `Interfaces` -> `Muon` -> `Muon Analysis`
Load a valid run or click `Load Current Run`
A plot should appear and the interface should not have moved

Fixes #27201 

*This does not require release notes* because **this was not in the previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
