### PR TITLE
Restore Python 2 compatability

### DIFF
--- a/Framework/PythonInterface/mantid/api/_workspaceops.py
+++ b/Framework/PythonInterface/mantid/api/_workspaceops.py
@@ -254,7 +254,8 @@ def attach_func_as_method(name, func_obj, self_param_name, workspace_types=None)
         signature = func_obj.__signature__.replace(parameters=func_parameters)
     else:
         signature = ['self']
-        signature = tuple(signature.extend(get_function_code(func_obj).co_varnames))
+        signature.extend(get_function_code(func_obj).co_varnames)
+        signature = tuple(signature)
     customise_func(_method_impl, func_obj.__name__,
                    signature, func_obj.__doc__)
 

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -246,10 +246,18 @@ if [ -z "$MANTID_DATA_STORE" ]; then
 fi
 
 ###############################################################################
-# Check if this is a Python 3 build and set CMake arguments.
+# Check if this is a Python 2 build and set CMake arguments.
 ###############################################################################
-DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
-PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
+PY2_BUILD=false
+PY3_BUILD=false
+if [[ ${JOB_NAME} == *python2* ]]; then
+    PY2_BUILD=true
+    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=OFF"
+else
+    PY3_BUILD=true
+    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
+    PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
+fi
 
 ###############################################################################
 # Packaging options
@@ -274,7 +282,7 @@ if [[ ${DO_BUILD_PKG} == true ]]; then
         fi
 
         if [[ ${JOB_NAME} == *release* ]] && [[ -z "${PACKAGE_SUFFIX}" ]]; then
-            # Traditional install path for python 2 release build
+            # Traditional install path for release build
             PACKAGINGVARS="${PACKAGINGVARS} -DCMAKE_INSTALL_PREFIX=/opt/Mantid -DCPACK_PACKAGE_SUFFIX="
         else
             # everything else uses lower-case values


### PR DESCRIPTION
**Description of work.**

#27764 was meant to switch the default build type to Python 3 but it also broke Python 2 compatability by accident. This fixes it. It also reintroduces checks in the buildscript so that a package suffixed with `-python2` can be built against Python 2.

**To test:**

Build under Python 2 and try to import `mantid.simpleapi`.

*This does not require release notes* because **it is an internal requirement**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
