### PR TITLE
plot script generator bug fix

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -39,8 +39,9 @@ Improvements
 
 Bugfixes
 ########
-- Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
 
+- Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
+- Fixed a couple of errors in the python scripts generated from plots for newer versions of Matplotlib.
 - Colorbar scale no longer vanish on colorfill plots with a logarithmic scale
 - Figure options no longer causes a crash when using 2d plots created from a script.
 - Running an algorithm that reduces the number of spectra on an active plot (eg SumSpectra) no longer causes an error

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -24,9 +24,9 @@ from workbench.plotting.plotscriptgenerator.utils import generate_workspace_retr
 FIG_VARIABLE = "fig"
 AXES_VARIABLE = "axes"
 if hasattr(Legend, "set_draggable"):
-    SET_DRAGGABLE_METHOD = "set_draggable"
+    SET_DRAGGABLE_METHOD = "set_draggable(True)"
 else:
-    SET_DRAGGABLE_METHOD = "draggable"
+    SET_DRAGGABLE_METHOD = "draggable()"
 
 
 def generate_script(fig, exclude_headers=False):
@@ -44,7 +44,7 @@ def generate_script(fig, exclude_headers=False):
         axes.set_xlabel and axes.set_ylabel()
         axes.set_xlim() and axes.set_ylim()
         axes.set_xscale() and axes.set_yscale()
-        axes.legend().draggable()     (if legend present)
+        axes.legend().draggable(true)     (if legend present)
         plt.show()
 
     :param fig: A matplotlib.pyplot.Figure object you want to create a script from
@@ -71,7 +71,7 @@ def generate_script(fig, exclude_headers=False):
     cmds.extend(generate_workspace_retrieval_commands(fig) + [''])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))
     cmds.extend(plot_commands)
-    cmds.append("plt.show()")
+    cmds.append("fig.show()")
     return '\n'.join(cmds)
 
 
@@ -112,7 +112,7 @@ def get_title_cmds(ax, ax_object_var):
 def get_legend_cmds(ax, ax_object_var):
     """Get command axes.set_legend"""
     if ax.legend_:
-        return ["{ax_obj}.legend().{draggable_method}()".format(ax_obj=ax_object_var,
+        return ["{ax_obj}.legend().{draggable_method}".format(ax_obj=ax_object_var,
                                                                 draggable_method=SET_DRAGGABLE_METHOD)]
     return []
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -44,7 +44,7 @@ def generate_script(fig, exclude_headers=False):
         axes.set_xlabel and axes.set_ylabel()
         axes.set_xlim() and axes.set_ylim()
         axes.set_xscale() and axes.set_yscale()
-        axes.legend().draggable(True)     (if legend present, or just draggable() for earlier matplotlib versions)
+        axes.legend().set_draggable(True)     (if legend present, or just draggable() for earlier matplotlib versions)
         plt.show()
 
     :param fig: A matplotlib.pyplot.Figure object you want to create a script from

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -44,7 +44,7 @@ def generate_script(fig, exclude_headers=False):
         axes.set_xlabel and axes.set_ylabel()
         axes.set_xlim() and axes.set_ylim()
         axes.set_xscale() and axes.set_yscale()
-        axes.legend().draggable(true)     (if legend present)
+        axes.legend().draggable(True)     (if legend present, or just draggable() for earlier matplotlib versions)
         plt.show()
 
     :param fig: A matplotlib.pyplot.Figure object you want to create a script from

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -113,7 +113,7 @@ def get_legend_cmds(ax, ax_object_var):
     """Get command axes.set_legend"""
     if ax.legend_:
         return ["{ax_obj}.legend().{draggable_method}".format(ax_obj=ax_object_var,
-                                                                draggable_method=SET_DRAGGABLE_METHOD)]
+                                                              draggable_method=SET_DRAGGABLE_METHOD)]
     return []
 
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -38,7 +38,7 @@ SAMPLE_SCRIPT = ("from mantid.api import AnalysisDataService\n"
                  "axes[1].set_xlim(...)\n"
                  "axes[1].set_ylim(...)\n"
                  "\n"
-                 "plt.show()")
+                 "fig.show()")
 
 
 class PlotScriptGeneratorTest(unittest.TestCase):
@@ -122,7 +122,7 @@ class PlotScriptGeneratorTest(unittest.TestCase):
         mock_ax = self._gen_mock_axes(legend_=True)
         mock_fig = Mock(get_axes=lambda: [mock_ax])
         if hasattr(Legend, "set_draggable"):
-            self.assertIn('.legend().set_draggable()', generate_script(mock_fig))
+            self.assertIn('.legend().set_draggable(True)', generate_script(mock_fig))
         else:
             self.assertIn('.legend().draggable()', generate_script(mock_fig))
 


### PR DESCRIPTION
**Description of work.**

A couple of minor changes to the scripts generated from plots in workbench.

**Report to:** @DanielMurphy22 


**To test:**

1. start workbench
1. create a workspace
   ``` python
   ws = CreateSampleWorkspace()
   ```
1. right click the workspace and plot a 1D graph
1. Click the script icon in the graph window to create a script to clipboard
1. Close the graph
1. Paste the script into a window and run it
1. the graph should be regenerated and look the same.

Also look at the issue for a sample script as well

Fixes #27885 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
