### PR TITLE
Make OpenMP for loops use max threads value from config

### DIFF
--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -409,9 +409,6 @@ void SofQWNormalisedPolygon::exec() {
     Resetting the number of threads here to what is set in the config file is a
     temporary solution.
     */
-  // TODO: Do this via a MultiThreaded.h macro via:
-  // https://github.com/mantidproject/mantid/issues/27375#issuecomment-553799284
-  FrameworkManager::Instance().setNumOMPThreadsToConfigValue();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -399,16 +399,6 @@ void SofQWNormalisedPolygon::exec() {
   const auto &inputIndices = inputWS->indexInfo();
   const auto &spectrumInfo = inputWS->spectrumInfo();
 
-  /*
-    On linux, the value value that is set at startup for the number of allowed
-    threads when mulitprocessing is not carried over to new execution threads.
-    As a result, mantid can segfault due to accessing workspaces that are
-    created in the main thread, as they have too few indexes that are supposed
-    to match the number of threads.
-
-    Resetting the number of threads here to what is set in the config file is a
-    temporary solution.
-    */
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
     PARALLEL_START_INTERUPT_REGION

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -136,7 +136,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *   code to be executed in parallel
  */
 #define PARALLEL_FOR_IF(condition)                                             \
-  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  setMaxCoresToConfig();                                                       \
   PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for if (condition) )
 
@@ -145,7 +145,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *   and therefore should not be used in any loops that access workspaces.
  */
 #define PARALLEL_FOR_NO_WSP_CHECK()                                            \
-  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  setMaxCoresToConfig();                                                       \
   PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for)
 
@@ -155,12 +155,12 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *  and therefore should not be used in any loops that access workspace.
  */
 #define PARALLEL_FOR_NOWS_CHECK_FIRSTPRIVATE(variable)                         \
-  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  setMaxCoresToConfig();                                                       \
   PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for firstprivate(variable) )
 
 #define PARALLEL_FOR_NO_WSP_CHECK_FIRSTPRIVATE2(variable1, variable2)          \
-  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  setMaxCoresToConfig();                                                       \
   PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for firstprivate(variable1, variable2) )
 
@@ -205,15 +205,13 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 
 #define PARALLEL_SECTION PRAGMA(omp section)
 
-#define PARALLEL_SET_THREADS_TO_CONFIG                                         \
-  {                                                                            \
-    const auto maxCores =                                                      \
-        Mantid::Kernel::ConfigService::Instance().getValue<int>(               \
-            "MultiThreaded.MaxCores");                                         \
-    if (maxCores.get_value_or(0) > 0) {                                        \
-      PARALLEL_SET_NUM_THREADS(maxCores.get());                                \
-    }                                                                          \
+inline void setMaxCoresToConfig() {
+  const auto maxCores = Mantid::Kernel::ConfigService::Instance().getValue<int>(
+      "MultiThreaded.MaxCores");
+  if (maxCores.get_value_or(0) > 0) {
+    PARALLEL_SET_NUM_THREADS(maxCores.get());
   }
+}
 
 /** General purpose define for OpenMP, becomes the equivalent of
  * #pragma omp EXPRESSION

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -137,6 +137,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  */
 #define PARALLEL_FOR_IF(condition)                                             \
   PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for if (condition) )
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
@@ -145,6 +146,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  */
 #define PARALLEL_FOR_NO_WSP_CHECK()                                            \
   PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for)
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
@@ -154,10 +156,12 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  */
 #define PARALLEL_FOR_NOWS_CHECK_FIRSTPRIVATE(variable)                         \
   PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for firstprivate(variable) )
 
 #define PARALLEL_FOR_NO_WSP_CHECK_FIRSTPRIVATE2(variable1, variable2)          \
   PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PARALLEL_SET_DYNAMIC(false);                                                 \
   PRAGMA(omp parallel for firstprivate(variable1, variable2) )
 
 /** Ensures that the next execution line or block is only executed if

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -202,12 +202,13 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 #define PARALLEL_SECTION PRAGMA(omp section)
 
 #define PARALLEL_SET_THREADS_TO_CONFIG                                         \
-  if (Mantid::Kernel::ConfigService::Instance()                                \
-          .getValue<int>("MultiThreaded.MaxCores")                             \
-          .get_value_or(0) > 0) {                                              \
-    PARALLEL_SET_NUM_THREADS(Mantid::Kernel::ConfigService::Instance()         \
-                                 .getValue<int>("MultiThreaded.MaxCores")      \
-                                 .get());                                      \
+  {                                                                            \
+    const auto maxCores =                                                      \
+        Mantid::Kernel::ConfigService::Instance().getValue<int>(               \
+            "MultiThreaded.MaxCores");                                         \
+    if (maxCores.get_value_or(0) > 0) {                                        \
+      PARALLEL_SET_NUM_THREADS(maxCores.get());                                \
+    }                                                                          \
   }
 
 /** General purpose define for OpenMP, becomes the equivalent of

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -127,6 +127,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 // compiler.
 #ifdef _OPENMP
 
+#include "MantidKernel/ConfigService.h"
 #include <omp.h>
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
@@ -135,14 +136,16 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *   code to be executed in parallel
  */
 #define PARALLEL_FOR_IF(condition)                                             \
-    PRAGMA(omp parallel for if (condition) )
+  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PRAGMA(omp parallel for if (condition) )
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
  *   This includes no checks to see if workspaces are suitable
  *   and therefore should not be used in any loops that access workspaces.
  */
 #define PARALLEL_FOR_NO_WSP_CHECK()                                            \
-    PRAGMA(omp parallel for)
+  PARALLEL_SET_THREADS_TO_CONFIG                                               \
+  PRAGMA(omp parallel for)
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
  *  and declare the variables to be firstprivate.
@@ -150,9 +153,11 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *  and therefore should not be used in any loops that access workspace.
  */
 #define PARALLEL_FOR_NOWS_CHECK_FIRSTPRIVATE(variable)                         \
+  PARALLEL_SET_THREADS_TO_CONFIG                                               \
   PRAGMA(omp parallel for firstprivate(variable) )
 
 #define PARALLEL_FOR_NO_WSP_CHECK_FIRSTPRIVATE2(variable1, variable2)          \
+  PARALLEL_SET_THREADS_TO_CONFIG                                               \
   PRAGMA(omp parallel for firstprivate(variable1, variable2) )
 
 /** Ensures that the next execution line or block is only executed if
@@ -195,6 +200,15 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 #define PARALLEL_SECTIONS PRAGMA(omp sections nowait)
 
 #define PARALLEL_SECTION PRAGMA(omp section)
+
+#define PARALLEL_SET_THREADS_TO_CONFIG                                         \
+  if (Mantid::Kernel::ConfigService::Instance()                                \
+          .getValue<int>("MultiThreaded.MaxCores")                             \
+          .get_value_or(0) > 0) {                                              \
+    PARALLEL_SET_NUM_THREADS(Mantid::Kernel::ConfigService::Instance()         \
+                                 .getValue<int>("MultiThreaded.MaxCores")      \
+                                 .get());                                      \
+  }
 
 /** General purpose define for OpenMP, becomes the equivalent of
  * #pragma omp EXPRESSION

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -14,7 +14,7 @@ include (InstallRequiredSystemLibraries)
 add_definitions ( -D_WINDOWS -DMS_VISUAL_STUDIO )
 add_definitions ( -D_USE_MATH_DEFINES -DNOMINMAX )
 add_definitions ( -DGSL_DLL -DJSON_DLL )
-add_definitions ( -DPOCO_DLL -DPOCO_NO_UNWINDOWS )
+add_definitions ( -DPOCO_DLL -DPOCO_NO_UNWINDOWS -DPOCO_NO_AUTOMATIC_LIBS)
 add_definitions ( -DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE )
 add_definitions ( -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS )
   # Prevent deprecation errors from std::tr1 in googletest until it is fixed upstream. In MSVC 2017 and later


### PR DESCRIPTION
**Description of work.**
Before each of the OpenMP parallel for macros, the max threads value is updated for the current scope to match the value in the config. 

This is a fix that can be generally applied to replace the solution from #27343.

**To test:**
1. Ensure that the value set in your local `mantid.user.properties`file for `MaxThreads` is lower than the number of cores on your machine.
2. Open the Indirect Data Reduction Interface
3. Load a workspace via the ISIS Energy Transfer tab (I've used 88888 as a run number). 
4. Switch to the S(Q, w) tab and run using the generated workspace. 
5. There should be no crash. 

Fixes #27375.

*This does not require release notes* because **there will be no user facing changes**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
