### PR TITLE
fixed getting started instructions for Linux

### DIFF
--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -84,7 +84,7 @@ Ubuntu
 .. code-block:: sh
 
    apt install gdebi-core
-   apt install ~/Downloads/mantid-developer.X.Y.Z.deb
+   gdebi ~/Downloads/mantid-developer.X.Y.Z.deb
 
 where ``X.Y.Z`` should be replaced with the version that was downloaded.
 


### PR DESCRIPTION
**Description of work.**
The developer docs had the wrong instructions for installing mantid developer on linux. This fixes the command.

There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
Does not need to be in release notes
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
