### PR TITLE
Handle corrupted data in SANS event slicing

### DIFF
--- a/Framework/Algorithms/src/FilterByTime.cpp
+++ b/Framework/Algorithms/src/FilterByTime.cpp
@@ -47,7 +47,7 @@ void FilterByTime::init() {
                   "sample log) is used as the zero. " +
                       commonHelp);
 
-  declareProperty("StopTime", 0.0,
+  declareProperty("StopTime", 0.0, min,
                   "The stop time, in seconds, since the start of the run. "
                   "Events at or after this time are filtered out. \nThe time "
                   "of the first pulse (i.e. the first entry in the "

--- a/docs/source/release/v4.3.0/sans.rst
+++ b/docs/source/release/v4.3.0/sans.rst
@@ -13,5 +13,7 @@ New
 Improved
 ########
 - :ref:`MaskBTP <algm-MaskBTP>` now handles both old and new instrument definitions for BIOSANS and GPSANS
+- Data with invalid proton charge logs will now be fixed before performing
+  slicing. A warning is emitted when this happens.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/SANS/sans/algorithm_detail/slice_sans_event.py
+++ b/scripts/SANS/sans/algorithm_detail/slice_sans_event.py
@@ -8,6 +8,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+from SANSUtility import _clean_logs
 from mantid.dataobjects import Workspace2D
 from sans.common.constants import EMPTY_NAME
 from sans.common.general_functions import append_to_sans_file_tag, get_charge_and_time, create_unmanaged_algorithm
@@ -30,6 +31,10 @@ def slice_sans_event(state_slice, input_ws, input_ws_monitor, data_type_str="Sam
     """
 
     data_type = DataType.from_string(data_type_str)
+
+    # This should be removed in the future when cycle 19/1 data is unlikely to be processed by users
+    # This prevents time slicing falling over, since we wrap around and get -0
+    _clean_logs(ws=input_ws, estimate_logs=True)
 
     if isinstance(input_ws, Workspace2D):
         sliced_workspace = input_ws


### PR DESCRIPTION
**Description of work.**
Since the mechanisms for cleaning corrupted proton logs (such as those found in cycle 19/1) exist in the SANS codebase and the script for fixing up individual files has gone AWOL it makes sense to re-use the implementation.
    
We now clean up sample logs before time slicing so that it no longer wraps around to negative vals. Additionally, I've added a validator to FilterByTime to give a better error message

**Report to:** ISIS/Steve

**To test:**
You need access to Babylon
- Check you have access to `Public/David Fairbrother/PR Data`
- Open the SANS GUI
- Set the mask file to the one given in the previously stated folder
- Set the batch file to `repro.csv`
- Go to settings -> General...etc. -> Slices
- Add 1:60:60
- Go back to Runs and process data
- If this finishes correctly the issue is resolved

Secondly:
- In Mantid create a SampleWorkspace
- Attempt to run FilterByTime with a stop time < 0 and a valid error is produced

Fixes #27490 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
