### PR TITLE
Build against Python 3 by default

### DIFF
--- a/Framework/PythonInterface/mantid/api/_workspaceops.py
+++ b/Framework/PythonInterface/mantid/api/_workspaceops.py
@@ -247,10 +247,16 @@ def attach_func_as_method(name, func_obj, self_param_name, workspace_types=None)
 
     # ------------------------------------------------------------------
     # Add correct meta-properties for the method
-    signature = ['self']
-    signature.extend(get_function_code(func_obj).co_varnames)
+    if hasattr(func_obj, '__signature__'):
+        from inspect import Parameter
+        func_parameters = list(func_obj.__signature__.parameters.values())
+        func_parameters.insert(0, Parameter("self", Parameter.POSITIONAL_ONLY))
+        signature = func_obj.__signature__.replace(parameters=func_parameters)
+    else:
+        signature = ['self']
+        signature = tuple(signature.extend(get_function_code(func_obj).co_varnames))
     customise_func(_method_impl, func_obj.__name__,
-                   tuple(signature), func_obj.__doc__)
+                   signature, func_obj.__doc__)
 
     if workspace_types or len(workspace_types) > 0:
         from mantid import api

--- a/Framework/PythonInterface/mantid/simpleapi.py
+++ b/Framework/PythonInterface/mantid/simpleapi.py
@@ -28,10 +28,11 @@ Importing this module starts the FrameworkManager instance.
 """
 from __future__ import (absolute_import, division, print_function)
 
+# std libs
+from collections import OrderedDict, namedtuple
+import inspect
 import os
 import sys
-# stdlib imports
-from collections import OrderedDict, namedtuple
 
 import six
 from six import iteritems
@@ -89,6 +90,44 @@ def extract_progress_kwargs(kwargs):
 
 
 def _create_generic_signature(algm_object):
+    """
+    Create a function signature appropriate for the given algorithm.
+    :param algm_object: An algorithm instance
+    :return: An inspect.Signature object if available else a 2 tuple
+             suitable for replacing co_varnames
+    """
+    # Calling help(...) on the wrapper function will produce a function
+    # signature along the lines of AlgorithmName(*args, **kwargs).
+    # We will replace the name "args" by the list of properties, and
+    # the name "kwargs" by "Version=X".
+    #   1 - Get the algorithm properties and build a string to list them,
+    #       taking care of giving no default values to mandatory parameters
+    #   2 - All output properties will be removed from the function
+    #       argument list
+    if hasattr(inspect, 'Signature'):
+        from inspect import Parameter, Signature
+        pos_or_keyword = Parameter.POSITIONAL_OR_KEYWORD
+        parameters = []
+        for name in algm_object.mandatoryProperties():
+            prop = algm_object.getProperty(name)
+            # Mandatory parameters are those for which the default value is not valid
+            if isinstance(prop.isValid, str):
+                valid_str = prop.isValid
+            else:
+                valid_str = prop.isValid()
+            if len(valid_str) > 0:
+                parameters.append(Parameter(name, pos_or_keyword))
+            else:
+                # None is not quite accurate here, but we are reproducing the
+                # behavior found in the C++ code for SimpleAPI.
+                parameters.append(Parameter(name, pos_or_keyword, default=None))
+        return Signature(parameters)
+    else:
+        return _create_generic_signature_legacy(algm_object)
+
+
+# Drop this when dropping Python 2
+def _create_generic_signature_legacy(algm_object):
     """
     Create a function signature appropriate for the given algorithm.
     :param algm_object: An algorithm instance

--- a/Framework/PythonInterface/plugins/algorithms/ViewBOA.py
+++ b/Framework/PythonInterface/plugins/algorithms/ViewBOA.py
@@ -25,12 +25,12 @@ class ViewBOA(PythonAlgorithm):
         now = datetime.datetime.now()
         self.declareProperty("Year",now.year,"Choose year",direction=Direction.Input)
         self.declareProperty('Numor',0,'Choose file number',direction=Direction.Input)
-        self.declareProperty('CD-Distance',6.000,'Chopper Detector distance in metres',direction=Direction.Input)
+        self.declareProperty('CDDistance',6.000,'Chopper Detector distance in metres',direction=Direction.Input)
 
     def PyExec(self):
         year=self.getProperty('Year').value
         num=self.getProperty('Numor').value
-        CD = self.getProperty('CD-Distance').value
+        CD = self.getProperty('CDDistance').value
         self.log().error('Running LoadBOA for file number ' + str(num))
         rawfile = 'tmp' + str(num)
         LoadSINQ('BOA',year,num, OutputWorkspace=rawfile)

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -6,14 +6,14 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 
+import inspect
 import unittest
+
 from mantid.api import (AlgorithmFactory, AlgorithmProxy, IAlgorithm, IEventWorkspace, ITableWorkspace,
                         PythonAlgorithm, MatrixWorkspace, mtd)
 import mantid.simpleapi as simpleapi
 import numpy
 import six
-
-#======================================================================================================================
 
 
 class SimpleAPITest(unittest.TestCase):
@@ -187,10 +187,16 @@ class SimpleAPITest(unittest.TestCase):
         self.assertEqual(MatrixWorkspace.rebin.__doc__, simpleapi.Rebin.__doc__)
 
         # Signature of method will have extra self argument
-        freefunction_sig = six.get_function_code(simpleapi.rebin).co_varnames
-        expected_method_sig = ['self']
-        expected_method_sig.extend(freefunction_sig)
-        self.assertEqual(six.get_function_code(MatrixWorkspace.rebin).co_varnames, tuple(expected_method_sig))
+        if hasattr(inspect, 'signature'):
+            method_parameters = list(MatrixWorkspace.rebin.__signature__.parameters)
+            self.assertEqual("self", method_parameters[0])
+            self.assertEqual(method_parameters[1:],
+                             list(simpleapi.rebin.__signature__.parameters))
+        else:
+            freefunction_sig = six.get_function_code(simpleapi.rebin).co_varnames
+            expected_method_sig = ['self']
+            expected_method_sig.extend(freefunction_sig)
+            self.assertEqual(six.get_function_code(MatrixWorkspace.rebin).co_varnames, tuple(expected_method_sig))
 
     def test_function_attached_as_workpace_method_does_the_same_as_the_free_function(self):
         # Use Rebin as a test

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -100,10 +100,19 @@ if(MSVC)
     set(PYTHON_VERSION_MINOR 7)
   endif()
   # used in later parts for MSVC to bundle Python
-  set(MSVC_PYTHON_EXECUTABLE_DIR ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
-  set(PYTHON_EXECUTABLE ${MSVC_PYTHON_EXECUTABLE_DIR}/python.exe CACHE FILEPATH "Location of python executable" FORCE)
-  set(PYTHONW_EXECUTABLE "${MSVC_PYTHON_EXECUTABLE_DIR}/pythonw.exe" CACHE FILEPATH
-      "The location of the pythonw executable. This suppresses the new terminal window on startup" FORCE )
+  set(MSVC_PYTHON_EXECUTABLE_DIR
+      ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
+  )
+  set(PYTHON_EXECUTABLE
+      ${THIRD_PARTY_DIR}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/python.exe
+  )
+  set(PYTHONW_EXECUTABLE
+      "${MSVC_PYTHON_EXECUTABLE_DIR}/pythonw.exe"
+      CACHE
+        FILEPATH
+        "The location of the pythonw executable. This suppresses the new terminal window on startup"
+        FORCE
+  )
   set(THIRD_PARTY_BIN
       "${THIRD_PARTY_DIR}/bin;${THIRD_PARTY_DIR}/lib/qt4/bin;${THIRD_PARTY_DIR}/lib/qt5/bin;${MSVC_PYTHON_EXECUTABLE_DIR}"
   )
@@ -171,12 +180,20 @@ endfunction()
 
 # Find python interpreter
 find_package(PythonInterp REQUIRED)
-message(STATUS "Python version is " ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.${PYTHON_VERSION_PATCH})
+message(
+  STATUS "Python version is "
+         ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.${PYTHON_VERSION_PATCH}
+)
 # Ensure FindPythonLibs finds the correct libraries
 set(Python_ADDITIONAL_VERSIONS ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
 
 # Handle switching between previously configured Python 2 & Python 3 builds
-if(PYTHON_INCLUDE_DIR AND NOT PYTHON_INCLUDE_DIR MATCHES ".*${PYTHON_VERSION_MAJOR}\.${PYTHON_VERSION_MINOR}.*" )
-  message(STATUS "Python version has changed. Clearing previous Python configuration." )
+if(PYTHON_INCLUDE_DIR
+   AND NOT PYTHON_INCLUDE_DIR MATCHES
+       ".*${PYTHON_VERSION_MAJOR}\.${PYTHON_VERSION_MINOR}.*"
+)
+  message(
+    STATUS "Python version has changed. Clearing previous Python configuration."
+  )
   unset_cached_python_variables()
 endif()

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -1,7 +1,7 @@
 # ##############################################################################
 # Configure required dependencies if necessary
 # ##############################################################################
-option(WITH_PYTHON3 "If true build against Python 3, else use Python 2" OFF)
+option(WITH_PYTHON3 "If true build against Python 3, else use Python 2" ON)
 
 if(MSVC)
   # Git LFS does not work properly with <= 1.9

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -248,16 +248,8 @@ fi
 ###############################################################################
 # Check if this is a Python 3 build and set CMake arguments.
 ###############################################################################
-PY2_BUILD=false
-PY3_BUILD=false
-if [[ ${JOB_NAME} == *python3* ]]; then
-    PY3_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
-    PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
-else
-    PY2_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=OFF"
-fi
+DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
+PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
 
 ###############################################################################
 # Packaging options
@@ -281,12 +273,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
             PACKAGE_SUFFIX="unstable"
         fi
 
-        if [[ ${PY3_BUILD} == true ]]; then
-            # Add '-python3' to package name and install path
-            PACKAGE_SUFFIX=${PACKAGE_SUFFIX}-python3
-        fi
-
-        if [[ ${JOB_NAME} == *release* ]] && [[ ${PY2_BUILD} == true ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
+        if [[ ${JOB_NAME} == *release* ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
             # Traditional install path for python 2 release build
             PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
         else

--- a/buildconfig/Jenkins/buildscript.bat
+++ b/buildconfig/Jenkins/buildscript.bat
@@ -34,7 +34,7 @@ if !_grep_exe! == "" (
 @echo Using grep: !_grep_exe!
 
 :: ParaView version
-set PARAVIEW_DIR=%PARAVIEW_DIR%
+set PARAVIEW_DIR=%PARAVIEW_DIR%-python3
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Pre-processing steps on the workspace itself
@@ -185,7 +185,7 @@ if not "%JOB_NAME%"=="%JOB_NAME:debug=%" (
   set VATES_OPT_VAL=ON
 )
 
-call cmake.exe -G "%CM_GENERATOR%" -A %CM_ARCH% -DCMAKE_SYSTEM_VERSION=%SDK_VERS% -DCONSOLE=OFF -DENABLE_CPACK=ON -DWITH_PYTHON3=OFF -DMAKE_VATES=%VATES_OPT_VAL% -DParaView_DIR=%PARAVIEW_DIR% -DMANTID_DATA_STORE=!MANTID_DATA_STORE! -DUSE_PRECOMPILED_HEADERS=ON %PACKAGE_OPTS% ..
+call cmake.exe -G "%CM_GENERATOR%" -A %CM_ARCH% -DCMAKE_SYSTEM_VERSION=%SDK_VERS% -DCONSOLE=OFF -DENABLE_CPACK=ON -DWITH_PYTHON3=ON -DMAKE_VATES=%VATES_OPT_VAL% -DParaView_DIR=!PARAVIEW_DIR! -DMANTID_DATA_STORE=!MANTID_DATA_STORE! -DUSE_PRECOMPILED_HEADERS=ON %PACKAGE_OPTS% ..
 
 if ERRORLEVEL 1 exit /B %ERRORLEVEL%
 

--- a/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
+++ b/buildconfig/dev-packages/rpm/mantid-developer/mantid-developer.spec
@@ -5,7 +5,7 @@
 %endif
 
 Name:           mantid-developer
-Version:        1.37
+Version:        1.38
 Release:        1%{?dist}
 Summary:        Meta Package to install dependencies for Mantid Development
 
@@ -47,7 +47,6 @@ Requires: poco-devel >= 1.4.6
 Requires: PyQt4-devel
 Requires: python2-h5py >= 2.3.1
 Requires: python2-matplotlib
-Requires: python2-matplotlib-qt4
 Requires: python2-matplotlib-qt4
 Requires: python2-mock
 Requires: python2-psutil
@@ -97,6 +96,7 @@ Requires: python%{python3_pkgversion}-h5py
 Requires: python%{python3_pkgversion}-ipython
 Requires: python%{python3_pkgversion}-ipython-gui
 Requires: python%{python3_pkgversion}-matplotlib-qt5
+Requires: python%{python3_pkgversion}-matplotlib-qt4
 Requires: python%{python3_pkgversion}-numpy
 Requires: python%{python3_pkgversion}-psutil
 %{?fedora:Requires: python%{python3_pkgversion}-PyQt4-devel}
@@ -133,6 +133,9 @@ required for Mantid development.
 %files
 
 %changelog
+* Fri Jan 24 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
+- Att matplotlib backend for Python 3
+
 * Thu Jan 16 2020 Martyn Gigg <martyn.gigg@stfc.ac.uk>
 - Merge fedora and rhel python 3 packages using python3_pkgversion
 

--- a/dev-docs/source/Python3.rst
+++ b/dev-docs/source/Python3.rst
@@ -2,6 +2,9 @@
 Python 3
 ========
 
+This is now the default configuration but we currently retain the ability to build against
+Python 2.
+
 Python 2 has an `end-of-life date set for 2020 <http://legacy.python.org/dev/peps/pep-0373/>`_
 and now that most third-party packages support both 2 and 3 we are starting to think about a
 migration strategy for Mantid.
@@ -12,7 +15,7 @@ migration strategy for Mantid.
 Building Against Python 3
 #########################
 
-This is currently possible on Ubuntu, Windows and macOS. For Ubuntu/macOS ensure dependencies are update to date.
+For Linux/macOS ensure dependencies are update to date.
 On Windows all of the required packages are in the third-party bundle that will be fetched for you.
 
 .. warning::

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -12,6 +12,8 @@ Framework Changes
 New Features
 ############
 
+- Mantid is now built against Python 3. Windows/macOS bundle Python 3.8 & 3.7 respectively. Ubuntu & Red Hat use system Python 3.6.
+
 Concepts
 --------
 

--- a/docs/sphinxext/mantiddoc/autodoc.py
+++ b/docs/sphinxext/mantiddoc/autodoc.py
@@ -9,7 +9,7 @@ Mantid customizations for the behaviour of the Sphinx autodoc
 extension
 """
 
-def skip(app, what, name, obj, skip, options):
+def skip_member(app, what, name, obj, skip, options):
     """
     Arguments:
       app: Sphinx application object
@@ -20,11 +20,22 @@ def skip(app, what, name, obj, skip, options):
       options: the options given to the directive: an object with attributes inherited_members, undoc_members,
                show_inheritance and noindex that are true if the flag option of same name was given to the auto directive
     """
-    if name == "__init__":
-        return False
-    return skip
+    exclusions = (
+        'from_bytes',
+        'to_bytes',
+        'real',
+        'imag',
+        'real',
+        'conjugate',
+        'denominator',
+        'numerator',
+    )
+
+    exclude = name in exclusions
+    return skip or exclude
+
 
 def setup(app):
     # Define which methods are skipped when running autodoc
     # on a member
-    app.connect("autodoc-skip-member", skip)
+    app.connect("autodoc-skip-member", skip_member)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -309,10 +309,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
                          self.new_legend.get_frame().get_alpha())
 
     def test_apply_properties_on_figure_with_legend_sets_entries_font(self):
-        if platform.system() == "Windows":
-            new_legend_props['entries_font'] = 'DejaVu Sans'
-        self.assertEqual(new_legend_props['entries_font'],
-                         self.new_legend.get_texts()[0].get_fontname())
+        self.assertTrue(self.new_legend.get_texts()[0].get_fontname().endswith('Sans'))
 
     def test_apply_properties_on_figure_with_legend_sets_entries_size(self):
         self.assertEqual(new_legend_props['entries_size'],
@@ -323,10 +320,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
                          self.new_legend.get_texts()[0].get_color())
 
     def test_apply_properties_on_figure_with_legend_sets_title_font(self):
-        if platform.system() == "Windows":
-            new_legend_props['title_font'] = 'DejaVu Sans'
-        self.assertEqual(new_legend_props['title_font'],
-                         self.new_legend.get_title().get_fontname())
+        self.assertTrue(self.new_legend.get_title().get_fontname().endswith('Sans'))
 
     def test_apply_properties_on_figure_with_legend_sets_title_size(self):
         self.assertEqual(new_legend_props['title_size'],

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 
-import platform
 import unittest
 
 import matplotlib


### PR DESCRIPTION
**Description of work.**

Sets CMake to build against Python 3 by default.

**To test:**

Run a clean cmake configure and see that the dependencies found are Python 3.

Refs #27605. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
