### PR TITLE
Add plotting options to context menu for WorkspaceGroups

### DIFF
--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -203,7 +203,7 @@ std::vector<Workspace_sptr> AnalysisDataServiceImpl::retrieveWorkspaces(
     using IteratorDifference =
         std::iterator_traits<WorkspacesVector::iterator>::difference_type;
 
-    bool done{false};
+    bool done{workspaces.size() == 0};
     size_t i{0};
     while (!done) {
       if (auto group =

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -204,7 +204,7 @@ std::vector<Workspace_sptr> AnalysisDataServiceImpl::retrieveWorkspaces(
         std::iterator_traits<WorkspacesVector::iterator>::difference_type;
 
     bool done{false};
-    int i{0};
+    size_t i{0};
     while (!done) {
       if (auto group =
               boost::dynamic_pointer_cast<WorkspaceGroup>(workspaces.at(i))) {

--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -202,7 +202,10 @@ std::vector<Workspace_sptr> AnalysisDataServiceImpl::retrieveWorkspaces(
   if (unrollGroups) {
     using IteratorDifference =
         std::iterator_traits<WorkspacesVector::iterator>::difference_type;
-    for (size_t i = 0; i < workspaces.size(); ++i) {
+
+    bool done{false};
+    int i{0};
+    while (!done) {
       if (auto group =
               boost::dynamic_pointer_cast<WorkspaceGroup>(workspaces.at(i))) {
         const auto groupLength(group->size());
@@ -214,6 +217,12 @@ std::vector<Workspace_sptr> AnalysisDataServiceImpl::retrieveWorkspaces(
                             group->getItem(j));
         }
         i += groupLength;
+      } else {
+        ++i;
+      }
+
+      if (i == workspaces.size()) {
+        done = true;
       }
     }
   }

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -28,7 +28,7 @@ Improvements
 - Normalization options have been added to 2d plots and sliceviewer.
 - The images tab in figure options no longer forces the max value to be greater than the min value.
 - Double clicking on a workspace that only has a single bin of data (for example from a constant wavelength source) will now plot that bin, also for single bin workspaces a plot bin option has been added to the right click plot menu of the workspace.
-
+- The context menu for WorkspaceGroups now contains plotting options so you can plot all of the workspaces in the group.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -53,15 +53,11 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
     def get_compatible_workspaces(workspaces):
         matrix_workspaces = []
         for ws in workspaces:
-            try:
-                if not isinstance(ws, MatrixWorkspace) :
-                    raise ValueError("{}: Expected MatrixWorkspace, found {}".format(ws.name(), ws.__class__.__name__))
-            except ValueError as e:
-                # Log the error but carry on so valid workspaces can be plotted.
-                logger.warning(str(e))
-                continue
-            else:
+            if isinstance(ws, MatrixWorkspace):
                 matrix_workspaces.append(ws)
+            else:
+                # Log an error but carry on so valid workspaces can be plotted.
+                logger.warning("{}: Expected MatrixWorkspace, found {}".format(ws.name(), ws.__class__.__name__))
 
         return matrix_workspaces
 

--- a/qt/python/mantidqt/dialogs/spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/spectraselectorutils.py
@@ -22,7 +22,7 @@ def get_spectra_selection(workspaces, parent_widget=None, show_colorfill_btn=Fal
     the request was cancelled
     :raises ValueError: if the workspaces are not of type MatrixWorkspace
     """
-    SpectraSelectionDialog.raise_error_if_workspaces_not_compatible(workspaces)
+    workspaces = SpectraSelectionDialog.get_compatible_workspaces(workspaces)
     single_spectra_ws = [wksp.getNumberHistograms() for wksp in workspaces if wksp.getNumberHistograms() == 1]
 
     if len(workspaces) == len(single_spectra_ws):

--- a/qt/python/mantidqt/dialogs/spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/spectraselectorutils.py
@@ -23,6 +23,9 @@ def get_spectra_selection(workspaces, parent_widget=None, show_colorfill_btn=Fal
     :raises ValueError: if the workspaces are not of type MatrixWorkspace
     """
     workspaces = SpectraSelectionDialog.get_compatible_workspaces(workspaces)
+    if len(workspaces) == 0:
+        return None
+
     single_spectra_ws = [wksp.getNumberHistograms() for wksp in workspaces if wksp.getNumberHistograms() == 1]
 
     if len(workspaces) == len(single_spectra_ws):

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import QDialogButtonBox
 from mantid.api import WorkspaceFactory
 from mantid.py3compat import mock
 from mantid.simpleapi import ExtractSpectra
+from mantidqt.dialogs import spectraselectordialog
 from mantidqt.dialogs.spectraselectordialog import parse_selection_str, SpectraSelectionDialog
 from mantidqt.dialogs.spectraselectorutils import get_spectra_selection
 from mantidqt.utils.qt.testing import start_qapplication
@@ -129,14 +130,19 @@ class SpectraSelectionDialogTest(unittest.TestCase):
         self.assertEqual([1, 2, 3, 5, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
                          parse_selection_str(s, 1, 20))
 
-    # --------------- failure tests -----------
-    def test_construction_with_non_MatrixWorkspace_type_raises_exception(self):
+    def test_construction_with_non_MatrixWorkspace_type_removes_non_MatrixWorkspaces_from_list(self):
         table = WorkspaceFactory.Instance().createTable()
-        self.assertRaises(ValueError, SpectraSelectionDialog, [self._single_spec_ws, table])
+        workspaces = [self._single_spec_ws, table]
+        ssd = SpectraSelectionDialog(workspaces)
+        spectraselectordialog.RED_ASTERISK = None
+        self.assertEqual(ssd._workspaces, [self._single_spec_ws])
 
-    def test_get_spectra_selection_raises_error_with_wrong_workspace_type(self):
+    def test_get_spectra_selection_removes_wrong_workspace_types_from_list(self):
         table = WorkspaceFactory.Instance().createTable()
-        self.assertRaises(ValueError, get_spectra_selection, [self._single_spec_ws, table])
+        workspaces = [self._single_spec_ws, table]
+        self.assertEqual(get_spectra_selection(workspaces).workspaces, [self._single_spec_ws])
+
+    # --------------- failure tests -----------
 
     def test_set_placeholder_text_raises_error_if_workspaces_have_no_common_spectra(self):
         spectra_1 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=0, EndWorkspaceIndex=5)

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectorutils.py
@@ -46,6 +46,7 @@ class SpectraSelectionUtilsTest(unittest.TestCase):
         mock_SpectraSelectionDialog.exec_.return_value = mock_SpectraSelectionDialog.Rejected
         mock_SpectraSelectionDialog.decision = QDialog.Rejected
         mock_SpectraSelectionDialog.selection = None
+        mock_SpectraSelectionDialog.get_compatible_workspaces.return_value = [self._multi_spec_ws]
 
         selection = get_spectra_selection([self._multi_spec_ws])
 
@@ -54,6 +55,7 @@ class SpectraSelectionUtilsTest(unittest.TestCase):
 
     @mock.patch('mantidqt.dialogs.spectraselectorutils.SpectraSelectionDialog')
     def test_get_spectra_selection_does_not_use_dialog_for_single_spectrum(self, dialog_mock):
+        dialog_mock.get_compatible_workspaces.return_value = [self._single_spec_ws]
         selection = get_spectra_selection([self._single_spec_ws])
 
         dialog_mock.assert_not_called()
@@ -64,6 +66,7 @@ class SpectraSelectionUtilsTest(unittest.TestCase):
     def test_get_spectra_selection_does_not_use_dialog_for_multiple__single_spectrum(self, dialog_mock):
         spectra_1 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=0, EndWorkspaceIndex=0)
         spectra_2 = ExtractSpectra(InputWorkspace=self._multi_spec_ws, StartWorkspaceIndex=1, EndWorkspaceIndex=1)
+        dialog_mock.get_compatible_workspaces.return_value = [spectra_1, spectra_2]
         selection = get_spectra_selection([spectra_1, spectra_2])
 
         dialog_mock.assert_not_called()

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -207,6 +207,8 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
     if plot_kwargs is None:
         plot_kwargs = {}
     _validate_plot_inputs(workspaces, spectrum_nums, wksp_indices, tiled, overplot)
+    workspaces = [ws for ws in workspaces if isinstance(ws, MatrixWorkspace)]
+
     if spectrum_nums is not None:
         kw, nums = 'specNum', spectrum_nums
     else:
@@ -337,6 +339,7 @@ def pcolormesh(workspaces, fig=None):
     """
     # check inputs
     _validate_pcolormesh_inputs(workspaces)
+    workspaces = [ws for ws in workspaces if isinstance(ws, MatrixWorkspace)]
 
     # create a subplot of the appropriate number of dimensions
     # extend in number of columns if the number of plottables is not a square number
@@ -437,7 +440,12 @@ def _raise_if_not_sequence(value, seq_name, element_type=None):
     if element_type is not None:
         def raise_if_not_type(x):
             if not isinstance(x, element_type):
-                raise ValueError("Unexpected type: '{}'".format(x.__class__.__name__))
+                if element_type == MatrixWorkspace:
+                    # If the workspace is the wrong type, log the error and remove it from the list so that the other
+                    # workspaces can still be plotted.
+                    LOGGER.warning("{} has unexpected type '{}'".format(x, x.__class__.__name__))
+                else:
+                    raise ValueError("Unexpected type: '{}'".format(x.__class__.__name__))
 
         # Map in Python3 is an iterator, so ValueError will not be raised unless the values are yielded.
         # converting to a list forces yielding

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -153,7 +153,35 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       menu->addAction(m_showAlgorithmHistory);
       menu->addAction(m_sampleLogs);
       menu->addAction(m_sliceViewer);
-    } else if (boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
+    } else if (auto wsGroup =
+                   boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
+      auto workspaces = wsGroup->getAllItems();
+      bool containsMatrixWorkspace{false};
+
+      for (auto ws : workspaces) {
+        if (auto matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
+          containsMatrixWorkspace = true;
+          break;
+        }
+      }
+
+      // Add plotting options if the group contains at least one matrix
+      // workspace.
+      if (containsMatrixWorkspace) {
+        QMenu *plotSubMenu(new QMenu("Plot", menu));
+
+        plotSubMenu->addAction(m_plotSpectrum);
+        plotSubMenu->addAction(m_overplotSpectrum);
+        plotSubMenu->addAction(m_plotSpectrumWithErrs);
+        plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+
+        plotSubMenu->addSeparator();
+        plotSubMenu->addAction(m_plotColorfill);
+        menu->addMenu(plotSubMenu);
+
+        menu->addSeparator();
+      }
+
       menu->addAction(m_showDetectors);
     }
 

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -157,11 +157,15 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
                    boost::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
       auto workspaces = wsGroup->getAllItems();
       bool containsMatrixWorkspace{false};
+      bool containsPeaksWorkspace{false};
 
       for (auto ws : workspaces) {
         if (auto matrixWS = boost::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
           containsMatrixWorkspace = true;
           break;
+        } else if (auto peaksWS =
+                       boost::dynamic_pointer_cast<IPeaksWorkspace>(ws)) {
+          containsPeaksWorkspace = true;
         }
       }
 
@@ -182,7 +186,9 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
         menu->addSeparator();
       }
 
-      menu->addAction(m_showDetectors);
+      if (containsMatrixWorkspace || containsPeaksWorkspace) {
+        menu->addAction(m_showDetectors);
+      }
     }
 
     menu->addSeparator();


### PR DESCRIPTION
**Description of work.**
This PR makes it so that you can right-click a WorkspaceGroup and plot the workspaces it contains, like in MantidPlot.

**To test:**
1. Make a WorkspaceGroup and right-click it. There should now be plotting options.
2. Plotting this way should produce a plot with lines from each workspace in the group. If one of the workspaces can't be plotted, such as a TableWorkspace, a warning will appear in the log but the rest of the workspaces will still be plotted.
3. A WorkspaceGroup containing only non-plottable workspaces should not have the plotting options when right-clicked.

Fixes #27820 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
