### PR TITLE
Preserve Lattice Parameters in PredictFractionalPeaks

### DIFF
--- a/Framework/Crystal/src/PredictFractionalPeaks.cpp
+++ b/Framework/Crystal/src/PredictFractionalPeaks.cpp
@@ -166,7 +166,8 @@ boost::shared_ptr<Mantid::API::IPeaksWorkspace> createOutputWorkspace(
   auto outPeaks = WorkspaceFactory::Instance().createPeaks();
   outPeaks->setInstrument(inputPeaks.getInstrument());
   if (modulationProps.saveOnLattice) {
-    auto lattice = std::make_unique<Mantid::Geometry::OrientedLattice>();
+    auto lattice = std::make_unique<Mantid::Geometry::OrientedLattice>(
+        inputPeaks.sample().getOrientedLattice());
     lattice->setMaxOrder(modulationProps.maxOrder);
     lattice->setCrossTerm(modulationProps.crossTerms);
     const auto &offsets = modulationProps.offsets;

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -37,6 +37,7 @@ Single Crystal Diffraction
 - :ref:`PredictFractionalPeaks <algm-PredictFractionalPeaks-v1>` now accepts the same set of modulation vector properties as :ref:`IndexPeaks <algm-IndexPeaks-v1>`.
 - New algorithm :ref:`ConvertHFIRSCDtoMDE <algm-ConvertHFIRSCDtoMDE-v1>` for converting HFIR single crystal data (from WAND and DEMAND) into MDEventWorkspace in units Q_sample.
 - ``IndexPeaksWithsatellites`` has been deleted as it had been deprecated and superseded by :ref:`IndexPeaks <algm-IndexPeaks-v1>`.
+- The output peak workspace from :ref:`PredictFractionalPeaks<algm-PredictFractionalPeaks-v1>` now keeps the same lattice parameters as the input workspace. 
 
 Imaging
 -------


### PR DESCRIPTION
**Description of work.**
Lattice parameters are now copied directly into the new workspace from the old one.

**To test:**
The workspaces produced by this script should have the same `Sample:` values as each other, when the drop down of information is opened in the workspace widget. 
```
LoadNexusProcessed(Filename='TOPAZ_3007.peaks.nxs', OutputWorkspace='peaks')
LoadIsawUB(InputWorkspace='peaks', Filename='TOPAZ_3007.mat')
IndexPeaks(PeaksWorkspace='peaks')
PredictFractionalPeaks(Peaks='peaks', RequirePeaksOnDetector=False, ModVector1='-0.5,0,0.5', MaxOrder=1, FracPeaks='frac')
```
Fixes #27624 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
