### PR TITLE
Add NumberOfBins property to LoadEventNexus

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -291,6 +291,10 @@ void LoadEventNexus::init() {
                       "LoadNexusInstrumentXML", true, Direction::Input),
                   "Reads the embedded Instrument XML from the NeXus file "
                   "(optional, default True). ");
+
+  declareProperty("NumberOfBins", 500, mustBePositive,
+                  "The number of bins intially defined. Use Rebin to change "
+                  "the binning later.  If there is no data loaded, or you select meta data only you will only get 1 bin.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1071,10 +1075,18 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     }
   }
   // Now, create a default X-vector for histogramming, with just 2 bins.
-  if (eventsLoaded > 0)
-    m_ws->setAllX(HistogramData::BinEdges{shortest_tof - 1, longest_tof + 1});
-  else
-    m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
+  if (eventsLoaded > 0) {
+    int nBins = getProperty("NumberOfBins");
+    auto binEdgesVec = std::vector<double>(nBins + 1);
+    binEdgesVec[0] = shortest_tof - 1;
+    binEdgesVec[nBins] = longest_tof + 1;
+    double binStep = (binEdgesVec[nBins] - binEdgesVec[0]) / nBins;
+    for (size_t binIndex = 1; binIndex < nBins; binIndex++) {
+      binEdgesVec[binIndex] = binEdgesVec[0] + (binStep * binIndex);
+    }
+    m_ws->setAllX(HistogramData::BinEdges{binEdgesVec});
+  }
+  else m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
 
   // if there is time_of_flight load it
   adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1082,7 +1082,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
     binEdgesVec[0] = shortest_tof - 1;
     binEdgesVec[nBins] = longest_tof + 1;
     double binStep = (binEdgesVec[nBins] - binEdgesVec[0]) / nBins;
-    for (size_t binIndex = 1; binIndex < nBins; binIndex++) {
+    for (int binIndex = 1; binIndex < nBins; binIndex++) {
       binEdgesVec[binIndex] = binEdgesVec[0] + (binStep * binIndex);
     }
     m_ws->setAllX(HistogramData::BinEdges{binEdgesVec});

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -294,7 +294,8 @@ void LoadEventNexus::init() {
 
   declareProperty("NumberOfBins", 500, mustBePositive,
                   "The number of bins intially defined. Use Rebin to change "
-                  "the binning later.  If there is no data loaded, or you select meta data only you will only get 1 bin.");
+                  "the binning later.  If there is no data loaded, or you "
+                  "select meta data only you will only get 1 bin.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1085,8 +1086,8 @@ void LoadEventNexus::loadEvents(API::Progress *const prog,
       binEdgesVec[binIndex] = binEdgesVec[0] + (binStep * binIndex);
     }
     m_ws->setAllX(HistogramData::BinEdges{binEdgesVec});
-  }
-  else m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
+  } else
+    m_ws->setAllX(HistogramData::BinEdges{0.0, 1.0});
 
   // if there is time_of_flight load it
   adjustTimeOfFlightISISLegacy(*m_file, m_ws, m_top_entry_name, classType);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -242,9 +242,9 @@ public:
     }
   }
 
-	void test_NumberOfBins() {
+  void test_NumberOfBins() {
     const std::string file = "SANS2D00022048.nxs";
-          int nBins = 273;
+    int nBins = 273;
     LoadEventNexus alg;
     alg.setChild(true);
     alg.setRethrows(true);

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -268,6 +268,7 @@ public:
     alg.initialize();
     alg.setProperty("Filename", file);
     alg.setProperty("OutputWorkspace", "dummy_for_child");
+    alg.setProperty("NumberOfBins", 1);
     alg.execute();
     Workspace_sptr ws = alg.getProperty("OutputWorkspace");
     auto eventWS = boost::dynamic_pointer_cast<EventWorkspace>(ws);
@@ -336,6 +337,7 @@ public:
     ld.setPropertyValue("Filename", "CNCS_7860_event.nxs");
     ld.setPropertyValue("OutputWorkspace", outws_name);
     ld.setPropertyValue("Precount", "0");
+    ld.setProperty("NumberOfBins", 1);
     ld.setProperty<bool>("LoadLogs", false); // Time-saver
     ld.execute();
     TS_ASSERT(ld.isExecuted());
@@ -378,6 +380,7 @@ public:
     ld2.setPropertyValue("OutputWorkspace", outws_name2);
     ld2.setPropertyValue("Precount", "1");
     ld2.setProperty<bool>("LoadLogs", false); // Time-saver
+    ld2.setProperty("NumberOfBins", 1);
     ld2.execute();
     TS_ASSERT(ld2.isExecuted());
 

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -242,6 +242,24 @@ public:
     }
   }
 
+	void test_NumberOfBins() {
+    const std::string file = "SANS2D00022048.nxs";
+          int nBins = 273;
+    LoadEventNexus alg;
+    alg.setChild(true);
+    alg.setRethrows(true);
+    alg.initialize();
+    alg.setProperty("Filename", file);
+    alg.setProperty("OutputWorkspace", "dummy_for_child");
+    alg.setProperty("NumberOfBins", nBins);
+    alg.execute();
+    Workspace_sptr ws = alg.getProperty("OutputWorkspace");
+    auto eventWS = boost::dynamic_pointer_cast<EventWorkspace>(ws);
+    TS_ASSERT(eventWS);
+
+    TS_ASSERT_EQUALS(eventWS->blocksize(), nBins);
+  }
+
   void test_load_event_nexus_sans2d_ess() {
     const std::string file = "SANS2D_ESS_example.nxs";
     LoadEventNexus alg;

--- a/Framework/DataHandling/test/SaveDaveGrpTest.h
+++ b/Framework/DataHandling/test/SaveDaveGrpTest.h
@@ -210,6 +210,7 @@ public:
     ld.setPropertyValue("Filename", "CNCS_7860_event.nxs");
     ld.setPropertyValue("OutputWorkspace", outws);
     ld.setPropertyValue("Precount", "0");
+    ld.setProperty("NumberOfBins", 1);
     ld.execute();
     TS_ASSERT(ld.isExecuted());
     AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();

--- a/Testing/SystemTests/tests/analysis/ReflectometryFloodCorrection.py
+++ b/Testing/SystemTests/tests/analysis/ReflectometryFloodCorrection.py
@@ -73,7 +73,7 @@ class ReflectometryApplyFloodWorkspace(systemtesting.MantidSystemTest):
     def runTest(self):
         flood = CreateFloodWorkspace('OFFSPEC00035946.nxs', StartSpectrum=250, EndSpectrum=600,
                                      ExcludeSpectra=[260, 261, 262, 516, 517, 518], OutputWorkspace='flood')
-        data = Load('OFFSPEC00044998.nxs')
+        data = Load('OFFSPEC00044998.nxs', NumberOfBins=1)
         ApplyFloodWorkspace(InputWorkspace=data, FloodWorkspace=flood, OutputWorkspace=self.out_ws_name)
 
     def validate(self):

--- a/docs/source/algorithms/ConvertToMatrixWorkspace-v1.rst
+++ b/docs/source/algorithms/ConvertToMatrixWorkspace-v1.rst
@@ -21,7 +21,7 @@ Usage
 
 .. testcode:: ConvertToMatrixWorkspaceSimpleExample
 
-   event_ws = Load('CNCS_7860_event.nxs',NumberO)
+   event_ws = Load('CNCS_7860_event.nxs')
    # Run the conversion algorithm
    histo_ws = ConvertToMatrixWorkspace(event_ws)
    # Check that the original workspace and the converted workspace have the same shape

--- a/docs/source/algorithms/ConvertToMatrixWorkspace-v1.rst
+++ b/docs/source/algorithms/ConvertToMatrixWorkspace-v1.rst
@@ -21,7 +21,7 @@ Usage
 
 .. testcode:: ConvertToMatrixWorkspaceSimpleExample
 
-   event_ws = Load('CNCS_7860_event.nxs')
+   event_ws = Load('CNCS_7860_event.nxs',NumberO)
    # Run the conversion algorithm
    histo_ws = ConvertToMatrixWorkspace(event_ws)
    # Check that the original workspace and the converted workspace have the same shape
@@ -30,8 +30,8 @@ Usage
 
 .. testoutput:: ConvertToMatrixWorkspaceSimpleExample
 
-   51200 1
-   51200 1
+   51200 500
+   51200 500
 
 **Example - Conversion when blocksize > 1**
 

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -10,9 +10,9 @@ Description
 -----------
 
 The LoadEventNeXus algorithm loads data from an EventNexus file into an
-:ref:`EventWorkspace <EventWorkspace>`. The default histogram bin
-boundaries consist of a single bin able to hold all events (in all
-pixels), and will have their :ref:`units <Unit Factory>` set to time-of-flight.
+:ref:`EventWorkspace <EventWorkspace>`. The histogram bin
+boundaries depend on the setting of NumberOfBins, which by default will be the whole range of time of flight able to hold all events (in all
+pixels) split into NumberOfBins linear bins, and will have their :ref:`units <Unit Factory>` set to time-of-flight.
 Since it is an :ref:`EventWorkspace <EventWorkspace>`, it can be rebinned
 to finer bins with no loss of data.
 

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -29,6 +29,7 @@ Algorithms
 Improvements
 ############
 
+- :ref:`LoadEventNexus <algm-LoadEventNexus>` Now has a new propery NumberOfBins to select how many linear bins to intially apply to the data.  This allows event data to be plotted immediately without having to :ref:`Rebin <algm-Rebin>` it first.  This is a change from before where event data was initally loaded with a single bin, now by default it will be split into 500 linear bins.
 - :ref:`SaveAscii <algm-SaveAscii>` can now save table workspaces, and :ref:`LoadAscii <algm-LoadAscii>` can load them again.
 - :ref:`TotScatCalculateSelfScattering <algm-TotScatCalculateSelfScattering>` will calculate a normalized self scattering correction for foccues total scattering data.
 - :ref:`MatchAndMergeWorkspaces <algm-MatchAndMergeWorkspaces>` will merge workspaces in a workspace group withing weighting from a set of limits for each workspace and using `MatchSpectra <algm-MatchSpectra>`.


### PR DESCRIPTION
It defaults to 500 bins.
This allows event data to be plotted without rebinning first.
**This is a change from before when it would all be in one bin.**
It does not change the underlying data that remains in events.


**Description of work.**
Added a new property to LoadEventNexus, and changes the initial X bin Boundaries when data is loaded (not if there were no events or meta data only).
This removes the confusion of users when they load event data but cannot plot it without knowing to rebin the data first.

**Labelled as Extra Attention as this is a very core algorithm.**

**To test:**
1. Load event data (it needs to be "Raw" event data that LoadEventNexus loads, not mantid files from SaveProcessedNexus.
1. Plot and look at the table created, by default it should have 500 linear bins.
1. play around with the NumberOfBins property, make sure you cannot set 0, or negative numbers or none integer numbers.
1. check that you can set NumberOfBins to 1 to replicate how it used to work.

Fixes #27731 . 

The training courses will need updating after this is merged.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
