### PR TITLE
Correct precision for header on data window

### DIFF
--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -48,6 +48,7 @@ Improvements
 - The keyboard shortcut Ctrl+D now aborts a running script.
 - Plot windows now stay on top of Workbench's main window, so you can easily drag and drop workspaces onto existing figures.
 - Opening more than one instance of an interface is now disallowed, as was the case in MantidPlot.
+- The X value headers on data display now shows values to 4 decimal places.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -22,7 +22,7 @@ class MatrixWorkspaceTableViewModelType(Enum):
 
 
 class MatrixWorkspaceTableViewModel(QAbstractTableModel):
-    HORIZONTAL_HEADER_DISPLAY_STRING = u"{0}\n{1:0.1f}{2}"
+    HORIZONTAL_HEADER_DISPLAY_STRING = u"{0}\n{1:0.3f}{2}"
     HORIZONTAL_HEADER_TOOLTIP_STRING = u"index {0}\n{1} {2:0.1f}{3} (bin centre)"
 
     HORIZONTAL_HEADER_DISPLAY_STRING_FOR_X_VALUES = "{0}"

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -22,8 +22,8 @@ class MatrixWorkspaceTableViewModelType(Enum):
 
 
 class MatrixWorkspaceTableViewModel(QAbstractTableModel):
-    HORIZONTAL_HEADER_DISPLAY_STRING = u"{0}\n{1:0.3f}{2}"
-    HORIZONTAL_HEADER_TOOLTIP_STRING = u"index {0}\n{1} {2:0.1f}{3} (bin centre)"
+    HORIZONTAL_HEADER_DISPLAY_STRING = u"{0}\n{1:0.4f}{2}"
+    HORIZONTAL_HEADER_TOOLTIP_STRING = u"index {0}\n{1} {2:0.6f}{3} (bin centre)"
 
     HORIZONTAL_HEADER_DISPLAY_STRING_FOR_X_VALUES = "{0}"
     HORIZONTAL_HEADER_TOOLTIP_STRING_FOR_X_VALUES = "index {0}"


### PR DESCRIPTION
This PR increases the level of precision for the header on the y and e tabs on a data window for a workspace. previously the header would only show a value to one decimal place, this PR instead sets the header to show 4 decimal places and hovering over the header will show the value to 6 decimal places.

**Report to:** SpencerHowells

**To test:**
Follow instructions from initial issue

Re #27013 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
