### PR TITLE
Fix colorbar scale so numbers appear on scale on log scale

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -11,6 +11,7 @@ Improvements
 Bugfixes
 ########
 
+- Colorbar scale no longer vanish on colorfill plots with a logarithmic scale
 - Figure options no longer causes a crash when using 2d plots created from a script.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -204,7 +204,6 @@ class ColorbarAxisEditor(AxisEditor):
             cb.colorbar.locator = locator
             cb.colorbar.update_ticks()
 
-
     def create_model(self):
         memento = AxisEditorModel()
         self._memento = memento

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -12,9 +12,13 @@ from __future__ import (absolute_import, unicode_literals)
 # std imports
 
 # 3rdparty imports
+from mantid.kernel import logger
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 from matplotlib.collections import QuadMesh
+from matplotlib.colors import LogNorm
+from matplotlib.ticker import LogLocator
+from numpy import arange
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
 
@@ -191,6 +195,15 @@ class ColorbarAxisEditor(AxisEditor):
         super(ColorbarAxisEditor, self).changes_accepted()
         cb = self.images[0]
         cb.set_clim(self.limit_min, self.limit_max)
+        if isinstance(self.images[0].norm, LogNorm):
+            locator = LogLocator(subs=arange(1, 10))
+            if locator.tick_values(vmin=self.limit_min, vmax=self.limit_max).size == 0:
+                locator = LogLocator()
+                logger.warning("Minor ticks on colorbar scale cannot be shown "
+                               "as the range between min value and max value is too large")
+            cb.colorbar.locator = locator
+            cb.colorbar.update_ticks()
+
 
     def create_model(self):
         memento = AxisEditorModel()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -8,6 +8,9 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
+from matplotlib.colors import LogNorm
+from matplotlib.ticker import LogLocator
+
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_images_from_fig
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
@@ -46,7 +49,11 @@ class ImagesTabWidgetPresenter:
         if current_axis_images.colorbar:
             current_axis_images.colorbar.remove()
 
-        self.fig.colorbar(image)
+        locator = None
+        if SCALES[props.scale] == LogNorm:
+            locator = LogLocator()
+
+        self.fig.colorbar(image, ticks=locator)
 
     def get_selected_image(self):
         return self.image_names_dict[self.view.get_selected_image_name()]

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
 
+from mantid.kernel import logger
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_images_from_fig
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
@@ -51,7 +52,11 @@ class ImagesTabWidgetPresenter:
 
         locator = None
         if SCALES[props.scale] == LogNorm:
-            locator = LogLocator()
+            locator = LogLocator(subs='all')
+            if locator.tick_values(vmin=props.vmin,  vmax=props.vmax).size == 0:
+                locator = LogLocator()
+                logger.warning("Minor ticks on colorbar scale cannot be shown "
+                               "as the range between min value and max value is too large")
 
         self.fig.colorbar(image, ticks=locator)
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 
 from __future__ import (absolute_import, unicode_literals)
+from numpy import arange
 
 from matplotlib.colors import LogNorm
 from matplotlib.ticker import LogLocator
@@ -52,7 +53,7 @@ class ImagesTabWidgetPresenter:
 
         locator = None
         if SCALES[props.scale] == LogNorm:
-            locator = LogLocator(subs='all')
+            locator = LogLocator(subs=arange(1, 10))
             if locator.tick_values(vmin=props.vmin,  vmax=props.vmax).size == 0:
                 locator = LogLocator()
                 logger.warning("Minor ticks on colorbar scale cannot be shown "


### PR DESCRIPTION
**Description of work.**

When the scale on a colorfill plot was changed to log with a large gap between xmin and xmax the number of the scale disappeared. 
The issue occurred because of the minor ticks on the plot. The only around this seems to be to do the plot without the minor ticks if the range is too large. Any attempt made to plot them otherwise resulted in the same error.

**To test:**
1. Load MAR11060
2. Create Colour Fill plot
3. Open up Figure Options
4. Go to Images tab and change Scale to Logarithmic
5. Press ok or apply, the colour scale bar should have numbers.

Fixes #27379

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
