### PR TITLE
Only run system tests on RHEL Python 3 builds

### DIFF
--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -126,6 +126,18 @@ else
     SCL_ENABLE="eval"
 fi
 
+# Check if this is a Python 2 build and set CMake arguments.
+PY2_BUILD=false
+PY3_BUILD=false
+if [[ ${JOB_NAME} == *python2* ]]; then
+    PY2_BUILD=true
+    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=OFF"
+else
+    PY3_BUILD=true
+    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
+    PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
+fi
+
 # For pull requests decide on what to build based on changeset and Jenkins
 # parameters.
 DO_BUILD_CODE=true
@@ -147,8 +159,10 @@ if [[ ${PRBUILD} == true ]]; then
     if [[ ${ON_RHEL7} == true ]]; then
         # rhel does system testing
         if ! ${SCRIPT_DIR}/check_for_changes docs-gui-only; then
-            DO_BUILD_PKG=true
-            DO_SYSTEMTESTS=true
+            if [[ ${PY3_BUILD} == true ]]; then
+               DO_BUILD_PKG=true
+               DO_SYSTEMTESTS=true
+            fi
         fi
         elif [[ ${ON_UBUNTU} == true ]]; then
         # ubuntu does the docs build
@@ -243,20 +257,6 @@ fi
 ###############################################################################
 if [ -z "$MANTID_DATA_STORE" ]; then
     export MANTID_DATA_STORE=$HOME/MantidExternalData
-fi
-
-###############################################################################
-# Check if this is a Python 2 build and set CMake arguments.
-###############################################################################
-PY2_BUILD=false
-PY3_BUILD=false
-if [[ ${JOB_NAME} == *python2* ]]; then
-    PY2_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=OFF"
-else
-    PY3_BUILD=true
-    DIST_FLAGS="${DIST_FLAGS} -DWITH_PYTHON3=ON"
-    PARAVIEW_DIR="${PARAVIEW_DIR}-python3"
 fi
 
 ###############################################################################


### PR DESCRIPTION
**Description of work.**

We don't want to run the system tests twice on PR builds so disable it for the Python 2 RHEL7 check.

The nightly build will still check them.

**To test:**

Check the jobs for this PR and see that the `RHEL7 + SystemTests` only has run the syystem tests but not the Python 2 build.

*There is no associated issue.*

*This does not require release notes* because **it is an internal matter.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
