### PR TITLE
Add Indirect note in the SaveAscii v1 Docs

### DIFF
--- a/docs/source/algorithms/SaveAscii-v1.rst
+++ b/docs/source/algorithms/SaveAscii-v1.rst
@@ -14,6 +14,9 @@ contains the X-values, followed by pairs of Y and E values. Columns are
 separated by commas. The resulting file can normally be loaded into a
 workspace by the :ref:`algm-LoadAscii` algorithm.
 
+As far as we are aware, this algorithm is only used by the ISIS Indirect group (including within the Indirect Diffraction GUI).
+Please see the new version: :ref:`algm-SaveAscii`.
+
 Limitations
 ###########
 


### PR DESCRIPTION
**Description of work.**
Add in note in the SaveAscii v1 docs to mention that this algorithm is exclusively used by the ISIS indirect group

**To test:**
Build docs.html if you wish, just a small change.

*There is no associated issue.*

*This does not require release notes* because **it is Documentation**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
