### PR TITLE
Remove workaround for GSL library name switch.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,15 +153,6 @@ if(ENABLE_WORKBENCH)
   separate_arguments(PYQT5_SIP_FLAGS)
 endif()
 
-# gsl is currently needed by Geometry, Algorithms, Curvefitting, & MantidPlot
-if(WIN32 AND GSL_CBLAS_LIBRARY AND NOT EXISTS ${GSL_CBLAS_LIBRARY})
-  # The GSL cblas library changes its name between v1 and v2 on Windows. Workaround
-  # the fact that CMake has cached the old path to a non-existant library.
-  unset(GSL_CBLAS_LIBRARY CACHE)
-  unset(GSL_CBLAS_LIBRARY_DEBUG CACHE)
-endif()
-find_package(GSL REQUIRED)
-
 # Now add in all the components
 
 # Flag that this is a full build, i.e not framework only

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -73,6 +73,7 @@ add_definitions(-D_SILENCE_CXX17_OLD_ALLOCATOR_MEMBERS_DEPRECATION_WARNING)
 find_package(Poco 1.4.6 REQUIRED)
 add_definitions(-DPOCO_ENABLE_CPP11)
 
+find_package(GSL REQUIRED)
 find_package(Nexus 4.3.1 REQUIRED)
 find_package(MuParser REQUIRED)
 find_package(JsonCPP 0.7.0 REQUIRED)


### PR DESCRIPTION
**Description of work.**

Small change to remove hack added when the library name for GSL changed on Windows. The change has been in long enough for it to now not be required.

**To test:**

Code review. A clean cmake configure should still find GSL.

Fixes #26493 

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
