### PR TITLE
Disallow opening multiple instances of an interface

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -369,7 +369,7 @@ class MainWindow(QMainWindow):
         """Create a new interface window if one does not already exist,
         else show existing window"""
         object_name = 'custom-cpp-interface-' + interface_name
-        window = find_window(object_name, UserSubWindow)
+        window = find_window(object_name, QMainWindow)
         if window is None:
             interface = self.interface_manager.createSubWindow(interface_name)
             interface.setObjectName(object_name)


### PR DESCRIPTION
**Description of work.**
This was resolved in #27160 however an issue was found during smoke testing due to the expected class. UserSubWindow has been replaced by QMainWindow, fixing the problem of opening multiple interfaces.

**To test:**
Follow instructions in #27160 

Fixes #27112

*This does not require release notes* as it is an internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
