### PR TITLE
Fix reflectometry enum deprecation warning when plotting

### DIFF
--- a/qt/applications/workbench/workbench/widgets/plotselector/view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/view.py
@@ -528,7 +528,7 @@ class PlotSelectorView(QWidget):
         :return: The sort type as a Column enum
         """
         column_number = self.table_widget.horizontalHeader().sortIndicatorSection()
-        return Column(column_number)
+        return Column[column_number]
 
     def set_sort_type(self, sort_type):
         """


### PR DESCRIPTION
**Description of work.**
This fixes the deprecated enum warning when plotting in the ISIS Reflectometry GUI

**To test:**
- Open ISIS Reflectometry GUI
- Enter run `13460` and angle `0.5`
- Process
- Plot
- Ensure no warning observed

*There is no associated issue.

*This does not require release notes* because **it is an internal fix**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
