### PR TITLE
Don't act differently on 0 offset M5

### DIFF
--- a/docs/source/release/v4.3.0/sans.rst
+++ b/docs/source/release/v4.3.0/sans.rst
@@ -19,4 +19,10 @@ Improved
   can copy the history of a workspace to their clipboard or a file and the data
   will be reproduced on that machine without requiring editing of the script.
 
+Fixed
+#####
+- A zero monitor shift did not previously account for the position
+  of the rear detector for Zoom. A 0.0mm offset now works correctly when
+  processing data from the SANS GUI or command interface.
+
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/SANS/sans/algorithm_detail/move_workspaces.py
+++ b/scripts/SANS/sans/algorithm_detail/move_workspaces.py
@@ -103,11 +103,6 @@ def move_backstop_monitor(ws, move_info, monitor_offset, monitor_spectrum_number
     :param monitor_offset: Offset to shift by (m)
     :param monitor_spectrum_number: The spectrum number of the monitor to shift
     """
-    # Back out early so we don't shift the monitor from the IDF position to the
-    # rear detector position by accident
-    if monitor_offset == 0.0:
-        return
-
     monitor_spectrum_number_as_string = str(monitor_spectrum_number)
     # TODO we should pass the detector ID through, not the spec num
     monitor_n_name = move_info.monitor_names[monitor_spectrum_number_as_string]

--- a/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
+++ b/scripts/test/SANS/algorithm_detail/move_workspaces_test.py
@@ -128,7 +128,8 @@ class MoveSans2DMonitor(unittest.TestCase):
 
         z_pos_mon_4_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=4, move_info=move_info)
 
-        self.assertAlmostEqual(z_pos_mon_4_before, z_pos_mon_4_after)
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_4_dist),
+                               z_pos_mon_4_after)
 
 
 class MoveZoomMonitors(unittest.TestCase):
@@ -223,7 +224,8 @@ class MoveZoomMonitors(unittest.TestCase):
         z_pos_mon_5_after = get_monitor_pos(ws=workspace, monitor_spectrum_no=5, move_info=move_info)
 
         self.assertAlmostEqual(z_pos_mon_4_before + mon_4_dist, z_pos_mon_4_after)
-        self.assertAlmostEqual(z_pos_mon_5_before, z_pos_mon_5_after)
+        self.assertAlmostEqual(calculate_new_pos_rel_to_rear(ws=workspace, move_info=move_info, offset=mon_5_dist),
+                               z_pos_mon_5_after)
 
     def test_moving_only_monitor_5(self):
         zoom_class = SANSMoveZOOM()


### PR DESCRIPTION
**Description of work.**

In a previous commit I added we treated 0. offset as a special case of
doing nothing, as naively I assumed the IDF position of M5 is correct

However, this skips the logic which repositions the monitor at the rear
detector, then applies a shift. So a shift in rear-detector relative to
the monitor IDF position would result in a different result.

This lead to confusing behaviour and incorrect results when a shift of 0
is set.

**Report to:** ISIS/Diego

**To test:**
- Open the ISIS SANS interface
- Use this 
[UserFile.txt](https://github.com/mantidproject/mantid/files/4118611/MaskFile.txt) as the UserFile
- In the user file check `TRANS/TRANSPEC=5 /shift=5` is present
- Load this batch file (you will need to rename to .csv) 
[repro.txt](https://github.com/mantidproject/mantid/files/4118616/repro.txt)
- Hit process all
- Go to convert units and convert - `sans_interface_raw_data -> 7281_trans_nxs` into wavelength
- Delete all other workspaces
- In the user file change the line to read `/shift=0`
- Reload the user file (you have to click the user file selection box again)
- Process again and convert to wavelength
- Compare spectrum 3/5, they should visually look similar (the gap previously was 1/2 the plot so it's obvious)

Fixes #27795 (there is another issue which will be fixed in #27791 )

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
