### PR TITLE
Fix minimising crash on linux

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -386,8 +386,8 @@ class MainWindow(QMainWindow):
                 interface.setParent(self, interface.windowFlags())
             interface.show()
         else:
-            if (window.windowState() ==  Qt.WindowState.WindowMinimized):
-                window.showNormal()
+            if window.windowState() == Qt.WindowMinimized:
+                window.setWindowState(Qt.WindowActive)
             else:
                 window.raise_()
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where mantid would crash when trying to raise a minimized c++ interface.

**To test:**
Open a c++ interface (Any indirect, Reflectometry or Muon ALC)
Minimise the interface
Open the same interface from the interface menu.
The interface should reappear - should not crash or create another instance of the interface

Fixes #27414 

*This does not require release notes* because **this was not in the previous release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
