### PR TITLE
Get tooltips from ReflectometryISISLoadAndProcess

### DIFF
--- a/docs/source/release/v4.3.0/reflectometry.rst
+++ b/docs/source/release/v4.3.0/reflectometry.rst
@@ -8,7 +8,7 @@ ISIS Reflectometry Interface
 Improved
 --------
 
-- The per-angle defaults table on the Experiment now has column-specific tooltips on the table cells.
+- The per-angle defaults table on the Experiment now has column-specific tooltips on the table cells which correspond to the [ReflectometryISISLoadAndProcess](https://docs.mantidproject.org/nightly/algorithms/ReflectometryISISLoadAndProcess-v1.html?highlight=reflectometryisisloadandprocess) documentation
 
 Algorithms
 ##########

--- a/qt/scientific_interfaces/CMakeLists.txt
+++ b/qt/scientific_interfaces/CMakeLists.txt
@@ -76,6 +76,11 @@ set(TEST_FILES
     test/ISISReflectometry/Common/EncoderTest.h
 )
 
+set(CXXTEST_EXTRA_HEADER_INCLUDE
+    ${CMAKE_CURRENT_LIST_DIR}/test/ScientificInterfacesTestInitialization.h)
+
+find_package(BoostPython REQUIRED)
+
 mtd_add_qt_tests(TARGET_NAME MantidQtScientificInterfacesTest
                  QT_VERSION 4
                  SRC ${TEST_FILES}
@@ -83,6 +88,7 @@ mtd_add_qt_tests(TARGET_NAME MantidQtScientificInterfacesTest
                    ../../Framework/DataObjects/inc
                    ../../Framework/TestHelpers/inc
                    inc
+                   ${PYTHON_INCLUDE_PATH}
                  TEST_HELPER_SRCS
                    ../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
                    ../../Framework/TestHelpers/src/DataProcessorTestHelper.cpp
@@ -95,6 +101,8 @@ mtd_add_qt_tests(TARGET_NAME MantidQtScientificInterfacesTest
                    ${TCMALLOC_LIBRARIES_LINKTIME}
                    ${CORE_MANTIDLIBS}
                    DataObjects
+                   PythonInterfaceCore
+                   ${PYTHON_LIBRARIES}
                    ${GMOCK_LIBRARIES}
                    ${GTEST_LIBRARIES}
                    ${POCO_LIBRARIES}
@@ -139,8 +147,6 @@ set(QT5_TEST_FILES
     test/ISISReflectometry/Common/DecoderTest.h
     test/ISISReflectometry/Common/EncoderTest.h
 )
-
-find_package(BoostPython REQUIRED)
 
 mtd_add_qt_tests(TARGET_NAME MantidQtScientificInterfacesTest
                  QT_VERSION 5

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<QtEventView> QtBatchView::createEventTab() {
 
 IAlgorithm_sptr QtBatchView::createReductionAlg() {
   return Mantid::API::AlgorithmManager::Instance().create(
-      "ReflectometryReductionOneAuto");
+      "ReflectometryISISLoadAndProcess");
 }
 
 std::unique_ptr<QtSaveView> QtBatchView::createSaveTab() {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PerThetaDefaults.h
@@ -43,19 +43,11 @@ public:
     RUN_SPECTRA = 8
   };
 
-  // The property name associated with each column. Unfortunately in
-  // QtBatchView we are still using ReflectometryReductionOneAuto to get the
-  // tooltips rather than ReflectometryISISLoadAndProcess. If we change it we
-  // will break the Encoder and Decoder unit tests because C++ tests cannot use
-  // python algorithms. The code needs to be reorganised to avoid creating the
-  // algorithm, or the tests rewritten in python. This only affects tooltips
-  // for a couple of the properties so is not an urgent fix, so for now just
-  // make the properties here match RROA.
   static auto constexpr ColumnPropertyName =
       std::array<const char *, OPTIONS_TABLE_COLUMN_COUNT>{
           "ThetaIn",
-          "FirstTransmissionRun",  // FirstTransmissionRunList in RILAP
-          "SecondTransmissionRun", // SecondTransmissionRunList in RILAP
+          "FirstTransmissionRunList",
+          "SecondTransmissionRunList",
           "TransmissionProcessingInstructions",
           "MomentumTransferMin",
           "MomentumTransferMax",

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/DecoderTest.h
@@ -11,7 +11,7 @@
 #include "../../../ISISReflectometry/GUI/Common/Decoder.h"
 #include "../ReflMockObjects.h"
 #include "CoderCommonTester.h"
-#include "MantidAPI/FrameworkManager.h"
+#include "MantidPythonInterface/core/WrapPython.h"
 #include "MantidQtWidgets/Common/QtJSONUtils.h"
 
 #include <cxxtest/TestSuite.h>
@@ -168,7 +168,10 @@ public:
   static DecoderTest *createSuite() { return new DecoderTest(); }
   static void destroySuite(DecoderTest *suite) { delete suite; }
 
-  void setUp() override { Mantid::API::FrameworkManager::Instance(); }
+  DecoderTest() {
+    PyRun_SimpleString("import mantid.api as api\n"
+                       "api.FrameworkManager.Instance()");
+  }
 
   void test_decode() {
     CoderCommonTester tester;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/EncoderTest.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/EncoderTest.h
@@ -11,7 +11,7 @@
 #include "../../../ISISReflectometry/GUI/Common/Encoder.h"
 #include "../ReflMockObjects.h"
 #include "CoderCommonTester.h"
-#include "MantidAPI/FrameworkManager.h"
+#include "MantidPythonInterface/core/WrapPython.h"
 
 #include <cxxtest/TestSuite.h>
 
@@ -27,7 +27,10 @@ public:
   static EncoderTest *createSuite() { return new EncoderTest(); }
   static void destroySuite(EncoderTest *suite) { delete suite; }
 
-  void setUp() override { Mantid::API::FrameworkManager::Instance(); }
+  EncoderTest() {
+    PyRun_SimpleString("import mantid.api as api\n"
+                       "api.FrameworkManager.Instance()");
+  }
 
   void test_encoder() {
     CoderCommonTester tester;

--- a/qt/scientific_interfaces/test/ISISReflectometry/Common/PlotterTestQt5.h
+++ b/qt/scientific_interfaces/test/ISISReflectometry/Common/PlotterTestQt5.h
@@ -12,22 +12,6 @@
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include <cxxtest/TestSuite.h>
 
-namespace {
-void setMatplotlibBackend() {
-  // Setup python and mantid python
-  Py_Initialize();
-  const MantidQt::Widgets::Common::Python::Object siteModule{
-      MantidQt::Widgets::Common::Python::NewRef(PyImport_ImportModule("site"))};
-  siteModule.attr("addsitedir")(
-      Mantid::Kernel::ConfigService::Instance().getPropertiesDir());
-
-  // Set matplotlib backend
-  auto mpl = MantidQt::Widgets::Common::Python::NewRef(
-      PyImport_ImportModule("matplotlib"));
-  mpl.attr("use")("Agg");
-}
-} // namespace
-
 class PlotterTestQt5 : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
@@ -35,12 +19,7 @@ public:
   static PlotterTestQt5 *createSuite() { return new PlotterTestQt5(); }
   static void destroySuite(PlotterTestQt5 *suite) { delete suite; }
 
-  void setUp() override {
-    Mantid::API::FrameworkManager::Instance();
-    setMatplotlibBackend();
-  }
-
-  void tearDown() override { Py_Finalize(); }
+  PlotterTestQt5() { Mantid::API::FrameworkManager::Instance(); }
 
   void testReflectometryPlot() {
     // Just test that it doesn't segfault when plotting as nothing is returned

--- a/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
+++ b/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
@@ -1,0 +1,20 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#ifndef REFLMPLCPPTESTGLOBALINITIALIZATION_H
+#define REFLMPLCPPTESTGLOBALINITIALIZATION_H
+
+#include "MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h"
+
+//------------------------------------------------------------------------------
+// Static definitions
+//
+// We rely on cxxtest only including this file once so that the following
+// statements do not cause multiple-definition errors.
+//------------------------------------------------------------------------------
+static PythonInterpreterGlobalFixture PYTHON_INTERPRETER;
+
+#endif // REFLMPLCPPTESTGLOBALINITIALIZATION_H

--- a/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
+++ b/qt/scientific_interfaces/test/ScientificInterfacesTestInitialization.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +


### PR DESCRIPTION
**Description of work.**
In the ISIS Reflectometry in QtBatchView we are now using ReflectometryISISLoadAndProcess to get the tooltips rather than ReflectometryReductionOneAuto. This required changes to allow the Python algorithm to be run in the Encoder and Decoder C++ unit tests.

**To test:**
- Open the ISIS Reflectometry interface
- Go to the Experiment tab
- Hover over the cell in the transmission runs columns
- The descriptions should match those from [ReflectometryISISLoadAndProcess](https://docs.mantidproject.org/nightly/algorithms/ReflectometryISISLoadAndProcess-v1.html?highlight=reflectometryisisloadandprocess) rather than [ReflectometryReductionOneAuto](https://docs.mantidproject.org/nightly/algorithms/ReflectometryReductionOneAuto-v3.html). 

---
- Run `ctest -C Debug -VV -R EncoderTest` and `ctest -C Debug -VV -R DecoderTest`.
They should both pass.


Fixes #27889 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
