### PR TITLE
Fix support for OpenMP on macOS 

### DIFF
--- a/Framework/Beamline/CMakeLists.txt
+++ b/Framework/Beamline/CMakeLists.txt
@@ -1,5 +1,5 @@
-set(SRC_FILES 
-    src/ComponentInfo.cpp 
+set(SRC_FILES
+    src/ComponentInfo.cpp
 	src/DetectorInfo.cpp
 	src/SpectrumInfo.cpp)
 
@@ -54,6 +54,7 @@ target_link_libraries(Beamline
                       LINK_PRIVATE
                       ${TCMALLOC_LIBRARIES_LINKTIME}
                       ${GSL_LIBRARIES}
+                      Kernel
                       ${MANTIDLIBS})
 
 # Add the unit tests directory

--- a/Framework/HistogramData/CMakeLists.txt
+++ b/Framework/HistogramData/CMakeLists.txt
@@ -135,6 +135,7 @@ target_link_libraries(HistogramData
                       LINK_PRIVATE
                       ${TCMALLOC_LIBRARIES_LINKTIME}
                       ${GSL_LIBRARIES}
+                      Kernel
                       ${MANTIDLIBS})
 
 # Add the unit tests directory

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries(Indexing
                       LINK_PRIVATE
                       ${TCMALLOC_LIBRARIES_LINKTIME}
                       ${MANTIDLIBS}
+                      Kernel
                       Parallel)
 
 if("${UNIX_CODENAME}" STREQUAL "trusty")

--- a/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/ReflectometryHelper.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/WorkspaceGroup_fwd.h"
 
+#include <string>
 #include <vector>
 
 namespace Mantid {

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -264,19 +264,13 @@ endif()
 include(VersionNumber)
 
 # ##############################################################################
-# Look for OpenMP and set compiler flags if found
+# Look for OpenMP
 # ##############################################################################
-
-find_package(OpenMP)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  if(NOT WIN32)
-    set(CMAKE_MODULE_LINKER_FLAGS
-        "${CMAKE_MODULE_LINKER_FLAGS} ${OpenMP_CXX_FLAGS}"
-    )
-  endif()
+find_package(OpenMP COMPONENTS CXX)
+if(OpenMP_CXX_FOUND)
+  link_libraries(OpenMP::OpenMP_CXX)
 endif()
+
 
 # ##############################################################################
 # Add linux-specific things


### PR DESCRIPTION
**Description of work.**

Uses modern CMake finder for OpenMP along with import targets to fix compilation issues on macOS when OpenMP is installed.

**To test:**

* Install `libomp` with Homebrew: `HOMEBREW_NO_AUTO_UPDATE=1 brew install libomp`
* Run CMake and check that it finds OpenMP. If it doesn't work try deleting the `CMakeCache.txt` file.
* Build and check the libraries are linked to libomp: `otool -L bin/libMantidKernel.dylib`

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal issue.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
