### PR TITLE
Fix SANS ILL Integration test flaky when default facility changed

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -1934,8 +1934,6 @@ const std::vector<FacilityInfo *> ConfigServiceImpl::getFacilities() const {
  */
 const std::vector<std::string> ConfigServiceImpl::getFacilityNames() const {
   auto names = std::vector<std::string>(m_facilities.size());
-  auto itFacilities = m_facilities.begin();
-
   std::transform(m_facilities.cbegin(), m_facilities.cend(), names.begin(),
                  [](const FacilityInfo *facility) { return facility->name(); });
 
@@ -1981,18 +1979,28 @@ ConfigServiceImpl::getFacility(const std::string &facilityName) const {
  * @throw NotFoundException if the facility is not found
  */
 void ConfigServiceImpl::setFacility(const std::string &facilityName) {
-  bool found = false;
-  // Look through the facilities for a matching one.
+  const FacilityInfo *foundFacility = nullptr;
+
   try {
     // Get facility looks up by string - so re-use that to check if the facility
     // is known
-    getFacility(facilityName);
-    setString("default.facility", facilityName);
+    foundFacility = &getFacility(facilityName);
   } catch (const Exception::NotFoundError &) {
     g_log.error("Failed to set default facility to be " + facilityName +
                 ". Facility not found");
     throw;
   }
+  assert(foundFacility);
+  setString("default.facility", facilityName);
+
+  const auto &associatedInsts = foundFacility->instruments();
+  if (associatedInsts.empty()) {
+    throw std::invalid_argument(
+        "The selected facility has no instruments associated with it");
+  }
+
+  // Update the default instrument to be one from this facility
+  setString("default.instrument", associatedInsts[0].name());
 }
 
 /**  Add an observer to a notification

--- a/Framework/Kernel/test/ConfigServiceTest.h
+++ b/Framework/Kernel/test/ConfigServiceTest.h
@@ -148,6 +148,22 @@ public:
     TS_ASSERT_EQUALS(fac1.name(), "SNS");
   }
 
+  void testChangingDefaultFacilityChangesInst() {
+    // When changing default facility using the setFacility method, we should
+    // also change the instrument to the default so we don't get weird
+    // inst/facility combinations
+    auto &config = ConfigService::Instance();
+
+    config.setFacility("ISIS");
+    const auto isisFirstInst = config.getString("default.instrument");
+    TS_ASSERT(!isisFirstInst.empty());
+
+    config.setFacility("SNS");
+    const auto snsFirstInst = config.getString("default.instrument");
+    TS_ASSERT(!snsFirstInst.empty());
+    TS_ASSERT_DIFFERS(snsFirstInst, isisFirstInst);
+  }
+
   void testFacilityList() {
     std::vector<FacilityInfo *> facilities =
         ConfigService::Instance().getFacilities();

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLIntegrationTest.py
@@ -7,6 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import unittest
+
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 from mantid.simpleapi import SANSILLIntegration, SANSILLReduction, config, mtd
 
@@ -17,13 +18,15 @@ class SANSILLIntegrationTest(unittest.TestCase):
 
     def setUp(self):
         self._facility = config['default.facility']
+        self._data_search_dirs = config.getDataSearchDirs()
         config.appendDataSearchSubDir('ILL/D11/')
         config.appendDataSearchSubDir('ILL/D33/')
-        config['default.facility'] = 'ILL'
+        config.setFacility("ILL")
         SANSILLReduction(Run='010569', ProcessAs='Sample', OutputWorkspace='sample')
 
     def tearDown(self):
-        config['default.facility'] = self._facility
+        config.setFacility(self._facility)
+        config.setDataSearchDirs(self._data_search_dirs)
         mtd.clear()
 
     def test_monochromatic(self):


### PR DESCRIPTION
**Description of work.**
Fixes the SANS ILL Integration test becoming flaky when the default facility is changed. This is because the file finder will prepend an instrument name, which the ILL does not use, as the instrument was not previously changed.

I've also taken this chance to modernise older code in the `ConfigService` 

**To test:**
- Open Mantid and change the default inst to SNS
- Run the `SANSILLIntegrationTest` using ctest and check is passes
- Open Mantid and change to something that is not SNS
- Rerun the test
- Re-open Mantid and check it's still set to your previous val

Fixes #27022. 

*This does not require release notes* because it is a change only dev's will notice

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
