### PR TITLE
Fix settings not being respected in SANS settings

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
+++ b/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
@@ -50,7 +50,7 @@ class PresenterCommon(with_metaclass(ABCMeta)):
     def _set_on_custom_model(self, attribute_name, model):
         attribute = getattr(self._view, attribute_name)
         if attribute is not None and attribute != '':
-            setattr(self._model, attribute_name, attribute)
+            setattr(model, attribute_name, attribute)
 
     def _set_on_view_to_custom_view(self, attribute_name, view):
         attribute = getattr(self._model, attribute_name)

--- a/scripts/test/SANS/gui_logic/presenter_tests/CMakeLists.txt
+++ b/scripts/test/SANS/gui_logic/presenter_tests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(TEST_PY_FILES
+    presenter_common_test.py
     settings_adjustment_presenter_test.py
     )
 

--- a/scripts/test/SANS/gui_logic/presenter_tests/presenter_common_test.py
+++ b/scripts/test/SANS/gui_logic/presenter_tests/presenter_common_test.py
@@ -1,0 +1,46 @@
+import unittest
+
+from mantid.py3compat import mock
+from sans.gui_logic.presenter.presenter_common import PresenterCommon
+
+
+class PresenterCommonMock(PresenterCommon):
+    def default_gui_setup(self):
+        pass
+
+    def update_model_from_view(self):
+        pass
+
+    def update_view_from_model(self):
+        pass
+
+
+class PresenterCommonTest(unittest.TestCase):
+
+    def test_set_on_model(self):
+        mocked_view = mock.Mock()
+        # This should not change as it's the presenters copy
+        presenter_model = mock.Mock()
+        custom_model = mock.Mock()
+
+        attr_to_set = 'test_attr'
+        original_val = 'not_changed'
+        new_val = 'views val'
+
+        setattr(presenter_model, attr_to_set, original_val)
+        setattr(custom_model, attr_to_set, original_val)
+
+        setattr(mocked_view, attr_to_set, new_val)
+
+        mocked_presenter = PresenterCommonMock(view=mocked_view, model=presenter_model)
+
+        self.assertEqual(original_val, getattr(presenter_model, attr_to_set))
+        self.assertEqual(original_val, getattr(custom_model, attr_to_set))
+
+        mocked_presenter._set_on_custom_model(attribute_name=attr_to_set, model=custom_model)
+        self.assertEqual(new_val, getattr(custom_model, attr_to_set))
+        self.assertEqual(original_val, getattr(presenter_model, attr_to_set))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
Fixes the settings not being pulled in until a user hits process twice.
This is because we were pulling in the model from the presenter rather
than the custom one passed by param.

**Report to:** ISIS/Sarah

**To test:**
- Load the LOQ dataset
- Go to the settings page and change the phi limit to 45, -45
- Hit process selected again
- If the final workspace name contains 45 the issue is resolved

Fixes #27417


*This does not require release notes* because it regressed between releases

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
