### PR TITLE
Fix figure options on matplotlib v1.5 - RHEL7 only

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/legend_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/legend_tab.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>527</width>
-    <height>562</height>
+    <height>446</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,25 +29,32 @@
    <item row="1" column="0">
     <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <spacer name="verticalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
       <layout class="QGridLayout" name="grid_layout">
        <property name="sizeConstraint">
         <enum>QLayout::SetDefaultConstraint</enum>
        </property>
-       <item row="13" column="2" colspan="2">
+       <item row="9" column="2" colspan="2">
+        <widget class="QWidget" name="title_color_selector_dummy_widget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="2" colspan="2">
         <widget class="QComboBox" name="entries_font_combo_box"/>
+       </item>
+       <item row="4" column="3">
+        <widget class="QSpinBox" name="transparency_spin_box">
+         <property name="suffix">
+          <string>%</string>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
        </item>
        <item row="2" column="2" colspan="2">
         <widget class="QWidget" name="background_color_selector_dummy_widget" native="true">
@@ -59,10 +66,10 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="transparency_label">
+       <item row="2" column="0">
+        <widget class="QLabel" name="background_color_label">
          <property name="text">
-          <string>Transparency</string>
+          <string>Background Color</string>
          </property>
         </widget>
        </item>
@@ -76,7 +83,14 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="4" column="0">
+        <widget class="QLabel" name="transparency_label">
+         <property name="text">
+          <string>Transparency</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
         <widget class="QLabel" name="title_label_2">
          <property name="font">
           <font>
@@ -90,27 +104,17 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="background_color_label">
+       <item row="1" column="0" colspan="2">
+        <widget class="QCheckBox" name="hide_box_check_box">
          <property name="text">
-          <string>Background Color</string>
+          <string>Hide Box</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="3">
-        <widget class="QSpinBox" name="transparency_spin_box">
-         <property name="suffix">
-          <string>%</string>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="edge_color_label">
+       <item row="12" column="0">
+        <widget class="QLabel" name="entries_size_label">
          <property name="text">
-          <string>Edge Color</string>
+          <string>Size</string>
          </property>
         </widget>
        </item>
@@ -128,18 +132,12 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0" colspan="4">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+       <item row="3" column="0">
+        <widget class="QLabel" name="edge_color_label">
+         <property name="text">
+          <string>Edge Color</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item row="3" column="2" colspan="2">
         <widget class="QWidget" name="edge_color_selector_dummy_widget" native="true">
@@ -151,67 +149,17 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="marker_size_label">
          <property name="text">
           <string>Length</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="0" colspan="4">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="QCheckBox" name="hide_box_check_box">
-         <property name="text">
-          <string>Hide Box</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0" colspan="4">
-        <spacer name="verticalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="14" column="0">
-        <widget class="QLabel" name="entries_size_label">
-         <property name="text">
-          <string>Size</string>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="2" colspan="2">
+       <item row="13" column="2" colspan="2">
         <widget class="QWidget" name="entries_color_selector_dummy_widget" native="true"/>
        </item>
-       <item row="10" column="2" colspan="2">
-        <widget class="QWidget" name="title_color_selector_dummy_widget" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="entries_font_label">
          <property name="text">
           <string>Font</string>
@@ -234,14 +182,14 @@
          </property>
         </spacer>
        </item>
-       <item row="15" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="entries_color_label">
          <property name="text">
           <string>Color</string>
          </property>
         </widget>
        </item>
-       <item row="14" column="2" colspan="2">
+       <item row="12" column="2" colspan="2">
         <widget class="QDoubleSpinBox" name="entries_size_spin_box">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -251,44 +199,44 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="6" column="0">
         <widget class="QLabel" name="title_label">
          <property name="text">
           <string>Title</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="2" colspan="2">
+       <item row="6" column="2" colspan="2">
         <widget class="QLineEdit" name="title_line_edit"/>
        </item>
-       <item row="8" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="label_2">
          <property name="text">
           <string>Font</string>
          </property>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
           <string>Color</string>
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Size</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="2" colspan="2">
+       <item row="7" column="2" colspan="2">
         <widget class="QComboBox" name="title_font_combo_box"/>
        </item>
-       <item row="9" column="2" colspan="2">
+       <item row="8" column="2" colspan="2">
         <widget class="QDoubleSpinBox" name="title_size_spin_box"/>
        </item>
-       <item row="12" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="entries_label">
          <property name="font">
           <font>
@@ -302,10 +250,10 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="2" colspan="2">
+       <item row="17" column="2" colspan="2">
         <widget class="QDoubleSpinBox" name="marker_size_spin_box"/>
        </item>
-       <item row="19" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="markers_label">
          <property name="font">
           <font>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -43,8 +43,7 @@ class LegendTabWidgetPresenter:
 
     def init_view(self):
         if int(matplotlib.__version__[0]) < 2:
-            self.view.background_color_selector_widget.setVisible(False)
-            self.view.edge_color_selector_widget.setVisible(False)
+            self.view.hide_box_properties()
 
         """Sets all of the initial values of the input fields when the tab is first loaded"""
         legend_props = LegendProperties.from_legend(self.axes[0].get_legend())
@@ -56,9 +55,10 @@ class LegendTabWidgetPresenter:
         self.view.set_edge_color(legend_props.edge_color)
 
         # Converts alpha value (opacity value between 0 and 1) to transparency percentage.
-        transparency = 100-(legend_props.transparency*100)
-        self.view.set_transparency_spin_box(transparency)
-        self.view.set_transparency_slider(transparency)
+        if int(matplotlib.__version__[0]) > 2:
+            transparency = 100-(legend_props.transparency*100)
+            self.view.set_transparency_spin_box(transparency)
+            self.view.set_transparency_slider(transparency)
         self.view.set_entries_font(legend_props.entries_font)
         self.view.set_entries_size(legend_props.entries_size)
         self.view.set_entries_color(legend_props.entries_color)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/view.py
@@ -53,6 +53,11 @@ class LegendTabWidgetView(QWidget):
     def get_transparency_spin_box_value(self):
         return self.transparency_spin_box.value()
 
+    def hide_transparency(self):
+        self.transparency_label.setHidden(True)
+        self.transparency_slider.setHidden(True)
+        self.transparency_spin_box.setHidden(True)
+
     def set_title(self, title):
         self.title_line_edit.setText(title)
 
@@ -130,3 +135,12 @@ class LegendTabWidgetView(QWidget):
         advanced_props = self.advanced_options.get_properties()
         props.update(advanced_props)
         return props
+
+    def hide_box_properties(self):
+        self.box_label.setHidden(True)
+        self.hide_box_check_box.setHidden(True)
+        self.background_color_label.setHidden(True)
+        self.background_color_selector_widget.setHidden(True)
+        self.edge_color_label.setHidden(True)
+        self.edge_color_selector_widget.setHidden(True)
+        self.hide_transparency()


### PR DESCRIPTION
**Description of work.**
Some of the properties in the legend tab in the figure options are not in matplotlib v1.5 causing a crash. Checks have been added and these properties hidden from the gui.

**To test:**

**This should be tested on a machine using Matplotlib v1.5 (RHEL or Ubuntu 16)**
Open Workbench.
Plot a workspace and open the plot options.
The option dialog should open with no error message.
All the options should work - in particular the ones in the legend tab

Fixes #27090 

*This does not require release notes* because **this bug was not in the previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
