### PR TITLE
Add warning message to Workbench when attempting to plot lots of spectra

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -34,6 +34,7 @@ Improvements
 - Double clicking on a workspace that only has a single bin of data (for example from a constant wavelength source) will now plot that bin, also for single bin workspaces a plot bin option has been added to the right click plot menu of the workspace.
 - Default values for algorithm properties now appear as placeholder (greyed-out) text on custm algorithm dialogs.
 - The context menu for WorkspaceGroups now contains plotting options so you can plot all of the workspaces in the group.
+- A warning now appears if you attempt to plot more than ten spectra.
 
 Bugfixes
 ########

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -100,11 +100,17 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
     def _check_number_of_plots(self, selection):
         index_length = len(selection.wksp_indices) if selection.wksp_indices else len(selection.spectra)
-        if selection.plot_type == SpectraSelection.Tiled and len(selection.workspaces) * index_length > 25:
+        number_of_lines_to_plot = len(selection.workspaces) * index_length
+        if selection.plot_type == SpectraSelection.Tiled and number_of_lines_to_plot > 25:
             response = QMessageBox.warning(self, 'Mantid Workbench',
                                            'You are attempting to create a tiled plot with more than 25 subplots,'
                                            'this is not recommended as it may lead to performance issues.'
                                            ' Do you wish to continue?', QMessageBox.Ok | QMessageBox.Cancel)
+            return response == QMessageBox.Ok
+        elif number_of_lines_to_plot > 10:
+            response = QMessageBox.warning(self, 'Mantid Workbench', 'You selected {} spectra to plot. Are you sure '
+                                           'you want to plot this many?'.format(number_of_lines_to_plot),
+                                           QMessageBox.Ok | QMessageBox.Cancel)
             return response == QMessageBox.Ok
 
         return True

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -101,13 +101,12 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
     def _check_number_of_plots(self, selection):
         index_length = len(selection.wksp_indices) if selection.wksp_indices else len(selection.spectra)
         number_of_lines_to_plot = len(selection.workspaces) * index_length
-        if selection.plot_type == SpectraSelection.Tiled and number_of_lines_to_plot > 25:
+        if selection.plot_type == SpectraSelection.Tiled and number_of_lines_to_plot > 12:
             response = QMessageBox.warning(self, 'Mantid Workbench',
-                                           'You are attempting to create a tiled plot with more than 25 subplots,'
-                                           'this is not recommended as it may lead to performance issues.'
-                                           ' Do you wish to continue?', QMessageBox.Ok | QMessageBox.Cancel)
+                                           'Are you sure you want to plot {} subplots?'.format(number_of_lines_to_plot),
+                                           QMessageBox.Ok | QMessageBox.Cancel)
             return response == QMessageBox.Ok
-        elif number_of_lines_to_plot > 10:
+        elif selection.plot_type != SpectraSelection.Tiled and number_of_lines_to_plot > 10:
             response = QMessageBox.warning(self, 'Mantid Workbench', 'You selected {} spectra to plot. Are you sure '
                                            'you want to plot this many?'.format(number_of_lines_to_plot),
                                            QMessageBox.Ok | QMessageBox.Cancel)

--- a/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
+++ b/qt/python/mantidqt/dialogs/test/test_spectraselectiondialog.py
@@ -36,6 +36,7 @@ class SpectraSelectionDialogTest(unittest.TestCase):
                                                                                 XLength=1, YLength=1)
             self.__class__._multi_spec_ws = WorkspaceFactory.Instance().create("Workspace2D", NVectors=200,
                                                                                XLength=1, YLength=1)
+        SpectraSelectionDialog._check_number_of_plots = mock.Mock(return_value=True)
 
     def test_initial_dialog_setup(self):
         workspaces = [self._multi_spec_ws]


### PR DESCRIPTION
Report to: Richard Heenan

**Description of work.**
This PR makes a warning appear when you attempt to plot more than ten spectra, asking you to confirm that you want to do this. This makes it harder to accidentally plot a lot of curves and crash Workbench.

**To test:**
1. Load or create a workspace with >10 spectra.
2. Double-click it and click Plot All.

Fixes #27867 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
