### PR TITLE
Fix crash when using figure options in 2d plots

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -11,4 +11,6 @@ Improvements
 Bugfixes
 ########
 
+- Figure options no longer causes a crash when using 2d plots created from a script.
+
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -41,7 +41,7 @@ class ImagesTabWidgetPresenter:
         if props.interpolation:
             image.set_interpolation(props.interpolation)
 
-        current_axis_images = self.fig.gca().images[-1]
+        current_axis_images = get_images_from_fig(self.fig)[-1]
 
         if current_axis_images.colorbar:
             current_axis_images.colorbar.remove()


### PR DESCRIPTION
**Description of work.**
This PR fixes the crash that occurred when opening the figure options in any 2d plots when it was created from a script.

**To test:**
Run the following to create and plot a 2d workspace (taken from [here](https://docs.mantidproject.org/nightly/plotting/index.html))

```
from matplotlib.colors import LogNorm

# generate a nice 2D multi-dimensional workspace
data = Load('CNCS_7860')
data = ConvertUnits(InputWorkspace=data,Target='DeltaE', EMode='Direct', EFixed=3)
data = Rebin(InputWorkspace=data, Params='-3,0.025,3', PreserveEvents=False)
md = ConvertToMD(InputWorkspace=data,
                 QDimensions='|Q|',
                 dEAnalysisMode='Direct')
sqw = BinMD(InputWorkspace=md,
            AlignedDim0='|Q|,0,3,100',
            AlignedDim1='DeltaE,-3,3,100')

#2D plot
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c = ax.pcolormesh(sqw, norm=LogNorm())
cbar=fig.colorbar(c)
cbar.set_label('Intensity (arb. units)') #add text to colorbar
fig.show()
```
Open the figure options and change some properties in the image tab and press ok or apply.
It should not crash

Fixes #27513

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
