### PR TITLE
Remove CropWorkspaceRagged from the workflow category

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/CropWorkspaceRagged.py
+++ b/Framework/PythonInterface/plugins/algorithms/CropWorkspaceRagged.py
@@ -15,7 +15,7 @@ import numpy as np
 class CropWorkspaceRagged(PythonAlgorithm):
 
     def category(self):
-        return 'Transforms\\Splitting;Workflow'
+        return 'Transforms\\Splitting'
 
     def seeAlso(self):
         return [ "CropWorkspace" ]


### PR DESCRIPTION
It didn't make any sense being in there anyway

**To test:**
1. look in the Workflow algorithm category, do not find CropWorkspaceRagged.
1. check you can still find it in Transforms\\splitting


*There is no associated issue.*



*This does not require release notes because is exceptionally minor*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
