### PR TITLE
Fix user sample thickness resetting when processing data

### DIFF
--- a/scripts/SANS/sans/gui_logic/models/table_model.py
+++ b/scripts/SANS/sans/gui_logic/models/table_model.py
@@ -15,6 +15,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 import re
 
+from mantid.kernel import Logger
 from sans.common.constants import ALL_PERIODS
 from sans.common.enums import RowState, SampleShape
 from sans.common.file_information import SANSFileInformationFactory
@@ -30,7 +31,9 @@ class TableModel(object):
                              "sample_shape", "options_column_model"]
     THICKNESS_ROW = 14
 
-    def __init__(self):
+    logger = Logger("ISIS SANS GUI")
+
+    def __init__(self, file_information_factory=SANSFileInformationFactory()):
         super(TableModel, self).__init__()
         self._user_file = ""
         self._batch_file = ""
@@ -38,6 +41,8 @@ class TableModel(object):
         self.work_handler = WorkHandler()
         self._subscriber_list = []
         self._id_count = 0
+
+        self._file_information = file_information_factory
 
     @staticmethod
     def _validate_file_name(file_name):
@@ -163,7 +168,6 @@ class TableModel(object):
         if not rows:
             rows = range(len(self._table_entries))
 
-        file_information_factory = SANSFileInformationFactory()
         for row in rows:
             entry = self._table_entries[row]
             if entry.is_empty():
@@ -171,7 +175,7 @@ class TableModel(object):
             entry.file_finding = True
 
             try:
-                file_info = file_information_factory.create_sans_file_information(entry.sample_scatter)
+                file_info = self._file_information.create_sans_file_information(entry.sample_scatter)
             except RuntimeError:
                 continue
 
@@ -179,6 +183,7 @@ class TableModel(object):
 
     def failure_handler(self, id, error):
         row = self.get_row_from_id(id)
+
         self._table_entries[row].update_attribute('file_information', '')
         self._table_entries[row].update_attribute('sample_thickness', '')
         self._table_entries[row].update_attribute('sample_height', '')
@@ -187,17 +192,43 @@ class TableModel(object):
         self._table_entries[row].file_finding = False
         self.set_row_to_error(row, str(error[1]))
 
-    def update_thickness_from_file_information(self, id, file_information):
-        row = self.get_row_from_id(id)
-        if file_information:
-            rounded_file_thickness = round(file_information.get_thickness(), 2)
-            rounded_file_height = round(file_information.get_height(), 2)
-            rounded_file_width = round(file_information.get_width(), 2)
+    @staticmethod
+    def convert_to_float_or_return_none(val):
+        """
+        Attempts to convert to a float or return None
+        :param val: The value to convert
+        :return: The float or None if the conversion failed
+        """
+        try:
+            converted_val = float(val)
+            return converted_val
+        except ValueError:
+            return None
 
+    def update_thickness_from_file_information(self, id, file_information):
+
+        row = self.get_row_from_id(id)
+        entry = self._table_entries[row]
+
+        for attr in ["sample_thickness", "sample_height", "sample_width"]:
+            original_val = getattr(entry, attr)
+            converted = self.convert_to_float_or_return_none(original_val)
+            setattr(entry, attr, converted)
+            if converted is None and original_val:
+                self.logger.warning(
+                    "The {0} entered ({1}) could not be converted to a length. Using the one from the original sample."
+                    .format(attr.replace('_', ' '), original_val))
+
+        thickness = float(entry.sample_thickness) if entry.sample_thickness else round(file_information.get_thickness(),
+                                                                                       2)
+        height = float(entry.sample_height) if entry.sample_height else round(file_information.get_height(), 2)
+        width = float(entry.sample_width) if entry.sample_width else round(file_information.get_width(), 2)
+
+        if file_information:
             self._table_entries[row].update_attribute('file_information', file_information)
-            self._table_entries[row].update_attribute('sample_thickness', rounded_file_thickness)
-            self._table_entries[row].update_attribute('sample_height', rounded_file_height)
-            self._table_entries[row].update_attribute('sample_width', rounded_file_width)
+            self._table_entries[row].update_attribute('sample_thickness', thickness)
+            self._table_entries[row].update_attribute('sample_height', height)
+            self._table_entries[row].update_attribute('sample_width', width)
             if self._table_entries[row].sample_shape_string == "":
                 self._table_entries[row].update_attribute('sample_shape', file_information.get_shape())
             self._table_entries[row].file_finding = False
@@ -234,8 +265,7 @@ class TableModel(object):
             row = self.get_number_of_rows() - 1
 
         entry = self._table_entries[row]
-        file_information_factory = SANSFileInformationFactory()
-        file_information = file_information_factory.create_sans_file_information(entry.sample_scatter)
+        file_information = self._file_information.create_sans_file_information(entry.sample_scatter)
         self.update_thickness_from_file_information(entry.id, file_information)
 
     def set_option(self, row, key, value):
@@ -394,9 +424,9 @@ class OptionsColumnModel(object):
                                   "MergeScale": 'The scale applied to the HAB when merging',
                                   "MergeShift": 'The shift applied to the HAB when merging',
                                   "EventSlices": 'The event slices to reduce.'
-                                  ' The format is the same as for the event slices'
-                                  ' box in settings, however if a comma separated list is given '
-                                  'it must be enclosed in quotes'})
+                                                 ' The format is the same as for the event slices'
+                                                 ' box in settings, however if a comma separated list is given '
+                                                 'it must be enclosed in quotes'})
 
     @staticmethod
     def _parse_string(options_column_string):
@@ -424,13 +454,13 @@ class OptionsColumnModel(object):
         # The findall option finds all instances of the pattern specified above in the options string.
         for key, value in option_pattern.findall(options_column_string_no_whitespace):
             if value.endswith(','):
-                value=value[:-1]
-            parsed.update({key:value})
+                value = value[:-1]
+            parsed.update({key: value})
 
         return parsed
 
     def _serialise_options_dict(self):
-        return ', '.join(['{}={}'.format(k,self._options[k]) for k in sorted(self._options)])
+        return ', '.join(['{}={}'.format(k, self._options[k]) for k in sorted(self._options)])
 
     @staticmethod
     def _get_options(options_column_string):

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -81,15 +81,6 @@ class GuiStateDirectorTest(unittest.TestCase):
         self.assertEqual(state.reduction.merge_scale, 1.2)
         self.assertEqual(state.reduction.merge_shift, 0.5)
 
-    def test_that_sample_thickness_set_on_state(self):
-        table_model = self._get_table_model()
-        state_model = self._get_state_gui_model()
-        director = GuiStateDirector(table_model, state_model, SANSFacility.ISIS)
-
-        state = director.create_state(0)
-        self.assertTrue(isinstance(state, State))
-
-        self.assertEqual(state.scale.thickness, 1.0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/SANS/gui_logic/table_model_test.py
+++ b/scripts/test/SANS/gui_logic/table_model_test.py
@@ -7,12 +7,13 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+from mock import patch, ANY
+from qtpy.QtCore import QCoreApplication
 
 from mantid.py3compat import mock
-from sans.gui_logic.models.table_model import (TableModel, TableIndexModel, OptionsColumnModel, SampleShapeColumnModel, options_column_bool)
-from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
-from qtpy.QtCore import QCoreApplication
 from sans.common.enums import (RowState, SampleShape)
+from sans.gui_logic.models.basic_hint_strategy import BasicHintStrategy
+from sans.gui_logic.models.table_model import (TableModel, TableIndexModel, OptionsColumnModel, options_column_bool)
 
 
 class TableModelTest(unittest.TestCase):
@@ -35,7 +36,7 @@ class TableModelTest(unittest.TestCase):
         table_index_model = TableIndexModel(*row_entry)
         table_model.add_table_entry(0, table_index_model)
         returned_model = table_model.get_table_entry(0)
-        self.assertEqual(returned_model.sample_scatter,  '')
+        self.assertEqual(returned_model.sample_scatter, '')
 
     def test_that_can_set_the_options_column_model(self):
         table_index_model = TableIndexModel('0', "", "", "", "", "", "",
@@ -43,14 +44,14 @@ class TableModelTest(unittest.TestCase):
                                             options_column_string="WavelengthMin=1, WavelengthMax=3, NotRegister2=1")
         options_column_model = table_index_model.options_column_model
         options = options_column_model.get_options()
-        self.assertEqual(len(options),  2)
-        self.assertEqual(options["WavelengthMin"],  1.)
-        self.assertEqual(options["WavelengthMax"],  3.)
+        self.assertEqual(len(options), 2)
+        self.assertEqual(options["WavelengthMin"], 1.)
+        self.assertEqual(options["WavelengthMax"], 3.)
 
     def test_that_raises_for_missing_equal(self):
         args = [0, "", "", "", "", "", "", "", "", "", "", "", "", "", ""]
         kwargs = {'options_column_string': "WavelengthMin=1, WavelengthMax=3, NotRegister2"}
-        self.assertRaises(ValueError,  TableIndexModel, *args, **kwargs)
+        self.assertRaises(ValueError, TableIndexModel, *args, **kwargs)
 
     def test_that_sample_shape_can_be_parsed(self):
         table_index_model = TableIndexModel('0', "", "", "", "", "", "",
@@ -75,15 +76,11 @@ class TableModelTest(unittest.TestCase):
         self.assertEqual(sample_shape_text, "FlatPlate")
 
     def test_that_incorrect_sample_shape_reverts_to_previous_sampleshape(self):
-        try:
-            table_index_model = TableIndexModel('0', "", "", "", "", "", "",
-                                                "", "", "", "", "", "", "", "",
-                                                sample_shape="Disc")
-            table_index_model.sample_shape = "not a sample shape"
-        except Exception as e:
-            self.fail("Did not except incorrect sample shape to raise error")
-        else:
-            self.assertEqual("Disc", table_index_model.sample_shape_string)
+        table_index_model = TableIndexModel('0', "", "", "", "", "", "",
+                                            "", "", "", "", "", "", "", "",
+                                            sample_shape="Disc")
+        table_index_model.sample_shape = "not a sample shape"
+        self.assertEqual("Disc", table_index_model.sample_shape_string)
 
     def test_that_empty_string_is_acceptable_sample_shape(self):
         table_index_model = TableIndexModel('0', "", "", "", "", "", "",
@@ -119,7 +116,7 @@ class TableModelTest(unittest.TestCase):
                                             "", "", "", "", "", "", "User_file_name")
         table_model.add_table_entry(2, table_index_model)
         user_file = table_model.get_row_user_file(0)
-        self.assertEqual(user_file,"User_file_name")
+        self.assertEqual(user_file, "User_file_name")
 
     def test_that_can_retrieve_sample_thickness_from_table_index_model(self):
         sample_thickness = '8.0'
@@ -130,6 +127,105 @@ class TableModelTest(unittest.TestCase):
         table_model.get_thickness_for_rows()
         row_entry = table_model.get_table_entry(0)
         self.assertEqual(row_entry.sample_thickness, sample_thickness)
+
+    @patch("sans.common.file_information.SANSFileInformation", autospec=True)
+    @patch("sans.common.file_information.SANSFileInformationFactory", autospec=True)
+    def test_that_sample_dimensions_are_respected(self, file_info_factory_mock, file_info_mock):
+        # Check that if the user enters their own sample dimensions we do not override them
+        file_info_mock.get_shape.return_value = ""
+
+        file_dimensions = 1.0
+        file_info_mock.get_height.return_value = file_dimensions
+        file_info_mock.get_thickness.return_value = file_dimensions
+        file_info_mock.get_width.return_value = file_dimensions
+
+        file_info_factory_mock.create_sans_file_information.return_value = file_info_mock
+
+        expected_dims = ['12.0', '13.0', '14.0']
+
+        table_model = TableModel(file_information_factory=file_info_factory_mock)
+        table_index_model = TableIndexModel("1", "", "", "", "", "",
+                                            "", "", "", "", "", "",
+                                            sample_thickness=expected_dims[0],
+                                            sample_height=expected_dims[1],
+                                            sample_width=expected_dims[2])
+        table_model.add_table_entry(row=1, table_index_model=table_index_model)
+        table_model.get_thickness_for_rows()
+
+        row_entry = table_model.get_table_entry(0)
+        file_info_factory_mock.create_sans_file_information.assert_any_call(ANY)
+        self.assertEqual(float(expected_dims[0]), row_entry.sample_thickness)
+        self.assertEqual(float(expected_dims[1]), row_entry.sample_height)
+        self.assertEqual(float(expected_dims[2]), row_entry.sample_width)
+
+    @patch("sans.common.file_information.SANSFileInformation", autospec=True)
+    @patch("sans.common.file_information.SANSFileInformationFactory", autospec=True)
+    def test_sample_dimensions_loaded_if_not_specified(self, file_info_factory_mock, file_info_mock):
+        file_info_mock.get_shape.return_value = ""
+
+        file_dimensions = 12.0
+        file_info_mock.get_height.return_value = file_dimensions
+        file_info_mock.get_thickness.return_value = file_dimensions
+        file_info_mock.get_width.return_value = file_dimensions
+
+        file_info_factory_mock.create_sans_file_information.return_value = file_info_mock
+
+        blank_dim = " "  # have a space to check whitespace isn't considered as a length
+
+        table_model = TableModel(file_information_factory=file_info_factory_mock)
+        table_index_model = TableIndexModel("1", "", "", "", "", "",
+                                            "", "", "", "", "", "",
+                                            sample_thickness=blank_dim,
+                                            sample_height=blank_dim,
+                                            sample_width=blank_dim)
+        table_model.add_table_entry(row=1, table_index_model=table_index_model)
+        table_model.get_thickness_for_rows()
+
+        row_entry = table_model.get_table_entry(0)
+        file_info_factory_mock.create_sans_file_information.assert_any_call(ANY)
+        self.assertEqual(file_dimensions, row_entry.sample_thickness)
+        self.assertEqual(file_dimensions, row_entry.sample_height)
+        self.assertEqual(file_dimensions, row_entry.sample_width)
+
+    @patch("sans.common.file_information.SANSFileInformation", autospec=True)
+    def test_bad_user_length_is_handled(self, file_info_mock):
+        file_dimensions = 12.0
+        file_info_mock.get_shape.return_value = ""
+        file_info_mock.get_height.return_value = file_dimensions
+        file_info_mock.get_thickness.return_value = file_dimensions
+        file_info_mock.get_width.return_value = file_dimensions
+
+        table_model = TableModel()
+        table_index_model = TableIndexModel("1", "", "", "", "", "",
+                                            "", "", "", "", "", "",
+                                            sample_thickness="a",
+                                            sample_height="b",
+                                            sample_width="c")
+        table_model.add_table_entry(0, table_index_model=table_index_model)
+
+        logger_mock = mock.Mock()
+        table_model.logger = logger_mock
+
+        table_model.update_thickness_from_file_information(id=0, file_information=file_info_mock)
+
+        logger_mock.warning.assert_any_call(ANY)
+        self.assertEqual(3, logger_mock.warning.call_count)  # One warning for each sample dim
+
+    def test_convert_to_float(self):
+        table_model = TableModel()
+
+        from_valid_string = table_model.convert_to_float_or_return_none("3.0")
+        self.assertEqual(3.0, from_valid_string)
+
+    def test_convert_to_float_from_existing_float(self):
+        table_model = TableModel()
+        from_existing_float = table_model.convert_to_float_or_return_none(4.0)
+        self.assertEqual(4.0, from_existing_float)
+
+    def test_convert_to_float_from_bad_input(self):
+        table_model = TableModel()
+        from_bad_input = table_model.convert_to_float_or_return_none("")
+        self.assertEqual(None, from_bad_input)
 
     def test_that_parse_string_returns_correctly(self):
         string_to_parse = 'EventSlices=1-6,5-9,4:5:89 , WavelengthMax=78 , WavelengthMin=9'
@@ -187,27 +283,27 @@ class TableModelTest(unittest.TestCase):
     def test_that_OptionsColumnModel_get_permissable_properties_returns_correct_properties(self):
         permissable_properties = OptionsColumnModel._get_permissible_properties()
 
-        self.assertEqual(permissable_properties, {"WavelengthMin":float, "WavelengthMax": float, "EventSlices": str,
+        self.assertEqual(permissable_properties, {"WavelengthMin": float, "WavelengthMax": float, "EventSlices": str,
                                                   "MergeScale": float, "MergeShift": float, "PhiMin": float,
                                                   "PhiMax": float, "UseMirror": options_column_bool})
 
     def test_that_OptionsColumnModel_get_hint_strategy(self):
         hint_strategy = OptionsColumnModel.get_hint_strategy()
         expected_hint_strategy = BasicHintStrategy({
-                                    "WavelengthMin": 'The min value of the wavelength when converting from TOF.',
-                                    "WavelengthMax": 'The max value of the wavelength when converting from TOF.',
-                                    "PhiMin": 'The min angle of the detector to accept.'
-                                              ' Anti-clockwise from horizontal.',
-                                    "PhiMax": 'The max angle of the detector to accept.'
-                                              ' Anti-clockwise from horizontal.',
-                                    "UseMirror": 'True or False. Whether or not to accept phi angle'
-                                                 ' in opposing quadrant',
-                                    "MergeScale": 'The scale applied to the HAB when merging',
-                                    "MergeShift": 'The shift applied to the HAB when merging',
-                                    "EventSlices": 'The event slices to reduce.'
-                                                   ' The format is the same as for the event slices'
-                                                   ' box in settings, however if a comma separated list is given '
-                                                   'it must be enclosed in quotes'})
+            "WavelengthMin": 'The min value of the wavelength when converting from TOF.',
+            "WavelengthMax": 'The max value of the wavelength when converting from TOF.',
+            "PhiMin": 'The min angle of the detector to accept.'
+                      ' Anti-clockwise from horizontal.',
+            "PhiMax": 'The max angle of the detector to accept.'
+                      ' Anti-clockwise from horizontal.',
+            "UseMirror": 'True or False. Whether or not to accept phi angle'
+                         ' in opposing quadrant',
+            "MergeScale": 'The scale applied to the HAB when merging',
+            "MergeShift": 'The shift applied to the HAB when merging',
+            "EventSlices": 'The event slices to reduce.'
+                           ' The format is the same as for the event slices'
+                           ' box in settings, however if a comma separated list is given '
+                           'it must be enclosed in quotes'})
 
         self.assertEqual(expected_hint_strategy, hint_strategy)
 
@@ -308,7 +404,7 @@ class TableModelTest(unittest.TestCase):
     def test_that_non_bool_option_raises_error_if_option_is_bool(self):
         with self.assertRaises(ValueError):
             OptionsColumnModel("UseMirror=SomeString")
-            
+
     def test_that_to_batch_list_is_correct_format(self):
         test_row = ['SANS2D00022024  ', '', 'SANS2D00022025 ', '', '   SANS2D00022026 ', '', '', '', '', '', '', '',
                     '    out_file', 'a_user_file ', 1.0, 5.0, 5.4, 'Disc', 'WavelengthMax=5.0']
@@ -316,7 +412,7 @@ class TableModelTest(unittest.TestCase):
 
         actual_list = table_index_model.to_batch_list()
         expected_list = ["SANS2D00022024", "SANS2D00022025", "SANS2D00022026",
-                         "", "", "",  "out_file", "a_user_file", "1.0", "5.0", "5.4"]
+                         "", "", "", "out_file", "a_user_file", "1.0", "5.0", "5.4"]
 
         self.assertEqual(actual_list, expected_list)
 


### PR DESCRIPTION
**Cannot be merged before #27239**

**Description of work.**
Custom sample thicknesses were not being preserved. This fixes the issue so that if a custom one is set in the table, we respect that rather than loading the file thickness over the top.

Additionally, I've improved the warning to help users find what they did wrong, previously it just said that we failed to convert to a float in the SANS state object.

**Report to:** ISIS/Steve

**To test:**
- Download the ISIS training data
- Open the ISIS SANS GUI
- Go to the LOQ demo folder and set the user file to `maskfile.txt`
- Set the batch file to `batch.csv`
- Modify the pre-set sample thicknesses to something that isn't 1.0
- Hit load then check they are what you set
- Select the first row and hit process selected, check it's still what you set
- Hit process all and check that it's still set
- Change the sample thickness to something that isn't a number
- Hit either load / process selected / process all and check a warning is emitted
- Check that 1.0 is used instead

Fixes #27239 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because this broke between releases

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
