### PR TITLE
Correct error on peak intensity in IntegrateEllipsoids

### DIFF
--- a/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
+++ b/Framework/MDAlgorithms/inc/MantidMDAlgorithms/Integrate3DEvents.h
@@ -51,21 +51,23 @@ struct IntegrationParameters {
 
  */
 
-using EventListMap =
-    std::unordered_map<int64_t,
-                       std::vector<std::pair<double, Mantid::Kernel::V3D>>>;
+using EventListMap = std::unordered_map<
+    int64_t,
+    std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>>>;
 using PeakQMap = std::unordered_map<int64_t, Mantid::Kernel::V3D>;
 
 class DLLExport Integrate3DEvents {
 public:
   /// Construct object to store events around peaks and integrate peaks
   Integrate3DEvents(
-      const std::vector<std::pair<double, Mantid::Kernel::V3D>> &peak_q_list,
+      const std::vector<std::pair<std::pair<double, double>,
+                                  Mantid::Kernel::V3D>> &peak_q_list,
       Kernel::DblMatrix const &UBinv, double radius,
       const bool useOnePercentBackgroundCorrection = true);
 
   Integrate3DEvents(
-      const std::vector<std::pair<double, Mantid::Kernel::V3D>> &peak_q_list,
+      const std::vector<std::pair<std::pair<double, double>,
+                                  Mantid::Kernel::V3D>> &peak_q_list,
       std::vector<Mantid::Kernel::V3D> const &hkl_list,
       std::vector<Mantid::Kernel::V3D> const &mnp_list,
       Kernel::DblMatrix const &UBinv, Kernel::DblMatrix const &ModHKL,
@@ -73,9 +75,9 @@ public:
       const bool useOnePercentBackgroundCorrection = true);
 
   /// Add event Q's to lists of events near peaks
-  void
-  addEvents(std::vector<std::pair<double, Mantid::Kernel::V3D>> const &event_qs,
-            bool hkl_integ);
+  void addEvents(std::vector<std::pair<std::pair<double, double>,
+                                       Mantid::Kernel::V3D>> const &event_qs,
+                 bool hkl_integ);
 
   /// Find the net integrated intensity of a peak, using ellipsoidal volumes
   boost::shared_ptr<const Mantid::Geometry::PeakShape> ellipseIntegrateEvents(
@@ -114,7 +116,7 @@ public:
 
 private:
   /// Get a list of events for a given Q
-  const std::vector<std::pair<double, Mantid::Kernel::V3D>> *
+  const std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> *
   getEvents(const Mantid::Kernel::V3D &peak_q);
 
   bool correctForDetectorEdges(std::tuple<double, double, double> &radii,
@@ -125,21 +127,25 @@ private:
                                const std::vector<double> &bkgOuterRadii);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
-  static double numInEllipsoid(
-      std::vector<std::pair<double, Mantid::Kernel::V3D>> const &events,
-      std::vector<Mantid::Kernel::V3D> const &directions,
-      std::vector<double> const &sizes);
+  static std::pair<double, double>
+  numInEllipsoid(std::vector<std::pair<std::pair<double, double>,
+                                       Mantid::Kernel::V3D>> const &events,
+                 std::vector<Mantid::Kernel::V3D> const &directions,
+                 std::vector<double> const &sizes);
 
   /// Calculate the number of events in an ellipsoid centered at 0,0,0
-  static double numInEllipsoidBkg(
-      std::vector<std::pair<double, Mantid::Kernel::V3D>> const &events,
-      std::vector<Mantid::Kernel::V3D> const &directions,
-      std::vector<double> const &sizes, std::vector<double> const &sizesIn,
-      const bool useOnePercentBackgroundCorrection);
+  static std::pair<double, double>
+  numInEllipsoidBkg(std::vector<std::pair<std::pair<double, double>,
+                                          Mantid::Kernel::V3D>> const &events,
+                    std::vector<Mantid::Kernel::V3D> const &directions,
+                    std::vector<double> const &sizes,
+                    std::vector<double> const &sizesIn,
+                    const bool useOnePercentBackgroundCorrection);
 
   /// Calculate the 3x3 covariance matrix of a list of Q-vectors at 0,0,0
   static void makeCovarianceMatrix(
-      std::vector<std::pair<double, Mantid::Kernel::V3D>> const &events,
+      std::vector<std::pair<std::pair<double, double>,
+                            Mantid::Kernel::V3D>> const &events,
       Kernel::DblMatrix &matrix, double radius);
 
   /// Calculate the eigen vectors of a 3x3 real symmetric matrix
@@ -148,7 +154,8 @@ private:
 
   /// Calculate the standard deviation of 3D events in a specified direction
   static double
-  stdDev(std::vector<std::pair<double, Mantid::Kernel::V3D>> const &events,
+  stdDev(std::vector<std::pair<std::pair<double, double>,
+                               Mantid::Kernel::V3D>> const &events,
          Mantid::Kernel::V3D const &direction, double radius);
 
   /// Form a map key as 10^12*h + 10^6*k + l from the integers h, k, l
@@ -163,15 +170,19 @@ private:
   int64_t getHklMnpKey2(Mantid::Kernel::V3D const &hkl);
 
   /// Add an event to the vector of events for the closest h,k,l
-  void addEvent(std::pair<double, Mantid::Kernel::V3D> event_Q, bool hkl_integ);
-  void addModEvent(std::pair<double, Mantid::Kernel::V3D> event_Q,
-                   bool hkl_integ);
+  void
+  addEvent(std::pair<std::pair<double, double>, Mantid::Kernel::V3D> event_Q,
+           bool hkl_integ);
+  void
+  addModEvent(std::pair<std::pair<double, double>, Mantid::Kernel::V3D> event_Q,
+              bool hkl_integ);
 
   /// Find the net integrated intensity of a list of Q's using ellipsoids
   boost::shared_ptr<const Mantid::DataObjects::PeakShapeEllipsoid>
   ellipseIntegrateEvents(
       std::vector<Kernel::V3D> E1Vec, Kernel::V3D const &peak_q,
-      std::vector<std::pair<double, Mantid::Kernel::V3D>> const &ev_list,
+      std::vector<std::pair<std::pair<double, double>,
+                            Mantid::Kernel::V3D>> const &ev_list,
       std::vector<Mantid::Kernel::V3D> const &directions,
       std::vector<double> const &sigmas, bool specify_size, double peak_radius,
       double back_inner_radius, double back_outer_radius,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -566,9 +566,10 @@ std::pair<double, double> Integrate3DEvents::numInEllipsoid(
       double comp = event.second.scalar_prod(directions[k]) / sizes[k];
       sum += comp * comp;
     }
-    if (sum <= 1)
-      count.first += event.first.first; // count
-    count.second += event.first.second; // error squared (add in quadrature)
+    if (sum <= 1) {
+      count.first += event.first.first;   // count
+      count.second += event.first.second; // error squared (add in quadrature)
+    }
   }
 
   return count;

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -45,7 +45,8 @@ using Mantid::Kernel::V3D;
  *                       correction should be used.
  */
 Integrate3DEvents::Integrate3DEvents(
-    const std::vector<std::pair<std::pair<double, double>, V3D>> &peak_q_list,
+    const std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>>
+        &peak_q_list,
     Kernel::DblMatrix const &UBinv, double radius,
     const bool useOnePercentBackgroundCorrection)
     : m_UBinv(UBinv), m_radius(radius), maxOrder(0), crossterm(0),
@@ -80,7 +81,8 @@ Integrate3DEvents::Integrate3DEvents(
  *                       correction should be used.
  */
 Integrate3DEvents::Integrate3DEvents(
-    const std::vector<std::pair<std::pair<double, double>, V3D>> &peak_q_list,
+    const std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>>
+        &peak_q_list,
     std::vector<V3D> const &hkl_list, std::vector<V3D> const &mnp_list,
     Kernel::DblMatrix const &UBinv, Kernel::DblMatrix const &ModHKL,
     double radius_m, double radius_s, int MaxO, const bool CrossT,
@@ -1123,7 +1125,8 @@ void Integrate3DEvents::addModEvent(
  */
 PeakShapeEllipsoid_const_sptr Integrate3DEvents::ellipseIntegrateEvents(
     std::vector<V3D> E1Vec, V3D const &peak_q,
-    std::vector<std::pair<std::pair<double, double>, V3D>> const &ev_list,
+    std::vector<std::pair<std::pair<double, double>, Mantid::Kernel::V3D>> const
+        &ev_list,
     std::vector<V3D> const &directions, std::vector<double> const &sigmas,
     bool specify_size, double peak_radius, double back_inner_radius,
     double back_outer_radius, std::vector<double> &axes_radii, double &inti,

--- a/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
+++ b/Framework/MDAlgorithms/src/Integrate3DEvents.cpp
@@ -614,10 +614,10 @@ std::pair<double, double> Integrate3DEvents::numInEllipsoidBkg(
   auto endIndex = eventVec.size();
   if (useOnePercentBackgroundCorrection) {
     // Remove top 1% of background
-    std::sort(eventVec.begin(), eventVec.end(),
-              [](std::pair<double, double> a, std::pair<double, double> b) {
-                return a.first < b.first;
-              });
+    std::sort(
+        eventVec.begin(), eventVec.end(),
+        [](const std::pair<double, double> &a,
+           const std::pair<double, double> &b) { return a.first < b.first; });
     endIndex = static_cast<size_t>(0.99 * static_cast<double>(endIndex));
   }
 

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -111,7 +111,7 @@ public:
       auto shape = integrator.ellipseIntegrateEvents(
           E1Vec, peak_q_list[i].second, specify_size, peak_radius,
           back_inner_radius, back_outer_radius, new_sigma, inti, sigi);
-      TS_ASSERT_DELTA(inti, 2*inti_all[i], 0.1);
+      TS_ASSERT_DELTA(inti, 2 * inti_all[i], 0.1);
       TS_ASSERT_DELTA(sigi, sigi_all[i], 0.01);
 
       auto ellipsoid_shape = boost::dynamic_pointer_cast<
@@ -127,7 +127,7 @@ public:
       integrator.ellipseIntegrateEvents(
           E1Vec, peak_q_list[i].second, specify_size, peak_radius,
           back_inner_radius, back_outer_radius, new_sigma, inti, sigi);
-      TS_ASSERT_DELTA(inti, 2*inti_some[i], 0.1);
+      TS_ASSERT_DELTA(inti, 2 * inti_some[i], 0.1);
       TS_ASSERT_DELTA(sigi, sigi_some[i], 0.01);
     }
   }
@@ -541,9 +541,7 @@ private:
       for (double j = lower; j < upper; j += step) {
         for (double k = lower; k < upper; k += step) {
           double cts = counts + d(gen);
-          event_Qs.emplace_back(
-              std::make_pair(cts, cts),
-              V3D(i, j, k)); // is it right to add 1. error here?
+          event_Qs.emplace_back(std::make_pair(cts, cts), V3D(i, j, k));
         }
       }
     }

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -27,7 +27,7 @@ public:
   // expected integration results are obtained using either fixed size
   // ellipsoids, or using ellipsoids with axis half-lengths set to
   // three standard deviations.
-  void test_1() {
+  void test_integrateMainPeaksWithFixedRadiiandDefaultScaledRadii() {
     double inti_all[] = {755, 704, 603};
     double sigi_all[] = {27.4773, 26.533, 24.5561};
 
@@ -59,37 +59,37 @@ public:
     std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     for (int i = -100; i <= 100; i++) {
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
+          std::make_pair(2., 1.), V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
+          std::make_pair(2., 1.), V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
+          std::make_pair(2., 1.), V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
 
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
+          std::make_pair(2., 1.), V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
+          std::make_pair(2., 1.), V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
+          std::make_pair(2., 1.), V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
 
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
+          std::make_pair(2., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
+          std::make_pair(2., 1.), V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
+          std::make_pair(2., 1.), V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
     }
 
     for (int i = -50; i <= 50; i++) {
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
+          std::make_pair(2., 1.), V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
+          std::make_pair(2., 1.), V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
     }
 
     for (int i = -25; i <= 25; i++) {
       event_Qs.emplace_back(std::make_pair(
-          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
+          std::make_pair(2., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
     }
 
     double radius = 1.3;
@@ -111,7 +111,7 @@ public:
       auto shape = integrator.ellipseIntegrateEvents(
           E1Vec, peak_q_list[i].second, specify_size, peak_radius,
           back_inner_radius, back_outer_radius, new_sigma, inti, sigi);
-      TS_ASSERT_DELTA(inti, inti_all[i], 0.1);
+      TS_ASSERT_DELTA(inti, 2*inti_all[i], 0.1);
       TS_ASSERT_DELTA(sigi, sigi_all[i], 0.01);
 
       auto ellipsoid_shape = boost::dynamic_pointer_cast<
@@ -127,7 +127,7 @@ public:
       integrator.ellipseIntegrateEvents(
           E1Vec, peak_q_list[i].second, specify_size, peak_radius,
           back_inner_radius, back_outer_radius, new_sigma, inti, sigi);
-      TS_ASSERT_DELTA(inti, inti_some[i], 0.1);
+      TS_ASSERT_DELTA(inti, 2*inti_some[i], 0.1);
       TS_ASSERT_DELTA(sigi, sigi_some[i], 0.01);
     }
   }

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -39,8 +39,10 @@ public:
     V3D peak_1(10, 0, 0);
     V3D peak_2(0, 5, 0);
     V3D peak_3(0, 0, 4);
-    std::vector<std::pair<double, V3D>> peak_q_list{
-        {1., peak_1}, {1., peak_2}, {1., peak_3}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1},
+        {std::make_pair(1., 1.), peak_2},
+        {std::make_pair(1., 1.), peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -54,40 +56,40 @@ public:
     // around peak 1, 704 events around
     // peak 2, and 603 events around
     // peak 3.
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     for (int i = -100; i <= 100; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
 
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
 
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
     }
 
     for (int i = -50; i <= 50; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
     }
 
     for (int i = -25; i <= 25; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
     }
 
     double radius = 1.3;
@@ -142,8 +144,10 @@ public:
     V3D peak_1(6, 0, 0);
     V3D peak_2(0, 5, 0);
     V3D peak_3(0, 0, 4);
-    std::vector<std::pair<double, V3D>> peak_q_list{
-        {1., peak_1}, {1., peak_2}, {1., peak_3}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1},
+        {std::make_pair(1., 1.), peak_2},
+        {std::make_pair(1., 1.), peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -167,40 +171,40 @@ public:
     // around peak 1, 704 events around
     // peak 2, and 603 events around
     // peak 3.
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     for (int i = -100; i <= 100; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D((double)i / 100.0, 0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D((double)i / 100.0, 0, 0))));
 
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 200.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, (double)i / 200.0, 0))));
 
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, 0, (double)i / 300.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_3 + V3D(0, 0, (double)i / 300.0))));
     }
 
     for (int i = -50; i <= 50; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, (double)i / 147.0, 0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_2 + V3D(0, (double)i / 147.0, 0))));
     }
 
     for (int i = -25; i <= 25; i++) {
-      event_Qs.emplace_back(
-          std::make_pair(1., V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
+      event_Qs.emplace_back(std::make_pair(
+          std::make_pair(1., 1.), V3D(peak_1 + V3D(0, 0, (double)i / 61.0))));
     }
 
     double radius = 0.3;
@@ -260,8 +264,10 @@ public:
     V3D peak_1(20, 0, 0);
     V3D peak_2(0, 20, 0);
     V3D peak_3(0, 0, 20);
-    std::vector<std::pair<double, V3D>> peak_q_list{
-        {1., peak_1}, {1., peak_2}, {1., peak_3}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1},
+        {std::make_pair(1., 1.), peak_2},
+        {std::make_pair(1., 1.), peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -269,7 +275,7 @@ public:
     UBinv.setRow(1, V3D(0, .2, 0));
     UBinv.setRow(2, V3D(0, 0, .25));
 
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     const int numStrongEvents = 10000;
     const int numWeakEvents = 100;
     generatePeak(event_Qs, peak_1, 0.1, numStrongEvents, 1); // strong peak
@@ -336,7 +342,8 @@ public:
     // synthesize two peaks
     V3D peak_1(20, 0, 0);
     V3D peak_2(0, 20, 0);
-    std::vector<std::pair<double, V3D>> peak_q_list{{1., peak_1}, {1., peak_2}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1}, {std::make_pair(1., 1.), peak_2}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -344,7 +351,7 @@ public:
     UBinv.setRow(1, V3D(0, .2, 0));
     UBinv.setRow(2, V3D(0, 0, .25));
 
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     const int numStrongEvents = 10000;
     const int numWeakEvents = 100;
     generatePeak(event_Qs, peak_1, 0.1, numStrongEvents, 1); // strong peak
@@ -394,8 +401,10 @@ public:
     V3D peak_1(20, 0, 0);
     V3D peak_2(0, 20, 0);
     V3D peak_3(0, 0, 20);
-    std::vector<std::pair<double, V3D>> peak_q_list{
-        {1., peak_1}, {1., peak_2}, {1., peak_3}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1},
+        {std::make_pair(1., 1.), peak_2},
+        {std::make_pair(1., 1.), peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -403,7 +412,7 @@ public:
     UBinv.setRow(1, V3D(0, .2, 0));
     UBinv.setRow(2, V3D(0, 0, .25));
 
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     const int numStrongEvents = 10000;
     const int numWeakEvents = 100;
     generatePeak(event_Qs, peak_1, 0.1, numStrongEvents, 1);   // strong peak
@@ -446,8 +455,10 @@ private:
     V3D peak_1(20, 0, 0);
     V3D peak_2(0, 20, 0);
     V3D peak_3(0, 0, 20);
-    std::vector<std::pair<double, V3D>> peak_q_list{
-        {1., peak_1}, {1., peak_2}, {1., peak_3}};
+    std::vector<std::pair<std::pair<double, double>, V3D>> peak_q_list{
+        {std::make_pair(1., 1.), peak_1},
+        {std::make_pair(1., 1.), peak_2},
+        {std::make_pair(1., 1.), peak_3}};
 
     // synthesize a UB-inverse to map
     DblMatrix UBinv(3, 3, false); // Q to h,k,l
@@ -455,7 +466,7 @@ private:
     UBinv.setRow(1, V3D(0, .2, 0));
     UBinv.setRow(2, V3D(0, 0, .25));
 
-    std::vector<std::pair<double, V3D>> event_Qs;
+    std::vector<std::pair<std::pair<double, double>, V3D>> event_Qs;
     const int numStrongEvents = 10000;
     const int numWeakEvents = 100;
     generatePeak(event_Qs, peak_1, 0.1, numStrongEvents, 1);   // strong peak
@@ -492,8 +503,10 @@ private:
    * @param numSamples :: number of samples to draw
    * @param seed :: the seed to the pseudo-random number generator
    */
-  void generatePeak(std::vector<std::pair<double, V3D>> &event_Qs, V3D center,
-                    double sigma = 5, size_t numSamples = 1000, int seed = 1) {
+  void
+  generatePeak(std::vector<std::pair<std::pair<double, double>, V3D>> &event_Qs,
+               V3D center, double sigma = 5, size_t numSamples = 1000,
+               int seed = 1) {
 
     std::mt19937 gen;
     std::normal_distribution<> d(0, sigma);
@@ -501,7 +514,8 @@ private:
 
     for (size_t i = 0; i < numSamples; ++i) {
       V3D offset(d(gen), d(gen), d(gen));
-      event_Qs.emplace_back(std::make_pair(1., center + offset));
+      event_Qs.emplace_back(
+          std::make_pair(std::make_pair(1., 1.), center + offset));
     }
   }
 
@@ -514,11 +528,10 @@ private:
    * @param countVariation :: how much the average background can vary by
    * @param seed :: the random seed to use (default 1)
    */
-  void generateUniformBackground(std::vector<std::pair<double, V3D>> &event_Qs,
-                                 size_t countsPerQ, const double lower,
-                                 const double upper,
-                                 const int countVariation = 3,
-                                 const double step = 0.5, int seed = 1) {
+  void generateUniformBackground(
+      std::vector<std::pair<std::pair<double, double>, V3D>> &event_Qs,
+      size_t countsPerQ, const double lower, const double upper,
+      const int countVariation = 3, const double step = 0.5, int seed = 1) {
     const auto counts = static_cast<double>(countsPerQ);
     std::mt19937 gen;
     std::uniform_real_distribution<> d(-countVariation, countVariation);
@@ -527,7 +540,9 @@ private:
     for (double i = lower; i < upper; i += step) {
       for (double j = lower; j < upper; j += step) {
         for (double k = lower; k < upper; k += step) {
-          event_Qs.emplace_back(counts + d(gen), V3D(i, j, k));
+          event_Qs.emplace_back(
+              std::make_pair(counts + d(gen), 1.),
+              V3D(i, j, k)); // is it right to add 1. error here?
         }
       }
     }

--- a/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
+++ b/Framework/MDAlgorithms/test/Integrate3DEventsTest.h
@@ -540,8 +540,9 @@ private:
     for (double i = lower; i < upper; i += step) {
       for (double j = lower; j < upper; j += step) {
         for (double k = lower; k < upper; k += step) {
+          double cts = counts + d(gen);
           event_Qs.emplace_back(
-              std::make_pair(counts + d(gen), 1.),
+              std::make_pair(cts, cts),
               V3D(i, j, k)); // is it right to add 1. error here?
         }
       }


### PR DESCRIPTION
**Description of work.**
Previously IntegrateEllipsoids calculated the error on the integrated intensity assuming that for each event the associated error was sqrt(counts). In general this is not true (e.g. normalised to a monitor) and this has been corrected. This fix also applies to IntegrateEllipsoidsTwoStep algorithm.

The ratio of integrated intensity/error was compared to another peak integration IntegratePeaksMD by hard-coding a spherical integration region of the same radius (and same background shell radii). The calculated error now agrees with the error from IntegratePeaksMD.

![image](https://user-images.githubusercontent.com/55979119/70999186-cd6d4c00-20d0-11ea-9051-d1b90bf69d14.png)

**To test:**

(1) Integrate a PeaksWorkspace using IntegreateEllipsoids and IntegrateEllipspodsTwoStep - is there an error? Can follow script here https://docs.mantidproject.org/nightly/algorithms/IntegrateEllipsoids-v1.html

Fixes #27446 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
