### PR TITLE
Make Simple Improvements to Engineering Diffraction 2 GUI

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.ui
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MWRunFiles.ui
@@ -156,6 +156,9 @@
    </item>
    <item>
     <widget class="QPushButton" name="browseBtn">
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
      <property name="text">
       <string>Browse</string>
      </property>

--- a/scripts/Engineering/gui/engineering_diffraction/main_window.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/main_window.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>640</width>
-    <height>197</height>
+    <height>253</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -128,6 +128,7 @@
   <tabstop>comboBox_instrument</tabstop>
   <tabstop>tab_main</tabstop>
   <tabstop>pushButton_help</tabstop>
+  <tabstop>btn_settings</tabstop>
   <tabstop>pushButton_close</tabstop>
  </tabstops>
  <resources/>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>661</width>
-    <height>236</height>
+    <width>673</width>
+    <height>305</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -107,6 +107,9 @@ QGroupBox:title {
               <height>0</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
            </widget>
           </item>
           <item row="3" column="0" colspan="3">
@@ -133,6 +136,9 @@ QGroupBox:title {
               <height>0</height>
              </size>
             </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
            </widget>
           </item>
           <item row="0" column="0" colspan="3">
@@ -158,6 +164,9 @@ QGroupBox:title {
               <width>0</width>
               <height>0</height>
              </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
            </widget>
           </item>
@@ -253,6 +262,11 @@ QGroupBox:title {
  </customwidgets>
  <tabstops>
   <tabstop>radio_newCalib</tabstop>
+  <tabstop>finder_vanadium</tabstop>
+  <tabstop>finder_sample</tabstop>
+  <tabstop>radio_loadCalib</tabstop>
+  <tabstop>finder_path</tabstop>
+  <tabstop>check_cropCalib</tabstop>
   <tabstop>check_plotOutput</tabstop>
   <tabstop>button_calibrate</tabstop>
  </tabstops>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -202,7 +202,7 @@ class CalibrationModel(object):
         plot_bank_2 = fig.add_subplot(gs[1], projection="mantid")
 
         for ax, ws, bank in zip([plot_bank_1, plot_bank_2], [bank_1_ws, bank_2_ws], [1, 2]):
-            ax.plot(ws, wkspIndex=0, linestyle="--", marker="o", markersize="3")
+            ax.plot(ws, wkspIndex=0, linestyle="", marker="o", markersize="3")
             ax.plot(ws, wkspIndex=1, linestyle="--", marker="o", markersize="3")
             ax.set_title("Engg Gui Difc Zero Peaks Bank " + str(bank))
             ax.legend(("Peaks Fitted", "DifC/TZero Fitted Straight Line"))
@@ -213,12 +213,13 @@ class CalibrationModel(object):
     def _plot_difc_tzero_single_bank_or_custom(bank):
         bank_ws = Ads.retrieve("engggui_difc_zero_peaks_bank_" + str(bank))
 
-        ax = plot([bank_ws], [0, 1],
+        ax = plot([bank_ws], [0],
                   plot_kwargs={
-                      "linestyle": "--",
+                      "linestyle": "",
                       "marker": "o",
                       "markersize": "3"
                   }).gca()
+        ax.plot(bank_ws, wkspIndex=1, linestyle="--", marker="o", markersize="3")
         ax.set_title("Engg Gui Difc Zero Peaks Bank " + str(bank))
         ax.legend(("Peaks Fitted", "DifC/TZero Fitted Straight Line"))
         ax.set_xlabel("Expected Peaks Centre(dSpacing, A)")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -111,7 +111,7 @@ class CalibrationModel(object):
         except RuntimeError:
             logger.error("Invalid file selected: ", file_path)
             return
-        vanadium_corrections.fetch_correction_workspaces(van_no, instrument)
+        vanadium_corrections.fetch_correction_workspaces(instrument+van_no, instrument)
         return instrument, van_no, sample_no
 
     @staticmethod
@@ -285,7 +285,8 @@ class CalibrationModel(object):
         :param bank: Optional parameter to crop by bank
         :param spectrum_numbers: Optional parameter to crop using spectrum numbers.
         """
-        kwargs = {"ceria_run": sample_path, "vanadium_run": vanadium_path}
+        kwargs = {"ceria_run": path_handling.get_run_number_from_path(sample_path, instrument),
+                  "vanadium_run": path_handling.get_run_number_from_path(vanadium_path, instrument)}
 
         def south_kwargs():
             kwargs["template_file"] = SOUTH_BANK_TEMPLATE_FILE

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -146,8 +146,7 @@ class CalibrationPresenter(object):
         self.view.set_calibrate_button_enabled(enabled)
         self.view.set_check_plot_output_enabled(enabled)
 
-    def _on_error(self, failure_info):
-        logger.warning(str(failure_info))
+    def _on_error(self, _):
         self.emit_enable_button_signal()
 
     def _on_success(self, success_info):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
@@ -187,9 +187,9 @@ class CalibrationModelTest(unittest.TestCase):
         self.assertEqual(write_file.call_count, 3)
         write_file.assert_called_with("test/" + filename, [0], [1],
                                       bank_names=['South'],
-                                      ceria_run=sample_path,
+                                      ceria_run="20",
                                       template_file="template_ENGINX_241391_236516_South_bank.prm",
-                                      vanadium_run=vanadium_path)
+                                      vanadium_run="10")
 
     def test_generate_table_workspace_name(self):
         self.assertEqual(self.model._generate_table_workspace_name(20),

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
@@ -119,13 +119,11 @@ class CalibrationPresenterTest(unittest.TestCase):
         self.view.set_check_plot_output_enabled.assert_called_with(True)
 
     @patch(tab_path + ".presenter.CalibrationPresenter.emit_enable_button_signal")
-    @patch(tab_path + ".presenter.logger.warning")
-    def test_on_error_posts_to_logger_and_enables_controls(self, logger, emit):
+    def test_on_error_posts_to_logger_and_enables_controls(self, emit):
         fail_info = 2024278
 
         self.presenter._on_error(fail_info)
 
-        logger.assert_called_with(str(fail_info))
         self.assertEqual(emit.call_count, 1)
 
     def test_validation_of_run_numbers(self):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
@@ -161,7 +161,14 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     # =================
 
     def setup_tabbing_order(self):
-        self.setTabOrder(self.radio_newCalib, self.finder_vanadium)
-        self.setTabOrder(self.finder_vanadium, self.finder_sample)
-        self.setTabOrder(self.finder_sample, self.check_plotOutput)
+        self.finder_vanadium.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.finder_sample.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.finder_path.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        self.setTabOrder(self.radio_newCalib, self.finder_vanadium.focusProxy())
+        self.setTabOrder(self.finder_vanadium.focusProxy(), self.finder_sample.focusProxy())
+        self.setTabOrder(self.finder_sample.focusProxy(), self.finder_path.focusProxy())
+        self.setTabOrder(self.finder_path.focusProxy(), self.check_cropCalib)
+        self.setTabOrder(self.check_cropCalib, self.widget_cropping)
+        self.setTabOrder(self.widget_cropping, self.check_plotOutput)
         self.setTabOrder(self.check_plotOutput, self.button_calibrate)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/cropping/cropping_widget.ui
@@ -25,6 +25,9 @@
      </item>
      <item row="0" column="1" colspan="2">
       <widget class="QComboBox" name="combo_bank">
+       <property name="focusPolicy">
+        <enum>Qt::StrongFocus</enum>
+       </property>
        <item>
         <property name="text">
          <string>1 (North)</string>
@@ -134,6 +137,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>combo_bank</tabstop>
+  <tabstop>edit_custom</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
@@ -212,6 +212,7 @@ QGroupBox:title {
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>check_cropFocus</tabstop>
   <tabstop>check_plotOutput</tabstop>
   <tabstop>button_focus</tabstop>
  </tabstops>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
@@ -76,7 +76,7 @@ class FocusPresenterTest(unittest.TestCase):
         self.view.set_plot_output_enabled.assert_called_with(True)
 
     @patch(tab_path + ".presenter.FocusPresenter.emit_enable_button_signal")
-    def test_on_worker_error_posts_to_logger_and_enables_controls(self, emit):
+    def test_on_worker_error_enables_controls(self, emit):
         fail_info = 2024278
 
         self.presenter._on_worker_error(fail_info)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
@@ -19,6 +19,7 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
     def __init__(self, parent=None, instrument="ENGINX"):
         super(FocusView, self).__init__(parent)
         self.setupUi(self)
+        self.setup_tabbing_order()
 
         self.finder_focus.setLabelText("Sample Run #")
         self.finder_focus.setInstrumentOverride(instrument)
@@ -77,3 +78,15 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
 
     def is_searching(self):
         return self.finder_focus.isSearching()
+
+    # =================
+    # Internal Setup
+    # =================
+
+    def setup_tabbing_order(self):
+        self.finder_focus.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
+
+        self.setTabOrder(self.finder_focus.focusProxy(), self.check_cropFocus)
+        self.setTabOrder(self.check_cropFocus, self.widget_cropping)
+        self.setTabOrder(self.widget_cropping, self.check_plotOutput)
+        self.setTabOrder(self.check_plotOutput, self.button_focus)


### PR DESCRIPTION
 ### ~Not for review until #27749  is merged~

**Description of work.**
Fixed some issues in response to comments made by instrument scientists in last meeting
- Fixed tabbing order of Calibration and Focus tabs. 
- Removed lines from raw data calibration output plot lines. 
- Reverted GSAS `.prm` output files to using run numbers instead of file paths to keep line length under 20 characters. 

**To test:**
1. Open Engineering Diffraction 2 GUI
2. Test the tabbing order works as you would expect. 
2. Create a calibration and plot outputs (V: 307521, Sample (CeO2): 305738)
3. Check that the peaks fitted data is only made up of makers, without lines.  
4. Check that none of the lines in the generated `.prm` file exceed 80 characters. (if you didn't have a save location saved, it should have appeared in `~/Engineering_Mantid/Calibration`). 
This is a requirement from GSAS, one of the other programs used by the instrument scientists. 

Fixes #27724 

*This does not require release notes* because **(as always) the interface is not user facing yet.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
