### PR TITLE
Fix issue with scripts containing unicode characters on unix systems

### DIFF
--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -45,6 +45,11 @@ class WriteToSignal(QObject):
                 self.sig_write_received.emit("Error: Unable to write to the console of the process.\n"
                                              "This error is not related to your script's execution.\n"
                                              "Original error: {}\n\n".format(str(e)))
-
+            except UnicodeEncodeError:
+                """
+                Scripts containing unicode characters could fail to run if mantid is not started from the
+                terminal on unix systems. The script runs fine if this exception is caught and discarded.
+                """
+                pass
         # always write to the message log
         self.sig_write_received.emit(txt)


### PR DESCRIPTION
**Description of work.**

Scripts containing unicode characters could fail to run if mantid was
not started from the terminal on unix systems. The script runs fine
if this exception is caught and discarded.

**To test:**
Open mantid from the application icon. NOT the terminal. 

Run:
```
#!/usr/bin/python
# -*- coding: utf-8 -*-
# The following line helps with future compatibility with Python 3
# print must now be used as a function, e.g print('Hello','World')
from __future__ import (absolute_import, division, print_function, unicode_literals)

# import mantid algorithms, numpy and matplotlib
#from mantid.simpleapi import *

#import matplotlib.pyplot as plt

#import numpy as np
import time

print ("hello world")

print ("new maths, one third is",1/3)

print ("alternate integer division, a third of 10 beans is",10//3)

a="unicode string with £ in it"
print (a)
b=u"Another £"
print (b)
print ("string", a,b)
print ("string", repr(a),repr(b))
#myprint=print

for x in range (3):
    print (x,"part 1")
    time.sleep(0.5)
    print (x,"part 2")
    time.sleep(0.5)
    print (x,"part 3")
    time.sleep(0.5)
    print (x,"part 3")

print ("finished")
print ("yes, really")
```
It should not fail. 

*There is no associated issue.*

*This does not require release notes* because **it fixes a regression.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
