### PR TITLE
exposed rebinned output to python and fix load save as nxs (no ticket)

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -76,7 +76,7 @@ private:
                  size_t &numZeros);
   specnum_t getOutputSpecNo(API::MatrixWorkspace_const_sptr localworkspace);
 
-  API::MatrixWorkspace_sptr replaceSpecialValues();
+  API::MatrixWorkspace_sptr replaceSpecialValues(bool forceCopy=false);
   void determineIndices(const size_t numberOfSpectra);
 
   /// The output spectrum number

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -76,7 +76,7 @@ private:
                  size_t &numZeros);
   specnum_t getOutputSpecNo(API::MatrixWorkspace_const_sptr localworkspace);
 
-  API::MatrixWorkspace_sptr replaceSpecialValues(bool forceCopy=false);
+  API::MatrixWorkspace_sptr replaceSpecialValues(bool forceCopy = false);
   void determineIndices(const size_t numberOfSpectra);
 
   /// The output spectrum number

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumSpectra.h
@@ -76,7 +76,7 @@ private:
                  size_t &numZeros);
   specnum_t getOutputSpecNo(API::MatrixWorkspace_const_sptr localworkspace);
 
-  API::MatrixWorkspace_sptr replaceSpecialValues(bool forceCopy = false);
+  API::MatrixWorkspace_sptr replaceSpecialValues();
   void determineIndices(const size_t numberOfSpectra);
 
   /// The output spectrum number

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -69,7 +69,7 @@ void CorrectKiKf::exec() {
   // If input and output workspaces are not the same, create a new workspace for
   // the output using the clone method to account for different workspace types
   if (outputWS != inputWS) {
-    outputWS = inputWS->clone(); 
+    outputWS = inputWS->clone();
   }
 
   const size_t size = inputWS->blocksize();

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -67,9 +67,9 @@ void CorrectKiKf::exec() {
   }
 
   // If input and output workspaces are not the same, create a new workspace for
-  // the output
+  // the output using the clone method to account for different workspace types
   if (outputWS != inputWS) {
-    outputWS = create<MatrixWorkspace>(*inputWS);
+    outputWS = inputWS->clone(); 
   }
 
   const size_t size = inputWS->blocksize();

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -155,6 +155,7 @@ void Rebin2D::exec() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
   if (useFractionalArea) {
+    FractionalRebinning::finalizeFractionalRebin(*outputRB);
     outputRB->finalize(true);
   }
 

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -155,7 +155,7 @@ void Rebin2D::exec() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
   if (useFractionalArea) {
-    outputRB->finalize(true, true);
+    outputRB->finalize(true);
   }
 
   FractionalRebinning::normaliseOutput(outputWS, inputWS, m_progress.get());

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -474,6 +474,7 @@ void SofQWNormalisedPolygon::exec() {
   }
   PARALLEL_CHECK_INTERUPT_REGION
 
+  FractionalRebinning::finalizeFractionalRebin(*outputWS);
   outputWS->finalize();
   FractionalRebinning::normaliseOutput(outputWS, inputWS, m_progress.get());
 

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -159,9 +159,9 @@ void SumSpectra::init() {
                   "If enabled floating point special values such as NaN or Inf"
                   " are removed before the spectra are summed.");
 
-  declareProperty(
-      "UseFractionalArea", true,
-      "Normalize to fractional area for RebinnedOutput workspaces.");
+  declareProperty("UseFractionalArea", true,
+                  "Normalize the output workspace to the fractional area for "
+                  "RebinnedOutput workspaces.");
 
   declareProperty("MultiplyBySpectra", true,
                   "For unnormalized data one should multiply the weighted sum "

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -159,8 +159,9 @@ void SumSpectra::init() {
                   "If enabled floating point special values such as NaN or Inf"
                   " are removed before the spectra are summed.");
 
-  declareProperty("UseFractionalArea", true,
-                  "Normalize to fractional area for RebinnedOutput workspaces.");
+  declareProperty(
+      "UseFractionalArea", true,
+      "Normalize to fractional area for RebinnedOutput workspaces.");
 
   declareProperty("MultiplyBySpectra", true,
                   "For unnormalized data one should multiply the weighted sum "

--- a/Framework/Algorithms/src/SumSpectra.cpp
+++ b/Framework/Algorithms/src/SumSpectra.cpp
@@ -524,7 +524,7 @@ void SumSpectra::doFractionalSum(MatrixWorkspace_sptr outputWorkspace,
   RebinnedOutput_sptr outWS =
       boost::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
 
-  // Check finalize state prior to the sum process, at the completion 
+  // Check finalize state prior to the sum process, at the completion
   // the output is unfinalized
   auto isFinalized = inWS->isFinalized();
 

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1302,6 +1302,13 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
   NXDataSetTyped<double> fracarea = errors;
   if (hasFracArea) {
     fracarea = wksp_cls.openNXDouble("frac_area");
+
+    // Set the fractional area attributes
+    auto rbWS = boost::dynamic_pointer_cast<RebinnedOutput>(local_workspace);
+    auto finalized = (fracarea.attributes("finalized") == "1");
+    rbWS->setFinalized(finalized);
+    auto sqrdErrs = (fracarea.attributes("sqrd_errors") == "1");
+    rbWS->setSqrdErrors(sqrdErrs);
   }
 
   // Check for x errors; as with fracArea we set it to xbins

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1303,11 +1303,14 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadNonEventEntry(
   if (hasFracArea) {
     fracarea = wksp_cls.openNXDouble("frac_area");
 
-    // Set the fractional area attributes
+    // Set the fractional area attributes, default values consistent with
+    // previous assumptions: finalized = true, sqrdErrs = false
     auto rbWS = boost::dynamic_pointer_cast<RebinnedOutput>(local_workspace);
-    auto finalized = (fracarea.attributes("finalized") == "1");
+    auto finalizedValue = fracarea.attributes("finalized");
+    auto finalized = (finalizedValue.empty() ? true : finalizedValue == "1");
     rbWS->setFinalized(finalized);
-    auto sqrdErrs = (fracarea.attributes("sqrd_errors") == "1");
+    auto sqrdErrsValue = fracarea.attributes("sqrd_errors");
+    auto sqrdErrs = (sqrdErrsValue.empty() ? false : sqrdErrsValue == "1");
     rbWS->setSqrdErrors(sqrdErrs);
   }
 

--- a/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
@@ -62,6 +62,10 @@ MANTID_DATAOBJECTS_DLL void rebinToFractionalOutput(
     const std::vector<double> &verticalAxis,
     const DataObjects::RebinnedOutput_const_sptr &inputRB = nullptr);
 
+/// Set finalize flag after fractional rebinning loop
+MANTID_DATAOBJECTS_DLL void
+finalizeFractionalRebin(DataObjects::RebinnedOutput &outputWS);
+
 } // namespace FractionalRebinning
 
 } // namespace DataObjects

--- a/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
@@ -69,6 +69,8 @@ public:
   void setF(const std::size_t index, const MantidVecPtr &F);
   /// Multiply the fractional area arrays by a scale factor
   void scaleF(const double scale);
+  /// Returns if the fractional area is non zero
+  bool nonZeroF() const;
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/RebinnedOutput.h
@@ -25,8 +25,9 @@ namespace DataObjects {
 */
 class DLLExport RebinnedOutput : public Workspace2D {
 public:
-  RebinnedOutput() : m_finalized(false) {}
-  RebinnedOutput(bool finalized) : m_finalized(finalized) {}
+  RebinnedOutput() : m_finalized(false), m_hasSqrdErrs(true) {}
+  RebinnedOutput(bool finalized, bool hasSqrdErrs)
+      : m_finalized(finalized), m_hasSqrdErrs(hasSqrdErrs) {}
   /// Returns a clone of the workspace
   std::unique_ptr<RebinnedOutput> clone() const {
     return std::unique_ptr<RebinnedOutput>(doClone());
@@ -46,18 +47,28 @@ public:
   /// Returns the fractional area
   virtual const MantidVec &dataF(const std::size_t index) const;
 
-  /// Create final representation
-  void finalize(bool hasSqrdErrs = true, bool force = false);
-  void unfinalize(bool hasSqrdErrs = false, bool force = false);
+  /// Finalize to fractional area representation
+  void finalize(bool hasSqrdErrs = true);
+  /// Undo fractional area representation
+  void unfinalize();
 
   /// Returns if finalize has been called
   bool isFinalized() const { return m_finalized; }
+  /// Override the finalized flag
+  void setFinalized(bool value) { m_finalized = value; }
+
+  /// Returns if using squared errors
+  bool hasSqrdErrors() const { return m_hasSqrdErrs; }
+  /// Override the squared errors flag
+  void setSqrdErrors(bool value) { m_hasSqrdErrs = value; }
 
   /// Returns a read-only (i.e. const) reference to the specified F array
   const MantidVec &readF(std::size_t const index) const;
 
   /// Set the fractional area array for a given index.
   void setF(const std::size_t index, const MantidVecPtr &F);
+  /// Multiply the fractional area arrays by a scale factor
+  void scaleF(const double scale);
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.
@@ -74,10 +85,13 @@ protected:
   /// Flag to indicate if finalize has been called, and if errors/variance used
   bool m_finalized;
 
+  /// Flag to indiciate if the finalized data used squared errors
+  bool m_hasSqrdErrs;
+
 private:
   RebinnedOutput *doClone() const override { return new RebinnedOutput(*this); }
   RebinnedOutput *doCloneEmpty() const override {
-    return new RebinnedOutput(m_finalized);
+    return new RebinnedOutput(m_finalized, m_hasSqrdErrs);
   }
 };
 

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -685,6 +685,16 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
   }
 }
 
+/**
+ * Called at the completion of the fractional rebinning loop
+ * to the set the finalize flag in the output workspace.
+ * @param outputWS Reference to the rebinned output workspace
+ */
+void finalizeFractionalRebin(RebinnedOutput &outputWS) {
+  // rebinToFractionalOutput() leaves the data in an unfinalized state
+  outputWS.setFinalized(false);
+}
+
 } // namespace FractionalRebinning
 
 } // namespace DataObjects

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -663,6 +663,8 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
     if (inputRB->isFinalized()) {
       signal *= inF[j];
       error *= inF[j];
+      if (inputRB->hasSqrdErrors())
+        error *= inF[j];
     }
   }
 

--- a/Framework/DataObjects/src/RebinnedOutput.cpp
+++ b/Framework/DataObjects/src/RebinnedOutput.cpp
@@ -137,7 +137,7 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
   if (!this->nonZeroF())
     return;
 
-   // Fix the squared error representation before returning  
+  // Fix the squared error representation before returning
   auto nHist = static_cast<int>(this->getNumberHistograms());
   if (m_finalized) {
     PARALLEL_FOR_IF(Kernel::threadSafe(*this))

--- a/Framework/DataObjects/src/RebinnedOutput.cpp
+++ b/Framework/DataObjects/src/RebinnedOutput.cpp
@@ -109,7 +109,6 @@ void RebinnedOutput::scaleF(const double scale) {
  * is easily visualized. The Rebin and Integration algorithms will have to
  * undo this in order to properly treat the data.
  * @param hasSqrdErrs :: does the workspace have squared errors?
- * @param force :: ignore finalize flag or not?
  */
 void RebinnedOutput::finalize(bool hasSqrdErrs) {
   if (m_finalized && hasSqrdErrs == m_hasSqrdErrs)
@@ -168,8 +167,6 @@ void RebinnedOutput::finalize(bool hasSqrdErrs) {
 /**
  * This function "unfinalizes" the workspace by taking the data/error arrays
  * and multiplying them by the corresponding fractional area array.
- * @param hasSqrdErrs :: does the workspace have squared errors?
- * @param force :: ignore finalize flag or not?
  */
 void RebinnedOutput::unfinalize() {
   if (!m_finalized)

--- a/Framework/DataObjects/src/ReflectometryTransform.cpp
+++ b/Framework/DataObjects/src/ReflectometryTransform.cpp
@@ -513,6 +513,7 @@ MatrixWorkspace_sptr ReflectometryTransform::executeNormPoly(
       }
     }
   }
+  FractionalRebinning::finalizeFractionalRebin(*outWS);
   outWS->finalize();
   FractionalRebinning::normaliseOutput(outWS, inputWS);
   // Set the output spectrum-detector mapping

--- a/Framework/Nexus/src/NexusFileIO.cpp
+++ b/Framework/Nexus/src/NexusFileIO.cpp
@@ -404,6 +404,12 @@ int NexusFileIO::writeNexusProcessedData2D(
         NXputslab(fileID, rebin_workspace->readF(s).data(), start, asize);
         start[0]++;
       }
+
+      std::string finalized = (rebin_workspace->isFinalized()) ? "1" : "0";
+      NXputattr(fileID, "finalized", finalized.c_str(), 2, NX_CHAR);
+      std::string sqrdErrs = (rebin_workspace->hasSqrdErrors()) ? "1" : "0";
+      NXputattr(fileID, "sqrd_errors", sqrdErrs.c_str(), 2, NX_CHAR);
+
       if (m_progress != nullptr)
         m_progress->reportIncrement(1, "Writing data");
     }

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
@@ -81,11 +81,12 @@ void export_RebinnedOutput() {
       .def("isFinalized", &RebinnedOutput::isFinalized, (arg("self")),
            "Returns if values are normalized to the fractional area array")
       .def("hasSqrdErrors", &RebinnedOutput::hasSqrdErrors, (arg("self")),
-           "Returns if squared errors are used with fractional area normalization")
+           "Returns if squared errors are used with fractional area "
+           "normalization")
       .def("setFinalized", &RebinnedOutput::setFinalized,
            (arg("self"), arg("value")),
            "Sets the value of the is finalized flag")
-	  .def("setSqrdErrors", &RebinnedOutput::setSqrdErrors,
+      .def("setSqrdErrors", &RebinnedOutput::setSqrdErrors,
            (arg("self"), arg("value")),
            "Sets the value of the squared errors flag");
   // register pointers

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
@@ -71,6 +71,8 @@ void export_RebinnedOutput() {
            "simple copy into the array")
       .def("scaleF", &RebinnedOutput::scaleF, (arg("self"), arg("scale")),
            "Scales the fractional area arrays")
+      .def("nonZeroF", &RebinnedOutput::nonZeroF, (arg("self")),
+           "Returns if the fractional area is non zero")
       .def("finalize", &RebinnedOutput::finalize,
            (arg("self"), arg("hasSqrdErrs")),
            "Divides the data/error arrays by the corresponding fractional area "

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
@@ -39,7 +39,7 @@ using return_readwrite_numpy =
  * Set the F values from an python array-style object
  * @param self :: A reference to the calling object
  * @param wsIndex :: The workspace index for the spectrum to set
- * @param values :: A numpy array. The length must match the size of the
+ * @param values :: A numpy array, length must match F array length
  */
 void setFFromPyObject(RebinnedOutput &self, const size_t wsIndex,
                       const boost::python::object &values) {

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/RebinnedOutput.cpp
@@ -5,22 +5,89 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidDataObjects/RebinnedOutput.h"
+#include "MantidPythonInterface/core/Converters/NDArrayToVector.h"
+#include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
+#include "MantidPythonInterface/core/Converters/WrapWithNDArray.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/Policies/VectorToNumpy.h"
 #include "MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h"
 
 #include <boost/python/class.hpp>
 
 using Mantid::DataObjects::RebinnedOutput;
 using Mantid::DataObjects::Workspace2D;
+using namespace Mantid::PythonInterface;
+using namespace Mantid::PythonInterface::Converters;
+using namespace Mantid::PythonInterface::Policies;
 using namespace Mantid::PythonInterface::Registry;
 using namespace boost::python;
 
 GET_POINTER_SPECIALIZATION(RebinnedOutput)
 
+namespace {
+/// Typedef for data access, i.e. dataX,Y,E members
+using data_modifier = Mantid::MantidVec &(RebinnedOutput::*)(const std::size_t);
+
+/// return_value_policy for read-only numpy array
+using return_readonly_numpy =
+    return_value_policy<VectorRefToNumpy<WrapReadOnly>>;
+/// return_value_policy for read-write numpy array
+using return_readwrite_numpy =
+    return_value_policy<VectorRefToNumpy<WrapReadWrite>>;
+
+/**
+ * Set the F values from an python array-style object
+ * @param self :: A reference to the calling object
+ * @param wsIndex :: The workspace index for the spectrum to set
+ * @param values :: A numpy array. The length must match the size of the
+ */
+void setFFromPyObject(RebinnedOutput &self, const size_t wsIndex,
+                      const boost::python::object &values) {
+
+  if (NDArray::check(values)) {
+    NDArrayToVector<double> converter(values);
+    converter.copyTo(self.dataF(wsIndex));
+  } else {
+    PySequenceToVector<double> converter(values);
+    converter.copyTo(self.dataF(wsIndex));
+  }
+}
+} // namespace
+
 void export_RebinnedOutput() {
   class_<RebinnedOutput, bases<Workspace2D>, boost::noncopyable>(
-      "RebinnedOutput", no_init);
-
+      "RebinnedOutput", no_init)
+      .def("readF", &RebinnedOutput::readF,
+           (arg("self"), arg("workspaceIndex")), return_readonly_numpy(),
+           "Creates a read-only numpy wrapper "
+           "around the original F data at the "
+           "given index")
+      .def("dataF", (data_modifier)&RebinnedOutput::dataF,
+           return_readwrite_numpy(), args("self", "workspaceIndex"),
+           "Creates a writable numpy wrapper around the original F data at the "
+           "given index")
+      .def("setF", &setFFromPyObject, args("self", "workspaceIndex", "x"),
+           "Set F values from a python list or numpy array. It performs a "
+           "simple copy into the array")
+      .def("scaleF", &RebinnedOutput::scaleF, (arg("self"), arg("scale")),
+           "Scales the fractional area arrays")
+      .def("finalize", &RebinnedOutput::finalize,
+           (arg("self"), arg("hasSqrdErrs")),
+           "Divides the data/error arrays by the corresponding fractional area "
+           "array")
+      .def("unfinalize", &RebinnedOutput::unfinalize, (arg("self")),
+           "Multiplies the data/error arrays by the corresponding fractional "
+           "area array")
+      .def("isFinalized", &RebinnedOutput::isFinalized, (arg("self")),
+           "Returns if values are normalized to the fractional area array")
+      .def("hasSqrdErrors", &RebinnedOutput::hasSqrdErrors, (arg("self")),
+           "Returns if squared errors are used with fractional area normalization")
+      .def("setFinalized", &RebinnedOutput::setFinalized,
+           (arg("self"), arg("value")),
+           "Sets the value of the is finalized flag")
+	  .def("setSqrdErrors", &RebinnedOutput::setSqrdErrors,
+           (arg("self"), arg("value")),
+           "Sets the value of the squared errors flag");
   // register pointers
   RegisterWorkspacePtrToPython<RebinnedOutput>();
 }

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -458,6 +458,51 @@ class MatrixWorkspaceTest(unittest.TestCase):
         for index in maskedBinsIndices:
             self.assertEqual(1, index)
 
+    def test_rebinnedOutput(self):
+        rebin = WorkspaceFactory.create("RebinnedOutput", 2, 3, 2)
+        fv = rebin.readF(1)
+        rebin.dataY(1)[:] = 10.0
+        rebin.dataE(1)[:] = 1.0
+        twos = np.ones(len(fv)) * 2.0
+        rebin.setF(1, twos)
+        rebin.setFinalized(False)
+        rebin.setSqrdErrors(False)
+        rebin.unfinalize()
+        self.assertFalse(rebin.isFinalized())
+        yv = rebin.readY(1)
+        ev = rebin.readE(1)
+        self.assertAlmostEqual(yv[0], 10.0)
+        self.assertAlmostEqual(ev[0], 1.0)
+
+        rebin.finalize(True)
+        self.assertTrue(rebin.isFinalized())
+        self.assertTrue(rebin.hasSqrdErrors())
+        yv = rebin.readY(1)
+        ev = rebin.readE(1)
+        self.assertAlmostEqual(yv[0], 5.0)
+        self.assertAlmostEqual(ev[0], 0.25)
+
+        rebin.finalize(False)
+        self.assertTrue(rebin.isFinalized())
+        self.assertFalse(rebin.hasSqrdErrors())
+        yv = rebin.readY(1)
+        ev = rebin.readE(1)
+        self.assertAlmostEqual(yv[0], 5.0)
+        self.assertAlmostEqual(ev[0], 0.5)
+
+        rebin.unfinalize()
+        self.assertFalse(rebin.isFinalized())
+        yv = rebin.readY(1)
+        ev = rebin.readE(1)
+        self.assertAlmostEqual(yv[0], 10.0)
+        self.assertAlmostEqual(ev[0], 1.0)
+
+        rebin.scaleF(2.0)
+        fv = rebin.readF(1)
+        self.assertAlmostEqual(fv[0], 4.0)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -460,11 +460,13 @@ class MatrixWorkspaceTest(unittest.TestCase):
 
     def test_rebinnedOutput(self):
         rebin = WorkspaceFactory.create("RebinnedOutput", 2, 3, 2)
+        self.assertFalse(rebin.nonZeroF())
         fv = rebin.readF(1)
         rebin.dataY(1)[:] = 10.0
         rebin.dataE(1)[:] = 1.0
         twos = np.ones(len(fv)) * 2.0
         rebin.setF(1, twos)
+        self.assertTrue(rebin.nonZeroF())
         rebin.setFinalized(False)
         rebin.setSqrdErrors(False)
         rebin.unfinalize()

--- a/Framework/PythonInterface/test/python/mantid/api/WorkspaceFactoryTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/WorkspaceFactoryTest.py
@@ -20,9 +20,9 @@ class WorkspaceFactoryTest(unittest.TestCase):
         return WorkspaceFactory.create("Workspace2D", NVectors=nhist,
                                        XLength=xlength, YLength=ylength)
 
-    def _verify(self, wksp, nhist, xlength, ylength):
+    def _verify(self, wksp, nhist, xlength, ylength, wsId="Workspace2D"):
         self.assertTrue(isinstance(wksp, MatrixWorkspace))
-        self.assertEqual(wksp.id(), "Workspace2D")
+        self.assertEqual(wksp.id(), wsId)
         self.assertEqual(wksp.getNumberHistograms(), nhist)
         self.assertEqual(len(wksp.readX(0)), xlength)
         self.assertEqual(wksp.blocksize(), ylength)
@@ -57,6 +57,13 @@ class WorkspaceFactoryTest(unittest.TestCase):
     def test_creating_a_peaksworkspace(self):
         peaks = WorkspaceFactory.createPeaks()
         self.assertTrue(isinstance(peaks, IPeaksWorkspace))
+
+    def test_creating_rebinnedoutput(self):
+        rebin = WorkspaceFactory.create("RebinnedOutput", 2, 6, 5)
+        self._verify(rebin, 2, 6, 5, wsId="RebinnedOutput")
+        fv = rebin.readF(1)
+        self.assertEqual(len(fv), 5)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -1278,13 +1278,14 @@ RebinnedOutput_sptr createRebinnedOutputWorkspace() {
   // Set representation
   outputWS->finalize();
 
-  // Make errors squared rooted
+  // Make errors squared rooted and set sqrd err flag
   for (int i = 0; i < numHist; ++i) {
     auto &mutableE = outputWS->mutableE(i);
     for (int j = 0; j < numX - 1; ++j) {
       mutableE[j] = std::sqrt(mutableE[j]);
     }
   }
+  outputWS->setSqrdErrors(false);
 
   return outputWS;
 }


### PR DESCRIPTION
Changes to the finalize/unfinalize method for RebinnedOutput to correct inconsistent behaviour, exposed to the methods to python and fixed load and saving rebinned output workspaces as nexus files.

<!-- Instructions for testing. -->

The changes are covered in the modifed python test scripts. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
