### PR TITLE
Fix settings test for python 3 in windows

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import unittest
+import sys
 
 from mantid.py3compat.mock import call, patch, Mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -157,10 +158,17 @@ class GeneralSettingsTest(unittest.TestCase):
         GeneralSettings(None)
 
         # calls().__int__() are the calls to int() on the retrieved value from ConfigService.getString
-        mock_CONF.get.assert_has_calls([call(GeneralSettings.PROMPT_SAVE_ON_CLOSE),
-                                        call().__index__(),
-                                        call(GeneralSettings.PROMPT_SAVE_EDITOR_MODIFIED),
-                                        call().__index__()])
+        # In python 3.8 it falls back to __index__() if __int__() is not defined
+        if sys.version_info < (3, 8):
+            mock_CONF.get.assert_has_calls([call(GeneralSettings.PROMPT_SAVE_ON_CLOSE),
+                                            call().__int__(),
+                                            call(GeneralSettings.PROMPT_SAVE_EDITOR_MODIFIED),
+                                            call().__int__()])
+        else:
+            mock_CONF.get.assert_has_calls([call(GeneralSettings.PROMPT_SAVE_ON_CLOSE),
+                                            call().__index__(),
+                                            call(GeneralSettings.PROMPT_SAVE_EDITOR_MODIFIED),
+                                            call().__index__()])
 
         mock_ConfigService.getString.assert_has_calls([call(GeneralSettings.PR_RECOVERY_ENABLED),
                                                        call(GeneralSettings.PR_TIME_BETWEEN_RECOVERY),

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -158,9 +158,9 @@ class GeneralSettingsTest(unittest.TestCase):
 
         # calls().__int__() are the calls to int() on the retrieved value from ConfigService.getString
         mock_CONF.get.assert_has_calls([call(GeneralSettings.PROMPT_SAVE_ON_CLOSE),
-                                        call().__int__(),
+                                        call().__index__(),
                                         call(GeneralSettings.PROMPT_SAVE_EDITOR_MODIFIED),
-                                        call().__int__()])
+                                        call().__index__()])
 
         mock_ConfigService.getString.assert_has_calls([call(GeneralSettings.PR_RECOVERY_ENABLED),
                                                        call(GeneralSettings.PR_TIME_BETWEEN_RECOVERY),
@@ -245,7 +245,7 @@ class GeneralSettingsTest(unittest.TestCase):
         test_dict = {'a': 1}
         mock_CONF.get.return_value = test_dict
 
-        self.assertEquals(test_dict, presenter.get_layout_dict())
+        self.assertEqual(test_dict, presenter.get_layout_dict())
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_get_layout_dict_key_error(self, mock_CONF):
@@ -253,7 +253,7 @@ class GeneralSettingsTest(unittest.TestCase):
         # setup CONF.get to return KeyError
         mock_CONF.get.side_effect = KeyError()
 
-        self.assertEquals({}, presenter.get_layout_dict())
+        self.assertEqual({}, presenter.get_layout_dict())
 
     @patch(WORKBENCH_CONF_CLASSPATH)
     def test_save_layout(self, mock_CONF):


### PR DESCRIPTION
**Description of work.**
This PR fixes the test `test_load_current_setting_values` in `test_general_setting`  as it was failing on windows when using python 3. 

**To test:**
On a python 3 build run the test: `test_general_settings` 
It should pass with no warnings or errors.

*There is no associated issue.*

*This does not require release notes* because **it is a change to a test**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
