### PR TITLE
Fix "is" with a literal. Did you mean "=="? warning from python 3.8

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -37,7 +37,7 @@ class LoadWAND(DataProcessorAlgorithm):
         issues = dict()
 
         if not self.getProperty("Filename").value:
-            if (self.getProperty("IPTS").value == Property.EMPTY_INT) or len(self.getProperty("RunNumbers").value) is 0:
+            if (self.getProperty("IPTS").value == Property.EMPTY_INT) or len(self.getProperty("RunNumbers").value) == 0:
                 issues["Filename"] = 'Must specify either Filename or IPTS AND RunNumbers'
 
         return issues


### PR DESCRIPTION
**Description of work.**

Fix "is" with a literal. Did you mean "=="? warning from python 3.8
This was popping up on startup of workbench each time

**To test:**
1. Start up Mantid workbench, and don't see the warning in the messages box.
1. The unit and doc tests will have checked that the algorithm still works

*There is no associated issue.*


*This does not require release notes* because it was introduced in this release

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
