### PR TITLE
Bundle Windows printer support plugin with Qt5 plugins.

### DIFF
--- a/buildconfig/CMake/WindowsNSISQt5.cmake
+++ b/buildconfig/CMake/WindowsNSISQt5.cmake
@@ -37,6 +37,7 @@ foreach( DLL ${QT5_PLUGINS_IMAGEFORMAT} )
 endforeach()
 
 install ( FILES ${QT5_PLUGIN_DIR}/platforms/qwindows.dll DESTINATION plugins/qt5/platforms )
+install ( FILES ${QT5_PLUGIN_DIR}/printsupport/windowsprintersupport.dll DESTINATION plugins/qt5/printsupport )
 install ( FILES ${QT5_PLUGIN_DIR}/sqldrivers/qsqlite.dll DESTINATION plugins/qt5/sqldrivers )
 install ( FILES ${QT5_PLUGIN_DIR}/styles/qwindowsvistastyle.dll DESTINATION plugins/qt5/styles )
 
@@ -45,7 +46,7 @@ install ( FILES ${QT5_INSTALL_PREFIX}/lib/qscintilla2_qt5.dll DESTINATION bin )
 ###########################################################################
 # Qt Resource Files for QtWebEngine
 ###########################################################################
-install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/qt/applications/workbench/qt.conf.webengine 
+install ( FILES ${CMAKE_CURRENT_BINARY_DIR}/qt/applications/workbench/qt.conf.webengine
           DESTINATION lib/qt5/bin RENAME qt.conf)
 install ( FILES ${QT5_INSTALL_PREFIX}/bin/QtWebEngineProcess.exe DESTINATION lib/qt5/bin )
 install ( DIRECTORY ${QT5_INSTALL_PREFIX}/resources DESTINATION lib/qt5 )


### PR DESCRIPTION
**Description of work.**

Fixes print support in workbench when run from a packaged build. The support plugin was missing and a warning was printed to stderr but the console is not visible for the package build.

**To test:**

* Build a package on Windows and install it.
* Create a plot and try to print it.
* The dialog should pop up.

Refs #27703 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
