### PR TITLE
For one bin workspaces add plot bin options

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -23,6 +23,7 @@ Improvements
 - You can now save Table Workspaces to Ascii using the `SaveAscii <algm-SaveAscii>` algorithm, and the Ascii Save option on the workspaces toolbox.
 - Normalization options have been added to 2d plots and sliceviewer.
 - The images tab in figure options no longer forces the max value to be greater than the min value.
+- Double clicking on a workspace that only has a single bin of data (for example from a constant wavelength source) will now plot that bin, also for single bin workspaces a plot bin option has been added to the right click plot menu of the workspace.
 
 
 Bugfixes

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -69,7 +69,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     @mock.patch('workbench.plugins.workspacewidget.plot', autospec=True)
     def test_plot_with_plot_bin(self,mock_plot):
         self.ws_widget._do_plot_bin([self.ws_names[0]], False, False)
-        mock_plot.assert_called_once_with(unittest.mock.ANY,errors=False, overplot=False, wksp_indices=[0],
+        mock_plot.assert_called_once_with(mock.ANY,errors=False, overplot=False, wksp_indices=[0],
                                           plot_kwargs={'axis': MantidAxType.BIN})
 
     @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -21,6 +21,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from qtpy.QtWidgets import QMainWindow, QApplication
 from workbench.plugins.workspacewidget import WorkspaceWidget
+from mantid.plots.utility import MantidAxType
 
 ALGORITHM_HISTORY_WINDOW_TYPE = "AlgorithmHistoryWindow"
 ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
@@ -28,7 +29,7 @@ ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
 MATRIXWORKSPACE_DISPLAY = "mantidqt.widgets.workspacedisplay.matrix." \
                           "presenter.MatrixWorkspaceDisplay"
 MATRIXWORKSPACE_DISPLAY_TYPE = "StatusBarView"
-
+PLOT_DISPLAY = "matplotlib.pyplot.Plot"
 app = QApplication([])
 
 
@@ -66,6 +67,21 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
             self.ws_widget._do_show_detectors([self.ws_names[0]])
         self.assert_widget_type_exists(MATRIXWORKSPACE_DISPLAY_TYPE)
 
+    @mock.patch('workbench.plugins.workspacewidget.plot', autospec=True)
+    def test_plot_with_plot_bin(self,mock_plot):
+        self.ws_widget._do_plot_bin([self.ws_names[0]], False, False)
+        mock_plot.assert_called_once_with(unittest.mock.ANY,errors=False, overplot=False, wksp_indices=[0],
+            plot_kwargs={'axis': MantidAxType.BIN})
+
+    @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)
+    def test_plot_with_plot_spectrum(self,mock_plot_from_names):
+        self.ws_widget._do_plot_spectrum([self.ws_names[0]], False, False)
+        mock_plot_from_names.assert_called_once_with([self.ws_names[0]], False, False)
+
+    @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
+    def test_plot_with_plot_colorfill(self,mock_plot_colorfill):
+        self.ws_widget._do_plot_colorfill([self.ws_names[0]])
+        mock_plot_colorfill.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -29,7 +29,6 @@ ALGORITHM_HISTORY_WINDOW = "mantidqt.widgets.workspacewidget." \
 MATRIXWORKSPACE_DISPLAY = "mantidqt.widgets.workspacedisplay.matrix." \
                           "presenter.MatrixWorkspaceDisplay"
 MATRIXWORKSPACE_DISPLAY_TYPE = "StatusBarView"
-PLOT_DISPLAY = "matplotlib.pyplot.Plot"
 app = QApplication([])
 
 

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -80,7 +80,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     @mock.patch('workbench.plugins.workspacewidget.pcolormesh', autospec=True)
     def test_plot_with_plot_colorfill(self,mock_plot_colorfill):
         self.ws_widget._do_plot_colorfill([self.ws_names[0]])
-        mock_plot_colorfill.assert_called_once()
+        mock_plot_colorfill.assert_called_once_with(mock.ANY)
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/test/test_workspacewidget.py
@@ -71,7 +71,7 @@ class WorkspaceWidgetTest(unittest.TestCase, QtWidgetFinder):
     def test_plot_with_plot_bin(self,mock_plot):
         self.ws_widget._do_plot_bin([self.ws_names[0]], False, False)
         mock_plot.assert_called_once_with(unittest.mock.ANY,errors=False, overplot=False, wksp_indices=[0],
-            plot_kwargs={'axis': MantidAxType.BIN})
+                                          plot_kwargs={'axis': MantidAxType.BIN})
 
     @mock.patch('workbench.plugins.workspacewidget.plot_from_names', autospec=True)
     def test_plot_with_plot_spectrum(self,mock_plot_from_names):

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -46,7 +46,7 @@ class WorkspaceWidget(PluginWidget):
         self.workspacewidget.plotSpectrumClicked.connect(partial(self._do_plot_spectrum,
                                                                  errors=False, overplot=False))
         self.workspacewidget.plotBinClicked.connect(partial(self._do_plot_bin,
-                                                                 errors=False, overplot=False))
+                                                            errors=False, overplot=False))
         self.workspacewidget.overplotSpectrumClicked.connect(partial(self._do_plot_spectrum,
                                                                      errors=False, overplot=True))
         self.workspacewidget.plotSpectrumWithErrorsClicked.connect(partial(self._do_plot_spectrum,
@@ -95,7 +95,7 @@ class WorkspaceWidget(PluginWidget):
                 return
 
         plot_from_names(names, errors, overplot)
-        
+
     def _do_plot_bin(self, names, errors, overplot):
         """
         Plot a single bin from the selected workspaces
@@ -111,7 +111,8 @@ class WorkspaceWidget(PluginWidget):
                 QMessageBox.warning(self, "", error_msg)
                 return
         plot_kwargs = {"axis": MantidAxType.BIN}
-        plot(self._ads.retrieveWorkspaces(names, unrollGroups=True), errors=errors, overplot=overplot,wksp_indices=[0], plot_kwargs=plot_kwargs)
+        plot(self._ads.retrieveWorkspaces(names, unrollGroups=True), errors=errors,
+             overplot=overplot,wksp_indices=[0], plot_kwargs=plot_kwargs)
 
     def _do_plot_colorfill(self, names):
         """

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -45,6 +45,8 @@ class WorkspaceWidget(PluginWidget):
         # behaviour
         self.workspacewidget.plotSpectrumClicked.connect(partial(self._do_plot_spectrum,
                                                                  errors=False, overplot=False))
+        self.workspacewidget.plotBinClicked.connect(partial(self._do_plot_bin,
+                                                                 errors=False, overplot=False))
         self.workspacewidget.overplotSpectrumClicked.connect(partial(self._do_plot_spectrum,
                                                                      errors=False, overplot=True))
         self.workspacewidget.plotSpectrumWithErrorsClicked.connect(partial(self._do_plot_spectrum,
@@ -93,6 +95,23 @@ class WorkspaceWidget(PluginWidget):
                 return
 
         plot_from_names(names, errors, overplot)
+        
+    def _do_plot_bin(self, names, errors, overplot):
+        """
+        Plot a single bin from the selected workspaces
+
+        :param names: A list of workspace names
+        :param errors: If true then error bars will be plotted on the points
+        :param overplot: If true then the add to the current figure if one
+                         exists and it is a compatible figure
+        """
+        if overplot:
+            compatible, error_msg = can_overplot()
+            if not compatible:
+                QMessageBox.warning(self, "", error_msg)
+                return
+        plot_kwargs = {"axis": MantidAxType.BIN}
+        plot(self._ads.retrieveWorkspaces(names, unrollGroups=True), errors=errors, overplot=overplot,wksp_indices=[0], plot_kwargs=plot_kwargs)
 
     def _do_plot_colorfill(self, names):
         """

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import QApplication, QMessageBox, QVBoxLayout
 from mantid.api import AnalysisDataService, WorkspaceGroup
 from mantid.kernel import logger
 from mantidqt.plotting.functions import can_overplot, pcolormesh, plot, plot_from_names
+from mantid.plots.utility import MantidAxType
 from mantid.simpleapi import CreateDetectorTable
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
@@ -210,10 +211,12 @@ class WorkspaceWidget(PluginWidget):
             TableWorkspaceDisplay.supports(ws)
             self._do_show_data([name])
         except ValueError:
-            if ws.blocksize() > 1:
-                plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
+            if ws.blocksize() == 1:
+                #this is just single bin data, it makes more sense to plot the bin
+                plot_kwargs = {"axis": MantidAxType.BIN}
+                plot([ws],errors=False, overplot=False, wksp_indices=[0], plot_kwargs=plot_kwargs)
             else:
-                self._do_show_data([name])
+                plot_from_names([name], errors=False, overplot=False, show_colorfill_btn=True)
 
     def refresh_workspaces(self):
         self.workspacewidget.refreshWorkspaces()

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -74,10 +74,9 @@ private slots:
 
 private:
   QAction *m_plotSpectrum, *m_plotBin, *m_overplotSpectrum,
-      *m_plotSpectrumWithErrs,
-      *m_overplotSpectrumWithErrs, *m_plotColorfill, *m_sampleLogs,
-      *m_sliceViewer, *m_showInstrument, *m_showData, *m_showAlgorithmHistory,
-      *m_showDetectors;
+      *m_plotSpectrumWithErrs, *m_overplotSpectrumWithErrs, *m_plotColorfill,
+      *m_sampleLogs, *m_sliceViewer, *m_showInstrument, *m_showData,
+      *m_showAlgorithmHistory, *m_showDetectors;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -43,6 +43,7 @@ public:
 
 signals:
   void plotSpectrumClicked(const QStringList &workspaceNames);
+  void plotBinClicked(const QStringList &workspaceNames);
   void overplotSpectrumClicked(const QStringList &workspaceNames);
   void plotSpectrumWithErrorsClicked(const QStringList &workspaceNames);
   void overplotSpectrumWithErrorsClicked(const QStringList &workspaceNames);
@@ -59,6 +60,7 @@ signals:
 
 private slots:
   void onPlotSpectrumClicked();
+  void onPlotBinClicked();
   void onOverplotSpectrumClicked();
   void onPlotSpectrumWithErrorsClicked();
   void onOverplotSpectrumWithErrorsClicked();
@@ -71,7 +73,8 @@ private slots:
   void onShowDetectorsClicked();
 
 private:
-  QAction *m_plotSpectrum, *m_overplotSpectrum, *m_plotSpectrumWithErrs,
+  QAction *m_plotSpectrum, *m_plotBin, *m_overplotSpectrum,
+      *m_plotSpectrumWithErrs,
       *m_overplotSpectrumWithErrs, *m_plotColorfill, *m_sampleLogs,
       *m_sliceViewer, *m_showInstrument, *m_showData, *m_showAlgorithmHistory,
       *m_showDetectors;

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -31,6 +31,7 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
                                                      QWidget *parent)
     : WorkspaceTreeWidget(new MantidTreeModel(), viewOnly, parent),
       m_plotSpectrum(new QAction("Spectrum...", this)),
+      m_plotBin(new QAction("Bin", this)),
       m_overplotSpectrum(new QAction("Overplot spectrum...", this)),
       m_plotSpectrumWithErrs(new QAction("Spectrum with errors...", this)),
       m_overplotSpectrumWithErrs(
@@ -50,6 +51,7 @@ WorkspaceTreeWidgetSimple::WorkspaceTreeWidgetSimple(bool viewOnly,
 
   connect(m_plotSpectrum, SIGNAL(triggered()), this,
           SLOT(onPlotSpectrumClicked()));
+  connect(m_plotBin, SIGNAL(triggered()), this, SLOT(onPlotBinClicked()));
   connect(m_overplotSpectrum, SIGNAL(triggered()), this,
           SLOT(onOverplotSpectrumClicked()));
   connect(m_plotSpectrumWithErrs, SIGNAL(triggered()), this,
@@ -103,10 +105,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     if (auto matrixWS =
             boost::dynamic_pointer_cast<MatrixWorkspace>(workspace)) {
       QMenu *plotSubMenu(new QMenu("Plot", menu));
-      plotSubMenu->addAction(m_plotSpectrum);
-      plotSubMenu->addAction(m_overplotSpectrum);
-      plotSubMenu->addAction(m_plotSpectrumWithErrs);
-      plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+      
 
       // Don't plot 1D spectra if only one X value
       bool multipleBins = false;
@@ -121,9 +120,14 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
           }
         }
       }
-      // disable the actions created so far if only one bin
-      for (auto action : plotSubMenu->actions()) {
-        action->setEnabled(multipleBins);
+
+      if (multipleBins) {
+        plotSubMenu->addAction(m_plotSpectrum);
+        plotSubMenu->addAction(m_overplotSpectrum);
+        plotSubMenu->addAction(m_plotSpectrumWithErrs);
+        plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+      } else {
+        plotSubMenu->addAction(m_plotBin);
       }
 
       plotSubMenu->addSeparator();
@@ -168,6 +172,10 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
 
 void WorkspaceTreeWidgetSimple::onPlotSpectrumClicked() {
   emit plotSpectrumClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+void WorkspaceTreeWidgetSimple::onPlotBinClicked() {
+  emit plotBinClicked(getSelectedWorkspaceNamesAsQList());
 }
 
 void WorkspaceTreeWidgetSimple::onOverplotSpectrumClicked() {

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -105,7 +105,6 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     if (auto matrixWS =
             boost::dynamic_pointer_cast<MatrixWorkspace>(workspace)) {
       QMenu *plotSubMenu(new QMenu("Plot", menu));
-      
 
       // Don't plot 1D spectra if only one X value
       bool multipleBins = false;


### PR DESCRIPTION
**Description of work.**
*Workbench only*
Adds plot bin to the workspace context menu and changes the double click option for one bin workspaces to plot the bin.

**Report to:** @gvardany 


**To test:**
```python
ws = CreateSampleWorkspace()
wsBin = Integration(ws)
```
1. Create some single and multiple bin workspaces
1. make sure that the double click actions are sensible and the plot options on the context menu are sensible and work.

Fixes #27750



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
