### PR TITLE
Fix bundling Python on Windows

### DIFF
--- a/Framework/PythonInterface/mantid/BundlePython.cmake
+++ b/Framework/PythonInterface/mantid/BundlePython.cmake
@@ -9,17 +9,17 @@ if( MSVC )
   #####################################################################
   # Bundle for package
   #####################################################################
-  install ( DIRECTORY ${PYTHON_DIR}/DLLs DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE
+  install ( DIRECTORY ${MSVC_PYTHON_EXECUTABLE_DIR}/DLLs DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE
                                                                           PATTERN "*_d.pyd" EXCLUDE PATTERN "*_d.dll" EXCLUDE )
-  install ( DIRECTORY ${PYTHON_DIR}/Lib DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.pyd" EXCLUDE )
-  install ( DIRECTORY ${PYTHON_DIR}/Scripts DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.py" EXCLUDE )
-  install ( DIRECTORY ${PYTHON_DIR}/tcl DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE )
-  install ( FILES ${PYTHON_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.dll
+  install ( DIRECTORY ${MSVC_PYTHON_EXECUTABLE_DIR}/Lib DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.pyd" EXCLUDE )
+  install ( DIRECTORY ${MSVC_PYTHON_EXECUTABLE_DIR}/Scripts DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE PATTERN "*_d.py" EXCLUDE )
+  install ( DIRECTORY ${MSVC_PYTHON_EXECUTABLE_DIR}/tcl DESTINATION bin PATTERN ".svn" EXCLUDE PATTERN ".git" EXCLUDE )
+  install ( FILES ${MSVC_PYTHON_EXECUTABLE_DIR}/python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}.dll
             ${PYTHON_EXECUTABLE} ${PYTHONW_EXECUTABLE}
             DESTINATION bin )
   # Python >= 3 has an minimal API DLL too
-  if ( EXISTS ${PYTHON_DIR}/python${PYTHON_VERSION_MAJOR}.dll )
-    install ( FILES ${PYTHON_DIR}/python${PYTHON_VERSION_MAJOR}.dll
+  if ( EXISTS ${MSVC_PYTHON_EXECUTABLE_DIR}/python${PYTHON_VERSION_MAJOR}.dll )
+    install ( FILES ${MSVC_PYTHON_EXECUTABLE_DIR}/python${PYTHON_VERSION_MAJOR}.dll
               DESTINATION bin )
   endif()
 endif()

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -99,14 +99,14 @@ if(MSVC)
     set(PYTHON_VERSION_MAJOR 2)
     set(PYTHON_VERSION_MINOR 7)
   endif()
-  set(_python_dir ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-  set(PYTHON_EXECUTABLE ${_python_dir}/python.exe CACHE FILEPATH "Location of python executable" FORCE)
-  set(PYTHONW_EXECUTABLE "${_python_dir}/pythonw.exe" CACHE FILEPATH
+  # used in later parts for MSVC to bundle Python
+  set(MSVC_PYTHON_EXECUTABLE_DIR ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+  set(PYTHON_EXECUTABLE ${MSVC_PYTHON_EXECUTABLE_DIR}/python.exe CACHE FILEPATH "Location of python executable" FORCE)
+  set(PYTHONW_EXECUTABLE "${MSVC_PYTHON_EXECUTABLE_DIR}/pythonw.exe" CACHE FILEPATH
       "The location of the pythonw executable. This suppresses the new terminal window on startup" FORCE )
   set(THIRD_PARTY_BIN
-      "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${_python_dir}"
+      "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${MSVC_PYTHON_EXECUTABLE_DIR}"
   )
-  unset(_python_dir)
   message(STATUS "Third party dependencies are in ${THIRD_PARTY_DIR}")
   # Add to the path so that cmake can configure correctly without the user
   # having to do it

--- a/qt/python/CMakeLists.txt
+++ b/qt/python/CMakeLists.txt
@@ -61,7 +61,7 @@ if(ENABLE_WORKBENCH OR ENABLE_WORKBENCH)
       add_custom_command(
         TARGET mantidqt POST_BUILD
         COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
-                ${PYTHON_DIR}/msvc-site-packages/debug/PyQt5
+                ${MSVC_PYTHON_EXECUTABLE_DIR}/msvc-site-packages/debug/PyQt5
                 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt5
         COMMENT "Copying debug PyQt5 to bin/Debug")
     endif()

--- a/qt/python/mantidqtpython/CMakeLists.txt
+++ b/qt/python/mantidqtpython/CMakeLists.txt
@@ -113,7 +113,7 @@ mtd_add_sip_module(MODULE_NAME mantidqtpython
                    FOLDER Qt4
                    OSX_INSTALL_RPATH
                      @loader_path/../Contents/MacOS
-		     @loader_path/../Contents/Frameworks
+                     @loader_path/../Contents/Frameworks
                    LINUX_INSTALL_RPATH
                      "\$ORIGIN/../${LIB_DIR}")
 
@@ -123,9 +123,9 @@ if(MSVC)
   # the special PyQt4 debug build to the bin directory
   add_custom_command(
     TARGET mantidqtpython
-	POST_BUILD
+    POST_BUILD
     COMMAND if 1==$<CONFIG:Debug> ${CMAKE_COMMAND} -E copy_directory
-            ${PYTHON_DIR}/msvc-site-packages/debug/PyQt4
+            ${MSVC_PYTHON_EXECUTABLE_DIR}/msvc-site-packages/debug/PyQt4
             ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${CMAKE_CFG_INTDIR}/PyQt4
     COMMENT "Copying debug PyQt4 to bin")
 endif()


### PR DESCRIPTION
**Description of work.**

Reintroduces a variable that was deleted by accident.

**To test:**

Before merging this branch open the file `<builddir>\Framework\PythonInterface\mantid\cmake_install.cmake`. There are several `file(INSTALL` commands that will have strings like `/DLLs`, `bin` etc after the `FILES` argument - these are invalid.

Merge the branch and run cmake. Check the file again and those paths should now be pointing to directories that exist on the machine.

*This does not require release notes* because **it is an internal change.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
