### PR TITLE
Upgrade HDF5 to 1.10 in Windows bundle

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -10,7 +10,7 @@ if( MSVC )
   include ( ExternalProject )
   set( EXTERNAL_ROOT ${PROJECT_SOURCE_DIR}/external CACHE PATH "Location to clone third party dependencies to" )
   set( THIRD_PARTY_GIT_URL "https://github.com/mantidproject/thirdparty-msvc2015.git" )
-  set ( THIRD_PARTY_GIT_SHA1 df6c47608066dc639d9313df5b15e7fd493895ac )
+  set ( THIRD_PARTY_GIT_SHA1 622c6d0aa7d4480cd4d338e153f1f09e52b8fb09 )
   set ( THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty )
   # Generates a script to do the clone/update in tmp
   set ( _project_name ThirdParty )

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -89,12 +89,13 @@ find_package(Doxygen) # optional
 
 if(CMAKE_HOST_WIN32)
   find_package(ZLIB REQUIRED CONFIGS zlib-config.cmake)
-  set(HDF5_DIR "${THIRD_PARTY_DIR}/cmake")
+  set(HDF5_DIR "${THIRD_PARTY_DIR}/cmake/hdf5")
   find_package(
     HDF5
     COMPONENTS CXX HL
     REQUIRED CONFIGS hdf5-config.cmake
   )
+  set (HDF5_LIBRARIES hdf5::hdf5_cpp-shared hdf5::hdf5_hl-shared)
 else()
   find_package(ZLIB REQUIRED)
   find_package(


### PR DESCRIPTION
**Description of work.**

This is a spin out of just the HDF5 upgrade from #27570. The Python 3 work requires a rebuild of h5py and it makes most sense to do this on top of 1.10 rather than 1.8 then 1.10 when we upgrade very shortly.

**To test:**

Test should pass

*There is no associated issue.*

*This does not require release notes* because **users do not directly see this.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
