### PR TITLE
Fix PreviewPlot for mpl3

### DIFF
--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -139,7 +139,11 @@ void Axes::setTitle(const char *label) {
 Artist Axes::legend(const bool draggable) {
   GlobalInterpreterLock lock;
   Artist legend{pyobj().attr("legend")()};
-  legend.pyobj().attr("draggable")(draggable);
+  const auto draggableAttr =
+      PyObject_HasAttrString(legend.pyobj().ptr(), "set_draggable")
+          ? "set_draggable"
+          : "draggable";
+  legend.pyobj().attr(draggableAttr)(draggable);
   return legend;
 }
 

--- a/qt/widgets/mplcpp/test/FigureCanvasQtTest.h
+++ b/qt/widgets/mplcpp/test/FigureCanvasQtTest.h
@@ -49,6 +49,16 @@ public:
     TS_ASSERT_DELTA(2.9, dataCoords.x(), 0.25);
     TS_ASSERT_DELTA(4.25, dataCoords.y(), 0.25);
   }
+
+  void testAddLegend() {
+    FigureCanvasQt canvas{111};
+    canvas.gca().plot({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}, QString("ro"),
+                      QString("Line1"));
+    auto legend = canvas.gca().legend(true);
+
+    if (PyObject_HasAttrString(legend.pyobj().ptr(), "get_draggable"))
+      TS_ASSERT_EQUALS(true, legend.pyobj().attr("get_draggable")());
+  }
 };
 
 #endif // MPLCPP_FIGURECANVASQTTEST_H

--- a/qt/widgets/mplcpp/test/FigureCanvasQtTest.h
+++ b/qt/widgets/mplcpp/test/FigureCanvasQtTest.h
@@ -52,8 +52,10 @@ public:
 
   void testAddLegend() {
     FigureCanvasQt canvas{111};
-    canvas.gca().plot({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}, QString("ro"),
-                      QString("Line1"));
+    // This return is needed for compatability with mpl 1.5 so that Line2D
+    // object reference is kept alive.
+    auto line = canvas.gca().plot({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5},
+                                  QString("ro"), QString("Line1"));
     auto legend = canvas.gca().legend(true);
 
     if (PyObject_HasAttrString(legend.pyobj().ptr(), "get_draggable"))


### PR DESCRIPTION
Draggable was deprecated in mpl2.2 and removed in 3.1. As we have versions spanning this range we need to check and then use the correct api.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
  * On windows or a build using matplotlib 3.1
  * Open Indirect Data Analysis, Go to the IQt tab and try and load irs26176_graphite002_red.nxs which can be found in the unittest directory.
  * The file should load succesfully

<!-- Instructions for testing. -->

*There is no associated issue.*


*This does not require release notes* because this issue was introduced this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
