### PR TITLE
Small fix in JSONGeometryParser

### DIFF
--- a/Framework/NexusGeometry/src/JSONGeometryParser.cpp
+++ b/Framework/NexusGeometry/src/JSONGeometryParser.cpp
@@ -382,7 +382,7 @@ void JSONGeometryParser::extractSampleContent() {
       Eigen::Quaterniond(Eigen::AngleAxisd(0, Eigen::Vector3d(1, 0, 0)));
   m_sampleName = (*m_sample)[NAME].asString();
   for (const auto &child : children) {
-    if (child[NAME] == TRANSFORMATIONS)
+    if (validateNXAttribute(child[ATTRIBUTES], NX_TRANSFORMATIONS))
       extractTransformations(child, m_samplePosition, m_sampleOrientation);
   }
 }
@@ -396,7 +396,7 @@ void JSONGeometryParser::extractSourceContent() {
     m_sourceName = (*m_source)[NAME].asCString();
     const auto &children = (*m_source)[CHILDREN];
     for (const auto &child : children) {
-      if (child[NAME] == TRANSFORMATIONS)
+      if (validateNXAttribute(child[ATTRIBUTES], NX_TRANSFORMATIONS))
         extractTransformations(child, m_sourcePosition, m_sourceOrientation);
     }
   }


### PR DESCRIPTION
**Description of work.**

Small fix to `JSONGeometryParser` in places where the word `transformations` was being used instead of searching for the presence of the `NX_transformations` class.

**To test:**

<!-- Instructions for testing. -->

Fixes #26769 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **fill in an explanation of why**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
