### PR TITLE
Add the mock lib to Windows Python 3 builds

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -17,7 +17,7 @@ if(MSVC)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 5a0617ecb9a99712b72276a92d6f400257132e2f)
+  set(THIRD_PARTY_GIT_SHA1 24d5a334ad2d3281b7c4cb233819f268bf7509da)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)


### PR DESCRIPTION
**Description of work.**
Adds the mock lib to Windows Python 3 builds, this brings Windows into
line with other platforms, so at a future date we can remove the
compatibility shim.

After this PR is merged this [PR](https://github.com/mantidproject/thirdparty-msvc2015/pull/53) needs to be merged

**To test:**
- Build on Windows with Python 3
- Check this runs
`import mock`


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
