### PR TITLE
MDFrame export to include isQ

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/MDFrame.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/MDFrame.cpp
@@ -22,5 +22,6 @@ void export_MDFrame() {
 
   class_<MDFrame, boost::noncopyable>("MDFrame", no_init)
       .def("getUnitLabel", &MDFrame::getUnitLabel, arg("self"))
-      .def("name", &MDFrame::name, arg("self"));
+      .def("name", &MDFrame::name, arg("self"))
+      .def("isQ", &MDFrame::isQ, arg("self"));
 }


### PR DESCRIPTION
`isQ` added to MDFrame export. Needed for scipp.

--------
Shouldn't require much testing, but the following illustrates this working.

```python
md_event = CreateMDWorkspace(Dimensions=3, Extents=[-10,10,-10,10,-10,10], Names='A,B,C', Units='U,U,U', StoreInADS=False)
md_event.getDimension(0).getMDFrame().isQ() # should be false
```

And
```python
import mantid.simpleapi as mantid

ws_name = "TOPAZ_3132"
filename = ws_name + "_event.nxs"
ws = mantid.LoadEventNexus(Filename=filename, FilterByTofMin=3000, FilterByTofMax=16000)

# Convert to Q space
LabQ = mantid.ConvertToDiffractionMDWorkspace(InputWorkspace=ws, LorentzCorrection='0',
                                              OutputDimensions='Q (lab frame)', SplitInto=2, SplitThreshold=150)
                                              
dim = LabQ.getDimension(0).getMDFrame().isQ() # should be true
````