### PR TITLE
Stop possible segmentation fault

### DIFF
--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -264,6 +264,13 @@ void SANSBeamFinder::maskEdges(MatrixWorkspace_sptr beamCenterWS, int high,
                   " to be a RectangularDetector. maskEdges not executed.");
     return;
   }
+
+  if (!component){
+    g_log.warning("Expecting the component " + componentName +
+                  " to be a RectangularDetector. maskEdges not executed.");
+    return;
+  }
+
   std::vector<int> IDs;
 
   // right

--- a/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSBeamFinder.cpp
@@ -265,7 +265,7 @@ void SANSBeamFinder::maskEdges(MatrixWorkspace_sptr beamCenterWS, int high,
     return;
   }
 
-  if (!component){
+  if (!component) {
     g_log.warning("Expecting the component " + componentName +
                   " to be a RectangularDetector. maskEdges not executed.");
     return;


### PR DESCRIPTION
**Description of work.**

The SANSBeamFinder algorithm is causing a segfault if the instrument geometry is not made out of rectangular detectors

**To test:**
Simple code review

*There is no associated issue.*

*This does not require release notes* because **bug related only to a small number of files**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
