### PR TITLE
RROA now scales IvsQ outputs

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto3.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/ReflectometryReductionOneAuto3.h
@@ -74,11 +74,13 @@ private:
   RebinParams getRebinParams(MatrixWorkspace_sptr inputWS, const double theta);
   boost::optional<double> getQStep(MatrixWorkspace_sptr inputWS,
                                    const double theta);
-  /// Rebin and scale a workspace in Q
+  // Optionally scale a workspace
   Mantid::API::MatrixWorkspace_sptr
-  rebinAndScale(Mantid::API::MatrixWorkspace_sptr inputWS,
-                const RebinParams &params);
-  /// Crop a workspace in Q
+  scale(Mantid::API::MatrixWorkspace_sptr inputWS);
+  /// Rebin a workspace in Q
+  Mantid::API::MatrixWorkspace_sptr
+  rebin(Mantid::API::MatrixWorkspace_sptr inputWS, const RebinParams &params);
+  /// Optionally crop a workspace in Q
   MatrixWorkspace_sptr cropQ(MatrixWorkspace_sptr inputWS,
                              const RebinParams &params);
   /// Populate algorithmic correction properties

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto3Test.h
@@ -518,6 +518,121 @@ public:
     TS_ASSERT_DELTA(outQ->binEdges(0)[6], 1.3414, 0.0001);
   }
 
+  void test_IvsQ_values() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outQ->counts(0).size(), 14);
+    // Y values in outQ
+    TS_ASSERT_DELTA(outQ->counts(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[13], 2.0000, 0.0001);
+  }
+
+  void test_IvsQ_values_scaled() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ScaleFactor", 0.1);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outQ->counts(0).size(), 14);
+    // Y values in outQ
+    TS_ASSERT_DELTA(outQ->counts(0)[0], 20.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[13], 20.0000, 0.0001);
+  }
+
+  void test_IvsQ_binned_values() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("MomentumTransferMin", 0.0);
+    alg.setProperty("MomentumTransferMax", 7.0);
+    alg.setProperty("MomentumTransferStep", -1.0);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspaceBinned");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outQ->counts(0).size(), 7);
+    // Y values in outQ
+    TS_ASSERT_DELTA(outQ->counts(0)[0], 21.1817, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[1], 5.2910, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[2], 1.5273, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[3], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[4], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[5], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[6], 0.0000, 0.0001);
+  }
+
+  void test_IvsQ_binned_values_scaled() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("MomentumTransferMin", 0.0);
+    alg.setProperty("MomentumTransferMax", 7.0);
+    alg.setProperty("MomentumTransferStep", -1.0);
+    alg.setProperty("ScaleFactor", 0.1);
+    alg.execute();
+    MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspaceBinned");
+
+    TS_ASSERT_EQUALS(outQ->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outQ->counts(0).size(), 7);
+    // Y values in outQ
+    TS_ASSERT_DELTA(outQ->counts(0)[0], 211.8171, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[1], 52.9097, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[2], 15.2731, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[3], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[4], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[5], 0.0000, 0.0001);
+    TS_ASSERT_DELTA(outQ->counts(0)[6], 0.0000, 0.0001);
+  }
+
+  void test_IvsLam_values() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.execute();
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+
+    TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outLam->counts(0).size(), 14);
+    // Y values in outLam
+    TS_ASSERT_DELTA(outLam->counts(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->counts(0)[13], 2.0000, 0.0001);
+  }
+
+  void test_IvsLam_values_are_not_scaled() {
+
+    ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
+    alg.setProperty("WavelengthMin", 1.5);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ScaleFactor", 0.1);
+    alg.execute();
+    MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
+
+    TS_ASSERT_EQUALS(outLam->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(outLam->counts(0).size(), 14);
+    // Y values in outLam
+    TS_ASSERT_DELTA(outLam->counts(0)[0], 2.0000, 0.0001);
+    TS_ASSERT_DELTA(outLam->counts(0)[13], 2.0000, 0.0001);
+  }
+
   void test_optional_outputs() {
     auto inter = loadRun("INTER00013460.nxs");
     const double theta = 0.7;

--- a/Framework/Algorithms/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Algorithms/test/ReflectometryReductionOneAuto3Test.h
@@ -64,17 +64,6 @@ private:
     return MatrixWorkspace_sptr();
   };
 
-  void momentumTransferHelper(ReflectometryReductionOneAuto3 &alg,
-                              MatrixWorkspace_sptr &inter,
-                              const double &theta) {
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inter);
-    alg.setProperty("ThetaIn", theta);
-    alg.setProperty("CorrectionAlgorithm", "None");
-    alg.setProperty("ProcessingInstructions", "4");
-    alg.setProperty("Debug", false);
-  }
-
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
@@ -105,78 +94,50 @@ public:
 
   void test_bad_input_workspace_units() {
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_notTOF);
+    setup_alg_on_workspace(alg, m_notTOF, boost::none, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "1");
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
   void test_bad_wavelength_range() {
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
     alg.setProperty("WavelengthMin", 15.0);
     alg.setProperty("WavelengthMax", 1.0);
-    alg.setProperty("ProcessingInstructions", "1");
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
   void test_bad_monitor_background_range() {
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "1");
     alg.setProperty("MonitorBackgroundWavelengthMin", 3.0);
     alg.setProperty("MonitorBackgroundWavelengthMax", 0.5);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
   void test_bad_monitor_integration_range() {
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "1");
     alg.setProperty("MonitorIntegrationWavelengthMin", 15.0);
     alg.setProperty("MonitorIntegrationWavelengthMax", 1.5);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
   void test_bad_first_transmission_run_units() {
     ReflectometryReductionOneAuto3 alg;
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "1");
     alg.setChild(true);
     alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
     alg.setProperty("FirstTransmissionRun", m_notTOF);
     alg.setProperty("WavelengthMin", 1.0);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "1");
     alg.setProperty("MonitorIntegrationWavelengthMin", 1.0);
     alg.setProperty("MonitorIntegrationWavelengthMax", 15.0);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     TS_ASSERT_THROWS_ANYTHING(alg.execute());
   }
 
@@ -265,15 +226,7 @@ public:
 
     // Use the default correction type, which is a vertical shift
     ReflectometryReductionOneAuto3 alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inter);
-    alg.setProperty("ThetaIn", theta);
-    alg.setProperty("CorrectionAlgorithm", "None");
-    alg.setProperty("OutputWorkspace", "IvsQ");
-    alg.setProperty("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setProperty("OutputWorkspaceWavelength", "IvsLam");
-    alg.setProperty("ProcessingInstructions", "4");
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.execute();
     MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspaceBinned");
 
@@ -318,17 +271,10 @@ public:
 
     // Correct by rotating detectors around the sample
     ReflectometryReductionOneAuto3 alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", polref);
-    alg.setProperty("ThetaIn", 1.5);
+    setup_alg_on_workspace(alg, polref, 1.5);
     alg.setProperty("DetectorCorrectionType", "RotateAroundSample");
     alg.setProperty("AnalysisMode", "MultiDetectorAnalysis");
-    alg.setProperty("CorrectionAlgorithm", "None");
     alg.setProperty("MomentumTransferStep", 0.01);
-    alg.setProperty("OutputWorkspace", "IvsQ");
-    alg.setProperty("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setProperty("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspace");
 
@@ -361,27 +307,20 @@ public:
 
   void test_correct_detector_position_vertical_CRISP() {
     // Histogram in this run corresponds to 'point-detector' component
-    auto polref = loadRun("CSP79590.raw");
+    auto crisp = loadRun("CSP79590.raw");
 
     // Correct by shifting detectors vertically
     // Also explicitly pass CorrectDetectors=1
     ReflectometryReductionOneAuto3 alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", polref);
-    alg.setProperty("ThetaIn", 0.25);
+    setup_alg_on_workspace(alg, crisp, 0.25);
     alg.setProperty("CorrectDetectors", "1");
     alg.setProperty("DetectorCorrectionType", "VerticalShift");
-    alg.setProperty("CorrectionAlgorithm", "None");
     alg.setProperty("MomentumTransferStep", 0.01);
-    alg.setProperty("OutputWorkspace", "IvsQ");
-    alg.setProperty("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setProperty("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr out = alg.getProperty("OutputWorkspace");
 
     // Compare instrument components before and after
-    auto instIn = polref->getInstrument();
+    auto instIn = crisp->getInstrument();
     auto instOut = out->getInstrument();
 
     // The following components should not have been moved
@@ -410,16 +349,9 @@ public:
 
     // Use theta from the logs to correct detector positions
     ReflectometryReductionOneAuto3 alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inter);
+    setup_alg_on_workspace(alg, inter, boost::none, "4");
     alg.setProperty("ThetaLogName", "theta");
     alg.setProperty("CorrectDetectors", "1");
-    alg.setProperty("CorrectionAlgorithm", "None");
-    alg.setProperty("OutputWorkspace", "IvsQ");
-    alg.setProperty("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setProperty("OutputWorkspaceWavelength", "IvsLam");
-    alg.setProperty("ProcessingInstructions", "4");
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 
@@ -455,16 +387,8 @@ public:
     auto inter = loadRun("INTER00013460.nxs");
 
     ReflectometryReductionOneAuto3 alg;
-    alg.initialize();
-    alg.setChild(true);
-    alg.setProperty("InputWorkspace", inter);
-    alg.setProperty("ThetaIn", 10.0);
+    setup_alg_on_workspace(alg, inter, 10.0, "4");
     alg.setProperty("CorrectDetectors", "0");
-    alg.setProperty("CorrectionAlgorithm", "None");
-    alg.setProperty("OutputWorkspace", "IvsQ");
-    alg.setProperty("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setProperty("OutputWorkspaceWavelength", "IvsLam");
-    alg.setProperty("ProcessingInstructions", "4");
     alg.execute();
     MatrixWorkspace_sptr corrected = alg.getProperty("OutputWorkspace");
 
@@ -483,18 +407,12 @@ public:
   void test_IvsQ_linear_binning() {
 
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "2");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "2");
     alg.setProperty("MomentumTransferMin", 1.0);
     alg.setProperty("MomentumTransferMax", 10.0);
     alg.setProperty("MomentumTransferStep", -0.04);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr outQbinned = alg.getProperty("OutputWorkspaceBinned");
 
@@ -516,18 +434,12 @@ public:
   void test_IvsQ_logarithmic_binning() {
 
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "2");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "2");
     alg.setProperty("MomentumTransferMin", 1.0);
     alg.setProperty("MomentumTransferMax", 10.0);
     alg.setProperty("MomentumTransferStep", 0.04);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr outQbinned = alg.getProperty("OutputWorkspaceBinned");
 
@@ -540,16 +452,10 @@ public:
   void test_IvsLam_range() {
 
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "3");
     alg.setProperty("MomentumTransferStep", 0.04);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
@@ -567,16 +473,10 @@ public:
   void test_IvsQ_range() {
 
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
-    alg.setProperty("ProcessingInstructions", "3");
     alg.setProperty("MomentumTransferStep", 0.04);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
@@ -599,18 +499,12 @@ public:
   void test_IvsQ_range_cropped() {
 
     ReflectometryReductionOneAuto3 alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspace", m_TOF);
+    setup_alg_on_workspace(alg, m_TOF, boost::none, "3");
     alg.setProperty("WavelengthMin", 1.5);
     alg.setProperty("WavelengthMax", 15.0);
     alg.setProperty("MomentumTransferMin", 0.5);
     alg.setProperty("MomentumTransferMax", 1.5);
-    alg.setProperty("ProcessingInstructions", "3");
     alg.setProperty("MomentumTransferStep", 0.04);
-    alg.setPropertyValue("OutputWorkspace", "IvsQ");
-    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
-    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
     alg.execute();
     MatrixWorkspace_sptr outQ = alg.getProperty("OutputWorkspace");
     MatrixWorkspace_sptr outLam = alg.getProperty("OutputWorkspaceWavelength");
@@ -1189,7 +1083,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferStep", 0.1);
     alg.setProperty("MomentumTransferMin", 0.1);
     alg.setProperty("MomentumTransferMax", 1.0);
@@ -1216,7 +1110,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferMin", 0.1);
     alg.execute();
 
@@ -1240,7 +1134,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferMax", 0.1);
     alg.execute();
 
@@ -1265,7 +1159,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferMin", 0.1);
     alg.setProperty("MomentumTransferMax", 1.0);
     alg.execute();
@@ -1291,7 +1185,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferStep", 0.1);
     alg.execute();
 
@@ -1316,7 +1210,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferStep", 0.1);
     alg.setProperty("MomentumTransferMin", 0.1);
     alg.execute();
@@ -1341,7 +1235,7 @@ public:
 
     ReflectometryReductionOneAuto3 alg;
     alg.initialize();
-    momentumTransferHelper(alg, inter, theta);
+    setup_alg_on_workspace(alg, inter, theta, "4");
     alg.setProperty("MomentumTransferStep", 0.1);
     alg.setProperty("MomentumTransferMax", 0.1);
     alg.execute();
@@ -1627,6 +1521,24 @@ private:
     alg.setProperty("ThetaIn", 10.0);
     alg.setProperty("ProcessingInstructions", "2");
     alg.setProperty("MomentumTransferStep", 0.04);
+  }
+
+  void setup_alg_on_workspace(
+      ReflectometryReductionOneAuto3 &alg, MatrixWorkspace_sptr &inter,
+      boost::optional<double> theta = boost::none,
+      boost::optional<const char *> processingInstructions = boost::none) {
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", inter);
+    if (theta)
+      alg.setProperty("ThetaIn", *theta);
+    alg.setProperty("CorrectionAlgorithm", "None");
+    if (processingInstructions)
+      alg.setProperty("ProcessingInstructions", *processingInstructions);
+    alg.setProperty("Debug", false);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
   }
 };
 

--- a/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
+++ b/docs/source/algorithms/ReflectometryReductionOneAuto-v3.rst
@@ -64,8 +64,9 @@ can be specified manually by setting the :literal:`CorrectionAlgorithm` to eithe
 Note that when using a correction algorithm, monitors will not be integrated, even if
 :literal:`NormalizeByIntegratedMonitors` was set to true.
 
-:literal:`OutputWorkspace` is cropped to `MomentumTransferMin` and/or
-:literal:`MomentumTransferMax`, if they are given.
+:literal:`OutputWorkspace` is scaled to :literal:`ScaleFactor` and cropped to
+:literal:`MomentumTransferMin` and/or :literal:`MomentumTransferMax`, if they
+are given.
 
 :literal:`OutputWorkspaceBinned` is rebinned to the resolution specified by
 :literal:`MomentumTransferStep`, if it is given; otherwise the algorithm
@@ -75,9 +76,6 @@ with a `vertical gap` must be defined in the instrument definition file - if it
 cannot be found, rebinning will not be done and a warning will be
 logged). `MomentumTransferMin` and `MomentumTransferMax` are used for the rebin
 if provided; otherwise the original min/max in Q is retained.
-
-Finally, `ScaleFactor` is used to scale the rebinned workspace
-:literal:`OutputWorkspaceBinned`.
 
 See :ref:`algm-ReflectometryReductionOne` for more information
 on how the input properties are used by the wrapped algorithm.

--- a/docs/source/release/v4.2.0/reflectometry.rst
+++ b/docs/source/release/v4.2.0/reflectometry.rst
@@ -17,7 +17,8 @@ New
 - **Project Recovery**: the interface state will be saved if Mantid crashes and will be reinstated as long as project recovery can recreate all of the workspaces.
 - The **live data update interval** can now be configured on the interface.
 - The **Slit Calculator** dialog can now be accessed from the Tools menu.
-- The **polarization correction** inputs have been simplified to a single checkbox which when ticked will apply polarization corrections based on properties in the instrument parameters file.
+- **Polarization correction** inputs have been simplified to a single checkbox which, when ticked, will apply polarization corrections based on properties in the instrument parameters file.
+- **ScaleFactor** is now applied to the stitched output and individual ``IvsQ`` workspaces (previously, only the ``IvsQ_binned`` workspaces were scaled).
 
 .. figure:: ../../images/Reflectometry-GUI-release4.2.png
    :class: screenshot
@@ -39,7 +40,11 @@ Bug fixes
 Algorithms
 ----------
 
-- :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto-v3>` has been updated to version 3. This version has simplified the polarization correction options to a single True/False argument. When True, this will apply polarization corrections based on properties in the instrument parameters file.
+- :ref:`ReflectometryReductionOneAuto <algm-ReflectometryReductionOneAuto-v3>` has been updated to version 3. Changes in this version are:
+
+  - ``PolarizationAnalysis`` is simplified to a single True/False argument which, when True, will apply corrections from the instrument parameters file;
+  - the unbinned ``IvsQ`` workspace is now scaled according to ``ScaleFactor`` (previously, only ``IvsQ_binned`` was scaled).
+
 - An issue has been fixed in `CreateTransmissionWorkspace <algm-CreateTransmissionWorkspace>` where the incorrect transmission workspaces were being output when debug is on/off.
 - The :ref:`ReflectometryISISLoadAndProcess <algm-ReflectometryISISLoadAndProcess>` algorithm now ensures that the TOF group cannot contain non-TOF workspaces or nested groups (nested groups are not supported so are now flattened into a single group instead).
 


### PR DESCRIPTION
In `ReflectometryReductionOneAuto`, the `ScaleFactor` was previously only applied to the `IvsQ_binned` output. This PR ensures that it is also applied to the `IvsQ` output. This is more in keeping with other settings, e.g. cropping to the Qmin/Qmax is also applied to the `IvsQ` output. This is important because this output is used when stitching results together so this ensures that the stitched results also obey the scale and cropping specified.

This PR also does some minor tidying of the crop/scale/rebin functions to make them more readable and consistent.

**To test:**

Follow the instructions in the linked issue and check that the stitched `IvsQ_13460_13462` output is now scaled the same as the left-hand-side workspace, `IvsQ_binned_13460`.

![image](https://user-images.githubusercontent.com/12895056/68473516-17822880-021b-11ea-9420-a3ac25d612c0.png)

Fixes #27317

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
