### PR TITLE
Fix plot types for plots created from data table

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -34,10 +34,7 @@ from mantid.plots import helperfunctions, plotfunctions, plotfunctions3D
 from mantid.plots.utility import autoscale_on_update
 from mantid.plots.helperfunctions import get_normalize_by_bin_width
 from mantid.plots.scales import PowerScale, SquareScale
-from mantid.plots.utility import artists_hidden
-
-BIN_AXIS = 0
-SPEC_AXIS = 1
+from mantid.plots.utility import artists_hidden, MantidAxType
 
 
 def plot_decorator(func):
@@ -182,10 +179,6 @@ class MantidAxes(Axes):
     # Required by Axes base class
     name = 'mantid'
 
-    # Enumerators for plotting directions
-    HORIZONTAL = BIN = 0
-    VERTICAL = SPECTRUM = 1
-
     # Store information for any workspaces attached to this axes instance
     tracked_workspaces = None
 
@@ -254,7 +247,7 @@ class MantidAxes(Axes):
     def is_axis_of_type(axis_type, kwargs):
         if kwargs.get('axis', None) is not None:
             return kwargs.get('axis', None) == axis_type
-        return axis_type == SPEC_AXIS
+        return axis_type == MantidAxType.SPECTRUM
 
     @staticmethod
     def get_spec_num_from_wksp_index(workspace, wksp_index):
@@ -266,15 +259,15 @@ class MantidAxes(Axes):
             return kwargs['specNum']
         elif kwargs.get('wkspIndex', None) is not None:
             # If wanting to plot a bin
-            if MantidAxes.is_axis_of_type(BIN_AXIS, kwargs):
+            if MantidAxes.is_axis_of_type(MantidAxType.BIN, kwargs):
                 return kwargs['wkspIndex']
             # If wanting to plot a spectrum
-            elif MantidAxes.is_axis_of_type(SPEC_AXIS, kwargs):
+            elif MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs):
                 return MantidAxes.get_spec_num_from_wksp_index(workspace, kwargs['wkspIndex'])
         elif getattr(workspace, 'getNumberHistograms', lambda: -1)() == 1:
             # If the workspace has one histogram, just plot that
             kwargs['wkspIndex'] = 0
-            if MantidAxes.is_axis_of_type(BIN_AXIS, kwargs):
+            if MantidAxes.is_axis_of_type(MantidAxType.BIN, kwargs):
                 return kwargs['wkspIndex']
             return MantidAxes.get_spec_num_from_wksp_index(workspace, kwargs['wkspIndex'])
         else:
@@ -618,7 +611,7 @@ class MantidAxes(Axes):
                 artist = self.track_workspace_artist(workspace,
                                                      plotfunctions.plot(self, *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
-                                                     MantidAxes.is_axis_of_type(SPEC_AXIS, kwargs))
+                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
             return artist
         else:
             return Axes.plot(self, *args, **kwargs)
@@ -726,7 +719,7 @@ class MantidAxes(Axes):
                 artist = self.track_workspace_artist(workspace,
                                                      plotfunctions.errorbar(self, *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
-                                                     MantidAxes.is_axis_of_type(SPEC_AXIS, kwargs))
+                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
             return artist
         else:
             return Axes.errorbar(self, *args, **kwargs)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -11,8 +11,11 @@ from __future__ import (print_function, absolute_import, unicode_literals)
 
 from qtpy.QtCore import Qt, Signal, Slot
 
+import matplotlib.pyplot
+
 from mantid import logger
 from mantid.api import AlgorithmManager, AnalysisDataService, ITableWorkspace, MatrixWorkspace
+from mantidqt.plotting.functions import plot
 from mantidqt.utils.qt import import_qt
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
@@ -544,8 +547,8 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         if AnalysisDataService.doesExist(name):
             ws = AnalysisDataService.retrieve(name)
             if isinstance(ws, MatrixWorkspace):
-                presenter = MatrixWorkspaceDisplay(ws)
+                presenter = MatrixWorkspaceDisplay(ws, plot=plot)
                 presenter.show_view()
             elif isinstance(ws, ITableWorkspace):
-                presenter = TableWorkspaceDisplay(ws)
+                presenter = TableWorkspaceDisplay(ws, plot=matplotlib.pyplot)
                 presenter.show_view()


### PR DESCRIPTION
**Description of work.**
This PR changes the plot types to the `MantidAxType` enums so when a comparison is made it can find the correct type.

**To test:**

Load a workspace and select `Show Data`.
Right click on a spectrum and select 'Plot spectrum (values only)'
In the figure window open the figure options - should open and not give an error
Open the fit window - should open and not give an error
Click generate script button  - should correctly generate script and not give error

Check the above works for `Plot spectrum (values and errors)` as well.

Fixes #27342 

*This does not require release notes* because **it was not in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
