### PR TITLE
Cache SANS File Information

### DIFF
--- a/docs/source/release/v4.3.0/sans.rst
+++ b/docs/source/release/v4.3.0/sans.rst
@@ -15,5 +15,9 @@ Improved
 - :ref:`MaskBTP <algm-MaskBTP>` now handles both old and new instrument definitions for BIOSANS and GPSANS
 - Data with invalid proton charge logs will now be fixed before performing
   slicing. A warning is emitted when this happens.
+- Multiple runs with any identical run numbers (such as can scattering runs)
+  now process faster whilst using the search data archive feature to find
+  those runs. Testing shows that typical user batch files process up to
+  55% faster.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/SANS/sans/common/FileInformationCache.py
+++ b/scripts/SANS/sans/common/FileInformationCache.py
@@ -1,0 +1,90 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+""" Caches the results from File Finder """
+import os
+
+from mantid import config
+
+
+class CachedRequest(object):
+    def __init__(self, requested_name, found_path):
+        self.requested_name = requested_name
+        self.found_path = found_path
+
+
+class FileInformationCache(object):
+    def __init__(self, max_len):
+        self._max_len = max_len
+
+        self._reset()
+
+    def add_new_element(self, cached_request):
+        """
+        Adds a new found run to the cache, removing the least recently used one if it exceeds the maximum length
+        :param cached_request: The cached request object to insert
+        :return: None
+        """
+        assert(isinstance(cached_request, CachedRequest))
+
+        self._cached_entries[cached_request.requested_name] = cached_request
+        self._update_element_time(cached_request.requested_name)
+
+        if len(self._cached_entries) > self._max_len:
+            self._pop_old_element()
+
+    def get_element(self, requested_name):
+        """
+        Returns a cached file information entry if it is present in the cache and the file still exists
+        :param requested_name: The name to be passed to file finder
+        :return: The associated file path, if it still exists. Or None
+        """
+        self._check_data_dirs_havent_changed()
+
+        if requested_name not in self._cached_entries:
+            return None
+
+        found_entry = self._cached_entries[requested_name]
+
+        if not os.path.exists(found_entry.found_path):
+            self._del_element(requested_name)
+            return None
+
+        self._update_element_time(requested_name)
+        return found_entry
+
+    def _check_data_dirs_havent_changed(self):
+        # If data dirs change we should reset the cache so unexpected results (such as a file from
+        # an old dir appearing) happen
+        returned = list(config.getDataSearchDirs())
+        if returned != self._data_search_dirs:
+            self._reset()
+
+    def _del_element(self, element_name):
+        del self._cached_entries[element_name]
+        self._access_order.remove(element_name)
+
+    def _pop_old_element(self):
+        if len(self._access_order) == 0:
+            return
+
+        element_name = self._access_order.pop(0)
+        del self._cached_entries[element_name]
+
+    def _reset(self):
+        self._cached_entries = {}
+        self._access_order = []
+        self._data_search_dirs = list(config.getDataSearchDirs())
+
+    def _update_element_time(self, element_name):
+        """
+        Rotates the specified element to the back of the LRU queue or adds it if not seen
+        :param element_name: The request element name
+        """
+        try:
+            self._access_order.append(self._access_order.pop(self._access_order.index(element_name)))
+        except ValueError:
+            self._access_order.append(element_name)

--- a/scripts/test/SANS/common/CMakeLists.txt
+++ b/scripts/test/SANS/common/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(TEST_PY_FILES
     enums_test.py
     file_information_test.py
+    FileInformationCacheTest.py
     log_tagger_test.py
     general_functions_test.py
     xml_parsing_test.py)

--- a/scripts/test/SANS/common/FileInformationCacheTest.py
+++ b/scripts/test/SANS/common/FileInformationCacheTest.py
@@ -1,0 +1,144 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mock import patch
+
+from sans.common.FileInformationCache import FileInformationCache, CachedRequest
+
+
+class FileInformationCacheTest(unittest.TestCase):
+
+    def test_returns_none_when_not_found(self):
+        instance = FileInformationCache(max_len=2)
+        self.assertIsNone(instance.get_element("FileNotFound.nxs"))
+
+    @patch("os.path")
+    def test_returns_cached_when_still_there(self, mocked_path):
+        instance = FileInformationCache(max_len=1)
+
+        mocked_path.exists.return_value = True
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=found_run)
+
+        self.assertEqual(instance.get_element(requested_name), found_run)
+
+    @patch("os.path")
+    def test_returns_cached_when_not_there(self, mocked_path):
+        instance = FileInformationCache(max_len=1)
+
+        mocked_path.exists.return_value = False
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=found_run)
+
+        self.assertIsNone(instance.get_element(requested_name))
+
+    @patch("os.path")
+    def test_rotates_new_element_in(self, mocked_path):
+        instance = FileInformationCache(max_len=1)
+
+        mocked_path.exists.return_value = True
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        original_run = CachedRequest(requested_name="a", found_path="a")
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=original_run)
+        instance.add_new_element(cached_request=found_run)
+
+        self.assertIsNone(instance.get_element("a"))  # Should rotate out
+        self.assertEqual(instance.get_element(requested_name), found_run)
+
+    @patch("os.path")
+    def test_multiple_cache_entries_one_not_found(self, mocked_path):
+        instance = FileInformationCache(max_len=2)
+        mocked_path.exists.return_value = False
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        original_run = CachedRequest(requested_name="a", found_path="a")
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=original_run)
+        instance.add_new_element(cached_request=found_run)
+
+        self.assertIsNone(instance.get_element("a"))  # Should not be found
+
+        mocked_path.exists.return_value = True
+        self.assertIsNone(instance.get_element("a"))
+        self.assertEqual(instance.get_element(requested_name), found_run)
+
+    @patch("os.path")
+    def test_multiple_cache_entries_first_rotates_out(self, mocked_path):
+        instance = FileInformationCache(max_len=2)
+        mocked_path.exists.return_value = True
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        original_run = CachedRequest(requested_name="a", found_path="a")
+        second_run = CachedRequest(requested_name="b", found_path="b")
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=original_run)
+        instance.add_new_element(cached_request=second_run)
+        instance.add_new_element(cached_request=found_run)
+
+        self.assertIsNone(instance.get_element("a"))  # Should not be found
+        self.assertEqual(instance.get_element("b"), second_run)
+        self.assertEqual(instance.get_element(requested_name), found_run)
+
+    @patch("os.path")
+    def test_multiple_cache_entries_second_rotated_out(self, mocked_path):
+        instance = FileInformationCache(max_len=2)
+        mocked_path.exists.return_value = True
+
+        requested_name = "test.nxs"
+        expected_path = "fake_path/test.nxs"
+        original_run = CachedRequest(requested_name="a", found_path="a")
+        second_run = CachedRequest(requested_name="b", found_path="b")
+        found_run = CachedRequest(requested_name=requested_name, found_path=expected_path)
+
+        instance.add_new_element(cached_request=original_run)
+        instance.add_new_element(cached_request=second_run)
+
+        instance.get_element("a")  # This should bump it to top of cache
+
+        instance.add_new_element(cached_request=found_run)  # Thus this should knock off the second run
+
+        self.assertIsNone(instance.get_element("b"))  # Should not be found
+        self.assertEqual(instance.get_element("a"), original_run)
+        self.assertEqual(instance.get_element(requested_name), found_run)
+
+    @patch("os.path")
+    @patch("sans.common.FileInformationCache.config")
+    def test_changed_data_search_resets_cache(self, mocked_config, mocked_path):
+        mocked_config.getDataSearchDirs.return_value = ["dir1", "dir2"]
+        instance = FileInformationCache(max_len=2)
+        mocked_path.exists.return_value = True
+
+        original_run = CachedRequest(requested_name="a", found_path="a")
+        second_run = CachedRequest(requested_name="b", found_path="b")
+
+        instance.add_new_element(cached_request=original_run)
+        instance.add_new_element(cached_request=second_run)
+
+        mocked_config.getDataSearchDirs.return_value = ["dir1", "dir3"]
+
+        self.assertIsNone(instance.get_element("a"))
+        self.assertIsNone(instance.get_element("b"))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
Benchmarking indicated we were spending a long time waiting for Mantid's
file finder. Inserting a LRU cache into the SANS code path results in a
50-60% speed-up by avoiding both querying the data search or local
filesystem searches.

This is primarily because runs like can samples are always identical


**To test:**
- Using the LOQ sample data from the ISIS training dataset:
- Open the SANS GUI 
- Set the user file to `maskfile.txt`
- Extend batch.csv in a spreadsheet tool to add more runs (or copy + paste)
- Move the .nxs files out of the folder 
- Load the batch file
- Ensure archive data search is enabled
- Process all and note the speed improvement before and after

*Note: The benchmarking was completed with user batch files I can't provide here, so your results will be much quicker (due to copy paste) than real world. However, the release notes reflect accurate figures from real-world data*

*There is no associated issue. - I noticed this low hanging fruit after doing a quick benchmark this afternoon*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
