### PR TITLE
Fix issues with workbench plotting with matplotlib 3.1

### DIFF
--- a/Framework/PythonInterface/mantid/BundlePython.cmake
+++ b/Framework/PythonInterface/mantid/BundlePython.cmake
@@ -15,6 +15,11 @@ if( MSVC )
   install ( DIRECTORY ${PYTHON_DIR}/Scripts DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.py" EXCLUDE )
   install ( DIRECTORY ${PYTHON_DIR}/tcl DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE )
   install ( FILES ${PYTHON_DIR}/python${PYTHON_MAJOR_VERSION}${PYTHON_MINOR_VERSION}.dll
-            ${PYTHON_DIR}/python${PYTHON_MAJOR_VERSION}.dll ${PYTHON_EXECUTABLE} ${PYTHONW_EXECUTABLE}
+            ${PYTHON_EXECUTABLE} ${PYTHONW_EXECUTABLE}
             DESTINATION bin )
+  # Python >= 3 has an minimal API DLL too
+  if ( EXISTS ${PYTHON_DIR}/python${PYTHON_MAJOR_VERSION}.dll )
+    install ( FILES ${PYTHON_DIR}/python${PYTHON_MAJOR_VERSION}.dll
+              DESTINATION bin )
+  endif()
 endif()

--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -38,7 +38,7 @@ from mantid.plots import helperfunctions, plotfunctions, plotfunctions3D
 from mantid.plots.utility import autoscale_on_update
 from mantid.plots.helperfunctions import get_normalize_by_bin_width
 from mantid.plots.scales import PowerScale, SquareScale
-from mantid.plots.utility import artists_hidden, MantidAxType
+from mantid.plots.utility import artists_hidden, MantidAxType, legend_set_draggable
 from mantidqt.widgets.plotconfigdialog.legendtabwidget import LegendProperties
 
 
@@ -501,7 +501,7 @@ class MantidAxes(Axes):
 
     def make_legend(self):
         if self.legend_ is None:
-            self.legend().draggable()
+            legend_set_draggable(self.legend(), True)
         else:
             props = LegendProperties.from_legend(self.legend_)
             LegendProperties.create_legend(props, self)
@@ -623,7 +623,7 @@ class MantidAxes(Axes):
 
                     # also remove the curve from the legend
                     if (not self.is_empty(self)) and self.legend_ is not None:
-                        self.legend().draggable()
+                        legend_set_draggable(self.legend(), True)
 
                 if new_kwargs:
                     _autoscale_on = new_kwargs.pop("autoscale_on_update", self.get_autoscale_on())
@@ -748,7 +748,7 @@ class MantidAxes(Axes):
                     container_new = []
                     # also remove the curve from the legend
                     if (not self.is_empty(self)) and self.legend_ is not None:
-                        self.legend().draggable()
+                        legend_set_draggable(self.legend(), True)
 
                 return container_new
 

--- a/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
+++ b/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
@@ -211,8 +211,6 @@ def imshow(axes, X, cmap=None, norm=None, aspect=None,
 
     Unlike matplotlib version, must explicitly specify axes
     """
-    if not axes._hold:
-        axes.cla()
     if norm is not None:
         assert(isinstance(norm, mcolors.Normalize))
     if aspect is None:

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -11,8 +11,15 @@ from contextlib import contextmanager
 
 from matplotlib import cm
 from matplotlib.container import ErrorbarContainer
+from matplotlib.legend import Legend
 
 from enum import Enum
+
+
+if hasattr(Legend, "set_draggable"):
+    SET_DRAGGABLE_METHOD = "set_draggable"
+else:
+    SET_DRAGGABLE_METHOD = "draggable"
 
 
 # Any changes here must be reflected in the definition in
@@ -115,6 +122,14 @@ def get_autoscale_limits(ax, axis):
     if not ax._tight:
         locator = getattr(ax, '{}axis'.format(axis)).get_major_locator()
         return locator.view_limits(axis_min, axis_max)
+
+
+def legend_set_draggable(legend, state, use_blit=False, update='loc'):
+    """Utility function to support varying Legend api around draggable status across
+    the versions of matplotlib we support. Function arguments match those from matplotlib.
+    See matplotlib documentation for argument descriptions
+    """
+    getattr(legend, SET_DRAGGABLE_METHOD)(state, use_blit, update)
 
 
 def zoom_axis(ax, coord, x_or_y, factor):

--- a/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
@@ -3,11 +3,9 @@ add_subdirectory(modest_image)
 # mantid.dataobjects tests
 
 set(TEST_PY_FILES
-  helperfunctionsTest.py
-  plotfunctionsTest.py
-  plotfunctions3DTest.py
-  plots__init__Test.py
-  ScalesTest.py)
+    helperfunctionsTest.py plotfunctionsTest.py plotfunctions3DTest.py
+    plots__init__Test.py ScalesTest.py UtilityTest.py
+)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
@@ -1,0 +1,37 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid package
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import absolute_import, division
+
+import unittest
+
+from mantid.plots.utility import legend_set_draggable
+from mantid.py3compat.mock import create_autospec
+from matplotlib.legend import Legend
+
+
+class UtilityTest(unittest.TestCase):
+
+    def test_legend_set_draggable(self):
+        legend = create_autospec(Legend)
+        args = (None, False, 'loc')
+        legend_set_draggable(legend, *args)
+
+        if hasattr(Legend, 'set_draggable'):
+            legend.set_draggable.assert_called_with(*args)
+        else:
+            legend.draggable.assert_called_with(*args)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 from mantid.plots import MantidAxes
 
 from mantidqt.widgets.plotconfigdialog import curve_in_ax
+from matplotlib.legend import Legend
 from workbench.plugins.editor import DEFAULT_CONTENT
 from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_commands,
                                                          generate_axis_label_commands,
@@ -22,6 +23,10 @@ from workbench.plotting.plotscriptgenerator.utils import generate_workspace_retr
 
 FIG_VARIABLE = "fig"
 AXES_VARIABLE = "axes"
+if hasattr(Legend, "set_draggable"):
+    SET_DRAGGABLE_METHOD = "set_draggable"
+else:
+    SET_DRAGGABLE_METHOD = "draggable"
 
 
 def generate_script(fig, exclude_headers=False):
@@ -107,7 +112,8 @@ def get_title_cmds(ax, ax_object_var):
 def get_legend_cmds(ax, ax_object_var):
     """Get command axes.set_legend"""
     if ax.legend_:
-        return ["{ax_obj}.legend().draggable()".format(ax_obj=ax_object_var)]
+        return ["{ax_obj}.legend().{draggable_method}()".format(ax_obj=ax_object_var,
+                                                                draggable_method=SET_DRAGGABLE_METHOD)]
     return []
 
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -11,6 +11,7 @@ import unittest
 import matplotlib
 matplotlib.use("Agg")  # noqa
 from matplotlib.axes import Axes
+from matplotlib.legend import Legend
 
 from mantid.plots import MantidAxes
 from mantid.py3compat.mock import Mock, patch
@@ -120,7 +121,10 @@ class PlotScriptGeneratorTest(unittest.TestCase):
 
         mock_ax = self._gen_mock_axes(legend_=True)
         mock_fig = Mock(get_axes=lambda: [mock_ax])
-        self.assertIn('.legend().draggable()', generate_script(mock_fig))
+        if hasattr(Legend, "set_draggable"):
+            self.assertIn('.legend().set_draggable()', generate_script(mock_fig))
+        else:
+            self.assertIn('.legend().draggable()', generate_script(mock_fig))
 
     @patch(GET_AUTOSCALE_LIMITS)
     @patch(GEN_WS_RETRIEVAL_CMDS)

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -76,7 +76,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                 if tooltip_text is not None:
                     a.setToolTip(tooltip_text)
 
-        self.buttons = {}
         # Add the x,y location widget at the right side of the toolbar
         # The stretch factor is 1 which means any resizing of the toolbar
         # will resize this label instead of the buttons.
@@ -87,9 +86,6 @@ class WorkbenchNavigationToolbar(NavigationToolbar2QT):
                 QtWidgets.QSizePolicy(QtWidgets.Expanding, QtWidgets.QSizePolicy.Ignored))
             labelAction = self.addWidget(self.locLabel)
             labelAction.setVisible(True)
-
-        # reference holder for subplots_adjust window
-        self.adj_window = None
 
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/__init__.py
@@ -8,6 +8,7 @@
 
 from __future__ import (absolute_import, unicode_literals)
 
+from mantid.plots.utility import legend_set_draggable
 from mantidqt.widgets.plotconfigdialog.colorselector import convert_color_to_hex
 import matplotlib
 from matplotlib.patches import BoxStyle
@@ -157,4 +158,4 @@ class LegendProperties(dict):
 
         legend.set_visible(props['visible'])
 
-        legend.draggable(True)
+        legend_set_draggable(legend, True)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -12,6 +12,7 @@ from functools import partial
 from qtpy.QtCore import Qt
 
 from mantid.kernel import logger
+from mantid.plots.utility import legend_set_draggable
 from mantidqt.widgets.observers.ads_observer import WorkspaceDisplayADSObserver
 from mantidqt.widgets.observers.observing_presenter import ObservingPresenter
 from mantidqt.widgets.workspacedisplay.data_copier import DataCopier
@@ -358,7 +359,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
                 return
 
             ax.set_ylabel(column_label)
-        ax.legend().draggable()
+        legend_set_draggable(ax.legend(), True)
         fig.show()
 
     def _get_plot_function_from_type(self, ax, type):

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -27,6 +27,7 @@ from qtpy.QtCore import (QEventLoop, Qt)  # noqa
 from qtpy.QtWidgets import (QAction, QCheckBox, QComboBox, QDialog, QFileDialog, QGridLayout, QHBoxLayout, QMenu, QLabel,
                             QLineEdit, QMainWindow, QMessageBox, QPushButton, QSizePolicy, QSpacerItem, QTabWidget,
                             QTextEdit, QVBoxLayout, QWidget)  # noqa
+from mantid.plots.utility import legend_set_draggable
 from mantidqt.MPLwidgets import FigureCanvasQTAgg as FigureCanvas
 from mantidqt.MPLwidgets import NavigationToolbar2QT as NavigationToolbar
 import matplotlib
@@ -280,7 +281,7 @@ class PyChopGui(QMainWindow):
                 self.plot_qe(ei, label_text, overplot)
             self.resaxes_xlim = max(ei, self.resaxes_xlim)
         self.resaxes.set_xlim([0, self.resaxes_xlim])
-        self.resaxes.legend().draggable()
+        legend_set_draggable(self.resaxes.legend(), True)
         self.resaxes.set_xlabel('Energy Transfer (meV)')
         self.resaxes.set_ylabel(r'$\Delta$E (meV FWHM)')
         self.rescanvas.draw()
@@ -299,7 +300,7 @@ class PyChopGui(QMainWindow):
         line, = self.qeaxes.plot(np.hstack(q2), np.concatenate((np.flipud(en), en)).tolist() * len(self.engine.detector.tthlims))
         line.set_label(label_text)
         self.qeaxes.set_xlim([0, self.qeaxes_xlim])
-        self.qeaxes.legend().draggable()
+        legend_set_draggable(self.qesaxes.legend(), True)
         self.qeaxes.set_xlabel(r'$|Q| (\mathrm{\AA}^{-1})$')
         self.qeaxes.set_ylabel('Energy Transfer (meV)')
         self.qecanvas.draw()
@@ -371,7 +372,7 @@ class PyChopGui(QMainWindow):
         self.flxaxes1.set_xlabel('Incident Energy (meV)')
         self.flxaxes2.set_ylabel('Elastic Resolution FWHM (meV)')
         lg = self.flxaxes2.legend()
-        lg.draggable()
+        legend_set_draggable(lg, True)
         self.flxcanvas.draw()
 
     def update_slider(self, val=None):
@@ -438,7 +439,7 @@ class PyChopGui(QMainWindow):
         line, = self.frqaxes2.plot(freqs, elres, 'o-')
         line.set_label('%s "%s" Ei = %5.3f meV' % (inst, chop, ei))
         lg = self.frqaxes2.legend()
-        lg.draggable()
+        legend_set_draggable(lg, True)
         self.frqaxes2.set_xlim([0, np.max(freqs)])
         self.frqcanvas.draw()
 


### PR DESCRIPTION
**Description of work.**

Windows/Mac are now shipping matplotlib 3.1 with Python 3. A few issues have cropped up preventing plotting from working. This fixes them and sneaks in a packaging fix for Python 2 (the last commit). 



**To test:**

Build the workbench with Python 3 on Windows.
Start workbench and plot something.
The plot should work and there are no warnings.

*There is no associated issue.*

*This does not require release notes* because **Python 3 support will be announced separately.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
