### PR TITLE
Remove Confusion from SaveNISTDAT example 

### DIFF
--- a/docs/source/algorithms/SaveNISTDAT-v1.rst
+++ b/docs/source/algorithms/SaveNISTDAT-v1.rst
@@ -20,7 +20,7 @@ Usage
 
 **Example - Saving Some Pre-existing Data**
 
-.. include:: ../trainingdata-note.txt
+.. include:: ../usagedata-note.txt
 
 .. testcode:: ExSaveRoundtrip
 
@@ -28,7 +28,7 @@ Usage
 
    # Load in some data which is already in a form that SaveNISTDAT expects,
    # then save it back out to a file.
-   data = Load("SANSLOQCan2D.nxs")
+   data = Load("saveNISTDAT_data.nxs")
    file_path = os.path.join(config["defaultsave.directory"], "example.dat")
    SaveNISTDAT(data, file_path)
 
@@ -48,7 +48,7 @@ Output:
 
 .. testoutput:: ExSaveRoundtrip
 
-   The data read back in is [-0.099 -0.099 -0.099 ...  0.099  0.099  0.099]
+   The data read back in is [-0.0735 -0.0735 -0.0735 ...,  0.0685  0.0685  0.0685]
 
 .. categories::
 

--- a/docs/source/algorithms/SaveNISTDAT-v1.rst
+++ b/docs/source/algorithms/SaveNISTDAT-v1.rst
@@ -20,7 +20,6 @@ Usage
 
 **Example - Saving Some Pre-existing Data**
 
-.. include:: ../usagedata-note.txt
 
 .. testcode:: ExSaveRoundtrip
 

--- a/docs/source/algorithms/SaveNISTDAT-v1.rst
+++ b/docs/source/algorithms/SaveNISTDAT-v1.rst
@@ -20,7 +20,7 @@ Usage
 
 **Example - Saving Some Pre-existing Data**
 
-.. include:: ../usagedata-note.txt
+.. include:: ../trainingdata-note.txt
 
 .. testcode:: ExSaveRoundtrip
 
@@ -28,13 +28,17 @@ Usage
 
    # Load in some data which is already in a form that SaveNISTDAT expects,
    # then save it back out to a file.
-   data = Load("saveNISTDAT_data.nxs")
+   data = Load("SANSLOQCan2D.nxs")
    file_path = os.path.join(config["defaultsave.directory"], "example.dat")
    SaveNISTDAT(data, file_path)
 
    # Load it back in and inspect what we have.
    reloaded_data = LoadAscii(file_path)
    print("The data read back in is " + str(reloaded_data.readY(0)))
+   # N.B. Mantid does not properly support reloading files output from 'SaveNISTDAT'
+   # Above, the reloaded file is vastly altered from the original
+   # due to the conversion performed upon running 'SaveNISTDAT'.
+   # To see this, 'Show Data' on the data and reloaded_data workspaces.
 
 .. testcleanup:: ExSaveRoundtrip
 
@@ -44,7 +48,7 @@ Output:
 
 .. testoutput:: ExSaveRoundtrip
 
-   The data read back in is [-0.0735 -0.0735 -0.0735 ...,  0.0685  0.0685  0.0685]
+   The data read back in is [-0.099 -0.099 -0.099 ...  0.099  0.099  0.099]
 
 .. categories::
 

--- a/docs/source/algorithms/SaveNISTDAT-v1.rst
+++ b/docs/source/algorithms/SaveNISTDAT-v1.rst
@@ -20,6 +20,7 @@ Usage
 
 **Example - Saving Some Pre-existing Data**
 
+.. include:: ../usagedata-note.txt
 
 .. testcode:: ExSaveRoundtrip
 

--- a/docs/source/trainingdata-note.txt
+++ b/docs/source/trainingdata-note.txt
@@ -1,0 +1,5 @@
+.. note::
+
+   To run these usage examples please first download the
+   `Training Course data <https://sourceforge.net/projects/mantid/files/Sample%20Data/TrainingCourseData.zip/download>`_,
+   and add these to your path. In MantidPlot this is done using `Manage User Directories <http://www.mantidproject.org/ManageUserDirectories>`_.

--- a/docs/source/trainingdata-note.txt
+++ b/docs/source/trainingdata-note.txt
@@ -1,5 +1,0 @@
-.. note::
-
-   To run these usage examples please first download the
-   `Training Course data <https://sourceforge.net/projects/mantid/files/Sample%20Data/TrainingCourseData.zip/download>`_,
-   and add these to your path. In MantidPlot this is done using `Manage User Directories <http://www.mantidproject.org/ManageUserDirectories>`_.


### PR DESCRIPTION
**Description of work.**
Updated the SaveNISTDAT-v1.rst to prevent confusion over whether the files output from this algorithm can be reloaded. Also changed the data file used as the old one was no longer in the UsageData folder linked. The new one is from the TrainingCourseData so a link to that has been added.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Check the additions to the example are sensible.
Build docs.html if you wish.
<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **documentation change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
