### PR TITLE
Correct typo to fix error when running a fit from script

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -506,7 +506,7 @@ class CompositeFunctionWrapper(FunctionWrapper):
         comp = self.fun
         if (isinstance(nameorindex, str) and not comp.hasParameter(nameorindex)) \
                 or (isinstance(nameorindex, int) and nameorindex >= comp.nParams()):
-            raise AttributeError("Parameter %s not found" % nameorIndex)
+            raise AttributeError("Parameter %s not found" % nameorindex)
         item = comp[nameorindex]
         if isinstance(item, float):
             return  item


### PR DESCRIPTION
**Description of work.**
When doing #27836 a typo was made to a parameter name, this PR corrects the type so no error is thrown.

**To test:**
```
ws = Load("MAR11060")
fitted = Fit("name=Gaussian", ws)
```
No error should be thrown

*There is no associated issue.*

*This does not require release notes* because **it is fixing a change made during this sprint**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
