### PR TITLE
Update naming iniqt fit

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -25,7 +25,6 @@ set(
   IndirectCorrections.cpp
   IndirectDataAnalysis.cpp
   IndirectDataAnalysisTab.cpp
-  IndirectDataAnalysisTab.cpp
   IndirectDataReduction.cpp
   IndirectDataReductionTab.cpp
   IndirectDataTablePresenterLegacy.cpp
@@ -158,7 +157,6 @@ set(
   IndirectBayesTab.h
   IndirectCorrections.h
   IndirectDataAnalysis.h
-  IndirectDataAnalysisTab.h
   IndirectDataAnalysisTab.h
   IndirectDataReduction.h
   IndirectDataReductionTab.h

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.h
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.h
@@ -24,7 +24,7 @@ window.
 @author Samuel Jackson, STFC
 */
 
-class DLLExport IndirectBayes : public IndirectInterface {
+class MANTIDQT_INDIRECT_DLL IndirectBayes : public IndirectInterface {
   Q_OBJECT
 
 public: // public constants and enums

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisTab.h
@@ -53,7 +53,7 @@ class RangeSelector;
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
-class DLLExport IndirectDataAnalysisTab : public IndirectTab {
+class MANTIDQT_INDIRECT_DLL IndirectDataAnalysisTab : public IndirectTab {
   Q_OBJECT
 
 public:

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -43,15 +43,15 @@ WorkspaceGroup_sptr getADSGroupWorkspace(std::string const &workspaceName) {
  * @return              The number of custom functions, with the specified name,
  *                      included in the selected model.
  */
-size_t
-getNumberOfSpecificFunctionContained(const std::string & functionName, IFunction_sptr compositeFunction) {
-  if(compositeFunction->nFunctions() == 0){
+size_t getNumberOfSpecificFunctionContained(const std::string &functionName,
+                                            IFunction_sptr compositeFunction) {
+  if (compositeFunction->nFunctions() == 0) {
     return compositeFunction->name() == functionName ? 1 : 0;
-  }
-  else{
+  } else {
     size_t count{0};
-    for(size_t i{0}; i<compositeFunction->nFunctions(); i++){
-      count += getNumberOfSpecificFunctionContained(functionName, compositeFunction->getFunction(i));
+    for (size_t i{0}; i < compositeFunction->nFunctions(); i++) {
+      count += getNumberOfSpecificFunctionContained(
+          functionName, compositeFunction->getFunction(i));
     }
     return count;
   }
@@ -254,10 +254,11 @@ QString IndirectFitAnalysisTab::selectedFitType() const {
  * @return              The number of custom functions, with the specified name,
  *                      included in the selected model.
  */
-size_t
-IndirectFitAnalysisTab::numberOfCustomFunctions(const std::string & functionName) const {
-  if(auto fittingFunction = m_fittingModel->getFittingFunction())
-    return getNumberOfSpecificFunctionContained(functionName, fittingFunction->getFunction(0));
+size_t IndirectFitAnalysisTab::numberOfCustomFunctions(
+    const std::string &functionName) const {
+  if (auto fittingFunction = m_fittingModel->getFittingFunction())
+    return getNumberOfSpecificFunctionContained(
+        functionName, fittingFunction->getFunction(0));
   else
     return 0;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -37,12 +37,31 @@ WorkspaceGroup_sptr getADSGroupWorkspace(std::string const &workspaceName) {
       workspaceName);
 }
 
+/**
+ * @param functionName  The name of the function.
+ * @param compositeFunction  The function to search within.
+ * @return              The number of custom functions, with the specified name,
+ *                      included in the selected model.
+ */
+size_t
+getNumberOfSpecificFunctionContained(const std::string & functionName, IFunction_sptr compositeFunction) {
+  if(compositeFunction->nFunctions() == 0){
+    return compositeFunction->name() == functionName ? 1 : 0;
+  }
+  else{
+    size_t count{0};
+    for(size_t i{0}; i<compositeFunction->nFunctions(); i++){
+      count += getNumberOfSpecificFunctionContained(functionName, compositeFunction->getFunction(i));
+    }
+    return count;
+  }
+}
+
 } // namespace
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
-
 IndirectFitAnalysisTab::IndirectFitAnalysisTab(IndirectFittingModel *model,
                                                QWidget *parent)
     : IndirectDataAnalysisTab(parent), m_fittingModel(model) {}
@@ -236,8 +255,11 @@ QString IndirectFitAnalysisTab::selectedFitType() const {
  *                      included in the selected model.
  */
 size_t
-IndirectFitAnalysisTab::numberOfCustomFunctions(const std::string &) const {
-  return 0;
+IndirectFitAnalysisTab::numberOfCustomFunctions(const std::string & functionName) const {
+  if(auto fittingFunction = m_fittingModel->getFittingFunction())
+    return getNumberOfSpecificFunctionContained(functionName, fittingFunction->getFunction(0));
+  else
+    return 0;
 }
 
 void IndirectFitAnalysisTab::setModelFitFunction() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -28,7 +28,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
-class DLLExport IndirectFitAnalysisTab : public IndirectDataAnalysisTab {
+class MANTIDQT_INDIRECT_DLL IndirectFitAnalysisTab
+    : public IndirectDataAnalysisTab {
   Q_OBJECT
 
 public:

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.h
@@ -28,6 +28,9 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace IDA {
 
+size_t getNumberOfSpecificFunctionContained(const std::string &functionName,
+                                            const IFunction *compositeFunction);
+
 class MANTIDQT_INDIRECT_DLL IndirectFitAnalysisTab
     : public IndirectDataAnalysisTab {
   Q_OBJECT
@@ -52,6 +55,10 @@ public:
   QString selectedFitType() const;
   size_t numberOfCustomFunctions(const std::string &functionName) const;
   void setConvolveMembers(bool convolveMembers);
+
+  static size_t
+  getNumberOfSpecificFunctionContained(const std::string &functionName,
+                                       const IFunction *compositeFunction);
 
 protected:
   IndirectFittingModel *fittingModel() const;
@@ -150,7 +157,7 @@ private:
   std::unique_ptr<IndirectFitPlotPresenter> m_plotPresenter;
   std::unique_ptr<IndirectSpectrumSelectionPresenter> m_spectrumPresenter;
   std::unique_ptr<IndirectFitOutputOptionsPresenter> m_outOptionsPresenter;
-  IndirectFitPropertyBrowser *m_fitPropertyBrowser;
+  IndirectFitPropertyBrowser *m_fitPropertyBrowser{nullptr};
   Mantid::API::IAlgorithm_sptr m_fittingAlgorithm;
 };
 

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -78,14 +78,14 @@ void IqtFit::fitFunctionChanged() {
 std::string IqtFit::fitTypeString() const {
   const auto numberOfExponential = numberOfCustomFunctions("ExpDecay");
   const auto numberOfStretched = numberOfCustomFunctions("StretchExp");
-
+  std::string functionType{""};
   if (numberOfExponential > 0)
-    return std::to_string(numberOfExponential) + "E";
+    functionType += std::to_string(numberOfExponential) + "E";
 
   if (numberOfStretched > 0)
-    return std::to_string(numberOfStretched) + "S";
+    functionType += std::to_string(numberOfStretched) + "S";
 
-  return "";
+  return functionType;
 }
 
 void IqtFit::setupFit(Mantid::API::IAlgorithm_sptr fitAlgorithm) {

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(
   ConvFitModelTest.h
   IndirectDataTablePresenterTest.h
   IndirectDataValidationHelperTest.h
+  IndirectFitAnalysisTabTest.h
   IndirectFitDataPresenterTest.h
   IndirectFitDataTest.h
   IndirectFitOutputOptionsModelTest.h

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
@@ -1,0 +1,60 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
+#define MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
+
+#include "IndirectFitAnalysisTab.cpp"
+#include "MantidAPI/FunctionFactory.h"
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+class IndirectFitAnalysisTabTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  IndirectFitAnalysisTabTest() {}
+
+  static IndirectFitAnalysisTabTest *createSuite() {
+    return new IndirectFitAnalysisTabTest();
+  }
+
+  static void destroySuite(IndirectFitAnalysisTabTest *suite) { delete suite; }
+
+  void test_that_single_function_correctly_identified() {
+    std::string functionName = "ExpDecay";
+    auto fitFunction =
+        Mantid::API::FunctionFactory::Instance().createFunction(functionName);
+    auto occurances =
+        getNumberOfSpecificFunctionContained(functionName, fitFunction);
+    TS_ASSERT_EQUALS(occurances, 1);
+  }
+
+  void test_that_single_layer_composite_function_handled_correctly() {
+    std::string functionName = "name=ExpDecay;name=StretchExp";
+    auto fitFunction =
+        Mantid::API::FunctionFactory::Instance().createInitialized(
+            functionName);
+    auto occurances =
+        getNumberOfSpecificFunctionContained("ExpDecay", fitFunction);
+    auto stretchOccurances =
+        getNumberOfSpecificFunctionContained("StretchExp", fitFunction);
+    TS_ASSERT_EQUALS(occurances, 1);
+    TS_ASSERT_EQUALS(stretchOccurances, 1);
+  }
+
+  void test_that_multi_layer_composite_function_handled_correctly() {
+    std::string functionName = "name=ExpDecay;name=ExpDecay;(composite="
+                               "ProductFunction,NumDeriv=false;name=ExpDecay;"
+                               "name=ExpDecay)";
+    auto fitFunction =
+        Mantid::API::FunctionFactory::Instance().createInitialized(
+            functionName);
+    auto occurances =
+        getNumberOfSpecificFunctionContained("ExpDecay", fitFunction);
+    TS_ASSERT_EQUALS(occurances, 4);
+  }
+};
+#endif

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitAnalysisTabTest.h
@@ -7,28 +7,25 @@
 #ifndef MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
 #define MANTIDQT_INDIRECTFITANALYSISTABTEST_H_
 
-#include "IndirectFitAnalysisTab.cpp"
+#include "IndirectFitAnalysisTab.h"
 #include "MantidAPI/FunctionFactory.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
+using namespace MantidQt::CustomInterfaces::IDA;
+
 class IndirectFitAnalysisTabTest : public CxxTest::TestSuite {
 public:
   /// Needed to make sure everything is initialized
-  IndirectFitAnalysisTabTest() {}
-
-  static IndirectFitAnalysisTabTest *createSuite() {
-    return new IndirectFitAnalysisTabTest();
-  }
-
-  static void destroySuite(IndirectFitAnalysisTabTest *suite) { delete suite; }
+  IndirectFitAnalysisTabTest() = default;
 
   void test_that_single_function_correctly_identified() {
     std::string functionName = "ExpDecay";
     auto fitFunction =
         Mantid::API::FunctionFactory::Instance().createFunction(functionName);
     auto occurances =
-        getNumberOfSpecificFunctionContained(functionName, fitFunction);
+        IndirectFitAnalysisTab::getNumberOfSpecificFunctionContained(
+            functionName, fitFunction.get());
     TS_ASSERT_EQUALS(occurances, 1);
   }
 
@@ -38,11 +35,24 @@ public:
         Mantid::API::FunctionFactory::Instance().createInitialized(
             functionName);
     auto occurances =
-        getNumberOfSpecificFunctionContained("ExpDecay", fitFunction);
+        IndirectFitAnalysisTab::getNumberOfSpecificFunctionContained(
+            "ExpDecay", fitFunction.get());
     auto stretchOccurances =
-        getNumberOfSpecificFunctionContained("StretchExp", fitFunction);
+        IndirectFitAnalysisTab::getNumberOfSpecificFunctionContained(
+            "StretchExp", fitFunction.get());
     TS_ASSERT_EQUALS(occurances, 1);
     TS_ASSERT_EQUALS(stretchOccurances, 1);
+  }
+
+  void test_that_no_matched_name_is_correct() {
+    std::string functionName = "name=ExpDecay;name=StretchExp";
+    auto fitFunction =
+        Mantid::API::FunctionFactory::Instance().createInitialized(
+            functionName);
+    auto occurances =
+        IndirectFitAnalysisTab::getNumberOfSpecificFunctionContained(
+            "NotHere", fitFunction.get());
+    TS_ASSERT_EQUALS(occurances, 0);
   }
 
   void test_that_multi_layer_composite_function_handled_correctly() {
@@ -53,8 +63,10 @@ public:
         Mantid::API::FunctionFactory::Instance().createInitialized(
             functionName);
     auto occurances =
-        getNumberOfSpecificFunctionContained("ExpDecay", fitFunction);
+        IndirectFitAnalysisTab::getNumberOfSpecificFunctionContained(
+            "ExpDecay", fitFunction.get());
     TS_ASSERT_EQUALS(occurances, 4);
   }
 };
-#endif
+
+#endif // MANTIDQT_INDIRECTFITANALYSISTABTEST_H_


### PR DESCRIPTION
**Description of work.**

The numberOfCustomFunctions function in the IndirectFitAnalysisTab class was previously a stub. This was causing the names of the fits outputted to lack information on what functions were being fitted. This PR updates this function to correctly parse out the information from the fitfunction object.

**Report to:** spencer

**To test:**

- Relevant data can be found in  #26631
- In the Iqt fit tab load some data and select a single exponential and so a fit. The output workspaces should have 1E in the name.
- Click on stretch exponential and do another fit. The output workspaces should have 1E1S in the name.

Partially Fixes #27198 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because this fixes an issue added in this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
