### PR TITLE
Remov canWrite checks in FileValidator

### DIFF
--- a/Framework/API/src/FileProperty.cpp
+++ b/Framework/API/src/FileProperty.cpp
@@ -43,8 +43,8 @@ IValidator_sptr createValidator(unsigned int action,
     return boost::make_shared<DirectoryValidator>(action ==
                                                   FileProperty::Directory);
   } else {
-    return boost::make_shared<FileValidator>(
-        exts, (action == FileProperty::Load), (action == FileProperty::Save));
+    return boost::make_shared<FileValidator>(exts,
+                                             (action == FileProperty::Load));
   }
 }
 

--- a/Framework/Kernel/inc/MantidKernel/FileValidator.h
+++ b/Framework/Kernel/inc/MantidKernel/FileValidator.h
@@ -27,7 +27,7 @@ class MANTID_KERNEL_DLL FileValidator : public TypedValidator<std::string> {
 public:
   explicit FileValidator(
       const std::vector<std::string> &extensions = std::vector<std::string>(),
-      bool testFileExists = true, bool testCanWrite = false);
+      bool testFileExists = true);
   std::vector<std::string> allowedValues() const override;
   IValidator_sptr clone() const override;
 
@@ -36,8 +36,6 @@ protected:
   std::vector<std::string> m_extensions;
   /// Flag indicating whether to test for existence of filename
   bool m_testExist;
-  /// Flag indicating whether to test for the file being writable
-  bool m_testCanWrite;
 
 private:
   std::string checkValidity(const std::string &value) const override;

--- a/Framework/Kernel/src/FileValidator.cpp
+++ b/Framework/Kernel/src/FileValidator.cpp
@@ -23,7 +23,6 @@ Logger g_log("FileValidator");
  *  @param extensions :: The permitted file extensions (e.g. .RAW)
  *  @param testFileExists :: Flag indicating whether to test for existence of
  * file (default: yes)
- *  @param testCanWrite :: Flag to check if file writing permissible.
  */
 FileValidator::FileValidator(const std::vector<std::string> &extensions,
                              bool testFileExists)

--- a/Framework/Kernel/src/FileValidator.cpp
+++ b/Framework/Kernel/src/FileValidator.cpp
@@ -26,9 +26,8 @@ Logger g_log("FileValidator");
  *  @param testCanWrite :: Flag to check if file writing permissible.
  */
 FileValidator::FileValidator(const std::vector<std::string> &extensions,
-                             bool testFileExists, bool testCanWrite)
-    : TypedValidator<std::string>(), m_testExist(testFileExists),
-      m_testCanWrite(testCanWrite) {
+                             bool testFileExists)
+    : TypedValidator<std::string>(), m_testExist(testFileExists) {
   for (const auto &extension : extensions) {
     const std::string ext = boost::to_lower_copy(extension);
     if (std::find(m_extensions.begin(), m_extensions.end(), ext) ==
@@ -90,47 +89,6 @@ std::string FileValidator::checkValidity(const std::string &value) const {
   // If the file is required to exist check it is there
   if (m_testExist && (value.empty() || !Poco::File(value).exists())) {
     return "File \"" + abspath + "\" not found";
-  }
-
-  // If the file is required to be writable...
-  if (m_testCanWrite) {
-    if (value.empty())
-      return "Cannot write to empty filename";
-
-    Poco::File file(value);
-    // the check for writable is different for whether or not a version exists
-    // this is taken from ConfigService near line 443
-    if (file.exists()) {
-      try {
-        if (!file.canWrite())
-          return "File \"" + abspath + "\" cannot be written";
-      } catch (std::exception &e) {
-        g_log.information()
-            << "Encountered exception while checking for writable: "
-            << e.what();
-      }
-    } else // if the file doesn't exist try to temporarily create one
-    {
-      try {
-        Poco::Path direc(value);
-        if (direc.isAbsolute()) {
-          // see if file is writable
-          if (Poco::File(direc).canWrite())
-            return "";
-          else
-            return "Cannot write to file \"" + direc.toString() + "\"";
-        }
-
-        g_log.debug() << "Do not have enough information to validate \""
-                      << abspath << "\"\n";
-      } catch (std::exception &e) {
-        g_log.information()
-            << "Encountered exception while checking for writable: "
-            << e.what();
-      } catch (...) {
-        g_log.information() << "Unknown exception while checking for writable";
-      }
-    }
   }
 
   // Otherwise we are okay, file extensions are just a suggestion so no

--- a/Framework/Kernel/test/FileValidatorTest.h
+++ b/Framework/Kernel/test/FileValidatorTest.h
@@ -104,21 +104,6 @@ public:
     FileValidator file_val;
     TS_ASSERT_EQUALS(file_val.isValid(""), "File \"\" not found");
   }
-
-  void testCanWrite() {
-    std::string filename("myJunkFile_hgfvj.cpp");
-
-    // file existance is optional
-    FileValidator v1(std::vector<std::string>(), false, true);
-    TS_ASSERT_EQUALS(v1.isValid(""), "Cannot write to empty filename");
-    TS_ASSERT_EQUALS(v1.isValid(filename), "");
-
-    // file existance is required
-    FileValidator v2(std::vector<std::string>(), true, true);
-    TS_ASSERT_EQUALS(v2.isValid(""), "File \"\" not found");
-    TS_ASSERT_EQUALS(v2.isValid(filename),
-                     "File \"" + filename + "\" not found");
-  }
 };
 
 #endif /*FILEVALIDATORTEST_H_*/

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -53,7 +53,8 @@ public:
 
   /// open the nexus file for writing
   void openNexusWrite(const std::string &fileName,
-                      optional_size_t entryNumber = optional_size_t());
+                      optional_size_t entryNumber = optional_size_t(),
+                      const bool append_to_file = true);
   /// write the header ifon for the Mantid workspace format
   int writeNexusProcessedHeader(const std::string &title,
                                 const std::string &wsName = "") const;

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -81,7 +81,8 @@ void NexusFileIO::resetProgress(Progress *prog) { m_progress = prog; }
 // </NXentry>
 
 void NexusFileIO::openNexusWrite(const std::string &fileName,
-                                 NexusFileIO::optional_size_t entryNumber) {
+                                 NexusFileIO::optional_size_t entryNumber,
+                                 const bool append_to_file) {
   // open named file and entry - file may exist
   // @throw Exception::FileError if cannot open Nexus file for writing
   //
@@ -93,7 +94,7 @@ void NexusFileIO::openNexusWrite(const std::string &fileName,
   // if so open as xml
   // format otherwise as compressed hdf5
   //
-  if (Poco::File(m_filename).exists())
+  if ((Poco::File(m_filename).exists() && append_to_file) || m_filehandle)
     mode = NXACC_RDWR;
 
   else {


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

This removes the `Poco::File::canWrite` checks in the `FileValidator`. It means that Mantid will not warn users that files may not be (over)writable in the `Save*` GUI dialogs but also fixes an issue on the Linux analysis clusters in multi-user environment where users with the correct group permissions are refused overwriting by Mantid because they do not own the file to be (over)written to.

**To test:**

<!-- Instructions for testing. -->

You need access to a Linux system with Mantid where you have access to two user accounts.

1. Using the first user account, create a file, and check that it is owned by the first user account and that its group is one which the second user account is not a member of (and its other permission is not writable - e.g. it has permissions mask `660` or some such).
2. As the second user account run Mantid and try to overwrite this file using a Save algorithm (e.g. `SaveNexus` or `SaveAscii`). This should give (correctly) an `Unable to create file` error.
3. Back as the first user account change the group of the file to one which the second user account *is* a member.
4. As the second user account, check that Mantid can now overwrite this file.

Fixes #27495  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
