### PR TITLE
Fix unrolling consecutive workflow algorithms in workspace history

### DIFF
--- a/Framework/API/src/HistoryView.cpp
+++ b/Framework/API/src/HistoryView.cpp
@@ -145,7 +145,7 @@ void HistoryView::rollChildren(std::vector<HistoryItem>::iterator it) {
       roll(it);
     else {
       ++it;
-	}
+    }
   }
 }
 

--- a/Framework/API/src/HistoryView.cpp
+++ b/Framework/API/src/HistoryView.cpp
@@ -143,6 +143,9 @@ void HistoryView::rollChildren(std::vector<HistoryItem>::iterator it) {
   for (size_t i = 0; i < numChildren; ++i) {
     if (it->isUnrolled())
       roll(it);
+    else {
+      ++it;
+	}
   }
 }
 

--- a/docs/source/release/v4.3.0/mantidplot.rst
+++ b/docs/source/release/v4.3.0/mantidplot.rst
@@ -11,5 +11,6 @@ Improvements
 Bugfixes
 ########
 - The Show Instruments right click menu option is now disabled for workspaces that have had their spectrum axis converted to another axis using :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.  Once this axis has been converetd the workspace loses it's link between the data values and the detectors they were recorded on so we cannot display it in the instrument view.
+- Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -27,6 +27,7 @@ Improvements
 
 Bugfixes
 ########
+- Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
 
 - Colorbar scale no longer vanish on colorfill plots with a logarithmic scale
 - Figure options no longer causes a crash when using 2d plots created from a script.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
@@ -86,6 +86,7 @@ private:
   void populateNestedHistory(AlgHistoryItem *parentWidget,
                              Mantid::API::AlgorithmHistory_sptr history);
   void uncheckAllChildren(QTreeWidgetItem *item, int index);
+  void removeHiddenChildren(QTreeWidgetItem *item);
   QString concatVersionwithName(const std::string &name, const int version);
 
   const static int UNROLL_COLUMN_INDEX = 1;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmHistoryWindow.h
@@ -81,12 +81,12 @@ private slots:
 
 private:
   void treeSelectionChanged();
+  void getItemIndex(QTreeWidgetItem *item, int &index);
   void itemChecked(QTreeWidgetItem *item, int index);
   void itemUnchecked(QTreeWidgetItem *item, int index);
   void populateNestedHistory(AlgHistoryItem *parentWidget,
                              Mantid::API::AlgorithmHistory_sptr history);
   void uncheckAllChildren(QTreeWidgetItem *item, int index);
-  void removeHiddenChildren(QTreeWidgetItem *item);
   QString concatVersionwithName(const std::string &name, const int version);
 
   const static int UNROLL_COLUMN_INDEX = 1;

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -643,14 +643,13 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
   QModelIndex modelIndex;
 
   QTreeWidgetItem *itemCopy;
-  QTreeWidgetItem *parent;
   auto userCheckedItem = item;
 
   QList<QTreeWidgetItem *> children;
   bool hadToCheck{false};
   std::vector<QTreeWidgetItem *> itemsChecked;
 
-  do {
+  do { 
     modelIndex = indexFromItem(item, index);
     indicies.emplace_back(modelIndex.row() + 1);
 
@@ -677,8 +676,7 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
     children = itemCopy->takeChildren();
     modelIndex = indexFromItem(item, index);
 
-    parent = item->parent();
-    if (parent) {
+    if (auto parent = item->parent()) {
       parent->insertChildren(modelIndex.row() + 1, children);
     } else {
       insertTopLevelItems(modelIndex.row() + 1, children);

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -662,7 +662,7 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
     // checked here are added to a list so we know which item's children need to
     // be copied.
     if (hadToCheck || currentItem == item) {
-      itemsChecked.emplace_back(item);
+      itemsChecked.emplace_back(currentItem);
     }
   }
 
@@ -674,12 +674,12 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
   // HistoryView, when an algorithm is unrolled a copy of its children is made,
   // added to the tree after the algorithm, and hidden.
   for (auto it = itemsChecked.rbegin(); it != itemsChecked.rend(); ++it) {
-    auto item{*it};
-    auto itemCopy{std::unique_ptr<QTreeWidgetItem>{item->clone()}};
+    auto currentItem{*it};
+    auto itemCopy{std::unique_ptr<QTreeWidgetItem>{currentItem->clone()}};
     auto children{itemCopy->takeChildren()};
-    modelIndex = indexFromItem(item, index);
+    modelIndex = indexFromItem(currentItem, index);
 
-    if (auto parent = item->parent()) {
+    if (auto parent = currentItem->parent()) {
       parent->insertChildren(modelIndex.row() + 1, children);
     } else {
       insertTopLevelItems(modelIndex.row() + 1, children);

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -667,6 +667,10 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
     item = item->parent();
   } while (item);
 
+  // When an algorithm is unrolled, a copy of its children is made, added to
+  // the tree after the algorithm being unrolled, and hidden.
+  // This means that the unrollIndicies which are passed to HistoryView line
+  // up correctly with the list of algorithms in m_historyItems
   for (auto it = itemsChecked.rbegin(); it != itemsChecked.rend(); ++it) {
     item = *it;
     itemCopy = item->clone();
@@ -702,6 +706,8 @@ void AlgHistoryTreeWidget::itemUnchecked(QTreeWidgetItem *item, int index) {
   int rollIndex = 0;
   QModelIndex modelIndex;
 
+  // The hidden copy of the algorithm's children which were made when the
+  // algorithm was unrolled are removed.
   removeHiddenChildren(item);
   // disable any children
   uncheckAllChildren(item, index);

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -649,7 +649,7 @@ void AlgHistoryTreeWidget::itemChecked(QTreeWidgetItem *item, int index) {
   bool hadToCheck{false};
   std::vector<QTreeWidgetItem *> itemsChecked;
 
-  do { 
+  do {
     modelIndex = indexFromItem(item, index);
     indicies.emplace_back(modelIndex.row() + 1);
 

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -737,22 +737,22 @@ void AlgHistoryTreeWidget::uncheckAllChildren(QTreeWidgetItem *item,
 }
 
 void AlgHistoryTreeWidget::removeHiddenChildren(QTreeWidgetItem *item) {
-  if (auto parent = item->parent()) {
-    int index{parent->indexOfChild(item)};
+  auto parent = item->parent();
 
-    for (int i = 0; i < item->childCount(); i++) {
-      if (item->child(i)->checkState(1) == Qt::Checked) {
-        removeHiddenChildren(item->child(i));
-      }
-      delete parent->child(index + 1);
+  for (int i = 0; i < item->childCount(); ++i) {
+    // Before removing the current item's hidden children, check if any of its
+    // children are unrolled and delete the hidden children for those.
+    if (item->child(i)->checkState(1) == Qt::Checked) {
+      removeHiddenChildren(item->child(i));
     }
-  } else {
-    int index{indexOfTopLevelItem(item)};
 
-    for (int i = 0; i < item->childCount(); ++i) {
-      if (item->child(i)->checkState(index) == Qt::Checked) {
-        removeHiddenChildren(item->child(i));
-      }
+    // Deleting an item is done differently depending on whether it is top-level
+    // or not.
+    if (parent) {
+      int index{parent->indexOfChild(item)};
+      delete parent->child(index + 1);
+    } else {
+      int index{indexOfTopLevelItem(item)};
       delete topLevelItem(index + 1);
     }
   }


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where ticking the box to unroll two consecutive workflow algorithms in workspace history would only actually unroll the first algorithm when the script is copied to file or clipboard. Now all algorithms unroll correctly.

**To test:**
Use either Plot or Workbench
1. Create a workspace history with multiple workflow algorithms (skip this step if you have your own way of doing this):

    - Download the ISIS sample data.
    - Interfaces -> SANS -> ISIS SANS.
    - Click Load User File and select SampleData-ISIS\loqdemo\MaskFile.txt
    - Click Load Batch File and select SampleData-ISIS\loqdemo\batch_mode_reduction.csv
    - Click Process All.
2. Right-click the workspace and select Show History.
3. In the history window, click the box in the Unroll column for both workflow algorithms.
4. Click Script to Clipboard and paste the script into the script editor.
5. Check that both algorithms are unrolled correctly.

Fixes #26826 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
