### PR TITLE
Windows: Fix switching between Python 2/3 without clean

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -99,12 +99,14 @@ if(MSVC)
     set(PYTHON_VERSION_MAJOR 2)
     set(PYTHON_VERSION_MINOR 7)
   endif()
-  set(PYTHON_EXECUTABLE
-      ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/python.exe
-  )
+  set(_python_dir ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+  set(PYTHON_EXECUTABLE ${_python_dir}/python.exe CACHE FILEPATH "Location of python executable" FORCE)
+  set(PYTHONW_EXECUTABLE "${_python_dir}/pythonw.exe" CACHE FILEPATH
+      "The location of the pythonw executable. This suppresses the new terminal window on startup" FORCE )
   set(THIRD_PARTY_BIN
-      "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}"
+      "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${_python_dir}"
   )
+  unset(_python_dir)
   message(STATUS "Third party dependencies are in ${THIRD_PARTY_DIR}")
   # Add to the path so that cmake can configure correctly without the user
   # having to do it

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -31,7 +31,7 @@ string ( REGEX REPLACE "/" "\\\\" THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/lib/" 
 # /external:I    - Ignore third party library warnings (similar to "isystem" in GCC)
 set ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
   /MP /W3 \
-  /experimental:external /external:W0 /external:I ${THIRD_PARTY_INCLUDE_DIR} /external:I ${THIRD_PARTY_LIB_DIR}\\python2.7\\ "
+  /experimental:external /external:W0 /external:I ${THIRD_PARTY_INCLUDE_DIR} /external:I ${THIRD_PARTY_LIB_DIR}\\python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\\ "
 )
 
 # Set PCH heap limit, the default does not work when running msbuild from the commandline for some reason
@@ -53,18 +53,9 @@ endif()
 set ( Qt5_DIR ${THIRD_PARTY_DIR}/lib/qt5/lib/cmake/Qt5 )
 
 ###########################################################################
-# On Windows we want to bundle Python.
+# Python development
 ###########################################################################
-set ( PYTHON_DIR ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR} )
-## Set the variables that FindPythonLibs would set
-set ( PYTHON_INCLUDE_PATH "${PYTHON_DIR}/Include" )
-set ( PYTHON_LIBRARIES ${PYTHON_DIR}/libs/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.lib )
-
-## The executable
-set ( PYTHON_EXECUTABLE "${PYTHON_DIR}/python.exe" CACHE FILEPATH "The location of the python executable" FORCE )
-# The "pythonw" executable that avoids raising another terminal when it runs. Used for IPython
-set ( PYTHONW_EXECUTABLE "${PYTHON_DIR}/pythonw.exe" CACHE FILEPATH
-      "The location of the pythonw executable. This suppresses the new terminal window on startup" FORCE )
+find_package ( PythonLibs REQUIRED )
 
 ###########################################################################
 # If required, find tcmalloc


### PR DESCRIPTION
**Description of work.**

Set cache variables for PYTHON_EXECUTABLE on windows
Also uses find_package rather than handwritten code to find
Python libraries so unsetting code works as expected.

**To test:**

If the builds work we are good.

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
