### PR TITLE
Bump Minimum CMake to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
-# CMake version check. Require CMake 3.5, required by ParaView 5.1.0
-cmake_minimum_required(VERSION 3.5)
+# CMake version check. Require CMake 3.13 - Required for add_link_options
+# 3.15 is required on Windows, but is not available to RHEL yet
+cmake_minimum_required(VERSION 3.13)
 
 # Define the project name.
 project(Mantid)

--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -73,10 +73,13 @@ Red Hat/Cent OS/Fedora
 
 Ubuntu
 ~~~~~~
-Follow the `Ubuntu instructions <http://download.mantidproject.org/ubuntu.html>`_ to add the
-stable release repository and mantid ppa. Download the latest
-`mantid-developer <https://sourceforge.net/projects/mantid/files/developer>`_
-package and install it:
+- Setup the Kitware APT repository to get a recent version of CMake by
+  following `these instructions <https://apt.kitware.com/>`_
+- Follow the `Ubuntu instructions <http://download.mantidproject.org/ubuntu.html>`_
+  to add the stable release repository and mantid ppa.
+- Download the latest
+  `mantid-developer <https://sourceforge.net/projects/mantid/files/developer>`_
+  package and install it:
 
 .. code-block:: sh
 


### PR DESCRIPTION
**Description of work.**

Bumps the minimum CMake version to 3.13, this allows us to use add_link_options on address sanitizers. When 3.16 is available widely we can investigate `target_precompile_headers`, so at some point developers will need to move to the kitware repo, but that is out scope for this PR.

At the moment 3.14 is available for RHEL7, 3.16 on Windows and 3.15 for Ubuntu using the kitware repo (otherwise 3.10). 
Windows requires 3.15 so in an ideal world we would just set our minimum to that, but it's not fully available.

When this merge is completed a message needs to go out to developers on Ubuntu to do the following:
```
# Grab the Kitware key
wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
sudo apt-get update
sudo apt-get install cmake
```

**To test:**
- Attempt to configure with CMake =< 3.12 and check the minimum warning is emitted.
- Attempt to configure with 3.13 and check that it configures correctly
- Check the new dev instructions make sense

There is no associated issue, as this is split out of #27483 

*This does not require release notes* because only developers are affected

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
