### PR TITLE
Make normalization of fit curve match the data curve

### DIFF
--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -66,10 +66,9 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
     if normalize_by_bin_width is not None:
         return normalize_by_bin_width, kwargs
     distribution = kwargs.get('distribution', None)
-    aligned, _ = check_resample_to_regular_grid(workspace, **kwargs)
     if distribution or (hasattr(workspace, 'isDistribution') and workspace.isDistribution()):
         return False, kwargs
-    elif distribution is False or aligned:
+    elif distribution is False:
         return True, kwargs
     else:
         try:
@@ -82,7 +81,10 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
                 [artist[0].is_normalized for artist in current_artists])
             normalization = current_normalization
         else:
-            normalization = mantid.kernel.config['graph1d.autodistribution'].lower() == 'on'
+            if mantid.kernel.config['graph1d.autodistribution'].lower() == 'on':
+                normalization = True
+            else:
+                normalization, _ = check_resample_to_regular_grid(workspace, **kwargs)
     return normalization, kwargs
 
 


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the fit curves were always being normalised even if the data curve wasn't. 

**To test:**
Plot a spectrum (WISH00046971.nxs was used in issue).
 Right-click and change the Bin-width normalisation to `None`.
Then fit a peak on the plot - the fitted curve should not be normalised.
Change the normalisation to `Bin Width`
Do a fit - the curve should now be normalised

Fixes #27622 

*This does not require release notes* because **this regression was during this sprint**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
