### PR TITLE
Add check on qt version to disable docking in I(Q, t) fit tab browser

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -155,6 +155,9 @@ void IndirectFitAnalysisTab::setFitPropertyBrowser(
     IndirectFitPropertyBrowser *browser) {
   browser->init();
   m_fitPropertyBrowser = browser;
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  m_fitPropertyBrowser->setFeatures(QDockWidget::NoDockWidgetFeatures);
+#endif
 }
 
 void IndirectFitAnalysisTab::loadSettings(const QSettings &settings) {


### PR DESCRIPTION
This PR disables the ability to pop out the fit browser in `Indirect` -> `Data Analysis` in workbench.
This implements the same QT version check to `IndirectFitAnalysisTab.cpp` that exists in `IndirectFitAnalysisTabLegacy.cpp`

**To test:**
1. open workbench
1. `Interfaces` -> `Indirect`-> `Data Analysis`
1. I(Q, t) Fit tab
1. The button to pop the Fit Function should not be available.
1. do the same with MantidPlot, the button should be present and functional.

Fixes #27247

*This does not require release notes* because this bug is new to this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
