### PR TITLE
Add normalize by bin width option for sliceviewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -843,7 +843,8 @@ class MantidAxes(Axes):
 
             workspace = args[0]
             normalize_by_bin_width, _ = get_normalize_by_bin_width(workspace, self, **kwargs)
-            is_normalized = normalize_by_bin_width or workspace.isDistribution()
+            is_normalized = normalize_by_bin_width or \
+                            (hasattr(workspace, 'isDistribution') and workspace.isDistribution())
             # We return the last mesh so the return type is a single artist like the standard Axes
             artists = self.track_workspace_artist(workspace,
                                                   plotfunctions_func(self, *args, **kwargs),

--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -17,7 +17,7 @@ from scipy.interpolate import interp1d
 
 import mantid.api
 import mantid.kernel
-from mantid.api import MultipleExperimentInfos
+from mantid.api import MultipleExperimentInfos, MatrixWorkspace
 from mantid.dataobjects import EventWorkspace, MDHistoWorkspace, Workspace2D
 from mantid.plots.utility import MantidAxType
 
@@ -566,7 +566,7 @@ def get_data_uneven_flag(workspace, **kwargs):
 
 
 def check_resample_to_regular_grid(ws, **kwargs):
-    if not isinstance(ws, MDHistoWorkspace):
+    if isinstance(ws, MatrixWorkspace):
         aligned = kwargs.pop('axisaligned', False)
         if not ws.isCommonBins() or aligned:
             return True, kwargs

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -312,7 +312,7 @@ class Plots__init__Test(unittest.TestCase):
             self.assertTrue(ws_artists[1].is_normalized)
             self.assertTrue(ws_artists[2].is_normalized)
 
-    def test_artists_normalization_state_labeled_correctly_for_2d_plots_of_non_dist_workspace(self):
+    def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_dist_argument_false(self):
         plot_funcs = ['imshow', 'pcolor', 'pcolormesh', 'pcolorfast', 'tripcolor',
                         'contour', 'contourf', 'tricontour', 'tricontourf']
         non_dist_2d_ws = CreateWorkspace(DataX=[10, 20, 10, 20],
@@ -327,10 +327,32 @@ class Plots__init__Test(unittest.TestCase):
             self.assertTrue(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
+    def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_dist_argument_true(self):
+        plot_funcs = ['imshow', 'pcolor', 'pcolormesh', 'pcolorfast', 'tripcolor',
+                      'contour', 'contourf', 'tricontour', 'tricontourf']
+        non_dist_2d_ws = CreateWorkspace(DataX=[10, 20, 10, 20],
+                                         DataY=[2, 3, 2, 3],
+                                         DataE=[1, 2, 1, 2],
+                                         NSpec=2,
+                                         Distribution=False,
+                                         OutputWorkspace='non_dist_workpace')
+        for plot_func in plot_funcs:
+            func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws, distribution=True)
             self.assertFalse(self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)
             del self.ax.tracked_workspaces[non_dist_2d_ws.name()]
 
+    def test_artists_normalization_labeled_correctly_for_2d_plots_of_non_dist_workspace_and_global_setting_on(self):
+        plot_funcs = ['imshow', 'pcolor', 'pcolormesh', 'pcolorfast', 'tripcolor',
+                      'contour', 'contourf', 'tricontour', 'tricontourf']
+        non_dist_2d_ws = CreateWorkspace(DataX=[10, 20, 10, 20],
+                                         DataY=[2, 3, 2, 3],
+                                         DataE=[1, 2, 1, 2],
+                                         NSpec=2,
+                                         Distribution=False,
+                                         OutputWorkspace='non_dist_workpace')
+        for plot_func in plot_funcs:
+            func = getattr(self.ax, plot_func)
             func(non_dist_2d_ws)
             auto_dist = (config['graph1d.autodistribution'] == 'On')
             self.assertEqual(auto_dist, self.ax.tracked_workspaces[non_dist_2d_ws.name()][0].is_normalized)

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -8,7 +8,7 @@ MantidWorkbench Changes
 Improvements
 ############
 
-- Normalization option have been added to 2d plots.
+- Normalization options have been added to 2d plots and sliceviewer.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -109,3 +109,8 @@ class SliceViewerModel(object):
                 return WS_TYPE.MDE
         else:
             raise ValueError("Unsupported workspace type")
+
+    def can_normalize_workspace(self):
+        if self.get_ws_type() == WS_TYPE.MATRIX and not self._get_ws().isDistribution():
+            return True
+        return False

--- a/qt/python/mantidqt/widgets/sliceviewer/samplingimage.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/samplingimage.py
@@ -16,6 +16,7 @@ class SamplingImage(mimage.AxesImage):
                  filternorm=1,
                  filterrad=4.0,
                  resample=False,
+                 normalize=mantid.api.MDNormalization.NoNormalization,
                  **kwargs):
         super(SamplingImage, self).__init__(
             ax,
@@ -30,6 +31,7 @@ class SamplingImage(mimage.AxesImage):
             **kwargs)
         self.ws = workspace
         self.transpose = transpose
+        self.normalization = normalize
 
     def _xlim_changed(self, ax):
         if self._update_extent():
@@ -56,7 +58,7 @@ class SamplingImage(mimage.AxesImage):
             xy = np.vstack((Y.ravel(),X.ravel())).T
         else:
             xy = np.vstack((X.ravel(),Y.ravel())).T
-        data = self.ws.getSignalAtCoord(xy, mantid.api.MDNormalization.NoNormalization).reshape(X.shape)
+        data = self.ws.getSignalAtCoord(xy, self.normalization).reshape(X.shape)
         self.set_data(data)
 
     def _update_extent(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -160,6 +160,27 @@ class SliceViewerModelTest(unittest.TestCase):
         self.assertEqual(dim_info['units'], 'meV')
         self.assertEqual(dim_info['type'], 'MATRIX')
 
+    def test_matrix_workspace_can_be_normalized_if_not_a_distribution(self):
+        ws2d = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30],
+                               DataY=[2, 3, 4, 5],
+                               DataE=[1, 2, 3, 4],
+                               NSpec=2,
+                               Distribution=False,
+                               OutputWorkspace='ws2d')
+        model = SliceViewerModel(ws2d)
+        self.assertTrue(model.can_normalize_workspace())
+
+    def test_matrix_workspace_cannot_be_normalized_if_a_distribution(self):
+        model = SliceViewerModel(self.ws2d_histo)
+        self.assertFalse(model.can_normalize_workspace())
+
+    def test_3d_workspaces_cannot_be_normalized(self):
+        model = SliceViewerModel(self.ws_MD_3D)
+        self.assertFalse(model.can_normalize_workspace())
+
+        model = SliceViewerModel(self.ws_MDE_3D)
+        self.assertFalse(model.can_normalize_workspace())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -174,10 +174,11 @@ class SliceViewerModelTest(unittest.TestCase):
         model = SliceViewerModel(self.ws2d_histo)
         self.assertFalse(model.can_normalize_workspace())
 
-    def test_3d_workspaces_cannot_be_normalized(self):
+    def test_MD_workspaces_cannot_be_normalized(self):
         model = SliceViewerModel(self.ws_MD_3D)
         self.assertFalse(model.can_normalize_workspace())
 
+    def test_MDE_workspaces_cannot_be_normalized(self):
         model = SliceViewerModel(self.ws_MDE_3D)
         self.assertFalse(model.can_normalize_workspace())
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -13,6 +13,7 @@ import matplotlib
 matplotlib.use('Agg') # noqa: E402
 import unittest
 
+import mantid.api
 from mantid.py3compat import mock
 from mantidqt.widgets.sliceviewer.model import SliceViewerModel, WS_TYPE
 from mantidqt.widgets.sliceviewer.presenter import SliceViewer
@@ -24,6 +25,7 @@ class SliceViewerTest(unittest.TestCase):
     def setUp(self):
         self.view = mock.Mock(spec=SliceViewerView)
         self.view.dimensions = mock.Mock()
+        self.view.norm_opts = mock.Mock()
 
         self.model = mock.Mock(spec=SliceViewerModel)
         self.model.get_ws = mock.Mock()
@@ -107,6 +109,15 @@ class SliceViewerTest(unittest.TestCase):
         self.assertEqual(self.model.get_ws.call_count, 1)
         self.assertEqual(self.view.dimensions.get_slicepoint.call_count, 0)
         self.assertEqual(self.view.plot_matrix.call_count, 1)
+
+    def test_normalization_change_set_correct_normalization(self):
+        self.model.get_ws_type = mock.Mock(return_value=WS_TYPE.MATRIX)
+        self.view.plot_matrix = mock.Mock()
+
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        presenter.normalization_changed("By bin width")
+        self.view.plot_matrix.assert_called_with(self.model.get_ws(),
+                                                 normalize=mantid.api.MDNormalization.VolumeNormalization)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -23,8 +23,8 @@ from .toolbar import SliceViewerNavigationToolbar
 import numpy as np
 
 from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (QComboBox, QLabel, QHBoxLayout, QMenu,
-                            QSpacerItem, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import QComboBox, QLabel, QHBoxLayout, QVBoxLayout, QWidget
+
 
 class SliceViewerView(QWidget):
     def __init__(self, presenter, dims_info, can_normalise, parent=None):
@@ -112,8 +112,8 @@ class SliceViewerView(QWidget):
         """
         self.ax.clear()
         self.im = self.ax.imshow(ws, origin='lower', aspect='auto',
-                         transpose=self.dimensions.transpose,
-                         norm=self.colorbar.get_norm(), **kwargs)
+                                 transpose=self.dimensions.transpose,
+                                 norm=self.colorbar.get_norm(), **kwargs)
         self.draw_plot()
 
     def plot_matrix(self, ws, **kwargs):

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -8,18 +8,23 @@
 #
 #
 from __future__ import (absolute_import, division, print_function)
-from qtpy.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout
-from qtpy.QtCore import Qt
-from mantidqt.MPLwidgets import FigureCanvas
-from .toolbar import SliceViewerNavigationToolbar
-from matplotlib.figure import Figure
 from matplotlib import gridspec
-from .dimensionwidget import DimensionWidget
-from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox, BboxTransform
-import numpy as np
-from .samplingimage import imshow_sampling
 
+import mantid.api
+from mantid.plots.helperfunctions import get_normalize_by_bin_width
+from mantidqt.MPLwidgets import FigureCanvas
+from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from .dimensionwidget import DimensionWidget
+from .samplingimage import imshow_sampling
+from .toolbar import SliceViewerNavigationToolbar
+
+import numpy as np
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import (QComboBox, QLabel, QHBoxLayout, QMenu,
+                            QSpacerItem, QVBoxLayout, QWidget)
 
 class SliceViewerView(QWidget):
     def __init__(self, presenter, dims_info, parent=None):
@@ -34,9 +39,22 @@ class SliceViewerView(QWidget):
         self.line_plots = False
 
         # Dimension widget
+        self.dimensions_layout = QHBoxLayout()
         self.dimensions = DimensionWidget(dims_info, parent=self)
         self.dimensions.dimensionsChanged.connect(self.presenter.new_plot)
         self.dimensions.valueChanged.connect(self.presenter.update_plot_data)
+        self.dimensions_layout.addWidget(self.dimensions)
+
+        # normalization options
+        self.norm_layout = QHBoxLayout()
+        self.norm_label = QLabel("Normalization = ")
+        self.norm_layout.addWidget(self.norm_label)
+        self.norm_opts = QComboBox()
+        self.norm_opts.addItems(["None", "Bin width/area"])
+        self.norm_opts.setToolTip("Normalization options")
+        self.norm_layout.addWidget(self.norm_opts)
+        self.norm_layout.setAlignment(Qt.AlignBottom)
+        self.dimensions_layout.addLayout(self.norm_layout)
 
         # MPL figure + colorbar
         self.mpl_layout = QHBoxLayout()
@@ -60,7 +78,7 @@ class SliceViewerView(QWidget):
 
         # layout
         self.layout = QVBoxLayout(self)
-        self.layout.addWidget(self.dimensions)
+        self.layout.addLayout(self.dimensions_layout)
         self.layout.addWidget(self.mpl_toolbar)
         self.layout.addLayout(self.mpl_layout, stretch=1)
 


### PR DESCRIPTION
~~**This PR cannot be merged until #27468**~~

**Description of work.**
This PR adds the option to normalize by bin width for matrix workspaces in slice viewer. In mantidplot this was done in the spectrum viewer by rebinning the data. This instead normalises the data by dividing it by the bin width.

**To test:**
See issue for detailed example.

Fixes #27359 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
