### PR TITLE
Implements EventList method to add a different pulsetime per event

### DIFF
--- a/Framework/API/inc/MantidAPI/IEventList.h
+++ b/Framework/API/inc/MantidAPI/IEventList.h
@@ -75,6 +75,8 @@ public:
   virtual void addTof(const double offset) = 0;
   /// Add a value to the pulse time values
   virtual void addPulsetime(const double seconds) = 0;
+  /// Add a separate value to each of the pulse time values
+  virtual void addPulsetimes(const std::vector<double> &seconds) = 0;
   /// Mask a given TOF range
   virtual void maskTof(const double tofMin, const double tofMax) = 0;
   /// Mask the events by the condition vector

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -243,6 +243,8 @@ public:
 
   void addPulsetime(const double seconds) override;
 
+  void addPulsetimes(const std::vector<double> &seconds) override;
+
   void maskTof(const double tofMin, const double tofMax) override;
   void maskCondition(const std::vector<bool> &mask) override;
 
@@ -453,6 +455,9 @@ private:
                         const double offset);
   template <class T>
   void addPulsetimeHelper(std::vector<T> &events, const double seconds);
+  template <class T>
+  void addPulsetimesHelper(std::vector<T> &events,
+                           const std::vector<double> &seconds);
   template <class T>
   static std::size_t maskTofHelper(std::vector<T> &events, const double tofMin,
                                    const double tofMax);

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2632,6 +2632,23 @@ void EventList::addPulsetimeHelper(std::vector<T> &events,
   }
 }
 
+/** Add an offset per event to the pulsetime (wall-clock time) of each event in
+ * the list. It is assumed that the vector sizes match.
+ *
+ * @param events :: reference to a vector of events to change.
+ * @param seconds :: The set of values to shift the pulsetime by, in seconds
+ */
+template <class T>
+void EventList::addPulsetimesHelper(std::vector<T> &events,
+                                    const std::vector<double> &seconds) {
+  auto eventIterEnd{events.end()};
+  auto secondsIter{seconds.cbegin()};
+  for (auto eventIter = events.begin(); eventIter < eventIterEnd;
+       ++eventIter, ++secondsIter) {
+    eventIter->m_pulsetime += *secondsIter;
+  }
+}
+
 // --------------------------------------------------------------------------
 /** Add an offset to the pulsetime (wall-clock time) of each event in the list.
  *
@@ -2648,6 +2665,34 @@ void EventList::addPulsetime(const double seconds) {
     break;
   case WEIGHTED:
     this->addPulsetimeHelper(this->weightedEvents, seconds);
+    break;
+  case WEIGHTED_NOTIME:
+    throw std::runtime_error("EventList::addPulsetime() called on an event "
+                             "list with no pulse times. You must call this "
+                             "algorithm BEFORE CompressEvents.");
+    break;
+  }
+}
+
+// --------------------------------------------------------------------------
+/** Add an offset to the pulsetime (wall-clock time) of each event in the list.
+ *
+ * @param seconds :: A set of values to shift the pulsetime by, in seconds
+ */
+void EventList::addPulsetimes(const std::vector<double> &seconds) {
+  if (this->getNumberEvents() <= 0)
+    return;
+  if (this->getNumberEvents() != seconds.size()) {
+    throw std::runtime_error("");
+  }
+
+  // Convert the list
+  switch (eventType) {
+  case TOF:
+    this->addPulsetimesHelper(this->events, seconds);
+    break;
+  case WEIGHTED:
+    this->addPulsetimesHelper(this->weightedEvents, seconds);
     break;
   case WEIGHTED_NOTIME:
     throw std::runtime_error("EventList::addPulsetime() called on an event "

--- a/Framework/DataObjects/test/EventListTest.h
+++ b/Framework/DataObjects/test/EventListTest.h
@@ -1503,7 +1503,6 @@ public:
     }
   }
 
-  //-----------------------------------------------------------------------------------------------
   void test_addPulseTime_allTypes() {
     // Go through each possible EventType as the input
     for (int this_type = 0; this_type < 3; this_type++) {
@@ -1515,6 +1514,45 @@ public:
         TS_ASSERT_THROWS_ANYTHING(this->el.addPulsetime(123e-9);)
       } else {
         this->el.addPulsetime(123e-9);
+        // Unchanged size
+        TS_ASSERT_EQUALS(old_num, this->el.getNumberEvents());
+        // original times were 0, 1, etc. nansoeconds
+        TSM_ASSERT_EQUALS(this_type,
+                          this->el.getEvent(0).pulseTime().totalNanoseconds(),
+                          123);
+        TSM_ASSERT_EQUALS(this_type,
+                          this->el.getEvent(1).pulseTime().totalNanoseconds(),
+                          124);
+        TSM_ASSERT_EQUALS(this_type,
+                          this->el.getEvent(2).pulseTime().totalNanoseconds(),
+                          125);
+      }
+    }
+  }
+
+  void test_addPulseTimes_vector_throws_if_size_not_match_number_events() {
+    // Go through each possible EventType as the input
+    const std::vector<double> offsets = {1, 2, 3, 4, 5, 6};
+    for (int this_type = 0; this_type < 3; this_type++) {
+      this->fake_uniform_time_data();
+      el.switchTo(static_cast<EventType>(this_type));
+      // Do convert
+      TS_ASSERT_THROWS(this->el.addPulsetimes(offsets), std::runtime_error);
+    }
+  }
+
+  void test_addPulseTimes_vector_allTypes() {
+    // Go through each possible EventType as the input
+    for (int this_type = 0; this_type < 3; this_type++) {
+      this->fake_uniform_time_data();
+      el.switchTo(static_cast<EventType>(this_type));
+      const size_t old_num = this->el.getNumberEvents();
+      std::vector<double> offsets(old_num, 123e-9);
+      // Do convert
+      if (static_cast<EventType>(this_type) == WEIGHTED_NOTIME) {
+        TS_ASSERT_THROWS_ANYTHING(this->el.addPulsetimes(offsets))
+      } else {
+        this->el.addPulsetimes(offsets);
         // Unchanged size
         TS_ASSERT_EQUALS(old_num, this->el.getNumberEvents());
         // original times were 0, 1, etc. nansoeconds

--- a/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IEventList.cpp
@@ -26,10 +26,15 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(IEventList)
 
 namespace {
+void addPulsetimes(IEventList &self, const NDArray &data) {
+  self.addPulsetimes(Converters::NDArrayToVector<double>(data)());
+}
+
 void maskCondition(IEventList &self, const NDArray &data) {
   self.maskCondition(Converters::NDArrayToVector<bool>(data)());
 }
 } // namespace
+
 /// return_value_policy for copied numpy array
 using return_clone_numpy = return_value_policy<Policies::VectorToNumpy>;
 
@@ -70,6 +75,9 @@ void export_IEventList() {
            "Add an offset to the TOF of each event in the list.")
       .def("addPulsetime", &IEventList::addPulsetime, args("self", "seconds"),
            "Add an offset to the pulsetime (wall-clock time) of each event in "
+           "the list.")
+      .def("addPulsetimes", &addPulsetimes, args("self", "seconds"),
+           "Add offsets to the pulsetime (wall-clock time) of each event in "
            "the list.")
       .def("maskTof", &IEventList::maskTof, args("self", "tofMin", "tofMax"),
            "Mask out events that have a tof between tofMin and tofMax "


### PR DESCRIPTION
**Description of work.**

A user wished to offset the pulsetime for each event by a different amount. Our current methods only allow a single offset for a whole list. This implements a method accepting a vector of offsets and exposes it to Python.

**To test:**
The following should so a difference of 1000000000 nanoseconds:

```python
import numpy as np

raw_data = CreateSampleWorkspace(WorkspaceType='Event')
evt_list = raw_data.getSpectrum(0)
pulsetimes_old = evt_list.getPulseTimesAsNumpy()
ones = np.ones(evt_list.getNumberEvents())
evt_list.addPulsetimes(ones)
pulsetimes_new = evt_list.getPulseTimesAsNumpy()
print(pulsetimes_new - pulsetimes_old)
```

*There is no associated issue.*

It's a small enough change to an API most users do not use so it has not been added to the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
