### PR TITLE
Adds Python TOML lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ if(ENABLE_CPACK)
         "${CPACK_RPM_PACKAGE_REQUIRES},"
         "boost169-python3,"
         "python36-numpy,python36-scipy,python36-h5py,python36-PyCifRW,"
-        "python36-six,python36-PyYAML,python36-requests,"
+        "python36-six,python36-PyYAML,python36-requests,python36-toml,"
         "python36-ipython,python36-ipython-notebook"
       )
       if(ENABLE_MANTIDPLOT)
@@ -519,6 +519,7 @@ if(ENABLE_CPACK)
           "python3-matplotlib,"
           "python3-qtpy,"
           "python3-scipy,"
+          "python3-toml,"
           "python3-pycifrw (>= 4.2.1),"
           "python3-yaml,"
           "ipython3-qtconsole") # transitional package for bionic

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -17,7 +17,7 @@ if(MSVC)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 0df29c0aac6d8debb494af2279bc95772b585081)
+  set(THIRD_PARTY_GIT_SHA1 5a0617ecb9a99712b72276a92d6f400257132e2f)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)

--- a/buildconfig/dev-packages/deb/mantid-developer/ns-control
+++ b/buildconfig/dev-packages/deb/mantid-developer/ns-control
@@ -3,7 +3,7 @@ Priority: optional
 Standards-Version: 3.9.2
 
 Package: mantid-developer
-Version: 1.4.1
+Version: 1.5
 Maintainer: Mantid Project <mantid-tech@mantidproject.org>
 Priority: optional
 Architecture: all
@@ -46,16 +46,16 @@ Depends: git,
   python-qt4-dbg,
   pyqt5-dev,
   pyqt5-dev-tools,
-  python-qtpy,
-  python-sphinx,
   python-dateutil,
-  python-sphinx-bootstrap-theme,
-  python-matplotlib,
   python-h5py,
-  python-yaml,
+  python-matplotlib,
   python-mock,
   python-psutil,
+  python-qtpy,
   python-requests,
+  python-sphinx,
+  python-sphinx-bootstrap-theme,
+  python-yaml,
   ipython-qtconsole (>=1.2.0),
   texlive,
   texlive-latex-extra,
@@ -75,13 +75,14 @@ Depends: git,
   python3-matplotlib,
   ipython3-qtconsole,
   python3-h5py,
-  python3-yaml,
   python3-mock,
   python3-psutil,
-  python3-requests
+  python3-requests,
+  python3-toml,
+  python3-yaml
 Description: Installs all packages required for a Mantid developer
  A metapackage which requires all the dependencies and tools that are
- required for Mantid development. It works for Ubuntu 16.04.
+ required for Mantid development. It works for Ubuntu 18.04.
  Some packages must be newer than those in the Ubuntu repository. Please
  follow instructions at http://www.mantidproject.org/Mantid_Prerequisites#Repositories
 Installed-Size: 0

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.38
+Version:        1.39
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -109,6 +109,7 @@ Requires: python%{python3_pkgversion}-scipy
 Requires: python%{python3_pkgversion}-setuptools
 Requires: python%{python3_pkgversion}-sphinx
 Requires: python%{python3_pkgversion}-sphinx-bootstrap-theme
+Requires: python%{python3_pkgversion}-toml
 Requires: python%{python3_pkgversion}-PyYAML
 %endif
 
@@ -133,6 +134,9 @@ required for Mantid development.
 %files
 
 %changelog
+* Mon Jan 28 2020 David Fairbrother <david.fairbrother@stfc.ac.uk>
+- Added Python TOML library
+
 * Fri Jan 24 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
 - Att matplotlib backend for Python 3
 

--- a/installers/MacInstaller/make_package.rb
+++ b/installers/MacInstaller/make_package.rb
@@ -54,6 +54,7 @@ BUNDLED_PY_MODULES_COMMON = [
   'sphinx',
   'sphinx_bootstrap_theme',
   'traitlets',
+  'toml',
   'urllib3',
   'wcwidth',
   'yaml',


### PR DESCRIPTION
**Description of work.**

**Note this cannot be merged before [the MSVC deps are updated](https://github.com/mantidproject/thirdparty-msvc2015/pull/51)**

Adds the Python library [toml](https://pypi.org/project/toml/) to the required packages list for RHEL / Debian / Mac. 
Additionally, it bumps the SHA for MSVC deps to a versionwith the required files

**To test:**
- The easiest way is to test on Windows (or build the updated dep package on Linux/RHEL and install that)
- Start Mantid and type
```python
import toml
```

Fixes #27654 . 

*This does not require release notes* because this is part of epic #18826

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
