### PR TITLE
Move axis functions from curves tab widget presenter to figure…

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -8,11 +8,7 @@
 """
 Controls the dynamic displaying of errors for line on the plot
 """
-from functools import partial
 from matplotlib.container import ErrorbarContainer
-from qtpy.QtWidgets import QMenu
-
-from mantid.plots import MantidAxes
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter import CurvesTabWidgetPresenter
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -17,20 +17,18 @@ from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
 
 class FigureErrorsManager(object):
-    ERROR_BARS_MENU_TEXT = "Error Bars"
-    SHOW_ERROR_BARS_BUTTON_TEXT = "Show all errors"
-    HIDE_ERROR_BARS_BUTTON_TEXT = "Hide all errors"
 
     AXES_NOT_MANTIDAXES_ERR_MESSAGE = "Plot axes are not MantidAxes. There is no way to automatically load error data."
 
     def __init__(self, canvas):
         self.canvas = canvas
-        self.active_lines = []
 
-    def toggle_all_errors(self, ax, make_visible):
-        for line in self.active_lines:
+    @classmethod
+    def toggle_all_errors(cls, ax, make_visible):
+        active_lines = cls.get_curves_from_ax(ax)
+        for line in active_lines:
             if curve_has_errors(line):
-                self.toggle_error_bars_for(ax, line, make_visible)
+                cls.toggle_error_bars_for(ax, line, make_visible)
 
     @classmethod
     def toggle_error_bars_for(cls, ax, curve, make_visible=None):

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -9,8 +9,10 @@
 Controls the dynamic displaying of errors for line on the plot
 """
 from matplotlib.container import ErrorbarContainer
-from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
-from mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter import CurvesTabWidgetPresenter
+from matplotlib.lines import Line2D
+from mantid.plots import MantidAxes
+from mantid.plots.helperfunctions import get_data_from_errorbar_container, set_errorbars_hidden
+from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties, remove_curve_from_ax
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
 
@@ -30,8 +32,8 @@ class FigureErrorsManager(object):
             if curve_has_errors(line):
                 self.toggle_error_bars_for(ax, line, make_visible)
 
-    @staticmethod
-    def toggle_error_bars_for(ax, curve, make_visible=None):
+    @classmethod
+    def toggle_error_bars_for(cls, ax, curve, make_visible=None):
         # get legend properties
         if ax.legend_:
             legend_props = LegendProperties.from_legend(ax.legend_)
@@ -42,7 +44,7 @@ class FigureErrorsManager(object):
         curve_props = CurveProperties.from_curve(curve)
         # and remove the ones that matplotlib doesn't recognise
         plot_kwargs = curve_props.get_plot_kwargs()
-        new_curve = CurvesTabWidgetPresenter.replot_curve(ax, curve, plot_kwargs)
+        new_curve = cls.replot_curve(ax, curve, plot_kwargs)
 
         # Inverts either the current state of hide_errors
         # or the make_visible kwarg that forces a state:
@@ -50,8 +52,8 @@ class FigureErrorsManager(object):
         # for the intended effect
         curve_props.hide_errors = not curve_props.hide_errors if make_visible is None else not make_visible
 
-        CurvesTabWidgetPresenter.toggle_errors(new_curve, curve_props)
-        CurvesTabWidgetPresenter.update_limits_and_legend(ax, legend_props)
+        cls.toggle_errors(new_curve, curve_props)
+        cls.update_limits_and_legend(ax, legend_props)
 
     def update_plot_after(self, func, *args, **kwargs):
         """
@@ -73,6 +75,56 @@ class FigureErrorsManager(object):
     def get_errorbars_from_ax(ax):
         return [cont for cont in ax.containers if isinstance(cont, ErrorbarContainer)]
 
+    @classmethod
+    def get_curves_from_ax(cls, ax):
+        return ax.get_lines() + cls.get_errorbars_from_ax(ax)
+
     @staticmethod
-    def get_curves_from_ax(ax):
-        return ax.get_lines() + CurvesTabWidgetPresenter.get_errorbars_from_ax(ax)
+    def update_limits_and_legend(ax, legend_props=None):
+        ax.relim()
+        ax.autoscale()
+        if legend_props:
+            LegendProperties.create_legend(legend_props, ax)
+
+    @staticmethod
+    def toggle_errors(curve, view_props):
+        hide_errors = view_props.hide_errors or view_props.hide
+        setattr(curve, 'hide_errors', hide_errors)
+        set_errorbars_hidden(curve, hide_errors)
+
+    @classmethod
+    def replot_curve(cls, ax, curve, plot_kwargs):
+        if isinstance(ax, MantidAxes):
+            try:
+                new_curve = ax.replot_artist(curve, errorbars=True, **plot_kwargs)
+            except ValueError:  # ValueError raised if Artist not tracked by Axes
+                new_curve = cls._replot_mpl_curve(ax, curve, plot_kwargs)
+        else:
+            new_curve = cls._replot_mpl_curve(ax, curve, plot_kwargs)
+        setattr(new_curve, 'errorevery', plot_kwargs.get('errorevery', 1))
+        return new_curve
+
+    @staticmethod
+    def _replot_mpl_curve(ax, curve, plot_kwargs):
+        """
+        Replot the given matplotlib curve with new kwargs
+        :param ax: The axis that the curve will be plotted on
+        :param curve: The curve that will be replotted
+        :param plot_kwargs: Kwargs for the plot that will be passed onto matplotlib
+        """
+        remove_curve_from_ax(curve)
+        if isinstance(curve, Line2D):
+            [plot_kwargs.pop(arg, None) for arg in
+             ['capsize', 'capthick', 'ecolor', 'elinewidth', 'errorevery']]
+            new_curve = ax.plot(curve.get_xdata(), curve.get_ydata(),
+                                **plot_kwargs)[0]
+        elif isinstance(curve, ErrorbarContainer):
+            # Because of "error every" option, we need to store the original
+            # error bar data on the curve or we will lose data on re-plotting
+            x, y, xerr, yerr = getattr(curve, 'errorbar_data',
+                                       get_data_from_errorbar_container(curve))
+            new_curve = ax.errorbar(x, y, xerr=xerr, yerr=yerr, **plot_kwargs)
+            setattr(new_curve, 'errorbar_data', [x, y, xerr, yerr])
+        else:
+            raise ValueError("Curve must have type 'Line2D' or 'ErrorbarContainer'. Found '{}'".format(type(curve)))
+        return new_curve

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -29,62 +29,7 @@ class FigureErrorsManager(object):
         self.canvas = canvas
         self.active_lines = []
 
-    def add_error_bars_menu(self, parent_menu, ax):
-        """
-        Add menu actions to toggle the errors for all lines in the plot.
-
-        Lines without errors are added in the context menu first,
-        then lines containing errors are appended afterwards.
-
-        This is done so that the context menu always has
-        the same order of curves as the legend is currently showing - and the
-        legend always appends curves with errors after the lines without errors.
-        Relevant source, as of 10 July 2019:
-        https://github.com/matplotlib/matplotlib/blob/154922992722db37a9d9c8680682ccc4acf37f8c/lib/matplotlib/legend.py#L1201
-
-        :param parent_menu: The menu to which the actions will be added
-        :type parent_menu: QMenu
-        :param ax: The Axes containing lines to toggle errors on
-        """
-        # if the ax is not a MantidAxes, and there are no errors plotted,
-        # then do not add any options for the menu
-        if not isinstance(ax, MantidAxes) and len(ax.containers) == 0:
-            return
-
-        error_bars_menu = QMenu(self.ERROR_BARS_MENU_TEXT, parent_menu)
-        error_bars_menu.addAction(self.SHOW_ERROR_BARS_BUTTON_TEXT,
-                                  partial(self._update_plot_after, self._toggle_all_errors, ax, make_visible=True))
-        error_bars_menu.addAction(self.HIDE_ERROR_BARS_BUTTON_TEXT,
-                                  partial(self._update_plot_after, self._toggle_all_errors, ax, make_visible=False))
-        parent_menu.addMenu(error_bars_menu)
-
-        self.active_lines = CurvesTabWidgetPresenter.get_curves_from_ax(ax)
-
-        # if there's more than one line plotted, then
-        # add a sub menu, containing an action to hide the
-        # error bar for each line
-        error_bars_menu.addSeparator()
-        add_later = []
-        for index, line in enumerate(self.active_lines):
-            if curve_has_errors(line):
-                curve_props = CurveProperties.from_curve(line)
-                # Add lines without errors first, lines with errors are appended later. Read docstring for more info
-                if not isinstance(line, ErrorbarContainer):
-                    action = error_bars_menu.addAction(line.get_label(), partial(
-                        self._update_plot_after, self.toggle_error_bars_for, ax, line))
-                    action.setCheckable(True)
-                    action.setChecked(not curve_props.hide_errors)
-                else:
-                    add_later.append((line.get_label(), partial(
-                        self._update_plot_after, self.toggle_error_bars_for, ax, line),
-                                      not curve_props.hide_errors))
-
-        for label, function, visible in add_later:
-            action = error_bars_menu.addAction(label, function)
-            action.setCheckable(True)
-            action.setChecked(visible)
-
-    def _toggle_all_errors(self, ax, make_visible):
+    def toggle_all_errors(self, ax, make_visible):
         for line in self.active_lines:
             if curve_has_errors(line):
                 self.toggle_error_bars_for(ax, line, make_visible)
@@ -112,7 +57,7 @@ class FigureErrorsManager(object):
         CurvesTabWidgetPresenter.toggle_errors(new_curve, curve_props)
         CurvesTabWidgetPresenter.update_limits_and_legend(ax, legend_props)
 
-    def _update_plot_after(self, func, *args, **kwargs):
+    def update_plot_after(self, func, *args, **kwargs):
         """
         Updates the legend and the plot after the function has been executed.
         Used to funnel through the updates through a common place
@@ -127,3 +72,11 @@ class FigureErrorsManager(object):
     @staticmethod
     def _supported_ax(ax):
         return hasattr(ax, 'creation_args')
+
+    @staticmethod
+    def get_errorbars_from_ax(ax):
+        return [cont for cont in ax.containers if isinstance(cont, ErrorbarContainer)]
+
+    @staticmethod
+    def get_curves_from_ax(ax):
+        return ax.get_lines() + CurvesTabWidgetPresenter.get_errorbars_from_ax(ax)

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -39,10 +39,6 @@ AXES_SCALE_MENU_OPTS = OrderedDict(
     [("Lin x/Lin y", ("linear", "linear")), ("Log x/Log y", ("log", "log")),
      ("Lin x/Log y", ("linear", "log")), ("Log x/Lin y", ("log", "linear"))])
 
-ERROR_BARS_MENU_TEXT = "Error Bars"
-SHOW_ERROR_BARS_BUTTON_TEXT = "Show all errors"
-HIDE_ERROR_BARS_BUTTON_TEXT = "Hide all errors"
-
 VALID_LINE_STYLE = ['solid', 'dashed', 'dotted', 'dashdot']
 VALID_COLORS = {
     'blue': '#1f77b4',
@@ -58,6 +54,10 @@ class FigureInteraction(object):
     Defines the behaviour of interaction events on a figure canvas. Note that
     this currently only works with Qt canvas types.
     """
+
+    ERROR_BARS_MENU_TEXT = "Error Bars"
+    SHOW_ERROR_BARS_BUTTON_TEXT = "Show all errors"
+    HIDE_ERROR_BARS_BUTTON_TEXT = "Hide all errors"
 
     def __init__(self, fig_manager):
         """
@@ -361,11 +361,11 @@ class FigureInteraction(object):
         if not isinstance(ax, MantidAxes) and len(ax.containers) == 0:
             return
 
-        error_bars_menu = QMenu(ERROR_BARS_MENU_TEXT, menu)
-        error_bars_menu.addAction(SHOW_ERROR_BARS_BUTTON_TEXT,
+        error_bars_menu = QMenu(self.ERROR_BARS_MENU_TEXT, menu)
+        error_bars_menu.addAction(self.SHOW_ERROR_BARS_BUTTON_TEXT,
                                   partial(self.errors_manager.update_plot_after,
                                           self.errors_manager.toggle_all_errors, ax, make_visible=True))
-        error_bars_menu.addAction(HIDE_ERROR_BARS_BUTTON_TEXT,
+        error_bars_menu.addAction(self.HIDE_ERROR_BARS_BUTTON_TEXT,
                                   partial(self.errors_manager.update_plot_after,
                                           self.errors_manager.toggle_all_errors, ax, make_visible=False))
         menu.addMenu(error_bars_menu)

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -15,6 +15,7 @@ from __future__ import (absolute_import, unicode_literals)
 from collections import OrderedDict
 from copy import copy
 from functools import partial
+from matplotlib.container import ErrorbarContainer
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QCursor
 from qtpy.QtWidgets import QActionGroup, QMenu, QApplication
@@ -26,6 +27,7 @@ from mantid.plots.utility import zoom
 from mantid.py3compat import iteritems
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.plotting.markers import SingleMarker
+from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 from workbench.plotting.propertiesdialog import (LabelEditor, XAxisEditor, YAxisEditor,
                                                  SingleMarkerEditor, GlobalMarkerEditor,
@@ -36,6 +38,11 @@ from workbench.plotting.toolbar import ToolbarStateManager
 AXES_SCALE_MENU_OPTS = OrderedDict(
     [("Lin x/Lin y", ("linear", "linear")), ("Log x/Log y", ("log", "log")),
      ("Lin x/Log y", ("linear", "log")), ("Log x/Lin y", ("log", "linear"))])
+
+ERROR_BARS_MENU_TEXT = "Error Bars"
+SHOW_ERROR_BARS_BUTTON_TEXT = "Show all errors"
+HIDE_ERROR_BARS_BUTTON_TEXT = "Hide all errors"
+
 VALID_LINE_STYLE = ['solid', 'dashed', 'dotted', 'dashdot']
 VALID_COLORS = {
     'blue': '#1f77b4',
@@ -289,7 +296,7 @@ class FigureInteraction(object):
         self._add_axes_scale_menu(menu, event.inaxes)
         if isinstance(event.inaxes, MantidAxes):
             self._add_normalization_option_menu(menu, event.inaxes)
-        self.errors_manager.add_error_bars_menu(menu, event.inaxes)
+        self.add_error_bars_menu(menu, event.inaxes)
         self._add_marker_option_menu(menu, event)
 
         menu.exec_(QCursor.pos())
@@ -331,6 +338,63 @@ class FigureInteraction(object):
             none_action.setChecked(True)
 
         menu.addMenu(norm_menu)
+
+    def add_error_bars_menu(self, menu, ax):
+        """
+        Add menu actions to toggle the errors for all lines in the plot.
+
+        Lines without errors are added in the context menu first,
+        then lines containing errors are appended afterwards.
+
+        This is done so that the context menu always has
+        the same order of curves as the legend is currently showing - and the
+        legend always appends curves with errors after the lines without errors.
+        Relevant source, as of 10 July 2019:
+        https://github.com/matplotlib/matplotlib/blob/154922992722db37a9d9c8680682ccc4acf37f8c/lib/matplotlib/legend.py#L1201
+
+        :param menu: The menu to which the actions will be added
+        :type menu: QMenu
+        :param ax: The Axes containing lines to toggle errors on
+        """
+        # if the ax is not a MantidAxes, and there are no errors plotted,
+        # then do not add any options for the menu
+        if not isinstance(ax, MantidAxes) and len(ax.containers) == 0:
+            return
+
+        error_bars_menu = QMenu(ERROR_BARS_MENU_TEXT, menu)
+        error_bars_menu.addAction(SHOW_ERROR_BARS_BUTTON_TEXT,
+                                  partial(self.errors_manager.update_plot_after,
+                                          self.errors_manager.toggle_all_errors, ax, make_visible=True))
+        error_bars_menu.addAction(HIDE_ERROR_BARS_BUTTON_TEXT,
+                                  partial(self.errors_manager.update_plot_after,
+                                          self.errors_manager.toggle_all_errors, ax, make_visible=False))
+        menu.addMenu(error_bars_menu)
+
+        self.errors_manager.active_lines = self.errors_manager.get_curves_from_ax(ax)
+
+        # if there's more than one line plotted, then
+        # add a sub menu, containing an action to hide the
+        # error bar for each line
+        error_bars_menu.addSeparator()
+        add_later = []
+        for index, line in enumerate(self.errors_manager.active_lines):
+            if curve_has_errors(line):
+                curve_props = CurveProperties.from_curve(line)
+                # Add lines without errors first, lines with errors are appended later. Read docstring for more info
+                if not isinstance(line, ErrorbarContainer):
+                    action = error_bars_menu.addAction(line.get_label(), partial(
+                        self.errors_manager.update_plot_after, self.errors_manager.toggle_error_bars_for, ax, line))
+                    action.setCheckable(True)
+                    action.setChecked(not curve_props.hide_errors)
+                else:
+                    add_later.append((line.get_label(), partial(
+                        self.errors_manager.update_plot_after, self.errors_manager.toggle_error_bars_for, ax, line),
+                                      not curve_props.hide_errors))
+
+        for label, function, visible in add_later:
+            action = error_bars_menu.addAction(label, function)
+            action.setCheckable(True)
+            action.setChecked(visible)
 
     def _add_marker_option_menu(self, menu, event):
         """

--- a/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
@@ -77,23 +77,12 @@ class FigureErrorsManagerTest(unittest.TestCase):
         del self.ax
         del self.errors_manager
 
-    def test_add_error_bars_menu(self):
-        main_menu = QMenu()
-        self.errors_manager.add_error_bars_menu(main_menu, self.ax)
-
-        # Check the expected sub-menu with buttons is added
-        added_menu = main_menu.children()[1]
-        self.assertTrue(
-            any(FigureErrorsManager.SHOW_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
-        self.assertTrue(
-            any(FigureErrorsManager.HIDE_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
-
     @plot_things(make_them_errors=False)
     def test_show_all_errors(self):
         # assert plot does not have errors
         self.assertEqual(0, len(self.ax.containers))
 
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=True)
+        self.errors_manager.toggle_all_errors(self.ax, make_visible=True)
 
         # check that the errors have been added
         self.assertEqual(2, len(self.ax.containers))
@@ -101,7 +90,7 @@ class FigureErrorsManagerTest(unittest.TestCase):
     @plot_things(make_them_errors=True)
     def test_hide_all_errors(self):
         self.assertEqual(2, len(self.ax.containers))
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=False)
+        self.errors_manager.toggle_all_errors(self.ax, make_visible=False)
         # errors still exist
         self.assertEqual(2, len(self.ax.containers))
         # they are just invisible
@@ -112,7 +101,7 @@ class FigureErrorsManagerTest(unittest.TestCase):
         # create a legend with a title
         self.ax.legend(title="Test")
 
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=False)
+        self.errors_manager.toggle_all_errors(self.ax, make_visible=False)
 
         # check that the legend still has a title
         self.assertEqual(self.ax.get_legend().get_title().get_text(), "Test")
@@ -122,113 +111,7 @@ class FigureErrorsManagerTest(unittest.TestCase):
         # create a legend with a title
         self.ax.legend(title="Test")
 
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=True)
+        self.errors_manager.toggle_all_errors(self.ax, make_visible=True)
 
         # check that the legend still has a title
         self.assertEqual(self.ax.get_legend().get_title().get_text(), "Test")
-
-
-@start_qapplication
-class ScriptedPlotFigureErrorsManagerTest(unittest.TestCase):
-    """
-    Test class that covers the interaction of the FigureErrorsManager with plots that
-    do not use the MantidAxes, which happens if they are scripted.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        cls.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30, 10, 20, 30],
-                                         DataY=[2, 3, 4, 5, 3, 5],
-                                         DataE=[1, 2, 3, 4, 1, 1],
-                                         NSpec=3,
-                                         Distribution=True,
-                                         UnitX='Wavelength',
-                                         VerticalAxisUnit='DeltaE',
-                                         VerticalAxisValues=[4, 6, 8],
-                                         OutputWorkspace='ws2d_histo')
-        # initialises the QApplication
-        super(cls, ScriptedPlotFigureErrorsManagerTest).setUpClass()
-
-    def setUp(self):
-        self.fig, self.ax = plt.subplots()  # type: matplotlib.figure.Figure, MantidAxes
-
-        self.errors_manager = FigureErrorsManager(self.fig.canvas)  # type: FigureErrorsManager
-
-    def tearDown(self):
-        plt.close('all')
-        del self.fig
-        del self.ax
-        del self.errors_manager
-
-    def test_context_menu_not_added_for_scripted_plot_without_errors(self):
-        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
-        self.ax.plot([0, 15000], [0, 14000], label='MyLabel 2')
-
-        main_menu = QMenu()
-        # QMenu always seems to have 1 child when empty,
-        # but just making sure the count as expected at this point in the test
-        self.assertEqual(1, len(main_menu.children()))
-
-        # plot above doesn't have errors, nor is a MantidAxes
-        # so no context menu will be added
-        self.errors_manager.add_error_bars_menu(main_menu, self.ax)
-
-        # number of children should remain unchanged
-        self.assertEqual(1, len(main_menu.children()))
-
-    def test_scripted_plot_line_without_label_handled_properly(self):
-        # having the special nolabel is usually present on lines with errors,
-        # but sometimes can be present on lines without errors, this test covers that case
-        self.ax.plot([0, 15000], [0, 15000], label='_nolegend_')
-        self.ax.plot([0, 15000], [0, 15000], label='_nolegend_')
-
-        main_menu = QMenu()
-        # QMenu always seems to have 1 child when empty,
-        # but just making sure the count as expected at this point in the test
-        self.assertEqual(1, len(main_menu.children()))
-
-        # plot above doesn't have errors, nor is a MantidAxes
-        # so no context menu will be added for error bars
-        self.errors_manager.add_error_bars_menu(main_menu, self.ax)
-
-        # number of children should remain unchanged
-        self.assertEqual(1, len(main_menu.children()))
-
-    def test_context_menu_added_for_scripted_plot_with_errors(self):
-        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
-        self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
-
-        main_menu = QMenu()
-        # QMenu always seems to have 1 child when empty,
-        # but just making sure the count as expected at this point in the test
-        self.assertEqual(1, len(main_menu.children()))
-
-        # plot above doesn't have errors, nor is a MantidAxes
-        # so no context menu will be added
-        self.errors_manager.add_error_bars_menu(main_menu, self.ax)
-
-        added_menu = main_menu.children()[1]
-
-        # actions should have been added now, which for this case are only `Show all` and `Hide all`
-        self.assertTrue(
-            any(FigureErrorsManager.SHOW_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
-        self.assertTrue(
-            any(FigureErrorsManager.HIDE_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
-
-    def test_scripted_plot_show_and_hide_all(self):
-        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
-        self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
-
-        anonymous_menu = QMenu()
-        # this initialises some of the class internals
-        self.errors_manager.add_error_bars_menu(anonymous_menu, self.ax)
-
-        self.assertTrue(self.ax.containers[0][2][0].get_visible())
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=False)
-        self.assertFalse(self.ax.containers[0][2][0].get_visible())
-
-        # make the menu again, this updates the internal state of the errors manager
-        # and is what actually happens when the user opens the menu again
-        self.errors_manager.add_error_bars_menu(anonymous_menu, self.ax)
-        self.errors_manager._toggle_all_errors(self.ax, make_visible=True)
-        self.assertTrue(self.ax.containers[0][2][0].get_visible())

--- a/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
@@ -14,10 +14,8 @@ import unittest
 import matplotlib
 matplotlib.use("AGG")  # noqa
 import matplotlib.pyplot as plt
-from qtpy.QtWidgets import QMenu
 
 # Pulling in the MantidAxes registers the 'mantid' projection
-from mantid.plots import MantidAxes  # noqa:F401
 from mantid.simpleapi import CreateWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
@@ -34,10 +32,6 @@ def plot_things(make_them_errors):
             else:
                 self.ax.errorbar(self.ws2d_histo, specNum=1)
                 self.ax.errorbar(self.ws2d_histo, wkspIndex=2)
-
-            anonymous_menu = QMenu()
-            # this initialises some of the class internals
-            self.errors_manager.add_error_bars_menu(anonymous_menu, self.ax)
             return func(self)
 
         return function_parameters
@@ -115,3 +109,15 @@ class FigureErrorsManagerTest(unittest.TestCase):
 
         # check that the legend still has a title
         self.assertEqual(self.ax.get_legend().get_title().get_text(), "Test")
+
+    def test_curve_has_all_errorbars_on_replot_after_error_every_increase(self):
+        curve = self.ax.errorbar([0, 1, 2, 4], [0, 1, 2, 4], yerr=[0.1, 0.2, 0.3, 0.4])
+        new_curve = FigureErrorsManager._replot_mpl_curve(self.ax, curve, {'errorevery': 2})
+        self.assertEqual(2, len(new_curve[2][0].get_segments()))
+        new_curve = FigureErrorsManager._replot_mpl_curve(self.ax, new_curve, {'errorevery': 1})
+        self.assertTrue(hasattr(new_curve, 'errorbar_data'))
+        self.assertEqual(4, len(new_curve[2][0].get_segments()))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -28,9 +28,11 @@ from mantid.py3compat.mock import MagicMock, PropertyMock, call, patch
 from mantid.simpleapi import CreateWorkspace
 from mantidqt.plotting.figuretype import FigureType
 from mantidqt.plotting.functions import plot
+from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figureinteraction import FigureInteraction
 
 
+@start_qapplication
 class FigureInteractionTest(unittest.TestCase):
 
     @classmethod
@@ -51,6 +53,8 @@ class FigureInteractionTest(unittest.TestCase):
             UnitX='Wavelength',
             YUnitLabel='Counts',
             OutputWorkspace='ws1')
+        # initialises the QApplication
+        super(cls, FigureInteractionTest).setUpClass()
 
     @classmethod
     def tearDownClass(cls):
@@ -67,7 +71,7 @@ class FigureInteractionTest(unittest.TestCase):
         plt.close('all')
         del self.fig
         del self.ax
-        del self.errors_manager
+        del self.interactor
 
     # Success tests
     def test_construction_registers_handler_for_button_press_event(self):
@@ -153,7 +157,7 @@ class FigureInteractionTest(unittest.TestCase):
                    autospec=True):
             with patch.object(interactor.toolbar_manager, 'is_tool_active',
                               lambda: False):
-                with patch.object(interactor.errors_manager, 'add_error_bars_menu', MagicMock()):
+                with patch.object(interactor, 'add_error_bars_menu', MagicMock()):
                     interactor.on_mouse_button_press(mouse_event)
                     self.assertEqual(0, qmenu_call1.addSeparator.call_count)
                     self.assertEqual(0, qmenu_call1.addAction.call_count)
@@ -205,6 +209,7 @@ class FigureInteractionTest(unittest.TestCase):
                                         plot_kwargs={'distribution': True, 'autoscale_on_update': False})
 
     def test_add_error_bars_menu(self):
+        self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
         main_menu = QMenu()
         self.interactor.add_error_bars_menu(main_menu, self.ax)
 
@@ -378,7 +383,7 @@ class FigureInteractionTest(unittest.TestCase):
 
         with patch('workbench.plotting.figureinteraction.QActionGroup', autospec=True):
             with patch.object(self.interactor.toolbar_manager, 'is_tool_active', lambda: False):
-                with patch.object(self.interactor.errors_manager, 'add_error_bars_menu', MagicMock()):
+                with patch.object(self.interactor, 'add_error_bars_menu', MagicMock()):
                     self.interactor.on_mouse_button_press(mouse_event)
                     self.assertEqual(0, qmenu_call1.addSeparator.call_count)
                     self.assertEqual(0, qmenu_call1.addAction.call_count)

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -16,8 +16,10 @@ import unittest
 import matplotlib
 
 matplotlib.use('AGG')  # noqa
+import matplotlib.pyplot as plt
 import numpy as np
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QMenu
 from testhelpers import assert_almost_equal
 
 # local package imports
@@ -59,6 +61,13 @@ class FigureInteractionTest(unittest.TestCase):
         fig_manager = self._create_mock_fig_manager_to_accept_right_click()
         fig_manager.fit_browser.tool = None
         self.interactor = FigureInteraction(fig_manager)
+        self.fig, self.ax = plt.subplots()  # type: matplotlib.figure.Figure, MantidAxes
+
+    def tearDown(self):
+        plt.close('all')
+        del self.fig
+        del self.ax
+        del self.errors_manager
 
     # Success tests
     def test_construction_registers_handler_for_button_press_event(self):
@@ -194,6 +203,90 @@ class FigureInteractionTest(unittest.TestCase):
     def test_normalization_toggle_with_no_autoscale_on_update_with_errors(self):
         self._test_toggle_normalization(errorbars_on=True,
                                         plot_kwargs={'distribution': True, 'autoscale_on_update': False})
+
+    def test_add_error_bars_menu(self):
+        main_menu = QMenu()
+        self.interactor.add_error_bars_menu(main_menu, self.ax)
+
+        # Check the expected sub-menu with buttons is added
+        added_menu = main_menu.children()[1]
+        self.assertTrue(
+            any(FigureInteraction.SHOW_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
+        self.assertTrue(
+            any(FigureInteraction.HIDE_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
+
+    def test_context_menu_not_added_for_scripted_plot_without_errors(self):
+        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
+        self.ax.plot([0, 15000], [0, 14000], label='MyLabel 2')
+
+        main_menu = QMenu()
+        # QMenu always seems to have 1 child when empty,
+        # but just making sure the count as expected at this point in the test
+        self.assertEqual(1, len(main_menu.children()))
+
+        # plot above doesn't have errors, nor is a MantidAxes
+        # so no context menu will be added
+        self.interactor.add_error_bars_menu(main_menu, self.ax)
+
+        # number of children should remain unchanged
+        self.assertEqual(1, len(main_menu.children()))
+
+    def test_scripted_plot_line_without_label_handled_properly(self):
+        # having the special nolabel is usually present on lines with errors,
+        # but sometimes can be present on lines without errors, this test covers that case
+        self.ax.plot([0, 15000], [0, 15000], label='_nolegend_')
+        self.ax.plot([0, 15000], [0, 15000], label='_nolegend_')
+
+        main_menu = QMenu()
+        # QMenu always seems to have 1 child when empty,
+        # but just making sure the count as expected at this point in the test
+        self.assertEqual(1, len(main_menu.children()))
+
+        # plot above doesn't have errors, nor is a MantidAxes
+        # so no context menu will be added for error bars
+        self.interactor.add_error_bars_menu(main_menu, self.ax)
+
+        # number of children should remain unchanged
+        self.assertEqual(1, len(main_menu.children()))
+
+    def test_context_menu_added_for_scripted_plot_with_errors(self):
+        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
+        self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
+
+        main_menu = QMenu()
+        # QMenu always seems to have 1 child when empty,
+        # but just making sure the count as expected at this point in the test
+        self.assertEqual(1, len(main_menu.children()))
+
+        # plot above doesn't have errors, nor is a MantidAxes
+        # so no context menu will be added
+        self.interactor.add_error_bars_menu(main_menu, self.ax)
+
+        added_menu = main_menu.children()[1]
+
+        # actions should have been added now, which for this case are only `Show all` and `Hide all`
+        self.assertTrue(
+            any(FigureInteraction.SHOW_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
+        self.assertTrue(
+            any(FigureInteraction.HIDE_ERROR_BARS_BUTTON_TEXT == child.text() for child in added_menu.children()))
+
+    def test_scripted_plot_show_and_hide_all(self):
+        self.ax.plot([0, 15000], [0, 15000], label='MyLabel')
+        self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')
+
+        anonymous_menu = QMenu()
+        # this initialises some of the class internals
+        self.interactor.add_error_bars_menu(anonymous_menu, self.ax)
+
+        self.assertTrue(self.ax.containers[0][2][0].get_visible())
+        self.interactor.errors_manager.toggle_all_errors(self.ax, make_visible=False)
+        self.assertFalse(self.ax.containers[0][2][0].get_visible())
+
+        # make the menu again, this updates the internal state of the errors manager
+        # and is what actually happens when the user opens the menu again
+        self.interactor.add_error_bars_menu(anonymous_menu, self.ax)
+        self.interactor.errors_manager.toggle_all_errors(self.ax, make_visible=True)
+        self.assertTrue(self.ax.containers[0][2][0].get_visible())
 
     # Failure tests
     def test_construction_with_non_qt_canvas_raises_exception(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -8,17 +8,13 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
-from matplotlib.axes import ErrorbarContainer
-from matplotlib.lines import Line2D
-
-from mantid.plots import MantidAxes
-from mantid.plots.helperfunctions import get_data_from_errorbar_container, set_errorbars_hidden
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.plotconfigdialog import get_axes_names_dict, curve_in_ax
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import (
     CurveProperties, curve_has_errors, remove_curve_from_ax)
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.view import CurvesTabWidgetView
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
+from workbench.plotting.figureerrorsmanager import FigureErrorsManager
 
 
 class CurvesTabWidgetPresenter:
@@ -74,23 +70,10 @@ class CurvesTabWidgetPresenter:
         curve = self.get_selected_curve()
         # Set the curve's new name in the names dict and combo box
         self.set_new_curve_name_in_dict_and_combo_box(curve, view_props.label)
-        self.toggle_errors(curve, view_props)
+        FigureErrorsManager.toggle_errors(curve, view_props)
         self.current_view_properties = view_props
 
-        self.update_limits_and_legend(ax, self.legend_props)
-
-    @staticmethod
-    def update_limits_and_legend(ax, legend_props=None):
-        ax.relim()
-        ax.autoscale()
-        if legend_props:
-            LegendProperties.create_legend(legend_props, ax)
-
-    @staticmethod
-    def toggle_errors(curve, view_props):
-        hide_errors = view_props.hide_errors or view_props.hide
-        setattr(curve, 'hide_errors', hide_errors)
-        set_errorbars_hidden(curve, hide_errors)
+        FigureErrorsManager.update_limits_and_legend(ax, self.legend_props)
 
     def close_tab(self):
         """Close the tab and set the view to None"""
@@ -119,49 +102,12 @@ class CurvesTabWidgetPresenter:
         """Get top level properties from view"""
         return self.view.get_properties()
 
-    @staticmethod
-    def _replot_mpl_curve(ax, curve, plot_kwargs):
-        """
-        Replot the given matplotlib curve with new kwargs
-        :param ax: The axis that the curve will be plotted on
-        :param curve: The curve that will be replotted
-        :param plot_kwargs: Kwargs for the plot that will be passed onto matplotlib
-        """
-        remove_curve_from_ax(curve)
-        if isinstance(curve, Line2D):
-            [plot_kwargs.pop(arg, None) for arg in
-             ['capsize', 'capthick', 'ecolor', 'elinewidth', 'errorevery']]
-            new_curve = ax.plot(curve.get_xdata(), curve.get_ydata(),
-                                **plot_kwargs)[0]
-        elif isinstance(curve, ErrorbarContainer):
-            # Because of "error every" option, we need to store the original
-            # error bar data on the curve or we will lose data on re-plotting
-            x, y, xerr, yerr = getattr(curve, 'errorbar_data',
-                                       get_data_from_errorbar_container(curve))
-            new_curve = ax.errorbar(x, y, xerr=xerr, yerr=yerr, **plot_kwargs)
-            setattr(new_curve, 'errorbar_data', [x, y, xerr, yerr])
-        else:
-            raise ValueError("Curve must have type 'Line2D' or 'ErrorbarContainer'. Found '{}'".format(type(curve)))
-        return new_curve
-
     def _replot_selected_curve(self, plot_kwargs):
         """Replot the selected curve with the given plot kwargs"""
         ax = self.get_selected_ax()
         curve = self.get_selected_curve()
-        new_curve = self.replot_curve(ax, curve, plot_kwargs)
+        new_curve = FigureErrorsManager.replot_curve(ax, curve, plot_kwargs)
         self.curve_names_dict[self.view.get_selected_curve_name()] = new_curve
-
-    @classmethod
-    def replot_curve(cls, ax, curve, plot_kwargs):
-        if isinstance(ax, MantidAxes):
-            try:
-                new_curve = ax.replot_artist(curve, errorbars=True, **plot_kwargs)
-            except ValueError:  # ValueError raised if Artist not tracked by Axes
-                new_curve = cls._replot_mpl_curve(ax, curve, plot_kwargs)
-        else:
-            new_curve = cls._replot_mpl_curve(ax, curve, plot_kwargs)
-        setattr(new_curve, 'errorevery', plot_kwargs.get('errorevery', 1))
-        return new_curve
 
     def populate_curve_combo_box_and_update_view(self):
         """
@@ -200,7 +146,7 @@ class CurvesTabWidgetPresenter:
 
         ax = self.get_selected_ax()
         # Update the legend and redraw
-        self.update_limits_and_legend(ax, self.legend_props)
+        FigureErrorsManager.update_limits_and_legend(ax, self.legend_props)
         ax.figure.canvas.draw()
 
         # Remove the curve from the curve selection combo box
@@ -265,11 +211,7 @@ class CurvesTabWidgetPresenter:
     def _get_selected_ax_errorbars(self):
         """Get all errorbar containers in selected axes"""
         ax = self.get_selected_ax()
-        return self.get_errorbars_from_ax(ax)
-
-    @staticmethod
-    def get_errorbars_from_ax(ax):
-        return [cont for cont in ax.containers if isinstance(cont, ErrorbarContainer)]
+        return FigureErrorsManager.get_errorbars_from_ax(ax)
 
     def _populate_select_curve_combo_box(self):
         """
@@ -284,17 +226,13 @@ class CurvesTabWidgetPresenter:
             self.view.close()
             return False
 
-        active_lines = self.get_curves_from_ax(selected_ax)
+        active_lines = FigureErrorsManager.get_curves_from_ax(selected_ax)
         for line in active_lines:
             self._update_selected_curve_name(line)
 
         self.view.populate_select_curve_combo_box(
             sorted(self.curve_names_dict.keys(), key=lambda s: s.lower()))
         return True
-
-    @staticmethod
-    def get_curves_from_ax(ax):
-        return ax.get_lines() + CurvesTabWidgetPresenter.get_errorbars_from_ax(ax)
 
     def _update_selected_curve_name(self, curve):
         """Update the selected curve's name in the curve_names_dict"""

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -191,18 +191,6 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         # Test only one errorbar is plotted
         self.assertEqual(1, len(new_err_container[2][0].get_segments()))
 
-    def test_curve_has_all_errorbars_on_replot_after_error_every_increase(self):
-        fig = figure()
-        ax = fig.add_subplot(111)
-        curve = ax.errorbar([0, 1, 2, 4], [0, 1, 2, 4], yerr=[0.1, 0.2, 0.3, 0.4])
-        new_curve = CurvesTabWidgetPresenter._replot_mpl_curve(ax, curve,
-                                                               {'errorevery': 2})
-        self.assertEqual(2, len(new_curve[2][0].get_segments()))
-        new_curve = CurvesTabWidgetPresenter._replot_mpl_curve(ax, new_curve,
-                                                               {'errorevery': 1})
-        self.assertTrue(hasattr(new_curve, 'errorbar_data'))
-        self.assertEqual(4, len(new_curve[2][0].get_segments()))
-
     def test_curve_errorbars_are_hidden_on_apply_properties_when_hide_curve_is_ticked(self):
         fig = figure()
         ax = fig.add_subplot(111)


### PR DESCRIPTION
This PR moves functions from CurvesTabWidgetPresenter that work exclusivly with the mantid axis and move them into the FigureErrorsManager class.
It also moves the function to create the context menu for the error bar generated when right clicking on a plot into the FigureInteraction class along with the other context menu functions

It also migrates the tests for these functions into the appropriate unit tests

**To test:**

1. Load some data
1. Plot some data.
1. Test the context menu for the errorbar options.
1. Test that the settings menu error tab still functions.

Fixes #26330

*This does not require release notes* because it is only changes to code, not functionality

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
