### PR TITLE
Allow waterfall plot to be made with single spectrum number and multiple workspaces

### DIFF
--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -264,7 +264,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         _do_single_plot(ax, workspaces, errors, show_title, nums, kw, plot_kwargs)
 
     # Can't have a waterfall plot with only one line.
-    if len(nums) * len(workspaces) == 1 and waterfall:
+    if len(nums)*len(workspaces) == 1 and waterfall:
         waterfall = False
 
     # The plot's initial xlim and ylim are used to offset each curve in a waterfall plot.

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -264,7 +264,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         _do_single_plot(ax, workspaces, errors, show_title, nums, kw, plot_kwargs)
 
     # Can't have a waterfall plot with only one line.
-    if len(nums) == 1 and waterfall:
+    if len(nums) * len(workspaces) == 1 and waterfall:
         waterfall = False
 
     # The plot's initial xlim and ylim are used to offset each curve in a waterfall plot.
@@ -279,7 +279,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         fig.canvas.set_window_title(figure_title(workspaces, fig.number))
     else:
         if ax.is_waterfall():
-            for i in range(len(nums)):
+            for i in range(len(nums)*len(workspaces)):
                 errorbar_cap_lines = helperfunctions.remove_and_return_errorbar_cap_lines(ax)
                 helperfunctions.convert_single_line_to_waterfall(ax, len(ax.get_lines())-(i+1))
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where you couldn't make a waterfall plot from multiple workspaces if you only entered one spectrum number because it thought that only one line was being plotted.

**To test:**
1. Select multiple workspaces, right-click and select Plot->Spectrum...
2. Enter one spectrum number and choose Waterfall as the plot type.
3. Check that the plot produced is a waterfall plot and not a regular 1D plot.
4. Select multiple workspaces again and overplot onto the existing plot, check that the correct lines are plotted and they join the waterfall.

Fixes #27905 

No release notes because waterfall plots aren't in a release yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
