### PR TITLE
Muon load next run

### DIFF
--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -157,12 +157,11 @@ class LoadRunWidgetPresenter(object):
         new_run = max(self.run_list)
 
         try:
-             file_name = file_utils.file_path_for_instrument_and_run(self.get_current_instrument(), new_run)
-             FileFinder.findRuns(file_name)
-             self.load_runs([file_name])
+            file_name = file_utils.file_path_for_instrument_and_run(self.get_current_instrument(), new_run)
+            FileFinder.findRuns(file_name)
+            self.load_runs([file_name])
         except:
-             self._view.warning_popup("Requested run exceeds the current run for this instrument ")
-
+            self._view.warning_popup("Requested run exceeds the current run for this instrument ")
 
     def handle_decrement_run(self):
         decremented_run_list = self.get_decremented_run_list()

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -14,6 +14,7 @@ import Muon.GUI.Common.utilities.muon_file_utils as file_utils
 import Muon.GUI.Common.utilities.load_utils as load_utils
 from Muon.GUI.Common.utilities.run_string_utils import flatten_run_list
 from mantidqt.utils.observer_pattern import Observable
+from mantid.api import FileFinder
 
 
 class LoadRunWidgetPresenter(object):
@@ -155,12 +156,13 @@ class LoadRunWidgetPresenter(object):
             return
         new_run = max(self.run_list)
 
-        if self._model.current_run and new_run > self._model.current_run[0]:
-            self._view.warning_popup("Requested run exceeds the current run for this instrument")
-            return
+        try:
+             file_name = file_utils.file_path_for_instrument_and_run(self.get_current_instrument(), new_run)
+             FileFinder.findRuns(file_name)
+             self.load_runs([file_name])
+        except:
+             self._view.warning_popup("Requested run exceeds the current run for this instrument ")
 
-        file_name = file_utils.file_path_for_instrument_and_run(self.get_current_instrument(), new_run)
-        self.load_runs([file_name])
 
     def handle_decrement_run(self):
         decremented_run_list = self.get_decremented_run_list()

--- a/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
+++ b/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py
@@ -160,7 +160,7 @@ class LoadRunWidgetPresenter(object):
             file_name = file_utils.file_path_for_instrument_and_run(self.get_current_instrument(), new_run)
             FileFinder.findRuns(file_name)
             self.load_runs([file_name])
-        except:
+        except RuntimeError:
             self._view.warning_popup("Requested run exceeds the current run for this instrument ")
 
     def handle_decrement_run(self):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -51,6 +51,10 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         self.load_utils_patcher = patcher.start()
         self.load_utils_patcher.exception_message_for_failed_files.return_value = ''
 
+        file_finder_patcher = mock.patch('Muon.GUI.Common.load_run_widget.load_run_presenter.FileFinder')
+        self.addCleanup(file_finder_patcher.stop)
+        file_finder_patcher.start()
+
         self.load_single_run()
 
     def tearDown(self):

--- a/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/scripts/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -54,6 +54,10 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         self.load_utils_patcher = patcher.start()
         self.load_utils_patcher.exception_message_for_failed_files.return_value = ''
 
+        file_finder_patcher = mock.patch('Muon.GUI.Common.load_run_widget.load_run_presenter.FileFinder')
+        self.addCleanup(file_finder_patcher.stop)
+        file_finder_patcher.start()
+
     def tearDown(self):
         self.obj = None
 


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
In the new muon analysis GUI the next run arrow does not work correctly. If the user loads the current run and then completes multiple runs after that, they are unable to use the next run button to exceed the previously loaded current run. 

The unit test will be added in issue #27349
**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Press load current run
Press the back button a few times
Press the next button, you should be able to go up the current run value (there are no new current runs at the moment).
Close mantid.

The next set of instructions are to replicate loading a current run then creating more runs.

replace https://github.com/mantidproject/mantid/blob/master/scripts/Muon/GUI/Common/load_run_widget/load_run_presenter.py#L135
with `current_run_file  = "62260"`
Start mantid
Open muon analysis and set the instrument to MUSR
Press load current run - it should load MUSR 62260
You can press the forward key to get past the 'current run'
Fixes #27257 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
