### PR TITLE
Fix crash in workbench when fitting in script editor

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -501,6 +501,9 @@ class CompositeFunctionWrapper(FunctionWrapper):
         """
 
         comp = self.fun
+        if (isinstance(nameorindex, str) and not comp.hasParameter(nameorindex)) \
+                or (isinstance(nameorindex, int) and nameorindex >= comp.nParams()):
+            raise AttributeError("Parameter not found")
         item = comp[nameorindex]
         if isinstance(item, float):
             return  item

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -103,7 +103,7 @@ class FunctionWrapper(object):
             if self.fun.hasParameter(name):
                 return self.fun.getParameterValue(name)
             else:
-                raise AttributeError("Parameter not found")
+                raise AttributeError("Parameter %s not found" % name)
 
     def __setitem__ (self, name, value):
         """
@@ -506,7 +506,7 @@ class CompositeFunctionWrapper(FunctionWrapper):
         comp = self.fun
         if (isinstance(nameorindex, str) and not comp.hasParameter(nameorindex)) \
                 or (isinstance(nameorindex, int) and nameorindex >= comp.nParams()):
-            raise AttributeError("Parameter not found")
+            raise AttributeError("Parameter %s not found" % nameorIndex)
         item = comp[nameorindex]
         if isinstance(item, float):
             return  item

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -100,7 +100,10 @@ class FunctionWrapper(object):
         if type(name) == type('string') and self.fun.hasAttribute(name):
             return self.fun.getAttributeValue(name)
         else:
-            return self.fun.getParameterValue(name)
+            if self.fun.hasParameter(name):
+                return self.fun.getParameterValue(name)
+            else:
+                raise AttributeError("Parameter not found")
 
     def __setitem__ (self, name, value):
         """


### PR DESCRIPTION
**Description of work.**
This fixes the crash when running a script with a fit in it in workbench. This was caused by the move to python 3, specifically a small change in `__hasattr__`, which meant the error was no longer being caught.

**To test:**
Run the following scripts in workbench
```
ws = Load("MAR11060")
fitted = Fit("name=Gaussian", ws)
```

and
```
ws = Load("MAR11060")
fitted = Fit("name=Gaussian;name=LinearBackground", ws)
```
They both should run successfully and not crash.

Fixes #27834 

*This does not require release notes* because **it was caused by the python migration during this sprint**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
