### PR TITLE
Restrict the input workspaces to MatrixWorkspaces …

### DIFF
--- a/Framework/DataHandling/src/SaveAscii.cpp
+++ b/Framework/DataHandling/src/SaveAscii.cpp
@@ -34,8 +34,8 @@ SaveAscii::SaveAscii() : m_separatorIndex() {}
 /// Initialisation method.
 void SaveAscii::init() {
   declareProperty(
-      std::make_unique<WorkspaceProperty<>>("InputWorkspace", "",
-                                            Direction::Input),
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "",
+                                                           Direction::Input),
       "The name of the workspace containing the data you want to save to a "
       "Ascii file.");
   const std::vector<std::string> asciiExts{".dat", ".txt", ".csv"};

--- a/Framework/DataHandling/src/SaveAscii2.cpp
+++ b/Framework/DataHandling/src/SaveAscii2.cpp
@@ -42,8 +42,8 @@ SaveAscii2::SaveAscii2()
 /// Initialisation method.
 void SaveAscii2::init() {
   declareProperty(
-      std::make_unique<WorkspaceProperty<>>("InputWorkspace", "",
-                                            Direction::Input),
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "",
+                                                           Direction::Input),
       "The name of the workspace containing the data you want to save to a "
       "Ascii file.");
 

--- a/docs/source/release/v4.2.0/framework.rst
+++ b/docs/source/release/v4.2.0/framework.rst
@@ -53,6 +53,7 @@ Algorithms
 - :ref:`IndexPeaks <algm-IndexPeaks>` now has options to enter modulation vectors and additional information required for satellite peak indexing. As
   a result :ref:`IndexPeaksWithSatellites <algm-IndexPeaksWithSatellites>` has been deprecated and will be removed in a future release.
 - :ref:`MaskAngle <algm-MaskAngle>` has an additional option of ``Angle='InPlane'``
+- The valiation in :ref:`SaveAscii <algm-SaveAscii>` has been improved to only accept MatrixWorkspaces.
 - The custom dialog for :ref:`CreateSampleShape <algm-CreateSampleShape>`
   has been removed. It will now fall back to the generic one.
 - A bug in the conversion to Q3D and ModQ for indirect spectrometers at high Q in :ref:`ConvertToMD <algm-ConvertToMD>` has been fixed.


### PR DESCRIPTION
Restricts the input property to MatrixWorkspaces, as that is what the code in exec expects anyway

**To test:**

Try to SaveAscii on a TableWorkspace from the GUI (it should not appear in the list) and python (hopefully get a useful error message, but no crash)

Refs #27363

release notes in framework.rst
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):


---
