### PR TITLE
Remove 'Of' in .getNumberPeaks()

### DIFF
--- a/docs/source/concepts/PeaksWorkspace.rst
+++ b/docs/source/concepts/PeaksWorkspace.rst
@@ -82,7 +82,7 @@ PeaksWorkspace Python Interface
 .. code-block:: python
 
     pws = mtd['name_of_peaks_workspace']
-    pws.getNumberOfPeaks()
+    pws.getNumberPeaks()
     p = pws.getPeak(12)
     pws.removePeak(34) 
 


### PR DESCRIPTION
**Description of work.**

On [this page](https://docs.mantidproject.org/nightly/concepts/PeaksWorkspace.html) of the docs this function is called .getNumberOfPeaks() but its just .getNumberPeaks()

This confused a user on the [Mantid Help Forum](https://forum.mantidproject.org/t/using-peaksworkspace/618), so its worth correcting this!

**To test:** Build docs.html if you wish, literally just this one word change!

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **documentation**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
