### PR TITLE
Fix various CMake and GCC Warnings

### DIFF
--- a/Framework/Algorithms/src/CreateDetectorTable.cpp
+++ b/Framework/Algorithms/src/CreateDetectorTable.cpp
@@ -307,7 +307,7 @@ void populateTable(ITableWorkspace_sptr &t, const MatrixWorkspace_sptr &ws,
 
       colValues << phi               // rtp
                 << isMonitorDisplay; // monitor
-    } catch (std::exception) {
+    } catch (const std::exception &) {
       // spectrumNo=-1, detID=0
       colValues << -1 << "0";
       // Y/E

--- a/Framework/Algorithms/test/CalculatePlaczekSelfScatteringTest.h
+++ b/Framework/Algorithms/test/CalculatePlaczekSelfScatteringTest.h
@@ -156,7 +156,7 @@ public:
     alg->setProperty("IncidentSpecta", IncidentSpecta);
     alg->setProperty("InputWorkspace", InputWorkspace);
     alg->setProperty("OutputWorkspace", "correction_ws");
-    TS_ASSERT_THROWS(alg->execute(), std::runtime_error)
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
   }
 
   void testCalculatePlaczekSelfScatteringDoesNotRunWithNoSample() {
@@ -170,7 +170,7 @@ public:
     alg->setProperty("IncidentSpecta", IncidentSpecta);
     alg->setProperty("InputWorkspace", InputWorkspace);
     alg->setProperty("OutputWorkspace", "correction_ws");
-    TS_ASSERT_THROWS(alg->execute(), std::runtime_error)
+    TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
   }
 
 private:

--- a/Framework/Algorithms/test/CreateDetectorTableTest.h
+++ b/Framework/Algorithms/test/CreateDetectorTableTest.h
@@ -164,7 +164,7 @@ public:
     TS_ASSERT(alg.isInitialized())
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS))
 
-    TS_ASSERT_THROWS(alg.executeAsChildAlg(), std::runtime_error);
+    TS_ASSERT_THROWS(alg.executeAsChildAlg(), const std::runtime_error &);
   }
 };
 

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -477,7 +477,8 @@ public:
     IndexPeaks alg;
     alg.initialize();
 
-    TS_ASSERT_THROWS(alg.setProperty("MaxOrder", -1), std::invalid_argument)
+    TS_ASSERT_THROWS(alg.setProperty("MaxOrder", -1),
+                     const std::invalid_argument &)
   }
 
   void test_modvector_with_list_length_not_three_throws() {
@@ -485,10 +486,11 @@ public:
     alg.initialize();
 
     for (const auto &propName : {"ModVector1", "ModVector2", "ModVector3"}) {
-      TS_ASSERT_THROWS(alg.setProperty(propName, "0"), std::invalid_argument)
-      TS_ASSERT_THROWS(alg.setProperty(propName, "0,0"), std::invalid_argument)
+      TS_ASSERT_THROWS(alg.setProperty(propName, "0"), std::invalid_argument &)
+      TS_ASSERT_THROWS(alg.setProperty(propName, "0,0"),
+                       std::invalid_argument &)
       TS_ASSERT_THROWS(alg.setProperty(propName, "0,0,0,0"),
-                       std::invalid_argument)
+                       std::invalid_argument &)
     }
   }
 

--- a/Framework/DataHandling/test/LoadNGEMTest.h
+++ b/Framework/DataHandling/test/LoadNGEMTest.h
@@ -136,7 +136,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MinEventsPerFrame", 20));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("MaxEventsPerFrame", 10));
 
-    TS_ASSERT_THROWS(alg.execute(), std::runtime_error);
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
   }
 
   void test_MinEventsPerFrame_removes_low_values() {

--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -439,7 +439,7 @@ public:
     dir.normalize();
     Track track(V3D(-10, 0, 0), dir);
 
-    TS_ASSERT_THROWS(geom_obj->distance(track), std::runtime_error)
+    TS_ASSERT_THROWS(geom_obj->distance(track), const std::runtime_error &)
   }
 
   void testTrackTwoIsolatedCubes()

--- a/Framework/Geometry/test/MeshObjectTest.h
+++ b/Framework/Geometry/test/MeshObjectTest.h
@@ -399,7 +399,7 @@ public:
     dir.normalize();
     Track track(V3D(-10, 0, 0), dir);
 
-    TS_ASSERT_THROWS(geom_obj->distance(track), std::runtime_error)
+    TS_ASSERT_THROWS(geom_obj->distance(track), const std::runtime_error &)
   }
 
   void testTrackTwoIsolatedCubes()

--- a/Framework/NexusGeometry/test/JSONInstrumentBuilderTest.h
+++ b/Framework/NexusGeometry/test/JSONInstrumentBuilderTest.h
@@ -32,7 +32,7 @@ public:
   }
 
   void test_constructor_fail_invalid_instrument() {
-    TS_ASSERT_THROWS(JSONInstrumentBuilder(""), std::invalid_argument);
+    TS_ASSERT_THROWS(JSONInstrumentBuilder(""), const std::invalid_argument &);
   }
 
   void test_build_geometry() {

--- a/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
@@ -109,7 +109,7 @@ used.
     TS_ASSERT_THROWS(NexusGeometrySave::saveInstrument(
                          instr, destinationFile, DEFAULT_ROOT_ENTRY_NAME,
                          logger, false /*append*/),
-                     std::invalid_argument);
+                     const std::invalid_argument &);
     TS_ASSERT(testing::Mock::VerifyAndClearExpectations(&logger));
   }
 

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -131,10 +131,6 @@ add_library(PythonKernelModule
             ${PYTHON_INSTALL_FILES})
 set_python_properties(PythonKernelModule _kernel)
 
-# GCC 8 onwards needs to disable functional casting at the Python interface
-target_compile_options( PythonKernelModule PRIVATE 
-  $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8.0>>:-Wno-cast-function-type> )
-
 target_include_directories(PythonKernelModule PUBLIC inc)
 
 # Add the required dependencies

--- a/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/kernel/CMakeLists.txt
@@ -131,6 +131,10 @@ add_library(PythonKernelModule
             ${PYTHON_INSTALL_FILES})
 set_python_properties(PythonKernelModule _kernel)
 
+# GCC 8 onwards needs to disable functional casting at the Python interface
+target_compile_options( PythonKernelModule PRIVATE 
+  $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8.0>>:-Wno-cast-function-type> )
+
 target_include_directories(PythonKernelModule PUBLIC inc)
 
 # Add the required dependencies

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -87,24 +87,19 @@ void export_Material() {
            "Returns True if any of the scattering values are non-zero")
 #endif
       .def("cohScatterXSection",
-           (double (Material::*)(double) const)(&Material::cohScatterXSection),
-           (arg("self"),
-            arg("lambda") = static_cast<double>(NeutronAtom::ReferenceLambda)),
+           (double (Material::*)() const)(&Material::cohScatterXSection),
+           (arg("self")),
            "Coherent Scattering Cross-Section for the given wavelength in "
            "barns")
-      .def(
-          "incohScatterXSection",
-          (double (Material::*)(double) const)(&Material::incohScatterXSection),
-          (arg("self"),
-           arg("lambda") = static_cast<double>(NeutronAtom::ReferenceLambda)),
-          "Incoherent Scattering Cross-Section for the given wavelength in "
-          "barns")
-      .def(
-          "totalScatterXSection",
-          (double (Material::*)(double) const)(&Material::totalScatterXSection),
-          (arg("self"),
-           arg("lambda") = static_cast<double>(NeutronAtom::ReferenceLambda)),
-          "Total Scattering Cross-Section for the given wavelength in barns")
+      .def("incohScatterXSection",
+           (double (Material::*)() const)(&Material::incohScatterXSection),
+           (arg("self")),
+           "Incoherent Scattering Cross-Section for the given wavelength in "
+           "barns")
+      .def("totalScatterXSection",
+           (double (Material::*)() const)(&Material::totalScatterXSection),
+           (arg("self")),
+           "Total Scattering Cross-Section for the given wavelength in barns")
       .def("absorbXSection",
            (double (Material::*)(double) const)(&Material::absorbXSection),
            (arg("self"),
@@ -154,6 +149,7 @@ void export_Material() {
            "Imaginary part of Incoherent Scattering Length for the given "
            "wavelength "
            "in fm")
+
       .def(
           "cohScatterLengthSqrd",
           (double (Material::*)(double) const)(&Material::cohScatterLengthSqrd),

--- a/MantidPlot/CMakeLists.txt
+++ b/MantidPlot/CMakeLists.txt
@@ -813,6 +813,10 @@ target_include_directories(MantidPlot
                                    ../qt/widgets/factory/inc
                                    ../Framework/PythonInterface/inc)
 
+# GCC 8 onwards needs to disable functional casting at the Python interface
+target_compile_options( MantidPlot PRIVATE 
+  $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8.0>>:-Wno-cast-function-type> )
+
 # Library dependencies
 target_link_libraries(MantidPlot
                       LINK_PRIVATE

--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -15,10 +15,6 @@ else()
   # Download and unpack Eigen at configure time
   configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/Eigen.in ${CMAKE_BINARY_DIR}/extern-eigen/CMakeLists.txt)
 
-  # The OLD behavior for this policy is to ignore the visibility properties
-  # for static libraries, object libraries, and executables without exports.
-  cmake_policy(SET CMP0063 "OLD")
-
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-eigen )
   execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-eigen )
 

--- a/buildconfig/CMake/Eigen.in
+++ b/buildconfig/CMake/Eigen.in
@@ -1,4 +1,7 @@
 cmake_minimum_required ( VERSION 3.5 )
+
+project(eigen-download NONE)
+
 include( ExternalProject )
 
 ExternalProject_Add(eigen

--- a/buildconfig/CMake/SipQtTargetFunctions.cmake
+++ b/buildconfig/CMake/SipQtTargetFunctions.cmake
@@ -81,6 +81,11 @@ function ( mtd_add_sip_module )
   )
 
   add_library ( ${PARSED_TARGET_NAME} MODULE ${_sip_generated_cpp} ${_sip_include_deps} )
+  # Suppress Warnings about sip bindings have PyObject -> PyFunc casts which
+  # is a valid pattern GCC8 onwards detects
+  # GCC 8 onwards needs to disable functional casting at the Python interface
+  target_compile_options( ${PARSED_TARGET_NAME} PRIVATE 
+    $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,8.0>>:-Wno-cast-function-type> )
   target_include_directories ( ${PARSED_TARGET_NAME} SYSTEM PRIVATE ${SIP_INCLUDE_DIR} )
   target_include_directories ( ${PARSED_TARGET_NAME} PRIVATE ${PARSED_INCLUDE_DIRS} )
   target_include_directories ( ${PARSED_TARGET_NAME} SYSTEM PRIVATE ${PARSED_SYSTEM_INCLUDE_DIRS} )

--- a/buildconfig/CMake/Span.cmake
+++ b/buildconfig/CMake/Span.cmake
@@ -5,10 +5,6 @@ message(STATUS "Using tcbrindle/span in ExternalProject")
 # Download and unpack Eigen at configure time
 configure_file(${CMAKE_SOURCE_DIR}/buildconfig/CMake/Span.in ${CMAKE_BINARY_DIR}/extern-span/CMakeLists.txt)
 
-# The OLD behavior for this policy is to ignore the visibility properties
-# for static libraries, object libraries, and executables without exports.
-cmake_policy(SET CMP0063 "OLD")
-
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" -DCMAKE_SYSTEM_VERSION=${CMAKE_SYSTEM_VERSION} . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-span )
 execute_process(COMMAND ${CMAKE_COMMAND} --build . WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/extern-span )
 

--- a/buildconfig/CMake/Span.in
+++ b/buildconfig/CMake/Span.in
@@ -1,4 +1,7 @@
 cmake_minimum_required ( VERSION 3.5 )
+
+project(span-download NONE)
+
 include( ExternalProject )
 
 ExternalProject_Add(span

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -204,7 +204,7 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   QMap<QString, QVariant> map;
   try {
     map = MantidQt::API::loadJSONFromFile(filename);
-  } catch (const std::runtime_error) {
+  } catch (const std::runtime_error &) {
     m_messageHandler->giveUserCritical(
         "Unable to load requested file. Please load a file of "
         "appropriate format saved from the GUI.",

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -209,7 +209,7 @@ IndirectFitPropertyBrowser::getFittingFunction() const {
       }
       return multiDomainFunction;
     }
-  } catch (std::invalid_argument) {
+  } catch (const std::invalid_argument &) {
     return boost::make_shared<MultiDomainFunction>();
   }
 }

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/ClipboardTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/ClipboardTest.h
@@ -36,33 +36,35 @@ public:
 
   void testCheckingClipboardTypeThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
-    TS_ASSERT_THROWS(clipboard.isGroupLocation(0), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.isGroupLocation(0), const std::runtime_error &);
   }
 
   void testCheckingGroupNameThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
-    TS_ASSERT_THROWS(clipboard.groupName(0), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.groupName(0), const std::runtime_error &);
   }
 
   void testSettingGroupNameThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
     TS_ASSERT_THROWS(clipboard.setGroupName(0, "test group"),
-                     std::runtime_error);
+                     const std::runtime_error &);
   }
 
   void testCreateGroupForRootThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
-    TS_ASSERT_THROWS(clipboard.createGroupForRoot(0), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.createGroupForRoot(0),
+                     const std::runtime_error &);
   }
 
   void testCreateRowsForAllRootsThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
-    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(),
+                     const std::runtime_error &);
   }
 
   void testContainsGroupsThrowsForEmptyClipboard() {
     auto clipboard = Clipboard();
-    TS_ASSERT_THROWS(containsGroups(clipboard), std::runtime_error);
+    TS_ASSERT_THROWS(containsGroups(clipboard), const std::runtime_error &);
   }
 
   void testClipboardIsInitializedWithRow() {
@@ -77,18 +79,19 @@ public:
 
   void testGettingGroupNameThrowsForRow() {
     auto clipboard = clipboardWithARow();
-    TS_ASSERT_THROWS(clipboard.groupName(0), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.groupName(0), const std::runtime_error &);
   }
 
   void testSettingGroupNameThrowsForRow() {
     auto clipboard = clipboardWithARow();
     TS_ASSERT_THROWS(clipboard.setGroupName(0, "test group"),
-                     std::runtime_error);
+                     const std::runtime_error &);
   }
 
   void testCreateGroupForRootThrowsForRow() {
     auto clipboard = clipboardWithARow();
-    TS_ASSERT_THROWS(clipboard.createGroupForRoot(0), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.createGroupForRoot(0),
+                     const std::runtime_error &);
   }
 
   void testCreateRowsForAllRootsSucceeds() {
@@ -133,7 +136,8 @@ public:
 
   void testCreateRowsForAllRootsThrowsForGroup() {
     auto clipboard = clipboardWithAGroup();
-    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(),
+                     const std::runtime_error &);
   }
 
   void testContainsGroupsReturnsTrueIfGroupsExist() {
@@ -173,7 +177,8 @@ public:
 
   void testCreateRowsForAllRootsThrowsForMultiGroupClipboard() {
     auto clipboard = clipboardWithTwoMultiRowGroups();
-    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(), std::runtime_error);
+    TS_ASSERT_THROWS(clipboard.createRowsForAllRoots(),
+                     const std::runtime_error &);
   }
 
   void testContainsGroupsReturnsTrueIfMultipleGroupsExist() {


### PR DESCRIPTION
**Description of work.**
Fixes various CMake and gcc-8 Warnings, which have been annoying me locally for a while

- Gives our download targets names on CMake
- Removes the old policy for Span and Eigen, since they aren't specifying `fvisibility` so hiding the flag from un-exported targets shouldn't apply
- Suppresses the invalid cast warnings on Python/C++ boundaries for GCC 8> but leaves this warning on for the rest of the project where this is valid (minus MantidPlot)
- Fixes some copied exceptions

**To test:**
- Code review
- Attempt to configure the project using GCC-7 (default)
- Attempt to configure and build PythonKernelModule to check there is no warnings with GCC-8
`CC=gcc-8 CXX=g++-8 cmake path/to/mantid/src -G Ninja && ninja PythonKernelModule`

There is no associated issue. - Part of the sanitizer maintenance series

This does not require release notes because internal only changes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
