### PR TITLE
Allow Scripts Containing Encoding Declarations to be Loaded and Run in Workbench

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -163,7 +163,7 @@ def generate_call_tips(definitions, prepend_module_name=None):
         return []
     call_tips = []
     for name, py_object in definitions.items():
-        if name.startswith('_'):
+        if name.startswith('_') or isinstance(py_object, unicode):
             continue
         if prepend_module_name is True and hasattr(py_object, '__module__'):
             module_name = py_object.__module__
@@ -204,7 +204,6 @@ def get_module_import_alias(import_name, text):
         text = text.encode(detect_encoding(StringIO(text).readline)[0])
     except UnicodeEncodeError:  # Script contains unicode symbol. Cannot run detect_encoding as it requires ascii.
         text = text.encode('utf-8')
-        logger.notice('Using utf-8 encoding.')
     for node in ast.walk(ast.parse(text)):
         if isinstance(node, ast.alias) and node.name == import_name:
             return node.asname

--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -162,7 +162,10 @@ def generate_call_tips(definitions, prepend_module_name=None):
         return []
     call_tips = []
     for name, py_object in definitions.items():
-        if name.startswith('_') or isinstance(py_object, unicode):
+        if PY2:
+            if isinstance(py_object, unicode):
+                continue
+        if name.startswith('_'):
             continue
         if prepend_module_name is True and hasattr(py_object, '__module__'):
             module_name = py_object.__module__

--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -35,7 +35,7 @@ from keyword import kwlist as python_keywords
 from collections import namedtuple
 
 from lib2to3.pgen2.tokenize import detect_encoding
-from cStringIO import StringIO
+from io import BytesIO
 from six import PY2, string_types
 
 if PY2:  # noqa
@@ -200,7 +200,7 @@ def get_line_number_from_index(string, index):
 
 def get_module_import_alias(import_name, text):
     try:
-        text = text.encode(detect_encoding(StringIO(text).readline)[0])
+        text = text.encode(detect_encoding(BytesIO(text.encode()).readline)[0])
     except UnicodeEncodeError:  # Script contains unicode symbol. Cannot run detect_encoding as it requires ascii.
         text = text.encode('utf-8')
     for node in ast.walk(ast.parse(text)):

--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -44,7 +44,6 @@ else:  # noqa
     from inspect import getfullargspec
 
 from mantidqt.widgets.codeeditor.editor import CodeEditor
-from mantid.simpleapi import logger
 
 ArgSpec = namedtuple("ArgSpec", "args varargs keywords defaults")
 

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -13,7 +13,7 @@ import __future__
 import ast
 import os
 import re
-from cStringIO import StringIO
+from io import BytesIO
 from lib2to3.pgen2.tokenize import detect_encoding
 
 from qtpy.QtCore import QObject, Signal
@@ -37,7 +37,7 @@ def _get_imported_from_future(code_str):
     """
     future_imports = []
     try:
-        code_str = code_str.encode(detect_encoding(StringIO(code_str).readline)[0])
+        code_str = code_str.encode(detect_encoding(BytesIO(code_str.encode()).readline)[0])
     except UnicodeEncodeError:  # Script contains unicode symbol. Cannot run detect_encoding as it requires ascii.
         code_str = code_str.encode('utf-8')
     for node in ast.walk(ast.parse(code_str)):

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -154,19 +154,6 @@ class PythonCodeExecution(QObject):
                                    dont_inherit=True, flags=flags)
                 exec (code_obj, self.globals_ns, self.globals_ns)
 
-    def get_code_string_encoding(self, code_str):
-        """
-        Attempt to determine the encoding of the file. If the file contains non-ascii symbols,
-        detect_encoding will fail, so default to utf-8.
-        :param code_str: Code string to be run.
-        :return: The encoding to use on the strings.
-        """
-        try:
-            encoding = detect_encoding(StringIO(code_str).readline)[0]
-        except UnicodeEncodeError:
-            encoding = 'utf-8'
-        return encoding
-
     def reset_context(self):
         # create new context for execution
         self._globals_ns, self._namespace = {}, {}

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -141,6 +141,7 @@ class PythonCodeExecution(QObject):
         except SyntaxError as e:  # Encoding declarations cause issues in compile calls. If found, remove them.
             if "encoding declaration in Unicode string" in str(e):
                 code_str = re.sub("coding[=:]\s*([-\w.]+)", "", code_str, 1)
+                compile(code_str, filename, mode=COMPILE_MODE, dont_inherit=True, flags=flags)
             else:
                 raise e
 


### PR DESCRIPTION
**Description of work.**
Scripts containing an encoding declaration in the first two lines are now able to be run and loaded without errors or encoding artifacts.

When the script is first compiled a specific error is returned. This is caught, the encoding declaration is removed, and the script is recompiled to check for any other syntax errors. 

**To test:**

<!-- Instructions for testing. -->
1. Load [script](https://github.com/mantidproject/mantid/files/3831625/test_py23.zip) into Mantid workbench.
2. Script should run correctly without errors or artifacts around Unicode characters. 

Fixes #27346 

*This does not require release notes* because **it fixes a regression**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
