### PR TITLE
Fix sliceviewer for matplotlib 3.1

### DIFF
--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -7,15 +7,22 @@
 #  This file is part of the mantid package
 from __future__ import absolute_import
 
+from collections import namedtuple
 from contextlib import contextmanager
 
-from matplotlib import cm
+from matplotlib import cm, __version__ as mpl_version_str
 from matplotlib.container import ErrorbarContainer
 from matplotlib.legend import Legend
 
 from enum import Enum
 
 
+# matplotlib version information
+MPLVersionInfo = namedtuple("MPLVersionInfo", ("major", "minor", "patch"))
+MATPLOTLIB_VERSION_INFO = MPLVersionInfo._make(map(int, mpl_version_str.split(".")))
+
+
+# Use the correct draggable method based on the matplotlib version
 if hasattr(Legend, "set_draggable"):
     SET_DRAGGABLE_METHOD = "set_draggable"
 else:
@@ -130,6 +137,11 @@ def legend_set_draggable(legend, state, use_blit=False, update='loc'):
     See matplotlib documentation for argument descriptions
     """
     getattr(legend, SET_DRAGGABLE_METHOD)(state, use_blit, update)
+
+
+def mpl_version_info():
+    """Returns a namedtuple of (major,minor,patch)"""
+    return MATPLOTLIB_VERSION_INFO
 
 
 def zoom_axis(ax, coord, x_or_y, factor):

--- a/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/toolbar.py
@@ -51,8 +51,6 @@ class SliceViewerNavigationToolbar(NavigationToolbar2QT):
                 if tooltip_text is not None:
                     a.setToolTip(tooltip_text)
 
-        self.buttons = {}
-
         # Add the x,y location widget at the right side of the toolbar
         # The stretch factor is 1 which means any resizing of the toolbar
         # will resize this label instead of the buttons.

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -8,6 +8,7 @@
 #
 #
 from __future__ import (absolute_import, division, print_function)
+
 from matplotlib import gridspec
 from matplotlib.figure import Figure
 from matplotlib.transforms import Bbox, BboxTransform
@@ -149,14 +150,14 @@ class SliceViewerView(QWidget):
         self.presenter.line_plots()
 
     def clear_line_plots(self):
-        try: # clear old plots
+        try:  # clear old plots
             del self.xfig
             del self.yfig
         except AttributeError:
             pass
 
     def update_data_clim(self):
-        self.im.set_clim(self.colorbar.colorbar.get_clim()) # force clim update, needed for RHEL7
+        self.im.set_clim(self.colorbar.colorbar.mappable.get_clim())
         self.canvas.draw_idle()
 
     def update_line_plot_limits(self):


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Try out slice viewer with matplotlib 3.1. Most easily done with a Windows/Python 3 build. It should be able to show a workspace image and be able to change the colour map, colour bar limits etc.

Fixes #27736 

*This does not require release notes* because **Python 3 upgrade to be announced separately.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
