### PR TITLE
Change test import to use PyCompat

### DIFF
--- a/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/add_runs_presenter_test.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import unittest
-from mock import patch
 
 from assert_called import assert_called
 from fake_signal import FakeSignal
@@ -69,8 +68,8 @@ class InitializationTest(AddRunsPagePresenterTestCase):
     def setUp(self):
         self.setUpFakeChildViews()
 
-    @patch('sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel', autospec=True)
-    @patch('sans.gui_logic.presenter.add_runs_presenter.RunSelectorPresenter', autospec=True)
+    @mock.patch('sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel', autospec=True)
+    @mock.patch('sans.gui_logic.presenter.add_runs_presenter.RunSelectorPresenter', autospec=True)
     def test_creates_run_selector_with_child_view(self, patched_presenter, patched_model):
         view = self._make_mock_view()
         parent_view = self._make_mock_parent_view()
@@ -80,8 +79,8 @@ class InitializationTest(AddRunsPagePresenterTestCase):
         patched_model.assert_called_once_with(mock.ANY)
         patched_presenter.assert_called_once_with(mock.ANY, patched_model.return_value, mock.ANY, mock.ANY, view)
 
-    @patch('sans.gui_logic.presenter.add_runs_presenter.SummationSettingsModel', autospec=True)
-    @patch('sans.gui_logic.presenter.add_runs_presenter.SummationSettingsPresenter', autospec=True)
+    @mock.patch('sans.gui_logic.presenter.add_runs_presenter.SummationSettingsModel', autospec=True)
+    @mock.patch('sans.gui_logic.presenter.add_runs_presenter.SummationSettingsPresenter', autospec=True)
     def test_creates_run_selector_with_child_view(self, patched_presenter, patched_model):
         view = self._make_mock_view()
         parent_view = self._make_mock_parent_view()
@@ -112,7 +111,7 @@ class SummationSettingsViewEnablednessTest(AddRunsPagePresenterTestCase):
         presenter._get_filename_manager = mock.Mock(return_value=MockedOutAddRunsFilenameManager())
         return presenter
 
-    @patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
     def test_enables_summation_settings_when_event_data(self, patched_init_run_selector):
         histogram_run = self._make_fake_histogram_run()
         runs = mock.MagicMock()
@@ -123,7 +122,7 @@ class SummationSettingsViewEnablednessTest(AddRunsPagePresenterTestCase):
         presenter._handle_selection_changed(run_selection=runs)
         assert_called(self.view.enable_summation_settings)
 
-    @patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
     def test_enables_summation_settings_when_event_and_histogram_data(self, _):
         histogram_run = self._make_fake_histogram_run()
         event_run = self._make_fake_event_run()
@@ -142,7 +141,7 @@ class SummationConfigurationTest(AddRunsPagePresenterTestCase):
         self.view = self._make_mock_view()
         self.parent_view = self._make_mock_parent_view()
 
-    @patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectorPresenter", autospec=True)
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectorPresenter", autospec=True)
     def test_passes_correct_config_when_summation_requested(self, patched_run_selector):
         # Ensure we know the type that was returned by the constructor
         run_selector_mock = mock.Mock()
@@ -164,7 +163,7 @@ class SummationConfigurationTest(AddRunsPagePresenterTestCase):
         self.view.sum.emit()
         run_summation.assert_called_with(mock.ANY, mock.ANY, 'LOQ00003-add')
 
-    @patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
+    @mock.patch("sans.gui_logic.presenter.add_runs_presenter.RunSelectionModel", autospec=True)
     def test_shows_error_when_empty_default_directory(self, _):
         view = self._make_mock_view()
         presenter = AddRunsPagePresenter(mock.MagicMock(), view, mock.Mock())


### PR DESCRIPTION
**Description of work.**
Fixes up an erranous import which previously included mock directly,
instead of using the PyCompat library. This was breaking builds on
Windows where the mock library is not widely available.

**To test:**
- Run `ctest -C Debug -R "add_runs_presenter"` on a Windows machine
- Check the test passes

There is no associated issue, this fixes a build regression introduced to master

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
