### PR TITLE
Fix speed regression when plotting spectra

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -638,7 +638,8 @@ class MantidAxes(Axes):
 
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(workspace,
-                                                     plotfunctions.plot(self, *args, **kwargs),
+                                                     plotfunctions.plot(self, normalize_by_bin_width = is_normalized,
+                                                                        *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
                                                      MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
             return artist

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -116,6 +116,7 @@ def _plot_impl(axes, workspace, args, kwargs):
         if kwargs.pop('update_axes_labels', True):
             _setLabels1D(axes, workspace, indices,
                          normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+    kwargs.pop('normalize_by_bin_width', None)
     return x, y, args, kwargs
 
 
@@ -137,6 +138,9 @@ def plot(axes, workspace, *args, **kwargs):
     :param normalization: ``None`` (default) ask the workspace. Applies to MDHisto workspaces. It can override
                           the value from displayNormalizationHisto. It checks only if
                           the normalization is mantid.api.MDNormalization.NumEventsNormalization
+    :param normalize_by_bin_width: ``None`` (default) ask the workspace. It can override
+                          the value from distribution. Is implemented so get_normalize_by_bin_width
+                          only need to be run once.
     :param LogName:   if specified, it will plot the corresponding sample log. The x-axis
                       of the plot is the time difference between the log time and the first
                       value of the `proton_charge` log (if available) or the sample log's


### PR DESCRIPTION
**Description of work.**
This PR reduces the amount of time it takes to plot spectra in workbench, particularly noticeable for large workspaces. The increase in time was due to a check being added which included checking if the workspace has common bins, the refactoring makes it so this check is only done once.

**To test:**
Load a large workspace (try WISH00038237.raw from SystemTest Data)
Plot a single spectrum from the Workspace
It should only take a couple of seconds - it will be quicker on a release build than a debug build

Fixes #27628 

*This does not require release notes* because **the regression was during this sprint**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
