### PR TITLE
Fix plotting bugs for bin plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -368,9 +368,13 @@ class MantidAxes(Axes):
             raise ValueError("Artist '{}' is not tracked and so does not have "
                              "an associated workspace.".format(artist))
         workspace, spec_num = self.get_artists_workspace_and_spec_num(artist)
-        workspace_index = workspace.getIndexFromSpectrumNumber(spec_num)
-        if any(workspace.readE(workspace_index) != 0):
-            return True
+        if artist.axes.creation_args[0].get('axis', None) == MantidAxType.BIN:
+            if any([workspace.readE(i)[spec_num] != 0 for i in range(0, workspace.getNumberHistograms())]):
+                return True
+        else:
+            workspace_index = workspace.getIndexFromSpectrumNumber(spec_num)
+            if any(workspace.readE(workspace_index) != 0):
+                return True
         return False
 
     def get_tracked_artists(self):
@@ -472,7 +476,10 @@ class MantidAxes(Axes):
         kwargs['distribution'] = not self.get_artist_normalization_state(artist)
         workspace, spec_num = self.get_artists_workspace_and_spec_num(artist)
         self.remove_artists_if(lambda art: art == artist)
-        workspace_index = workspace.getIndexFromSpectrumNumber(spec_num)
+        if kwargs.get('axis', None) == MantidAxType.BIN:
+            workspace_index = spec_num
+        else:
+            workspace_index = workspace.getIndexFromSpectrumNumber(spec_num)
         self._remove_matching_curve_from_creation_args(workspace.name(), workspace_index, spec_num)
 
         if errorbars:

--- a/Framework/PythonInterface/mantid/plots/helperfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/helperfunctions.py
@@ -70,7 +70,9 @@ def get_normalize_by_bin_width(workspace, axes, **kwargs):
     if normalize_by_bin_width is not None:
         return normalize_by_bin_width, kwargs
     distribution = kwargs.get('distribution', None)
-    if distribution or (hasattr(workspace, 'isDistribution') and workspace.isDistribution()):
+    axis = kwargs.get('axis', None)
+    if axis == MantidAxType.BIN or distribution or \
+            (hasattr(workspace, 'isDistribution') and workspace.isDistribution()):
         return False, kwargs
     elif distribution is False:
         return True, kwargs

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -19,6 +19,7 @@ from mantid.kernel import config
 from mantid.plots import helperfunctions
 from mantid.plots.legend import convert_color_to_hex
 from mantid.plots.plotfunctions import get_colorplot_extents
+from mantid.plots.utility import MantidAxType
 from mantid.py3compat.mock import Mock, patch
 from mantid.simpleapi import (CreateWorkspace, CreateSampleWorkspace, DeleteWorkspace,
                               RemoveSpectra, AnalysisDataService as ADS)
@@ -269,6 +270,21 @@ class Plots__init__Test(unittest.TestCase):
         ax = fig.add_subplot(111, projection='3d')
         self.assertRaises(Exception, ax.plot_wireframe, self.ws2d_histo)
         self.assertRaises(Exception, ax.plot_surface, self.ws2d_histo)
+
+    def test_plot_is_not_normalized_for_bin_plots(self):
+        workspace = CreateWorkspace(DataX=[10, 20],
+                                    DataY=[2, 3, 4, 5, 6],
+                                    DataE=[1, 2, 1, 2, 1],
+                                    NSpec=5,
+                                    Distribution=False,
+                                    OutputWorkspace='workspace')
+        self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN, distribution=False)
+        self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN, distribution=True)
+        self.ax.plot(workspace, specNum=1, axis=MantidAxType.BIN)
+        ws_artists = self.ax.tracked_workspaces[workspace.name()]
+        self.assertFalse(ws_artists[0].is_normalized)
+        self.assertFalse(ws_artists[1].is_normalized)
+        self.assertFalse(ws_artists[2].is_normalized)
 
     def test_artists_normalization_state_labeled_correctly_for_dist_workspace(self):
         dist_ws = CreateWorkspace(DataX=[10, 20],

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -47,5 +47,6 @@ Bugfixes
 - Fix crash when loading a script with syntax errors
 - The Show Instruments right click menu option is now disabled for workspaces that have had their spectrum axis converted to another axis using :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.  Once this axis has been converetd the workspace loses it's link between the data values and the detectors they were recorded on so we cannot display it in the instrument view.
 - MonitorLiveData now appears promptly in the algorithm details window, allowing live data sessions to be cancelled.
+- Figure options on bin plots open without throwing an error.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -111,6 +111,9 @@ class FigureErrorsManager(object):
     @classmethod
     def replot_curve(cls, ax, curve, plot_kwargs):
         if isinstance(ax, MantidAxes):
+            axis = ax.creation_args[0].get('axis', None)
+            if axis:
+                plot_kwargs['axis'] = axis
             try:
                 new_curve = ax.replot_artist(curve, errorbars=True, **plot_kwargs)
             except ValueError:  # ValueError raised if Artist not tracked by Axes

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -25,7 +25,7 @@ from matplotlib.collections import Collection
 # third party imports
 from mantid.api import AnalysisDataService as ads
 from mantid.plots import helperfunctions, MantidAxes
-from mantid.plots.utility import zoom
+from mantid.plots.utility import zoom, MantidAxType
 from mantid.py3compat import iteritems
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.plotting.markers import SingleMarker
@@ -706,8 +706,9 @@ class FigureInteraction(object):
         :return: bool
         """
         plotted_normalized = []
+        axis = ax.creation_args[0].get('axis', None)
         for workspace_name, artists in ax.tracked_workspaces.items():
-            if not ads.retrieve(workspace_name).isDistribution() and ax.data_replaced:
+            if axis != MantidAxType.BIN and not ads.retrieve(workspace_name).isDistribution() and ax.data_replaced:
                 plotted_normalized += [a.is_normalized for a in artists]
             else:
                 return False

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -351,7 +351,7 @@ class FigureInteractionTest(unittest.TestCase):
         return fig_manager
 
     def _create_mock_right_click(self):
-        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = []))
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}]))
         type(mouse_event).button = PropertyMock(return_value=3)
         return mouse_event
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -18,6 +18,7 @@ from numpy import array_equal
 
 from mantid.simpleapi import CreateWorkspace
 from mantid.plots import helperfunctions
+from mantid.plots.utility import MantidAxType
 from mantid.py3compat.mock import Mock, patch
 from mantidqt.widgets.plotconfigdialog.colorselector import convert_color_to_hex
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import CurveProperties
@@ -176,6 +177,24 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         ax = fig.add_subplot(111, projection='mantid')
         curve = ax.plot(self.ws, specNum=1)[0]
         self.assertTrue(curve_has_errors(curve))
+
+    def test_curve_has_errors_returns_false_on_bin_plot_workspace_with_no_errors(self):
+        ws = CreateWorkspace(DataX=[0, 1], DataY=[0, 1], NSpec=2,
+                             OutputWorkspace='test_ws')
+        fig = figure()
+        ax = fig.add_subplot(111, projection='mantid')
+        curve = ax.plot(ws, wkspIndex=0, axis=MantidAxType.BIN)[0]
+        self.assertFalse(curve_has_errors(curve))
+        ws.delete()
+
+    def test_curve_has_errors_returns_true_on_bin_plot_workspace_with_errors(self):
+        ws = CreateWorkspace(DataX=[0, 1], DataY=[0, 1], DataE=[0.1, 0.1], NSpec=2,
+                             OutputWorkspace='test_ws')
+        fig = figure()
+        ax = fig.add_subplot(111, projection='mantid')
+        curve = ax.plot(ws, wkspIndex=0, axis=MantidAxType.BIN)[0]
+        self.assertTrue(curve_has_errors(curve))
+        ws.delete()
 
     def test_replot_selected_curve(self):
         fig = figure()


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the figure options and the right-clicking options on bin plots were throwing errors due to the checks it was making for error bars.
An additional check has also been added so that bin plots are not normalised by bin width (this makes no sense for bin plots)

**Report to:** @gvardany 

**To test:**
Plot a bin plot using the following:
```
ws = CreateSampleWorkspace()
wsBin = Integration(ws)
```
Check the plot is not normalised. 
Right-click on the plot and change show errors and check this works as expected.
Note the normalise option should not appear.
Open the figure options (this should not crash)
Try changing the error bar options in the curves tab and check these work the same as a spectrum plot.

Fixes #27762 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
