### PR TITLE
Fix Crash in SaveGSS Algorithm when Using Group Workspaces

### DIFF
--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -119,12 +119,13 @@ void writeBankHeader(std::stringstream &out, const std::string &bintype,
 //----------------------------------------------------------------------------------------------
 // Initialise the algorithm
 void SaveGSS::init() {
+  const std::vector<std::string> exts{".gsa", ".gss", ".gda", ".txt"};
   declareProperty(std::make_unique<API::WorkspaceProperty<MatrixWorkspace>>(
                       "InputWorkspace", "", Kernel::Direction::Input),
                   "The input workspace");
 
-  declareProperty(std::make_unique<API::FileProperty>("Filename", "",
-                                                      API::FileProperty::Save),
+  declareProperty(std::make_unique<API::FileProperty>(
+                      "Filename", "", API::FileProperty::Save, exts),
                   "The filename to use for the saved data");
 
   declareProperty(
@@ -716,8 +717,8 @@ std::map<std::string, std::string> SaveGSS::validateInputs() {
 
   API::MatrixWorkspace_const_sptr input_ws = getProperty("InputWorkspace");
   if (!input_ws) {
-    result.emplace("InputWorkspace",
-                   "The input workspace cannot be a GroupWorkspace.");
+    result["InputWorkspace"] =
+        "The input workspace cannot be a GroupWorkspace.";
     return result;
   }
   // Check the number of histogram/spectra < 99

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -119,7 +119,7 @@ void writeBankHeader(std::stringstream &out, const std::string &bintype,
 //----------------------------------------------------------------------------------------------
 // Initialise the algorithm
 void SaveGSS::init() {
-  declareProperty(std::make_unique<API::WorkspaceProperty<>>(
+  declareProperty(std::make_unique<API::WorkspaceProperty<MatrixWorkspace>>(
                       "InputWorkspace", "", Kernel::Direction::Input),
                   "The input workspace");
 
@@ -715,7 +715,11 @@ std::map<std::string, std::string> SaveGSS::validateInputs() {
   std::map<std::string, std::string> result;
 
   API::MatrixWorkspace_const_sptr input_ws = getProperty("InputWorkspace");
-
+  if (!input_ws) {
+    result.emplace("InputWorkspace",
+                   "The input workspace cannot be a GroupWorkspace.");
+    return result;
+  }
   // Check the number of histogram/spectra < 99
   const auto nHist = static_cast<int>(input_ws->getNumberHistograms());
   const bool split = getProperty("SplitFiles");

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -43,6 +43,8 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
+- Fixed a bug where `SaveGSS <algm-SaveGSS-v1>` could crash when attempting to pass a group workspace into it.
+
 Single Crystal Diffraction
 --------------------------
 


### PR DESCRIPTION
When a Group workspace was loaded into the dialog for the algorithm, it
would cause an unhandled exception due to a null pointer. There is now a
check to ensure that a group workspace is not used.

**To test:**
1. Load some workspaces and put them into a group. 
2. Launch the `SaveGSS` algorithm from the algorithm manager (this issue was not present when running the algorithm in the script interpreter).
3. Select the Group Workspace and attempt to run the algorithm. 
4. No error reporter should appear. 

Fixes #27592

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
