### PR TITLE
Update CIFS mounting instructions

### DIFF
--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -152,9 +152,7 @@ Linux
 ------
 1. Install packages:
 
-* ``autofs``
-* ``smbfs`` - Ubuntu 12.04
-* ``cifs-utils`` - Ubuntu 14.04
+``sudo apt-get install -y autofs cifs-utils keyutils``
 
 2. Create an ``/archive.creds`` file in the root directory containing this, filling in the relevant details:
 
@@ -176,7 +174,7 @@ This should only be done if full disk encryption is enabled or if the ``archive.
 
 .. code-block:: text
 
-   *     -fstype=cifs,ro,credentials=/archive.creds,file_mode=0444,dir_mode=0555       ://isisdatar55/&\$
+   *     -fstype=cifs,ro,credentials=/archive.creds,file_mode=0444,dir_mode=0555,vers=3.0,noserverino,nounix    ://isis.cclrc.ac.uk/inst\$/&
 
 5. Enter the following commands:
 


### PR DESCRIPTION
Updates the CIFS mounting instructions to specify SMB 3.0, point to the
DFS share rather than a individual server and add some extra flags for
warnings

**To test:**

- Ensures docs build and check it reads in a user friendly way (since these docs are targetted to new devs)

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
