### PR TITLE
Add Cropping Options to Eng Diff Focus Tab

### DIFF
--- a/docs/source/interfaces/Engineering Diffraction 2.rst
+++ b/docs/source/interfaces/Engineering Diffraction 2.rst
@@ -104,8 +104,12 @@ In order to use the tab, a new or existing calibration must be created or loaded
 Currently, the focusing tab only supports one focusing mode:
 
 - **Normal Focusing:**
-    The user is able to select which banks they want to focus, and all the spectra from those banks will be considered.
+    A run number can be entered and both banks will be focused.
     The output workspaces will have a suffix denoting which bank they are for.
+
+- **Cropped Focusing:**
+    The entered workspace can be cropped to one of the two banks or to a user defined set of spectra.
+    Custom cropped workspaces will have the suffix "cropped".
 
 The focused data files are saved in NeXus format to:
 
@@ -121,3 +125,10 @@ Parameters
 
 Sample Run Number
     The run number or file path to the data file to be focused.
+
+Bank/Spectra
+    Select which bank to restrict the focusing to or allow for the entry of custom spectra. 
+
+Custom Spectra
+    A comma separated list of spectra to restrict the calibration to. Can be provided as single spectrum numbers
+    or ranges using hyphens (e.g. 14-150, 405, 500-600).

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -36,7 +36,7 @@ class CalibrationPresenter(object):
 
         # Cropping Options
         self.cropping_widget = CroppingWidget(self.view, view=self.view.get_cropping_widget())
-        self.view.set_cropping_widget_hidden()
+        self.show_cropping(False)
 
     def connect_view_signals(self):
         self.view.set_on_calibrate_clicked(self.on_calibrate_clicked)
@@ -169,7 +169,7 @@ class CalibrationPresenter(object):
             self.set_calibrate_button_text("Load")
             self.view.set_check_plot_output_enabled(False)
             self.view.set_check_cropping_enabled(False)
-            self.view.set_check_cropping_state(0)
+            self.view.set_check_cropping_checked(False)
 
     def set_calibrate_button_text(self, text):
         self.view.set_calibrate_button_text(text)
@@ -179,10 +179,7 @@ class CalibrationPresenter(object):
         self.view.find_vanadium_files()
 
     def show_cropping(self, show):
-        if show:
-            self.view.set_cropping_widget_visible()
-        else:
-            self.view.set_cropping_widget_hidden()
+        self.view.set_cropping_widget_visibility(show)
 
     # -----------------------
     # Observers / Observables

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -125,7 +125,7 @@ class CalibrationPresenter(object):
         if not self.validate_run_numbers():
             create_error_message(self.view, "Check run numbers/path is valid.")
             return False
-        if not self.cropping_widget.is_valid():
+        if self.view.get_crop_checked() and not self.cropping_widget.is_valid():
             create_error_message(self.view, "Check cropping values are valid.")
             return False
         return True

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
@@ -281,9 +281,9 @@ class CalibrationPresenterTest(unittest.TestCase):
     def test_cropping_disabled_when_loading_calib(self):
         self.presenter.set_load_existing_enabled(True)
 
-        self.assertEqual(self.view.set_cropping_widget_hidden.call_count, 1)
+        self.view.set_cropping_widget_visibility.assert_called_with(False)
         self.view.set_check_cropping_enabled.assert_called_with(False)
-        self.view.set_check_cropping_state.assert_called_with(0)
+        self.view.set_check_cropping_checked.assert_called_with(False)
 
     def check_calibration_equal(self, a, b):
         self.assertEqual(a.get_vanadium(), b.get_vanadium())

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
@@ -93,17 +93,14 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_calibrate_button_text(self, text):
         self.button_calibrate.setText(text)
 
-    def set_cropping_widget_visible(self):
-        self.widget_cropping.show()
-
-    def set_cropping_widget_hidden(self):
-        self.widget_cropping.hide()
+    def set_cropping_widget_visibility(self, visible):
+        self.widget_cropping.setVisible(visible)
 
     def set_check_cropping_enabled(self, enabled):
         self.check_cropCalib.setEnabled(enabled)
 
-    def set_check_cropping_state(self, state):
-        self.check_cropCalib.setCheckState(state)
+    def set_check_cropping_checked(self, checked):
+        self.check_cropCalib.setChecked(checked)
 
     # =================
     # Component Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_model.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import re
 
-ENGINX_MAX_SPECTRA = 2513
+ENGINX_MAX_SPECTRA = 2400  # 2512 spectra appear in the ws. But from testing, anything > 2400 doesn't work.
 VALID_PUNCT = [",", " ", "-"]
 SPLITTING_REGEX = ",|-"
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_model.py
@@ -22,7 +22,7 @@ class CroppingModel(object):
                 numbers = self._clean_spectrum_numbers(numbers)
                 return "", numbers
             else:
-                return "Invalid spectrum numbers entered. Limits are 0-" + str(ENGINX_MAX_SPECTRA), ""
+                return "Invalid spectrum numbers entered. Limits are 1-" + str(ENGINX_MAX_SPECTRA), ""
         except ValueError as e:
             return str(e), ""
 
@@ -48,7 +48,7 @@ class CroppingModel(object):
     @staticmethod
     def validate_spectrum(number):
         number = number.strip()
-        return number.isdigit() and 0 <= int(number) <= ENGINX_MAX_SPECTRA
+        return number.isdigit() and 1 <= int(number) <= ENGINX_MAX_SPECTRA
 
     def _clean_spectrum_numbers(self, numbers):
         numbers = [word.strip() for word in numbers.split(",")]

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
@@ -73,14 +73,14 @@ QGroupBox:title {
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="1" column="0">
-         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0,0">
+         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0" columnstretch="0,0,0">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <property name="verticalSpacing">
            <number>6</number>
           </property>
-          <item row="2" column="0" colspan="3">
+          <item row="1" column="0" colspan="3">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -96,7 +96,7 @@ QGroupBox:title {
             </property>
            </spacer>
           </item>
-          <item row="7" column="2">
+          <item row="6" column="2">
            <widget class="QPushButton" name="button_focus">
             <property name="enabled">
              <bool>true</bool>
@@ -122,44 +122,14 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
-           <layout class="QHBoxLayout" name="layout_banks">
-            <item>
-             <widget class="QCheckBox" name="check_northBank">
-              <property name="text">
-               <string>North - 1</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <property name="tristate">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="check_southBank">
-              <property name="text">
-               <string>South - 2</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-              <property name="tristate">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="3" column="0" colspan="3">
+          <item row="2" column="0" colspan="3">
            <widget class="Line" name="line">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="7" column="0" colspan="2">
+          <item row="6" column="0" colspan="2">
            <widget class="QCheckBox" name="check_plotOutput">
             <property name="enabled">
              <bool>true</bool>
@@ -169,7 +139,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="3">
+          <item row="5" column="0" colspan="3">
            <widget class="Line" name="line_2">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -188,14 +158,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_banks">
-            <property name="text">
-             <string>Select Banks:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="3">
+          <item row="4" column="0" colspan="3">
            <widget class="CroppingView" name="widget_cropping" native="true">
             <property name="minimumSize">
              <size>
@@ -205,7 +168,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="3" column="0" colspan="3">
            <widget class="QCheckBox" name="check_cropFocus">
             <property name="text">
              <string>Crop Focus</string>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>617</width>
-    <height>153</height>
+    <height>197</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -73,56 +73,13 @@ QGroupBox:title {
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="1" column="0">
-         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0" columnstretch="0,0,0">
+         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0" columnstretch="0,0,0">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <property name="verticalSpacing">
            <number>6</number>
           </property>
-          <item row="4" column="2">
-           <widget class="QPushButton" name="button_focus">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Focus</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QCheckBox" name="check_plotOutput">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Plot Focused Workspace</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="3">
-           <widget class="Line" name="line">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0" colspan="3">
-           <widget class="FileFinder" name="finder_focus" native="true">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0" colspan="3">
            <spacer name="verticalSpacer">
             <property name="orientation">
@@ -139,10 +96,29 @@ QGroupBox:title {
             </property>
            </spacer>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_banks">
+          <item row="7" column="2">
+           <widget class="QPushButton" name="button_focus">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
             <property name="text">
-             <string>Select Banks:</string>
+             <string>Focus</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0" colspan="3">
+           <widget class="FileFinder" name="finder_focus" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
            </widget>
           </item>
@@ -176,6 +152,66 @@ QGroupBox:title {
             </item>
            </layout>
           </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="Line" name="line">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0" colspan="2">
+           <widget class="QCheckBox" name="check_plotOutput">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Plot Focused Workspace</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0" colspan="3">
+           <widget class="Line" name="line_2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_banks">
+            <property name="text">
+             <string>Select Banks:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="3">
+           <widget class="CroppingView" name="widget_cropping" native="true">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="check_cropFocus">
+            <property name="text">
+             <string>Crop Focus</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
        </layout>
@@ -203,6 +239,12 @@ QGroupBox:title {
    <class>FileFinder</class>
    <extends>QWidget</extends>
    <header>mantidqt.widgets.filefinder</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>CroppingView</class>
+   <extends>QWidget</extends>
+   <header>Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_view</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -20,7 +20,7 @@ FOCUSED_OUTPUT_WORKSPACE_NAME = "engggui_focusing_output_ws_bank_"
 
 
 class FocusModel(object):
-    def focus_run(self, sample_path, banks, plot_output, instrument, rb_num):
+    def focus_run(self, sample_path, banks, plot_output, instrument, rb_num, spectrum_numbers):
         """
         Focus some data using the current calibration.
         :param sample_path: The path to the data to be focused.
@@ -28,6 +28,7 @@ class FocusModel(object):
         :param plot_output: True if the output should be plotted.
         :param instrument: The instrument that the data came from.
         :param rb_num: The experiment number, used to create directories. Can be None
+        :param spectrum_numbers: The specific spectra that should be focused. Used instead of banks.
         """
         if not Ads.doesExist(vanadium_corrections.INTEGRATED_WORKSPACE_NAME) and not Ads.doesExist(
                 vanadium_corrections.CURVES_WORKSPACE_NAME):
@@ -42,13 +43,20 @@ class FocusModel(object):
             full_calib_workspace = path_handling.load_workspace(full_calib_path)
         else:
             full_calib_workspace = None
-        for name in banks:
-            output_workspace_name = FOCUSED_OUTPUT_WORKSPACE_NAME + str(name)
+        if spectrum_numbers is None:
+            for name in banks:
+                output_workspace_name = FOCUSED_OUTPUT_WORKSPACE_NAME + str(name)
+                self._run_focus(sample_workspace, output_workspace_name, integration_workspace,
+                                curves_workspace, name, full_calib_workspace)
+                output_workspaces.append(output_workspace_name)
+                # Save the output to the file system.
+                self._save_output(instrument, sample_path, name, output_workspace_name, rb_num)
+        else:
+            output_workspace_name = FOCUSED_OUTPUT_WORKSPACE_NAME + "cropped"
             self._run_focus(sample_workspace, output_workspace_name, integration_workspace,
-                            curves_workspace, name, full_calib_workspace)
+                            curves_workspace, None, full_calib_workspace, spectrum_numbers)
             output_workspaces.append(output_workspace_name)
-            # Save the output to the file system.
-            self._save_output(instrument, sample_path, name, output_workspace_name, rb_num)
+            self._save_output(instrument, sample_path, "cropped", output_workspace_name, rb_num)
         # Plot the output
         if plot_output:
             self._plot_focused_workspaces(output_workspaces)
@@ -59,21 +67,24 @@ class FocusModel(object):
                    vanadium_integration_ws,
                    vanadium_curves_ws,
                    bank,
-                   full_calib_ws=None):
+                   full_calib_ws=None,
+                   spectrum_numbers=None):
+        kwargs = {
+            "InputWorkspace": input_workspace,
+            "OutputWorkspace": output_workspace,
+            "VanIntegrationWorkspace": vanadium_integration_ws,
+            "VanCurvesWorkspace": vanadium_curves_ws
+        }
+        if full_calib_ws is not None:
+            kwargs["DetectorPositions"] = full_calib_ws
+
+        if bank is None:
+            kwargs["SpectrumNumbers"] = spectrum_numbers
+        else:
+            kwargs["Bank"] = bank
+
         try:
-            if full_calib_ws is not None:
-                return EnggFocus(InputWorkspace=input_workspace,
-                                 OutputWorkspace=output_workspace,
-                                 VanIntegrationWorkspace=vanadium_integration_ws,
-                                 VanCurvesWorkspace=vanadium_curves_ws,
-                                 Bank=bank,
-                                 DetectorPositions=full_calib_ws)
-            else:
-                return EnggFocus(InputWorkspace=input_workspace,
-                                 OutputWorkspace=output_workspace,
-                                 VanIntegrationWorkspace=vanadium_integration_ws,
-                                 VanCurvesWorkspace=vanadium_curves_ws,
-                                 Bank=bank)
+            return EnggFocus(**kwargs)
         except RuntimeError as e:
             logger.error(
                 "Error in focusing, Could not run the EnggFocus algorithm successfully for bank " +

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -10,6 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 from Engineering.gui.engineering_diffraction.tabs.common import INSTRUMENT_DICT, create_error_message
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
 from Engineering.gui.engineering_diffraction.tabs.common.vanadium_corrections import check_workspaces_exist
+from Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_widget import CroppingWidget
 from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.utils.observer_pattern import Observer
 from mantid.simpleapi import logger
@@ -25,11 +26,16 @@ class FocusPresenter(object):
         # Connect view signals to local methods.
         self.view.set_on_focus_clicked(self.on_focus_clicked)
         self.view.set_enable_controls_connection(self.set_focus_controls_enabled)
+        self.view.set_on_check_cropping_state_changed(self.show_cropping)
 
         # Variables from other GUI tabs.
         self.current_calibration = CalibrationInfo()
         self.instrument = "ENGINX"
         self.rb_num = None
+
+        # Cropping Options
+        self.cropping_widget = CroppingWidget(self.view, view=self.view.get_cropping_widget())
+        self.view.set_cropping_widget_hidden()
 
     def on_focus_clicked(self):
         banks = self._get_banks()
@@ -114,6 +120,12 @@ class FocusPresenter(object):
         :param calibration: The new current calibration.
         """
         self.current_calibration = calibration
+
+    def show_cropping(self, visible):
+        if visible:
+            self.view.set_cropping_widget_visible()
+        else:
+            self.view.set_cropping_widget_hidden()
 
     # -----------------------
     # Observers / Observables

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -71,7 +71,6 @@ class FocusPresenter(object):
     def _validate(self):
         """
         Ensure that the worker is ready to be started.
-        :param banks: A list of banks to focus.
         :return: True if the worker can be started safely.
         """
         if self.view.is_searching():

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -13,7 +13,6 @@ from Engineering.gui.engineering_diffraction.tabs.common.vanadium_corrections im
 from Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_widget import CroppingWidget
 from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.utils.observer_pattern import Observer
-from mantid.simpleapi import logger
 
 
 class FocusPresenter(object):
@@ -95,8 +94,7 @@ class FocusPresenter(object):
             return False
         return True
 
-    def _on_worker_error(self, failure_info):
-        logger.warning(str(failure_info))
+    def _on_worker_error(self, _):
         self.emit_enable_button_signal()
 
     def set_focus_controls_enabled(self, enabled):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -34,7 +34,7 @@ class FocusPresenter(object):
 
         # Cropping Options
         self.cropping_widget = CroppingWidget(self.view, view=self.view.get_cropping_widget())
-        self.view.set_cropping_widget_hidden()
+        self.show_cropping(False)
 
     def on_focus_clicked(self):
         if not self._validate():
@@ -121,10 +121,7 @@ class FocusPresenter(object):
         self.current_calibration = calibration
 
     def show_cropping(self, visible):
-        if visible:
-            self.view.set_cropping_widget_visible()
-        else:
-            self.view.set_cropping_widget_hidden()
+        self.view.set_cropping_widget_visibility(visible)
 
     # -----------------------
     # Observers / Observables

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -29,7 +29,7 @@ class FocusModelTest(unittest.TestCase):
     @patch(file_path + ".vanadium_corrections.Ads.doesExist")
     def test_focus_cancelled_if_van_wsp_missing(self, ads_exist, load):
         ads_exist.return_value = False
-        self.model.focus_run("307593", ["1", "2"], False, "ENGINX", "0")
+        self.model.focus_run("307593", ["1", "2"], False, "ENGINX", "0", None)
         self.assertEqual(load.call_count, 0)
 
     @patch(file_path + ".Ads")
@@ -41,11 +41,26 @@ class FocusModelTest(unittest.TestCase):
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", banks, False, "ENGINX", "0")
+        self.model.focus_run("305761", banks, False, "ENGINX", "0", None)
         self.assertEqual(len(banks), run_focus.call_count)
         run_focus.assert_called_with("mocked_sample",
                                      model.FOCUSED_OUTPUT_WORKSPACE_NAME + banks[-1], "test_wsp",
                                      "test_wsp", banks[-1], None)
+
+    @patch(file_path + ".Ads")
+    @patch(file_path + ".FocusModel._save_output")
+    @patch(file_path + ".FocusModel._run_focus")
+    @patch(file_path + ".path_handling.load_workspace")
+    def test_focus_run_for_custom_spectra(self, load_focus, run_focus, output, ads):
+        ads.retrieve.return_value = "test_wsp"
+        spectra = "20-50"
+        load_focus.return_value = "mocked_sample"
+
+        self.model.focus_run("305761", None, False, "ENGINX", "0", spectra)
+        self.assertEqual(1, run_focus.call_count)
+        run_focus.assert_called_with("mocked_sample",
+                                     model.FOCUSED_OUTPUT_WORKSPACE_NAME + "cropped", "test_wsp",
+                                     "test_wsp", None, None, spectra)
 
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
@@ -60,7 +75,7 @@ class FocusModelTest(unittest.TestCase):
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", banks, True, "ENGINX", "0")
+        self.model.focus_run("305761", banks, True, "ENGINX", "0", None)
         self.assertEqual(1, plot_focus.call_count)
 
     @patch(file_path + ".Ads")
@@ -75,7 +90,7 @@ class FocusModelTest(unittest.TestCase):
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", banks, False, "ENGINX", "0")
+        self.model.focus_run("305761", banks, False, "ENGINX", "0", None)
         self.assertEqual(0, plot_focus.call_count)
 
     @patch(file_path + ".SaveFocusedXYE")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
@@ -10,7 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 import unittest
 
 from mantid.py3compat import mock
-from mantid.py3compat.mock import patch
+from mantid.py3compat.mock import patch, MagicMock
 from Engineering.gui.engineering_diffraction.tabs.focus import model, view, presenter
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
 
@@ -22,6 +22,7 @@ class FocusPresenterTest(unittest.TestCase):
         self.view = mock.create_autospec(view.FocusView)
         self.model = mock.create_autospec(model.FocusModel)
         self.presenter = presenter.FocusPresenter(self.model, self.view)
+        self.presenter.cropping_widget = MagicMock()
 
     @patch(tab_path + ".presenter.check_workspaces_exist")
     @patch(tab_path + ".presenter.FocusPresenter.start_focus_worker")
@@ -30,14 +31,29 @@ class FocusPresenterTest(unittest.TestCase):
                                                              sample_path="Fake/Path",
                                                              instrument="ENGINX")
         self.view.get_focus_filename.return_value = "305738"
-        self.view.get_north_bank.return_value = False
-        self.view.get_south_bank.return_value = True
+        self.presenter.cropping_widget.get_bank.return_value = "2"
+        self.presenter.cropping_widget.is_custom.return_value = False
         self.view.get_plot_output.return_value = True
         self.view.is_searching.return_value = False
         wsp_exists.return_value = True
 
         self.presenter.on_focus_clicked()
-        worker.assert_called_with("305738", ["South"], True, None)
+        worker.assert_called_with("305738", ["2"], True, None, None)
+
+    @patch(tab_path + ".presenter.check_workspaces_exist")
+    @patch(tab_path + ".presenter.FocusPresenter.start_focus_worker")
+    def test_worker_started_with_correct_params_custom_crop(self, worker, wsp_exists):
+        self.presenter.current_calibration = CalibrationInfo(vanadium_path="Fake/Path",
+                                                             sample_path="Fake/Path",
+                                                             instrument="ENGINX")
+        self.view.get_focus_filename.return_value = "305738"
+        self.presenter.cropping_widget.get_custom_spectra.return_value = "2-45"
+        self.view.get_plot_output.return_value = True
+        self.view.is_searching.return_value = False
+        wsp_exists.return_value = True
+
+        self.presenter.on_focus_clicked()
+        worker.assert_called_with("305738", None, True, None, "2-45")
 
     @patch(tab_path + ".presenter.FocusPresenter._validate")
     @patch(tab_path + ".presenter.FocusPresenter.start_focus_worker")
@@ -70,35 +86,31 @@ class FocusPresenterTest(unittest.TestCase):
         self.assertEqual(emit.call_count, 1)
 
     def test_get_both_banks(self):
-        self.view.get_north_bank.return_value = True
-        self.view.get_south_bank.return_value = True
-
-        self.assertEqual(["North", "South"], self.presenter._get_banks())
+        self.view.get_crop_checked.return_value = False
+        self.assertEqual((["1", "2"], None), self.presenter._get_banks())
 
     def test_get_north_bank(self):
-        self.view.get_north_bank.return_value = True
-        self.view.get_south_bank.return_value = False
+        self.presenter.cropping_widget.is_custom.return_value = False
+        self.presenter.cropping_widget.get_bank.return_value = "1"
 
-        self.assertEqual(["North"], self.presenter._get_banks())
+        self.assertEqual((["1"], None), self.presenter._get_banks())
 
     def test_get_south_bank(self):
-        self.view.get_north_bank.return_value = False
-        self.view.get_south_bank.return_value = True
+        self.presenter.cropping_widget.is_custom.return_value = False
+        self.presenter.cropping_widget.get_bank.return_value = "2"
 
-        self.assertEqual(["South"], self.presenter._get_banks())
+        self.assertEqual((["2"], None), self.presenter._get_banks())
 
-    def test_getting_no_banks(self):
-        self.view.get_north_bank.return_value = False
-        self.view.get_south_bank.return_value = False
+    def test_get_custom_spectra(self):
+        self.presenter.cropping_widget.get_custom_spectra.return_value = "10-15"
 
-        self.assertEqual([], self.presenter._get_banks())
+        self.assertEqual((None, "10-15"), self.presenter._get_banks())
 
     @patch(tab_path + ".presenter.create_error_message")
     def test_validate_with_invalid_focus_path(self, error_message):
         self.view.get_focus_valid.return_value = False
-        banks = ["North", "South"]
 
-        self.assertFalse(self.presenter._validate(banks))
+        self.assertFalse(self.presenter._validate())
         self.assertEqual(error_message.call_count, 1)
 
     @patch(tab_path + ".presenter.create_error_message")
@@ -107,9 +119,8 @@ class FocusPresenterTest(unittest.TestCase):
                                                              sample_path=None,
                                                              instrument=None)
         self.view.is_searching.return_value = False
-        banks = ["North", "South"]
 
-        self.presenter._validate(banks)
+        self.presenter._validate()
         create_error.assert_called_with(
             self.presenter.view,
             "Create or Load a calibration via the Calibration tab before focusing.")
@@ -122,23 +133,22 @@ class FocusPresenterTest(unittest.TestCase):
                                                              instrument="ENGINX")
         self.view.is_searching.return_value = True
         wsp_check.return_value = True
-        banks = ["North", "South"]
 
-        self.assertEqual(False, self.presenter._validate(banks))
+        self.assertEqual(False, self.presenter._validate())
         self.assertEqual(1, create_error.call_count)
 
     @patch(tab_path + ".presenter.check_workspaces_exist")
     @patch(tab_path + ".presenter.create_error_message")
-    def test_validate_with_no_banks_selected(self, create_error, wsp_check):
+    def test_validate_with_invalid_spectra(self, create_error, wsp_check):
         self.presenter.current_calibration = CalibrationInfo(vanadium_path="Fake/Path",
                                                              sample_path="Fake/Path",
                                                              instrument="ENGINX")
         self.view.is_searching.return_value = False
-        banks = []
         wsp_check.return_value = True
+        self.presenter.cropping_widget.is_valid.return_value = False
 
-        self.presenter._validate(banks)
-        create_error.assert_called_with(self.presenter.view, "Please select at least one bank.")
+        self.presenter._validate()
+        create_error.assert_called_with(self.presenter.view, "Check cropping values are valid.")
 
 
 if __name__ == '__main__':

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
@@ -76,14 +76,12 @@ class FocusPresenterTest(unittest.TestCase):
         self.view.set_plot_output_enabled.assert_called_with(True)
 
     @patch(tab_path + ".presenter.FocusPresenter.emit_enable_button_signal")
-    @patch(tab_path + ".presenter.logger.warning")
-    def test_on_worker_error_posts_to_logger_and_enables_controls(self, logger, emit):
+    def test_on_worker_error_posts_to_logger_and_enables_controls(self, emit):
         fail_info = 2024278
 
         self.presenter._on_worker_error(fail_info)
 
-        logger.assert_called_with(str(fail_info))
-        self.assertEqual(emit.call_count, 1)
+        self.assertEqual(1, emit.call_count)
 
     def test_get_both_banks(self):
         self.view.get_crop_checked.return_value = False

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
@@ -49,17 +49,8 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
     def set_plot_output_enabled(self, enabled):
         self.check_plotOutput.setEnabled(enabled)
 
-    def set_cropping_widget_hidden(self):
-        self.widget_cropping.hide()
-
-    def set_cropping_widget_visible(self):
-        self.widget_cropping.show()
-
-    def set_check_cropping_enabled(self, enabled):
-        self.check_cropFocus.setEnabled(enabled)
-
-    def set_check_cropping_state(self, state):
-        self.check_cropFocus.setCheckState(state)
+    def set_cropping_widget_visibility(self, visible):
+        self.widget_cropping.setVisible(visible)
 
     # =================
     # Component Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
@@ -71,12 +71,6 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
     def get_focus_valid(self):
         return self.finder_focus.isValid()
 
-    def get_north_bank(self):
-        return self.check_northBank.isChecked()
-
-    def get_south_bank(self):
-        return self.check_southBank.isChecked()
-
     def get_plot_output(self):
         return self.check_plotOutput.isChecked()
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
@@ -33,6 +33,9 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
     def set_enable_controls_connection(self, slot):
         self.sig_enable_controls.connect(slot)
 
+    def set_on_check_cropping_state_changed(self, slot):
+        self.check_cropFocus.stateChanged.connect(slot)
+
     # =================
     # Component Setters
     # =================
@@ -45,6 +48,18 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
 
     def set_plot_output_enabled(self, enabled):
         self.check_plotOutput.setEnabled(enabled)
+
+    def set_cropping_widget_hidden(self):
+        self.widget_cropping.hide()
+
+    def set_cropping_widget_visible(self):
+        self.widget_cropping.show()
+
+    def set_check_cropping_enabled(self, enabled):
+        self.check_cropFocus.setEnabled(enabled)
+
+    def set_check_cropping_state(self, state):
+        self.check_cropFocus.setCheckState(state)
 
     # =================
     # Component Getters
@@ -64,6 +79,12 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
 
     def get_plot_output(self):
         return self.check_plotOutput.isChecked()
+
+    def get_crop_checked(self):
+        return self.check_cropFocus.isChecked()
+
+    def get_cropping_widget(self):
+        return self.widget_cropping
 
     # =================
     # State Getters


### PR DESCRIPTION
~**Not ready for review until #27714 is merged**~

**Description of work.**
Cropping can now be done when focusing a run.
The GUI now allows for cropping by bank (1 or 2), or by specific spectrum numbers.

**To test:**
1. Add this line to "mantid.user.properties": `mantidqt.python_interfaces=Direct/DGS_Reduction.py Direct/DGSPlanner.py Direct/PyChop.py Direct/MSlice.py SANS/ORNL_SANS.py Utility/TofConverter.py Reflectometry/ISIS_Reflectometry_Old.py Diffraction/Engineering_Diffraction_2.py Diffraction/Powder_Diffraction_Reduction.py Utility/FilterEvents.py Diffraction/HFIR_4Circle_Reduction.py Utility/QECoverage.py SANS/ISIS_SANS.py Muon/Frequency_Domain_Analysis.py Muon/Elemental_Analysis.py Muon/Frequency_Domain_Analysis_Old.py Muon/Muon_Analysis.py` to allow access to the Engineering Diffraction 2 GUI.
1.   Open Engineering Diffraction 2 GUI
1. Switch to the Focus tab
  1. Use 305761 as the run number
  0.  Check that the combo box selector appears when the cropping check box is selected
  0.  Check selecting custom spectra reveals a Text entry
   0. Check that only sane values can be entered and error messages make sense. (1200-1400 should guarantee an output)
  0.  Check that outputs are restricted by the cropping and have sane names.

Fixes #27188

*This does not require release notes* because **the GUI is not yet visible to users.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
