### PR TITLE
Fix incorrect sign when checking valid satellite peak if q convention is set to crystallography

### DIFF
--- a/Framework/Crystal/src/PredictSatellitePeaks.cpp
+++ b/Framework/Crystal/src/PredictSatellitePeaks.cpp
@@ -432,7 +432,7 @@ void PredictSatellitePeaks::predictOffsetsWithCrossTerms(
             goniometer * UB * satelliteHKL * 2.0 * M_PI * m_qConventionFactor;
 
         // Check if Q is non-physical
-        if (Qs.Z() <= 0)
+        if (Qs.Z() * m_qConventionFactor <= 0)
           continue;
 
         auto peak(Peaks->createPeak(Qs, 1));

--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -61,6 +61,7 @@ Single Crystal Diffraction
 --------------------------
 
 - Support added for DEMAND (HB3A) to the algorithms :ref:`ConvertWANDSCDtoQ <algm-ConvertWANDSCDtoQ-v1>` and :ref:`FindPeaksMD <algm-FindPeaksMD-v1>` in order to handle additional goniometers.
+- Fixed PredictSatellitePeaks producing an empty table when using cross-terms with crystallography convention for sign of Q.
 
 Imaging
 -------


### PR DESCRIPTION
One line change to correct sign error when checking for unphysical Q when using crystallography q convention when using PredictSatellitePeaks with cross terms = true (see original issue).

Check that the predicted peak tables are not empty and that the different Q conventions just change the sign of Q (and the HKL)
```
LoadNexus(Filename='C:/Users/xhg73778/Desktop/TOPAZ_3132_peaks.nxs', OutputWorkspace='peaks') 
PredictPeaks(InputWorkspace='peaks', MinDSpacing=0.8, OutputWorkspace='pp')
config['Q.convention'] = 'Crystallography'
PredictSatellitePeaks(Peaks='pp', SatellitePeaks='pfp_xtalTrue_ctTrue', 
    ModVector1='0.1,0,0', ModVector2='0,0.1,0', MaxOrder=1, CrossTerms=True)
PredictSatellitePeaks(Peaks='pp', SatellitePeaks='pfp_xtalTrue_ctFalse', 
    ModVector1='0.1,0,0', ModVector2='0,0.1,0', MaxOrder=1) 
config['Q.convention'] = 'Crystallography'
PredictSatellitePeaks(Peaks='pp', SatellitePeaks='pfp_xtalFalse_ctTrue', 
    ModVector1='0.1,0,0', ModVector2='0,0.1,0', MaxOrder=1, CrossTerms=True) 
PredictSatellitePeaks(Peaks='pp', SatellitePeaks='pfp_xtalFalse_ctFalse', 
    ModVector1='0.1,0,0', ModVector2='0,0.1,0', MaxOrder=1) 
```
Note it looks like the scripted way of changing the Q convention only works in mantid plot

Fixes #27822 

