### PR TITLE
Add missing custom stylesheet for docs with newer sphinx_bootstrap_theme

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -53,3 +53,4 @@
      Later versions of sphinx-theme-bootstrap-theme ignore this value but we keep it so that old versions still work
  -->
 {% set bootswatch_css_custom = ['_static/custom.css'] %}
+{% set css_files = css_files + ['_static/custom.css'] %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,10 @@ if LooseVersion(sphinx_version) > LooseVersion("1.6"):
     def setup(app):
         """Called automatically by Sphinx when starting the build process
         """
-        app.add_stylesheet("custom.css")
+        if hasattr(app, 'add_css_file'):  # >=v1.8
+            app.add_css_file("custom.css")
+        else:
+            app.add_stylesheet("custom.css")  # v1.6-1.8
 
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
**Description of work.**

Updates the templates for the Sphinx theme to include setting a different attribute that points to any custom css files that may be present. Without it the custom CSS is missing when built with a Sphinx < v1.6 and `sphinx_bootstrap_theme` > 0.7.

The reference for this is at https://github.com/ryan-roemer/sphinx-bootstrap-theme/blob/0ecb1832f1ed53656392b702073e1d0513b8cbb6/README.rst#adding-custom-css

**To test:**

Most easily tested with a virtual environment on Linux. To set up:
* Have a mantid built without the virtual environment
* Create a new environment `python3 -m virtualenv -p /usr/bin/python3 ~/.virtualenvs/docs-sandbox`
* Activate new environment: `source ~/.virtualenvs/docs-sandbox/bin/activate`
* Build the docs and see the colours match some older [official release](https://docs.mantidproject.org/v4.2.0) pages.

Fixes #27785

*This does not require release notes* because **it fixes a regression in the documentation build**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
