### PR TITLE
Fix problem with help window appearing behind Indirect settings

### DIFF
--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -16127,6 +16127,7 @@ void ApplicationWindow::setGeometry(MdiSubWindow *usr_win,
             frame.bottomRight() + user_interface->geometry().bottomRight());
   usr_win->setGeometry(iface_geom);
   usr_win->setName(user_interface->windowTitle());
+  usr_win->setWindowModality(user_interface->windowModality());
   addMdiSubWindow(usr_win);
 }
 
@@ -16255,6 +16256,7 @@ FloatingWindow *ApplicationWindow::addMdiSubWindowAsFloating(MdiSubWindow *w,
     pos += mdiAreaTopLeft();
   }
   fw->setWindowTitle(w->name());
+  fw->setWindowModality(w->windowModality());
   fw->setMdiSubWindow(w);
   fw->resize(sz);
   fw->move(pos);

--- a/MantidPlot/src/ApplicationWindow.cpp
+++ b/MantidPlot/src/ApplicationWindow.cpp
@@ -15732,7 +15732,7 @@ void ApplicationWindow::performCustomAction(QAction *action) {
     usr_win->setAttribute(Qt::WA_DeleteOnClose, false);
     MantidQt::API::InterfaceManager interfaceManager;
     MantidQt::API::UserSubWindow *user_interface =
-        interfaceManager.createSubWindow(action_data, usr_win);
+        interfaceManager.createSubWindow(action_data, usr_win, false);
     if (user_interface) {
       setGeometry(usr_win, user_interface);
       connect(user_interface, SIGNAL(runAsPythonScript(const QString &, bool)),

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -377,7 +377,7 @@ class MainWindow(QMainWindow):
         object_name = 'custom-cpp-interface-' + interface_name
         window = find_window(object_name, UserSubWindow)
         if window is None:
-            interface = self.interface_manager.createSubWindow(interface_name)
+            interface = self.interface_manager.createSubWindow(interface_name,self)
             interface.setObjectName(object_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
             interface.show()

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
@@ -17,7 +17,7 @@ namespace CustomInterfaces {
 IndirectInterface::IndirectInterface(QWidget *parent)
     : UserSubWindow(parent),
       m_settings(dynamic_cast<IndirectSettings *>(
-          InterfaceManager().createSubWindow("Settings"))) {
+          InterfaceManager().createSubWindow("Settings", this))) {
 
   connect(m_settings.get(), SIGNAL(applySettings()), this,
           SLOT(applySettings()));
@@ -30,7 +30,7 @@ void IndirectInterface::help() {
 
 void IndirectInterface::settings() {
   m_settings->loadSettings();
-  m_settings->setWindowModality(Qt::ApplicationModal);
+  m_settings->setWindowModality(Qt::WindowModal);
   m_settings->show();
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -71,7 +71,7 @@ void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }
 
 void IndirectSettings::closeSettings() {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    getDockedOrFloatingWindow()->close();
+  getDockedOrFloatingWindow()->close();
 #else
   if (auto settingsWindow = window())
     settingsWindow->close();
@@ -80,7 +80,7 @@ void IndirectSettings::closeSettings() {
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
 QWidget *IndirectSettings::getDockedOrFloatingWindow() {
-  QWidget * widget = this;
+  QWidget *widget = this;
   while (widget) {
     auto const className = std::string(widget->metaObject()->className());
     if (className == "DockedWindow" || widget->isWindow())

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -71,7 +71,7 @@ void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }
 
 void IndirectSettings::closeSettings() {
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  getDockedOrFloatingWindow()->close();
+    getDockedOrFloatingWindow()->close();
 #else
   if (auto settingsWindow = window())
     settingsWindow->close();
@@ -79,11 +79,11 @@ void IndirectSettings::closeSettings() {
 }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-QWidget *IndirectSettings::getDockedOrFloatingWindow() const {
-  auto widget = parentWidget();
+QWidget *IndirectSettings::getDockedOrFloatingWindow() {
+  QWidget * widget = this;
   while (widget) {
     auto const className = std::string(widget->metaObject()->className());
-    if (className == "DockedWindow" || className == "FloatingWindow")
+    if (className == "DockedWindow" || widget->isWindow())
       return widget;
     widget = widget->parentWidget();
   }

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -54,7 +54,7 @@ private:
 
   void connectIndirectInterface(QPointer<UserSubWindow> window);
 
-  QWidget *getDockedOrFloatingWindow() const;
+  QWidget *getDockedOrFloatingWindow();
 
   std::unique_ptr<IndirectSettingsPresenter> m_presenter;
   Ui::IndirectSettings m_uiForm;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/InterfaceManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/InterfaceManager.h
@@ -77,7 +77,8 @@ public:
 
   /// Create a new instance of the correct type of UserSubWindow
   UserSubWindow *createSubWindow(const QString &interface_name,
-                                 QWidget *parent = nullptr);
+                                 QWidget *parent = nullptr,
+                                 bool isWindow = true);
 
   /**
    * Function that instantiates the Vates simple user interface.

--- a/qt/widgets/common/src/InterfaceManager.cpp
+++ b/qt/widgets/common/src/InterfaceManager.cpp
@@ -156,9 +156,11 @@ AlgorithmDialog *InterfaceManager::createDialogFromName(
  * Create a new instance of the correct type of UserSubWindow
  * @param interface_name :: The registered name of the interface
  * @param parent :: The parent widget
+ * @param isWindow :: Should the widget be an independent window
  */
 UserSubWindow *InterfaceManager::createSubWindow(const QString &interface_name,
-                                                 QWidget *parent) {
+                                                 QWidget *parent,
+                                                 bool isWindow) {
   UserSubWindow *user_win = nullptr;
   std::string iname = interface_name.toStdString();
   try {
@@ -168,7 +170,15 @@ UserSubWindow *InterfaceManager::createSubWindow(const QString &interface_name,
   }
   if (user_win) {
     g_log.debug() << "Created a specialised interface for " << iname << '\n';
-    user_win->setParent(parent);
+
+    // set the parent. Note - setParent without flags parameter resets the flags
+    // ie window becomes a child widget
+    if (isWindow) {
+      user_win->setParent(parent, user_win->windowFlags());
+    } else {
+      user_win->setParent(parent);
+    }
+
     user_win->setInterfaceName(interface_name);
     user_win->initializeLayout();
 


### PR DESCRIPTION
**Description of work.**

Made help window accessible when created from the modal Indirect settings screen (specifically when Indirect settings is accessed from one of the Indirect interface screen eg Bayes)

Main change was to alter the Qt modality setting on the Indirect Settings screen from "ApplicationModal" to "WindowModal". Then found two complexities:

a) WindowModal wasn't working for C++ guis created from Workbench because parents weren't set up. So have set up parents on the Indirect Settings screen and the Indirect interface screens (eg Bayes)

b) setting up a parent can cause the Qt window to be interpreted as a child rather than an independent window so have also had to make sure the WindowFlags are set up correctly

**To test:**

The change affects all of the screens accessible in MantidPlot and Workbench on the Interfaces, Indirect menu. So fire up 2-3 of the interfaces and check the settings screen is accessible and can be edited. Further check that the help button from the settings screen works and you can type into the resulting help screen. I suggest you do this in both MantidPlot and Workbench.

In addition to these it's worth doing some tests to make sure nothing else is broken:

Three further C++ interface screens call InterfaceManager::createSubWindow (which is one of the code changes) although there is no functional change here: 
a) Direct, ALF View
b) Muon, ALC
c) Reflectometry, ISIS Reflectometry

Suggest you check these can be opened up OK from the main menu in both MantidPlot and Workbench

Fixes #27163.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
