### PR TITLE
Resolve a bug with algrothim tree building in workbench settings

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
@@ -121,7 +121,7 @@ class CategoriesSettings(object):
                         # we need to go back up the category tree to find the first seen grandparent
                         # to attach the new tree node to the correct parent
                         grand_parent_cat = None
-                        for k in range (i > 1,-1,-1):
+                        for k in range (i - 1,-1,-1):
                             grand_parent_name = split_cat[k]
                             if split_cat[k] in seen_categories:
                                 grand_parent_cat = seen_categories[split_cat[k]]

--- a/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
@@ -122,7 +122,6 @@ class CategoriesSettings(object):
                         # to attach the new tree node to the correct parent
                         grand_parent_cat = None
                         for k in range (i - 1,-1,-1):
-                            grand_parent_name = split_cat[k]
                             if split_cat[k] in seen_categories:
                                 grand_parent_cat = seen_categories[split_cat[k]]
                         parent_category = self.view.add_checked_widget_item(widget, parent_name,

--- a/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/categories/presenter.py
@@ -118,8 +118,16 @@ class CategoriesSettings(object):
                     # Check if parent categories have already been added and if not add them
                     parent_name = str(split_cat[i])
                     if split_cat[i] not in seen_categories:
+                        # we need to go back up the category tree to find the first seen grandparent
+                        # to attach the new tree node to the correct parent
+                        grand_parent_cat = None
+                        for k in range (i > 1,-1,-1):
+                            grand_parent_name = split_cat[k]
+                            if split_cat[k] in seen_categories:
+                                grand_parent_cat = seen_categories[split_cat[k]]
                         parent_category = self.view.add_checked_widget_item(widget, parent_name,
-                                                                            category_and_states[category_location])
+                                                                            category_and_states[category_location],
+                                                                            grand_parent_cat)
                         seen_categories[parent_name] = parent_category
 
                 child_name = str(split_cat[-1])


### PR DESCRIPTION
It could not handle when multiple tree levels were added rather than one at a time
so this would cause a problem
\\Workflow
\\Workflow\MLZ\MIDAS
as it adds two levels in one step



**To test:**
1. Look at the screenshot in #27857 to see what was wrong, MLZ was appearing at the end of the list, rather than underneath workflow
1. Start workbench
1. File->Settings
1. Categories tab
1. Check that MLZ is correctly under workflow
1. the rest of the list should match that from the algorithms widget (apart from those that are hidden)


Fixes #27857. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

This does not require release notes we introduced it in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
