### PR TITLE
Handle point/binned numeric axes in workbench data table.

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -84,27 +84,32 @@ class MatrixWorkspaceTableViewModel(QAbstractTableModel):
             raise ValueError("Unknown model type {0}".format(self.type))
 
     def _makeVerticalHeader(self, section, role):
+        def _numeric_axis_value_unit(axis):
+            # binned/point data
+            if axis.length() == self.ws.getNumberHistograms() + 1:
+                value = 0.5 * (float(axis.label(section)) + float(axis.label(section + 1)))
+            else:
+                value = float(axis.label(section))
+            return value, axis.getUnit().symbol().utf8()
+
         axis_index = 1
         # check that the vertical axis actually exists in the workspace
         if self.ws.axes() > axis_index:
+            axis = self.ws.getAxis(axis_index)
             if role == Qt.DisplayRole:
-                if not self.ws.getAxis(axis_index).isNumeric():
+                if not axis.isNumeric():
                     return self.VERTICAL_HEADER_DISPLAY_STRING.format(
-                        section, self.ws.getAxis(axis_index).label(section))
+                        section, axis.label(section))
                 else:
-                    bin_center = (float(self.ws.getAxis(axis_index).label(section)) +
-                                  float(self.ws.getAxis(axis_index).label(section+1)))/2.0
-                    unit = self.ws.getAxis(axis_index).getUnit().symbol().utf8()
-                    return self.VERTICAL_HEADER_DISPLAY_STRING_FOR_NUMERIC_AXIS.format(section, bin_center, unit)
+                    display_value, unit = _numeric_axis_value_unit(axis)
+                    return self.VERTICAL_HEADER_DISPLAY_STRING_FOR_NUMERIC_AXIS.format(section, display_value, unit)
             else:
-                if not self.ws.getAxis(axis_index).isNumeric():
+                if not axis.isNumeric():
                     spectrum_number = self.ws.getSpectrum(section).getSpectrumNo()
                     return self.VERTICAL_HEADER_TOOLTIP_STRING.format(section, spectrum_number)
                 else:
-                    bin_center = (float(self.ws.getAxis(axis_index).label(section)) +
-                                  float(self.ws.getAxis(axis_index).label(section+1)))/2.0
-                    unit = self.ws.getAxis(axis_index).getUnit().symbol().utf8()
-                    return self.VERTICAL_HEADER_TOOLTIP_STRING_FOR_NUMERIC_AXIS.format(section, bin_center, unit)
+                    display_value, unit = _numeric_axis_value_unit(axis)
+                    return self.VERTICAL_HEADER_TOOLTIP_STRING_FOR_NUMERIC_AXIS.format(section, display_value, unit)
         else:
             raise NotImplementedError("What do we do here? Handle if the vertical axis does NOT exist")
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py
@@ -386,13 +386,13 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
                                                                                               MockSpectrum.SPECTRUM_NO)
         self.assertEqual(expected_output, output)
 
-    def test_headerData_vertical_header_display_for_numeric_axis(self):
+    def test_headerData_vertical_header_display_for_numeric_axis_with_point_data(self):
         dummy_unit = 'unit'
-        bin_center = 0.5
         ws = MockWorkspace()
         mock_axis = Mock()
         mock_axis.isNumeric.return_value = True
-        mock_axis.label = MagicMock(side_effect=lambda x: x)
+        expected_value = 0.
+        mock_axis.label = MagicMock(side_effect=[str(expected_value)])
         mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
         ws.getAxis.return_value = mock_axis
 
@@ -403,17 +403,41 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
 
         expected_output = MatrixWorkspaceTableViewModel.VERTICAL_HEADER_DISPLAY_STRING_FOR_NUMERIC_AXIS.format(
             mock_section,
-            bin_center,
+            expected_value,
             dummy_unit)
         self.assertEqual(expected_output, output)
 
-    def test_headerData_vertical_header_tooltip_for_numeric_axis(self):
+    def test_headerData_vertical_header_display_for_numeric_axis_with_binned_data(self):
         dummy_unit = 'unit'
-        bin_center = 0.5
         ws = MockWorkspace()
         mock_axis = Mock()
         mock_axis.isNumeric.return_value = True
-        mock_axis.label = MagicMock(side_effect=lambda x: x)
+        # single spectrum with length 2 axis
+        ws.getNumberHistograms.return_value = 1
+        mock_axis.length.return_value = 2
+        mock_axis.label = MagicMock(side_effect=["0", "1"])
+        mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
+        ws.getAxis.return_value = mock_axis
+
+        model_type = MatrixWorkspaceTableViewModelType.y
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+        mock_section = 0
+        output = model.headerData(mock_section, Qt.Vertical, Qt.DisplayRole)
+
+        expected_output = MatrixWorkspaceTableViewModel.VERTICAL_HEADER_DISPLAY_STRING_FOR_NUMERIC_AXIS.format(
+            mock_section,
+            0.5,
+            dummy_unit)
+        self.assertEqual(expected_output, output)
+
+    def test_headerData_vertical_header_tooltip_for_numeric_axis_with_point_data(self):
+        dummy_unit = 'unit'
+        ws = MockWorkspace()
+        mock_axis = Mock()
+        mock_axis.isNumeric.return_value = True
+        ws.getNumberHistograms.return_value = 1
+        mock_axis.length.return_value = 1
+        mock_axis.label = MagicMock(side_effect=["0"])
         mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
         ws.getAxis.return_value = mock_axis
 
@@ -424,7 +448,29 @@ class MatrixWorkspaceDisplayTableViewModelTest(unittest.TestCase):
 
         expected_output = MatrixWorkspaceTableViewModel.VERTICAL_HEADER_TOOLTIP_STRING_FOR_NUMERIC_AXIS.format(
             mock_section,
-            bin_center,
+            0,
+            dummy_unit)
+        self.assertEqual(expected_output, output)
+
+    def test_headerData_vertical_header_tooltip_for_numeric_axis_with_binned_data(self):
+        dummy_unit = 'unit'
+        ws = MockWorkspace()
+        mock_axis = Mock()
+        mock_axis.isNumeric.return_value = True
+        ws.getNumberHistograms.return_value = 1
+        mock_axis.length.return_value = 2
+        mock_axis.label = MagicMock(side_effect=["0", "1"])
+        mock_axis.getUnit().symbol().utf8.return_value = dummy_unit
+        ws.getAxis.return_value = mock_axis
+
+        model_type = MatrixWorkspaceTableViewModelType.y
+        model = MatrixWorkspaceTableViewModel(ws, model_type)
+        mock_section = 0
+        output = model.headerData(mock_section, Qt.Vertical, Qt.ToolTipRole)
+
+        expected_output = MatrixWorkspaceTableViewModel.VERTICAL_HEADER_TOOLTIP_STRING_FOR_NUMERIC_AXIS.format(
+            mock_section,
+            0.5,
             dummy_unit)
         self.assertEqual(expected_output, output)
 


### PR DESCRIPTION
**Description of work.**

Queries length of workspace to check if the axis is actually bins or point values and calculates the values in the vertical header accordingly in workbench.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Test with the script in issue and see it doesn't crash.
Test with [iris26176_graphite002_sqw.zip](https://github.com/mantidproject/mantid/files/3723769/iris26176_graphite002_sqw.zip) and compare the values in the row labels with MantidPlot. They should match.

Fixes #27400  

*This does not require release notes* because **this is a regression from 4.1**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
