### PR TITLE
Re Expose getting time averaged std to python

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -166,6 +166,9 @@ public:
     return getPropertyAsSingleValue(name, statistic);
   }
 
+  /// Get the time averaged standard deviation for a log
+  double getTimeAveragedStd(const std::string &name) const;
+
   /// Empty the values out of all TimeSeriesProperty logs
   void clearTimeSeriesLogs();
   /// Empty all but the last value out of all TimeSeriesProperty logs
@@ -179,7 +182,6 @@ public:
                          bool keepOpen = false);
   /// Clear the logs
   void clearLogs();
-
 protected:
   /// Load the run from a NeXus file with a given group name
   void loadNexus(::NeXus::File *file,

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -182,6 +182,7 @@ public:
                          bool keepOpen = false);
   /// Clear the logs
   void clearLogs();
+
 protected:
   /// Load the run from a NeXus file with a given group name
   void loadNexus(::NeXus::File *file,

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -343,14 +343,7 @@ LogManager::getTimeSeriesProperty(const std::string &name) const {
  * @return A single double value
  */
 double LogManager::getTimeAveragedStd(const std::string &name) const {
-  auto prop = this->getProperty(name);
-  auto tsp = dynamic_cast<Kernel::TimeSeriesProperty<double> *>(prop);
-  if (!tsp) {
-    throw std::runtime_error("Could not retrieve a double time series property "
-                             "for the property name " +
-                             name);
-  }
-  return tsp->getStatistics().time_standard_deviation;
+  return getTimeSeriesProperty<double>(name)->getStatistics().time_standard_deviation;
 }
 
 /**

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -343,7 +343,9 @@ LogManager::getTimeSeriesProperty(const std::string &name) const {
  * @return A single double value
  */
 double LogManager::getTimeAveragedStd(const std::string &name) const {
-  return getTimeSeriesProperty<double>(name)->getStatistics().time_standard_deviation;
+  return getTimeSeriesProperty<double>(name)
+      ->getStatistics()
+      .time_standard_deviation;
 }
 
 /**

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -343,13 +343,13 @@ LogManager::getTimeSeriesProperty(const std::string &name) const {
  * @return A single double value
  */
 double LogManager::getTimeAveragedStd(const std::string &name) const {
-  auto prop=this->getProperty(name);
+  auto prop = this->getProperty(name);
   auto tsp = dynamic_cast<Kernel::TimeSeriesProperty<double> *>(prop);
   if (!tsp) {
-      throw std::runtime_error(
-          "Could not retrieve a double time series property for the property name " +
-          name);
-    }
+    throw std::runtime_error("Could not retrieve a double time series property "
+                             "for the property name " +
+                             name);
+  }
   return tsp->getStatistics().time_standard_deviation;
 }
 

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -338,6 +338,22 @@ LogManager::getTimeSeriesProperty(const std::string &name) const {
 }
 
 /**
+ * Returns the time dependent standard deviation
+ * @param name :: The name of the property
+ * @return A single double value
+ */
+double LogManager::getTimeAveragedStd(const std::string &name) const {
+  auto prop=this->getProperty(name);
+  auto tsp = dynamic_cast<Kernel::TimeSeriesProperty<double> *>(prop);
+  if (!tsp) {
+      throw std::runtime_error(
+          "Could not retrieve a double time series property for the property name " +
+          name);
+    }
+  return tsp->getStatistics().time_standard_deviation;
+}
+
+/**
  * Get the value of a property as the requested type. Throws if the type is not
  * correct
  * @param name :: The name of the property

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -407,6 +407,14 @@ public:
     TS_ASSERT_EQUALS(runInfo.getPropertyAsSingleValue(name), value);
   }
 
+  void test_getTimeAveragedStd() {
+    LogManager run;
+    const std::string name = "series";
+    addTestTimeSeries<double>(run, name);
+
+    TS_ASSERT_DELTA(run.getTimeAveragedStd(name),8.5239,0.001);
+  }
+
   void test_clear() {
     // Set up a Run object with 3 properties in it (1 time series, 2 single
     // value)

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -412,7 +412,7 @@ public:
     const std::string name = "series";
     addTestTimeSeries<double>(run, name);
 
-    TS_ASSERT_DELTA(run.getTimeAveragedStd(name),8.5239,0.001);
+    TS_ASSERT_DELTA(run.getTimeAveragedStd(name), 8.5239, 0.001);
   }
 
   void test_clear() {

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -178,6 +178,11 @@ void export_Run() {
            "Return a log as a single float value. Time series values are "
            "averaged.")
 
+      .def("getTimeAveragedStd",
+           &Run::getTimeAveragedStd,
+           (arg("self"), arg("name")),
+           "Returns the time averaged standard deviation")
+
       .def("getProperties", &Run::getProperties, arg("self"),
            return_internal_reference<>(),
            "Return the list of run properties managed by this object.")

--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -178,8 +178,7 @@ void export_Run() {
            "Return a log as a single float value. Time series values are "
            "averaged.")
 
-      .def("getTimeAveragedStd",
-           &Run::getTimeAveragedStd,
+      .def("getTimeAveragedStd", &Run::getTimeAveragedStd,
            (arg("self"), arg("name")),
            "Returns the time averaged standard deviation")
 

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -9,8 +9,9 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 import copy
 from mantid.geometry import Goniometer
-from mantid.kernel import DateAndTime
+from mantid.kernel import DateAndTime, FloatTimeSeriesProperty
 from mantid.api import Run
+import numpy as np
 
 class RunTest(unittest.TestCase):
 
@@ -35,7 +36,7 @@ class RunTest(unittest.TestCase):
         run = self._run
         charge = run.getProtonCharge()
         self.assertEqual(type(charge), float)
-        self.assertAlmostEquals(charge, 10.05, 2)
+        self.assertAlmostEqual(charge, 10.05)
 
     def test_run_hasProperty(self):
         self.assertTrue(self._run.hasProperty('start_time'))
@@ -122,6 +123,22 @@ class RunTest(unittest.TestCase):
             runendstr, "2008-12-18T17:59:40 "
         )  # The space at the end is to get around an IPython bug (#8351)
         self.assertTrue(isinstance(runend, DateAndTime))
+
+    def test_timestd(self):
+        """
+        """
+        run = Run()
+        start_time = DateAndTime("2008-12-18T17:58:38")
+        nanosec = 1000000000
+        # === Float type ===
+        temp1 = FloatTimeSeriesProperty("TEMP1")
+        vals = np.arange(10) * 2.
+        for i in range(10):
+            temp1.addValue(start_time + i*nanosec, vals[i])
+        run.addProperty(temp1.name, temp1,True)
+        # ignore the last value
+        expected = vals[:-1].std()
+        self.assertEqual(run.getTimeAveragedStd("TEMP1"), expected)
 
     def do_test_copyable(self, copy_op):
         original = self._run

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -52,4 +52,6 @@ Improvements
 Python
 ------
 
+- added :py:meth:`mantid.api.Run.getTimeAveragedStd` method to the :py:obj:`mantid.api.Run` object
+
 :ref:`Release 4.3.0 <v4.3.0>`


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Get a handle to any workspace with a float time series property. `ws.getRun().getTimeAveragedStd('logName')` would get you the answer


Fixes #27704 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
