### PR TITLE
Disable the plotting context menu options if a matrix ws has 1 bin

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -203,13 +203,17 @@ class WorkspaceWidget(PluginWidget):
         CreateDetectorTable(InputWorkspace=ws)
 
     def _action_double_click_workspace(self, name):
+        ws = self._ads.retrieve(name)
         try:
             # if this is a table workspace (or peaks workspace),
             # then it can't be plotted automatically, so the data is shown instead
-            TableWorkspaceDisplay.supports(self._ads.retrieve(name))
+            TableWorkspaceDisplay.supports(ws)
             self._do_show_data([name])
         except ValueError:
-            plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+            if ws.blocksize() > 1:
+                plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+            else:
+                self._do_show_data([name])
 
     def refresh_workspaces(self):
         self.workspacewidget.refreshWorkspaces()

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -121,10 +121,10 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           }
         }
       }
-      m_plotSpectrum->setEnabled(multipleBins);
-      m_overplotSpectrum->setEnabled(multipleBins);
-      m_plotSpectrumWithErrs->setEnabled(multipleBins);
-      m_overplotSpectrumWithErrs->setEnabled(multipleBins);
+      //disable the actions created so far if only one bin
+      for (auto action : plotSubMenu->actions()) {
+        action->setEnabled(multipleBins);
+      }
 
       plotSubMenu->addSeparator();
       plotSubMenu->addAction(m_plotColorfill);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -108,7 +108,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       plotSubMenu->addAction(m_plotSpectrumWithErrs);
       plotSubMenu->addAction(m_overplotSpectrumWithErrs);
 
-			// Don't plot 1D spectra if only one X value
+      // Don't plot 1D spectra if only one X value
       bool multipleBins = false;
       try {
         multipleBins = (matrixWS->blocksize() > 1);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -121,7 +121,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           }
         }
       }
-      //disable the actions created so far if only one bin
+      // disable the actions created so far if only one bin
       for (auto action : plotSubMenu->actions()) {
         action->setEnabled(multipleBins);
       }

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -107,6 +107,25 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       plotSubMenu->addAction(m_overplotSpectrum);
       plotSubMenu->addAction(m_plotSpectrumWithErrs);
       plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+
+			// Don't plot 1D spectra if only one X value
+      bool multipleBins = false;
+      try {
+        multipleBins = (matrixWS->blocksize() > 1);
+      } catch (...) {
+        const size_t numHist = matrixWS->getNumberHistograms();
+        for (size_t i = 0; i < numHist; ++i) {
+          if (matrixWS->y(i).size() > 1) {
+            multipleBins = true;
+            break;
+          }
+        }
+      }
+      m_plotSpectrum->setEnabled(multipleBins);
+      m_overplotSpectrum->setEnabled(multipleBins);
+      m_plotSpectrumWithErrs->setEnabled(multipleBins);
+      m_overplotSpectrumWithErrs->setEnabled(multipleBins);
+
       plotSubMenu->addSeparator();
       plotSubMenu->addAction(m_plotColorfill);
       menu->addMenu(plotSubMenu);


### PR DESCRIPTION
Workbench only this makes it the same as mantidplot

**Description of work.**
This only affect the matrix workspace context menu.  If it has only 1 bin (i.e. raw event workspaces before rebin) then the 1D plotting options are disabled.


**To test:**
1. Load a raw event file, or rebin any workspace to one bin
1. check that the right click context menu plotting options are disabled.
1. run rebin to add more bins
1. check that the plotting options are enabled

<!-- Instructions for testing. -->

Re #27731. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it just harmonizes with Mantidplot

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
