### PR TITLE
FitPeaks automation for pseudo-Voigt

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/FitPeaks.h
@@ -135,7 +135,7 @@ private:
   double fitIndividualPeak(size_t wi, API::IAlgorithm_sptr fitter,
                            const double expected_peak_center,
                            const std::pair<double, double> &fitwindow,
-                           const bool observe_peak_width,
+                           const bool observe_peak_params,
                            API::IPeakFunction_sptr peakfunction,
                            API::IBackgroundFunction_sptr bkgdfunc);
 
@@ -146,7 +146,7 @@ private:
                        API::MatrixWorkspace_sptr dataws, size_t wsindex,
                        double xmin, double xmax,
                        const double &expected_peak_center,
-                       bool observe_peak_width, bool estimate_background);
+                       bool observe_peak_shape, bool estimate_background);
 
   double fitFunctionMD(API::IFunction_sptr fit_function,
                        API::MatrixWorkspace_sptr dataws, size_t wsindex,
@@ -158,7 +158,7 @@ private:
                                    const std::pair<double, double> &fit_window,
                                    const size_t &ws_index,
                                    const double &expected_peak_center,
-                                   bool observe_peak_width,
+                                   bool observe_peak_shape,
                                    API::IPeakFunction_sptr peakfunction,
                                    API::IBackgroundFunction_sptr bkgdfunc);
 
@@ -198,8 +198,8 @@ private:
                              API::IBackgroundFunction_sptr bkgdfunction,
                              bool observe_peak_width);
 
-  bool decideToEstimatePeakWidth(const bool firstPeakInSpectrum,
-                                 API::IPeakFunction_sptr peak_function);
+  bool decideToEstimatePeakParams(const bool firstPeakInSpectrum,
+                                  API::IPeakFunction_sptr peak_function);
 
   /// observe peak center
   int observePeakCenter(const HistogramData::Histogram &histogram,

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -262,12 +262,13 @@ void FitPeaks::init() {
                   "Last workspace index to fit (which is included)");
 
   // properties about peak positions to fit
-  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::PEAK_CENTERS),
-                  "List of peak centers to fit against.");
   declareProperty(
-      std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-          PropertyNames::PEAK_CENTERS_WKSP, "", Direction::Input, PropertyMode::Optional),
-      "MatrixWorkspace containing peak centers");
+      std::make_unique<ArrayProperty<double>>(PropertyNames::PEAK_CENTERS),
+      "List of peak centers to fit against.");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
+                      PropertyNames::PEAK_CENTERS_WKSP, "", Direction::Input,
+                      PropertyMode::Optional),
+                  "MatrixWorkspace containing peak centers");
 
   const std::string peakcentergrp("Peak Positions");
   setPropertyGroup(PropertyNames::PEAK_CENTERS, peakcentergrp);
@@ -313,9 +314,9 @@ void FitPeaks::init() {
   setPropertyGroup(PropertyNames::FIT_WINDOW_WKSP, fitrangeegrp);
 
   // properties about peak parameters' names and value
-  declareProperty(
-      std::make_unique<ArrayProperty<std::string>>(PropertyNames::PEAK_PARAM_NAMES),
-      "List of peak parameters' names");
+  declareProperty(std::make_unique<ArrayProperty<std::string>>(
+                      PropertyNames::PEAK_PARAM_NAMES),
+                  "List of peak parameters' names");
   declareProperty(
       std::make_unique<ArrayProperty<double>>(PropertyNames::PEAK_PARAM_VALUES),
       "List of peak parameters' value");
@@ -432,7 +433,8 @@ std::map<std::string, std::string> FitPeaks::validateInputs() {
   bool haveCommonPeakParameters(false);
   std::vector<string> suppliedParameterNames =
       getProperty(PropertyNames::PEAK_PARAM_NAMES);
-  std::vector<double> peakParamValues = getProperty(PropertyNames::PEAK_PARAM_VALUES);
+  std::vector<double> peakParamValues =
+      getProperty(PropertyNames::PEAK_PARAM_VALUES);
   if ((!suppliedParameterNames.empty()) || (!peakParamValues.empty())) {
     haveCommonPeakParameters = true;
     if (suppliedParameterNames.size() != peakParamValues.size()) {
@@ -454,7 +456,8 @@ std::map<std::string, std::string> FitPeaks::validateInputs() {
       issues[PropertyNames::PEAK_PARAM_NAMES] = msg;
       issues[PropertyNames::PEAK_PARAM_VALUES] = msg;
     } else {
-      m_profileStartingValueTable = getProperty(PropertyNames::PEAK_PARAM_TABLE);
+      m_profileStartingValueTable =
+          getProperty(PropertyNames::PEAK_PARAM_TABLE);
       suppliedParameterNames = m_profileStartingValueTable->getColumnNames();
     }
   }
@@ -635,7 +638,7 @@ void FitPeaks::processInputFunctions() {
     m_initParamValues = getProperty(PropertyNames::PEAK_PARAM_VALUES);
     // convert the parameter name in string to parameter name in integer index
     convertParametersNameToIndex();
-    //m_uniformProfileStartingValue = true;
+    // m_uniformProfileStartingValue = true;
   } else if ((!partablename.empty()) && m_peakParamNames.empty()) {
     // use non-uniform starting value of peak parameters
     m_profileStartingValueTable = getProperty(partablename);
@@ -1127,9 +1130,8 @@ void FitPeaks::fitSpectrumPeaks(
  * @param peak_function :: peak function to set parameter values to
  * @return :: flag whether the peak width shall be observed
  */
-bool
-FitPeaks::decideToEstimatePeakParams(const bool firstPeakInSpectrum,
-                                     API::IPeakFunction_sptr peak_function) {
+bool FitPeaks::decideToEstimatePeakParams(
+    const bool firstPeakInSpectrum, API::IPeakFunction_sptr peak_function) {
   // should observe the peak width if the user didn't supply all of the peak
   // function parameters
   bool observe_peak_shape(m_initParamIndexes.size() !=

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -46,6 +46,39 @@ using namespace std;
 namespace Mantid {
 namespace Algorithms {
 
+namespace {
+namespace PropertyNames {
+const std::string INPUT_WKSP("InputWorkspace");
+const std::string OUTPUT_WKSP("OutputWorkspace");
+const std::string START_WKSP_INDEX("StartWorkspaceIndex");
+const std::string STOP_WKSP_INDEX("StopWorkspaceIndex");
+const std::string PEAK_CENTERS("PeakCenters");
+const std::string PEAK_CENTERS_WKSP("PeakCentersWorkspace");
+const std::string PEAK_FUNC("PeakFunction");
+const std::string BACK_FUNC("BackgroundType");
+const std::string FIT_WINDOW_LIST("FitWindowBoundaryList");
+const std::string FIT_WINDOW_WKSP("FitPeakWindowWorkspace");
+const std::string PEAK_WIDTH_PERCENT("PeakWidthPercent");
+const std::string PEAK_PARAM_NAMES("PeakParameterNames");
+const std::string PEAK_PARAM_VALUES("PeakParameterValues");
+const std::string PEAK_PARAM_TABLE("PeakParameterValueTable");
+const std::string FIT_FROM_RIGHT("FitFromRight");
+const std::string MINIMIZER("Minimizer");
+const std::string COST_FUNC("CostFunction");
+const std::string MAX_FIT_ITER("MaxFitIterations");
+const std::string BACKGROUND_Z_SCORE("FindBackgroundSigma");
+const std::string HIGH_BACKGROUND("HighBackground");
+const std::string POSITION_TOL("PositionTolerance");
+const std::string PEAK_MIN_HEIGHT("MinimumPeakHeight");
+const std::string CONSTRAIN_PEAK_POS("ConstrainPeakPositions");
+const std::string OUTPUT_WKSP_MODEL("FittedPeaksWorkspace");
+const std::string OUTPUT_WKSP_PARAMS("OutputPeakParametersWorkspace");
+const std::string OUTPUT_WKSP_PARAM_ERRS("OutputParameterFitErrorsWorkspace");
+const std::string RAW_PARAMS("RawPeakParameters");
+
+} // namespace PropertyNames
+} // namespace
+
 namespace FitPeaksAlgorithm {
 
 //----------------------------------------------------------------------------------------------
@@ -206,10 +239,10 @@ FitPeaks::FitPeaks()
  */
 void FitPeaks::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "InputWorkspace", "", Direction::Input),
+                      PropertyNames::INPUT_WKSP, "", Direction::Input),
                   "Name of the input workspace for peak fitting.");
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "OutputWorkspace", "", Direction::Output),
+                      PropertyNames::OUTPUT_WKSP, "", Direction::Output),
                   "Name of the output workspace containing peak centers for "
                   "fitting offset."
                   "The output workspace is point data."
@@ -223,135 +256,131 @@ void FitPeaks::init() {
                   "and -3 for non-converged fitting.");
 
   // properties about fitting range and criteria
-  declareProperty("StartWorkspaceIndex", EMPTY_INT(),
+  declareProperty(PropertyNames::START_WKSP_INDEX, EMPTY_INT(),
                   "Starting workspace index for fit");
-  declareProperty("StopWorkspaceIndex", EMPTY_INT(),
+  declareProperty(PropertyNames::STOP_WKSP_INDEX, EMPTY_INT(),
                   "Last workspace index to fit (which is included)");
 
   // properties about peak positions to fit
-  declareProperty(std::make_unique<ArrayProperty<double>>("PeakCenters"),
+  declareProperty(std::make_unique<ArrayProperty<double>>(PropertyNames::PEAK_CENTERS),
                   "List of peak centers to fit against.");
   declareProperty(
       std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-          "PeakCentersWorkspace", "", Direction::Input, PropertyMode::Optional),
+          PropertyNames::PEAK_CENTERS_WKSP, "", Direction::Input, PropertyMode::Optional),
       "MatrixWorkspace containing peak centers");
 
-  std::string peakcentergrp("Peak Positions");
-  setPropertyGroup("PeakCenters", peakcentergrp);
-  setPropertyGroup("PeakCentersWorkspace", peakcentergrp);
+  const std::string peakcentergrp("Peak Positions");
+  setPropertyGroup(PropertyNames::PEAK_CENTERS, peakcentergrp);
+  setPropertyGroup(PropertyNames::PEAK_CENTERS_WKSP, peakcentergrp);
 
   // properties about peak profile
-  std::vector<std::string> peakNames =
+  const std::vector<std::string> peakNames =
       FunctionFactory::Instance().getFunctionNames<API::IPeakFunction>();
-  declareProperty("PeakFunction", "Gaussian",
+  declareProperty(PropertyNames::PEAK_FUNC, "Gaussian",
                   boost::make_shared<StringListValidator>(peakNames));
-  vector<string> bkgdtypes{"Flat", "Linear", "Quadratic"};
-  declareProperty("BackgroundType", "Linear",
+  const vector<string> bkgdtypes{"Flat", "Linear", "Quadratic"};
+  declareProperty(PropertyNames::BACK_FUNC, "Linear",
                   boost::make_shared<StringListValidator>(bkgdtypes),
                   "Type of Background.");
 
-  std::string funcgroup("Function Types");
-  setPropertyGroup("PeakFunction", funcgroup);
-  setPropertyGroup("BackgroundType", funcgroup);
+  const std::string funcgroup("Function Types");
+  setPropertyGroup(PropertyNames::PEAK_FUNC, funcgroup);
+  setPropertyGroup(PropertyNames::BACK_FUNC, funcgroup);
 
   // properties about peak range including fitting window and peak width
   // (percentage)
   declareProperty(
-      std::make_unique<ArrayProperty<double>>("FitWindowBoundaryList"),
+      std::make_unique<ArrayProperty<double>>(PropertyNames::FIT_WINDOW_LIST),
       "List of left boundaries of the peak fitting window corresponding to "
       "PeakCenters.");
 
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-                      "FitPeakWindowWorkspace", "", Direction::Input,
+                      PropertyNames::FIT_WINDOW_WKSP, "", Direction::Input,
                       PropertyMode::Optional),
                   "MatrixWorkspace for of peak windows");
 
   auto min = boost::make_shared<BoundedValidator<double>>();
   min->setLower(1e-3);
   // min->setUpper(1.); TODO make this a limit
-  declareProperty("PeakWidthPercent", EMPTY_DBL(), min,
+  declareProperty(PropertyNames::PEAK_WIDTH_PERCENT, EMPTY_DBL(), min,
                   "The estimated peak width as a "
                   "percentage of the d-spacing "
                   "of the center of the peak. Value must be less than 1.");
 
-  std::string fitrangeegrp("Peak Range Setup");
-  setPropertyGroup("PeakWidthPercent", fitrangeegrp);
-  setPropertyGroup("FitWindowBoundaryList", fitrangeegrp);
-  setPropertyGroup("FitPeakWindowWorkspace", fitrangeegrp);
+  const std::string fitrangeegrp("Peak Range Setup");
+  setPropertyGroup(PropertyNames::PEAK_WIDTH_PERCENT, fitrangeegrp);
+  setPropertyGroup(PropertyNames::FIT_WINDOW_LIST, fitrangeegrp);
+  setPropertyGroup(PropertyNames::FIT_WINDOW_WKSP, fitrangeegrp);
 
   // properties about peak parameters' names and value
   declareProperty(
-      std::make_unique<ArrayProperty<std::string>>("PeakParameterNames"),
+      std::make_unique<ArrayProperty<std::string>>(PropertyNames::PEAK_PARAM_NAMES),
       "List of peak parameters' names");
   declareProperty(
-      std::make_unique<ArrayProperty<double>>("PeakParameterValues"),
+      std::make_unique<ArrayProperty<double>>(PropertyNames::PEAK_PARAM_VALUES),
       "List of peak parameters' value");
   declareProperty(std::make_unique<WorkspaceProperty<TableWorkspace>>(
-                      "PeakParameterValueTable", "", Direction::Input,
+                      PropertyNames::PEAK_PARAM_TABLE, "", Direction::Input,
                       PropertyMode::Optional),
                   "Name of the an optional workspace, whose each column "
                   "corresponds to given peak parameter names"
                   ", and each row corresponds to a subset of spectra.");
 
-  std::string startvaluegrp("Starting Parameters Setup");
-  setPropertyGroup("PeakParameterNames", startvaluegrp);
-  setPropertyGroup("PeakParameterValues", startvaluegrp);
-  setPropertyGroup("PeakParameterValueTable", startvaluegrp);
+  const std::string startvaluegrp("Starting Parameters Setup");
+  setPropertyGroup(PropertyNames::PEAK_PARAM_NAMES, startvaluegrp);
+  setPropertyGroup(PropertyNames::PEAK_PARAM_VALUES, startvaluegrp);
+  setPropertyGroup(PropertyNames::PEAK_PARAM_TABLE, startvaluegrp);
 
   // optimization setup
-  declareProperty("FitFromRight", true,
+  declareProperty(PropertyNames::FIT_FROM_RIGHT, true,
                   "Flag for the order to fit peaks.  If true, peaks are fitted "
                   "from rightmost;"
                   "Otherwise peaks are fitted from leftmost.");
 
-  std::vector<std::string> minimizerOptions =
+  const std::vector<std::string> minimizerOptions =
       API::FuncMinimizerFactory::Instance().getKeys();
-  declareProperty("Minimizer", "Levenberg-Marquardt",
+  declareProperty(PropertyNames::MINIMIZER, "Levenberg-Marquardt",
                   Kernel::IValidator_sptr(
                       new Kernel::StartsWithValidator(minimizerOptions)),
-                  "Minimizer to use for fitting. Minimizers available are "
-                  "\"Levenberg-Marquardt\", \"Simplex\","
-                  "\"Conjugate gradient (Fletcher-Reeves imp.)\", \"Conjugate "
-                  "gradient (Polak-Ribiere imp.)\", \"BFGS\", and "
-                  "\"Levenberg-MarquardtMD\"");
+                  "Minimizer to use for fitting.");
 
-  std::array<string, 2> costFuncOptions = {{"Least squares", "Rwp"}};
-  declareProperty("CostFunction", "Least squares",
+  const std::array<string, 2> costFuncOptions = {{"Least squares", "Rwp"}};
+  declareProperty(PropertyNames::COST_FUNC, "Least squares",
                   Kernel::IValidator_sptr(
                       new Kernel::ListValidator<std::string>(costFuncOptions)),
                   "Cost functions");
 
   auto min_max_iter = boost::make_shared<BoundedValidator<int>>();
   min_max_iter->setLower(49);
-  declareProperty("MaxFitIterations", 50, min_max_iter,
+  declareProperty(PropertyNames::MAX_FIT_ITER, 50, min_max_iter,
                   "Maximum number of function fitting iterations.");
 
-  std::string optimizergrp("Optimization Setup");
-  setPropertyGroup("Minimizer", optimizergrp);
-  setPropertyGroup("CostFunction", optimizergrp);
+  const std::string optimizergrp("Optimization Setup");
+  setPropertyGroup(PropertyNames::MINIMIZER, optimizergrp);
+  setPropertyGroup(PropertyNames::COST_FUNC, optimizergrp);
 
   // other helping information
   declareProperty(
-      "FindBackgroundSigma", 1.0,
+      PropertyNames::BACKGROUND_Z_SCORE, 1.0,
       "Multiplier of standard deviations of the variance for convergence of "
       "peak elimination.  Default is 1.0. ");
 
-  declareProperty("HighBackground", true,
+  declareProperty(PropertyNames::HIGH_BACKGROUND, true,
                   "Flag whether the data has high background comparing to "
                   "peaks' intensities. "
                   "For example, vanadium peaks usually have high background.");
 
   declareProperty(
-      std::make_unique<ArrayProperty<double>>("PositionTolerance"),
+      std::make_unique<ArrayProperty<double>>(PropertyNames::POSITION_TOL),
       "List of tolerance on fitted peak positions against given peak positions."
       "If there is only one value given, then ");
 
-  declareProperty("MinimumPeakHeight", 0.,
+  declareProperty(PropertyNames::PEAK_MIN_HEIGHT, 0.,
                   "Minimum peak height such that all the fitted peaks with "
                   "height under this value will be excluded.");
 
   declareProperty(
-      "ConstrainPeakPositions", true,
+      PropertyNames::CONSTRAIN_PEAK_POS, true,
       "If true peak position will be constrained by estimated positions "
       "(highest Y value position) and "
       "the peak width either estimted by observation or calculate.");
@@ -359,7 +388,7 @@ void FitPeaks::init() {
   // additional output for reviewing
   declareProperty(
       std::make_unique<WorkspaceProperty<MatrixWorkspace>>(
-          "FittedPeaksWorkspace", "", Direction::Output,
+          PropertyNames::OUTPUT_WKSP_MODEL, "", Direction::Output,
           PropertyMode::Optional),
       "Name of the output matrix workspace with fitted peak. "
       "This output workspace have the same dimesion as the input workspace."
@@ -368,31 +397,29 @@ void FitPeaks::init() {
 
   declareProperty(
       std::make_unique<WorkspaceProperty<API::ITableWorkspace>>(
-          "OutputPeakParametersWorkspace", "", Direction::Output),
+          PropertyNames::OUTPUT_WKSP_PARAMS, "", Direction::Output),
       "Name of table workspace containing all fitted peak parameters.");
 
   // Optional output table workspace for each individual parameter's fitting
   // error
   declareProperty(
       std::make_unique<WorkspaceProperty<API::ITableWorkspace>>(
-          "OutputParameterFitErrorsWorkspace", "", Direction::Output,
+          PropertyNames::OUTPUT_WKSP_PARAM_ERRS, "", Direction::Output,
           PropertyMode::Optional),
       "Name of workspace containing all fitted peak parameters' fitting error."
       "It must be used along with FittedPeaksWorkspace and RawPeakParameters "
       "(True)");
 
-  declareProperty("RawPeakParameters", true,
+  declareProperty(PropertyNames::RAW_PARAMS, true,
                   "false generates table with effective centre/width/height "
                   "parameters. true generates a table with peak function "
                   "parameters");
 
-  std::string addoutgrp("Analysis");
-  setPropertyGroup("OutputPeakParametersWorkspace", addoutgrp);
-  setPropertyGroup("FittedPeaksWorkspace", addoutgrp);
-  setPropertyGroup("OutputParameterFitErrorsWorkspace", addoutgrp);
-  setPropertyGroup("RawPeakParameters", addoutgrp);
-
-  return;
+  const std::string addoutgrp("Analysis");
+  setPropertyGroup(PropertyNames::OUTPUT_WKSP_PARAMS, addoutgrp);
+  setPropertyGroup(PropertyNames::OUTPUT_WKSP_MODEL, addoutgrp);
+  setPropertyGroup(PropertyNames::OUTPUT_WKSP_PARAM_ERRS, addoutgrp);
+  setPropertyGroup(PropertyNames::RAW_PARAMS, addoutgrp);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -404,37 +431,37 @@ std::map<std::string, std::string> FitPeaks::validateInputs() {
   // check that the peak parameters are in parallel properties
   bool haveCommonPeakParameters(false);
   std::vector<string> suppliedParameterNames =
-      getProperty("PeakParameterNames");
-  std::vector<double> peakParamValues = getProperty("PeakParameterValues");
+      getProperty(PropertyNames::PEAK_PARAM_NAMES);
+  std::vector<double> peakParamValues = getProperty(PropertyNames::PEAK_PARAM_VALUES);
   if ((!suppliedParameterNames.empty()) || (!peakParamValues.empty())) {
     haveCommonPeakParameters = true;
     if (suppliedParameterNames.size() != peakParamValues.size()) {
-      issues["PeakParameterNames"] =
+      issues[PropertyNames::PEAK_PARAM_NAMES] =
           "must have same number of values as PeakParameterValues";
-      issues["PeakParameterValues"] =
+      issues[PropertyNames::PEAK_PARAM_VALUES] =
           "must have same number of values as PeakParameterNames";
     }
   }
 
   // get the information out of the table
-  std::string partablename = getPropertyValue("PeakParameterValueTable");
+  std::string partablename = getPropertyValue(PropertyNames::PEAK_PARAM_TABLE);
   if (!partablename.empty()) {
     if (haveCommonPeakParameters) {
       const std::string msg = "Parameter value table and initial parameter "
                               "name/value vectors cannot be given "
                               "simultanenously.";
-      issues["PeakParameterValueTable"] = msg;
-      issues["PeakParameterNames"] = msg;
-      issues["PeakParameterValues"] = msg;
+      issues[PropertyNames::PEAK_PARAM_TABLE] = msg;
+      issues[PropertyNames::PEAK_PARAM_NAMES] = msg;
+      issues[PropertyNames::PEAK_PARAM_VALUES] = msg;
     } else {
-      m_profileStartingValueTable = getProperty("PeakParameterValueTable");
+      m_profileStartingValueTable = getProperty(PropertyNames::PEAK_PARAM_TABLE);
       suppliedParameterNames = m_profileStartingValueTable->getColumnNames();
     }
   }
 
   // check that the suggested peak parameter names exist in the peak function
   if (!suppliedParameterNames.empty()) {
-    std::string peakfunctiontype = getPropertyValue("PeakFunction");
+    std::string peakfunctiontype = getPropertyValue(PropertyNames::PEAK_FUNC);
     m_peakFunction = boost::dynamic_pointer_cast<IPeakFunction>(
         API::FunctionFactory::Instance().createFunction(peakfunctiontype));
 
@@ -456,22 +483,22 @@ std::map<std::string, std::string> FitPeaks::validateInputs() {
     if (failed) {
       std::string msg = "Specified invalid parameter for peak function";
       if (haveCommonPeakParameters)
-        issues["PeakParameterNames"] = msg;
+        issues[PropertyNames::PEAK_PARAM_NAMES] = msg;
       else
-        issues["PeakParameterValueTable"] = msg;
+        issues[PropertyNames::PEAK_PARAM_TABLE] = msg;
     }
   }
 
   // check inputs for uncertainty (fitting error)
   const std::string error_table_name =
-      getPropertyValue("OutputParameterFitErrorsWorkspace");
+      getPropertyValue(PropertyNames::OUTPUT_WKSP_PARAM_ERRS);
   if (!error_table_name.empty()) {
-    const bool use_raw_params = getProperty("RawPeakParameters");
+    const bool use_raw_params = getProperty(PropertyNames::RAW_PARAMS);
     if (!use_raw_params) {
       const std::string msg =
           "FitPeaks must output RAW peak parameters if fitting error "
           "is chosen to be output";
-      issues["RawPeakParameters"] = msg;
+      issues[PropertyNames::RAW_PARAMS] = msg;
     }
   }
 
@@ -501,7 +528,7 @@ void FitPeaks::exec() {
 //----------------------------------------------------------------------------------------------
 void FitPeaks::processInputs() {
   // input workspaces
-  m_inputMatrixWS = getProperty("InputWorkspace");
+  m_inputMatrixWS = getProperty(PropertyNames::INPUT_WKSP);
 
   if (m_inputMatrixWS->getAxis(0)->unit()->unitID() == "dSpacing")
     m_inputIsDSpace = true;
@@ -509,14 +536,14 @@ void FitPeaks::processInputs() {
     m_inputIsDSpace = false;
 
   // spectra to fit
-  int start_wi = getProperty("StartWorkspaceIndex");
+  int start_wi = getProperty(PropertyNames::START_WKSP_INDEX);
   if (isEmpty(start_wi))
     m_startWorkspaceIndex = 0;
   else
     m_startWorkspaceIndex = static_cast<size_t>(start_wi);
 
   // last spectrum's workspace index, which is included
-  int stop_wi = getProperty("StopWorkspaceIndex");
+  int stop_wi = getProperty(PropertyNames::STOP_WKSP_INDEX);
   if (isEmpty(stop_wi))
     m_stopWorkspaceIndex = m_inputMatrixWS->getNumberHistograms() - 1;
   else {
@@ -526,11 +553,11 @@ void FitPeaks::processInputs() {
   }
 
   // optimizer, cost function and fitting scheme
-  m_minimizer = getPropertyValue("Minimizer");
-  m_costFunction = getPropertyValue("CostFunction");
-  m_fitPeaksFromRight = getProperty("FitFromRight");
-  m_constrainPeaksPosition = getProperty("ConstrainPeakPositions");
-  m_fitIterations = getProperty("MaxFitIterations");
+  m_minimizer = getPropertyValue(PropertyNames::MINIMIZER);
+  m_costFunction = getPropertyValue(PropertyNames::COST_FUNC);
+  m_fitPeaksFromRight = getProperty(PropertyNames::FIT_FROM_RIGHT);
+  m_constrainPeaksPosition = getProperty(PropertyNames::CONSTRAIN_PEAK_POS);
+  m_fitIterations = getProperty(PropertyNames::MAX_FIT_ITER);
 
   // Peak centers, tolerance and fitting range
   processInputPeakCenters();
@@ -538,7 +565,7 @@ void FitPeaks::processInputs() {
   if (m_numPeaksToFit == 0)
     throw std::runtime_error("number of peaks to fit is zero.");
   // about how to estimate the peak width
-  m_peakWidthPercentage = getProperty("PeakWidthPercent");
+  m_peakWidthPercentage = getProperty(PropertyNames::PEAK_WIDTH_PERCENT);
   if (isEmpty(m_peakWidthPercentage))
     m_peakWidthPercentage = -1;
   if (m_peakWidthPercentage >= 1.) // TODO
@@ -546,8 +573,8 @@ void FitPeaks::processInputs() {
   g_log.debug() << "peak width/value = " << m_peakWidthPercentage << "\n";
 
   // set up background
-  m_highBackground = getProperty("HighBackground");
-  m_bkgdSimga = getProperty("FindBackgroundSigma");
+  m_highBackground = getProperty(PropertyNames::HIGH_BACKGROUND);
+  m_bkgdSimga = getProperty(PropertyNames::BACKGROUND_Z_SCORE);
 
   // Set up peak and background functions
   processInputFunctions();
@@ -574,12 +601,12 @@ void FitPeaks::processInputs() {
  */
 void FitPeaks::processInputFunctions() {
   // peak functions
-  std::string peakfunctiontype = getPropertyValue("PeakFunction");
+  std::string peakfunctiontype = getPropertyValue(PropertyNames::PEAK_FUNC);
   m_peakFunction = boost::dynamic_pointer_cast<IPeakFunction>(
       API::FunctionFactory::Instance().createFunction(peakfunctiontype));
 
   // background functions
-  std::string bkgdfunctiontype = getPropertyValue("BackgroundType");
+  std::string bkgdfunctiontype = getPropertyValue(PropertyNames::BACK_FUNC);
   std::string bkgdname;
   if (bkgdfunctiontype == "Linear")
     bkgdname = "LinearBackground";
@@ -599,18 +626,18 @@ void FitPeaks::processInputFunctions() {
 
   // TODO check that both parameter names and values exist
   // input peak parameters
-  std::string partablename = getPropertyValue("PeakParameterValueTable");
-  m_peakParamNames = getProperty("PeakParameterNames");
+  std::string partablename = getPropertyValue(PropertyNames::PEAK_PARAM_TABLE);
+  m_peakParamNames = getProperty(PropertyNames::PEAK_PARAM_NAMES);
 
+  m_uniformProfileStartingValue = false;
   if (partablename.empty() && (!m_peakParamNames.empty())) {
     // use uniform starting value of peak parameters
-    m_initParamValues = getProperty("PeakParameterValues");
+    m_initParamValues = getProperty(PropertyNames::PEAK_PARAM_VALUES);
     // convert the parameter name in string to parameter name in integer index
     convertParametersNameToIndex();
-    m_uniformProfileStartingValue = true;
+    //m_uniformProfileStartingValue = true;
   } else if ((!partablename.empty()) && m_peakParamNames.empty()) {
     // use non-uniform starting value of peak parameters
-    m_uniformProfileStartingValue = false;
     m_profileStartingValueTable = getProperty(partablename);
   } else {
     // user specifies nothing
@@ -628,10 +655,10 @@ void FitPeaks::processInputFunctions() {
  */
 void FitPeaks::processInputFitRanges() {
   // get peak fit window
-  std::vector<double> peakwindow = getProperty("FitWindowBoundaryList");
-  std::string peakwindowname = getPropertyValue("FitPeakWindowWorkspace");
+  std::vector<double> peakwindow = getProperty(PropertyNames::FIT_WINDOW_LIST);
+  std::string peakwindowname = getPropertyValue(PropertyNames::FIT_WINDOW_WKSP);
   API::MatrixWorkspace_const_sptr peakwindowws =
-      getProperty("FitPeakWindowWorkspace");
+      getProperty(PropertyNames::FIT_WINDOW_WKSP);
 
   // in most case, calculate window by instrument resolution is False
   m_calculateWindowInstrument = false;
@@ -673,7 +700,7 @@ void FitPeaks::processInputFitRanges() {
     // END for uniform peak window
   } else if (peakwindow.empty() && peakwindowws != nullptr) {
     // use matrix workspace for non-uniform peak windows
-    m_peakWindowWorkspace = getProperty("FitPeakWindowWorkspace");
+    m_peakWindowWorkspace = getProperty(PropertyNames::FIT_WINDOW_WKSP);
     m_uniformPeakWindows = false;
 
     // check size
@@ -758,13 +785,13 @@ void FitPeaks::processInputFitRanges() {
  */
 void FitPeaks::processInputPeakCenters() {
   // peak centers
-  m_peakCenters = getProperty("PeakCenters");
+  m_peakCenters = getProperty(PropertyNames::PEAK_CENTERS);
   API::MatrixWorkspace_const_sptr peakcenterws =
-      getProperty("PeakCentersWorkspace");
+      getProperty(PropertyNames::PEAK_CENTERS_WKSP);
   if (!peakcenterws)
     g_log.error("There is no peak center workspace");
 
-  std::string peakpswsname = getPropertyValue("PeakCentersWorkspace");
+  std::string peakpswsname = getPropertyValue(PropertyNames::PEAK_CENTERS_WKSP);
   if ((!m_peakCenters.empty()) && peakcenterws == nullptr) {
     // peak positions are uniform among all spectra
     m_uniformPeakPositions = true;
@@ -773,7 +800,7 @@ void FitPeaks::processInputPeakCenters() {
   } else if (m_peakCenters.empty() && peakcenterws != nullptr) {
     // peak positions can be different among spectra
     m_uniformPeakPositions = false;
-    m_peakCenterWorkspace = getProperty("PeakCentersWorkspace");
+    m_peakCenterWorkspace = getProperty(PropertyNames::PEAK_CENTERS_WKSP);
     // number of peaks to fit!
     m_numPeaksToFit = m_peakCenterWorkspace->x(0).size();
     g_log.warning() << "Input peak center workspace: "
@@ -831,7 +858,7 @@ void FitPeaks::processInputPeakTolerance() {
                              "ProcessInputPeakCenters()");
 
   // peak tolerance
-  m_peakPosTolerances = getProperty("PositionTolerance");
+  m_peakPosTolerances = getProperty(PropertyNames::POSITION_TOL);
 
   if (m_peakPosTolerances.empty()) {
     // case 2, 3, 4
@@ -852,7 +879,7 @@ void FitPeaks::processInputPeakTolerance() {
   }
 
   // minimum peak height: set default to zero
-  m_minPeakHeight = getProperty("MinimumPeakHeight");
+  m_minPeakHeight = getProperty(PropertyNames::PEAK_MIN_HEIGHT);
   if (isEmpty(m_minPeakHeight) || m_minPeakHeight < 0.)
     m_minPeakHeight = 0.;
 
@@ -879,9 +906,9 @@ void FitPeaks::convertParametersNameToIndex() {
   // map the input parameter names to parameter indexes
   for (const auto &paramName : m_peakParamNames) {
     auto locator = parname_index_map.find(paramName);
-    if (locator != parname_index_map.end())
+    if (locator != parname_index_map.end()) {
       m_initParamIndexes.emplace_back(locator->second);
-    else {
+    } else {
       // a parameter name that is not defined in the peak profile function.  An
       // out-of-range index is thus set to this
       g_log.warning() << "Given peak parameter " << paramName
@@ -1388,8 +1415,6 @@ void FitPeaks::estimateBackground(const Histogram &histogram,
     bkgd_function->setParameter(1, bkgd_a1);
   if (bkgd_function->nParams() > 2)
     bkgd_function->setParameter(2, 0.);
-
-  return;
 }
 
 //----------------------------------------------------------------------------------------------
@@ -1957,7 +1982,7 @@ void FitPeaks::setupParameterTableWorkspace(
  */
 void FitPeaks::generateFittedParametersValueWorkspaces() {
   // peak parameter workspace
-  m_rawPeaksTable = getProperty("RawPeakParameters");
+  m_rawPeaksTable = getProperty(PropertyNames::RAW_PARAMS);
 
   // create parameters
   // peak
@@ -1982,7 +2007,7 @@ void FitPeaks::generateFittedParametersValueWorkspaces() {
 
   // for error workspace
   std::string fiterror_table_name =
-      getPropertyValue("OutputParameterFitErrorsWorkspace");
+      getPropertyValue(PropertyNames::OUTPUT_WKSP_PARAM_ERRS);
   // do nothing if user does not specifiy
   if (fiterror_table_name.empty()) {
     // not specified
@@ -2002,7 +2027,7 @@ void FitPeaks::generateFittedParametersValueWorkspaces() {
  */
 void FitPeaks::generateCalculatedPeaksWS() {
   // matrix workspace contained calculated peaks from fitting
-  std::string fit_ws_name = getPropertyValue("FittedPeaksWorkspace");
+  std::string fit_ws_name = getPropertyValue(PropertyNames::OUTPUT_WKSP_MODEL);
   if (fit_ws_name.size() == 0) {
     // skip if user does not specify
     m_fittedPeakWS = nullptr;
@@ -2018,12 +2043,12 @@ void FitPeaks::generateCalculatedPeaksWS() {
 void FitPeaks::processOutputs(
     std::vector<boost::shared_ptr<FitPeaksAlgorithm::PeakFitResult>>
         fit_result_vec) {
-  setProperty("OutputWorkspace", m_outputPeakPositionWorkspace);
-  setProperty("OutputPeakParametersWorkspace", m_fittedParamTable);
+  setProperty(PropertyNames::OUTPUT_WKSP, m_outputPeakPositionWorkspace);
+  setProperty(PropertyNames::OUTPUT_WKSP_PARAMS, m_fittedParamTable);
 
   if (m_fitErrorTable) {
     g_log.warning("Output error table workspace");
-    setProperty("OutputParameterFitErrorsWorkspace", m_fitErrorTable);
+    setProperty(PropertyNames::OUTPUT_WKSP_PARAM_ERRS, m_fitErrorTable);
   } else {
     g_log.warning("No error table output");
   }
@@ -2032,7 +2057,7 @@ void FitPeaks::processOutputs(
   if (m_fittedPeakWS && m_fittedParamTable) {
     g_log.debug("about to calcualte fitted peaks");
     calculateFittedPeaks(fit_result_vec);
-    setProperty("FittedPeaksWorkspace", m_fittedPeakWS);
+    setProperty(PropertyNames::OUTPUT_WKSP_MODEL, m_fittedPeakWS);
   }
 }
 

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -407,6 +407,61 @@ public:
     return;
   }
 
+  void Ntest_singlePeakMultiSpectraPseudoVoigt() {
+    // Generate input workspace
+    // std::string input_ws_name = loadVulcanHighAngleData();
+
+    // Generate peak and background parameters
+    std::vector<string> peakparnames{ "Mixing" };
+    std::vector<double> peakparvalues{ 0.5 };
+
+    // Initialize FitPeak
+    FitPeaks fitpeaks;
+
+    fitpeaks.initialize();
+    TS_ASSERT(fitpeaks.isInitialized());
+
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("InputWorkspace", m_inputWorkspaceName));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("StartWorkspaceIndex", 19990));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("StopWorkspaceIndex", 20000));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("PeakFunction", "PseudoVoigt"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakCenters", "1.0758"));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("FitWindowLeftBoundary", "1.05"));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("FitWindowRightBoundary", "1.15"));
+    TS_ASSERT_THROWS_NOTHING(fitpeaks.setProperty("PeakRanges", "0.02"));
+    TS_ASSERT_THROWS_NOTHING(
+        fitpeaks.setProperty("PeakParameterValues", peakparvalues));
+
+    fitpeaks.setProperty("OutputWorkspace", "PeakPositionsWS3");
+    fitpeaks.setProperty("OutputPeakParametersWorkspace", "PeakParametersWS3");
+    fitpeaks.setProperty("FittedPeaksWorkspace", "FittedPeaksWS3");
+
+    fitpeaks.execute();
+    TS_ASSERT(fitpeaks.isExecuted());
+
+    // check output workspaces
+    TS_ASSERT(
+        API::AnalysisDataService::Instance().doesExist("PeakPositionsWS3"));
+    TS_ASSERT(
+        API::AnalysisDataService::Instance().doesExist("PeakParametersWS3"));
+    TS_ASSERT(API::AnalysisDataService::Instance().doesExist("FittedPeaksWS3"));
+
+    // about the parameters
+    API::MatrixWorkspace_sptr peak_params_ws =
+        boost::dynamic_pointer_cast<API::MatrixWorkspace>(
+            AnalysisDataService::Instance().retrieve("PeakParametersWS3"));
+    TS_ASSERT(peak_params_ws);
+    TS_ASSERT_EQUALS(peak_params_ws->getNumberHistograms(), 5);
+    TS_ASSERT_EQUALS(peak_params_ws->histogram(0).x().size(), 10);
+
+    return;
+  }
+
   //----------------------------------------------------------------------------------------------
   /** Test on init and setup
    */

--- a/Framework/Algorithms/test/FitPeaksTest.h
+++ b/Framework/Algorithms/test/FitPeaksTest.h
@@ -412,8 +412,8 @@ public:
     // std::string input_ws_name = loadVulcanHighAngleData();
 
     // Generate peak and background parameters
-    std::vector<string> peakparnames{ "Mixing" };
-    std::vector<double> peakparvalues{ 0.5 };
+    std::vector<string> peakparnames{"Mixing"};
+    std::vector<double> peakparvalues{0.5};
 
     // Initialize FitPeak
     FitPeaks fitpeaks;

--- a/docs/source/algorithms/FitPeaks-v1.rst
+++ b/docs/source/algorithms/FitPeaks-v1.rst
@@ -74,7 +74,19 @@ will be estimated via *observation*.
 Estimation of values of peak profiles
 #####################################
 
-Peak intensity and peak center are estimated by observing the maximum value within peak fit window.
+Peak height, center, and FWHM and peak center are estimated by
+observing the maximum value within peak fit window and calculating the
+first two moments.
+
+When using peak profiles that do not have a one-to-one mapping between
+effective and raw parameters, you may need to supply starting
+information for more of the parameters. This can be done by specifying
+``PeakParameterNames`` and ``PeakParameterValues`` for some or all of
+the parameters (e.g. ``Mixing`` for a :ref:`func-PseudoVoigt`) which
+will be used for the first peak fit in each spectrum. To supply *all*
+parameters, ``PeakParameterNames`` and ``PeakParameterValueTable`` can
+be used. **WARNING** Partially specifying peak parameters such as
+height and position will be overwritten by observed values.
 
 Subalgorithms used
 ##################
@@ -284,21 +296,21 @@ It is a :py:obj:`MatrixWorkspace <mantid.api.MatrixWorkspace>` containing the pe
 OutputPeakParametersWorkspace
 =============================
 
-It is an output :py:obj:`MatrixWorkspace <mantid.api.ITableWorkspace>` containing function parameters' fitted values 
-for all peaks that are specified to fit. 
+It is an output :py:obj:`MatrixWorkspace <mantid.api.ITableWorkspace>` containing function parameters' fitted values
+for all peaks that are specified to fit.
 The order of the peaks will be exactly the sequence of peaks as the order of the given positions of peaks.
 
-If user specifies a subset of spectra to fit, this TableWorksapce will only contain function 
+If user specifies a subset of spectra to fit, this TableWorksapce will only contain function
 parameters' value that corresponds to the spectra that are fitted.
 
 OutputParameterFitErrorsWorkspace
 =================================
 
-It is an optional output :py:obj:`MatrixWorkspace <mantid.api.ITableWorkspace>` containing function parameters' fitting error, 
+It is an optional output :py:obj:`MatrixWorkspace <mantid.api.ITableWorkspace>` containing function parameters' fitting error,
 i.e., uncertainties, for all peaks that are specified to fit.
 The order of the peaks will be exactly the sequence of peaks as the order of the given positions of peaks.
 
-If user specifies a subset of spectra to fit, this TableWorksapce will only contain function 
+If user specifies a subset of spectra to fit, this TableWorksapce will only contain function
 parameters' uncertainties that corresponds to the spectra that are fitted.
 
 It has one less column than OutputPeakParametersWorkspace, which is chi2.
@@ -306,7 +318,7 @@ It has one less column than OutputPeakParametersWorkspace, which is chi2.
 FittedPeaksWorkspace
 ====================
 
-It is an optional output :py:obj:`MatrixWorkspace <mantid.api.MatrixWorkspace>` containing the peaks 
+It is an optional output :py:obj:`MatrixWorkspace <mantid.api.MatrixWorkspace>` containing the peaks
 calculated from fitting result.
 
 

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -27,7 +27,8 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
-- :ref:`EnggCalibrateFull <algm-EnggCalibrateFull-v1>` now uses the new :ref:`SaveAscii <algm-SaveAscii-v2>` to save its output files as TSVs, allowing them to be loaded back into mantid. 
+- :ref:`EnggCalibrateFull <algm-EnggCalibrateFull-v1>` now uses the new :ref:`SaveAscii <algm-SaveAscii-v2>` to save its output files as TSVs, allowing them to be loaded back into mantid.
+- :ref:`FitPeaks <algm-FitPeaks-v1>` allows for specifying some of the peak parameters (e.g. only ``Mixing`` for :ref:`func-PseudoVoigt`) and observing the other parameters. The new functionality allows for more automated execution for peak functions other than :ref:`func-Gaussian`.
 
 Single Crystal Diffraction
 --------------------------


### PR DESCRIPTION
In [PyRS](https://github.com/neutrons/PyRS) it is desired to automate fitting the pseudo-Voigt function by specifying the peak center and a default mixing parameter. This PR adds that functionality to `FitPeaks`.

**To test:**

Run the PyRS interface and fit pseudo-Voigt peak shapes.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
