### PR TITLE
Add modulation vector inputs to PredictFractionalPeaks

### DIFF
--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SRC_FILES
     src/NormaliseVanadium.cpp
     src/OptimizeCrystalPlacement.cpp
     src/OptimizeLatticeForCellType.cpp
+    src/PeakAlgorithmHelpers.cpp
     src/PeakBackground.cpp
     src/PeakClusterProjection.cpp
     src/PeakHKLErrors.cpp
@@ -115,6 +116,7 @@ set(INC_FILES
     inc/MantidCrystal/NormaliseVanadium.h
     inc/MantidCrystal/OptimizeCrystalPlacement.h
     inc/MantidCrystal/OptimizeLatticeForCellType.h
+    inc/MantidCrystal/PeakAlgorithmHelpers.h
     inc/MantidCrystal/PeakBackground.h
     inc/MantidCrystal/PeakClusterProjection.h
     inc/MantidCrystal/PeakHKLErrors.h

--- a/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
+++ b/Framework/Crystal/inc/MantidCrystal/PeakAlgorithmHelpers.h
@@ -1,0 +1,54 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef MANTID_CRYSTAL_PEAKALGORITHMHELPERS_H
+#define MANTID_CRYSTAL_PEAKALGORITHMHELPERS_H
+#include "MantidAPI/IAlgorithm.h"
+
+namespace Mantid::Kernel {
+class V3D;
+}
+
+namespace Mantid::Crystal {
+
+/// Tie together a modulated peak number with its offset
+using MNPOffset = std::tuple<double, double, double, Kernel::V3D>;
+
+/// Tie together the names of the properties for the modulation vectors
+struct ModulationProperties {
+  inline const static std::string ModVector1{"ModVector1"};
+  inline const static std::string ModVector2{"ModVector2"};
+  inline const static std::string ModVector3{"ModVector3"};
+  inline const static std::string MaxOrder{"MaxOrder"};
+  inline const static std::string CrossTerms{"CrossTerms"};
+
+  static void appendTo(API::IAlgorithm *alg);
+  static ModulationProperties create(const API::IAlgorithm &alg);
+
+  std::vector<MNPOffset> offsets;
+  int maxOrder;
+  bool crossTerms;
+  bool saveOnLattice;
+};
+
+/// Create a list of valid modulation vectors from the input
+std::vector<Kernel::V3D>
+validModulationVectors(const std::vector<double> &modVector1,
+                       const std::vector<double> &modVector2,
+                       const std::vector<double> &modVector3);
+
+/// Calculate a list of HKL offsets from the given modulation vectors.
+std::vector<MNPOffset>
+generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,
+                      const int maxOrder, const bool crossTerms);
+/// Calculate a list of HKL offsets from the given lists of offsets
+std::vector<MNPOffset>
+generateOffsetVectors(const std::vector<double> &hOffsets,
+                      const std::vector<double> &kOffsets,
+                      const std::vector<double> &lOffsets);
+} // namespace Mantid::Crystal
+
+#endif // MANTID_CRYSTAL_PEAKALGORITHMHELPERS_H

--- a/Framework/Crystal/inc/MantidCrystal/PredictFractionalPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/PredictFractionalPeaks.h
@@ -6,46 +6,41 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #ifndef MANTID_CRYSTAL_PREDICTFRACTIONALPEAKS_H_
 #define MANTID_CRYSTAL_PREDICTFRACTIONALPEAKS_H_
-
 #include "MantidAPI/Algorithm.h"
-#include "MantidKernel/System.h"
+#include "MantidCrystal/PeakAlgorithmHelpers.h"
+#include <tuple>
 
-namespace Mantid {
-namespace Crystal {
+namespace Mantid::Kernel {
+class V3D;
+}
+
+namespace Mantid::Crystal {
 
 /**
- *
+ * Using a set of offset vectors, either provided as separate lists or as a set
+ * of vectors, predict whether
  */
 class DLLExport PredictFractionalPeaks : public API::Algorithm {
 public:
-  /// Algorithm's name for identification
   const std::string name() const override { return "PredictFractionalPeaks"; }
-  /// Summary of algorithms purpose
   const std::string summary() const override {
     return "The offsets can be from hkl values in a range of hkl values or "
            "from peaks in the input PeaksWorkspace";
   }
-
-  /// Algorithm's version for identification
-  int version() const override { return 1; };
+  int version() const override { return 1; }
   const std::vector<std::string> seeAlso() const override {
     return {"PredictPeaks"};
   }
-
-  /// Algorithm's category for identification
   const std::string category() const override { return "Crystal\\Peaks"; }
-  /// Return any errors in cross-property validation
   std::map<std::string, std::string> validateInputs() override;
 
 private:
-  /// Initialise the properties
   void init() override;
-
-  /// Run the algorithm
   void exec() override;
+
+  ModulationProperties getModulationInfo();
 };
 
-} // namespace Crystal
-} // namespace Mantid
+} // namespace Mantid::Crystal
 
 #endif /* MANTID_CRYSTAL_PREDICTFRACTIONALPEAKS */

--- a/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
+++ b/Framework/Crystal/src/PeakAlgorithmHelpers.cpp
@@ -1,0 +1,195 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidCrystal/PeakAlgorithmHelpers.h"
+#include "MantidKernel/ArrayLengthValidator.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/BoundedValidator.h"
+#include "MantidKernel/V3D.h"
+
+using Mantid::Kernel::ArrayLengthValidator;
+using Mantid::Kernel::ArrayProperty;
+using Mantid::Kernel::BoundedValidator;
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::V3D;
+
+namespace Mantid::Crystal {
+
+/**
+ * Append the common set of properties that relate to modulation vectors
+ * to the given algorithm
+ * @param alg A pointer to the algorithm that will receive the properties
+ */
+void ModulationProperties::appendTo(API::IAlgorithm *alg) {
+  auto mustBeLengthThree = boost::make_shared<ArrayLengthValidator<double>>(3);
+  alg->declareProperty(
+      std::make_unique<ArrayProperty<double>>(ModulationProperties::ModVector1,
+                                              "0.0,0.0,0.0", mustBeLengthThree),
+      "Modulation Vector 1: dh, dk, dl");
+  alg->declareProperty(
+      std::make_unique<ArrayProperty<double>>(ModulationProperties::ModVector2,
+                                              "0.0,0.0,0.0", mustBeLengthThree),
+      "Modulation Vector 2: dh, dk, dl");
+  alg->declareProperty(
+      std::make_unique<ArrayProperty<double>>(ModulationProperties::ModVector3,
+                                              "0.0,0.0,0.0", mustBeLengthThree),
+      "Modulation Vector 3: dh, dk, dl");
+  auto mustBePositiveOrZero = boost::make_shared<BoundedValidator<int>>();
+  mustBePositiveOrZero->setLower(0);
+  alg->declareProperty(ModulationProperties::MaxOrder, 0, mustBePositiveOrZero,
+                       "Maximum order to apply Modulation Vectors. Default = 0",
+                       Direction::Input);
+  alg->declareProperty(
+      ModulationProperties::CrossTerms, false,
+      "Include combinations of modulation vectors in satellite search",
+      Direction::Input);
+}
+
+/**
+ * Create a ModulationProperties object from an algorithm
+ * @param alg An algorithm containing the user input
+ * @return A new ModulationProperties object
+ */
+ModulationProperties ModulationProperties::create(const API::IAlgorithm &alg) {
+  const int maxOrder{alg.getProperty(ModulationProperties::MaxOrder)};
+  const bool crossTerms{alg.getProperty(ModulationProperties::CrossTerms)};
+  auto offsets = generateOffsetVectors(
+      validModulationVectors(alg.getProperty(ModulationProperties::ModVector1),
+                             alg.getProperty(ModulationProperties::ModVector2),
+                             alg.getProperty(ModulationProperties::ModVector3)),
+      maxOrder, crossTerms);
+  const bool saveOnLattice{true};
+  return {std::move(offsets), maxOrder, crossTerms, saveOnLattice};
+}
+
+/**
+ * Check each input is a valid modulation and add it to a list
+ * to return.
+ * @param modVector1 List of 3 doubles specifying an offset
+ * @param modVector2 List of 3 doubles specifying an offset
+ * @param modVector3 List of 3 doubles specifying an offset
+ * @return A list of valid modulation vectors
+ */
+std::vector<Kernel::V3D>
+validModulationVectors(const std::vector<double> &modVector1,
+                       const std::vector<double> &modVector2,
+                       const std::vector<double> &modVector3) {
+  std::vector<V3D> modVectors;
+  auto addIfNonZero = [&modVectors](const auto &modVec) {
+    if (std::fabs(modVec[0]) > 0 || std::fabs(modVec[1]) > 0 ||
+        std::fabs(modVec[2]) > 0)
+      modVectors.emplace_back(V3D(modVec[0], modVec[1], modVec[2]));
+  };
+  addIfNonZero(modVector1);
+  addIfNonZero(modVector2);
+  addIfNonZero(modVector3);
+  return modVectors;
+}
+
+/**
+ * @param maxOrder Integer specifying the multiples of the
+ * modulation vector.
+ * @param modVectors A list of modulation vectors form the user
+ * @param crossTerms If true then compute products of the
+ * modulation vectors
+ * @return A list of (m, n, p, V3D) were m,n,p specifies the
+ * modulation structure number and V3D specifies the offset to
+ * be tested
+ */
+std::vector<MNPOffset>
+generateOffsetVectors(const std::vector<Kernel::V3D> &modVectors,
+                      const int maxOrder, const bool crossTerms) {
+  assert(modVectors.size() <= 3);
+
+  std::vector<MNPOffset> offsets;
+  if (crossTerms && modVectors.size() > 1) {
+    const auto &modVector0{modVectors[0]}, modVector1{modVectors[1]};
+    if (modVectors.size() == 2) {
+      // Calculate m*mod_vec1 + n*mod_vec2 for combinations of
+      // m, n in
+      // [-maxOrder,maxOrder]
+      offsets.reserve(2 * maxOrder);
+      for (auto m = -maxOrder; m <= maxOrder; ++m) {
+        for (auto n = -maxOrder; n <= maxOrder; ++n) {
+          if (m == 0 && n == 0)
+            continue;
+          offsets.emplace_back(
+              std::make_tuple(m, n, 0, modVector0 * m + modVector1 * n));
+        }
+      }
+    } else {
+      // Calculate m*mod_vec1 + n*mod_vec2 + p*mod_vec3 for
+      // combinations of m, n, p in [-maxOrder,maxOrder]
+      const auto &modVector2{modVectors[2]};
+      offsets.reserve(3 * maxOrder);
+      for (auto m = -maxOrder; m <= maxOrder; ++m) {
+        for (auto n = -maxOrder; n <= maxOrder; ++n) {
+          for (auto p = -maxOrder; p <= maxOrder; ++p) {
+            if (m == 0 && n == 0 && p == 0)
+              continue;
+            offsets.emplace_back(std::make_tuple(
+                m, n, p, modVector0 * m + modVector1 * n + modVector2 * p));
+          }
+        }
+      }
+    }
+  } else {
+    // No cross terms: Compute coeff*mod_vec_i for each
+    // modulation vector separately for coeff in [-maxOrder,
+    // maxOrder]
+    for (auto i = 0u; i < modVectors.size(); ++i) {
+      const auto &modVector = modVectors[i];
+      for (int order = -maxOrder; order <= maxOrder; ++order) {
+        if (order == 0)
+          continue;
+        V3D offset{modVector * order};
+        switch (i) {
+        case 0:
+          offsets.emplace_back(std::make_tuple(order, 0, 0, std::move(offset)));
+          break;
+        case 1:
+          offsets.emplace_back(std::make_tuple(0, order, 0, std::move(offset)));
+          break;
+        case 2:
+          offsets.emplace_back(std::make_tuple(0, 0, order, std::move(offset)));
+          break;
+        }
+      }
+    }
+  }
+
+  return offsets;
+}
+
+/**
+ * The final offset vector is computed as
+ * (hoffsets[i],koffsets[j],loffsets[k]) for each combination of
+ * i,j,k. All offsets are considered order 1
+ * @param hOffsets A list of offsets in the h direction
+ * @param kOffsets A list of offsets in the k direction
+ * @param lOffsets A list of offsets in the l direction
+ * @return A list of (1, 1, 1, V3D) were m,n,p specifies the
+ * modulation structure number and V3D specifies the offset to
+ * be tested */
+std::vector<MNPOffset>
+generateOffsetVectors(const std::vector<double> &hOffsets,
+                      const std::vector<double> &kOffsets,
+                      const std::vector<double> &lOffsets) {
+  std::vector<MNPOffset> offsets;
+  for (double hOffset : hOffsets) {
+    for (double kOffset : kOffsets) {
+      for (double lOffset : lOffsets) {
+        // mnp = 0, 0, 0 as
+        // it's not quite clear how to interpret them as mnp indices
+        offsets.emplace_back(
+            std::make_tuple(0, 0, 0, V3D(hOffset, kOffset, lOffset)));
+      }
+    }
+  }
+  return offsets;
+}
+
+} // namespace Mantid::Crystal

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -420,6 +420,16 @@ std::map<std::string, std::string> PredictFractionalPeaks::validateInputs() {
   validateRange(PropertyNames::KMIN, PropertyNames::KMAX);
   validateRange(PropertyNames::LMIN, PropertyNames::LMAX);
 
+  // If a modulation vector is provided then maxOrder is needed
+  const auto modVectors =
+      validModulationVectors(getProperty(ModulationProperties::ModVector1),
+                             getProperty(ModulationProperties::ModVector2),
+                             getProperty(ModulationProperties::ModVector3));
+  const int maxOrder = getProperty(ModulationProperties::MaxOrder);
+  if (maxOrder == 0 && !modVectors.empty()) {
+    helpMessages[ModulationProperties::MaxOrder] =
+        "Maxorder required when specifying a modulation vector.";
+  }
   return helpMessages;
 }
 

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -360,7 +360,34 @@ void PredictFractionalPeaks::init() {
                             std::move(includeInRangeEqOne),
                             std::move(reflConditionNotEmpty), Kernel::OR));
   }
-
+  // group offset/modulations options together
+  for (const auto &name : {PropertyNames::HOFFSET, PropertyNames::KOFFSET,
+                           PropertyNames::LOFFSET}) {
+    setPropertyGroup(name, "Separate Offsets");
+  }
+  for (const auto &name :
+       {ModulationProperties::ModVector1, ModulationProperties::ModVector2,
+        ModulationProperties::ModVector3, ModulationProperties::MaxOrder,
+        ModulationProperties::CrossTerms}) {
+    setPropertyGroup(name, "Modulation Vectors");
+  }
+  // enable/disable offsets & modulation vectors appropriately
+  for (const auto &offsetName : {PropertyNames::HOFFSET, PropertyNames::KOFFSET,
+                                 PropertyNames::LOFFSET}) {
+    EnabledWhenProperty modVectorOneIsDefault{ModulationProperties::ModVector1,
+                                              Kernel::IS_DEFAULT};
+    EnabledWhenProperty modVectorTwoIsDefault{ModulationProperties::ModVector2,
+                                              Kernel::IS_DEFAULT};
+    EnabledWhenProperty modVectorThreeIsDefault{
+        ModulationProperties::ModVector3, Kernel::IS_DEFAULT};
+    EnabledWhenProperty modVectorOneAndTwoIsDefault{
+        std::move(modVectorOneIsDefault), std::move(modVectorTwoIsDefault),
+        Kernel::AND};
+    setPropertySettings(offsetName,
+                        std::make_unique<Kernel::EnabledWhenProperty>(
+                            std::move(modVectorOneAndTwoIsDefault),
+                            std::move(modVectorThreeIsDefault), Kernel::AND));
+  }
   // Outputs
   declareProperty(
       std::make_unique<WorkspaceProperty<PeaksWorkspace_sptr::element_type>>(

--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -21,6 +21,7 @@
 #include "MantidKernel/ListValidator.h"
 #include "MantidKernel/WarningSuppressions.h"
 
+#include <boost/iterator/iterator_facade.hpp>
 #include <boost/math/special_functions/round.hpp>
 
 using Mantid::API::Algorithm;
@@ -32,6 +33,7 @@ using Mantid::Geometry::HKLFilter;
 using Mantid::Geometry::HKLFilter_uptr;
 using Mantid::Geometry::HKLGenerator;
 using Mantid::Geometry::Instrument_const_sptr;
+using Mantid::Geometry::OrientedLattice;
 using Mantid::Geometry::ReflectionCondition_sptr;
 using Mantid::Kernel::DblMatrix;
 using Mantid::Kernel::V3D;
@@ -152,91 +154,133 @@ private:
 };
 
 /**
+ * Create the output PeaksWorkspace
+ * @param inputPeaks The input workspace provided by the user
+ * @param modulationProps The set of modulation properties
+ * @return A new PeaksWorkspace
+ */
+boost::shared_ptr<Mantid::API::IPeaksWorkspace> createOutputWorkspace(
+    const PeaksWorkspace &inputPeaks,
+    const Mantid::Crystal::ModulationProperties &modulationProps) {
+  using Mantid::API::WorkspaceFactory;
+  auto outPeaks = WorkspaceFactory::Instance().createPeaks();
+  outPeaks->setInstrument(inputPeaks.getInstrument());
+  if (modulationProps.saveOnLattice) {
+    auto lattice = std::make_unique<Mantid::Geometry::OrientedLattice>();
+    lattice->setMaxOrder(modulationProps.maxOrder);
+    lattice->setCrossTerm(modulationProps.crossTerms);
+    const auto &offsets = modulationProps.offsets;
+    // there should be a maximum of 3 modulation vectors. Store the
+    // order=(1,0,0),(0,1,0), (0,0,1) vectors
+    for (const auto &offset : offsets) {
+      const V3D &modVector{std::get<3>(offset)};
+      const double m{std::get<0>(offset)}, n{std::get<1>(offset)},
+          p{std::get<2>(offset)};
+      int modNum(-1);
+      if (m == 1 && n == 0 && p == 0)
+        modNum = 1;
+      else if (m == 0 && n == 1 && p == 0)
+        modNum = 2;
+      else if (m == 0 && n == 0 && p == 1)
+        modNum = 3;
+      switch (modNum) {
+      case 1:
+        lattice->setModVec1(modVector);
+        break;
+      case 2:
+        lattice->setModVec2(modVector);
+        break;
+      case 3:
+        lattice->setModVec3(modVector);
+        break;
+      }
+    }
+    outPeaks->mutableSample().setOrientedLattice(std::move(lattice));
+  }
+  return outPeaks;
+}
+
+/**
  * Predict fractional peaks in the range specified by [hklMin, hklMax] and
  * add them to a new PeaksWorkspace
  * @param alg The host algorithm pointer
- * @param hOffsets Offsets to apply to HKL in H direction
- * @param kOffsets Offsets to apply to HKL in K direction
- * @param lOffsets Offsets to apply to HKL in L direction
- * @param requirePeaksOnDetector If true the peaks is required to hit a detector
+ * @param requirePeaksOnDetector If true the peaks is required to hit a
+ * detector
  * @param inputPeaks A peaks workspace used to created new peaks. Defines the
  * instrument and metadata for the search
+ * @param modVectors The set of modulation vectors to use in the search
  * @param strategy An object defining were to start the search and how to
  * advance to the next HKL
  * @return A new PeaksWorkspace containing the predicted fractional peaks
  */
 template <typename SearchStrategy>
-IPeaksWorkspace_sptr
-predictPeaks(Algorithm *const alg, const std::vector<double> &hOffsets,
-             const std::vector<double> &kOffsets,
-             const std::vector<double> &lOffsets,
-             const bool requirePeaksOnDetector,
-             const PeaksWorkspace &inputPeaks, SearchStrategy strategy) {
-  using Mantid::API::WorkspaceFactory;
-  auto outPeaks = WorkspaceFactory::Instance().createPeaks();
-  const auto instrument = inputPeaks.getInstrument();
-  outPeaks->setInstrument(instrument);
-
+IPeaksWorkspace_sptr predictFractionalPeaks(
+    Algorithm *const alg, const bool requirePeaksOnDetector,
+    const PeaksWorkspace &inputPeaks,
+    const Mantid::Crystal::ModulationProperties &modulationProps,
+    SearchStrategy searchStrategy) {
   using Mantid::Geometry::InstrumentRayTracer;
-  const InstrumentRayTracer tracer(instrument);
+
+  const InstrumentRayTracer tracer(inputPeaks.getInstrument());
   const auto &UB = inputPeaks.sample().getOrientedLattice().getUB();
+  const auto &offsets = modulationProps.offsets;
+  auto outPeaks = createOutputWorkspace(inputPeaks, modulationProps);
   using PeakHash = std::array<int, 4>;
   std::vector<PeakHash> alreadyDonePeaks;
 
   V3D currentHKL;
   DblMatrix gonioMatrix;
   int runNumber{0};
-  strategy.initialHKL(&currentHKL, &gonioMatrix, &runNumber);
-  auto progressReporter = strategy.createProgressReporter(alg);
+  searchStrategy.initialHKL(&currentHKL, &gonioMatrix, &runNumber);
+  auto progressReporter = searchStrategy.createProgressReporter(alg);
   while (true) {
-    for (double hOffset : hOffsets) {
-      for (double kOffset : kOffsets) {
-        for (double lOffset : lOffsets) {
-          const V3D candidateHKL(currentHKL[0] + hOffset,
-                                 currentHKL[1] + kOffset,
-                                 currentHKL[2] + lOffset);
-          const V3D qLab = (gonioMatrix * UB * candidateHKL) * 2 * M_PI;
-          if (qLab[2] <= 0)
-            continue;
+    for (const auto &mnpOffset : offsets) {
+      const V3D candidateHKL{currentHKL + std::get<3>(mnpOffset)};
+      const V3D qLab = (gonioMatrix * UB * candidateHKL) * 2 * M_PI;
+      if (qLab[2] <= 0)
+        continue;
 
-          using Mantid::Geometry::IPeak;
-          std::unique_ptr<IPeak> peak;
-          try {
-            peak = inputPeaks.createPeak(qLab);
-          } catch (...) {
-            // If we can't create a valid peak we have no choice but to skip it
-            continue;
-          }
-
-          peak->setGoniometerMatrix(gonioMatrix);
-          if (requirePeaksOnDetector && peak->getDetectorID() < 0)
-            continue;
-          GNU_DIAG_OFF("missing-braces")
-          PeakHash savedPeak{runNumber,
-                             boost::math::iround(1000.0 * candidateHKL[0]),
-                             boost::math::iround(1000.0 * candidateHKL[1]),
-                             boost::math::iround(1000.0 * candidateHKL[2])};
-          GNU_DIAG_ON("missing-braces")
-          auto it =
-              find(alreadyDonePeaks.begin(), alreadyDonePeaks.end(), savedPeak);
-          if (it == alreadyDonePeaks.end())
-            alreadyDonePeaks.emplace_back(std::move(savedPeak));
-          else
-            continue;
-
-          peak->setHKL(candidateHKL);
-          peak->setRunNumber(runNumber);
-          outPeaks->addPeak(*peak);
-        }
+      using Mantid::Geometry::IPeak;
+      std::unique_ptr<IPeak> peak;
+      try {
+        peak = inputPeaks.createPeak(qLab);
+      } catch (...) {
+        // If we can't create a valid peak we have no choice but to skip
+        // it
+        continue;
       }
+
+      peak->setGoniometerMatrix(gonioMatrix);
+      if (requirePeaksOnDetector && peak->getDetectorID() < 0)
+        continue;
+      GNU_DIAG_OFF("missing-braces")
+      PeakHash savedPeak{runNumber,
+                         boost::math::iround(1000.0 * candidateHKL[0]),
+                         boost::math::iround(1000.0 * candidateHKL[1]),
+                         boost::math::iround(1000.0 * candidateHKL[2])};
+      GNU_DIAG_ON("missing-braces")
+      auto it =
+          find(alreadyDonePeaks.begin(), alreadyDonePeaks.end(), savedPeak);
+      if (it == alreadyDonePeaks.end())
+        alreadyDonePeaks.emplace_back(std::move(savedPeak));
+      else
+        continue;
+
+      peak->setHKL(candidateHKL);
+      const double m{std::get<0>(mnpOffset)}, n{std::get<1>(mnpOffset)},
+          p{std::get<2>(mnpOffset)};
+      if (fabs(m) > 0. || fabs(n) > 0. || fabs(p) > 0.)
+        peak->setIntMNP(V3D(m, n, p));
+      peak->setRunNumber(runNumber);
+      outPeaks->addPeak(*peak);
     }
     progressReporter.report();
-    if (!strategy.nextHKL(&currentHKL, &gonioMatrix, &runNumber))
+    if (!searchStrategy.nextHKL(&currentHKL, &gonioMatrix, &runNumber))
       break;
   }
 
   return outPeaks;
-} // namespace
+}
 
 } // namespace
 
@@ -300,6 +344,7 @@ void PredictFractionalPeaks::init() {
                   "If true then the predicted peaks are required to hit a "
                   "detector pixel. Default=true",
                   Direction::Input);
+  ModulationProperties::appendTo(this);
 
   // enable range properties if required
   using Kernel::EnabledWhenProperty;
@@ -323,6 +368,10 @@ void PredictFractionalPeaks::init() {
       "Workspace of Peaks with peaks with fractional h,k, and/or l values");
 }
 
+/**
+ * Validate the input once all values are set
+ * @return A map<string,string> containting an help messages for the user
+ */
 std::map<std::string, std::string> PredictFractionalPeaks::validateInputs() {
   std::map<std::string, std::string> helpMessages;
   const PeaksWorkspace_sptr peaks = getProperty(PropertyNames::PEAKS);
@@ -347,17 +396,10 @@ std::map<std::string, std::string> PredictFractionalPeaks::validateInputs() {
   return helpMessages;
 }
 
+/// Execute the algorithm
 void PredictFractionalPeaks::exec() {
   PeaksWorkspace_sptr inputPeaks = getProperty(PropertyNames::PEAKS);
-  std::vector<double> hOffsets = getProperty(PropertyNames::HOFFSET);
-  std::vector<double> kOffsets = getProperty(PropertyNames::KOFFSET);
-  std::vector<double> lOffsets = getProperty(PropertyNames::LOFFSET);
-  if (hOffsets.empty())
-    hOffsets.emplace_back(0.0);
-  if (kOffsets.empty())
-    kOffsets.emplace_back(0.0);
-  if (lOffsets.empty())
-    lOffsets.emplace_back(0.0);
+  auto modulationInfo = getModulationInfo();
   const bool includePeaksInRange = getProperty("IncludeAllPeaksInRange");
   const V3D hklMin{getProperty(PropertyNames::HMIN),
                    getProperty(PropertyNames::KMIN),
@@ -386,16 +428,43 @@ void PredictFractionalPeaks::exec() {
       using Mantid::Geometry::HKLFilterNone;
       filter = std::make_unique<HKLFilterNone>();
     }
-    outPeaks = predictPeaks(
-        this, hOffsets, kOffsets, lOffsets, requirePeakOnDetector, *inputPeaks,
+    outPeaks = predictFractionalPeaks(
+        this, requirePeakOnDetector, *inputPeaks, std::move(modulationInfo),
         PeaksInRangeStrategy(hklMin, hklMax, filter.get(), inputPeaks.get()));
-
   } else {
-    outPeaks =
-        predictPeaks(this, hOffsets, kOffsets, lOffsets, requirePeakOnDetector,
-                     *inputPeaks, PeaksFromIndexedStrategy(inputPeaks.get()));
+    outPeaks = predictFractionalPeaks(
+        this, requirePeakOnDetector, *inputPeaks, std::move(modulationInfo),
+        PeaksFromIndexedStrategy(inputPeaks.get()));
   }
   setProperty(PropertyNames::FRACPEAKS, outPeaks);
+}
+
+/**
+ * @return The list of modulation vectors based on the user input. Anything
+ * specified by the modulation vector parameters takes precedence over the
+ * offsets
+ */
+ModulationProperties PredictFractionalPeaks::getModulationInfo() {
+  // Input validation ensures that we have either specified offests or
+  // modulation vectors
+  const int maxOrder = getProperty(ModulationProperties::MaxOrder);
+
+  if (maxOrder == 0) {
+    std::vector<double> hOffsets = getProperty(PropertyNames::HOFFSET);
+    std::vector<double> kOffsets = getProperty(PropertyNames::KOFFSET);
+    std::vector<double> lOffsets = getProperty(PropertyNames::LOFFSET);
+    if (hOffsets.empty())
+      hOffsets.emplace_back(0.0);
+    if (kOffsets.empty())
+      kOffsets.emplace_back(0.0);
+    if (lOffsets.empty())
+      lOffsets.emplace_back(0.0);
+    const bool crossTerms{false}, saveOnLattice{false};
+    return {generateOffsetVectors(hOffsets, kOffsets, lOffsets), maxOrder,
+            crossTerms, saveOnLattice};
+  } else {
+    return ModulationProperties::create(*this);
+  }
 }
 
 } // namespace Crystal

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -297,6 +297,17 @@ public:
     doInvalidRangeTest("L");
   }
 
+  void test_modulation_vector_requires_maxOrder_gt_0() {
+    PredictFractionalPeaks alg;
+    alg.initialize();
+    alg.setProperty("Peaks", WorkspaceCreationHelper::createPeaksWorkspace(0));
+    alg.setProperty("ModVector1", "0.5,0,0.5");
+
+    auto helpMsgs = alg.validateInputs();
+
+    TS_ASSERT(helpMsgs.find("MaxOrder") != helpMsgs.cend())
+  }
+
 private:
   void doInvalidRangeTest(const std::string &dimension) {
     PredictFractionalPeaks alg;

--- a/Framework/Crystal/test/PredictFractionalPeaksTest.h
+++ b/Framework/Crystal/test/PredictFractionalPeaksTest.h
@@ -229,6 +229,50 @@ public:
     TS_ASSERT_EQUALS(fracPeaks->getPeak(24).getDetectorID(), 3157981)
   }
 
+  void test_providing_modulation_vector_saves_properties_to_lattice() {
+    const auto fracPeaks = runPredictFractionalPeaks(
+        m_indexedPeaks, {{"ModVector1", "-0.5,0,0.5"},
+                         {"ModVector2", "0.0,0.5,0.5"},
+                         {"MaxOrder", "1"},
+                         {"CrossTerms", "0"}});
+
+    TS_ASSERT_EQUALS(124, fracPeaks->getNumberPeaks())
+
+    // check lattice
+    const auto &lattice = fracPeaks->sample().getOrientedLattice();
+    TS_ASSERT_EQUALS(1, lattice.getMaxOrder())
+    TS_ASSERT_EQUALS(false, lattice.getCrossTerm())
+    const auto mod1 = lattice.getModVec(0);
+    TS_ASSERT_EQUALS(-0.5, mod1.X())
+    TS_ASSERT_EQUALS(0.0, mod1.Y())
+    TS_ASSERT_EQUALS(0.5, mod1.Z())
+    const auto mod2 = lattice.getModVec(1);
+    TS_ASSERT_EQUALS(0.0, mod2.X())
+    TS_ASSERT_EQUALS(0.5, mod2.Y())
+    TS_ASSERT_EQUALS(0.5, mod2.Z())
+
+    // check a couple of peaks
+    const auto &peak0 = fracPeaks->getPeak(0);
+    TS_ASSERT_DELTA(peak0.getH(), -4.5, .0001)
+    TS_ASSERT_DELTA(peak0.getK(), 7.0, .0001)
+    TS_ASSERT_DELTA(peak0.getL(), -4.5, .0001)
+    TS_ASSERT_EQUALS(peak0.getDetectorID(), 1129591)
+    const auto mnp0 = peak0.getIntMNP();
+    TS_ASSERT_DELTA(mnp0.X(), -1., 1e-08)
+    TS_ASSERT_DELTA(mnp0.Y(), 0., 1e-08)
+    TS_ASSERT_DELTA(mnp0.Z(), 0., 1e-08)
+
+    const auto &peak34 = fracPeaks->getPeak(34);
+    TS_ASSERT_DELTA(peak34.getH(), -7, .0001)
+    TS_ASSERT_DELTA(peak34.getK(), 7.5, .0001)
+    TS_ASSERT_DELTA(peak34.getL(), -2.5, .0001)
+    TS_ASSERT_EQUALS(peak34.getDetectorID(), 1812163)
+    const auto mnp34 = peak34.getIntMNP();
+    TS_ASSERT_DELTA(mnp34.X(), 0., 1e-08)
+    TS_ASSERT_DELTA(mnp34.Y(), 1., 1e-08)
+    TS_ASSERT_DELTA(mnp34.Z(), 0., 1e-08)
+  }
+
   // ---------------- Failure tests -----------------------------
   void test_empty_peaks_workspace_is_not_allowed() {
     PredictFractionalPeaks alg;

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -67,6 +67,132 @@ public:
   virtual void declareOrReplaceProperty(std::unique_ptr<Property> p,
                                         const std::string &doc = "") = 0;
 
+  /** Add a property of the template type to the list of managed properties
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param validator :: Pointer to the (optional) validator.
+   *  @param doc :: The (optional) documentation string
+   *  @param direction :: The (optional) direction of the property, in, out or
+   * inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  template <typename T>
+  void declareProperty(
+      const std::string &name, T value,
+      IValidator_sptr validator = boost::make_shared<NullValidator>(),
+      const std::string &doc = "",
+      const unsigned int direction = Direction::Input) {
+    std::unique_ptr<PropertyWithValue<T>> p =
+        std::make_unique<PropertyWithValue<T>>(name, value, validator,
+                                               direction);
+    declareProperty(std::move(p), doc);
+  }
+
+  /** Add a property to the list of managed properties with no validator
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param doc :: The documentation string
+   *  @param direction :: The (optional) direction of the property, in
+   * (default), out or inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  template <typename T>
+  void declareProperty(const std::string &name, T value, const std::string &doc,
+                       const unsigned int direction = Direction::Input) {
+    std::unique_ptr<PropertyWithValue<T>> p =
+        std::make_unique<PropertyWithValue<T>>(
+            name, value, boost::make_shared<NullValidator>(), direction);
+    declareProperty(std::move(p), doc);
+  }
+
+  /** Add a property of the template type to the list of managed properties
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param direction :: The direction of the property, in, out or inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  template <typename T>
+  void declareProperty(const std::string &name, T value,
+                       const unsigned int direction) {
+    std::unique_ptr<PropertyWithValue<T>> p =
+        std::make_unique<PropertyWithValue<T>>(
+            name, value, boost::make_shared<NullValidator>(), direction);
+    declareProperty(std::move(p));
+  }
+
+  /** Specialised version of declareProperty template method to prevent the
+   * creation of a
+   *  PropertyWithValue of type const char* if an argument in quotes is passed
+   * (it will be
+   *  converted to a string). The validator, if provided, needs to be a string
+   * validator.
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param validator :: Pointer to the (optional) validator. Ownership will be
+   * taken over.
+   *  @param doc :: The (optional) documentation string
+   *  @param direction :: The (optional) direction of the property, in, out or
+   * inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  void declareProperty(
+      const std::string &name, const char *value,
+      IValidator_sptr validator = boost::make_shared<NullValidator>(),
+      const std::string &doc = std::string(),
+      const unsigned int direction = Direction::Input) {
+    // Simply call templated method, converting character array to a string
+    declareProperty(name, std::string(value), std::move(validator), doc,
+                    direction);
+  }
+
+  /** Specialised version of declareProperty template method to prevent the
+   * creation of a
+   *  PropertyWithValue of type const char* if an argument in quotes is passed
+   * (it will be
+   *  converted to a string). The validator, if provided, needs to be a string
+   * validator.
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param doc :: The (optional) documentation string
+   *  @param validator :: Pointer to the (optional) validator. Ownership will be
+   * taken over.
+   *  @param direction :: The (optional) direction of the property, in, out or
+   * inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  void declareProperty(
+      const std::string &name, const char *value, const std::string &doc,
+      IValidator_sptr validator = boost::make_shared<NullValidator>(),
+      const unsigned int direction = Direction::Input) {
+    // Simply call templated method, converting character array to a string
+    declareProperty(name, std::string(value), std::move(validator), doc,
+                    direction);
+  }
+
+  /** Add a property of string type to the list of managed properties
+   *  @param name :: The name to assign to the property
+   *  @param value :: The initial value to assign to the property
+   *  @param direction :: The direction of the property, in, out or inout
+   *  @throw Exception::ExistsError if a property with the given name already
+   * exists
+   *  @throw std::invalid_argument  if the name argument is empty
+   */
+  void declareProperty(const std::string &name, const char *value,
+                       const unsigned int direction) {
+    declareProperty(name, std::string(value),
+                    boost::make_shared<NullValidator>(), "", direction);
+  }
+
   /// Removes the property from management
   virtual void removeProperty(const std::string &name,
                               const bool delproperty = true) = 0;
@@ -226,132 +352,6 @@ public:
   virtual void filterByProperty(const TimeSeriesProperty<bool> & /*filte*/) = 0;
 
 protected:
-  /** Add a property of the template type to the list of managed properties
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param validator :: Pointer to the (optional) validator.
-   *  @param doc :: The (optional) documentation string
-   *  @param direction :: The (optional) direction of the property, in, out or
-   * inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  template <typename T>
-  void declareProperty(
-      const std::string &name, T value,
-      IValidator_sptr validator = boost::make_shared<NullValidator>(),
-      const std::string &doc = "",
-      const unsigned int direction = Direction::Input) {
-    std::unique_ptr<PropertyWithValue<T>> p =
-        std::make_unique<PropertyWithValue<T>>(name, value, validator,
-                                               direction);
-    declareProperty(std::move(p), doc);
-  }
-
-  /** Add a property to the list of managed properties with no validator
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param doc :: The documentation string
-   *  @param direction :: The (optional) direction of the property, in
-   * (default), out or inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  template <typename T>
-  void declareProperty(const std::string &name, T value, const std::string &doc,
-                       const unsigned int direction = Direction::Input) {
-    std::unique_ptr<PropertyWithValue<T>> p =
-        std::make_unique<PropertyWithValue<T>>(
-            name, value, boost::make_shared<NullValidator>(), direction);
-    declareProperty(std::move(p), doc);
-  }
-
-  /** Add a property of the template type to the list of managed properties
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param direction :: The direction of the property, in, out or inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  template <typename T>
-  void declareProperty(const std::string &name, T value,
-                       const unsigned int direction) {
-    std::unique_ptr<PropertyWithValue<T>> p =
-        std::make_unique<PropertyWithValue<T>>(
-            name, value, boost::make_shared<NullValidator>(), direction);
-    declareProperty(std::move(p));
-  }
-
-  /** Specialised version of declareProperty template method to prevent the
-   * creation of a
-   *  PropertyWithValue of type const char* if an argument in quotes is passed
-   * (it will be
-   *  converted to a string). The validator, if provided, needs to be a string
-   * validator.
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param validator :: Pointer to the (optional) validator. Ownership will be
-   * taken over.
-   *  @param doc :: The (optional) documentation string
-   *  @param direction :: The (optional) direction of the property, in, out or
-   * inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  void declareProperty(
-      const std::string &name, const char *value,
-      IValidator_sptr validator = boost::make_shared<NullValidator>(),
-      const std::string &doc = std::string(),
-      const unsigned int direction = Direction::Input) {
-    // Simply call templated method, converting character array to a string
-    declareProperty(name, std::string(value), std::move(validator), doc,
-                    direction);
-  }
-
-  /** Specialised version of declareProperty template method to prevent the
-   * creation of a
-   *  PropertyWithValue of type const char* if an argument in quotes is passed
-   * (it will be
-   *  converted to a string). The validator, if provided, needs to be a string
-   * validator.
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param doc :: The (optional) documentation string
-   *  @param validator :: Pointer to the (optional) validator. Ownership will be
-   * taken over.
-   *  @param direction :: The (optional) direction of the property, in, out or
-   * inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  void declareProperty(
-      const std::string &name, const char *value, const std::string &doc,
-      IValidator_sptr validator = boost::make_shared<NullValidator>(),
-      const unsigned int direction = Direction::Input) {
-    // Simply call templated method, converting character array to a string
-    declareProperty(name, std::string(value), std::move(validator), doc,
-                    direction);
-  }
-
-  /** Add a property of string type to the list of managed properties
-   *  @param name :: The name to assign to the property
-   *  @param value :: The initial value to assign to the property
-   *  @param direction :: The direction of the property, in, out or inout
-   *  @throw Exception::ExistsError if a property with the given name already
-   * exists
-   *  @throw std::invalid_argument  if the name argument is empty
-   */
-  void declareProperty(const std::string &name, const char *value,
-                       const unsigned int direction) {
-    declareProperty(name, std::string(value),
-                    boost::make_shared<NullValidator>(), "", direction);
-  }
-
   /// Get a property by an index
   virtual Property *getPointerToPropertyOrdinal(const int &index) const = 0;
 

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -25,6 +25,8 @@ Engineering Diffraction
 Single Crystal Diffraction
 --------------------------
 
+- :ref:`PredictFractionalPeaks <algm-PredictFractionalPeaks-v1>` now accepts the same set of modulation vector properties as :ref:`IndexPeaks <algm-IndexPeaks-v1>`.
+
 Imaging
 -------
 


### PR DESCRIPTION
**Description of work.**

PredictFractionalPeaks accepted only 3 lists of offsets that were then combined to form vector. WISH request that it also accept the offset vector directly. The same inputs as `IndexPeaks` have been added. Some refactoring was done to avoid dupiicating code between the two.

This will also make it far simpler to save the modulation information in the JANA format in #27111 

**To test:**
The following script gets a peaks workspace to feed to `PredictFractionalPeaks`.

```python
peaks = LoadNexusProcessed('TOPAZ_3007.peaks.nxs')
LoadIsawUB(peaks,'TOPAZ_3007.mat')
IndexPeaks(peaks)
```

The simplest check is checking that given the offsets as a ModVector or as a separate offsets that they given the same list of peaks. The following inputs should match:
* ModVector1=-0.5, 0, 0.5
* HOffsets=-0.5, KOffsets=0, LOffsets=0.5

Refs #26839

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
