### PR TITLE
Asserts a minimum size for colour fill plots

### DIFF
--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -38,6 +38,8 @@ PROJECTION = 'mantid'
 # See https://matplotlib.org/api/_as_gen/matplotlib.figure.SubplotParams.html#matplotlib.figure.SubplotParams
 SUBPLOT_WSPACE = 0.5
 SUBPLOT_HSPACE = 0.5
+COLORPLOT_MIN_WIDTH = 8
+COLORPLOT_MIN_HEIGHT = 7
 LOGGER = Logger("workspace.plotting.functions")
 
 MARKER_MAP = {'square': 's', 'plus (filled)': 'P', 'point': '.', 'tickdown': 3,
@@ -407,6 +409,10 @@ def pcolormesh(workspaces, fig=None):
     fig.subplots_adjust(wspace=SUBPLOT_WSPACE, hspace=SUBPLOT_HSPACE)
     fig.colorbar(pcm, ax=axes.ravel().tolist(), pad=0.06)
     fig.canvas.set_window_title(figure_title(workspaces, fig.number))
+    #assert a minimum size, otherwise we can lose axis labels
+    size = fig.get_size_inches()
+    if (size[0] <= COLORPLOT_MIN_WIDTH) or (size[1] <= COLORPLOT_MIN_HEIGHT):
+        fig.set_size_inches(COLORPLOT_MIN_WIDTH, COLORPLOT_MIN_HEIGHT, forward=True)
     fig.canvas.draw()
     fig.show()
     return fig


### PR DESCRIPTION
Set a slighty larger minimum size for colour fill plots than other plots (yo account for the color bar)
Otherwise you can lose the axis labels off the edge.


**To test:**
1. to be tested by someone without a huge screen
1. start mantid workbench
1. load MAR11060
1. plot a colour fill plot
1. both axis labels should be visible without having to resize the window,

Fixes #27877. 

*This does not require release notes as it had not been reported by users, and is a minor change*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
