### PR TITLE
Add Full Calibration Saving and Loading to Eng Diff GUI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggCalibrateFull.py
@@ -9,6 +9,7 @@ import math
 
 from mantid.kernel import *
 from mantid.api import *
+from mantid.simpleapi import SaveAscii
 import EnggUtils
 
 
@@ -316,9 +317,10 @@ class EnggCalibrateFull(PythonAlgorithm):
 
         return json.dumps(all_dict)
 
-    def _output_det_pos_file(self, filename, tbl):
+    @staticmethod
+    def _output_det_pos_file(filename, tbl):
         """
-        Writes a text (csv) file with the detector positions information that also goes into the
+        Writes a text (TSV) file with the detector positions information that also goes into the
         output DetectorPostions table workspace.
 
         @param filename :: name of the file to write. If it is empty nothing is saved/written.
@@ -327,22 +329,8 @@ class EnggCalibrateFull(PythonAlgorithm):
         if not filename:
             return
 
-        if 9 > tbl.columnCount():
-            return
-
-        self.log().information("Saving detector positions in file: %s" % filename)
-        with open(filename, "w") as f:
-            f.write('# detector ID, old position (x), old position (y), old position (z), '
-                    'calibrated position (x), calibrated position (y), calibrated position (z), '
-                    'calib. L2, calib. 2\\theta, calib. \\phi, delta L2 (calibrated - old), difc, zero\n')
-            for r in range(0, tbl.rowCount()):
-                f.write('{0:d},'.format(tbl.cell(r, 0)))
-                f.write('{0:.7f},{1:.7f},{2:.7f},{3:.7f},{4:.7f},{5:.7f},'.
-                        format(tbl.cell(r, 1).getX(), tbl.cell(r, 1).getY(), tbl.cell(r, 1).getZ(),
-                               tbl.cell(r, 2).getX(), tbl.cell(r, 2).getY(), tbl.cell(r, 2).getZ()))
-                f.write('{0:.10f},{1:.10f},{2:.10f},{3:.10f},{4:.10f},{5:.10f}\n'.
-                        format(tbl.cell(r, 3), tbl.cell(r, 4), tbl.cell(r, 5),
-                               tbl.cell(r, 6), tbl.cell(r, 7), tbl.cell(r, 8)))
+        if filename.strip():
+            SaveAscii(InputWorkspace=tbl, Filename=filename, WriteXError=True, WriteSpectrumID=False, Separator="Tab")
 
     def _get_calibrated_det_pos(self, new_difc, det, ws):
         """

--- a/docs/source/algorithms/EnggCalibrateFull-v1.rst
+++ b/docs/source/algorithms/EnggCalibrateFull-v1.rst
@@ -145,14 +145,16 @@ Output:
    print("Got details on the peaks fitted for {0:d} detector(s)".format(peaks_info.rowCount()))
    print("Was the file created? {}".format(os.path.exists(pos_filename)))
    with open(pos_filename) as csvf:
-      reader = csv.reader(csvf, dialect='excel')
+      reader = csv.reader(csvf, dialect='excel', delimiter="\t")
+      next(reader)  # Skip the two metadata lines
       next(reader)
       calibOK = True
       for i,row in enumerate(reader):
          cal_pos = pos_table.column(2)[i]
-         calibOK = calibOK and (abs(float(row[4]) - cal_pos.getX()) < 1e-6) and\
-                   (abs(float(row[5]) - cal_pos.getY()) < 1e-6) and\
-                   (abs(float(row[6]) - cal_pos.getZ()) < 1e-6)
+         detector_pos_list = row[2].strip("[]").split(',')
+         calibOK = calibOK and (float(detector_pos_list[0]) - cal_pos.getX()) < 1e-6 and\
+                               (float(detector_pos_list[1]) - cal_pos.getY()) < 1e-6 and\
+                               (float(detector_pos_list[2]) - cal_pos.getZ()) < 1e-6
          if not calibOK: break
    print("Does the calibration file have the expected values? {}".format(calibOK))
 

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -25,6 +25,8 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
+- :ref:`EnggCalibrateFull <algm-EnggCalibrateFull-v1>` now uses the new :ref:`SaveAscii <algm-SaveAscii-v2>` to save its output files as TSVs, allowing them to be loaded back into mantid. 
+
 Single Crystal Diffraction
 --------------------------
 

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -57,6 +57,11 @@ class SettingsPresenter(object):
             self.view.set_save_location(self.settings["save_location"])
             self.view.set_full_calibration(self.settings["full_calibration"])
             self.view.set_van_recalc(self.settings["recalc_vanadium"])
+        self._find_files()
+
+    def _find_files(self):
+        self.view.find_full_calibration()
+        self.view.find_save()
 
     def _save_settings_to_file(self):
         if self._validate_settings(self.settings):

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -64,3 +64,13 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def set_van_recalc(self, checked):
         self.check_vanRecalc.setChecked(checked)
+
+    # =================
+    # Force Actions
+    # =================
+
+    def find_full_calibration(self):
+        self.finder_fullCalib.findFiles(True)
+
+    def find_save(self):
+        self.finder_save.findFiles(True)

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -25,9 +25,6 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
         self.finder_fullCalib.setLabelText("Full Calibration")
         self.finder_fullCalib.isForRunFiles(False)
-        # TODO: Once it becomes possible to load the .csv containing the full calibration into mantid,
-        #  this can be used. Until then, this option is hidden from the user.
-        self.finder_fullCalib.hide()
 
     # ===============
     # Slot Connectors

--- a/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/test/test_settings_presenter.py
@@ -41,6 +41,18 @@ class SettingsPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.set_full_calibration.call_count, 1)
         self.assertEqual(self.view.set_van_recalc.call_count, 1)
 
+    def test_file_searched_on_opening(self):
+        self.model.get_settings_dict.return_value = {
+            "save_location": "result",
+            "full_calibration": "value",
+            "recalc_vanadium": False
+        }
+
+        self.presenter.load_existing_settings()
+
+        self.assertEqual(1, self.view.find_full_calibration.call_count)
+        self.assertEqual(1, self.view.find_save.call_count)
+
     def test_load_invalid_settings(self):
         self.model.get_settings_dict.return_value = {
             "foo": "dud",

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from mantid.api import AnalysisDataService as Ads
 from mantid.kernel import logger
 from mantid.simpleapi import EnggCalibrate, DeleteWorkspace, CloneWorkspace, \
-    CreateWorkspace, AppendSpectra, CreateEmptyTableWorkspace
+    CreateWorkspace, AppendSpectra, CreateEmptyTableWorkspace, LoadAscii
 from mantidqt.plotting.functions import plot
 from Engineering.EnggUtils import write_ENGINX_GSAS_iparam_file
 from Engineering.gui.engineering_diffraction.tabs.common import vanadium_corrections
@@ -55,7 +55,7 @@ class CalibrationModel(object):
         full_calib_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
                                       path_handling.ENGINEERING_PREFIX, "full_calibration")
         if full_calib_path is not None and path.exists(full_calib_path):
-            full_calib = path_handling.load_workspace(full_calib_path)
+            full_calib = LoadAscii(full_calib_path, OutputWorkspace="det_pos", Separator="Tab")
             output = self.run_calibration(sample_workspace,
                                           van_integration,
                                           van_curves,

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
@@ -58,22 +58,24 @@ class CalibrationModelTest(unittest.TestCase):
     @patch(file_path + '.get_setting')
     @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')
+    @patch(file_path + '.LoadAscii')
     @patch(file_path + ".path_handling.load_workspace")
     @patch(class_path + '.run_calibration')
     @patch(file_path + '.vanadium_corrections.fetch_correction_workspaces')
-    def test_having_full_calib_set_uses_file(self, van_corr, calibrate_alg, load_workspace,
+    def test_having_full_calib_set_uses_file(self, van_corr, calibrate_alg, load_workspace, load_ascii,
                                              output_files, update_table, setting, path):
         path.return_value = True
         setting.return_value = "mocked/out/path"
         van_corr.return_value = ("mocked_integration", "mocked_curves")
         load_workspace.return_value = "mocked_workspace"
+        load_ascii.return_value = "mocked_det_pos"
         self.model.create_new_calibration(VANADIUM_NUMBER, CERIUM_NUMBER, False, "ENGINX")
         calibrate_alg.assert_called_with("mocked_workspace",
                                          "mocked_integration",
                                          "mocked_curves",
                                          None,
                                          None,
-                                         full_calib_ws="mocked_workspace")
+                                         full_calib_ws="mocked_det_pos")
 
     @patch(class_path + '.update_calibration_params_table')
     @patch(class_path + '.create_output_files')

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/path_handling.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/path_handling.py
@@ -25,9 +25,9 @@ def get_output_path():
     return location if location is not None else ""
 
 
-def load_workspace(file_path, **kwargs):
+def load_workspace(file_path):
     try:
-        return Load(Filename=file_path, OutputWorkspace="engggui_calibration_sample_ws", **kwargs)
+        return Load(Filename=file_path, OutputWorkspace="engggui_calibration_sample_ws")
     except Exception as e:
         logger.error("Error while loading workspace. "
                      "Could not run the algorithm Load successfully for the data file "

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/path_handling.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/path_handling.py
@@ -25,9 +25,9 @@ def get_output_path():
     return location if location is not None else ""
 
 
-def load_workspace(file_path):
+def load_workspace(file_path, **kwargs):
     try:
-        return Load(Filename=file_path, OutputWorkspace="engggui_calibration_sample_ws")
+        return Load(Filename=file_path, OutputWorkspace="engggui_calibration_sample_ws", **kwargs)
     except Exception as e:
         logger.error("Error while loading workspace. "
                      "Could not run the algorithm Load successfully for the data file "

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -13,7 +13,8 @@ import matplotlib.pyplot as plt
 
 from Engineering.gui.engineering_diffraction.tabs.common import vanadium_corrections, path_handling
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
-from mantid.simpleapi import EnggFocus, logger, AnalysisDataService as Ads, SaveNexus, SaveGSS, SaveFocusedXYE
+from mantid.simpleapi import EnggFocus, logger, AnalysisDataService as Ads, SaveNexus, SaveGSS, SaveFocusedXYE, \
+    LoadAscii
 
 SAMPLE_RUN_WORKSPACE_NAME = "engggui_focusing_input_ws"
 FOCUSED_OUTPUT_WORKSPACE_NAME = "engggui_focusing_output_ws_bank_"
@@ -39,7 +40,7 @@ class FocusModel(object):
         full_calib_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
                                       path_handling.ENGINEERING_PREFIX, "full_calibration")
         if full_calib_path is not None and path.exists(full_calib_path):
-            full_calib_workspace = path_handling.load_workspace(full_calib_path)
+            full_calib_workspace = LoadAscii(full_calib_path, OutputWorkspace="det_pos", Separator="Tab")
         else:
             full_calib_workspace = None
         for name in banks:


### PR DESCRIPTION
**Description of work.**
- Makes `EnggCalibrateFull` make use of the new `SaveAscii` algorithm to create its output files so that they can be loaded back into mantid. 
- Shows the full calibration selection functionality from the Engineering Diffraction 2 GUI.
**To test:**
1. Load CeO2: ENGINX193749 and V: ENGNIX194547 (cycle_12_4)
1. Run EnggCalibrateFull, making sure to specify an output file (OutDetPosFilename), Expected peaks = [0.855618487, 0.956610, 1.104599, 1.352852, 1.562138, 1.631600, 1.913221, 2.705702376, 3.124277511]
2. Open the engineering diffraction 2 GUI.
3. Click the settings button. 
4. Set the Full Calibration to the generated file. 
5. Run a new calibration using V: 307521 and CeO2: 305738
6. A workspace called det_pos should be output if it worked as expected. 

Fixes #27659

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
