### PR TITLE
Added some protection around loading config files in workbench

### DIFF
--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -52,7 +52,7 @@ class UserConfig(object):
         for key in self.all_keys():
             try:
                 value = self.get(key)
-            except KeyError:
+            except (KeyError, TypeError):
                 continue
             if value == 'true':
                 self.set(key, True)

--- a/qt/python/mantidqt/widgets/messagedisplay.py
+++ b/qt/python/mantidqt/widgets/messagedisplay.py
@@ -44,9 +44,9 @@ class MessageDisplay(MessageDisplay_cpp):
 
     def readSettings(self, qsettings):
         super(MessageDisplay, self).readSettings(qsettings)
-        self.setShowFrameworkOutput(self.ReadSettingSafely(qsettings, SHOW_FRAMEWORK_OUTPUT_KEY, True,bool))
-        self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True,bool))
-        self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ALL_SCRIPT_OUTPUT_KEY, False,bool))
+        self.setShowFrameworkOutput(self.ReadSettingSafely(qsettings, SHOW_FRAMEWORK_OUTPUT_KEY, True, bool))
+        self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True, bool))
+        self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ALL_SCRIPT_OUTPUT_KEY, False, bool))
 
     def ReadSettingSafely(self,qsettings,key,default,type):
         """

--- a/qt/python/mantidqt/widgets/messagedisplay.py
+++ b/qt/python/mantidqt/widgets/messagedisplay.py
@@ -44,9 +44,9 @@ class MessageDisplay(MessageDisplay_cpp):
 
     def readSettings(self, qsettings):
         super(MessageDisplay, self).readSettings(qsettings)
-        self.setShowFrameworkOutput(self.ReadSettingSafely(qsettings,SHOW_FRAMEWORK_OUTPUT_KEY, True,bool))
-        self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings,SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True,bool))
-        self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings,SHOW_ALL_SCRIPT_OUTPUT_KEY, False,bool))
+        self.setShowFrameworkOutput(self.ReadSettingSafely(qsettings, SHOW_FRAMEWORK_OUTPUT_KEY, True,bool))
+        self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True,bool))
+        self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ALL_SCRIPT_OUTPUT_KEY, False,bool))
 
     def ReadSettingSafely(self,qsettings,key,default,type):
         """

--- a/qt/python/mantidqt/widgets/messagedisplay.py
+++ b/qt/python/mantidqt/widgets/messagedisplay.py
@@ -44,9 +44,24 @@ class MessageDisplay(MessageDisplay_cpp):
 
     def readSettings(self, qsettings):
         super(MessageDisplay, self).readSettings(qsettings)
-        self.setShowFrameworkOutput(qsettings.value(SHOW_FRAMEWORK_OUTPUT_KEY, True))
-        self.setShowActiveScriptOutput(qsettings.value(SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True))
-        self.setShowAllScriptOutput(qsettings.value(SHOW_ALL_SCRIPT_OUTPUT_KEY, False))
+        self.setShowFrameworkOutput(self.ReadSettingSafely(qsettings,SHOW_FRAMEWORK_OUTPUT_KEY, True,bool))
+        self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings,SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True,bool))
+        self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings,SHOW_ALL_SCRIPT_OUTPUT_KEY, False,bool))
+
+    def ReadSettingSafely(self,qsettings,key,default,type):
+        """
+        Reads a value from qsettings, returning the default if the value is missing or the type is wrong
+        :param qsettings: the qsettings object
+        :param key: the key to read
+        :param default: the default value
+        :param type: the type to check the returned value for
+        :return: The value from qsettings, or default if the value is missing or the type is wrong
+        """
+        try:
+            settingValue = qsettings.value(key, default)
+            return settingValue if isinstance(settingValue, type) else default
+        except TypeError:
+            return default
 
     def writeSettings(self, qsettings):
         super(MessageDisplay, self).writeSettings(qsettings)


### PR DESCRIPTION
**Description of work.**

Handles corrupt QObjects, and some of the sensitive fields in MessageDisplay, that HAVE to be boolean as they are passed to a C++ base class

**To test:**

<!-- Instructions for testing. -->
1. Find your mantidworkbench.ini file (on windows it is in %appdata%\mantidproject)
1. Take a copy of your file so you can restore it after
1. Delete it
1. Start workbench, if it creates a new .ini file you know you re looking at the right file
1. Stop workbench and edit the new file. Paste in this corrupted version.
```
[General]
high_dpi_scaling=true

[project]
prompt_save_editor_modified=5.58
prompt_save_on_close=TrUe
prompt_on_deleting_workspace=flase

[Editors]
SessionTabs=@Variant(\0\0\0\x7f\0\0\0\xePyQt_PyObject\0\0\0\0\xf3\x63__builtin__\nset\np0\n((lp1\nVC:/Users/jsl28/Desktop/test_py23.py\np2\naVM:/doc/Summer student 2019/Doug internship work/Python/Degrader Calculator.py\np3\naVM:/doc/Summer student 2019/Doug internship work/Python/degrader_dictionary2.py\np4\natp5\nRp6\n.)
ZoomLevel=false

[MessageDisplay]
ShowFrameworkOutput=1e-8
ShowAllScriptOutput=Herbie_Goes_Bananas
ShowActiveScriptOutput=@Variant(\0\0\0\x7f\0\0\0\xePyQt_PyObject\0\0\0)
```
1. Start workbench
1. If it starts up - success




Fixes #26632. 

This does not require release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
