### PR TITLE
Add a check for specialized vglrun wrapper script

### DIFF
--- a/buildconfig/CMake/LinuxPackageScripts.cmake
+++ b/buildconfig/CMake/LinuxPackageScripts.cmake
@@ -148,12 +148,16 @@ endif()
 # common definition of work for virtualgl - lots of escaping things from cmake
 set ( VIRTUAL_GL_WRAPPER
 "# whether or not to use vglrun
-if [ -n \"\${NXSESSIONID}\" ]; then
+if [ -n \"\${NXSESSIONID}\" ]; then  # running in nx
   command -v vglrun >/dev/null 2>&1 || { echo >&2 \"MantidPlot requires VirtualGL but it's not installed.  Aborting.\"; exit 1; }
   VGLRUN=\"vglrun\"
-elif [ -n \"\${TLSESSIONDATA}\" ]; then
+elif [ -n \"\${TLSESSIONDATA}\" ]; then  # running in thin-linc
   command -v vglrun >/dev/null 2>&1 || { echo >&2 \"MantidPlot requires VirtualGL but it's not installed.  Aborting.\"; exit 1; }
-  VGLRUN=\"vglrun\"
+  if [ command -v vgl-wrapper.sh ]; then
+    VGLRUN=\"vgl-wrapper.sh\"
+  else
+    VGLRUN=\"vglrun\"
+  fi
 fi" )
 
 # The scripts need tcmalloc to be resolved to the runtime library as the plain

--- a/docs/source/release/v4.3.0/framework.rst
+++ b/docs/source/release/v4.3.0/framework.rst
@@ -13,6 +13,7 @@ New Features
 ############
 
 - Mantid is now built against Python 3. Windows/macOS bundle Python 3.8 & 3.7 respectively. Ubuntu & Red Hat use system Python 3.6.
+- Users at ORNL have a more rhobust usage of ``vglrun`` when using mantidplot/mantidworkbench remotely through thin-linc
 
 Concepts
 --------


### PR DESCRIPTION
At ORNL there is a custom script, `vgl-wrapper.sh`, that can be used for a more rhobust vgl call. Modify the launch script to use it if present.

**To test:**

Add `set -x` near the top of the launch script and start mantidworkbench/mantidplot from local, ssh, and thin-linc. Note that the vglrun command changes as expected.

Fixes #27835

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
