### PR TITLE
Fix crash when setting max cores lower than machine cores on Linux

### DIFF
--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -409,6 +409,8 @@ void SofQWNormalisedPolygon::exec() {
     Resetting the number of threads here to what is set in the config file is a
     temporary solution.
     */
+  // TODO: Do this via a MultiThreaded.h macro via:
+  // https://github.com/mantidproject/mantid/issues/27375#issuecomment-553799284
   FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/SofQWNormalisedPolygon.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/SpectrumDetectorMapping.h"
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/WorkspaceFactory.h"
@@ -398,6 +399,17 @@ void SofQWNormalisedPolygon::exec() {
   const auto &inputIndices = inputWS->indexInfo();
   const auto &spectrumInfo = inputWS->spectrumInfo();
 
+  /*
+    On linux, the value value that is set at startup for the number of allowed
+    threads when mulitprocessing is not carried over to new execution threads.
+    As a result, mantid can segfault due to accessing workspaces that are
+    created in the main thread, as they have too few indexes that are supposed
+    to match the number of threads.
+
+    Resetting the number of threads here to what is set in the config file is a
+    temporary solution.
+    */
+  FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -409,7 +409,7 @@ void SofQWNormalisedPolygon::exec() {
     Resetting the number of threads here to what is set in the config file is a
     temporary solution.
     */
-  PARALLEL_SET_MAX_THREADS_TO_CONFIG
+  FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -409,7 +409,7 @@ void SofQWNormalisedPolygon::exec() {
     Resetting the number of threads here to what is set in the config file is a
     temporary solution.
     */
-  FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
+  PARALLEL_SET_MAX_THREADS_TO_CONFIG
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -7,7 +7,6 @@
 #ifndef MANTID_KERNEL_MULTITHREADED_H_
 #define MANTID_KERNEL_MULTITHREADED_H_
 
-#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DataItem.h"
 
 #include <atomic>
@@ -205,13 +204,6 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  */
 #define PRAGMA_OMP(expression) PRAGMA(omp expression)
 
-#define PARALLEL_SET_MAX_THREADS_TO_CONFIG                                     \
-  auto maxCores = Kernel::ConfigService::Instance().getValue<int>(             \
-      "MultiThreaded.MaxCores");                                               \
-  if (maxCores.get_value_or(0) > 0) {                                          \
-    PARALLEL_SET_NUM_THREADS(maxCores.get());                                  \
-  }
-
 #else //_OPENMP
 
 /// Empty definitions - to enable set your complier to enable openMP
@@ -232,7 +224,6 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 #define PARALLEL_SECTIONS
 #define PARALLEL_SECTION
 #define PRAGMA_OMP(expression)
-#define PARALLEL_SET_MAX_THREADS_TO_CONFIG
 #endif //_OPENMP
 
 #endif // MANTID_KERNEL_MULTITHREADED_H_

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -7,6 +7,7 @@
 #ifndef MANTID_KERNEL_MULTITHREADED_H_
 #define MANTID_KERNEL_MULTITHREADED_H_
 
+#include "MantidKernel/ConfigService.h"
 #include "MantidKernel/DataItem.h"
 
 #include <atomic>
@@ -204,6 +205,13 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  */
 #define PRAGMA_OMP(expression) PRAGMA(omp expression)
 
+#define PARALLEL_SET_MAX_THREADS_TO_CONFIG                                     \
+  auto maxCores = Kernel::ConfigService::Instance().getValue<int>(             \
+      "MultiThreaded.MaxCores");                                               \
+  if (maxCores.get_value_or(0) > 0) {                                          \
+    PARALLEL_SET_NUM_THREADS(maxCores.get());                                  \
+  }
+
 #else //_OPENMP
 
 /// Empty definitions - to enable set your complier to enable openMP
@@ -224,6 +232,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 #define PARALLEL_SECTIONS
 #define PARALLEL_SECTION
 #define PRAGMA_OMP(expression)
+#define PARALLEL_SET_MAX_THREADS_TO_CONFIG
 #endif //_OPENMP
 
 #endif // MANTID_KERNEL_MULTITHREADED_H_

--- a/docs/source/release/v4.2.0/indirect_geometry.rst
+++ b/docs/source/release/v4.2.0/indirect_geometry.rst
@@ -48,6 +48,7 @@ BugFixes
 ########
 
 - A bug has been fixed in :ref:`MatchPeaks <algm-MatchPeaks>` which was causing wrong alignment in :ref:`IndirectILLReductionQENS <algm-IndirectILLReductionQENS>` with unmirror option 7, when the peaks in the alignment run are too narrow to be fitted.
+- Fixed a bug where mantid could crash when using the S(Q,w) tab with a workspace created by the Energy Transfer Tab.
 
 ``*`` See associated image ``*``
 


### PR DESCRIPTION
If the maximum number of cores mantid can use is set to be lower than the number of cores on the machine, certain algorithms would ignore this limit and run extra threads.

As a result, workspaces that were not created with this higher number of threads (created in the main thread) would cause a seg fault when the algorithm attempted to access an index of a vector that was out of range.

The root cause of the issue is that threads created separately from the main one do not keep the value set in the `mantid.user.properties` file for the max number of cores. Since this could cause issues in other areas, fixing this will be delayed until the next release. 

**To test:**

1. Change `mantid.user.properties` so that the max cores setting is less than the number of cores on the machine you are testing on.
1. Interfaces -> Indirect -> Data Reduction -> ISIS Energy Transfer
2. Enter a valid run number (26184)
3. Click Run
4. S(Q, w) tab
5. Select the workspace just created
6. Click run
7. No crash should occur

<!-- Instructions for testing. -->

Fixes #27158

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
