### PR TITLE
Use the longest form of a filename as ws name for drag drop

### DIFF
--- a/qt/widgets/common/src/MantidTreeWidget.cpp
+++ b/qt/widgets/common/src/MantidTreeWidget.cpp
@@ -73,7 +73,7 @@ void MantidTreeWidget::dropEvent(QDropEvent *de) {
   for (int i = 0; i < filenames.size(); ++i) {
     try {
       QFileInfo fi(filenames[i]);
-      QString basename = fi.baseName();
+      QString basename = fi.completeBaseName();
       auto alg = m_mantidUI->createAlgorithm("Load");
       alg->initialize();
       alg->setProperty("Filename", filenames[i].toStdString());


### PR DESCRIPTION
This gets the longest version of the filename without the extension, so file.0.nxs will be ws file.0, not just file as before

**Description of work.**

**To test:**

1. rename a file for it has an extra .bit in the filename, e.g. file.0.nxs 
1. Drag that file onto the workspaces toolbox
1. It should create a file with only the extension removed, not the filename up to the first .

Fixes #27438. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it is very niche, and the only person to ever notice raised this issue


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
