### PR TITLE
Fix crash when opening any help menu after opening the Manage User Directories help menu

### DIFF
--- a/docs/source/release/v4.2.0/mantidplot.rst
+++ b/docs/source/release/v4.2.0/mantidplot.rst
@@ -26,5 +26,6 @@ Bugfixes
 - Fixes an issue where the Load dialog would not resize correctly after clicking Run.
 - Useless Help [?] buttons removed from multiple dialogs.
 - Dragging and dropping workspaces onto the Spectrum Viewer no longer causes a crash.
+- Fixes an issue where opening any help menu after previously opening the help menu in the Manage User Directories window would crash MantidPlot.
 
 :ref:`Release 4.2.0 <v4.2.0>`

--- a/docs/source/release/v4.2.0/mantidworkbench.rst
+++ b/docs/source/release/v4.2.0/mantidworkbench.rst
@@ -120,6 +120,7 @@ Bugfixes
 - "MantidPlot" in window titles have been removed.
 - If multiple plots of the same workspace are open, the fit property browser will change the default output name so any output workspaces are not overridden. 
 - When showing the data table for a sqw workspace the vertical header now shows the bin center value and unit.
+- Fixes an issue where opening any help menu after previously opening the help menu in the Manage User Directories window would crash Workbench.
 
 Known Issues
 #############

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -194,7 +194,7 @@ QListWidget *ManageUserDirectories::listWidget() {
 
 // SLOTS
 void ManageUserDirectories::helpClicked() {
-  HelpWindow::showCustomInterface(this, QString("ManageUserDirectories"));
+  HelpWindow::showCustomInterface(nullptr, QString("ManageUserDirectories"));
 }
 void ManageUserDirectories::cancelClicked() { this->close(); }
 void ManageUserDirectories::confirmClicked() {


### PR DESCRIPTION
**Description of work.**
See title.

This fix changes the ```HelpWindow::showCustomInterface()``` call in the MUD class so that instead of the MUD window being the help menu's parent, the help menu has no parent. Apart from stopping the crash, the only change this has is that closing the MUD window does not also close the help window, when previously both would close.

I searched the code and it seems like every other use of ```HelpWindow::showCustomInterface()```, apart from in the MUD class previously, passes in nullptr as the help window's parent.  So perhaps there needs to be an investigation into why setting a parent causes this problem.

**To test:**
Test with both Plot and Workbench
1. Go to File ->Manage User Directories.
2. Click the help button.
3. Close the help menu and the MUD window.
4. Press F1, the help menu should open and Mantid should not crash.

Fixes #27150 
Fixes #27415 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
