### PR TITLE
Remove check that max value is greater than min value in the figure options images tab

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -9,6 +9,7 @@ Improvements
 ############
 
 - Normalization option have been added to 2d plots.
+- The images tab in figure options no longer forces the max value to be greater than the min value.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/images_tab.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/images_tab.ui
@@ -353,7 +353,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer_3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -365,6 +365,28 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="max_min_value_warning">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Text&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="scaledContents">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -48,6 +48,19 @@ class ImagesTabWidgetPresenter:
 
         self.fig.colorbar(image)
 
+        if props.vmin > props.vmax:
+            self.view.max_min_value_warning.setVisible(True)
+            self.view.max_min_value_warning.setText("<html> <head/> <body> <p> <span style=\"color:#ff0000;\">Max "
+                                                    "value is less than min value so they have been "
+                                                    "swapped.</span></p></body></html>")
+        elif props.vmin == props.vmax:
+            self.view.max_min_value_warning.setVisible(True)
+            self.view.max_min_value_warning.setText("<html><head/><body><p><span style=\"color:#ff0000;\">Min and max "
+                                                    "value are the same so they have been "
+                                                    "adjusted.</span></p></body></html>")
+        else:
+            self.view.max_min_value_warning.setVisible(False)
+
     def get_selected_image(self):
         return self.image_names_dict[self.view.get_selected_image_name()]
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -47,20 +47,6 @@ class ImagesTabWidgetView(QWidget):
             spin_box = getattr(self, '%s_value_spin_box' % bound)
             spin_box.setRange(0, np.finfo(np.float32).max)
 
-        # Make sure min scale value always less than max
-        self.min_value_spin_box.valueChanged.connect(self._check_max_min_consistency_min_changed)
-        self.max_value_spin_box.valueChanged.connect(self._check_max_min_consistency_max_changed)
-
-    def _check_max_min_consistency_min_changed(self):
-        """Check min value smaller than max value after min_value changed"""
-        if self.get_min_value() >= self.get_max_value():
-            self.set_max_value(self.get_min_value() + 0.01)
-
-    def _check_max_min_consistency_max_changed(self):
-        """Check min value smaller than max value after max value changed"""
-        if self.get_min_value() >= self.get_max_value():
-            self.set_min_value(self.get_max_value() - 0.01)
-
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():
             qt_img = create_colormap_img(cmap_name)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -47,6 +47,8 @@ class ImagesTabWidgetView(QWidget):
             spin_box = getattr(self, '%s_value_spin_box' % bound)
             spin_box.setRange(0, np.finfo(np.float32).max)
 
+        self.max_min_value_warning.setVisible(False)
+
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():
             qt_img = create_colormap_img(cmap_name)


### PR DESCRIPTION
**Description of work.**
Report to: [James Lord]/[ISIS]
This PR stops the min/max value fields in the figure options images tab from automatically changing to ensure that the max is always greater than the min. The associated issue explains the annoyances this caused. Warnings have been added if the user applies an input where the min value is greater than the max value or they are equal.

**To test:**
1. Load a workspace, right-click it and select Plot->Colorfill.
2. Open figure options, go to the Images tab.
3. Check that it is possible to input a max value that is less than the min value.
4. When you click Apply the plot should just treat the max value as the min value and the min value as the max value and warning text should appear in the dialog.
5. Set the max and min value to be equal, a different warning should appear.
6. Set the min value to be less than the max value, the warning should disappear.

Fixes #27575 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
