### PR TITLE
Fix problem with naming of output workspaces from Jump Fit (aka F(Q) Fit)

### DIFF
--- a/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFitModel.cpp
@@ -368,7 +368,7 @@ std::string JumpFitModel::getResultLogName() const { return "SourceName"; }
 
 std::string JumpFitModel::constructOutputName() const {
   auto const name = createOutputName("%1%_FofQFit_" + m_fitType, "", 0);
-  auto const position = name.find("_Results");
+  auto const position = name.find("_Result");
   if (position != std::string::npos)
     return name.substr(0, position) + name.substr(position + 7, name.size());
   return name;


### PR DESCRIPTION
Fix problem with the names of the workspaces created by the F(Q) Fit process on the Indirect Data Analysis screen. They had the same name as workspaces output from the (nearby) Conv Fit tab eg the _Parameters workspace output by the two tabs had the same name

**Description of work.**

Changed the function JumpFitModel::constructOutputName so it removes the text "_Result" (from the middle of the name of the input workspace) instead of "_Results". The function used to do this prior to pull request https://github.com/mantidproject/mantid/pull/24348 but I think it was incorrectly changed as part of an effort to correct some workspace group names.

**To test:**

Follow the F(Q) Fit Example Workflow in the "Indirect Data Analysis" section of the MantidPlot help. You can use this file as input:

[irs26176_graphite002_conv_Delta1LFitF_s0_to_50_Result.zip](https://github.com/mantidproject/mantid/files/3831785/irs26176_graphite002_conv_Delta1LFitF_s0_to_50_Result.zip)

Before fix the workspaces that are output are called (ignore the 2nd and 3rd ones - they are input workspaces):
![image](https://user-images.githubusercontent.com/56295817/68594597-cdee4380-048f-11ea-9dd6-887e2001bdf1.png)

...and after the fix they are called:
![image](https://user-images.githubusercontent.com/56295817/68595534-85d02080-0491-11ea-91b3-bc7391139f6f.png)





Fixes #27282.

*This does not require release notes* because it's a minor change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
