### PR TITLE
Correct instrument view default axis

### DIFF
--- a/docs/source/release/v4.3.0/ui.rst
+++ b/docs/source/release/v4.3.0/ui.rst
@@ -29,3 +29,8 @@ SliceViewer and Vates Simple Interface
 --------------------------------------
 
 :ref:`Release 4.3.0 <v4.3.0>`
+
+Bugs
+----
+
+- Fixed a bug on the instrument viewer where changing projection and back to Full 3D would display from the wrong point of view.

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -490,10 +490,6 @@ void InstrumentWidget::setSurfaceType(int type) {
     surface->setShowPeakRelativeIntensityFlag(showPeakRelativeIntensity);
     // set new surface
     setSurface(surface);
-    if (surfaceType == FULL3D) {
-      setViewDirection(
-          QString::fromStdString(getInstrumentActor().getDefaultAxis()));
-    }
 
     // init tabs with new surface
     foreach (InstrumentWidgetTab *tab, m_tabs) { tab->initSurface(); }

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -490,6 +490,10 @@ void InstrumentWidget::setSurfaceType(int type) {
     surface->setShowPeakRelativeIntensityFlag(showPeakRelativeIntensity);
     // set new surface
     setSurface(surface);
+    if (surfaceType == FULL3D) {
+      setViewDirection(
+          QString::fromStdString(getInstrumentActor().getDefaultAxis()));
+    }
 
     // init tabs with new surface
     foreach (InstrumentWidgetTab *tab, m_tabs) { tab->initSurface(); }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -517,6 +517,7 @@ void InstrumentWidgetRenderTab::setScaleType(ColorMap::ScaleType type) {
 }
 
 void InstrumentWidgetRenderTab::setAxis(const QString &axisNameArg) {
+  mAxisCombo->setCurrentIndex(mAxisCombo->findText("Z+"));
   QString axisName = axisNameArg.toUpper();
   int axisInd = mAxisCombo->findText(axisName.toUpper());
   if (axisInd < 0)


### PR DESCRIPTION
**Description of work.**
On the instrument view tab, when switching from Full 3D to another projection and then back to 3D, the axis view would not get back to the defined default on the image, although the box would say it does (except for Z+).
This was because the viewport's rotation matrix is changed only if the QtComboBox is notified that the axis has changed, which it does not have if the view was left on default axis before switching to another projection. Hence no modification of the view axis, and so it shows the instrument by a Z+ point of view.

As such, the fix only consist on switching the view to Z+ before switching it back to the default value . Thus if the default axis was Z+, no call is made because there is no change. If it is not, the combo box is notified there have been at least one change and thus adapt the view. 

**To test:**
- Run `LoadEmptyInstrument` with D33.
- Switch projection to anything and then back to Full 3D and check that the view is still correctly set on Z-.
<!-- Instructions for testing. -->

Fixes #27793 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
