### PR TITLE
Accept spec nums other than 4 or 5 for SANS Monitor

### DIFF
--- a/scripts/SANS/sans/user_file/user_file_parser.py
+++ b/scripts/SANS/sans/user_file/user_file_parser.py
@@ -1391,12 +1391,16 @@ class TransParser(UserFileComponentParser):
 
         dist, monitor = int(split_vars[0]), int(split_vars[1])
 
-        if monitor == 4:
-            return {TransId.spec_4_shift: dist}
-        elif monitor == 5:
+        if monitor == 5:
             return {TransId.spec_5_shift: dist}
+        elif monitor >= 0:
+            # Some instruments (i.e. LOQ) do not have monitor 4 on spectrum 4, as ZOOM
+            # is currently the only one with monitor 5 at spectrum 5 we can make it an edge case
+            # If a future instrument wants to use monitor 5 at a different spectrum number or
+            # uses monitor 4 at spectrum 5 this should be updated
+            return {TransId.spec_4_shift: dist}
         else:
-            raise RuntimeError("The monitor {0} cannot be shifted".format(monitor))
+            raise RuntimeError("Monitor {0} cannot be shifted".format(monitor))
 
     def _extract_trans_spec(self, line):
         trans_spec_string = re.sub(self._trans_spec, "", line)
@@ -1418,11 +1422,14 @@ class TransParser(UserFileComponentParser):
         trans_spec_shift_string = re.sub(" ", "", trans_spec_shift_string)
         trans_spec_shift = convert_string_to_float(trans_spec_shift_string)
 
-        # Pair up the monitor and shift amount
-        if trans_spec == 4:
-            return {TransId.spec_4_shift: trans_spec_shift, TransId.spec: trans_spec}
-        elif trans_spec == 5:
+        if trans_spec == 5:
             return {TransId.spec_5_shift: trans_spec_shift, TransId.spec: trans_spec}
+        elif trans_spec >= 0:
+            # Some instruments (i.e. LOQ) do not have monitor 4 on spectrum 4, as ZOOM
+            # is currently the only one with monitor 5 at spectrum 5 we can make it an edge case
+            # If a future instrument wants to use monitor 5 at a different spectrum number or
+            # uses monitor 4 at spectrum 5 this should be updated
+            return {TransId.spec_4_shift: trans_spec_shift, TransId.spec: trans_spec}
         else:
             raise RuntimeError("Monitor {0} cannot be shifted".format(trans_spec))
 

--- a/scripts/test/SANS/user_file/user_file_parser_test.py
+++ b/scripts/test/SANS/user_file/user_file_parser_test.py
@@ -597,24 +597,27 @@ class TransParserTest(unittest.TestCase):
                           "TRANS/ SHIFT=4000 5": {TransId.spec_5_shift: 4000},
                           "TRANS /SHIFT=4000 5": {TransId.spec_5_shift: 4000},
                           "TRANS/SHIFT=4000      5": {TransId.spec_5_shift: 4000},
+                          # An unrecognised monitor position (i.e. not 5) should be considered as 4
+                          # see source code for details
+                          "TRANS/SHIFT=1000 12": {TransId.spec_4_shift: 1000},
+                          "TRANS/SHIFT=4000 =12": {TransId.spec_4_shift: 4000},
+                          "TRANS/SHIFT=4000 =1": {TransId.spec_4_shift: 4000},
+                          "TRANS/SHIFT4000 120": {TransId.spec_4_shift: 4000},
+                          "TRANS/SHIFT 4000 999": {TransId.spec_4_shift: 4000},
                           }
 
-        invalid_settings = {"TRANS/SHIFT=1000 12": RuntimeError,
+        invalid_settings = {
                             "TRANS/SHIFT=4000 -1" : RuntimeError,
                             "TRANS/SHIFT+4000 -1": RuntimeError,
                             "TRANS/TRANSSHIFT=4000 -1": RuntimeError,
                             "TRANS/SHIFTAab=4000 -1": RuntimeError,
                             "TRANS/SHIF=4000 1": RuntimeError,
                             "TRANS/SHIFT4000": RuntimeError,
-                            "TRANS/SHIFT4000 1": RuntimeError,
-                            "TRANS/SHIFT 4000 1": RuntimeError,
                             "TRANS/SHIFT 1": RuntimeError,
                             "TRANS/SHIFT 4000": RuntimeError,
                             "TRANS/SHIFT=4000": RuntimeError,
                             "TRANS/SHIFT=4000 a": RuntimeError,
-                            "TRANS/SHIFT=4000 =12": RuntimeError,
-                            "TRANS/SHIFT=4000 =1": RuntimeError,
-        }
+                            }
 
         trans_parser = TransParser()
         do_test(trans_parser, valid_settings, invalid_settings, self.assertTrue, self.assertRaises)
@@ -622,11 +625,11 @@ class TransParserTest(unittest.TestCase):
     def test_that_trans_spec_shift_is_parsed_correctly(self):
         valid_settings = {"TRANS/TRANSPEC=4/SHIFT=23": {TransId.spec_4_shift: 23, TransId.spec: 4},
                           "TRANS/TRANSPEC =4/ SHIFT = 23": {TransId.spec_4_shift: 23, TransId.spec: 4},
+                          "TRANS/TRANSPEC =900/ SHIFT = 23": {TransId.spec_4_shift: 23, TransId.spec: 900},
 
                           }
 
         invalid_settings = {
-                            "TRANS/TRANSPEC =6/ SHIFT = 23": RuntimeError,
                             "TRANS/TRANSPEC=4/SHIFT/23": RuntimeError,
                             "TRANS/TRANSPEC=4/SHIFT 23": RuntimeError,
                             "TRANS/TRANSPEC/SHIFT=23": RuntimeError,


### PR DESCRIPTION
**Description of work.**
Accept spectrum numbers other than 4 or 5. LOQ, for example, uses a
spectrum number around 17000 for their offset, which internally is
mapped to monitor 4. The exception is ZOOM which also can use monitor 5,
however it is (currently) the only instrument using spec 5 so a simple
check will suffice

**Report to:** 
ISIS/Steve

**To test:**
Open the following file 
[USER_LOQ_192D_M4_Lu_12mm_Changer_MAIN_LIN.txt](https://github.com/mantidproject/mantid/files/3815686/USER_LOQ_192D_M4_Lu_12mm_Changer_MAIN_LIN.txt)

If an error does not pop up the problem is solved
Go to the settings -> monitor page, check monitor 4 has a shift

Fixes #27281 . 

*This does not require release notes* because this was not broken in the previous release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
