### PR TITLE
Fix test failure on RHEL 7 when not using UTC timezone

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/EventListTest.py
@@ -14,7 +14,7 @@ from mantid.kernel import DateAndTime
 from mantid.api import EventType
 from mantid.dataobjects import EventList
 
-gps_epoch_plus_42_nanoseconds = np.datetime64('1990-01-01T00:00:00.000000042', 'ns')
+gps_epoch_plus_42_nanoseconds = np.datetime64('1990-01-01T00:00:00.000000042Z', 'ns')
 
 class EventListTest(unittest.TestCase):
 


### PR DESCRIPTION
**Description of work.**
If the test is run in an environment not using the UTC timezone, then
the test could fail due to a the conversions to the C++ DateAndTime
followed by numpy printing the result in the local timezone. This was
only occurring on machines running an earlier version of numpy than 1.11
due to this change:
https://docs.scipy.org/doc/numpy/reference/arrays.datetime.html#changes-with-numpy-1-11

**To test:**
1. Launch a machine (such as docker CentOS) with an older than 1.11 version of numpy and a timezone set to something different from UTC.
1. Run the python EventListTest.
2. It should pass

*There is no associated issue.*

*This does not require release notes* because **the issue only concerns unit tests**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
