### PR TITLE
LoadNGEM: Convert tof to double when converting to microseconds

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadNGEM.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadNGEM.h
@@ -108,18 +108,12 @@ private:
   void exec() override;
   /// Load a file into the event lists.
   void loadSingleFile(const std::vector<std::string> &filePath,
-                      int &eventCountInFrame, int &maxToF, int &minToF,
+                      int &eventCountInFrame, double &maxToF, double &minToF,
                       int &rawFrames, int &goodFrames, const int &minEventsReq,
                       const int &maxEventsReq, MantidVec &frameEventCounts,
                       std::vector<DataObjects::EventList> &events,
                       std::vector<DataObjects::EventList> &eventsInFrame,
                       const size_t &totalFilePaths, int &fileCount);
-  /// Add some text information to the sample logs.
-  void addToSampleLog(const std::string &logName, const std::string &logText,
-                      DataObjects::EventWorkspace_sptr &ws);
-  /// Add some number information to the sample logs.
-  void addToSampleLog(const std::string &logName, const int &logNumber,
-                      DataObjects::EventWorkspace_sptr &ws);
   /// Check that a file to be loaded is in 128 bit words.
   size_t verifyFileSize(std::ifstream &file);
   /// Reports progress and checks cancel flag.

--- a/Framework/DataHandling/src/LoadNGEM.cpp
+++ b/Framework/DataHandling/src/LoadNGEM.cpp
@@ -103,13 +103,10 @@ void addFrameToOutputWorkspace(
 void createEventWorkspace(const double &maxToF, const double &binWidth,
                           std::vector<DataObjects::EventList> &events,
                           DataObjects::EventWorkspace_sptr &dataWorkspace) {
-  std::vector<double> xAxis;
-  // Round up number of bins needed and reserve the space in the vector.
-  const int nbins{int(std::ceil(maxToF / binWidth))};
-  xAxis.reserve(nbins);
-  for (auto i = 0; i < nbins; i++) {
-    xAxis.emplace_back(i * binWidth);
-  }
+  // Round up number of bins needed
+  std::vector<double> xAxis(int(std::ceil(maxToF / binWidth)));
+  std::generate(xAxis.begin(), xAxis.end(),
+                [i = 0, &binWidth]() mutable { return binWidth * i++; });
 
   dataWorkspace = DataObjects::create<DataObjects::EventWorkspace>(
       NUM_OF_SPECTRA, HistogramData::Histogram(HistogramData::BinEdges(xAxis)));

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -12,6 +12,11 @@ Framework Changes
 Concepts
 --------
 
+Improvements
+############
+
+- Fixed a bug in :ref:`LoadNGEM <algm-LoadNGEM>` where precision was lost due to integer arithmetic.
+
 Algorithms
 ----------
 


### PR DESCRIPTION
**Description of work.**

The original accidentally kept with integer arithmetic during the conversion to microseconds. This chopped off any fractional values and limited the resolution to 1us.
Added tests for data/sample logs for small bin widths.

**Report to:** Davide Raspino/ISIS

**To test:**

* Use the file `/Testing/Data/UnitTest/GEM000005_00_000_short.edb`.
* Load it with the bin width 0.1 and run sum spectra.
* Look at the data view
* On master the counts are all at integer tof positions. With this fix they are at the correct positions.

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
