### PR TITLE
Fixing crash with fit constraints in the Muon Analysis 2 GUI

### DIFF
--- a/docs/source/release/v4.3.0/muon.rst
+++ b/docs/source/release/v4.3.0/muon.rst
@@ -23,5 +23,6 @@ Bug Fixes
 #########
 
 - The elemental analysis GUI can now handle legacy data which is missing a response dataset, e.g Delayed.
+- Fixed a bug with constraints in the Muon Analysis 2 GUI which would cause Mantid to crash.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -209,8 +209,8 @@ protected:
   /// Check if a parameter property has a upper bound
   bool hasUpperBound(QtProperty *prop) const;
   /// Get a constraint string
-  QString getConstraint(const QString &paramName, const QString &lowerBound,
-                        const QString &upperBound) const;
+  QString getConstraint(const QString &paramName, const double &lowerBound,
+                        const double &upperBound) const;
   /// Get a pair of function index (eg f0.f2.) and constraint expression given a
   /// parameter property
   std::pair<QString, QString> getFunctionAndConstraint(QtProperty *prop) const;
@@ -286,7 +286,7 @@ protected:
   /// Manager for function tie properties
   QtStringPropertyManager *m_tieManager;
   /// Manager for parameter constraint properties
-  QtStringPropertyManager *m_constraintManager;
+  QtDoublePropertyManager *m_constraintManager;
   /// Manager for file name attributes
   QtStringPropertyManager *m_filenameManager;
   /// Manager for Formula attributes

--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_presenter.py
@@ -363,7 +363,7 @@ class FittingTabPresenter(object):
         else:
             self._fit_function = [self.view.fit_object.clone() for _ in self.selected_data] \
                 if self.selected_data else [self.view.fit_object.clone()]
-        self.clear_fit_information()
+
         if self.automatically_update_fit_name:
             self.view.function_name = self.model.get_function_name(
                 self.view.fit_object)


### PR DESCRIPTION
**Description of work.**
Fixed a crash which would occur if a constraint was added to a fit function in the Muon Analysis 2 GUI. This crash had two aspects, firstly it would crash if a constraint was changed, which once fixed exposed another bug with character inputs into the constraints (e.g any letter) which would cause Mantid to crash.


**Report to:** James Lord


**To test:**
Open the Muon Analysis 2 GUI
Load some data e.g (MUSR 62260)
Go to fitting
Add a function -> general -> stretch exp
Add constraints (custom->both) to the stretch parameter
Change one of the constraints - Mantid should no longer crash
Also the box should now reject character inputs and therefore Mantid will no longer crash.

<!-- Instructions for testing. -->

Fixes #27542  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
