### PR TITLE
Fix legend resetting after clearing fit curves

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -138,7 +138,7 @@ class _WorkspaceArtists(object):
                     pass
 
         if (not axes.is_empty(axes)) and axes.legend_ is not None:
-            axes.legend().draggable()
+            axes.make_legend()
 
     def replace_data(self, workspace, plot_kwargs=None):
         """Replace or replot artists based on a new workspace


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where if a figure's legend properties had been changed, doing a fit and then clearing the fit curves would reset the legend.

**To test:**
1. In Workbench, plot a figure and change the legend in the figure options.
2. Open the fit property browser, do a fit, and then go to Display->Clear fit curves.
3. Check that the legend removes the entries for the fit curves but does not lose the properties you set.

Fixes #27378 

No release notes because the bug is not in a release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
