### PR TITLE
Reload data sets in Muon Analysis without crash

### DIFF
--- a/docs/source/release/v4.3.0/muon.rst
+++ b/docs/source/release/v4.3.0/muon.rst
@@ -33,5 +33,6 @@ Bug Fixes
 - The elemental analysis GUI can now handle legacy data which is missing a response dataset, e.g Delayed.
 - Fixed a bug with constraints in the Muon Analysis 2 GUI which would cause Mantid to crash.
 - Fixed a bug in Muon Analysis Old that prevented the muon fitting functions from appearing in the data analysis tab.
+- Data sets can now be reloaded while the Instrument View is open without crashing Mantid.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -107,6 +107,8 @@ public:
   Mantid::Kernel::V3D getSurfaceAxis(const int surfaceType) const;
   /// Get pointer to the projection surface
   boost::shared_ptr<ProjectionSurface> getSurface() const;
+  /// True if the workspace is being replaced
+  bool isWsBeingReplaced() const;
   /// True if the GL instrument display is currently on
   bool isGLEnabled() const;
   /// Toggle between the GL and simple instrument display widgets
@@ -338,6 +340,7 @@ private:
   /// Save tabs on the widget to a string
   std::string saveTabs() const;
 
+  bool m_wsReplace;
   QPushButton *m_help;
 };
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
@@ -37,26 +37,29 @@ InstrumentWidgetEncoder::encode(const InstrumentWidget &obj,
                                 const QString &projectPath,
                                 const bool saveMask) {
   QMap<QString, QVariant> map;
-  m_projectPath = projectPath.toStdString();
-  m_saveMask = saveMask;
+  // there is no reference to the workspace if it is being replaced, so return
+  // the empty map
+  if (!obj.isWsBeingReplaced()) {
+    m_projectPath = projectPath.toStdString();
+    m_saveMask = saveMask;
 
-  map.insert(QString("workspaceName"), QVariant(obj.getWorkspaceName()));
+    map.insert(QString("workspaceName"), QVariant(obj.getWorkspaceName()));
 
-  map.insert(QString("surfaceType"), QVariant(obj.getSurfaceType()));
+    map.insert(QString("surfaceType"), QVariant(obj.getSurfaceType()));
 
-  map.insert(QString("currentTab"), QVariant(obj.getCurrentTab()));
+    map.insert(QString("currentTab"), QVariant(obj.getCurrentTab()));
 
-  QList<QVariant> energyTransferList;
-  energyTransferList.append(QVariant(obj.m_xIntegration->getMinimum()));
-  energyTransferList.append(QVariant(obj.m_xIntegration->getMaximum()));
-  map.insert(QString("energyTransfer"), QVariant(energyTransferList));
+    QList<QVariant> energyTransferList;
+    energyTransferList.append(QVariant(obj.m_xIntegration->getMinimum()));
+    energyTransferList.append(QVariant(obj.m_xIntegration->getMaximum()));
+    map.insert(QString("energyTransfer"), QVariant(energyTransferList));
 
-  map.insert(QString("surface"),
-             QVariant(this->encodeSurface(obj.getSurface())));
-  map.insert(QString("actor"),
-             QVariant(this->encodeActor(obj.m_instrumentActor)));
-  map.insert(QString("tabs"), QVariant(this->encodeTabs(obj)));
-
+    map.insert(QString("surface"),
+               QVariant(this->encodeSurface(obj.getSurface())));
+    map.insert(QString("actor"),
+               QVariant(this->encodeActor(obj.m_instrumentActor)));
+    map.insert(QString("tabs"), QVariant(this->encodeTabs(obj)));
+  }
   return map;
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -1382,20 +1382,19 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(
 
     // get masked detector workspace from actor
     const auto &actor = m_instrWidget->getInstrumentActor();
-    auto outputWS = actor.getMaskMatrixWorkspace();
-
-    if (!outputWS)
-      return false; // no mask workspace was found
-
-    // save mask to file inside project folder
-    auto alg = AlgorithmManager::Instance().createUnmanaged("SaveMask", -1);
-    alg->setChild(true);
-    alg->setProperty("InputWorkspace",
-                     boost::dynamic_pointer_cast<Workspace>(outputWS));
-    alg->setPropertyValue("OutputFile", fileName);
-    alg->setLogging(false);
-    alg->execute();
-
+    if (actor.hasMaskWorkspace()) {
+      auto outputWS = actor.getMaskMatrixWorkspace();
+      // save mask to file inside project folder
+      auto alg = AlgorithmManager::Instance().createUnmanaged("SaveMask", -1);
+      alg->setChild(true);
+      alg->setProperty("InputWorkspace",
+                       boost::dynamic_pointer_cast<Workspace>(outputWS));
+      alg->setPropertyValue("OutputFile", fileName);
+      alg->setLogging(false);
+      alg->execute();
+    } else {
+      return false;
+    }
   } catch (...) {
     // just fail silently, if we can't save the mask then we should
     // give up at this point.


### PR DESCRIPTION
**Description of work.**
This PR allows data sets to be reloaded within the Muon Analysis GUI (Workbench) without crashing Mantid while the Instrument View is open.

**To test:**
- Open Workbench
- Open Muon Analysis GUI
- Type in 62260 as the run number
- Show Instrument on the "EMU62260_raw_data MA" workspace
- Enter the Pick tab and click on some detectors
- Go back to the Muon Analysis GUI and use the <> buttons to move to the next run, and then back to 62260
- Should **not** crash

Fixes #27881 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
