### PR TITLE
Add Compiler Check for Setting OpenMP Thread Count Using Config Value

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -85,8 +85,12 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
 // GCC
 #ifdef _MSC_VER
 #define PRAGMA __pragma
+#define PARALLEL_SET_CONFIG_THREADS
 #else //_MSC_VER
 #define PRAGMA(x) _Pragma(#x)
+#define PARALLEL_SET_CONFIG_THREADS                                            \
+  setMaxCoresToConfig();                                                       \
+  PARALLEL_SET_DYNAMIC(false);
 #endif //_MSC_VER
 
 /** Begins a block to skip processing is the algorithm has been interupted
@@ -136,8 +140,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *   code to be executed in parallel
  */
 #define PARALLEL_FOR_IF(condition)                                             \
-  setMaxCoresToConfig();                                                       \
-  PARALLEL_SET_DYNAMIC(false);                                                 \
+  PARALLEL_SET_CONFIG_THREADS                                                  \
   PRAGMA(omp parallel for if (condition) )
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
@@ -145,8 +148,7 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *   and therefore should not be used in any loops that access workspaces.
  */
 #define PARALLEL_FOR_NO_WSP_CHECK()                                            \
-  setMaxCoresToConfig();                                                       \
-  PARALLEL_SET_DYNAMIC(false);                                                 \
+  PARALLEL_SET_CONFIG_THREADS                                                  \
   PRAGMA(omp parallel for)
 
 /** Includes code to add OpenMP commands to run the next for loop in parallel.
@@ -155,13 +157,11 @@ void AtomicOp(std::atomic<T> &f, T d, BinaryOp op) {
  *  and therefore should not be used in any loops that access workspace.
  */
 #define PARALLEL_FOR_NOWS_CHECK_FIRSTPRIVATE(variable)                         \
-  setMaxCoresToConfig();                                                       \
-  PARALLEL_SET_DYNAMIC(false);                                                 \
+  PARALLEL_SET_CONFIG_THREADS                                                  \
   PRAGMA(omp parallel for firstprivate(variable) )
 
 #define PARALLEL_FOR_NO_WSP_CHECK_FIRSTPRIVATE2(variable1, variable2)          \
-  setMaxCoresToConfig();                                                       \
-  PARALLEL_SET_DYNAMIC(false);                                                 \
+  PARALLEL_SET_CONFIG_THREADS                                                  \
   PRAGMA(omp parallel for firstprivate(variable1, variable2) )
 
 /** Ensures that the next execution line or block is only executed if


### PR DESCRIPTION
**Description of work.**
Windows devices have been running into issues in places where calling
the functions created to fix an issue on Unix machines in parallel
regions was causing error messages to  appear.

This is due to changes in implementation of omp_set_num_threads between
OpenMP v2 and v2.5+. As MSVC uses the older version of OpenMP I have
added a check that does not bother with the changes from the previous
fix if compiled with MSVC, as the original issue only appeared on non
MSVC compiled versions anyway.

**To test:**
1. Open a non-debug version of mantid plot and workbench on Windows and something else. 
2. Run the SaveGSS algorithm. 
3. No error message should appear. 

*This does not require release notes* because **it fixes an issue not present in the previous release.**

Fixes #27582

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
