### PR TITLE
Stop mantid from outputting to non-tty terminals as the original stdout

### DIFF
--- a/dev-docs/source/GettingStartedWithPyCharm.rst
+++ b/dev-docs/source/GettingStartedWithPyCharm.rst
@@ -207,6 +207,8 @@ Setting up PyCharm on Linux
 
 3. Go to Run->Run... and select Edit Configurations. Go to Templates > Python. Make ``<Mantid Build Directory>/bin;`` the ``Working Directory``. This will then be used for all Python configurations you make.
 
+4. Tick the "Emulate terminal in output console" check box. This will ensure that all output from mantid is sent to the debug terminal.
+
 
 Useful Plugins
 ##############

--- a/dev-docs/source/Workbench/UsingPycharmWithWorkbench.rst
+++ b/dev-docs/source/Workbench/UsingPycharmWithWorkbench.rst
@@ -26,6 +26,8 @@ Note that the only difference here is the change from ``/bin/Debug/`` to ``/bin/
 
 Make sure you have finished the build you are using (Debug or Release), or there will be import errors.
 
+Make sure to tick the "Emulate terminal in output console" check box. This will ensure that all output from mantid is sent to the debug terminal.
+
 Common errors
 -------------
 

--- a/qt/python/mantidqt/utils/test/test_writetosignal.py
+++ b/qt/python/mantidqt/utils/test/test_writetosignal.py
@@ -27,18 +27,18 @@ class Receiver(QObject):
 @start_qapplication
 class WriteToSignalTest(unittest.TestCase):
 
-    def test_run_with_output_present(self):
+    def test_run_with_tty_output_present(self):
         with patch("sys.stdout") as mock_stdout:
             mock_stdout.fileno.return_value = 10
             writer = WriteToSignal(mock_stdout)
-            mock_stdout.fileno.assert_called_once_with()
+            mock_stdout.isatty.assert_called_once_with()
             self.assertEqual(writer._original_out, mock_stdout)
 
-    def test_run_without_output_present(self):
+    def test_run_without_tty_output_present(self):
         with patch("sys.stdout") as mock_stdout:
-            mock_stdout.fileno.return_value = -1
+            mock_stdout.isatty.return_value = False
             writer = WriteToSignal(mock_stdout)
-            mock_stdout.fileno.assert_called_once_with()
+            mock_stdout.isatty.assert_called_once()
             self.assertEqual(writer._original_out, None)
 
     def test_connected_receiver_receives_text(self):
@@ -51,13 +51,7 @@ class WriteToSignalTest(unittest.TestCase):
             writer.write(txt)
             QCoreApplication.processEvents()
             self.assertEqual(txt, recv.captured_txt)
-            mock_stdout.fileno.assert_called_once_with()
-
-    def test_with_fileno_not_defined(self):
-        with patch('sys.stdout') as mock_stdout:
-            del mock_stdout.fileno
-            writer = WriteToSignal(mock_stdout)
-            self.assertEqual(writer._original_out, None)
+            mock_stdout.isatty.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/utils/writetosignal.py
+++ b/qt/python/mantidqt/utils/writetosignal.py
@@ -22,8 +22,8 @@ class WriteToSignal(QObject):
 
     def __init__(self, original_out):
         QObject.__init__(self)
-        # If the file descriptor of the stream is < 0 then we are running in a no-external-console mode
-        if not hasattr(original_out, 'fileno') or original_out.fileno() < 0:
+        # Check if the output stream is a printable terminal.
+        if not original_out.isatty():
             self._original_out = None
         else:
             self._original_out = original_out
@@ -33,9 +33,6 @@ class WriteToSignal(QObject):
 
     def flush(self):
         pass
-
-    def isatty(self):
-        return False
 
     def write(self, txt):
         if self._original_out:
@@ -47,8 +44,8 @@ class WriteToSignal(QObject):
                                              "Original error: {}\n\n".format(str(e)))
             except UnicodeEncodeError:
                 """
-                Scripts containing unicode characters could fail to run if mantid is not started from the
-                terminal on unix systems. The script runs fine if this exception is caught and discarded.
+                Scripts containing unicode characters could fail to run if the original_out does not
+                support those characters. If this occurs, just don't print to that terminal and continue.
                 """
                 pass
         # always write to the message log


### PR DESCRIPTION
**Description of work.**
TTY terminals are able to support unicode, and are the main `stdout`s
that Mantid is ever going to print to. Other `stdout`s may be unable to
support unicode and so can cause issues if the scripts print something
containing a unicode character to the terminal.

This PR adds a check to see if the original `stdout` (such as the the terminal used to launch mantid)  is a TTY like terminal before trying to output to it, to avoid wasted time spent outputting to the terminal. 

**To test:**
1. Launch mantid workbench
2. Run a script containing print statements with unicode characters (£) and check they are still printed to both the mantid message log and the terminal. 

Fixes #27429

*This does not require release notes* because **there should be no user facing changes**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
