### PR TITLE
Fix import error opening old Reflectometry GUI

### DIFF
--- a/scripts/Interface/ui/reflectometer/refl_gui.py
+++ b/scripts/Interface/ui/reflectometer/refl_gui.py
@@ -26,7 +26,7 @@ from isis_reflectometry import load_live_runs
 from isis_reflectometry.combineMulti import *
 import mantidqtpython
 from mantid.api import Workspace, WorkspaceGroup, CatalogManager, AlgorithmManager
-from mantid import UsageService, FeatureType
+from mantid.kernel import UsageService, FeatureType
 from mantid import logger
 
 from ui.reflectometer.ui_refl_window import Ui_windowRefl


### PR DESCRIPTION
**Description of work.**

This PR fixes a recent regression where the `ISIS Reflectometry (Old)` interface could not be opened due to changes in the usage service which meant that the original imports could no longer be found. Changing the imports to be from `mantid.kernel` fixes the problem.

**To test:**

- Open the `ISIS Reflectometry (Old)` interface.
- Previously this was displaying an error `ImportError: cannot import name FeatureType` and the interface would not open. Check that this error no longer appears in the log and that the interface opens ok.

*There is no associated issue.*

*This does not require release notes* because **it is a regression since the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
