### PR TITLE
Bypass no-nexus groups

### DIFF
--- a/Framework/Kernel/src/NexusDescriptor.cpp
+++ b/Framework/Kernel/src/NexusDescriptor.cpp
@@ -257,6 +257,9 @@ void NexusDescriptor::walkFile(::NeXus::File &file, const std::string &rootPath,
     const std::string &entryClass = it->second;
     const std::string entryPath =
         std::string(rootPath).append("/").append(entryName);
+    if (entryClass.empty()) {
+      continue; // Ignore groups without a nx class.
+    }
     if (entryClass == "SDS" || entryClass == "ILL_data_scan_vars") {
       pmap.emplace(entryPath, entryClass);
     } else if (entryClass == "CDF0.0") {


### PR DESCRIPTION
Fixes V20 issue found with file `nicos_00000750.hdf5`, which has `detector_1/readout_system_1` which is a hdf5 group, but has no NX_class attributes.

Essentially it should be OK to simply ignore these groups as they would fail to load anyway.