### PR TITLE
Make c++ interfaces not children of workbench

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -372,7 +372,7 @@ class MainWindow(QMainWindow):
     def launch_custom_python_gui(self, filename):
         self.interface_executor.execute(open(filename).read(), filename)
 
-    def launch_custom_cpp_gui(self, interface_name):
+    def launch_custom_cpp_gui(self, interface_name, submenu = None):
         """Create a new interface window if one does not already exist,
         else show existing window"""
         object_name = 'custom-cpp-interface-' + interface_name
@@ -381,8 +381,8 @@ class MainWindow(QMainWindow):
             interface = self.interface_manager.createSubWindow(interface_name)
             interface.setObjectName(object_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
-            # make indirect settings a child of workbench
-            if interface_name == "Settings":
+            # make indirect interfaces children of workbench
+            if submenu == "Indirect":
                 interface.setParent(self, interface.windowFlags())
             interface.show()
         else:
@@ -407,8 +407,8 @@ class MainWindow(QMainWindow):
                     action.triggered.connect(lambda checked_py, script=script: self.launch_custom_python_gui(script))
                 else:
                     action = submenu.addAction(name)
-                    action.triggered.connect(lambda checked_cpp, name=name:
-                                             self.launch_custom_cpp_gui(name))
+                    action.triggered.connect(lambda checked_cpp, name=name, key=key:
+                                             self.launch_custom_cpp_gui(name, key))
 
     def _discover_python_interfaces(self, interface_dir):
         """Return a dictionary mapping a category to a set of named Python interfaces"""

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -386,7 +386,10 @@ class MainWindow(QMainWindow):
                 interface.setParent(self, interface.windowFlags())
             interface.show()
         else:
-            window.raise_()
+            if (window.windowState() ==  Qt.WindowState.WindowMinimized):
+                window.showNormal()
+            else:
+                window.raise_()
 
     def populate_interfaces_menu(self):
         """Populate then Interfaces menu with all Python and C++ interfaces"""

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -378,9 +378,12 @@ class MainWindow(QMainWindow):
         object_name = 'custom-cpp-interface-' + interface_name
         window = find_window(object_name, QMainWindow)
         if window is None:
-            interface = self.interface_manager.createSubWindow(interface_name,self)
+            interface = self.interface_manager.createSubWindow(interface_name)
             interface.setObjectName(object_name)
             interface.setAttribute(Qt.WA_DeleteOnClose, True)
+            # make indirect settings a child of workbench
+            if interface_name == "Settings":
+                interface.setParent(self, interface.windowFlags())
             interface.show()
         else:
             window.raise_()


### PR DESCRIPTION
This PR removes workbench from being a parent of c++ classes so they are can be minimized and re-raised as they did in earlier releases.

Indirect settings is a special case and should remain as a child so it is treated as a separate case.

**To test:**
Open a c++ interface (Any indirect interface, Reflectometry, ALF View and ALC)
Minimise it and reopen from settings, the interface should be raised (and another should not be created)
Test the changes in #27322 still work 

*There is no associated issue.*

*This does not require release notes* because **it was not in the previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
