### PR TITLE
Make overplotting preserve legend properties

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -35,6 +35,7 @@ from mantid.plots.utility import autoscale_on_update
 from mantid.plots.helperfunctions import get_normalize_by_bin_width
 from mantid.plots.scales import PowerScale, SquareScale
 from mantid.plots.utility import artists_hidden
+from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
 BIN_AXIS = 0
 SPEC_AXIS = 1
@@ -493,6 +494,13 @@ class MantidAxes(Axes):
             xys = [[lower_xlim, lower_ylim], [upper_xlim, upper_ylim]]
             # update_datalim will update limits with union of current lims and xys
             self.update_datalim(xys)
+
+    def make_legend(self):
+        if self.legend_ is None:
+            self.legend().draggable()
+        else:
+            props = LegendProperties.from_legend(self.legend_)
+            LegendProperties.create_legend(props, self)
 
     @staticmethod
     def is_empty(axes):

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -254,7 +254,7 @@ def _do_single_plot(ax, workspaces, errors, set_title, nums, kw, plot_kwargs):
             plot_kwargs[kw] = num
             plot_fn(ws, **plot_kwargs)
 
-    ax.legend().draggable()
+    ax.make_legend()
     if set_title:
         title = workspaces[0].name()
         ax.set_title(title)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where overplotting would reset the legend.

It also lays the groundwork for #27097 as it adds a ```make_legend``` function to the ```MantidAxes``` class so that it can be called rather than having to retrieve and apply the legend properties every time a legend is updated.

**To test:**
Follow the instructions in the associated issue and check that any changes made to the legend are retained.

Fixes #27096 

No release notes because the bug is not in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
