### PR TITLE
Fix no script output when Workbench is first opened

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -222,6 +222,7 @@ class MainWindow(QMainWindow):
         self.set_splash("Loading code editing widget")
         from workbench.plugins.editor import MultiFileEditor
         self.editor = MultiFileEditor(self)
+        self.messagedisplay.display.setActiveScript(self.editor.editors.current_tab_filename)
         self.editor.register_plugin()
         self.widgets.append(self.editor)
         self.editor.editors.sig_code_exec_start.connect(self.messagedisplay.script_executing)


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where Workbench is unaware that the initial tab in the script editor is the active tab and so no output is shown in the messages window until a new tab is opened.

**To test:**
1. Open Workbench and type ```print(100)``` into the script editor.
2. Press Ctrl+Enter to execute the script and check that the output appears in the messages window.
3. Mess around with multiple script tabs and changing between views (right-click the Messages window) to make sure everything still works as intended.

Fixes #27184 

No release notes because the bug is not present in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
