### PR TITLE
Fix ISIS command iface expecting user file in batch

### DIFF
--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -16,7 +16,6 @@ from mantid.kernel import Logger
 import isis_reduction_steps
 import isis_reducer
 from centre_finder import *
-# import SANSReduction
 from mantid.simpleapi import *
 from mantid.api import WorkspaceGroup, ExperimentInfo
 import copy
@@ -24,6 +23,15 @@ from SANSadd2 import *
 import SANSUtility as su
 from SANSUtility import deprecated
 import SANSUserFileParser as UserFileParser
+
+import warnings
+warnings.simplefilter("default", category=DeprecationWarning)
+warnings.warn("This ISIS Command Interface is deprecated.\n"
+              "Please change 'import ISISCommandInterface' or 'from ISISCommandInterface'"
+              "to use 'sans.command_interface.ISISCommandInterface' instead.", DeprecationWarning,
+              stacklevel=2)
+warnings.simplefilter("ignore", category=DeprecationWarning)
+
 sanslog = Logger("SANS")
 
 # disable plotting if running outside Mantidplot

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -880,9 +880,7 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs=None, verbose=Fals
         # A new user file. If a new user file is provided then this will overwrite all other settings from,
         # otherwise we might have cross-talk between user files.
         user_file = parsed_batch_entry.get(BatchReductionEntry.USER_FILE)
-
-        if user_file:
-            MaskFile(user_file)
+        MaskFile(user_file)
 
         # Sample scatter
         sample_scatter = parsed_batch_entry[BatchReductionEntry.SAMPLE_SCATTER]

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -333,7 +333,7 @@ def MaskFile(file_name):
 
     file_path = file_name if os.path.exists(file_name) else find_full_file_path(file_name)
 
-    if not file_path or not os.path.isfile(file_name):
+    if not file_path or not os.path.isfile(file_path):
         raise FileNotFoundError("Could not find MaskFile: {0}".format(file_name))
 
     print_message('#Opening "' + file_path + '"')

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -5,8 +5,12 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
+
+import os
 import re
 import inspect
+
+import six
 from six import types
 from mantid.kernel import config
 from mantid.api import (AnalysisDataService, WorkspaceGroup)
@@ -23,6 +27,11 @@ from sans.common.enums import (DetectorType, FitType, RangeStepType, ReductionDi
                                ReductionMode, SANSFacility, SaveType, BatchReductionEntry, OutputMode, FindDirectionEnum)
 from sans.common.general_functions import (convert_bank_name_to_detector_type_isis, get_output_name,
                                            is_part_of_reduced_output_workspace_group)
+
+if six.PY2:
+    # This can be swapped with in box FileNotFoundError
+    FileNotFoundError = IOError
+
 
 # Disable plotting if running outside Mantidplot
 try:
@@ -319,11 +328,16 @@ def MaskFile(file_name):
 
     @param file_name: path to the user file.
     """
-    print_message('#Opening "' + file_name + '"')
+    if not file_name:
+        raise ValueError("An empty filename was passed to MaskFile")
 
-    # Get the full file path
-    file_name_full = find_full_file_path(file_name)
-    user_file_command = NParameterCommand(command_id=NParameterCommandId.USER_FILE, values=[file_name_full])
+    file_path = file_name if os.path.exists(file_name) else find_full_file_path(file_name)
+
+    if not file_path or not os.path.isfile(file_name):
+        raise FileNotFoundError("Could not find MaskFile: {0}".format(file_name))
+
+    print_message('#Opening "' + file_path + '"')
+    user_file_command = NParameterCommand(command_id=NParameterCommandId.USER_FILE, values=[file_path])
     director.add_command(user_file_command)
 
 
@@ -865,8 +879,9 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs=None, verbose=Fals
     for parsed_batch_entry in parsed_batch_entries:
         # A new user file. If a new user file is provided then this will overwrite all other settings from,
         # otherwise we might have cross-talk between user files.
-        if BatchReductionEntry.USER_FILE in list(parsed_batch_entry.keys()):
-            user_file = parsed_batch_entry[BatchReductionEntry.USER_FILE]
+        user_file = parsed_batch_entry.get(BatchReductionEntry.USER_FILE)
+
+        if user_file:
             MaskFile(user_file)
 
         # Sample scatter

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -880,7 +880,9 @@ def BatchReduce(filename, format, plotresults=False, saveAlgs=None, verbose=Fals
         # A new user file. If a new user file is provided then this will overwrite all other settings from,
         # otherwise we might have cross-talk between user files.
         user_file = parsed_batch_entry.get(BatchReductionEntry.USER_FILE)
-        MaskFile(user_file)
+
+        if user_file:
+            MaskFile(user_file)
 
         # Sample scatter
         sample_scatter = parsed_batch_entry[BatchReductionEntry.SAMPLE_SCATTER]

--- a/scripts/test/SANS/command_interface/CMakeLists.txt
+++ b/scripts/test/SANS/command_interface/CMakeLists.txt
@@ -2,10 +2,12 @@
 
 set(TEST_PY_FILES
     batch_csv_file_parser_test.py
-    command_interface_state_director_test.py)
+    command_interface_state_director_test.py
+    ISISCommandInterfaceTest.py
+    )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 
 # Prefix for test name=PythonAlgorithms
-pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.SANS.common_interface
+pyunittest_add_test(${CMAKE_CURRENT_SOURCE_DIR} python.SANS.command_interface
                     ${TEST_PY_FILES})

--- a/scripts/test/SANS/command_interface/CMakeLists.txt
+++ b/scripts/test/SANS/command_interface/CMakeLists.txt
@@ -3,7 +3,7 @@
 set(TEST_PY_FILES
     batch_csv_file_parser_test.py
     command_interface_state_director_test.py
-    ISISCommandInterfaceTest.py
+    isis_command_interface_test.py
     )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/scripts/test/SANS/command_interface/ISISCommandInterfaceTest.py
+++ b/scripts/test/SANS/command_interface/ISISCommandInterfaceTest.py
@@ -1,0 +1,45 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import os
+import tempfile
+import unittest
+import uuid
+
+import six
+
+from sans.command_interface.ISISCommandInterface import MaskFile
+
+if six.PY2:
+    FileNotFoundError = IOError
+
+
+class ISISCommandInterfaceTest(unittest.TestCase):
+    def test_mask_file_raises_for_empty_file_name(self):
+        with self.assertRaises(ValueError):
+            MaskFile(file_name="")
+
+    def test_mask_file_handles_folder_paths(self):
+        tmp_dir = tempfile.gettempdir()
+        non_existent_folder = str(uuid.uuid1())
+        path_not_there = os.path.join(tmp_dir, non_existent_folder)
+
+        self.assertFalse(os.path.exists(path_not_there))
+        with self.assertRaises(FileNotFoundError):
+            MaskFile(path_not_there)
+
+    def test_mask_file_handles_non_existent_user_files(self):
+        tmp_dir = tempfile.gettempdir()
+        non_existent_file = str(uuid.uuid1())
+        file_not_there = os.path.join(tmp_dir, non_existent_file)
+
+        self.assertFalse(os.path.exists(file_not_there))
+        with self.assertRaises(FileNotFoundError):
+            MaskFile(file_not_there)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/SANS/command_interface/isis_command_interface_test.py
+++ b/scripts/test/SANS/command_interface/isis_command_interface_test.py
@@ -11,6 +11,7 @@ import uuid
 
 import six
 
+from mantid.py3compat import mock
 from sans.command_interface.ISISCommandInterface import MaskFile
 
 if six.PY2:
@@ -39,6 +40,23 @@ class ISISCommandInterfaceTest(unittest.TestCase):
         self.assertFalse(os.path.exists(file_not_there))
         with self.assertRaises(FileNotFoundError):
             MaskFile(file_not_there)
+
+    def test_mask_file_works_for_full_path(self):
+        tmp_file = tempfile.NamedTemporaryFile(mode='r')
+        path = tmp_file.name
+        self.assertTrue(os.path.isfile(path))
+
+        self.assertIsNone(MaskFile(path))
+
+    def test_mask_file_for_existing_file(self):
+        tmp_file = tempfile.NamedTemporaryFile(mode='r')
+
+        file_name = os.path.basename(tmp_file.name)
+        with mock.patch('sans.command_interface.ISISCommandInterface.find_full_file_path') as mocked_finder:
+            mocked_finder.return_value = tmp_file.name
+            self.assertIsNone(MaskFile(file_name))
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
Fixes the ISIS command interface expecting a user file to specified in the provided batch file

**To test:**
- Run the script attached to the original issue

Fixes #27758 

*This does not require release notes* because it has only been noticed by a developer (future users could run into it though and it's not obvious the problem, hence fixing it now)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
