### PR TITLE
Update HDF5 docs URL to fix sphinx warning

### DIFF
--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -168,7 +168,7 @@ epub_uid = "Mantid Reference: " + version
 # -- Link to other projects ----------------------------------------------------
 
 intersphinx_mapping = {
-    'h5py': ('http://docs.h5py.org/en/latest/', None),
+    'h5py': ('https://h5py.readthedocs.io/en/stable/', None),
     'matplotlib': ('http://matplotlib.org', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'python': ('https://docs.python.org/3/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -208,7 +208,7 @@ exec(compile(open(html_theme_cfg).read(), html_theme_cfg, 'exec'))
 # -- Link to other projects ----------------------------------------------------
 
 intersphinx_mapping = {
-    'h5py': ('https://docs.h5py.org/en/latest/', None),
+    'h5py': ('https://h5py.readthedocs.io/en/stable/', None),
     'matplotlib': ('https://matplotlib.org', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
**Description of work.**

Updates the HDF5 URL to the new one. Using browsers or wget would
correctly redirect the request to the new URL, whilst sphinx would get a
HTTP 403 instead.

Updating this URL should fix the sphinx warning, restoring the master
incremental and clean builds to stable (hopefully)

**To test:**
- Build the docs target, I'd recommend piping the output to a file or increasing the scrollback limit
- Check there is no 403 HTTP error when loading the Sphinx inventory (completed before reading from files)


*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
