### PR TITLE
Added application to feature usage messages

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/UsageService.h
+++ b/Framework/Kernel/inc/MantidKernel/UsageService.h
@@ -41,7 +41,8 @@ enum class FeatureType { Algorithm, Interface, Feature };
 class FeatureUsage {
 public:
   /// Constructor
-  FeatureUsage(const FeatureType &type, std::string name, const bool internal);
+  FeatureUsage(const FeatureType &type, std::string name, const bool internal,
+               std::string application);
   bool operator<(const FeatureUsage &r) const;
 
   ::Json::Value asJson() const;
@@ -49,6 +50,7 @@ public:
   FeatureType type;
   std::string name;
   bool internal;
+  std::string application;
 
 protected:
   std::string featureTypeToString() const;

--- a/Framework/Kernel/src/UsageService.cpp
+++ b/Framework/Kernel/src/UsageService.cpp
@@ -37,8 +37,9 @@ Kernel::Logger g_log("UsageServiceImpl");
 /** FeatureUsage
  */
 FeatureUsage::FeatureUsage(const FeatureType &type, std::string name,
-                           const bool internal)
-    : type(type), name(std::move(name)), internal(internal) {}
+                           const bool internal, std::string application)
+    : type(type), name(std::move(name)), internal(internal),
+      application(std::move(application)) {}
 
 // Better brute force.
 bool FeatureUsage::operator<(const FeatureUsage &r) const {
@@ -80,6 +81,7 @@ std::string FeatureUsage::featureTypeToString() const {
   retVal["type"] = featureTypeToString();
   retVal["name"] = name;
   retVal["internal"] = internal;
+  retVal["application"] = application;
 
   return retVal;
 }
@@ -136,7 +138,8 @@ void UsageServiceImpl::registerFeatureUsage(
     std::lock_guard<std::mutex> _lock(m_mutex);
 
     using boost::algorithm::join;
-    m_FeatureQueue.push(FeatureUsage(type, join(name, SEPARATOR), internal));
+    m_FeatureQueue.push(FeatureUsage(type, join(name, SEPARATOR), internal,
+                                     getApplicationName()));
   }
 }
 
@@ -145,8 +148,8 @@ void UsageServiceImpl::registerFeatureUsage(const FeatureType &type,
                                             const bool internal) {
   if (isEnabled()) {
     std::lock_guard<std::mutex> _lock(m_mutex);
-
-    m_FeatureQueue.push(FeatureUsage(type, name, internal));
+    m_FeatureQueue.push(
+        FeatureUsage(type, name, internal, getApplicationName()));
   }
 }
 


### PR DESCRIPTION
**Description of work.**

This adds the application which generated a feature usage to feature usage messages. 

This should be tested in conjunction with the updates to the server testing instructions for which can be found here https://github.com/mantidproject/reports/pull/26 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #26991 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because this is a developer facing change


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
