### PR TITLE
Add a CMake option to disable OpenGL

### DIFF
--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -118,7 +118,6 @@ set(SRC_FILES
     src/Rasterize.cpp
     src/Rendering/GeometryHandler.cpp
     src/Rendering/GeometryTriangulator.cpp
-    src/Rendering/RenderingHelpers.cpp
     src/Rendering/ShapeInfo.cpp
     src/Rendering/vtkGeometryCacheReader.cpp
     src/Rendering/vtkGeometryCacheWriter.cpp
@@ -280,7 +279,6 @@ set(INC_FILES
     inc/MantidGeometry/Rasterize.h
     inc/MantidGeometry/Rendering/GeometryHandler.h
     inc/MantidGeometry/Rendering/GeometryTriangulator.h
-    inc/MantidGeometry/Rendering/OpenGL_Headers.h
     inc/MantidGeometry/Rendering/RenderingHelpers.h
     inc/MantidGeometry/Rendering/RenderingMesh.h
     inc/MantidGeometry/Rendering/ShapeInfo.h
@@ -458,12 +456,25 @@ if(APPLE)
   add_definitions(-DHAVE_IOSTREAM -DHAVE_LIMITS -DHAVE_IOMANIP)
 endif()
 
+if(ENABLE_OPENGL)
+  list(APPEND
+    INC_FILES
+    inc/MantidGeometry/Rendering/OpenGL_Headers.h)
+  list(APPEND
+    SRC_FILES
+    src/Rendering/RenderingHelpersOpenGL.cpp)
+else()
+  list(APPEND
+    SRC_FILES
+    src/Rendering/RenderingHelpersThrowing.cpp)
+endif()
+
 # Add a precompiled header where they are supported
 enable_precompiled_headers(inc/MantidGeometry/PrecompiledHeader.h SRC_FILES)
 # Add the target for this directory
 add_library(Geometry ${SRC_FILES} ${INC_FILES})
 
-target_include_directories(Geometry SYSTEM PUBLIC ${OPENGL_INCLUDE_DIR} ${TBB_INCLUDE_DIRS} ${GSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
+target_include_directories(Geometry SYSTEM PUBLIC  ${TBB_INCLUDE_DIRS} ${GSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS})
 
 # Set the name of the generated library
 set_target_properties(Geometry
@@ -501,6 +512,14 @@ target_link_libraries(Geometry
                       LINK_PUBLIC
                       ${TBB_LIBRARIES}
                       ${TBB_MALLOC_LIBRARIES})
+
+if(ENABLE_OPENGL)
+  target_include_directories(Geometry SYSTEM PRIVATE ${OPENGL_INCLUDE_DIR})
+  target_link_libraries(Geometry
+    LINK_PRIVATE
+    ${OPENGL_gl_LIBRARY}
+    ${OPENGL_glu_LIBRARY})
+endif()
 
 if(ENABLE_OPENCASCADE)
   target_link_libraries(Geometry LINK_PRIVATE ${OPENCASCADE_LIBRARIES})

--- a/Framework/Geometry/inc/MantidGeometry/Rendering/RenderingHelpers.h
+++ b/Framework/Geometry/inc/MantidGeometry/Rendering/RenderingHelpers.h
@@ -8,7 +8,6 @@
 #define MANTID_GEOMETRY_RENDERER_H_
 
 #include "MantidGeometry/DllConfig.h"
-#include "MantidGeometry/Rendering/OpenGL_Headers.h"
 #include <vector>
 
 class TopoDS_Shape;

--- a/Framework/Geometry/src/Rendering/RenderingHelpersOpenGL.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpersOpenGL.cpp
@@ -4,13 +4,14 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidGeometry/Rendering/RenderingHelpers.h"
 #include "MantidGeometry/IObjComponent.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Objects/ShapeFactory.h"
 #include "MantidGeometry/Rendering/GeometryHandler.h"
 #include "MantidGeometry/Rendering/GeometryTriangulator.h"
+#include "MantidGeometry/Rendering/OpenGL_Headers.h"
+#include "MantidGeometry/Rendering/RenderingHelpers.h"
 #include "MantidGeometry/Rendering/ShapeInfo.h"
 #include "MantidGeometry/Surfaces/Cone.h"
 #include "MantidGeometry/Surfaces/Cylinder.h"

--- a/Framework/Geometry/src/Rendering/RenderingHelpersThrowing.cpp
+++ b/Framework/Geometry/src/Rendering/RenderingHelpersThrowing.cpp
@@ -1,0 +1,36 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidGeometry/Rendering/RenderingHelpers.h"
+#include <stdexcept>
+
+namespace {
+void throwNoOpenGLError(const std::string &function) {
+  throw std::runtime_error(
+      function + ": Rendering not supported in a build without OpenGL. Rebuild "
+                 "with ENABLE_OPENGL to enable support.");
+}
+
+} // namespace
+
+namespace Mantid {
+namespace Geometry {
+namespace RenderingHelpers {
+void renderIObjComponent(const IObjComponent &) {
+  throwNoOpenGLError("renderIObjComponent");
+}
+
+void renderTriangulated(detail::GeometryTriangulator &) {
+  throwNoOpenGLError("renderTriangulated");
+}
+
+void renderShape(const detail::ShapeInfo &) {
+  throwNoOpenGLError("renderShape");
+}
+
+} // namespace RenderingHelpers
+} // namespace Geometry
+} // namespace Mantid

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -75,7 +75,9 @@ find_package(Nexus 4.3.1 REQUIRED)
 find_package(MuParser REQUIRED)
 find_package(JsonCPP 0.7.0 REQUIRED)
 
+option(ENABLE_OPENGL "Enable OpenGLbased rendering" ON)
 option(ENABLE_OPENCASCADE "Enable OpenCascade-based 3D visualisation" ON)
+
 if(ENABLE_OPENCASCADE)
   find_package(OpenCascade REQUIRED)
   add_definitions(-DENABLE_OPENCASCADE)

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT ENABLE_OPENGL)
+  message(FATAL_ERROR "Building instrument view with OpenGL disabled is not supported. Please set ENABLE_OPENGL=ON to continue.")
+endif()
+
 set(
   SRC_FILES
   src/BankRenderingHelpers.cpp


### PR DESCRIPTION
**Description of work.**

A framework only build does not need OpenGL and its presence complicates things like the conda build. Adds a flag to allow disabling its inclusion.

**To test:**

Build with the following CMake options `-DENABLE_OPENGL=OFF -DENABLE_MANTIDPLOT=OFF -DENABLE_WORKBENCH=OFF` and observe that `import mantid.simpleapi` works in python

*There is no associated issue.*

*This does not require release notes* because **it is an internal clean up.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
