### PR TITLE
Fix CreateDetectorTable causing crash when value entered for WorkspaceIndices is outside of the range of workspace indices

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CreateDetectorTable.h
@@ -43,6 +43,7 @@ public:
     return "Create a table showing detector information for the given "
            "workspace and optionally the data for that detector";
   }
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   /// Initialisation code

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -93,7 +93,7 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
   const auto matrix = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS);
 
   if (matrix) {
-    const int numSpectra = matrix->getNumberHistograms();
+    const int numSpectra = static_cast<int>(matrix->getNumberHistograms());
     const std::vector<int> indices = getProperty("WorkspaceIndices");
 
     if (std::any_of(indices.cbegin(), indices.cend(),

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -90,16 +90,19 @@ std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
   std::map<std::string, std::string> validationOutput;
 
   Workspace_sptr inputWS = getProperty("InputWorkspace");
-  const int numSpectra = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS)
-                             ->getNumberHistograms();
-  const std::vector<int> indices = getProperty("WorkspaceIndices");
+  const auto matrix = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS);
 
-  if (std::any_of(indices.cbegin(), indices.cend(),
-                  [numSpectra](const auto index) {
-                    return (index >= numSpectra) || (index < 0);
-                  })) {
-    validationOutput["WorkspaceIndices"] =
-        "One or more indices out of range of available spectra.";
+  if (matrix) {
+    const int numSpectra = matrix->getNumberHistograms();
+    const std::vector<int> indices = getProperty("WorkspaceIndices");
+
+    if (std::any_of(indices.cbegin(), indices.cend(),
+                    [numSpectra](const auto index) {
+                      return (index >= numSpectra) || (index < 0);
+                    })) {
+      validationOutput["WorkspaceIndices"] =
+          "One or more indices out of range of available spectra.";
+    }
   }
 
   return validationOutput;

--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -80,6 +80,31 @@ void CreateDetectorTable::exec() {
   setProperty("DetectorTableWorkspace", detectorTable);
 }
 
+/*
+ * Validate the input parameters
+ * @returns map with keys corresponding to properties with errors and values
+ * containing the error messages.
+ */
+std::map<std::string, std::string> CreateDetectorTable::validateInputs() {
+  // create the map
+  std::map<std::string, std::string> validationOutput;
+
+  Workspace_sptr inputWS = getProperty("InputWorkspace");
+  const int numSpectra = boost::dynamic_pointer_cast<MatrixWorkspace>(inputWS)
+                             ->getNumberHistograms();
+  const std::vector<int> indices = getProperty("WorkspaceIndices");
+
+  if (std::any_of(indices.cbegin(), indices.cend(),
+                  [numSpectra](const auto index) {
+                    return (index >= numSpectra) || (index < 0);
+                  })) {
+    validationOutput["WorkspaceIndices"] =
+        "One or more indices out of range of available spectra.";
+  }
+
+  return validationOutput;
+}
+
 /**
  * Create the instrument detector table workspace from a MatrixWorkspace
  * @param ws :: A pointer to a MatrixWorkspace


### PR DESCRIPTION
**Description of work.**
See title.

**To test:**
Follow the instructions in the associated issue and check that a crash does not occur.

Fixes #27353

No release notes because it is for a bug that isn't present in a release.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
