### PR TITLE
Set sample and run via python

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -23,6 +23,7 @@
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::ExperimentInfo;
+using Mantid::API::Sample;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
@@ -47,6 +48,12 @@ BOOST_PYTHON_FUNCTION_OVERLOADS(getInstrumentFilename_Overload,
                                 ExperimentInfo::getInstrumentFilename, 1, 2)
 GNU_DIAG_ON("conversion")
 GNU_DIAG_ON("unused-local-typedef")
+
+namespace {
+void setSample(ExperimentInfo &expInfo, const Mantid::API::Sample &sample) {
+  expInfo.mutableSample() = sample;
+}
+} // namespace
 
 void export_ExperimentInfo() {
   register_ptr_to_python<boost::shared_ptr<ExperimentInfo>>();
@@ -75,39 +82,30 @@ void export_ExperimentInfo() {
            getInstrumentFilename_Overload(
                "Returns IDF filename", (arg("instrument"), arg("date") = "")))
       .staticmethod("getInstrumentFilename")
-
       .def("sample", &ExperimentInfo::sample,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return the :class:`~mantid.api.Sample` object. This cannot be "
            "modified, use mutableSample to modify.")
-
       .def("mutableSample", &ExperimentInfo::mutableSample,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return a modifiable :class:`~mantid.api.Sample` object.")
-
       .def("run", &ExperimentInfo::run,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return the :class:`~mantid.api.Run` object. This cannot be "
            "modified, use mutableRun to modify.")
-
       .def("mutableRun", &ExperimentInfo::mutableRun,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return a modifiable :class:`~mantid.api.Run` object.")
-
       .def("getRunNumber", &ExperimentInfo::getRunNumber, args("self"),
            "Returns the run identifier for this run.")
-
       .def("getEFixed",
            (double (ExperimentInfo::*)(const Mantid::detid_t) const) &
                ExperimentInfo::getEFixed,
            args("self", "detId"))
-
       .def("setEFixed", &ExperimentInfo::setEFixed,
            args("self", "detId", "value"))
-
       .def("getEMode", &ExperimentInfo::getEMode, args("self"),
            "Returns the energy mode.")
-
       .def("detectorInfo", &ExperimentInfo::detectorInfo,
            return_value_policy<reference_existing_object>(), args("self"),
            "Return a const reference to the "
@@ -121,5 +119,13 @@ void export_ExperimentInfo() {
            return_value_policy<reference_existing_object>(), args("self"),
            "Return a const reference to the "
            ":class:`~mantid.geometry.ComponentInfo` "
-           "object.");
+           "object.")
+      .def("setSample", setSample, args("self", "sample"))
+      /*
+      .add_property("sample",
+      make_function(&ExperimentInfo::sample,return_value_policy<reference_existing_object>()),
+                     make_function(&ExperimentInfo::mutableSample,return_value_policy<reference_existing_object>())
+                      );
+      */
+      ;
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -23,7 +23,6 @@
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::API::ExperimentInfo;
-using Mantid::API::Sample;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 using namespace Mantid::PythonInterface;
 using namespace boost::python;
@@ -52,6 +51,9 @@ GNU_DIAG_ON("unused-local-typedef")
 namespace {
 void setSample(ExperimentInfo &expInfo, const Mantid::API::Sample &sample) {
   expInfo.mutableSample() = sample;
+}
+void setRun(ExperimentInfo &expInfo, const Mantid::API::Run &run) {
+  expInfo.mutableRun() = run;
 }
 } // namespace
 
@@ -121,11 +123,6 @@ void export_ExperimentInfo() {
            ":class:`~mantid.geometry.ComponentInfo` "
            "object.")
       .def("setSample", setSample, args("self", "sample"))
-      /*
-      .add_property("sample",
-      make_function(&ExperimentInfo::sample,return_value_policy<reference_existing_object>()),
-                     make_function(&ExperimentInfo::mutableSample,return_value_policy<reference_existing_object>())
-                      );
-      */
+      .def("setRun", setRun, args("self", "run"))
       ;
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ExperimentInfo.cpp
@@ -123,6 +123,5 @@ void export_ExperimentInfo() {
            ":class:`~mantid.geometry.ComponentInfo` "
            "object.")
       .def("setSample", setSample, args("self", "sample"))
-      .def("setRun", setRun, args("self", "run"))
-      ;
+      .def("setRun", setRun, args("self", "run"));
 }

--- a/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
@@ -54,15 +54,20 @@ class ExperimentInfoTest(unittest.TestCase):
         sample.setThickness(12.5)
 
         self._expt_ws.setSample(sample)
-        held = self._expt_ws.sample()
+        held_sample = self._expt_ws.sample()
 
-        self.assertNotEqual(id(held), id(sample))
-        self.assertEqual(held.getThickness(), sample.getThickness())
+        self.assertNotEqual(id(held_sample), id(sample))
+        self.assertEqual(held_sample.getThickness(), sample.getThickness())
 
-#    def test_set_and_get_efixed(self):
-#      ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(1, 5, False, False)
-#        ws.setEFixed(1, pi)
-#      self.assertEqual(ws.getEFixed(1), pi)
+    def test_setRun(self):
+        run = Run()
+        run.addProperty("run_property", 1, True)
+
+        self._expt_ws.setRun(run)
+        held_run = self._expt_ws.run()
+
+        self.assertNotEqual(id(held_run), id(run))
+        self.assertTrue(held_run.hasProperty('run_property'))
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ExperimentInfoTest.py
@@ -49,6 +49,16 @@ class ExperimentInfoTest(unittest.TestCase):
         # No instrument in test workspace, so size is 0.
         self.assertEqual(detInfo.size(), 0)
 
+    def test_setSample(self):
+        sample = Sample()
+        sample.setThickness(12.5)
+
+        self._expt_ws.setSample(sample)
+        held = self._expt_ws.sample()
+
+        self.assertNotEqual(id(held), id(sample))
+        self.assertEqual(held.getThickness(), sample.getThickness())
+
 #    def test_set_and_get_efixed(self):
 #      ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(1, 5, False, False)
 #        ws.setEFixed(1, pi)


### PR DESCRIPTION
Adds setters for sample and run.

Property route would be nicer but we have to deal with name clash (existing `run` and `sample` methods) and deprecation warnings.