### PR TITLE
Fix crash when opening script with syntax error

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -12,5 +12,6 @@ Bugfixes
 ########
 
 - Figure options no longer causes a crash when using 2d plots created from a script.
+- Fix crash when loading a script with syntax errors
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -206,6 +206,10 @@ def get_module_import_alias(import_name, text):
         text = text.encode(detect_encoding(BytesIO(text.encode()).readline)[0])
     except UnicodeEncodeError:  # Script contains unicode symbol. Cannot run detect_encoding as it requires ascii.
         text = text.encode('utf-8')
+    try:
+        ast.parse(text)
+    except SyntaxError:  # Script contains syntax errors so cannot parse text
+        return import_name
     for node in ast.walk(ast.parse(text)):
         if isinstance(node, ast.alias) and node.name == import_name:
             return node.asname

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -48,6 +48,9 @@ class CodeCompletionTest(unittest.TestCase):
         self._run_check_call_tip_generated("import numpy as np\n# My code",
                                            "np\.asarray\(a, \[dtype\], .*\)")
 
+    def test_call_tips_generated_if_syntax_errors_in_script(self):
+        self._run_check_call_tip_generated("from mantid.simpleapi import *\n print 'Hello', 'World", "Rebin")
+
     def test_pyplot_call_tips_generated_if_imported_in_script(self):
         self._run_check_call_tip_generated("import matplotlib.pyplot as plt\n# My code",
                                            "plt\.figure\(\[num\], .*\)")

--- a/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -49,7 +49,7 @@ class CodeCompletionTest(unittest.TestCase):
                                            "np\.asarray\(a, \[dtype\], .*\)")
 
     def test_call_tips_generated_if_syntax_errors_in_script(self):
-        self._run_check_call_tip_generated("from mantid.simpleapi import *\n print 'Hello', 'World", "Rebin")
+        self._run_check_call_tip_generated("from mantid.simpleapi import *\n print 'Hello', 'World'", "Rebin")
 
     def test_pyplot_call_tips_generated_if_imported_in_script(self):
         self._run_check_call_tip_generated("import matplotlib.pyplot as plt\n# My code",


### PR DESCRIPTION
**Description of work.**

When opening a script with an import and a syntax error it caused a crash. This occurred due to the code completion failing to parse the import so an extra check has been added

**Report to:** James Lord

**To test:**
Save the following script in workbench:
```
from __future__ import (absolute_import, division, print_function, unicode_literals)
import numpy as np
print 'hello','world'
```
Open it back into workbench - it should load and not crash

Fixes #27507

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
