### PR TITLE
Add nested categories for fit functions

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -25,6 +25,7 @@ Improvements
    :align: left
 
 - You can now save Table Workspaces to Ascii using the `SaveAscii <algm-SaveAscii>` algorithm, and the Ascii Save option on the workspaces toolbox.
+- Fit functions can now be put into nested categories and into multiple categories.
 - Normalization options have been added to 2d plots and sliceviewer.
 - The images tab in figure options no longer forces the max value to be greater than the min value.
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -21,8 +21,8 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/IWorkspaceFitControl.h"
+#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 
 /* Forward declarations */

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -21,6 +21,7 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/SelectFunctionDialog.h"
 #include "MantidQtWidgets/Common/IWorkspaceFitControl.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 
@@ -54,6 +55,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 
 class PropertyHandler;
+class SelectFunctionDialog;
 /**
  * Class FitPropertyBrowser implements QtPropertyBrowser to display
  * and control fitting function parameters and settings.
@@ -629,7 +631,7 @@ private:
   QLabel *m_status;
 
   // The widget for choosing the fit function.
-  QDialog *m_fitSelector;
+  SelectFunctionDialog *m_fitSelector;
   // The tree widget containing the fit functions.
   QTreeWidget *m_fitTree;
 

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -112,15 +112,15 @@ void SelectFunctionDialog::constructFunctionTree(
         // go through the path and add the folders if they don't already exist
         QString currentPath = subCategories[0];
         QTreeWidgetItem *catItem = nullptr;
-        int n = subCategories.size();
+        int subCategoryNo = subCategories.size();
         bool show = false;
-        for (int j = 0; j < n; j++) {
+        for (int j = 0; j < subCategoryNo; ++j) {
           if (showCategory(subCategories[j].toStdString())) {
             show = true;
           }
         }
         if (show) {
-          for (int j = 0; j < n; j++) {
+          for (int j = 0; j < subCategoryNo; ++j) {
             if (categories.contains(currentPath)) {
               catItem = categories[currentPath];
             } else {
@@ -134,7 +134,7 @@ void SelectFunctionDialog::constructFunctionTree(
               }
               catItem = newCatItem;
             }
-            if (j != n - 1)
+            if (j != subCategoryNo - 1)
               currentPath += "\\" + subCategories[j + 1];
             else {
               // This is the end of the path so add the functions

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -93,45 +93,55 @@ void SelectFunctionDialog::constructFunctionTree(
   QMap<QString, QTreeWidgetItem *> categories;
 
   for (const auto &entry : categoryFunctionsMap) {
-    // if (showCategory(entry.first)) {}
+
     QString categoryName = QString::fromStdString(entry.first);
     QStringList subCategories = categoryName.split('\\');
     if (!categories.contains(categoryName)) {
       if (subCategories.size() == 1) {
-        QTreeWidgetItem *catItem =
-            new QTreeWidgetItem(QStringList(categoryName));
-        categories.insert(categoryName, catItem);
-        m_form->fitTree->addTopLevelItem(catItem);
-        for (const auto &function : entry.second) {
-          QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
-          fit->setText(0, QString::fromStdString(function));
+        if (showCategory(entry.first)) {
+          QTreeWidgetItem *catItem =
+              new QTreeWidgetItem(QStringList(categoryName));
+          categories.insert(categoryName, catItem);
+          m_form->fitTree->addTopLevelItem(catItem);
+          for (const auto &function : entry.second) {
+            QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+            fit->setText(0, QString::fromStdString(function));
+          }
         }
       } else {
         // go through the path and add the folders if they don't already exist
         QString currentPath = subCategories[0];
         QTreeWidgetItem *catItem = nullptr;
         int n = subCategories.size();
+        bool show = false;
         for (int j = 0; j < n; j++) {
-          if (categories.contains(currentPath)) {
-            catItem = categories[currentPath];
-          } else {
-            QTreeWidgetItem *newCatItem =
-                new QTreeWidgetItem(QStringList(subCategories[j]));
-            categories.insert(currentPath, newCatItem);
-            if (!catItem) {
-              m_form->fitTree->addTopLevelItem(newCatItem);
-            } else {
-              catItem->addChild(newCatItem);
-            }
-            catItem = newCatItem;
+          if (showCategory(subCategories[j].toStdString())) {
+            show = true;
           }
-          if (j != n - 1)
-            currentPath += "\\" + subCategories[j + 1];
-          else {
-            // This is the end of the path so add the functions
-            for (const auto &function : entry.second) {
-              QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
-              fit->setText(0, QString::fromStdString(function));
+        }
+        if (show) {
+          for (int j = 0; j < n; j++) {
+            if (categories.contains(currentPath)) {
+              catItem = categories[currentPath];
+            } else {
+              QTreeWidgetItem *newCatItem =
+                  new QTreeWidgetItem(QStringList(subCategories[j]));
+              categories.insert(currentPath, newCatItem);
+              if (!catItem) {
+                m_form->fitTree->addTopLevelItem(newCatItem);
+              } else {
+                catItem->addChild(newCatItem);
+              }
+              catItem = newCatItem;
+            }
+            if (j != n - 1)
+              currentPath += "\\" + subCategories[j + 1];
+            else {
+              // This is the end of the path so add the functions
+              for (const auto &function : entry.second) {
+                QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+                fit->setText(0, QString::fromStdString(function));
+              }
             }
           }
         }

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -89,14 +89,52 @@ void SelectFunctionDialog::constructFunctionTree(
     }
   };
 
-  for (const auto &entry : categoryFunctionsMap) {
-    if (showCategory(entry.first)) {
-      QTreeWidgetItem *category = new QTreeWidgetItem(m_form->fitTree);
-      category->setText(0, QString::fromStdString(entry.first));
+  // keeps track of categories added to the tree
+  QMap<QString, QTreeWidgetItem *> categories;
 
-      for (const auto &function : entry.second) {
-        QTreeWidgetItem *fit = new QTreeWidgetItem(category);
-        fit->setText(0, QString::fromStdString(function));
+  for (const auto &entry : categoryFunctionsMap) {
+    // if (showCategory(entry.first)) {}
+    QString categoryName = QString::fromStdString(entry.first);
+    QStringList subCategories = categoryName.split('\\');
+    if (!categories.contains(categoryName)) {
+      if (subCategories.size() == 1) {
+        QTreeWidgetItem *catItem =
+            new QTreeWidgetItem(QStringList(categoryName));
+        categories.insert(categoryName, catItem);
+        m_form->fitTree->addTopLevelItem(catItem);
+        for (const auto &function : entry.second) {
+          QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+          fit->setText(0, QString::fromStdString(function));
+        }
+      } else {
+        // go through the path and add the folders if they don't already exist
+        QString currentPath = subCategories[0];
+        QTreeWidgetItem *catItem = nullptr;
+        int n = subCategories.size();
+        for (int j = 0; j < n; j++) {
+          if (categories.contains(currentPath)) {
+            catItem = categories[currentPath];
+          } else {
+            QTreeWidgetItem *newCatItem =
+                new QTreeWidgetItem(QStringList(subCategories[j]));
+            categories.insert(currentPath, newCatItem);
+            if (!catItem) {
+              m_form->fitTree->addTopLevelItem(newCatItem);
+            } else {
+              catItem->addChild(newCatItem);
+            }
+            catItem = newCatItem;
+          }
+          if (j != n - 1)
+            currentPath += "\\" + subCategories[j + 1];
+          else {
+            // This is the end of the path so add the functions
+            for (const auto &function : entry.second) {
+              QTreeWidgetItem *fit = new QTreeWidgetItem(catItem);
+              fit->setText(0, QString::fromStdString(function));
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
**Description of work.**
This PR adds the functionality for fit functions to be stored in nested categories, using the separator `\\` (the same as algorithms). In making these changes it also means the functions can appear in multiple categories (uses `;` as a separator)

**To test:**
Change the category of an existing function to be a nested category e.g. `General\\NewCategory`
Open Workbench
Load a workspace and do a plot.
Click fit and right click on the propertybrowser and click `add function`
The function you changed should appear in a nested category.

Fixes #27586 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
