### PR TITLE
Fix error bars on normalised fits

### DIFF
--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -342,6 +342,9 @@ FitMW::createOutputWorkspace(const std::string &baseName,
       auto &Y = mws.mutableY(ispec);
       std::transform(binWidths.begin() + 1, binWidths.end(), Y.begin(),
                      Y.begin(), std::multiplies<double>());
+      auto& E = mws.mutableE(ispec);
+      std::transform(binWidths.begin() + 1, binWidths.end(), E.begin(),
+        E.begin(), std::multiplies<double>());
     }
   }
   return ws;

--- a/Framework/CurveFitting/src/FitMW.cpp
+++ b/Framework/CurveFitting/src/FitMW.cpp
@@ -342,9 +342,9 @@ FitMW::createOutputWorkspace(const std::string &baseName,
       auto &Y = mws.mutableY(ispec);
       std::transform(binWidths.begin() + 1, binWidths.end(), Y.begin(),
                      Y.begin(), std::multiplies<double>());
-      auto& E = mws.mutableE(ispec);
+      auto &E = mws.mutableE(ispec);
       std::transform(binWidths.begin() + 1, binWidths.end(), E.begin(),
-        E.begin(), std::multiplies<double>());
+                     E.begin(), std::multiplies<double>());
     }
   }
   return ws;

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -24,6 +24,7 @@ Improvements
 - Prevent units that are not suitable for :ref:`ConvertUnits <algm-ConvertUnits>` being entered as the target unit.
 - Fixed an uncaught exception when plotting logs on single spectrum workspaces in mantidworkbench
 - Save the units for single value logs in :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>`
+- Error bars on calculated normalized fits are now correct.
 
 Algorithms
 ----------


### PR DESCRIPTION
**Description of work.**
This PR fixes the error when doing a normalised fit. During the fit they are normalised by bin width so this must be reverted when the fit has finished in a similar way to they y values.

**Report to:** Pascal Manuel

**To test:**
Run the following (taken from issue):
```
ws = Load('WISH46971')
ws_101 = ExtractSingleSpectrum('ws',101)
ws_101_d = ConvertUnits('ws_101', 'dSpacing')
ws_101_d_rb = Rebunch('ws_101_d', 10)
ws_101_d_rb_c = CropWorkspace('ws_101_d_rb', 2.2,2.6)
plotSpectrum('ws_101_d_rb_c',0)
Fitted = Fit(Function='name=Gaussian,Height=11107.5,PeakCentre=2.36016,Sigma=0.0139854;name=LinearBackground,A0=-63.7323,A1=28.6087', InputWorkspace='ws_101_d_rb_c', Output='Fitted', OutputCompositeMembers=True, StartX=2.2000256026349665, EndX=2.5914432895244435, Normalise=True)
plotSpectrum('Fitted_Workspace',[0,1,2,3],error_bars = True)
```

This should create a plot with reasonable error bars.

Fixes #27621 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
