### PR TITLE
Add exclude option to the fit property browser

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -26,6 +26,7 @@ Improvements
 
 - You can now save Table Workspaces to Ascii using the `SaveAscii <algm-SaveAscii>` algorithm, and the Ascii Save option on the workspaces toolbox.
 - Normalization options have been added to 2d plots and sliceviewer.
+- An exclude property has been added to the fit property browser
 - The images tab in figure options no longer forces the max value to be greater than the min value.
 
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -172,6 +172,8 @@ public:
   int maxIterations() const;
   /// Get the peak radius for peak functions
   int getPeakRadius() const;
+  /// Get the excluded range for the fit
+  std::string getExcludeRange() const;
   /// Get the X limits of the workspace
   QVector<double> getXRange();
 
@@ -512,6 +514,7 @@ protected:
   QtProperty *m_peakRadius;
   QtProperty *m_logValue;
   QtProperty *m_plotDiff;
+  QtProperty *m_excludeRange;
   QtProperty *m_plotCompositeMembers;
   QtProperty *m_convolveMembers;
   QtProperty *m_rawData;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -19,10 +19,6 @@
 #include "MantidAPI/IBackgroundFunction.h"
 #include "MantidAPI/ICostFunction.h"
 #include "MantidAPI/IFuncMinimizer.h"
-#include "MantidAPI/IFunction1DSpectrum.h"
-#include "MantidAPI/IFunctionGeneral.h"
-#include "MantidAPI/IFunctionMD.h"
-#include "MantidAPI/ILatticeFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -1720,7 +1716,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
         alg->setProperty("ConvolveMembers", convolveMembers());
       }
     }
-    if (getExcludeRange() != "") {
+    if (!getExcludeRange().empty()) {
       if (alg->getPropertyValue("EvaluationType") != "Histogram")
         alg->setProperty("Exclude", getExcludeRange());
       else {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -82,9 +82,10 @@ FitPropertyBrowser::FitPropertyBrowser(QWidget *parent, QObject *mantidui)
       m_startX(nullptr), m_endX(nullptr), m_output(nullptr),
       m_minimizer(nullptr), m_ignoreInvalidData(nullptr),
       m_costFunction(nullptr), m_maxIterations(nullptr), m_peakRadius(nullptr),
-      m_logValue(nullptr), m_plotDiff(nullptr), m_plotCompositeMembers(nullptr),
-      m_convolveMembers(nullptr), m_rawData(nullptr), m_xColumn(nullptr),
-      m_yColumn(nullptr), m_errColumn(nullptr), m_showParamErrors(nullptr),
+      m_logValue(nullptr), m_plotDiff(nullptr), m_excludeRange(nullptr),
+      m_plotCompositeMembers(nullptr), m_convolveMembers(nullptr),
+      m_rawData(nullptr), m_xColumn(nullptr), m_yColumn(nullptr),
+      m_errColumn(nullptr), m_showParamErrors(nullptr),
       m_evaluationType(nullptr), m_compositeFunction(), m_browser(nullptr),
       m_fitActionUndoFit(nullptr), m_fitActionSeqFit(nullptr),
       m_fitActionFit(nullptr), m_fitActionEvaluate(nullptr),
@@ -213,6 +214,10 @@ void FitPropertyBrowser::init() {
   bool plotDiff = settings.value("Plot Difference", QVariant(true)).toBool();
   m_boolManager->setValue(m_plotDiff, plotDiff);
 
+  m_excludeRange = m_stringManager->addProperty("Exclude Range");
+  m_excludeRange->setToolTip(
+    "A list of pairs of real numbers which define the region to exclude");
+
   m_plotCompositeMembers = m_boolManager->addProperty("Plot Composite Members");
   bool plotCompositeItems =
       settings.value(m_plotCompositeMembers->propertyName(), QVariant(false))
@@ -259,6 +264,7 @@ void FitPropertyBrowser::init() {
   settingsGroup->addSubProperty(m_maxIterations);
   settingsGroup->addSubProperty(m_peakRadius);
   settingsGroup->addSubProperty(m_plotDiff);
+  settingsGroup->addSubProperty(m_excludeRange);
   settingsGroup->addSubProperty(m_plotCompositeMembers);
   settingsGroup->addSubProperty(m_convolveMembers);
   settingsGroup->addSubProperty(m_showParamErrors);
@@ -1298,6 +1304,11 @@ int FitPropertyBrowser::getPeakRadius() const {
   return m_intManager->value(m_peakRadius);
 }
 
+/// Get the excluded range
+std::string FitPropertyBrowser::getExcludeRange() const {
+  return m_stringManager->value(m_excludeRange).QString::toStdString();
+}
+
 /// Get the registered function names
 void FitPropertyBrowser::populateFunctionNames() {
   const std::vector<std::string> names =
@@ -1703,7 +1714,8 @@ void FitPropertyBrowser::doFit(int maxIterations) {
       if (alg->existsProperty("ConvolveMembers")) {
         alg->setProperty("ConvolveMembers", convolveMembers());
       }
-    }
+    } 
+    alg->setProperty("Exclude", getExcludeRange());
     observeFinish(alg);
     alg->executeAsync();
 


### PR DESCRIPTION
**Description of work.**
This adds the option to the fit property browser to exclude a region from a fit. This was already available from [script](https://docs.mantidproject.org/nightly/algorithms/Fit-v1.html?highlight=fit#excluding-data-from-fit) so this PR just adds the property to the GUI.

**To test:**
Load a workspace and do a plot
Enter a valid string into the exclude property such as `5,10`.
Click fit and the fit should not use the data within the excluded region to do the fit

Fixes #27716.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
