### PR TITLE
Use algorithm documentation for tooltips on the table

### DIFF
--- a/docs/source/interfaces/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/ISIS Reflectometry.rst
@@ -755,7 +755,9 @@ exist.
   *The per-angle defaults table*
 
 Entries in the per-angle defaults table are similar to the table on the Runs
-tab. Default transmission runs can be specified and each input can take a
+tab. Hover over a table cell to see a tooltip describing what the value is for.
+
+Default transmission runs can be specified and each input can take a
 single run/workspace or a number of runs/workspaces that will be summed before
 processing. Specific spectra of interest can be specified for the input runs
 and separate spectra, if required, can be specified for the transmission runs -

--- a/docs/source/release/v4.3.0/reflectometry.rst
+++ b/docs/source/release/v4.3.0/reflectometry.rst
@@ -2,6 +2,17 @@
 Reflectometry Changes
 =====================
 
+ISIS Reflectometry Interface
+############################
+
+Improved
+--------
+
+- The per-angle defaults table on the Experiment now has column-specific tooltips on the table cells.
+
+Algorithms
+##########
+
 New
 ---
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -115,6 +115,9 @@ public slots:
   void onPerAngleDefaultsChanged(int row, int column);
 
 private:
+  void
+  initializeTableColumns(QTableWidget &table,
+                         Mantid::API::IAlgorithm_sptr algorithmForTooltips);
   void initializeTableItems(QTableWidget &table);
   void initializeTableRow(QTableWidget &table, int row);
   void initializeTableRow(QTableWidget &table, int row,
@@ -124,8 +127,8 @@ private:
   QString messageFor(const InstrumentParameterTypeMissmatch &typeError) const;
 
   /// Initialise the interface
-  void initLayout();
-  void initOptionsTable();
+  void initLayout(Mantid::API::IAlgorithm_sptr algorithmForTooltips);
+  void initOptionsTable(Mantid::API::IAlgorithm_sptr algorithmForTooltips);
   void initFloodControls();
   void registerSettingsWidgets(Mantid::API::IAlgorithm_sptr alg);
   void registerExperimentSettingsWidgets(Mantid::API::IAlgorithm_sptr alg);
@@ -175,6 +178,8 @@ private:
   std::unique_ptr<QShortcut> m_deleteShortcut;
   Ui::ExperimentWidget m_ui;
   ExperimentViewSubscriber *m_notifyee;
+  std::array<QString, PerThetaDefaults::OPTIONS_TABLE_COLUMN_COUNT>
+      m_columnToolTips;
 
   friend class Encoder;
   friend class Decoder;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -26,6 +26,9 @@ namespace ISISReflectometry {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL PerThetaDefaults {
 public:
+  static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 9;
+  using ValueArray = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
+
   enum Column {
     // 0-based column indices for cells in a row. The Actual values are
     // important here so set them explicitly
@@ -40,8 +43,25 @@ public:
     RUN_SPECTRA = 8
   };
 
-  static auto constexpr OPTIONS_TABLE_COLUMN_COUNT = 9;
-  using ValueArray = std::array<std::string, OPTIONS_TABLE_COLUMN_COUNT>;
+  // The property name associated with each column. Unfortunately in
+  // QtBatchView we are still using ReflectometryReductionOneAuto to get the
+  // tooltips rather than ReflectometryISISLoadAndProcess. If we change it we
+  // will break the Encoder and Decoder unit tests because C++ tests cannot use
+  // python algorithms. The code needs to be reorganised to avoid creating the
+  // algorithm, or the tests rewritten in python. This only affects tooltips
+  // for a couple of the properties so is not an urgent fix, so for now just
+  // make the properties here match RROA.
+  static auto constexpr ColumnPropertyName =
+      std::array<const char *, OPTIONS_TABLE_COLUMN_COUNT>{
+          "ThetaIn",
+          "FirstTransmissionRun",  // FirstTransmissionRunList in RILAP
+          "SecondTransmissionRun", // SecondTransmissionRunList in RILAP
+          "TransmissionProcessingInstructions",
+          "MomentumTransferMin",
+          "MomentumTransferMax",
+          "MomentumTransferStep",
+          "ScaleFactor",
+          "ProcessingInstructions"};
 
   PerThetaDefaults(
       boost::optional<double> theta, TransmissionRunPair tranmissionRuns,


### PR DESCRIPTION
This PR improves the tooltips on the per-theta settings table by setting a separate tooltip for each column. Previously, all columns had the same tooltip. The tooltips are taken from the algorithm documentation for the relevant property.

Note that the tooltips are only set on the table cells. The table headers all have the original default tooltip, which explains the context of what the table does.

This is a useful change in itself but is also preparative work for issue #27826 which will add further complexity to the per-theta defaults table, making the tooltips more important.

Refs #27826

**To test:**

- Open the `ISIS Reflectometry` interface and set the instrument to `INTER`
- On the Experiment tab, check that the tooltips for the table display column-specific information for the table cells but a generic description of the table for the column headers.
- Try adding new rows with the Add Row button or deleting rows with the Delete key. Check the tooltips remain correct.
- Enter some information e.g. FirstTransmissionRun = `13463`
- Back on the Runs tab, enter Run = `13460` and angle = `0.5` and click Process. Check that the reduction completes without error.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
