### PR TITLE
Fix legend transparency not showing correct value in figure options

### DIFF
--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -55,7 +55,7 @@ class LegendTabWidgetPresenter:
         self.view.set_edge_color(legend_props.edge_color)
 
         # Converts alpha value (opacity value between 0 and 1) to transparency percentage.
-        if int(matplotlib.__version__[0]) > 2:
+        if int(matplotlib.__version__[0]) >= 2:
             transparency = 100-(legend_props.transparency*100)
             self.view.set_transparency_spin_box(transparency)
             self.view.set_transparency_slider(transparency)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the transparency spinbox and slider in the legend tab of figure options would revert to 0% when the menu is closed and reopened. A matplotlib version check has been fixed so that the value in the menu reflects the actual transparency value of the legend when using an OS that isn't RHEL7.

**To test:**
1. In Workbench, plot a figure, open figure options, and go to the legend tab.
2. Change the transparency value and click OK.
3. Reopen figure options and check that the legend transparency spinbox and slider have retained the value you set.

Fixes #27348

No release notes because the bug isn't present in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
