### PR TITLE
Add a space between Mantid and Workbench/Plot on Win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
       set(_icon_filename ${_icon_filename}${_icon_suffix})
     endif()
     install_desktop_files(mantidplot${CPACK_PACKAGE_SUFFIX}.desktop
-                          MantidPlot${_app_name_suffix}
+                          "Mantid Plot ${_app_name_suffix}"
                           ${CMAKE_INSTALL_PREFIX}/bin/MantidPlot
                           ${_icon_filename}.png
                           mantidplot${CPACK_PACKAGE_SUFFIX}.png )
@@ -345,7 +345,7 @@ if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
       set(_icon_filename ${_icon_filename}${_icon_suffix})
     endif()
     install_desktop_files(mantidworkbench${CPACK_PACKAGE_SUFFIX}.desktop
-                          MantidWorkbench${_app_name_suffix}
+                          "Mantid Workbench ${_app_name_suffix}"
                           ${CMAKE_INSTALL_PREFIX}/bin/mantidworkbench
                           ${_icon_filename}.png
                           mantid_workbench${CPACK_PACKAGE_SUFFIX}.png)

--- a/buildconfig/CMake/WindowsNSIS.cmake
+++ b/buildconfig/CMake/WindowsNSIS.cmake
@@ -177,8 +177,8 @@ install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/images/${WINDOWS_NSIS_MANTIDNOTEBOOK
 ###########################################################################
 # On install. The blank lines seem to be required or it doesn't create the shortcut
 
-set ( MANTIDPLOT_LINK_NAME "MantidPlot${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
-set ( MANTIDNOTEBOOK_LINK_NAME "MantidNotebook${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
+set ( MANTIDPLOT_LINK_NAME "Mantid Plot ${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
+set ( MANTIDNOTEBOOK_LINK_NAME "Mantid Notebook ${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
 
 set (CPACK_NSIS_CREATE_ICONS_EXTRA "
   CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\${MANTIDPLOT_LINK_NAME}' '$SYSDIR\\\\wscript.exe' '\\\"$INSTDIR\\\\bin\\\\launch_mantidplot.vbs\\\"' '$INSTDIR\\\\bin\\\\${WINDOWS_NSIS_MANTIDPLOT_ICON_NAME}.ico'
@@ -212,7 +212,7 @@ set (CPACK_NSIS_EXTRA_UNINSTALL_COMMANDS "
 # this is done via appending the relevant commands to the already declared variables
 if ( ENABLE_WORKBENCH )
   install ( FILES ${CMAKE_CURRENT_SOURCE_DIR}/images/${WINDOWS_NSIS_MANTIDWORKBENCH_ICON_NAME}.ico DESTINATION bin )
-  set ( MANTIDWORKBENCH_LINK_NAME "MantidWorkbench${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
+  set ( MANTIDWORKBENCH_LINK_NAME "Mantid Workbench ${WINDOWS_CAPITALIZED_PACKAGE_SUFFIX}.lnk" )
   message(STATUS "Adding icons for Workbench as it is being packaged in the installation.")
   set (CPACK_NSIS_CREATE_ICONS_EXTRA "
     CreateShortCut '$SMPROGRAMS\\\\$STARTMENU_FOLDER\\\\${MANTIDWORKBENCH_LINK_NAME}' '\\\"$INSTDIR\\\\bin\\\\launch_workbench.exe\\\"' '' '$INSTDIR\\\\bin\\\\${WINDOWS_NSIS_MANTIDWORKBENCH_ICON_NAME}.ico'

--- a/docs/source/release/v4.3.0/ui.rst
+++ b/docs/source/release/v4.3.0/ui.rst
@@ -11,6 +11,9 @@ UI & Usability Changes
 
 Installation
 ------------
+- Mantid Plot and Workbench can now be opened on Windows by typing
+  "Workbench", "Plot" or "Mantid" into the start menu, previously only
+  "Mantid" worked.
 
 MantidPlot
 ----------


### PR DESCRIPTION
**Description of work.**
Adds a space between the word Mantid and Workbench or Plot on Windows.

This allows Windows search to find results based on the word plot or Workbench, whereas before Mantid was the only word it selected on.

I'm keen to get this in really early in the release window, so we have a long time for it to stew since it involves the primary way users access our software.

Some notes from my research following on in #27484 :
- This only affects Windows (because of how CMake is wired up) but other platforms are not affected at all. This includes the application names, only shortcuts names (i.e. start menu) is changed.
- After this change Best Match seems to 'work' correctly. For me it changed to Workbench when I typed 'Mantid' in. After manually selecting plot 3/4 times typing 'Mantid' would default open Plot instead.
- We have no ability to hint or control the order Window's start menu will order in, so it's purely based on whatever secret heuristic Microsoft use to order apps in
- Users will now be able to type 'Plot' or 'Workbench' if they have strong feelings about one or another. This could help adoption, as typing 'Mantid' gets you Plot by default, and if you really feel strongly against workbench you can just type plot to know (or let Windows figure it out).


**To test:**
- You must have CPack configured, see the dev instructions on building Windows Installers 
- Run CMake with -DENABLE_CPACK=ON -DCPACK_PACKAGE_SUFFIX=""
- (Or alternatively in the CMake GUI set ENABLE_CPACK and change CPACK_PACKAGE_SUFFIX to nothing)
- Build a release build, a debug build is not supported for packaging
- Uninstall Mantid release whilst you wait
- Build a Windows Installer using the installer instructions
- Install your bespoke version and test out the start menu
- Ensure you uninstall and delete your bespoke version, so you don't get it confused with an official release.
- Try this for a nightly or unstable release and check `plot`, `workbench` and `mantid` still work correctly

Fixes #27484 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
