### PR TITLE
Fix crash in Indirect ILL Reduction GUI

### DIFF
--- a/docs/source/release/v4.3.0/indirect_geometry.rst
+++ b/docs/source/release/v4.3.0/indirect_geometry.rst
@@ -30,5 +30,6 @@ BugFixes
 
 - The Abins file parser no longer fails to read data from non-periodic vibration calculations performed with CRYSTAL17.
 - :ref:`ApplyPaalmanPingsCorrection <algm-ApplyPaalmanPingsCorrection>` will now run also for fixed window scan reduced data and will not crash on workspace groups.
+- Fixed a bug crashing the ``Indirect ILL Data Reduction GUI`` when Run is clicked.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReductionTab.cpp
@@ -51,7 +51,9 @@ void IndirectDataReductionTab::runTab() {
     emit updateRunButton(false, "disable", "Running...",
                          "Running data reduction...");
     try {
-      m_plotOptionsPresenter->clearWorkspaces();
+      if (m_plotOptionsPresenter) {
+        m_plotOptionsPresenter->clearWorkspaces();
+      }
       run();
     } catch (std::exception const &ex) {
       m_tabRunning = false;


### PR DESCRIPTION
**Description of work.**
See the title.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Set the facility to ILL.
2. Go to Interfaces>Indirect>Data Reduction
3. Browse to `UnitTest/ILL/IN16B/136558.nxs`
4. Click run, it should not crash and it should produce a workspace group
5. Ideally repeat on workbench and plot.

<!-- Instructions for testing. -->

Fixes #27815 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
