### PR TITLE
Rename Iqt fit multifit workspaces with run and spectrum numbe…

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -222,7 +222,6 @@ std::vector<std::string> strsplit(const std::string &string_in,
   std::vector<std::string> out;
   size_t last = 0;
   size_t next = 0;
-  std::string token;
   while ((next = string_in.find(delim, last)) != std::string::npos) {
     out.push_back(string_in.substr(last, next - last));
     last = next + 1;

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -227,7 +227,7 @@ std::vector<std::string> strsplit(const std::string &string_in,
 std::vector<std::string> srange(const std::string &string_range) {
   // e.g. string_range = "0-2+4"
   // output = "0", "1", "2", "4"
-  std::vector<std::string> limits = strsplit(string_range, "-");
+  const auto limits = strsplit(string_range, "-");
   if (limits.size() == 1) {
     return limits;
   } else {
@@ -250,19 +250,19 @@ void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
     const auto name = ws->getName();
     // extract relevent parts of the name
     const auto nameParts = strsplit(name, "_iqt");
-    std::string runstr = nameParts[0];
-    std::size_t istart = nameParts[1].rfind("_s");
-    std::size_t iend = nameParts[1].rfind("_R");
-    std::string specstr = nameParts[1].substr(istart + 2, iend - (istart + 2));
+    const auto runstr = nameParts[0];
+    const auto istart = nameParts[1].rfind("_s");
+    const auto iend = nameParts[1].rfind("_R");
+    const auto specstr = nameParts[1].substr(istart + 2, iend - (istart + 2));
     // get all spectra included in fit from that file
-    std::vector<std::string> ranges = strsplit(specstr, "+");
+    const auto ranges = strsplit(specstr, "+");
     for (std::size_t irange = 0; irange != ranges.size(); irange++) {
       // specstr[irange] is a string that defines a range e.g "1-4"
       const auto spec = srange(ranges[irange]);
       // loop over spec and rename corresponding workspace
       for (std::size_t ispec = 0; ispec != spec.size(); ispec++) {
-        std::string currentName = (resultGroup->getItem(indexWS))->getName();
-        std::string newName = runstr + "_s" + spec[ispec] + "_Workspace";
+        const auto currentName = (resultGroup->getItem(indexWS))->getName();
+        const auto newName = runstr + "_s" + spec[ispec] + "_Workspace";
         renameWorkspace(currentName, newName);
         ++indexWS;
       }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -217,6 +217,65 @@ void renameResult(WorkspaceGroup_sptr resultWorkspace,
     renameResultWithoutSpectra(resultWorkspace, fitDataBegin, fitDataEnd);
 }
 
+//std::vector<std::string> strsplit(const std::string &string_in,
+//                                  const std::string &delim) {
+//  std::vector<std::string> out;
+//  size_t last = 0;
+//  size_t next = 0;
+//  std::string token;
+//  while ((next = string_in.find(delim, last)) != std::string::npos) {
+//    out.push_back(string_in.substr(last, next - last));
+//    last = next + 1;
+//  }
+//  out.push_back(string_in.substr(last, std::string::npos));
+//  return out;
+//}
+//
+//std::vector<std::string> srange(const std::string &string_in) {
+//
+//  std::vector<std::string> limits = strsplit(string_in, "-");
+//  if (limits.size() == 1) {
+//    return limits;
+//  } else {
+//    std::vector<std::string> out;
+//    for (int i = boost::lexical_cast<int>(limits[0]);
+//         i != boost::lexical_cast<int>(limits[1]) + 1; ++i) {
+//      out.push_back(boost::lexical_cast<std::string>(i));
+//    }
+//    return out;
+//  }
+//}
+
+//void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
+//                        WorkspaceGroup_sptr resultWorkspace) {
+//  // rename the fit data workspaces using result workspace names
+//  std::size_t indexWS = 0; // index of fit workspace in resultGroup
+//  auto numel = static_cast<std::size_t>(resultWorkspace->size());
+//  for (std::size_t index = 0; index != numel; ++index) {
+//    auto ws = resultWorkspace->getItem(index);
+//    std::string name = ws->getName();
+//    // extract relevent parts of the name
+//    std::vector<std::string> nameParts = strsplit(name, "_iqt");
+//    std::string runstr = nameParts[0];
+//    std::size_t istart = nameParts[1].rfind("_s");
+//    std::size_t iend = nameParts[1].rfind("_R");
+//    std::string specstr = nameParts[1].substr(istart + 2, iend - 5);
+//    // get all spectra included in fit from that file
+//    std::vector<std::string> ranges = strsplit(specstr, "+");
+//    for (std::size_t irange = 0; irange != ranges.size(); irange++) {
+//      // specstr[irange] is a string that defines a range e.g "1-4"
+//      std::vector<std::string> spec = srange(ranges[irange]);
+//      // loop over spec and rename corresponding workspace
+//      for (std::size_t ispec = 0; ispec != spec.size(); ispec++) {
+//        std::string currentName = (resultGroup->getItem(indexWS))->getName();
+//        std::string newName = runstr + "_s" + spec[ispec] + "_Workspace";
+//        renameWorkspace(currentName, newName);
+//        ++indexWS;
+//      }
+//    }
+//  }
+//}
+
 template <typename Map, typename Key>
 typename Map::mapped_type &findOrCreateDefaultInMap(Map &map, const Key &key) {
   auto valueIt = map.find(key);
@@ -330,6 +389,7 @@ void IndirectFitOutput::addOutput(WorkspaceGroup_sptr resultGroup,
   updateParameters(parameterTable, fitDataBegin, fitDataEnd);
   updateFitResults(resultGroup, fitDataBegin, fitDataEnd);
   renameResult(resultWorkspace, fitDataBegin, fitDataEnd);
+  //renameFitWorkspace(resultGroup, resultWorkspace);
   m_resultWorkspace = resultWorkspace;
   m_resultGroup = resultGroup;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -259,7 +259,7 @@ void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
     std::string runstr = nameParts[0];
     std::size_t istart = nameParts[1].rfind("_s");
     std::size_t iend = nameParts[1].rfind("_R");
-    std::string specstr = nameParts[1].substr(istart + 2, iend - (istart+2));
+    std::string specstr = nameParts[1].substr(istart + 2, iend - (istart + 2));
     // get all spectra included in fit from that file
     std::vector<std::string> ranges = strsplit(specstr, "+");
     for (std::size_t irange = 0; irange != ranges.size(); irange++) {

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -219,20 +219,15 @@ void renameResult(WorkspaceGroup_sptr resultWorkspace,
 
 std::vector<std::string> strsplit(const std::string &string_in,
                                   const std::string &delim) {
-  std::vector<std::string> out;
-  size_t last = 0;
-  size_t next = 0;
-  while ((next = string_in.find(delim, last)) != std::string::npos) {
-    out.push_back(string_in.substr(last, next - last));
-    last = next + 1;
-  }
-  out.push_back(string_in.substr(last, std::string::npos));
-  return out;
+  std::vector<std::string> split_vect;
+  iter_split(split_vect, string_in, boost::algorithm::first_finder(delim));
+  return split_vect;
 }
 
-std::vector<std::string> srange(const std::string &string_in) {
-
-  std::vector<std::string> limits = strsplit(string_in, "-");
+std::vector<std::string> srange(const std::string &string_range) {
+  // e.g. string_range = "0-2+4"
+  // output = "0", "1", "2", "4"
+  std::vector<std::string> limits = strsplit(string_range, "-");
   if (limits.size() == 1) {
     return limits;
   } else {
@@ -249,12 +244,12 @@ void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
                         WorkspaceGroup_sptr resultWorkspace) {
   // rename the fit data workspaces using result workspace names
   std::size_t indexWS = 0; // index of fit workspace in resultGroup
-  auto numel = static_cast<std::size_t>(resultWorkspace->size());
-  for (std::size_t index = 0; index != numel; ++index) {
-    auto ws = resultWorkspace->getItem(index);
-    std::string name = ws->getName();
+  const auto numRuns = static_cast<std::size_t>(resultWorkspace->size());
+  for (std::size_t index = 0; index != numRuns; ++index) {
+    const auto ws = resultWorkspace->getItem(index);
+    const auto name = ws->getName();
     // extract relevent parts of the name
-    std::vector<std::string> nameParts = strsplit(name, "_iqt");
+    const auto nameParts = strsplit(name, "_iqt");
     std::string runstr = nameParts[0];
     std::size_t istart = nameParts[1].rfind("_s");
     std::size_t iend = nameParts[1].rfind("_R");
@@ -263,7 +258,7 @@ void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
     std::vector<std::string> ranges = strsplit(specstr, "+");
     for (std::size_t irange = 0; irange != ranges.size(); irange++) {
       // specstr[irange] is a string that defines a range e.g "1-4"
-      std::vector<std::string> spec = srange(ranges[irange]);
+      const auto spec = srange(ranges[irange]);
       // loop over spec and rename corresponding workspace
       for (std::size_t ispec = 0; ispec != spec.size(); ispec++) {
         std::string currentName = (resultGroup->getItem(indexWS))->getName();

--- a/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitOutput.cpp
@@ -217,64 +217,64 @@ void renameResult(WorkspaceGroup_sptr resultWorkspace,
     renameResultWithoutSpectra(resultWorkspace, fitDataBegin, fitDataEnd);
 }
 
-//std::vector<std::string> strsplit(const std::string &string_in,
-//                                  const std::string &delim) {
-//  std::vector<std::string> out;
-//  size_t last = 0;
-//  size_t next = 0;
-//  std::string token;
-//  while ((next = string_in.find(delim, last)) != std::string::npos) {
-//    out.push_back(string_in.substr(last, next - last));
-//    last = next + 1;
-//  }
-//  out.push_back(string_in.substr(last, std::string::npos));
-//  return out;
-//}
-//
-//std::vector<std::string> srange(const std::string &string_in) {
-//
-//  std::vector<std::string> limits = strsplit(string_in, "-");
-//  if (limits.size() == 1) {
-//    return limits;
-//  } else {
-//    std::vector<std::string> out;
-//    for (int i = boost::lexical_cast<int>(limits[0]);
-//         i != boost::lexical_cast<int>(limits[1]) + 1; ++i) {
-//      out.push_back(boost::lexical_cast<std::string>(i));
-//    }
-//    return out;
-//  }
-//}
+std::vector<std::string> strsplit(const std::string &string_in,
+                                  const std::string &delim) {
+  std::vector<std::string> out;
+  size_t last = 0;
+  size_t next = 0;
+  std::string token;
+  while ((next = string_in.find(delim, last)) != std::string::npos) {
+    out.push_back(string_in.substr(last, next - last));
+    last = next + 1;
+  }
+  out.push_back(string_in.substr(last, std::string::npos));
+  return out;
+}
 
-//void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
-//                        WorkspaceGroup_sptr resultWorkspace) {
-//  // rename the fit data workspaces using result workspace names
-//  std::size_t indexWS = 0; // index of fit workspace in resultGroup
-//  auto numel = static_cast<std::size_t>(resultWorkspace->size());
-//  for (std::size_t index = 0; index != numel; ++index) {
-//    auto ws = resultWorkspace->getItem(index);
-//    std::string name = ws->getName();
-//    // extract relevent parts of the name
-//    std::vector<std::string> nameParts = strsplit(name, "_iqt");
-//    std::string runstr = nameParts[0];
-//    std::size_t istart = nameParts[1].rfind("_s");
-//    std::size_t iend = nameParts[1].rfind("_R");
-//    std::string specstr = nameParts[1].substr(istart + 2, iend - 5);
-//    // get all spectra included in fit from that file
-//    std::vector<std::string> ranges = strsplit(specstr, "+");
-//    for (std::size_t irange = 0; irange != ranges.size(); irange++) {
-//      // specstr[irange] is a string that defines a range e.g "1-4"
-//      std::vector<std::string> spec = srange(ranges[irange]);
-//      // loop over spec and rename corresponding workspace
-//      for (std::size_t ispec = 0; ispec != spec.size(); ispec++) {
-//        std::string currentName = (resultGroup->getItem(indexWS))->getName();
-//        std::string newName = runstr + "_s" + spec[ispec] + "_Workspace";
-//        renameWorkspace(currentName, newName);
-//        ++indexWS;
-//      }
-//    }
-//  }
-//}
+std::vector<std::string> srange(const std::string &string_in) {
+
+  std::vector<std::string> limits = strsplit(string_in, "-");
+  if (limits.size() == 1) {
+    return limits;
+  } else {
+    std::vector<std::string> out;
+    for (int i = boost::lexical_cast<int>(limits[0]);
+         i != boost::lexical_cast<int>(limits[1]) + 1; ++i) {
+      out.push_back(boost::lexical_cast<std::string>(i));
+    }
+    return out;
+  }
+}
+
+void renameFitWorkspace(WorkspaceGroup_sptr resultGroup,
+                        WorkspaceGroup_sptr resultWorkspace) {
+  // rename the fit data workspaces using result workspace names
+  std::size_t indexWS = 0; // index of fit workspace in resultGroup
+  auto numel = static_cast<std::size_t>(resultWorkspace->size());
+  for (std::size_t index = 0; index != numel; ++index) {
+    auto ws = resultWorkspace->getItem(index);
+    std::string name = ws->getName();
+    // extract relevent parts of the name
+    std::vector<std::string> nameParts = strsplit(name, "_iqt");
+    std::string runstr = nameParts[0];
+    std::size_t istart = nameParts[1].rfind("_s");
+    std::size_t iend = nameParts[1].rfind("_R");
+    std::string specstr = nameParts[1].substr(istart + 2, iend - (istart+2));
+    // get all spectra included in fit from that file
+    std::vector<std::string> ranges = strsplit(specstr, "+");
+    for (std::size_t irange = 0; irange != ranges.size(); irange++) {
+      // specstr[irange] is a string that defines a range e.g "1-4"
+      std::vector<std::string> spec = srange(ranges[irange]);
+      // loop over spec and rename corresponding workspace
+      for (std::size_t ispec = 0; ispec != spec.size(); ispec++) {
+        std::string currentName = (resultGroup->getItem(indexWS))->getName();
+        std::string newName = runstr + "_s" + spec[ispec] + "_Workspace";
+        renameWorkspace(currentName, newName);
+        ++indexWS;
+      }
+    }
+  }
+}
 
 template <typename Map, typename Key>
 typename Map::mapped_type &findOrCreateDefaultInMap(Map &map, const Key &key) {
@@ -389,7 +389,7 @@ void IndirectFitOutput::addOutput(WorkspaceGroup_sptr resultGroup,
   updateParameters(parameterTable, fitDataBegin, fitDataEnd);
   updateFitResults(resultGroup, fitDataBegin, fitDataEnd);
   renameResult(resultWorkspace, fitDataBegin, fitDataEnd);
-  //renameFitWorkspace(resultGroup, resultWorkspace);
+  renameFitWorkspace(resultGroup, resultWorkspace);
   m_resultWorkspace = resultWorkspace;
   m_resultGroup = resultGroup;
 }


### PR DESCRIPTION
**Description of work.**
When fitting multiple spectra from multiple runs (sequentially or simultaneously) the workspaces containing the data, fit and difference fro each spectra were not named with the run number and spectrum number.  This has been solved by renaming the workspaces based on the results workspace (one for each run with spectra fitted). 

Longer term it might be better to have the fit name workspaces sensibly in the first place at the point where it is known which spectra is associated with which run (see issue #27324).

**To test:**

(1) Run the following to load data

from mantid.simpleapi import *
Load(Filename='irs26174_graphite002_red.nxs', OutputWorkspace='irs26174_graphite002_red')
Load(Filename='irs26173_graphite002_res.nxs', OutputWorkspace='irs26173_graphite002_res')
TransformToIqt(SampleWorkspace='irs26174_graphite002_red', ResolutionWorkspace='irs26173_graphite002_res',
ParameterWorkspace='irs26174_graphite002_TransformToIqtParameters', OutputWorkspace='irs26174_graphite002_iqt')
Load(Filename='irs26176_graphite002_red.nxs', OutputWorkspace='irs26176_graphite002_red')
Load(Filename='irs26173_graphite002_res.nxs', OutputWorkspace='irs26173_graphite002_res')
TransformToIqt(SampleWorkspace='irs26176_graphite002_red', ResolutionWorkspace='irs26173_graphite002_res',
ParameterWorkspace='irs26176_graphite002_TransformToIqtParameters', OutputWorkspace='irs26176_graphite002_iqt')

(2) Open the Indirect data analysis interface > I(Q,t) Fit tab
(3) Load some spectra from the two available workspaces and attempt to fit (e.g an exponential).
(4) Does the workspace name contain the run number/file from the data workspace and the spectrum number.
(5) Repeat the above fitting spectra from only one run.

Fixes #27284 

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
This does not require release notes because it is a minor change to workspace naming convention and further changes are anticipated.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
