### PR TITLE
Remove disconnected start and end x comboboxes

### DIFF
--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -29,6 +29,7 @@ public:
   virtual bool isMultipleDataTabSelected() const = 0;
   virtual bool isResolutionHidden() const = 0;
   virtual void setResolutionHidden(bool hide) = 0;
+  virtual void setStartAndEndHidden(bool hidden) = 0;
   virtual void disableMultipleDataTab() = 0;
 
   virtual std::string getSelectedSample() const = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataViewLegacy.h
@@ -29,6 +29,7 @@ public:
   virtual bool isMultipleDataTabSelected() const = 0;
   virtual bool isResolutionHidden() const = 0;
   virtual void setResolutionHidden(bool hide) = 0;
+  virtual void setStartAndEndHidden(bool hidden) = 0;
   virtual void disableMultipleDataTab() = 0;
 
   virtual std::string getSelectedSample() const = 0;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -25,6 +25,7 @@ IndirectFitDataView::IndirectFitDataView(QWidget *parent)
   m_dataForm->setupUi(this);
   m_dataForm->dsResolution->hide();
   m_dataForm->lbResolution->hide();
+  m_dataForm->wgtStartEnd->hide();
   m_dataForm->dsbStartX->setRange(-1e100, 1e100);
   m_dataForm->dsbEndX->setRange(-1e100, 1e100);
 
@@ -192,6 +193,10 @@ void IndirectFitDataView::emitViewSelected(int index) {
     emit singleDataViewSelected();
   else
     emit multipleDataViewSelected();
+}
+
+void IndirectFitDataView::setStartAndEndHidden(bool hidden) {
+  m_dataForm->wgtStartEnd->setHidden(hidden);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.h
@@ -30,6 +30,7 @@ public:
   virtual bool isMultipleDataTabSelected() const override;
   bool isResolutionHidden() const override;
   void setResolutionHidden(bool hide) override;
+  void setStartAndEndHidden(bool hidden) override;
   void disableMultipleDataTab() override;
 
   virtual std::string getSelectedSample() const override;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>654</width>
-    <height>222</height>
+    <width>617</width>
+    <height>313</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,11 +35,17 @@
    <attribute name="title">
     <string>Single Input</string>
    </attribute>
-   <layout class="QGridLayout" name="gridLayout" columnstretch="0,1">
-    <item row="0" column="0">
-     <widget class="QLabel" name="lbSample">
-      <property name="text">
-       <string>Sample</string>
+   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
+    <item row="1" column="1">
+     <widget class="MantidQt::MantidWidgets::DataSelector" name="dsResolution" native="true">
+      <property name="autoLoad" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="ShowGroups" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLoad" stdset="0">
+       <bool>false</bool>
       </property>
      </widget>
     </item>
@@ -63,80 +69,79 @@
       </property>
      </widget>
     </item>
-    <item row="1" column="1">
-     <widget class="MantidQt::MantidWidgets::DataSelector" name="dsResolution" native="true">
-      <property name="autoLoad" stdset="0">
+    <item row="0" column="0">
+     <widget class="QLabel" name="lbSample">
+      <property name="text">
+       <string>Sample</string>
+      </property>
+     </widget>
+    </item>
+    <item row="2" column="0">
+     <widget class="QWidget" name="wgtStartEnd" native="true">
+      <property name="enabled">
        <bool>true</bool>
       </property>
-      <property name="ShowGroups" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="showLoad" stdset="0">
-       <bool>false</bool>
-      </property>
-    </widget>
-  </item>
-  <item row="2" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,0">
-      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Start X</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QDoubleSpinBox" name="dsbStartX">
-          <property name="minimumSize">
-            <size>
-              <width>100</width>
-              <height>0</height>
-            </size>
-          </property>
-          <property name="decimals">
-            <number>6</number>
-          </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
         </widget>
-      </item>
-      <item>
+       </item>
+       <item>
         <widget class="QLabel" name="label_2">
-          <property name="text">
-            <string>End X</string>
-          </property>
+         <property name="text">
+          <string>End X</string>
+         </property>
         </widget>
-      </item>
-      <item>
+       </item>
+       <item>
         <widget class="QDoubleSpinBox" name="dsbEndX">
-          <property name="minimumSize">
-            <size>
-              <width>100</width>
-              <height>0</height>
-            </size>
-          </property>
-          <property name="decimals">
-            <number>6</number>
-          </property>
-          <property name="minimum">
-            <double>-1000000000.000000000000000</double>
-          </property>
-          <property name="maximum">
-            <double>1000000000.000000000000000</double>
-          </property>
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
+         <property name="minimum">
+          <double>-1000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000000.000000000000000</double>
+         </property>
         </widget>
-      </item>
-      <item>
+       </item>
+       <item>
         <spacer name="horizontalSpacer_2">
-          <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-            <size>
-              <width>40</width>
-              <height>20</height>
-            </size>
-          </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
         </spacer>
-      </item>
-    </layout>
-  </item>
-  <item row="2" column="0">
-    <widget class="QLabel" name="label">
-      <property name="text">
-        <string>Start X</string>
-      </property>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.cpp
@@ -26,6 +26,7 @@ IndirectFitDataViewLegacy::IndirectFitDataViewLegacy(QWidget *parent)
   m_dataForm->setupUi(this);
   m_dataForm->dsResolution->hide();
   m_dataForm->lbResolution->hide();
+  m_dataForm->wgtStartEnd->hide();
 
   connect(m_dataForm->dsSample, SIGNAL(dataReady(const QString &)), this,
           SIGNAL(sampleLoaded(const QString &)));
@@ -175,6 +176,10 @@ void IndirectFitDataViewLegacy::emitViewSelected(int index) {
     emit singleDataViewSelected();
   else
     emit multipleDataViewSelected();
+}
+
+void IndirectFitDataViewLegacy::setStartAndEndHidden(bool hidden) {
+  m_dataForm->wgtStartEnd->setHidden(hidden);
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataViewLegacy.h
@@ -31,6 +31,7 @@ public:
   virtual bool isMultipleDataTabSelected() const override;
   bool isResolutionHidden() const override;
   void setResolutionHidden(bool hide) override;
+  void setStartAndEndHidden(bool hidden) override;
   void disableMultipleDataTab() override;
 
   virtual std::string getSelectedSample() const override;

--- a/qt/scientific_interfaces/Indirect/IqtFit.cpp
+++ b/qt/scientific_interfaces/Indirect/IqtFit.cpp
@@ -37,7 +37,6 @@ IqtFit::IqtFit(QWidget *parent)
       m_uiForm(new Ui::IqtFit) {
   m_uiForm->setupUi(parent);
   m_iqtFittingModel = dynamic_cast<IqtFitModel *>(fittingModel());
-
   setFitDataPresenter(std::make_unique<IndirectFitDataPresenter>(
       m_iqtFittingModel, m_uiForm->fitDataView));
   setPlotView(m_uiForm->pvFitPlotView);
@@ -48,6 +47,7 @@ IqtFit::IqtFit(QWidget *parent)
   setFitPropertyBrowser(m_uiForm->fitPropertyBrowser);
 
   setEditResultVisible(true);
+  setStartAndEndHidden(false);
 }
 
 void IqtFit::setupFitTab() {
@@ -99,6 +99,10 @@ void IqtFit::setRunIsRunning(bool running) {
 }
 
 void IqtFit::setRunEnabled(bool enable) { m_uiForm->pbRun->setEnabled(enable); }
+
+void IqtFit::setStartAndEndHidden(bool hidden) {
+  m_uiForm->fitDataView->setStartAndEndHidden(hidden);
+}
 
 } // namespace IDA
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IqtFit.h
+++ b/qt/scientific_interfaces/Indirect/IqtFit.h
@@ -50,6 +50,7 @@ private:
   std::string fitTypeString() const;
   void setupFitTab() override;
   EstimationDataSelector getEstimationDataSelector() const override;
+  void setStartAndEndHidden(bool hidden);
 
   IqtFitModel *m_iqtFittingModel;
   std::unique_ptr<Ui::IqtFit> m_uiForm;

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -51,6 +51,7 @@ public:
   MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
   MOCK_CONST_METHOD0(isResolutionHidden, bool());
   MOCK_METHOD1(setResolutionHidden, void(bool hide));
+  MOCK_METHOD1(setStartAndEndHidden, void(bool hidden));
   MOCK_METHOD0(disableMultipleDataTab, void());
 
   MOCK_CONST_METHOD0(getSelectedSample, std::string());

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -67,6 +67,7 @@ public:
   MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
   MOCK_CONST_METHOD0(isResolutionHidden, bool());
   MOCK_METHOD1(setResolutionHidden, void(bool hide));
+  MOCK_METHOD1(setStartAndEndHidden, void(bool hidden));
   MOCK_METHOD0(disableMultipleDataTab, void());
 
   MOCK_CONST_METHOD0(getSelectedSample, std::string());

--- a/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/JumpFitDataPresenterTest.h
@@ -77,6 +77,7 @@ public:
   MOCK_CONST_METHOD0(isMultipleDataTabSelected, bool());
   MOCK_CONST_METHOD0(isResolutionHidden, bool());
   MOCK_METHOD1(setResolutionHidden, void(bool hide));
+  MOCK_METHOD1(setStartAndEndHidden, void(bool hidden));
   MOCK_METHOD0(disableMultipleDataTab, void());
 
   MOCK_CONST_METHOD0(getSelectedSample, std::string());


### PR DESCRIPTION
**Description of work.**

Removes unlinked combo boxes from tabs that don't use them yet in the Indirect Data Analysis GUI.

**To test:**
1. Open Interfaces -> Indirect -> Data Analysis.
2. Check `StartX` and `EndX` boxes are only present in the `I(Q, t) Fit` tab.


Fixes #27280 


*This does not require release notes* because **it fixes something in new functionality not present in the previous release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
