### PR TITLE
Corrected Fermi and sample distance on MAPS for PyChop

### DIFF
--- a/scripts/PyChop/maps.yaml
+++ b/scripts/PyChop/maps.yaml
@@ -3,7 +3,7 @@ name: MAPS
 
 chopper_system:
   name: MAPS chopper system
-  chop_sam: 1.9                 # Distance (x1) from final chopper to sample (m)
+  chop_sam: 1.899               # Distance (x1) from final chopper to sample (m)
   sam_det: 6.0                  # Distance (x2) from sample to detector (m)
   aperture_width: 0.094         # Width of aperture at moderator face (m)
   aperture_height: 0.094        # Height of aperture at moderator face (m)
@@ -26,7 +26,7 @@ chopper_system:
       phaseName: 'Multirep mode number'
     -
       name: MAPS Fermi
-      distance: 10.1            # Distance from moderator to this chopper in metres
+      distance: 10.143          # Distance from moderator to this chopper in metres
       aperture_distance: 8.27   # Distance from aperture (moderator face) to this chopper (only for Fermi)
       packages:                 # A hash of chopper packages
         A:

--- a/scripts/test/PyChopTest.py
+++ b/scripts/test/PyChopTest.py
@@ -34,10 +34,11 @@ class PyChop2Tests(unittest.TestCase):
         self.assertGreater(flux[2], flux[1])
         # Note that MAPS has been upgraded so now should have higher flux than MARI.
         self.assertGreater(flux[0], flux[1])
-        # Checks that the resolution should be best for MARI, MAPS, and MERLIN in that order
-        # actually MAPS and MARI resolutions are very close
-        self.assertLess(res[1][0], res[0][0])
-        self.assertLess(res[0][0], res[2][0])
+        # Checks that the resolution should be best for MAPS, MARI, and MERLIN in that order
+        # actually MAPS and MARI resolutions are very close (previous error in MAPS distances
+        # meant that MARI was calculated to have a better resolution, but it *should* be MAPS)
+        self.assertLess(res[0][0], res[1][0])
+        self.assertLess(res[1][0], res[2][0])
         # Now tests the standalone function
         for inc, instname in enumerate(instnames):
             rr, ff = PyChop2.calculate(instname, 's', 200, 18, 0)


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

Corrects the distances of the MAPS Fermi chopper by 4.3cm, from information given by MAPS instrument scientist. This affects the calculation of the incident energy of low energy reps in rep-rate multiplication mode, which are currently unmeasurable on MAPS but might be measurable if they get a new chopper.

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because it does not affect current usage of the program.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
