### PR TITLE
Set minimum required standard to C++17

### DIFF
--- a/Framework/API/src/FileFinder.cpp
+++ b/Framework/API/src/FileFinder.cpp
@@ -163,20 +163,18 @@ FileFinderImpl::getInstrument(const string &hint) const {
     } else {
       // go forwards looking for the run number to start
       {
-        string::const_iterator it = std::find_if(
-            instrName.begin(), instrName.end(), std::ptr_fun(isdigit));
-        std::string::size_type nChars = std::distance(
-            static_cast<string::const_iterator>(instrName.begin()), it);
+        const auto it =
+            std::find_if(instrName.begin(), instrName.end(), isdigit);
+        const auto nChars = std::distance(instrName.begin(), it);
         instrName = instrName.substr(0, nChars);
       }
 
       // go backwards looking for the instrument name to end - gets around
       // delimiters
       if (!instrName.empty()) {
-        string::const_reverse_iterator it = std::find_if(
-            instrName.rbegin(), instrName.rend(), std::ptr_fun(isalpha));
-        string::size_type nChars = std::distance(
-            it, static_cast<string::const_reverse_iterator>(instrName.rend()));
+        const auto it =
+            std::find_if(instrName.rbegin(), instrName.rend(), isalpha);
+        const auto nChars = std::distance(it, instrName.rend());
         instrName = instrName.substr(0, nChars);
       }
     }
@@ -207,8 +205,8 @@ FileFinderImpl::toInstrumentAndNumber(const std::string &hint) const {
     runPart = hint;
   } else {
     /// Find the last non-digit as the instrument name can contain numbers
-    std::string::const_reverse_iterator it = std::find_if(
-        hint.rbegin(), hint.rend(), std::not1(std::ptr_fun(isdigit)));
+    std::string::const_reverse_iterator it =
+        std::find_if(hint.rbegin(), hint.rend(), std::not_fn(isdigit));
     // No non-digit or all non-digits
     if (it == hint.rend() || it == hint.rbegin()) {
       throw std::invalid_argument(

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -252,16 +252,16 @@ bool groupnumber(std::string groupi, std::string groupj) {
   int i = 0;
   std::string groupName = groupi;
   // Take out the "group" part of the group name and convert to an int
-  groupName.erase(remove_if(groupName.begin(), groupName.end(),
-                            not1(std::ptr_fun(::isdigit))),
-                  groupName.end());
+  groupName.erase(
+      remove_if(groupName.begin(), groupName.end(), std::not_fn(::isdigit)),
+      groupName.end());
   Strings::convert(groupName, i);
   int j = 0;
   groupName = groupj;
   // Take out the "group" part of the group name and convert to an int
-  groupName.erase(remove_if(groupName.begin(), groupName.end(),
-                            not1(std::ptr_fun(::isdigit))),
-                  groupName.end());
+  groupName.erase(
+      remove_if(groupName.begin(), groupName.end(), std::not_fn(::isdigit)),
+      groupName.end());
   Strings::convert(groupName, j);
   return (i < j);
 }

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -70,7 +70,7 @@ void Integration::init() {
  * @return true if first argument < second argument (with some
  * tolerance/epsilon)
  */
-struct tolerant_less : public std::binary_function<double, double, bool> {
+struct tolerant_less {
 public:
   bool operator()(const double &left, const double &right) const {
     // soft equal, if the diff left-right is below a numerical error

--- a/Framework/Algorithms/src/RebinByTimeBase.cpp
+++ b/Framework/Algorithms/src/RebinByTimeBase.cpp
@@ -28,9 +28,7 @@ using Types::Core::DateAndTime;
  Helper method to transform a MantidVector containing absolute times in
  nanoseconds to relative times in seconds given an offset.
  */
-class ConvertToRelativeTime
-    : public std::unary_function<const MantidVec::value_type &,
-                                 MantidVec::value_type> {
+class ConvertToRelativeTime {
 private:
   double m_offSet;
 

--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -108,8 +108,8 @@ public:
     return componentIndex - m_assemblySortedDetectorIndices->size();
   }
 
-  Eigen::Vector3d position(const size_t componentIndex) const;
-  Eigen::Vector3d position(const std::pair<size_t, size_t> &index) const;
+  const Eigen::Vector3d &position(const size_t componentIndex) const;
+  const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
   Eigen::Quaterniond rotation(const size_t componentIndex) const;
   Eigen::Quaterniond rotation(const std::pair<size_t, size_t> &index) const;
   Eigen::Vector3d relativePosition(const size_t componentIndex) const;
@@ -129,8 +129,8 @@ public:
   void setDetectorInfo(DetectorInfo *detectorInfo);
   bool hasSource() const;
   bool hasSample() const;
-  Eigen::Vector3d sourcePosition() const;
-  Eigen::Vector3d samplePosition() const;
+  const Eigen::Vector3d &sourcePosition() const;
+  const Eigen::Vector3d &samplePosition() const;
   size_t source() const;
   size_t sample() const;
   size_t root() const;

--- a/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/DetectorInfo.h
@@ -68,10 +68,11 @@ public:
   void setMasked(const size_t index, bool masked);
   void setMasked(const std::pair<size_t, size_t> &index, bool masked);
   bool hasMaskedDetectors() const;
-  Eigen::Vector3d position(const size_t index) const;
-  Eigen::Vector3d position(const std::pair<size_t, size_t> &index) const;
-  Eigen::Quaterniond rotation(const size_t index) const;
-  Eigen::Quaterniond rotation(const std::pair<size_t, size_t> &index) const;
+  const Eigen::Vector3d &position(const size_t index) const;
+  const Eigen::Vector3d &position(const std::pair<size_t, size_t> &index) const;
+  const Eigen::Quaterniond &rotation(const size_t index) const;
+  const Eigen::Quaterniond &
+  rotation(const std::pair<size_t, size_t> &index) const;
   void setPosition(const size_t index, const Eigen::Vector3d &position);
   void setPosition(const std::pair<size_t, size_t> &index,
                    const Eigen::Vector3d &position);
@@ -85,8 +86,8 @@ public:
   void setComponentInfo(ComponentInfo *componentInfo);
   bool hasComponentInfo() const;
   double l1() const;
-  Eigen::Vector3d sourcePosition() const;
-  Eigen::Vector3d samplePosition() const;
+  const Eigen::Vector3d &sourcePosition() const;
+  const Eigen::Vector3d &samplePosition() const;
 
   /** The `merge()` operation was made private in `DetectorInfo`, and only
    * accessible through `ComponentInfo` (via this `friend` declaration)
@@ -134,13 +135,13 @@ inline bool DetectorInfo::isScanning() const {
  *
  * Convenience method for beamlines with static (non-moving) detectors.
  * Throws if there are time-dependent detectors. */
-inline Eigen::Vector3d DetectorInfo::position(const size_t index) const {
+inline const Eigen::Vector3d &DetectorInfo::position(const size_t index) const {
   checkNoTimeDependence();
   return (*m_positions)[index];
 }
 
 /// Returns the position of the detector with given index.
-inline Eigen::Vector3d
+inline const Eigen::Vector3d &
 DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
   return (*m_positions)[linearIndex(index)];
 }
@@ -149,13 +150,14 @@ DetectorInfo::position(const std::pair<size_t, size_t> &index) const {
  *
  * Convenience method for beamlines with static (non-moving) detectors.
  * Throws if there are time-dependent detectors. */
-inline Eigen::Quaterniond DetectorInfo::rotation(const size_t index) const {
+inline const Eigen::Quaterniond &
+DetectorInfo::rotation(const size_t index) const {
   checkNoTimeDependence();
   return (*m_rotations)[index];
 }
 
 /// Returns the rotation of the detector with given index.
-inline Eigen::Quaterniond
+inline const Eigen::Quaterniond &
 DetectorInfo::rotation(const std::pair<size_t, size_t> &index) const {
   return (*m_rotations)[linearIndex(index)];
 }

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -179,7 +179,8 @@ ComponentInfo::numberOfDetectorsInSubtree(const size_t componentIndex) const {
   return std::distance(range.begin(), range.end());
 }
 
-Eigen::Vector3d ComponentInfo::position(const size_t componentIndex) const {
+const Eigen::Vector3d &
+ComponentInfo::position(const size_t componentIndex) const {
   checkNoTimeDependence();
   if (isDetector(componentIndex)) {
     return m_detectorInfo->position(componentIndex);
@@ -188,7 +189,7 @@ Eigen::Vector3d ComponentInfo::position(const size_t componentIndex) const {
   return (*m_positions)[rangesIndex];
 }
 
-Eigen::Vector3d
+const Eigen::Vector3d &
 ComponentInfo::position(const std::pair<size_t, size_t> &index) const {
 
   const auto componentIndex = index.first;
@@ -481,7 +482,7 @@ bool ComponentInfo::hasSource() const { return m_sourceIndex >= 0; }
 
 bool ComponentInfo::hasSample() const { return m_sampleIndex >= 0; }
 
-Eigen::Vector3d ComponentInfo::sourcePosition() const {
+const Eigen::Vector3d &ComponentInfo::sourcePosition() const {
   if (!hasSource()) {
     throw std::runtime_error("Source component has not been specified");
   }
@@ -490,7 +491,7 @@ Eigen::Vector3d ComponentInfo::sourcePosition() const {
   return position({static_cast<size_t>(m_sourceIndex), 0});
 }
 
-Eigen::Vector3d ComponentInfo::samplePosition() const {
+const Eigen::Vector3d &ComponentInfo::samplePosition() const {
   if (!hasSample()) {
     throw std::runtime_error("Sample component has not been specified");
   }

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -225,7 +225,7 @@ double DetectorInfo::l1() const {
   return m_componentInfo->l1();
 }
 
-Eigen::Vector3d DetectorInfo::sourcePosition() const {
+const Eigen::Vector3d &DetectorInfo::sourcePosition() const {
   // TODO Not scan safe yet for scanning ComponentInfo
   if (!hasComponentInfo()) {
     throw std::runtime_error("DetectorInfo has no valid ComponentInfo thus "
@@ -234,7 +234,7 @@ Eigen::Vector3d DetectorInfo::sourcePosition() const {
   return m_componentInfo->sourcePosition();
 }
 
-Eigen::Vector3d DetectorInfo::samplePosition() const {
+const Eigen::Vector3d &DetectorInfo::samplePosition() const {
   // TODO Not scan safe yet for scanning ComponentInfo
   if (!hasComponentInfo()) {
     throw std::runtime_error("DetectorInfo has no valid ComponentInfo thus "

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -755,6 +755,12 @@ public:
     TS_ASSERT(compInfo.relativePosition(subComponentIndex)
                   .isApprox(subCompPosition - rootPosition));
 
+    // We deliberately avoid auto here as it does not mix well with Eigen and
+    // its expression templates. If position returned by value (as it used to)
+    // then const auto diffPos is an expression template that refers to
+    // stack-based values that go out of scope after this line as run and
+    // evaluating diffPos after that leads to undefined behaviour. Address
+    // sanitizer will show a stack-use-after-scope error.
     const Vector3d diffPos =
         compInfo.position(subComponentIndex) - compInfo.position(rootIndex);
     TSM_ASSERT("Vector between comp and root is not the same as relative "

--- a/Framework/Beamline/test/ComponentInfoTest.h
+++ b/Framework/Beamline/test/ComponentInfoTest.h
@@ -755,7 +755,7 @@ public:
     TS_ASSERT(compInfo.relativePosition(subComponentIndex)
                   .isApprox(subCompPosition - rootPosition));
 
-    const auto diffPos =
+    const Vector3d diffPos =
         compInfo.position(subComponentIndex) - compInfo.position(rootIndex);
     TSM_ASSERT("Vector between comp and root is not the same as relative "
                "position. Rotation involved.",

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -551,9 +551,9 @@ void AnvredCorrection::scale_exec(std::string &bankName, double &lambda,
   double eff_R = 1.0 - exp(-mu * pathlength); // efficiency at point R
   value *= eff_center / eff_R;                // slant path efficiency ratio
   // Take out the "bank" part of the bank name
-  bankName.erase(remove_if(bankName.begin(), bankName.end(),
-                           not1(std::ptr_fun(::isdigit))),
-                 bankName.end());
+  bankName.erase(
+      remove_if(bankName.begin(), bankName.end(), std::not_fn(::isdigit)),
+      bankName.end());
   if (inst->hasParameter("detScale" + bankName))
     value *=
         static_cast<double>(inst->getNumberParameter("detScale" + bankName)[0]);

--- a/Framework/Crystal/src/SaveHKL.cpp
+++ b/Framework/Crystal/src/SaveHKL.cpp
@@ -366,9 +366,9 @@ void SaveHKL::exec() {
           continue;
         }
         // Take out the "bank" part of the bank name and convert to an int
-        bankName.erase(remove_if(bankName.begin(), bankName.end(),
-                                 not1(std::ptr_fun(::isdigit))),
-                       bankName.end());
+        bankName.erase(
+            remove_if(bankName.begin(), bankName.end(), std::not_fn(::isdigit)),
+            bankName.end());
         Strings::convert(bankName, bank);
 
         // Two-theta = polar angle = scattering angle = between +Z vector and

--- a/Framework/Crystal/src/SaveLauenorm.cpp
+++ b/Framework/Crystal/src/SaveLauenorm.cpp
@@ -194,9 +194,9 @@ void SaveLauenorm::exec() {
          p.getRow() > (nRows - widthBorder)))
       continue;
     // Take out the "bank" part of the bank name and convert to an int
-    bankName.erase(remove_if(bankName.begin(), bankName.end(),
-                             not1(std::ptr_fun(::isdigit))),
-                   bankName.end());
+    bankName.erase(
+        remove_if(bankName.begin(), bankName.end(), std::not_fn(::isdigit)),
+        bankName.end());
     if (type.compare(0, 2, "Ba") == 0) {
       Strings::convert(bankName, sequence);
     }
@@ -270,9 +270,9 @@ void SaveLauenorm::exec() {
          p.getRow() > (nRows - widthBorder)))
       continue;
     // Take out the "bank" part of the bank name and convert to an int
-    bankName.erase(remove_if(bankName.begin(), bankName.end(),
-                             not1(std::ptr_fun(::isdigit))),
-                   bankName.end());
+    bankName.erase(
+        remove_if(bankName.begin(), bankName.end(), std::not_fn(::isdigit)),
+        bankName.end());
     if (type.compare(0, 2, "Ba") == 0) {
       Strings::convert(bankName, sequence);
     }

--- a/Framework/Crystal/test/FindSXPeaksHelperTest.h
+++ b/Framework/Crystal/test/FindSXPeaksHelperTest.h
@@ -179,8 +179,7 @@ public:
     // WHEN + THEN
     TSM_ASSERT_THROWS("Should throw a invalid argument error when background "
                       "strategy is not AbsoluteBackgroundStrategy",
-                      std::make_unique<AllPeaksStrategy>(
-                          backgroundStrategy.get(), spectrumInfo);
+                      AllPeaksStrategy(backgroundStrategy.get(), spectrumInfo);
                       , const std::invalid_argument &);
   }
 

--- a/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/LeBailFit.cpp
@@ -958,11 +958,10 @@ void LeBailFit::parseInstrumentParametersTable() {
         // string data
         g_log.debug() << "Col-name = " << colname << ", ";
         trow >> strvalue;
-        strvalue.erase(
-            std::find_if(strvalue.rbegin(), strvalue.rend(),
-                         std::not1(std::ptr_fun<int, int>(std::isspace)))
-                .base(),
-            strvalue.end());
+        strvalue.erase(std::find_if(strvalue.rbegin(), strvalue.rend(),
+                                    std::not_fn(::isspace))
+                           .base(),
+                       strvalue.end());
 
         g_log.debug() << "Value = " << strvalue << ".\n";
         tempstrmap.emplace(colname, strvalue);

--- a/Framework/DataHandling/src/LoadPSIMuonBin.cpp
+++ b/Framework/DataHandling/src/LoadPSIMuonBin.cpp
@@ -19,9 +19,8 @@
 #include "MantidKernel/UnitFactory.h"
 #include "MantidKernel/UnitLabelTypes.h"
 
-#include <Poco/Path.h>
-#include <Poco/RecursiveDirectoryIterator.h>
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/shared_ptr.hpp>
 #include <fstream>
 #include <map>
@@ -30,13 +29,15 @@ namespace Mantid {
 namespace DataHandling {
 
 namespace {
-const std::map<std::string, std::string> months{
+const std::map<std::string, std::string> MONTHS{
     {"JAN", "01"}, {"FEB", "02"}, {"MAR", "03"}, {"APR", "04"},
     {"MAY", "05"}, {"JUN", "06"}, {"JUL", "07"}, {"AUG", "08"},
     {"SEP", "09"}, {"OCT", "10"}, {"NOV", "11"}, {"DEC", "12"}};
-const std::vector<std::string> psiMonths{"JAN", "FEB", "MAR", "APR",
-                                         "MAY", "JUN", "JUL", "AUG",
-                                         "SEP", "OCT", "NOV", "DEC"};
+const std::vector<std::string> PSI_MONTHS{"JAN", "FEB", "MAR", "APR",
+                                          "MAY", "JUN", "JUL", "AUG",
+                                          "SEP", "OCT", "NOV", "DEC"};
+constexpr int TEMPERATURE_FILE_MAX_SEARCH_DEPTH = 3;
+constexpr auto TEMPERATURE_FILE_EXT = ".mon";
 } // namespace
 
 DECLARE_FILELOADER_ALGORITHM(LoadPSIMuonBin)
@@ -204,7 +205,7 @@ std::string LoadPSIMuonBin::getFormattedDateTime(std::string date,
   } else {
     year = "20" + date.substr(7, 2);
   }
-  return year + "-" + months.find(date.substr(3, 3))->second + "-" +
+  return year + "-" + MONTHS.find(date.substr(3, 3))->second + "-" +
          date.substr(0, 2) + "T" + time;
 }
 
@@ -672,8 +673,8 @@ void LoadPSIMuonBin::processHeaderLine(const std::string &line) {
   if (line.find("Title") != std::string::npos) {
     // Find sample log titles from the header
     processTitleHeaderLine(line);
-  } else if (std::find(std::begin(psiMonths), std::end(psiMonths),
-                       line.substr(5, 3)) != std::end(psiMonths)) {
+  } else if (std::find(std::begin(PSI_MONTHS), std::end(PSI_MONTHS),
+                       line.substr(5, 3)) != std::end(PSI_MONTHS)) {
     // If the line contains a Month in the PSI format then assume it conains a
     // date on the line. 5 is the index of the line that is where the month is
     // found and 3 is the length of the month.
@@ -751,24 +752,39 @@ void LoadPSIMuonBin::processLine(const std::string &line,
 }
 
 std::string LoadPSIMuonBin::detectTempFile() {
-  const std::string binFileName = getPropertyValue("Filename");
-  const Poco::Path fileDir(Poco::Path(binFileName).parent());
+  // Perform a breadth-first search starting from
+  // directory containing the main file. The search has
+  // a fixed limited depth to ensure we don't accidentally
+  // crawl the while filesystem.
+  namespace fs = boost::filesystem;
+  const fs::path searchDir{
+      fs ::path{getPropertyValue("Filename")}.parent_path()};
 
-  Poco::SiblingsFirstRecursiveDirectoryIterator end;
-  // 3 represents the maximum recursion depth for this search
-  const uint16_t maxRecursionDepth = 3;
-  for (Poco::SiblingsFirstRecursiveDirectoryIterator it(fileDir,
-                                                        maxRecursionDepth);
-       it != end; ++it) {
-    // If it is not a directory, exists, has the extension '.mon', and it
-    // contains the current run number.
-    const Poco::Path path = it->path();
-    if (!it->isDirectory() && it->exists() && path.getExtension() == "mon" &&
-        path.getFileName().find(std::to_string(m_header.numberOfRuns)) !=
-            std::string::npos) {
-      return path.toString();
+  std::deque<fs::path> queue;
+  queue.push_back(fs::path{searchDir});
+  while (!queue.empty()) {
+    const auto entry = queue.front();
+    queue.pop_front();
+    for (fs::directory_iterator dirIter{entry};
+         dirIter != fs::directory_iterator(); ++dirIter) {
+      const auto &entry{dirIter->path()};
+
+      if (fs::is_directory(entry)) {
+        const auto relPath{entry.lexically_relative(searchDir)};
+        if (std::distance(relPath.begin(), relPath.end()) <
+            TEMPERATURE_FILE_MAX_SEARCH_DEPTH) {
+          // save the directory for searching when we have exhausted
+          // the file entries at this level
+          queue.push_back(entry);
+        }
+      } else if (entry.extension() == TEMPERATURE_FILE_EXT &&
+                 entry.filename().string().find(std::to_string(
+                     m_header.numberOfRuns)) != std::string::npos) {
+        return entry.string();
+      }
     }
   }
+
   return "";
 }
 

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -63,9 +63,7 @@ int64_t calculateCorrectedFullTime(const EventType &event,
 /**
  * Type for comparing events in terms of time at sample
  */
-template <typename EventType>
-class CompareTimeAtSample
-    : public std::binary_function<EventType, EventType, bool> {
+template <typename EventType> class CompareTimeAtSample {
 private:
   const double m_tofFactor;
   const double m_tofShift;

--- a/Framework/DataObjects/src/PeaksWorkspace.cpp
+++ b/Framework/DataObjects/src/PeaksWorkspace.cpp
@@ -81,7 +81,7 @@ PeaksWorkspace::PeaksWorkspace(const PeaksWorkspace &other)
 //=====================================================================================
 /** Comparator class for sorting peaks by one or more criteria
  */
-class PeakComparator : public std::binary_function<Peak, Peak, bool> {
+class PeakComparator {
 public:
   std::vector<std::pair<std::string, bool>> &criteria;
 

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -297,14 +297,12 @@ public:
     this->fake_data();
     TS_ASSERT_EQUALS(el.getEvents().size(), NUMEVENTS);
     TS_ASSERT_EQUALS(el.getNumberEvents(), NUMEVENTS);
-    TS_ASSERT_THROWS(el.getWeightedEvents().size(), const std::runtime_error &);
-    TS_ASSERT_THROWS(el.getWeightedEventsNoTime().size(),
-                     const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getWeightedEvents(), const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getWeightedEventsNoTime(), const std::runtime_error &);
 
     el.switchTo(WEIGHTED);
-    TS_ASSERT_THROWS(el.getEvents().size(), const std::runtime_error &);
-    TS_ASSERT_THROWS(el.getWeightedEventsNoTime().size(),
-                     const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getEvents(), const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getWeightedEventsNoTime(), const std::runtime_error &);
     TS_ASSERT_EQUALS(el.getWeightedEvents().size(), NUMEVENTS);
     TS_ASSERT_EQUALS(el.getNumberEvents(), NUMEVENTS);
     TS_ASSERT_EQUALS(el.getEvent(0).weight(), 1.0);
@@ -316,8 +314,8 @@ public:
     // Start with a bit of fake data
     this->fake_data();
     el.switchTo(WEIGHTED_NOTIME);
-    TS_ASSERT_THROWS(el.getEvents().size(), const std::runtime_error &);
-    TS_ASSERT_THROWS(el.getWeightedEvents().size(), const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getEvents(), const std::runtime_error &);
+    TS_ASSERT_THROWS(el.getWeightedEvents(), const std::runtime_error &);
     TS_ASSERT_EQUALS(el.getWeightedEventsNoTime().size(), NUMEVENTS);
     TS_ASSERT_EQUALS(el.getNumberEvents(), NUMEVENTS);
     TS_ASSERT_EQUALS(el.getWeightedEventsNoTime()[0].weight(), 1.0);

--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -15,6 +15,7 @@
 #include "MantidDataObjects/EventList.h"
 #include "MantidDataObjects/Histogram1D.h"
 #include "MantidHistogramData/LinearGenerator.h"
+#include "MantidKernel/WarningSuppressions.h"
 
 using namespace Mantid;
 using namespace API;
@@ -170,16 +171,22 @@ public:
   }
   void testrangeexceptionX() {
     h.setPoints(x1);
+    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataX().at(nel), const std::out_of_range &);
+    MSVC_DIAG_ON()
   }
   void testrangeexceptionY() {
     h.setCounts(y1);
+    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataY().at(nel), const std::out_of_range &);
+    MSVC_DIAG_ON()
   }
   void testrangeexceptionE() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
+    MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataE().at(nel), const std::out_of_range &);
+    MSVC_DIAG_ON()
   }
 
   void test_copy_constructor() {

--- a/Framework/DataObjects/test/Histogram1DTest.h
+++ b/Framework/DataObjects/test/Histogram1DTest.h
@@ -171,12 +171,16 @@ public:
   }
   void testrangeexceptionX() {
     h.setPoints(x1);
+    // vector.at() is marked nodiscard in MSVC but we just want to test it
+    // throws so suppress the warning
     MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataX().at(nel), const std::out_of_range &);
     MSVC_DIAG_ON()
   }
   void testrangeexceptionY() {
     h.setCounts(y1);
+    // vector.at() is marked nodiscard in MSVC but we just want to test it
+    // throws so suppress the warning
     MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataY().at(nel), const std::out_of_range &);
     MSVC_DIAG_ON()
@@ -184,6 +188,8 @@ public:
   void testrangeexceptionE() {
     h.setCounts(y1);
     h.setCountStandardDeviations(e1);
+    // vector.at() is marked nodiscard in MSVC but we just want to test it
+    // throws so suppress the warning
     MSVC_DIAG_OFF(4834)
     TS_ASSERT_THROWS(h.dataE().at(nel), const std::out_of_range &);
     MSVC_DIAG_ON()

--- a/Framework/Geometry/inc/MantidGeometry/Math/MapSupport.h
+++ b/Framework/Geometry/inc/MantidGeometry/Math/MapSupport.h
@@ -36,8 +36,7 @@ namespace MapSupport {
 */
 
 // Note this needs to be non-constant unary_function return
-template <typename T, typename U>
-class PFirst : public std::unary_function<std::pair<T, U>, T> {
+template <typename T, typename U> class PFirst {
 public:
   /// Functional to the first object
   T operator()(const std::pair<T, U> &A) { return A.first; }
@@ -51,8 +50,7 @@ public:
   \brief Class to access the second object in index pair.
 */
 
-template <typename T, typename U>
-class PSecond : public std::unary_function<std::pair<T, U>, U> {
+template <typename T, typename U> class PSecond {
 public:
   /// Functional to the first object
   U operator()(const std::pair<T, U> &A) { return A.second; }
@@ -134,9 +132,7 @@ public:
   This functor swaps the components in a map.
 */
 
-template <typename KeyPart, typename BodyPart>
-class mapSwap : public std::unary_function<std::pair<BodyPart, KeyPart>,
-                                           std::pair<KeyPart, BodyPart>> {
+template <typename KeyPart, typename BodyPart> class mapSwap {
 public:
   /// Operator()
   std::pair<BodyPart, KeyPart>
@@ -180,9 +176,7 @@ public:
   key not found.
 */
 
-template <typename KeyPart, typename NumPart>
-class sndValue
-    : public std::unary_function<std::map<KeyPart, NumPart>, NumPart> {
+template <typename KeyPart, typename NumPart> class sndValue {
 private:
   const std::map<KeyPart, NumPart> &MRef; ///< Map begin accessd
 

--- a/Framework/Geometry/src/MDGeometry/MDGeometryXMLParser.cpp
+++ b/Framework/Geometry/src/MDGeometry/MDGeometryXMLParser.cpp
@@ -19,24 +19,20 @@
 namespace Mantid {
 namespace Geometry {
 /// Helper unary comparison type for finding IMDDimensions by a specified id.
-struct findID
-    : public std::unary_function<Mantid::Geometry::IMDDimension_sptr, bool> {
+struct findID {
   const std::string m_id;
   explicit findID(const std::string &id) : m_id(id) {}
 
   bool operator()(const Mantid::Geometry::IMDDimension_sptr obj) const {
     return m_id == obj->getDimensionId();
   }
-  findID &operator=(const findID &);
 };
 
 /// Helper unary comparison type for finding non-integrated dimensions.
-struct findIntegrated
-    : public std::unary_function<Mantid::Geometry::IMDDimension_sptr, bool> {
+struct findIntegrated {
   bool operator()(const Mantid::Geometry::IMDDimension_sptr obj) const {
     return obj->getIsIntegrated();
   }
-  findIntegrated &operator=(const findIntegrated &);
 };
 
 /**
@@ -254,7 +250,7 @@ MDGeometryXMLParser::getIntegratedDimensions() const {
   validate();
   Mantid::Geometry::VecIMDDimension_sptr temp = m_vecAllDims;
   temp.erase(
-      std::remove_if(temp.begin(), temp.end(), std::not1(findIntegrated())),
+      std::remove_if(temp.begin(), temp.end(), std::not_fn(findIntegrated())),
       temp.end());
   return temp;
 }

--- a/Framework/Geometry/src/Math/Acomp.cpp
+++ b/Framework/Geometry/src/Math/Acomp.cpp
@@ -214,8 +214,8 @@ Complementary subtraction is by making A-B == A*B'
 
   // Have DNF parts and will return the same...
   // Sort the components of the list
-  std::for_each(Fparts.begin(), Fparts.end(), std::mem_fun_ref(&Acomp::Sort));
-  std::for_each(Gparts.begin(), Gparts.end(), std::mem_fun_ref(&Acomp::Sort));
+  std::for_each(Fparts.begin(), Fparts.end(), std::mem_fn(&Acomp::Sort));
+  std::for_each(Gparts.begin(), Gparts.end(), std::mem_fn(&Acomp::Sort));
 
   // Sort the list itself...
   std::sort(Gparts.begin(), Gparts.end());
@@ -603,7 +603,7 @@ Decends down the Comp Tree.
 {
   std::sort(Units.begin(), Units.end());
   // Sort each decending object first
-  std::for_each(Comp.begin(), Comp.end(), std::mem_fun_ref(&Acomp::Sort));
+  std::for_each(Comp.begin(), Comp.end(), std::mem_fn(&Acomp::Sort));
   // use the sorted components to sort our component list
   std::sort(Comp.begin(), Comp.end());
 }
@@ -756,9 +756,6 @@ literals
   for (cc = Comp.begin(); cc != Comp.end(); ++cc) {
     cc->getLiterals(literalMap);
   }
-  // Doesn't work because literal map is a reference
-  //  for_each(Comp.begin(),Comp.end(),
-  // std::bind2nd(std::mem_fun(&Acomp::getLiterals), literalMap));
 }
 
 int Acomp::isSimple() const
@@ -838,7 +835,7 @@ i.e. one pass.
     // set PI status to 1
     using std::placeholders::_1;
     for_each(Work.begin(), Work.end(),
-             std::bind(std::mem_fun_ref(&BnId::setPI), _1, 1));
+             std::bind(std::mem_fn(&BnId::setPI), _1, 1));
 
     // Collect into pairs which have a difference of +/- one
     // object
@@ -1522,7 +1519,7 @@ ab -> a'+b'
             std::bind(std::multiplies<int>(), _1, -1));
   sort(Units.begin(), Units.end()); /// Resort the list. use reverse?
 
-  for_each(Comp.begin(), Comp.end(), std::mem_fun_ref(&Acomp::complement));
+  for_each(Comp.begin(), Comp.end(), std::mem_fn(&Acomp::complement));
   sort(Comp.begin(), Comp.end());
 }
 

--- a/Framework/Geometry/src/Objects/CSGObject.cpp
+++ b/Framework/Geometry/src/Objects/CSGObject.cpp
@@ -881,7 +881,7 @@ std::vector<int> CSGObject::getSurfaceIndex() const {
   std::vector<int> out;
   transform(m_SurList.begin(), m_SurList.end(),
             std::insert_iterator<std::vector<int>>(out, out.begin()),
-            std::mem_fun(&Surface::getName));
+            std::mem_fn(&Surface::getName));
   return out;
 }
 

--- a/Framework/Kernel/inc/MantidKernel/LogFilter.h
+++ b/Framework/Kernel/inc/MantidKernel/LogFilter.h
@@ -12,10 +12,7 @@
 //----------------------------------------------------------------------
 #include "MantidKernel/DllConfig.h"
 
-#ifndef Q_MOC_RUN
-#include <boost/scoped_ptr.hpp>
-#endif
-
+#include <memory>
 #include <vector>
 
 namespace Mantid {

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -7,8 +7,6 @@
 #ifndef MANTID_KERNEL_MULTITHREADED_H_
 #define MANTID_KERNEL_MULTITHREADED_H_
 
-#include "MantidKernel/DataItem.h"
-
 #include <atomic>
 #include <mutex>
 

--- a/Framework/Kernel/inc/MantidKernel/VectorHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/VectorHelper.h
@@ -163,7 +163,7 @@ template <typename T> std::vector<T> normalizeVector(const std::vector<T> &x) {
 
 /// Functor used for computing the sum of the square values of a vector, using
 /// the accumulate algorithm
-template <class T> struct SumGaussError : public std::binary_function<T, T, T> {
+template <class T> struct SumGaussError {
   SumGaussError() = default;
   /// Sums the arguments in quadrature
   inline T operator()(const T &l, const T &r) const {
@@ -177,7 +177,7 @@ template <class T> struct SumGaussError : public std::binary_function<T, T, T> {
  * More generally add errors in quadrature using the square of one of the errors
  * (variance = error^2)
  */
-template <class T> struct AddVariance : public std::binary_function<T, T, T> {
+template <class T> struct AddVariance {
   AddVariance() = default;
   /// adds the square of the left-hand argument to the right hand argument and
   /// takes the square root
@@ -185,28 +185,28 @@ template <class T> struct AddVariance : public std::binary_function<T, T, T> {
 };
 
 /// Functor to accumulate a sum of squares
-template <class T> struct SumSquares : public std::binary_function<T, T, T> {
+template <class T> struct SumSquares {
   SumSquares() = default;
   /// Adds the square of the right-hand argument to the left hand one
   T operator()(const T &r, const T &x) const { return (r + x * x); }
 };
 
 /// Functor giving the product of the squares of the arguments
-template <class T> struct TimesSquares : public std::binary_function<T, T, T> {
+template <class T> struct TimesSquares {
   TimesSquares() = default;
   /// Multiplies the squares of the arguments
   T operator()(const T &l, const T &r) const { return (r * r * l * l); }
 };
 
 /// Square functor
-template <class T> struct Squares : public std::unary_function<T, T> {
+template <class T> struct Squares {
   Squares() = default;
   /// Returns the square of the argument
   T operator()(const T &x) const { return (x * x); }
 };
 
 /// Log functor
-template <class T> struct Log : public std::unary_function<T, T> {
+template <class T> struct Log {
   Log() = default;
   /// Returns the logarithm of the argument
   /// @throws std::range_error if x <= 0
@@ -219,15 +219,14 @@ template <class T> struct Log : public std::unary_function<T, T> {
 };
 
 // Non-throwing version of the Log functor
-template <class T> struct LogNoThrow : public std::unary_function<T, T> {
+template <class T> struct LogNoThrow {
   LogNoThrow() = default;
   // Returns the logarithm of the argument
   T operator()(const T &x) const { return std::log(x); }
 };
 
 /// Divide functor with result reset to 0 if the denominator is null
-template <class T>
-struct DividesNonNull : public std::binary_function<T, T, T> {
+template <class T> struct DividesNonNull {
   DividesNonNull() = default;
   /// Returns l/r if r is non-zero, otherwise returns l.
   T operator()(const T &l, const T &r) const {
@@ -238,7 +237,7 @@ struct DividesNonNull : public std::binary_function<T, T, T> {
 };
 
 /// A binary functor to compute the simple average of 2 numbers
-template <class T> struct SimpleAverage : public std::binary_function<T, T, T> {
+template <class T> struct SimpleAverage {
   SimpleAverage() = default;
   /// Return the average of the two arguments
   T operator()(const T &x, const T &y) const {

--- a/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
+++ b/Framework/Kernel/inc/MantidKernel/WarningSuppressions.h
@@ -76,6 +76,19 @@
 #define GNU_DIAG_ON(x)
 #endif
 
+// Similar macros for MSVC
+#if defined(_MSC_VER)
+// clang-format off
+#define MSVC_DIAG_OFF(id)                                                        \
+  __pragma(warning(push))                                                        \
+  __pragma(warning(disable : id))
+#define MSVC_DIAG_ON() __pragma(warning(pop))
+// clang-format on
+#else
+#define MSVC_DIAG_OFF(x)
+#define MSVC_DIAG_ON(x)
+#endif
+
 // Defining this macro separately since clang-tidy tries to add spaces around
 // the hyphen and we use it in a lot of test files.
 // clang-format off

--- a/Framework/Kernel/test/ThreadPoolRunnableTest.h
+++ b/Framework/Kernel/test/ThreadPoolRunnableTest.h
@@ -22,7 +22,7 @@ int ThreadPoolRunnableTest_value;
 class ThreadPoolRunnableTest : public CxxTest::TestSuite {
 public:
   void test_constructor() {
-    TS_ASSERT_THROWS(std::make_unique<ThreadPoolRunnable>(0, nullptr),
+    TS_ASSERT_THROWS(ThreadPoolRunnable(0, nullptr),
                      const std::invalid_argument &);
   }
 

--- a/Framework/MDAlgorithms/src/CreateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/CreateMDHistoWorkspace.cpp
@@ -20,7 +20,7 @@ namespace MDAlgorithms {
 /**
 Helper type to compute the square in-place.
 */
-struct Square : public std::unary_function<double, void> {
+struct Square {
   void operator()(double &i) { i *= i; }
 };
 

--- a/Framework/MDAlgorithms/src/ImportMDHistoWorkspaceBase.cpp
+++ b/Framework/MDAlgorithms/src/ImportMDHistoWorkspaceBase.cpp
@@ -29,7 +29,7 @@ namespace MDAlgorithms {
 /**
 Functor to compute the product of the set.
 */
-struct Product : public std::unary_function<size_t, void> {
+struct Product {
   Product() : result(1) {}
   size_t result;
   void operator()(size_t x) { result *= x; }

--- a/Framework/MDAlgorithms/src/MaskMD.cpp
+++ b/Framework/MDAlgorithms/src/MaskMD.cpp
@@ -55,8 +55,7 @@ struct InputArgument {
 };
 
 /// Comparator to allow sorting by dimension index.
-struct LessThanIndex
-    : std::binary_function<InputArgument, InputArgument, bool> {
+struct LessThanIndex {
   bool operator()(const InputArgument &a, const InputArgument &b) const {
     return a.index < b.index;
   }

--- a/Framework/MPIAlgorithms/src/GatherWorkspaces.cpp
+++ b/Framework/MPIAlgorithms/src/GatherWorkspaces.cpp
@@ -31,7 +31,7 @@ namespace {
 
 /// Functor used for computing the sum of the square values of a vector
 // Used by the eplus templates below
-template <class T> struct SumGaussError : public std::binary_function<T, T, T> {
+template <class T> struct SumGaussError {
   SumGaussError() {}
   /// Sums the arguments in quadrature
   inline T operator()(const T &l, const T &r) const {

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 c0ab451678efa06bea22748c1ee811eccb70d62b )
+  set ( THIRD_PARTY_GIT_SHA1 df6c47608066dc639d9313df5b15e7fd493895ac )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -284,9 +284,9 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
 endif()
 
 # ##############################################################################
-# Set the c++ standard to 14 - cmake should do the right thing with msvc
+# Set the c++ standard to 17 - cmake should do the right thing with msvc
 # ##############################################################################
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # ##############################################################################

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -67,6 +67,8 @@ find_package(
 add_definitions(-DBOOST_ALL_DYN_LINK -DBOOST_ALL_NO_LIB)
 # Need this defined globally for our log time values
 add_definitions(-DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG)
+# Silence issues with deprecated allocator methods in boost regex
+add_definitions(-D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
 
 find_package(Poco 1.4.6 REQUIRED)
 add_definitions(-DPOCO_ENABLE_CPP11)

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -23,11 +23,16 @@ add_definitions ( -D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING )
 ##########################################################################
 # Additional compiler flags
 ##########################################################################
-string ( REGEX REPLACE "/" "\\\\" THIRD_PARTY_INCLUDE_DIR "${THIRD_PARTY_DIR}/include/" )  # Replace "/" with "\" for use in command prompt
+# Replace "/" with "\" for use in command prompt
+string ( REGEX REPLACE "/" "\\\\" THIRD_PARTY_INCLUDE_DIR "${THIRD_PARTY_DIR}/include/" )
+string ( REGEX REPLACE "/" "\\\\" THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/lib/" )
 # /MP            - Compile .cpp files in parallel
 # /W3            - Warning Level 3 (This is also the default)
 # /external:I    - Ignore third party library warnings (similar to "isystem" in GCC)
-set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /W3 /experimental:external /external:I ${THIRD_PARTY_INCLUDE_DIR}" )
+set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+  /MP /W3 \
+  /experimental:external /external:W0 /external:I ${THIRD_PARTY_INCLUDE_DIR} /external:I ${THIRD_PARTY_LIB_DIR}\\python2.7\\ "
+)
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason
 # Any other value lower or higher seems to work but not the default. It is fine without this when compiling

--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -100,6 +100,7 @@ set ( MISC_CORE_DIST_DLLS
     libNeXusCPP-0.dll
     librdkafka.dll
     librdkafkacpp.dll
+    muparser.dll
     ssleay32.dll
     szip.dll
     tbb.dll

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FieldDataToMetadata.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/FieldDataToMetadata.h
@@ -22,8 +22,7 @@ namespace VATES {
  @date 09/02/2011
  */
 
-class DLLExport FieldDataToMetadata
-    : public std::binary_function<vtkFieldData *, std::string, std::string> {
+class DLLExport FieldDataToMetadata {
 public:
   /// Act as Functor.
   std::string operator()(vtkFieldData *fieldData, const std::string &id) const;

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeStepToTimeStep.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeStepToTimeStep.h
@@ -8,7 +8,6 @@
 #define MANTID_PARAVIEW_TIMESTEP_TO_TIMESTEP
 
 #include "MantidKernel/System.h"
-#include <functional>
 
 /** Maps from a timestep to a timestep. Provides the static compile time
  polymorphism required by vtkDataSetFactory type classes.
@@ -19,7 +18,8 @@
 
 namespace Mantid {
 namespace VATES {
-class DLLExport TimeStepToTimeStep : std::unary_function<int, int> {
+
+class DLLExport TimeStepToTimeStep {
 private:
   TimeStepToTimeStep(double timeMin, double timeMax, size_t intervalStep);
 

--- a/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeToTimeStep.h
+++ b/qt/paraview_ext/VatesAPI/inc/MantidVatesAPI/TimeToTimeStep.h
@@ -8,7 +8,6 @@
 #define MANTID_PARAVIEW_TIME_TO_TIMESTEP
 
 #include "MantidKernel/System.h"
-#include <functional>
 
 /** Unary operation applying visualisation platforms specific conversion from a
  time to a timestep understood by underlying mantid code, where time is treated
@@ -21,17 +20,17 @@
 
 namespace Mantid {
 namespace VATES {
-class DLLExport TimeToTimeStep : std::unary_function<double, int> {
+class DLLExport TimeToTimeStep {
 private:
   // Minimum time.
-  double m_timeMin;
+  double m_timeMin{0.0};
   // Maximum time
-  double m_timeMax;
+  double m_timeMax{0.0};
   // Used for internal linear calculations.
-  double m_c;
+  double m_c{0.0};
   // Used for internal linear calculations.
-  double m_fraction;
-  bool m_runnable;
+  double m_fraction{0.0};
+  bool m_runnable{false};
 
   /// Constructor only accessible via 'construct' static member function.
   TimeToTimeStep(double timeMin, double timeMax, size_t nIntervalSteps);
@@ -41,7 +40,7 @@ public:
   static TimeToTimeStep construct(double timeMin, double timeMax,
                                   size_t nIntervalSteps);
 
-  TimeToTimeStep();
+  TimeToTimeStep() = default;
 
   size_t operator()(double time) const;
 };

--- a/qt/paraview_ext/VatesAPI/src/TimeToTimeStep.cpp
+++ b/qt/paraview_ext/VatesAPI/src/TimeToTimeStep.cpp
@@ -40,13 +40,6 @@ TimeToTimeStep::TimeToTimeStep(double timeMin, double timeMax,
 }
 
 /**
-  Default constructor.
-*/
-TimeToTimeStep::TimeToTimeStep()
-    : m_timeMin(0.0), m_timeMax(0.0), m_c(0.0), m_fraction(0.0),
-      m_runnable(false) {}
-
-/**
   Overloaded funtion operator.
   @param time : time/property value wrt max and min property values of this
   type.

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
@@ -639,7 +639,7 @@ void IqtFunctionModel::estimateExpParameters() {
     if (!heightName2 || !lifeTimeName2)
       return;
   }
-  assert(getNumberDomains() == m_estimationData.size());
+  assert(getNumberDomains() == static_cast<int>(m_estimationData.size()));
   for (auto i = 0; i < getNumberDomains(); ++i) {
     // estimate first exp
     auto const &x = m_estimationData[i].x;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -107,10 +107,12 @@ FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject *mantidui)
       m_shouldBeNormalised(false), m_oldWorkspaceIndex(-1) {
   Mantid::API::FrameworkManager::Instance().loadPlugins();
 
-  // Try to create a Gaussian. Failing will mean that CurveFitting dll is not
-  // loaded
-  boost::shared_ptr<Mantid::API::IFunction>(
-      Mantid::API::FunctionFactory::Instance().createFunction("Gaussian"));
+  // If Gaussian does not exist then the plugins did not load.
+  if (!Mantid::API::FunctionFactory::Instance().exists("Gaussian")) {
+    throw std::runtime_error(
+        "FitPropertyBrowser: Unable to find Gaussian function\n"
+        "Has the CurveFitting plugin loaded?");
+  }
   if (m_autoBgName.toLower() == "none") {
     m_autoBgName = "";
   } else {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/SafeQwtPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/SafeQwtPlot.h
@@ -10,7 +10,14 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Plotting/DllOption.h"
 #include "qwt_text.h"
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4244)
+#endif
 #include <QPainter>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 #include <qwt_plot.h>
 
 namespace MantidQt {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/SafeQwtPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/SafeQwtPlot.h
@@ -8,16 +8,12 @@
 #define MANTID_MANTIDWIDGETS_SAFEQWTPLOT_H_
 
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Plotting/DllOption.h"
 #include "qwt_text.h"
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#endif
+MSVC_DIAG_OFF(4244)
 #include <QPainter>
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
+MSVC_DIAG_ON()
 #include <qwt_plot.h>
 
 namespace MantidQt {

--- a/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
+++ b/qt/widgets/sliceviewer/src/CompositePeaksPresenter.cpp
@@ -472,8 +472,7 @@ bool CompositePeaksPresenter::getShowBackground(
 
 namespace {
 // Helper comparitor type.
-class MatchWorkspaceName
-    : public std::unary_function<SetPeaksWorkspaces::value_type, bool> {
+class MatchWorkspaceName {
 private:
   const QString m_wsName;
 
@@ -552,7 +551,7 @@ void CompositePeaksPresenter::performUpdate() {
 
 namespace {
 // Private helper class
-class MatchPointer : public std::unary_function<bool, PeaksPresenter_sptr> {
+class MatchPointer {
 private:
   PeaksPresenter *m_toFind;
 


### PR DESCRIPTION
**Description of work.**

Require a compiler with support for the C++17 language standard as a minimum. Note that this does not require a C++17 compliant std library implementation. For example macOS High Sierra has Apple Clang 10 (based on LLVM clang 6) that is C++17 language complete but libcxx does not have std::filesystem yet.

Despite this, access to the C++17 language features is still a win. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Builds should pass.

Fixes #26464

*This does not require release notes* because **it is maintenance.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
