### PR TITLE
Rewrite the HB3A IDF

### DIFF
--- a/instrument/HB3A_Definition_20190926_3.xml
+++ b/instrument/HB3A_Definition_20190926_3.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='ASCII'?>
-<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-09-26 14:43:00.375183" name="HB3A" valid-from="2018-10-20 23:59:59" valid-to="3018-10-20 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
-  <!--Created by Wenduo Zhou-->
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-11-14 11:49:00.375183" name="HB3A" valid-from="2018-10-20 23:59:59" valid-to="3018-10-20 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+  <!--Created by Ross Whitfield-->
   <!--SOURCE-->
   <component type="moderator">
     <location z="-2.0"/>
@@ -11,148 +11,67 @@
     <location x="0.0" y="0.0" z="0.0"/>
   </component>
   <type is="SamplePos" name="sample-position"/>
-  <!--PANEL Lower-->
-  <component type="arm1">
-    <location name="bank1">
-      <parameter name="p-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="r-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="roty">
-        <logfile eq="-value+0.0" id="2theta"/>
-      </parameter>
-      <parameter name="t-position">
-        <value val="0.0"/>
-      </parameter>
-    </location>
+  <!--PANEL Bottom-->
+  <component type="bank1">
+    <!-- beam center is at (256, 268) y=0.0-0.0002265625*12.5 -->
+    <location x="0.0" y="-0.00283203125" z="0.0"/>
   </component>
-  <type name="arm1">
-    <component type="panel1">
+  <type name="bank1">
+    <component type="panel" idfillbyfirst="x" idstart="1" idstepbyrow="512">
       <location>
-        <parameter name="rotx">
-          <logfile eq="value+0.0" id="cal::rotx1"/>
+        <parameter name="r-position">
+          <logfile eq="value/1000" id="det_trans"/>
+        </parameter>
+        <parameter name="t-position">
+          <logfile eq="-value" id="2theta"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="value+0.0" id="cal::roty1"/>
-        </parameter>
-        <parameter name="rotz">
-          <logfile eq="value+0.0" id="cal::rotz1"/>
-        </parameter>
-        <parameter name="z">
-          <logfile eq="value+0.375" id="cal::diffz1"/>
-        </parameter>
-      </location>
-    </component>
-  </type>
-  <type name="panel1">
-    <component type="shiftpanel" idfillbyfirst="x" idstart="1" idstepbyrow="512" >
-      <location>
-        <parameter name="x">
-          <logfile eq="value" id="cal::diffx1"/>
-        </parameter>
-        <parameter name="y">
-          <logfile eq="0.0+value" id="cal::diffy1"/>
+          <logfile eq="-value" id="2theta"/>
         </parameter>
       </location>
     </component>
   </type>
   <!--PANEL Middle-->
-  <component type="arm2">
-    <location name="bank2">
-      <parameter name="p-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="r-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="roty">
-        <logfile eq="-value+0.0" id="2theta"/>
-      </parameter>
-      <parameter name="t-position">
-        <value val="0.0"/>
-      </parameter>
-    </location>
+  <component type="bank2">
+    <!-- beam center is at (256, 268), detector is 11.6cm and gap is 5mm y=0.116+0.005-0.0002265625*12.5 -->
+    <location x="0.0" y="0.11816796875" z="0.0"/>
   </component>
-  <type name="arm2">
-    <component type="panel2">
+  <type name="bank2">
+    <component type="panel" idfillbyfirst="x" idstart="262145" idstepbyrow="512">
       <location>
-        <parameter name="rotx">
-          <logfile eq="value+0.0" id="cal::rotx2"/>
+        <parameter name="r-position">
+          <logfile eq="value/1000" id="det_trans"/>
+        </parameter>
+        <parameter name="t-position">
+          <logfile eq="-value" id="2theta"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="value+0.0" id="cal::roty2"/>
-        </parameter>
-        <parameter name="rotz">
-          <logfile eq="value+0.0" id="cal::rotz2"/>
-        </parameter>
-        <parameter name="z">
-          <logfile eq="value+0.375" id="cal::diffz2"/>
-        </parameter>
-      </location>
-    </component>
-  </type>
-  <type name="panel2">
-    <component type="shiftpanel" idfillbyfirst="x" idstart="262145" idstepbyrow="512" >
-      <location>
-        <parameter name="x">
-          <logfile eq="value" id="cal::diffx2"/>
-        </parameter>
-        <parameter name="y">
-          <logfile eq="0.12+value" id="cal::diffy2"/>
+          <logfile eq="-value" id="2theta"/>
         </parameter>
       </location>
     </component>
   </type>
   <!--PANEL Upper-->
-  <component type="arm3">
-    <location name="bank3">
-      <parameter name="p-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="r-position">
-        <value val="0.0"/>
-      </parameter>
-      <parameter name="roty">
-        <logfile eq="-value+0.0" id="2theta"/>
-      </parameter>
-      <parameter name="t-position">
-        <value val="0.0"/>
-      </parameter>
-    </location>
+  <component type="bank3">
+    <!-- beam center is at (256, 268), detectoris 11.6cmand gapis 5mm y=(0.116+0.005)*2-0.0002265625*12.5 -->
+    <location x="0.0" y="0.23916796875" z="0.0"/>
   </component>
-  <type name="arm3">
-    <component type="panel3">
+  <type name="bank3">
+    <component type="panel" idfillbyfirst="x" idstart="524289" idstepbyrow="512">
       <location>
-        <parameter name="rotx">
-          <logfile eq="value+0.0" id="cal::rotx3"/>
+        <parameter name="r-position">
+          <logfile eq="value/1000" id="det_trans"/>
+        </parameter>
+        <parameter name="t-position">
+          <logfile eq="-value" id="2theta"/>
         </parameter>
         <parameter name="roty">
-          <logfile eq="value+0.0" id="cal::roty3"/>
-        </parameter>
-        <parameter name="rotz">
-          <logfile eq="value+0.0" id="cal::rotz3"/>
-        </parameter>
-        <parameter name="z">
-          <logfile eq="value+0.375" id="cal::diffz3"/>
+          <logfile eq="-value" id="2theta"/>
         </parameter>
       </location>
     </component>
   </type>
-  <type name="panel3">
-    <component type="shiftpanel" idfillbyfirst="x" idstart="524289" idstepbyrow="512">
-      <location>
-        <parameter name="x">
-          <logfile eq="value" id="cal::diffx3"/>
-        </parameter>
-        <parameter name="y">
-          <logfile eq="0.24+value" id="cal::diffy3"/>
-        </parameter>
-      </location>
-    </component>
-  </type>
-  <type is="rectangular_detector" name="shiftpanel" type="pixel"
+  <type is="rectangular_detector" name="panel" type="pixel"
 	xpixels="512" xstart="0.05788671875" xstep="-0.0002265625"
 	ypixels="512" ystart="-0.05788671875" ystep="0.0002265625"/>
   <type is="detector" name="pixel">


### PR DESCRIPTION
Almost entire rewrite, simplfy everything. Use the det_trans log value instead of hard coded value. Remove all the `cal::` values, the calibration will be set in the IDF. Correct the detector positions relative to the beam (centered on pixel (256, 268)) and the calibrated detector gap of 5mm.

**To test:**

Try different `2theta` and `det_trans` values. When `2theta=0` the beam should pass through the row 268 in the vertical direction.

```python
wksp = CreateWorkspace(
        NSpec=1,
        DataX=[0],
        DataY=[0])

AddSampleLog(
    Workspace=wksp,
    LogName='2theta',
    LogText='30.0',
    LogType='Number Series')
AddSampleLog(
    Workspace=wksp,
    LogName='det_trans',
    LogText='400.',
    LogType='Number Series')
LoadInstrument(
    Workspace=wksp,
    Filename='/path/to/HB3A_Definition_20190926_3.xml',
    RewriteSpectraMap=False)
```

*There is no associated issue.*

Doesn't need release notes, minor change to previous IDF, still work in progress.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
