### PR TITLE
Elemental analysis cannot load if dirty paths

### DIFF
--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -38,7 +38,7 @@ class LModel(object):
             for filename in to_load if get_filename(filename, self.run) is not None
         }
         unique_workspaces = {}
-        for path, workspace in workspaces.iteritems():
+        for path, workspace in iteritems(workspaces):
             if workspace not in unique_workspaces.values():
                 unique_workspaces[path] = workspace
         workspaces = unique_workspaces

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -37,6 +37,13 @@ class LModel(object):
             filename: get_filename(filename, self.run)
             for filename in to_load if get_filename(filename, self.run) is not None
         }
+        countWorkspaces = {}
+        unique_workspaces = {}
+        for path, workspace in workspaces.iteritems():
+            countWorkspaces[workspace] = countWorkspaces.get(workspace, 0) + 1
+            if countWorkspaces[workspace] == 1:
+                unique_workspaces[path] = workspace
+        workspaces = unique_workspaces
         self._load(workspaces)
         self.loaded_runs[self.run] = merge_workspaces(self.run, workspaces.values())
         self.last_loaded_runs.append(self.run)
@@ -65,6 +72,7 @@ def search_user_dirs(run):
     for user_dir in config["datasearch.directories"].split(";"):
         path = os.path.join(user_dir, "ral{}.rooth*.dat".format(pad_run(run)))
         files.extend([file for file in glob.iglob(path)])
+
     return files
 
 

--- a/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -37,11 +37,9 @@ class LModel(object):
             filename: get_filename(filename, self.run)
             for filename in to_load if get_filename(filename, self.run) is not None
         }
-        countWorkspaces = {}
         unique_workspaces = {}
         for path, workspace in workspaces.iteritems():
-            countWorkspaces[workspace] = countWorkspaces.get(workspace, 0) + 1
-            if countWorkspaces[workspace] == 1:
+            if workspace not in unique_workspaces.values():
                 unique_workspaces[path] = workspace
         workspaces = unique_workspaces
         self._load(workspaces)


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where if multiple user directories contained the run data used in the element analysis GUI an error would occur. This was due to the same workspace being loaded multiple times. Fixed by making the workspace dictionary {path,workspace} unique with respect to the workspace value. 

Issue raised by Adrian Hillier

**To test:**

(1) Open elemental analysis
(2) Set the search path to have 2 different paths, but have the data in both paths
(3) Load the duplicated data
(4) **It should no longer fall over**

<!-- Instructions for testing. -->

Fixes #27418. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
