### PR TITLE
Catch save ascii from menu error

### DIFF
--- a/MantidPlot/src/Mantid/MantidUI.cpp
+++ b/MantidPlot/src/Mantid/MantidUI.cpp
@@ -1674,10 +1674,17 @@ void MantidUI::showAlgorithmDialog(const QString &algName,
   if (!alg)
     return;
 
-  for (QHash<QString, QString>::Iterator it = paramList.begin();
-       it != paramList.end(); ++it) {
-    alg->setPropertyValue(it.key().toStdString(), it.value().toStdString());
+  try {
+    for (QHash<QString, QString>::Iterator it = paramList.begin();
+         it != paramList.end(); ++it) {
+      alg->setPropertyValue(it.key().toStdString(), it.value().toStdString());
+    }
+  } catch (std::exception &ex) {
+    g_log.error() << "Error setting the properties for algotithm "
+                  << algName.toStdString() << ": " << ex.what() << '\n';
+    return;
   }
+
   MantidQt::API::AlgorithmDialog *dlg = createAlgorithmDialog(alg);
 
   if (algName == "Load") {

--- a/qt/widgets/common/src/MantidTreeModel.cpp
+++ b/qt/widgets/common/src/MantidTreeModel.cpp
@@ -97,9 +97,15 @@ void MantidTreeModel::showAlgorithmDialog(const QString &algName,
   if (!alg)
     return;
 
-  for (QHash<QString, QString>::Iterator it = paramList.begin();
-       it != paramList.end(); ++it) {
-    alg->setPropertyValue(it.key().toStdString(), it.value().toStdString());
+  try {
+    for (QHash<QString, QString>::Iterator it = paramList.begin();
+         it != paramList.end(); ++it) {
+      alg->setPropertyValue(it.key().toStdString(), it.value().toStdString());
+    }
+  } catch (std::exception &ex) {
+    g_log.error() << "Error setting the properties for algotithm "
+                  << algName.toStdString() << ": " << ex.what() << '\n';
+    return;
   }
   MantidQt::API::AlgorithmDialog *dlg = createAlgorithmDialog(alg);
   if (obs) {

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -464,9 +464,9 @@ void WorkspaceTreeWidget::saveWorkspaces(const StringList &wsNames) {
         saveAlg->setProperty("InputWorkspace", wsName);
         saveAlg->setProperty("Filename", filename);
         saveAlg->execute();
-      } catch (std::runtime_error &rte) {
+      } catch (std::exception &ex) {
         docklog.error() << "Error saving workspace " << wsName << ": "
-                        << rte.what() << '\n';
+                        << ex.what() << '\n';
       }
     }
   }


### PR DESCRIPTION
The code was not catching errors for bad algorithm property settings.

Different code for plot and workbench, and I found another instance where the wrong exception was being caught.

**To test:**

1. in mplot and workbench
1. use CreateEmptyTableWorkspace to create a table workspace
1. from the workspaces toolbox, select the workspace and click Save and select one of the ASCIIs
1. Now you should get a logged error, not a crash

Fixes #27363 

Release notes went in on an earlier PR #27371
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
