### PR TITLE
 Muon analysis old has muon fittting funcs

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Abragam.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Abragam.h
@@ -34,7 +34,7 @@ public:
   std::string name() const override { return "Abragam"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonSpecific"; }
+  const std::string category() const override { return "Muon\\MuonSpecific"; }
   void functionDeriv(const API::FunctionDomain &domain,
                      API::Jacobian &jacobian) override;
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
@@ -34,7 +34,7 @@ public:
 
   /// overwrite base class methods
   std::string name() const override { return "DynamicKuboToyabe"; }
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
   /// Returns the number of attributes associated with the function
   size_t nAttributes() const override { return 1; }

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
@@ -34,7 +34,7 @@ public:
 
   /// overwrite base class methods
   std::string name() const override { return "DynamicKuboToyabe"; }
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
   /// Returns the number of attributes associated with the function
   size_t nAttributes() const override { return 1; }

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
@@ -30,7 +30,7 @@ public:
   std::string name() const override { return "ExpDecayMuon"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
@@ -30,7 +30,7 @@ public:
   std::string name() const override { return "ExpDecayMuon"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
@@ -31,7 +31,7 @@ public:
   std::string name() const override { return "ExpDecayOsc"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void setActiveParameter(size_t i, double value) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
@@ -31,7 +31,7 @@ public:
   std::string name() const override { return "ExpDecayOsc"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void setActiveParameter(size_t i, double value) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
@@ -29,7 +29,7 @@ public:
   std::string name() const override { return "GausDecay"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void setActiveParameter(size_t i, double value) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
@@ -29,7 +29,7 @@ public:
   std::string name() const override { return "GausDecay"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void setActiveParameter(size_t i, double value) override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
@@ -29,7 +29,7 @@ public:
   std::string name() const override { return "GausOsc"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
@@ -29,7 +29,7 @@ public:
   std::string name() const override { return "GausOsc"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Keren.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Keren.h
@@ -27,7 +27,7 @@ public:
   /// Name of function
   std::string name() const override { return "Keren"; }
   /// Category for function
-  const std::string category() const override { return "MuonSpecific"; }
+  const std::string category() const override { return "Muon\\MuonSpecific"; }
   /// Set active parameter
   void setActiveParameter(size_t i, double value) override;
   /// Get active parameter

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MuonFInteraction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MuonFInteraction.h
@@ -30,7 +30,7 @@ public:
   std::string name() const override { return "MuonFInteraction"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonSpecific"; }
+  const std::string category() const override { return "Muon\\MuonSpecific"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
@@ -30,7 +30,7 @@ public:
   std::string name() const override { return "StaticKuboToyabe"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
@@ -30,7 +30,7 @@ public:
   std::string name() const override { return "StaticKuboToyabe"; }
 
   /// overwrite IFunction base class methods
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
@@ -28,7 +28,7 @@ class DLLExport StaticKuboToyabeTimesExpDecay : public API::ParamFunction,
 public:
   std::string name() const override { return "StaticKuboToyabeTimesExpDecay"; }
 
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
@@ -28,7 +28,7 @@ class DLLExport StaticKuboToyabeTimesExpDecay : public API::ParamFunction,
 public:
   std::string name() const override { return "StaticKuboToyabeTimesExpDecay"; }
 
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
@@ -28,7 +28,7 @@ class DLLExport StaticKuboToyabeTimesGausDecay : public API::ParamFunction,
 public:
   std::string name() const override { return "StaticKuboToyabeTimesGausDecay"; }
 
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
@@ -28,7 +28,7 @@ class DLLExport StaticKuboToyabeTimesGausDecay : public API::ParamFunction,
 public:
   std::string name() const override { return "StaticKuboToyabeTimesGausDecay"; }
 
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
@@ -30,7 +30,7 @@ public:
     return "StaticKuboToyabeTimesStretchExp";
   }
 
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
@@ -30,7 +30,7 @@ public:
     return "StaticKuboToyabeTimesStretchExp";
   }
 
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
@@ -26,7 +26,7 @@ class DLLExport StretchExpMuon : public API::ParamFunction,
 public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "StretchExpMuon"; }
-  const std::string category() const override { return "MuonGeneric"; }
+  const std::string category() const override { return "Muon;MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
@@ -26,7 +26,7 @@ class DLLExport StretchExpMuon : public API::ParamFunction,
 public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "StretchExpMuon"; }
-  const std::string category() const override { return "Muon;MuonGeneric"; }
+  const std::string category() const override { return "Muon\\MuonGeneric"; }
 
 protected:
   void function1D(double *out, const double *xValues,

--- a/Framework/CurveFitting/test/Functions/AbragamTest.h
+++ b/Framework/CurveFitting/test/Functions/AbragamTest.h
@@ -21,7 +21,7 @@ public:
 
     // check its categories
     TS_ASSERT(ab.categories().size() == 1);
-    TS_ASSERT(ab.category() == "MuonSpecific");
+    TS_ASSERT(ab.category() == "Muon\\MuonSpecific");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
@@ -21,7 +21,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
@@ -21,7 +21,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
@@ -21,7 +21,7 @@ public:
     ExpDecayOsc fn;
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
@@ -21,7 +21,7 @@ public:
     ExpDecayOsc fn;
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/GausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/GausDecayTest.h
@@ -19,7 +19,7 @@ public:
 
     GausDecay fn;
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/GausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/GausDecayTest.h
@@ -19,7 +19,7 @@ public:
 
     GausDecay fn;
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/GausOscTest.h
+++ b/Framework/CurveFitting/test/Functions/GausOscTest.h
@@ -20,7 +20,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/GausOscTest.h
+++ b/Framework/CurveFitting/test/Functions/GausOscTest.h
@@ -20,7 +20,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/KerenTest.h
+++ b/Framework/CurveFitting/test/Functions/KerenTest.h
@@ -49,7 +49,7 @@ public:
 
   void test_category() {
     Keren function;
-    TS_ASSERT_EQUALS("MuonSpecific", function.category());
+    TS_ASSERT_EQUALS("Muon\\MuonSpecific", function.category());
   }
 
   void test_relaxation() {

--- a/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
+++ b/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
@@ -109,7 +109,7 @@ public:
     // check it categories
     const std::vector<std::string> categories = out->categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "MuonSpecific");
+    TS_ASSERT(categories[0] == "Muon\\MuonSpecific");
 
     AnalysisDataService::Instance().remove(wsName);
   }

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
@@ -21,7 +21,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
@@ -21,7 +21,7 @@ public:
     fn.initialize();
 
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
@@ -41,7 +41,7 @@ public:
   void test_Category() {
     const std::vector<std::string> categories = fn.categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "Muon;MuonGeneric");
+    TS_ASSERT(categories[0] == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
@@ -41,7 +41,7 @@ public:
   void test_Category() {
     const std::vector<std::string> categories = fn.categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "MuonGeneric");
+    TS_ASSERT(categories[0] == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
@@ -41,7 +41,7 @@ public:
   void test_Category() {
     const std::vector<std::string> categories = fn.categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "Muon;MuonGeneric");
+    TS_ASSERT(categories[0] == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
@@ -41,7 +41,7 @@ public:
   void test_Category() {
     const std::vector<std::string> categories = fn.categories();
     TS_ASSERT(categories.size() == 1);
-    TS_ASSERT(categories[0] == "MuonGeneric");
+    TS_ASSERT(categories[0] == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
@@ -41,7 +41,7 @@ public:
 
   void test_category() {
     TS_ASSERT_EQUALS(fn.categories().size(), 1);
-    TS_ASSERT_EQUALS(fn.category(), "MuonGeneric");
+    TS_ASSERT_EQUALS(fn.category(), "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
@@ -41,7 +41,7 @@ public:
 
   void test_category() {
     TS_ASSERT_EQUALS(fn.categories().size(), 1);
-    TS_ASSERT_EQUALS(fn.category(), "Muon;MuonGeneric");
+    TS_ASSERT_EQUALS(fn.category(), "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
@@ -19,7 +19,7 @@ public:
 
     StretchExpMuon fn;
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon\\MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
@@ -19,7 +19,7 @@ public:
 
     StretchExpMuon fn;
     TS_ASSERT(fn.categories().size() == 1);
-    TS_ASSERT(fn.category() == "MuonGeneric");
+    TS_ASSERT(fn.category() == "Muon;MuonGeneric");
   }
 
   void test_values() {

--- a/Framework/PythonInterface/plugins/functions/AFMLF.py
+++ b/Framework/PythonInterface/plugins/functions/AFMLF.py
@@ -13,7 +13,7 @@ import numpy as np
 class AFMLF(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/AFMZF.py
+++ b/Framework/PythonInterface/plugins/functions/AFMZF.py
@@ -13,7 +13,7 @@ import numpy as np
 class AFMZF(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/Bessel.py
+++ b/Framework/PythonInterface/plugins/functions/Bessel.py
@@ -14,7 +14,7 @@ from scipy import special as sp
 class Bessel(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 1, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/CombGaussLorentzKT.py
+++ b/Framework/PythonInterface/plugins/functions/CombGaussLorentzKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class CombGaussLorentzKT(IFunction1D):
 
     def category(self):
-        return "MuonGeneric"
+        return "Muon;MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/CombGaussLorentzKT.py
+++ b/Framework/PythonInterface/plugins/functions/CombGaussLorentzKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class CombGaussLorentzKT(IFunction1D):
 
     def category(self):
-        return "Muon;MuonGeneric"
+        return "Muon\\MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/CompositePCRmagnet.py
+++ b/Framework/PythonInterface/plugins/functions/CompositePCRmagnet.py
@@ -13,7 +13,7 @@ import numpy as np
 class CompositePCRmagnet(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/DampedBessel.py
+++ b/Framework/PythonInterface/plugins/functions/DampedBessel.py
@@ -14,7 +14,7 @@ from scipy import special as sp
 class DampedBessel(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Asymmetry')

--- a/Framework/PythonInterface/plugins/functions/FmuF.py
+++ b/Framework/PythonInterface/plugins/functions/FmuF.py
@@ -13,7 +13,7 @@ import numpy as np
 class FmuF(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/GauBroadGauKT.py
+++ b/Framework/PythonInterface/plugins/functions/GauBroadGauKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class GauBroadGauKT(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/GaussBessel.py
+++ b/Framework/PythonInterface/plugins/functions/GaussBessel.py
@@ -14,7 +14,7 @@ import scipy.special as sp
 class GaussBessel(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/HighTFMuonium.py
+++ b/Framework/PythonInterface/plugins/functions/HighTFMuonium.py
@@ -13,7 +13,7 @@ import numpy as np
 class HighTFMuonium(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.1)

--- a/Framework/PythonInterface/plugins/functions/LowTFMuonium.py
+++ b/Framework/PythonInterface/plugins/functions/LowTFMuonium.py
@@ -13,7 +13,7 @@ import numpy as np
 class LowTFMuonium(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/Meier.py
+++ b/Framework/PythonInterface/plugins/functions/Meier.py
@@ -13,7 +13,7 @@ import numpy as np
 class Meier(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/ModOsc.py
+++ b/Framework/PythonInterface/plugins/functions/ModOsc.py
@@ -14,7 +14,7 @@ import scipy.special as sp
 class ModOsc(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/MuH.py
+++ b/Framework/PythonInterface/plugins/functions/MuH.py
@@ -13,7 +13,7 @@ import numpy as np
 class MuH(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/MuMinusExpTF.py
+++ b/Framework/PythonInterface/plugins/functions/MuMinusExpTF.py
@@ -13,7 +13,7 @@ import numpy as np
 class MuMinusExpTF(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A", 1)

--- a/Framework/PythonInterface/plugins/functions/PCRmagRedfield.py
+++ b/Framework/PythonInterface/plugins/functions/PCRmagRedfield.py
@@ -13,7 +13,7 @@ import numpy as np
 class PCRmagRedfield(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/PCRmagnet.py
+++ b/Framework/PythonInterface/plugins/functions/PCRmagnet.py
@@ -13,7 +13,7 @@ import numpy as np
 class PCRmagnet(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/PCRmagnetZFKT.py
+++ b/Framework/PythonInterface/plugins/functions/PCRmagnetZFKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class PCRmagnetZFKT(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/PCRmagnetfnorm.py
+++ b/Framework/PythonInterface/plugins/functions/PCRmagnetfnorm.py
@@ -13,7 +13,7 @@ import numpy as np
 class PCRmagnetfnorm(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/RFresonance.py
+++ b/Framework/PythonInterface/plugins/functions/RFresonance.py
@@ -13,7 +13,7 @@ import numpy as np
 class RFresonance(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/Redfield.py
+++ b/Framework/PythonInterface/plugins/functions/Redfield.py
@@ -12,7 +12,7 @@ from mantid.api import IFunction1D, FunctionFactory
 class Redfield(IFunction1D):
 
     def category(self):
-        return "MuonModelling"
+        return "Muon\\MuonModelling"
 
     def init(self):
         self.declareParameter("A0", 1)

--- a/Framework/PythonInterface/plugins/functions/SCgapSwave.py
+++ b/Framework/PythonInterface/plugins/functions/SCgapSwave.py
@@ -15,7 +15,7 @@ from scipy.integrate import quad
 class SCgapSwave(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("Delta", 1.2, 'Gap Value')

--- a/Framework/PythonInterface/plugins/functions/SpinGlass.py
+++ b/Framework/PythonInterface/plugins/functions/SpinGlass.py
@@ -13,7 +13,7 @@ import numpy as np
 class SpinGlass(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2, 'Asymmetry')

--- a/Framework/PythonInterface/plugins/functions/StandardSC.py
+++ b/Framework/PythonInterface/plugins/functions/StandardSC.py
@@ -13,7 +13,7 @@ import numpy as np
 class StandardSC(IFunction1D):
 
     def category(self):
-        return "Muon;Muon;MuonGeneric"
+        return "Muon\\MuonGeneric"
 
     def init(self):
         self.declareParameter(

--- a/Framework/PythonInterface/plugins/functions/StandardSC.py
+++ b/Framework/PythonInterface/plugins/functions/StandardSC.py
@@ -13,7 +13,7 @@ import numpy as np
 class StandardSC(IFunction1D):
 
     def category(self):
-        return "MuonGeneric"
+        return "Muon;MuonGeneric"
 
     def init(self):
         self.declareParameter(

--- a/Framework/PythonInterface/plugins/functions/StandardSC.py
+++ b/Framework/PythonInterface/plugins/functions/StandardSC.py
@@ -13,7 +13,7 @@ import numpy as np
 class StandardSC(IFunction1D):
 
     def category(self):
-        return "Muon;MuonGeneric"
+        return "Muon;Muon;MuonGeneric"
 
     def init(self):
         self.declareParameter(

--- a/Framework/PythonInterface/plugins/functions/StaticLorentzianKT.py
+++ b/Framework/PythonInterface/plugins/functions/StaticLorentzianKT.py
@@ -15,7 +15,7 @@ from scipy.integrate import quad
 class StaticLorentzianKT(IFunction1D):
 
     def category(self):
-        return "Muon;MuonGeneric"
+        return "Muon\\MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/StaticLorentzianKT.py
+++ b/Framework/PythonInterface/plugins/functions/StaticLorentzianKT.py
@@ -15,7 +15,7 @@ from scipy.integrate import quad
 class StaticLorentzianKT(IFunction1D):
 
     def category(self):
-        return "MuonGeneric"
+        return "Muon;MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/StretchedKT.py
+++ b/Framework/PythonInterface/plugins/functions/StretchedKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class StretchedKT(IFunction1D):
 
     def category(self):
-        return "MuonGeneric"
+        return "Muon;MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 1)

--- a/Framework/PythonInterface/plugins/functions/StretchedKT.py
+++ b/Framework/PythonInterface/plugins/functions/StretchedKT.py
@@ -13,7 +13,7 @@ import numpy as np
 class StretchedKT(IFunction1D):
 
     def category(self):
-        return "Muon;MuonGeneric"
+        return "Muon\\MuonGeneric"
 
     def init(self):
         self.declareParameter("A0", 1)

--- a/Framework/PythonInterface/plugins/functions/TFMuonium.py
+++ b/Framework/PythonInterface/plugins/functions/TFMuonium.py
@@ -13,7 +13,7 @@ import numpy as np
 class TFMuonium(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.5, 'Amplitude')

--- a/Framework/PythonInterface/plugins/functions/ZFMuonium.py
+++ b/Framework/PythonInterface/plugins/functions/ZFMuonium.py
@@ -14,7 +14,7 @@ import numpy as np
 class ZFMuonium(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/ZFdipole.py
+++ b/Framework/PythonInterface/plugins/functions/ZFdipole.py
@@ -13,7 +13,7 @@ import numpy as np
 class ZFdipole(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/ZFelectronDipole.py
+++ b/Framework/PythonInterface/plugins/functions/ZFelectronDipole.py
@@ -13,7 +13,7 @@ import numpy as np
 class ZFelectronDipole(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.2)

--- a/Framework/PythonInterface/plugins/functions/ZFprotonDipole.py
+++ b/Framework/PythonInterface/plugins/functions/ZFprotonDipole.py
@@ -13,7 +13,7 @@ import numpy as np
 class ZFprotonDipole(IFunction1D):
 
     def category(self):
-        return "MuonSpecific"
+        return "Muon\\MuonSpecific"
 
     def init(self):
         self.declareParameter("A0", 0.5)

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -25,6 +25,7 @@ Improvements
    :align: left
 
 - You can now save Table Workspaces to Ascii using the `SaveAscii <algm-SaveAscii>` algorithm, and the Ascii Save option on the workspaces toolbox.
+- Fit functions can now be put into nested categories and into multiple categories.
 - Normalization options have been added to 2d plots and sliceviewer.
 - The images tab in figure options no longer forces the max value to be greater than the min value.
 

--- a/docs/source/release/v4.3.0/muon.rst
+++ b/docs/source/release/v4.3.0/muon.rst
@@ -32,5 +32,6 @@ Bug Fixes
 
 - The elemental analysis GUI can now handle legacy data which is missing a response dataset, e.g Delayed.
 - Fixed a bug with constraints in the Muon Analysis 2 GUI which would cause Mantid to crash.
+- Fixed a bug in Muon Analysis Old that prevented the muon fitting functions from appearing in the data analysis tab.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -21,8 +21,8 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/IWorkspaceFitControl.h"
+#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 
 /* Forward declarations */

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -21,6 +21,7 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/IWorkspaceFitControl.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 
@@ -54,6 +55,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 class PropertyHandler;
+class SelectFunctionDialog;
 /**
  * Class FitPropertyBrowser implements QtPropertyBrowser to display
  * and control fitting function parameters and settings.
@@ -629,7 +631,7 @@ private:
   QLabel *m_status;
 
   // The widget for choosing the fit function.
-  QDialog *m_fitSelector;
+  SelectFunctionDialog *m_fitSelector;
   // The tree widget containing the fit functions.
   QTreeWidget *m_fitTree;
 

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -621,8 +621,7 @@ void MuonFitPropertyBrowser::populateFunctionNames() {
     bool muon = false;
     for (const auto &category : categories) {
       if ((category == "MuonModelling") || (category == "MuonSpecific") ||
-          (category == "MuonGeneric") ||
-          (category == "General") ||
+          (category == "MuonGeneric") || (category == "General") ||
           (category == "Background"))
         muon = true;
     }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -620,7 +620,9 @@ void MuonFitPropertyBrowser::populateFunctionNames() {
     const std::vector<std::string> categories = f->categories();
     bool muon = false;
     for (const auto &category : categories) {
-      if ((category == "Muon") || (category == "General") ||
+      if ((category == "MuonModelling") || (category == "MuonSpecific") ||
+          (category == "MuonGeneric") ||
+          (category == "General") ||
           (category == "Background"))
         muon = true;
     }

--- a/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/MuonFitPropertyBrowser.cpp
@@ -620,8 +620,7 @@ void MuonFitPropertyBrowser::populateFunctionNames() {
     const std::vector<std::string> categories = f->categories();
     bool muon = false;
     for (const auto &category : categories) {
-      if ((category == "MuonModelling") || (category == "MuonSpecific") ||
-          (category == "MuonGeneric") || (category == "General") ||
+      if ((category == "Muon") || (category == "General") ||
           (category == "Background"))
         muon = true;
     }

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -112,15 +112,15 @@ void SelectFunctionDialog::constructFunctionTree(
         // go through the path and add the folders if they don't already exist
         QString currentPath = subCategories[0];
         QTreeWidgetItem *catItem = nullptr;
-        int n = subCategories.size();
+        int subCategoryNo = subCategories.size();
         bool show = false;
-        for (int j = 0; j < n; j++) {
+        for (int j = 0; j < subCategoryNo; ++j) {
           if (showCategory(subCategories[j].toStdString())) {
             show = true;
           }
         }
         if (show) {
-          for (int j = 0; j < n; j++) {
+          for (int j = 0; j < subCategoryNo; ++j) {
             if (categories.contains(currentPath)) {
               catItem = categories[currentPath];
             } else {
@@ -134,7 +134,7 @@ void SelectFunctionDialog::constructFunctionTree(
               }
               catItem = newCatItem;
             }
-            if (j != n - 1)
+            if (j != subCategoryNo - 1)
               currentPath += "\\" + subCategories[j + 1];
             else {
               // This is the end of the path so add the functions

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -93,45 +93,55 @@ void SelectFunctionDialog::constructFunctionTree(
   QMap<QString, QTreeWidgetItem *> categories;
 
   for (const auto &entry : categoryFunctionsMap) {
-    // if (showCategory(entry.first)) {}
+
     QString categoryName = QString::fromStdString(entry.first);
     QStringList subCategories = categoryName.split('\\');
     if (!categories.contains(categoryName)) {
       if (subCategories.size() == 1) {
-        QTreeWidgetItem *catItem =
-            new QTreeWidgetItem(QStringList(categoryName));
-        categories.insert(categoryName, catItem);
-        m_form->fitTree->addTopLevelItem(catItem);
-        for (const auto &function : entry.second) {
-          QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
-          fit->setText(0, QString::fromStdString(function));
+        if (showCategory(entry.first)) {
+          QTreeWidgetItem *catItem =
+              new QTreeWidgetItem(QStringList(categoryName));
+          categories.insert(categoryName, catItem);
+          m_form->fitTree->addTopLevelItem(catItem);
+          for (const auto &function : entry.second) {
+            QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+            fit->setText(0, QString::fromStdString(function));
+          }
         }
       } else {
         // go through the path and add the folders if they don't already exist
         QString currentPath = subCategories[0];
         QTreeWidgetItem *catItem = nullptr;
         int n = subCategories.size();
+        bool show = false;
         for (int j = 0; j < n; j++) {
-          if (categories.contains(currentPath)) {
-            catItem = categories[currentPath];
-          } else {
-            QTreeWidgetItem *newCatItem =
-                new QTreeWidgetItem(QStringList(subCategories[j]));
-            categories.insert(currentPath, newCatItem);
-            if (!catItem) {
-              m_form->fitTree->addTopLevelItem(newCatItem);
-            } else {
-              catItem->addChild(newCatItem);
-            }
-            catItem = newCatItem;
+          if (showCategory(subCategories[j].toStdString())) {
+            show = true;
           }
-          if (j != n - 1)
-            currentPath += "\\" + subCategories[j + 1];
-          else {
-            // This is the end of the path so add the functions
-            for (const auto &function : entry.second) {
-              QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
-              fit->setText(0, QString::fromStdString(function));
+        }
+        if (show) {
+          for (int j = 0; j < n; j++) {
+            if (categories.contains(currentPath)) {
+              catItem = categories[currentPath];
+            } else {
+              QTreeWidgetItem *newCatItem =
+                  new QTreeWidgetItem(QStringList(subCategories[j]));
+              categories.insert(currentPath, newCatItem);
+              if (!catItem) {
+                m_form->fitTree->addTopLevelItem(newCatItem);
+              } else {
+                catItem->addChild(newCatItem);
+              }
+              catItem = newCatItem;
+            }
+            if (j != n - 1)
+              currentPath += "\\" + subCategories[j + 1];
+            else {
+              // This is the end of the path so add the functions
+              for (const auto &function : entry.second) {
+                QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+                fit->setText(0, QString::fromStdString(function));
+              }
             }
           }
         }

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -89,14 +89,52 @@ void SelectFunctionDialog::constructFunctionTree(
     }
   };
 
-  for (const auto &entry : categoryFunctionsMap) {
-    if (showCategory(entry.first)) {
-      QTreeWidgetItem *category = new QTreeWidgetItem(m_form->fitTree);
-      category->setText(0, QString::fromStdString(entry.first));
+  // keeps track of categories added to the tree
+  QMap<QString, QTreeWidgetItem *> categories;
 
-      for (const auto &function : entry.second) {
-        QTreeWidgetItem *fit = new QTreeWidgetItem(category);
-        fit->setText(0, QString::fromStdString(function));
+  for (const auto &entry : categoryFunctionsMap) {
+    // if (showCategory(entry.first)) {}
+    QString categoryName = QString::fromStdString(entry.first);
+    QStringList subCategories = categoryName.split('\\');
+    if (!categories.contains(categoryName)) {
+      if (subCategories.size() == 1) {
+        QTreeWidgetItem *catItem =
+            new QTreeWidgetItem(QStringList(categoryName));
+        categories.insert(categoryName, catItem);
+        m_form->fitTree->addTopLevelItem(catItem);
+        for (const auto &function : entry.second) {
+          QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+          fit->setText(0, QString::fromStdString(function));
+        }
+      } else {
+        // go through the path and add the folders if they don't already exist
+        QString currentPath = subCategories[0];
+        QTreeWidgetItem *catItem = nullptr;
+        int n = subCategories.size();
+        for (int j = 0; j < n; j++) {
+          if (categories.contains(currentPath)) {
+            catItem = categories[currentPath];
+          } else {
+            QTreeWidgetItem *newCatItem =
+                new QTreeWidgetItem(QStringList(subCategories[j]));
+            categories.insert(currentPath, newCatItem);
+            if (!catItem) {
+              m_form->fitTree->addTopLevelItem(newCatItem);
+            } else {
+              catItem->addChild(newCatItem);
+            }
+            catItem = newCatItem;
+          }
+          if (j != n - 1)
+            currentPath += "\\" + subCategories[j + 1];
+          else {
+            // This is the end of the path so add the functions
+            for (const auto &function : entry.second) {
+              QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+              fit->setText(0, QString::fromStdString(function));
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
~~Going to use #27818 to move the new muon categories into a overall muon category.~~

**Description of work.**
The muon fitting functions have been moved into a muon category, which has 3 subcategories. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open MantidPlot
Open Muon Analysis Old
Load some data
Go to the data analysis tab
Add a fitting function (there should be 3 muon categories inside Muon) 
Fixes #27768. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
