### PR TITLE
Fixing layouts in IndirectFitDataView

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
@@ -35,24 +35,11 @@
    <attribute name="title">
     <string>Single Input</string>
    </attribute>
-   <layout class="QGridLayout" name="gridLayout" columnstretch="0,0">
-    <item row="1" column="1">
-     <widget class="MantidQt::MantidWidgets::DataSelector" name="dsResolution" native="true">
-      <property name="autoLoad" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="ShowGroups" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="showLoad" stdset="0">
-       <bool>false</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="lbResolution">
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <widget class="QLabel" name="lbSample">
       <property name="text">
-       <string>Resolution</string>
+       <string>Sample</string>
       </property>
      </widget>
     </item>
@@ -69,14 +56,14 @@
       </property>
      </widget>
     </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="lbSample">
+    <item row="2" column="0">
+     <widget class="QLabel" name="lbResolution">
       <property name="text">
-       <string>Sample</string>
+       <string>Resolution</string>
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
+    <item row="3" column="1">
      <widget class="QWidget" name="wgtStartEnd" native="true">
       <property name="enabled">
        <bool>true</bool>
@@ -142,6 +129,19 @@
         </spacer>
        </item>
       </layout>
+     </widget>
+    </item>
+    <item row="2" column="1">
+     <widget class="MantidQt::MantidWidgets::DataSelector" name="dsResolution" native="true">
+      <property name="autoLoad" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="ShowGroups" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLoad" stdset="0">
+       <bool>false</bool>
+      </property>
      </widget>
     </item>
    </layout>


### PR DESCRIPTION
**Description of work.**

This updates the layouts in the INdriectFitData view so that the IqtFit tab has it's workspace selectors properly placed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open the Indirect->Data Analysis interface on workbench and mantidplot. Check that the layouts of the data selection widget looks sensible on all the tabs.
<!-- Instructions for testing. -->

*There is no associated issue.*



*This does not require release notes* because issue introduced this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
