### PR TITLE
Add enum34 backport to RHEL rpm

### DIFF
--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from matplotlib import cm
 from matplotlib.container import ErrorbarContainer
 
-from mantid.py3compat import Enum
+from enum import Enum
 
 
 # Any changes here must be reflected in the definition in

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -147,6 +147,9 @@ required for Mantid development.
 
 %changelog
 
+* Tue Dec 03 2019 David Fairbrother <david.fairbrother@stfc.ac.uk>
+- Added Python Enum34 back-port to the required Python dependencies
+
 * Tue Nov 5 2019 Martyn Gigg <martyn.gigg@stfc.ac.uk>
 - Switch to python{2,3}-qt5-devel
 - Remove python2-scikit-image

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.34
+Version:        1.35
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -57,6 +57,7 @@ Requires: python2-sphinx-bootstrap-theme
 Requires: PyYAML
 Requires: python2-mock
 Requires: python2-psutil
+Requires: python-enum34
 Requires: qscintilla-devel
 Requires: qt-devel >= 4.6
 Requires: qwt5-qt4-devel

--- a/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
+++ b/qt/applications/workbench/workbench/plotting/globalfiguremanager.py
@@ -16,7 +16,7 @@ import gc
 # 3rd party imports
 import six
 
-from mantid.py3compat import Enum
+from enum import Enum
 from .observabledictionary import DictionaryAction, ObservableDictionary
 
 

--- a/qt/applications/workbench/workbench/plotting/observabledictionary.py
+++ b/qt/applications/workbench/workbench/plotting/observabledictionary.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantid workbench.
 #
 #
-from mantid.py3compat import Enum
+from enum import Enum
 
 
 class DictionaryAction(Enum):

--- a/qt/python/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/plotting/figuretype.py
@@ -13,7 +13,7 @@ Provides facilities to check plot types
 from __future__ import absolute_import
 
 # third party
-from mantid.py3compat import Enum
+from enum import Enum
 from matplotlib.container import ErrorbarContainer
 
 

--- a/qt/python/mantidqt/widgets/embedded_find_replace_dialog/presenter.py
+++ b/qt/python/mantidqt/widgets/embedded_find_replace_dialog/presenter.py
@@ -7,7 +7,7 @@
 #  This file is part of the mantidqt package
 from __future__ import (absolute_import, division, print_function)
 
-from mantid.py3compat import Enum
+from enum import Enum
 from mantidqt.widgets.embedded_find_replace_dialog.view import EmbeddedFindReplaceDialogView
 
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/table_view_model.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from qtpy import QtGui
 from qtpy.QtCore import QVariant, Qt, QAbstractTableModel
-from mantid.py3compat import Enum
+from enum import Enum
 
 
 class MatrixWorkspaceTableViewModelType(Enum):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/plot_type.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/plot_type.py
@@ -1,4 +1,4 @@
-from mantid.py3compat import Enum
+from enum import Enum
 
 
 class PlotType(Enum):

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, unicode_literals)
 
 from mantid.api import AnalysisDataService as ads, WorkspaceFactory
 from mantid.kernel import FloatTimeSeriesProperty
-from mantid.py3compat import Enum
+from enum import Enum
 
 from mantidqt.utils.observer_pattern import GenericObserver
 


### PR DESCRIPTION
**Description of work.**
Adds the enum34 backport to the RHEL developers repo and converts the Mantid codebase to avoid using the shim

(Reasons can be found in #27540)

~~TODO: Update docker images to also have the enum 34 backport~~ - the docker container pulls this RPM
**To test:**
- Build the RPM for RHEL-7
- Install the RPM and checkout this code
- Check all tests still pass (notably the SANS code uses enums extensively)
- Open Mantid Workbench/Plot and attempt to do: `import Enum`

Fixes #27540 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
