### PR TITLE
Updates the Eigen repo URL to an upstream mirror

### DIFF
--- a/buildconfig/CMake/Eigen.in
+++ b/buildconfig/CMake/Eigen.in
@@ -2,8 +2,8 @@ cmake_minimum_required ( VERSION 3.5 )
 include( ExternalProject )
 
 ExternalProject_Add(eigen
-  URL "https://bitbucket.org/eigen/eigen/get/3.3.4.tar.gz"
-  URL_HASH "MD5=1a47e78efe365a97de0c022d127607c3"
+  URL "https://github.com/eigenteam/eigen-git-mirror/archive/3.3.4.tar.gz"
+  URL_HASH "MD5=1896a1f682e6cdcffd91b6e5ba8286a2"
   DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern-eigen/download
   SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern-eigen/source
   INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/extern-eigen/install


### PR DESCRIPTION
**Description of work.**
Developers may start to see their Eigen downloads fall over if they clean configure a project (or on the build servers)

Updates the Eigen repo to use an upstream mirror, since the offical
upstream is mid-migration and have not fully updated the Gitlab
permission to make the repo public yet (it will randomly 401 for me)

Since the tar.gz has a different name (they add -git-mirror- into the
name) the md5 must also be updated too.

**To test:**
- Remove the extern-eigen folder from your build directory
- Before this PR the download would fail with a 401
- This PR should now clone correctly and the build should configure

Fixes #25743. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
