### PR TITLE
Convert output workspace from elemental analysis to histogram

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -97,6 +97,7 @@ def merge_workspaces(run, workspaces):
             merged_ws = create_merged_workspace(workspace_list)
             # add merged ws to ADS
             mantid.mtd.add(detector, merged_ws)
+            mantid.ConvertToHistogram(InputWorkspace=detector, OutputWorkspace=detector)
             overall_ws.add(detector)
 
     mantid.AnalysisDataService.remove("tmp")


### PR DESCRIPTION
This PR changes the output from the elemental analyisis from point data to histogram.

**To test:**

1. open Workbench
1. `Muon` -> `Elemental Analyisis`
1. load data (2695)
1. from ads plot spectra from the output workspaces.
1. the data should be a histogram (allow for normalizing by bin width.)

Fixes #27291. 

*This does not require release notes* because it fixes a bug introduced in this itteration.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
