### PR TITLE
Fix colorfill right-click change colorbar scale

### DIFF
--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -14,6 +14,8 @@ import datetime
 import numpy as np
 from matplotlib.collections import PolyCollection
 from matplotlib.container import ErrorbarContainer
+from matplotlib.colors import LogNorm
+from matplotlib.ticker import LogLocator
 from scipy.interpolate import interp1d
 
 import mantid.api
@@ -993,3 +995,20 @@ def line_colour_fill(ax):
             i = i + 1
 
     ax.get_figure().canvas.draw()
+
+
+# Update the color bar scale on a given image
+def update_colorbar_scale(figure, image, scale, vmin, vmax):
+    if vmin == 0:
+        vmin += 1e-6  # Avoid 0 log scale error
+    image.set_norm(scale(vmin=vmin, vmax=vmax))
+    if image.colorbar:
+        image.colorbar.remove()
+        locator = None
+        if scale == LogNorm:
+            locator = LogLocator(subs=np.arange(1, 10))
+            if locator.tick_values(vmin=vmin, vmax=vmax).size == 0:
+                locator = LogLocator()
+                mantid.kernel.logger.warning("Minor ticks on colorbar scale cannot be shown "
+                                             "as the range between min value and max value is too large")
+        figure.colorbar(image, ticks=locator)

--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -997,9 +997,17 @@ def line_colour_fill(ax):
     ax.get_figure().canvas.draw()
 
 
-# Update the color bar scale on a given image
 def update_colorbar_scale(figure, image, scale, vmin, vmax):
-    if vmin == 0:
+    """"
+    Updates the colorbar to the scale and limits given.
+
+    :param figure: A matplotlib figure instance
+    :param image: The matplotlib image containing the colorbar
+    :param scale: The norm scale of the colorbar, this should be a matplotlib colormap norm type
+    :param vmin: the minimum value on the colorbar
+    :param vmax: the maximum value on the colorbar
+    """
+    if vmin == 0 and scale == LogNorm:
         vmin += 1e-6  # Avoid 0 log scale error
     image.set_norm(scale(vmin=vmin, vmax=vmax))
     if image.colorbar:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -735,8 +735,5 @@ class FigureInteraction(object):
         for ax in self.canvas.figure.get_axes():
             images = ax.get_images() + [col for col in ax.collections if isinstance(col, Collection)]
             for image in images:
-                image.set_norm(scale_type())
-                if image.colorbar:
-                    image.colorbar.remove()
-                    self.canvas.figure.colorbar(image)
+                helperfunctions.update_colorbar_scale(self.canvas.figure, image, scale_type, image.norm.vmin, image.norm.vmax)
         self.canvas.draw_idle()

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -13,10 +13,11 @@ from __future__ import (absolute_import, unicode_literals)
 
 # 3rdparty imports
 from mantid.kernel import logger
+from mantid.plots.helperfunctions import update_colorbar_scale
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 from matplotlib.collections import QuadMesh
-from matplotlib.colors import LogNorm
+from matplotlib.colors import LogNorm, Normalize
 from matplotlib.ticker import LogLocator
 from numpy import arange
 from qtpy.QtGui import QDoubleValidator, QIcon
@@ -193,16 +194,10 @@ class ColorbarAxisEditor(AxisEditor):
 
     def changes_accepted(self):
         super(ColorbarAxisEditor, self).changes_accepted()
-        cb = self.images[0]
-        cb.set_clim(self.limit_min, self.limit_max)
+        scale = Normalize
         if isinstance(self.images[0].norm, LogNorm):
-            locator = LogLocator(subs=arange(1, 10))
-            if locator.tick_values(vmin=self.limit_min, vmax=self.limit_max).size == 0:
-                locator = LogLocator()
-                logger.warning("Minor ticks on colorbar scale cannot be shown "
-                               "as the range between min value and max value is too large")
-            cb.colorbar.locator = locator
-            cb.colorbar.update_ticks()
+            scale = LogNorm
+        update_colorbar_scale(self.canvas.figure, self.images[0], scale, self.limit_min, self.limit_max)
 
     def create_model(self):
         memento = AxisEditorModel()

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -12,14 +12,11 @@ from __future__ import (absolute_import, unicode_literals)
 # std imports
 
 # 3rdparty imports
-from mantid.kernel import logger
 from mantid.plots.helperfunctions import update_colorbar_scale
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 from matplotlib.collections import QuadMesh
 from matplotlib.colors import LogNorm, Normalize
-from matplotlib.ticker import LogLocator
-from numpy import arange
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -7,12 +7,8 @@
 #  This file is part of the mantid workbench.
 
 from __future__ import (absolute_import, unicode_literals)
-from numpy import arange
 
-from matplotlib.colors import LogNorm
-from matplotlib.ticker import LogLocator
-
-from mantid.kernel import logger
+from mantid.plots.helperfunctions import update_colorbar_scale
 from mantidqt.utils.qt import block_signals
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_images_from_fig
 from mantidqt.widgets.plotconfigdialog.imagestabwidget import ImageProperties
@@ -40,26 +36,10 @@ class ImagesTabWidgetPresenter:
         image = self.get_selected_image()
         self.set_selected_image_label(props.label)
         image.set_cmap(props.colormap)
-        if props.vmin == 0:
-            props.vmin += 1e-6  # Avoid 0 log scale error
-        image.set_norm(SCALES[props.scale](vmin=props.vmin, vmax=props.vmax))
         if props.interpolation:
             image.set_interpolation(props.interpolation)
 
-        current_axis_images = get_images_from_fig(self.fig)[-1]
-
-        if current_axis_images.colorbar:
-            current_axis_images.colorbar.remove()
-
-        locator = None
-        if SCALES[props.scale] == LogNorm:
-            locator = LogLocator(subs=arange(1, 10))
-            if locator.tick_values(vmin=props.vmin,  vmax=props.vmax).size == 0:
-                locator = LogLocator()
-                logger.warning("Minor ticks on colorbar scale cannot be shown "
-                               "as the range between min value and max value is too large")
-
-        self.fig.colorbar(image, ticks=locator)
+        update_colorbar_scale(self.fig, image, SCALES[props.scale], props.vmin, props.vmax)
 
         if props.vmin > props.vmax:
             self.view.max_min_value_warning.setVisible(True)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -120,8 +120,7 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
         presenter.apply_properties()
         self.assertEqual("New Label", img.get_label())
         self.assertEqual('jet', img.cmap.name)
-        # We should not get 0 as a log plot with a colour fill bar will attempt to scale to inf.
-        self.assertEqual(1e-6, img.norm.vmin)
+        self.assertEqual(0, img.norm.vmin)
         self.assertEqual(2, img.norm.vmax)
         self.assertTrue(isinstance(img.norm, Normalize))
 


### PR DESCRIPTION
**Description of work.**
In workbench if the colorbar scale was changed to log and `vmin` was 0 by default mantid would crash due to a division by zero. After this crash if you continued and changed the scale in the figure options it created a second colorbar. The figure options has a checks for this but the right-click option didn't so to avoid repeating code the right-click option now calls the same code as the figure option.

**To test:**
Load a workspace (e.g.MAR11060) and plot a colorfill plot.
Change the colorbar scale to log by right clicking on the plot.
This should change as expected and not crash.
Change the colorbar in the figure options and this should also work as expected.

Fixes #27824 

*This does not require release notes* because **it was not broken in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
