### PR TITLE
Fix workbench double-spacing on saving Python scripts on Windows 

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -37,11 +37,13 @@ Improvements
 - The context menu for WorkspaceGroups now contains plotting options so you can plot all of the workspaces in the group.
 - Most changes in the settings dialog now take place immediately, no longer needing a restart, such as hiding algorithm categories, interfaces or choosing wether to see invisible workspaces.
 - A warning now appears if you attempt to plot more than ten spectra.
+- Toggle Whitespace in the editor now shows line endings as well as spaces and tabs
 - The Save menu action in the workspaces toolbox to save using version 1 of the SaveAscii algorithm has been removed as no one was using it and it only added confusion. The option to save using the most recent version of SaveASCII is still available.
 
 Bugfixes
 ########
 - Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
+- Workbench now saves python files properly on windows and does not double up on line feed characters.
 - Fixed a couple of errors in the python scripts generated from plots for newer versions of Matplotlib.
 - Colorbar scale no longer vanish on colorfill plots with a logarithmic scale
 - Figure options no longer causes a crash when using 2d plots created from a script.

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -35,9 +35,9 @@ if sys.version_info < (3,0):
                        os.linesep + os.linesep
 
 DEFAULT_CONTENT += "# import mantid algorithms, numpy and matplotlib" + os.linesep + \
-"from mantid.simpleapi import *" + os.linesep + \
-"import matplotlib.pyplot as plt" + os.linesep + \
-"import numpy as np" + os.linesep + os.linesep
+                   "from mantid.simpleapi import *" + os.linesep + \
+                   "import matplotlib.pyplot as plt" + os.linesep + \
+                   "import numpy as np" + os.linesep + os.linesep
 
 # Accepted extensions for drag-and-drop to editor
 ACCEPTED_FILE_EXTENSIONS = ['.py', '.pyw']

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -12,6 +12,7 @@ from __future__ import (absolute_import, unicode_literals)
 # system imports
 import os.path as osp
 import os
+import sys
 
 # third-party library imports
 from qtpy.QtWidgets import QVBoxLayout
@@ -26,16 +27,17 @@ from ..plugins.base import PluginWidget
 
 
 # Initial content
-DEFAULT_CONTENT = "# The following line helps with future compatibility with Python 3" + os.linesep + \
-"# print must now be used as a function, e.g print('Hello','World')" + os.linesep + \
-"from __future__ import (absolute_import, division, print_function, unicode_literals)" + os.linesep + \
-os.linesep + \
-"# import mantid algorithms, numpy and matplotlib" + os.linesep + \
+DEFAULT_CONTENT = ""
+if sys.version_info < (3,0):
+    DEFAULT_CONTENT += "# The following line helps with future compatibility with Python 3" + os.linesep + \
+                       "# print must now be used as a function, e.g print('Hello','World')" + os.linesep + \
+                       "from __future__ import (absolute_import, division, print_function, unicode_literals)" + \
+                       os.linesep + os.linesep
+
+DEFAULT_CONTENT += "# import mantid algorithms, numpy and matplotlib" + os.linesep + \
 "from mantid.simpleapi import *" + os.linesep + \
-os.linesep + \
 "import matplotlib.pyplot as plt" + os.linesep + \
-os.linesep + \
-"import numpy as np" + os.linesep
+"import numpy as np" + os.linesep + os.linesep
 
 # Accepted extensions for drag-and-drop to editor
 ACCEPTED_FILE_EXTENSIONS = ['.py', '.pyw']

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -11,6 +11,7 @@ from __future__ import (absolute_import, unicode_literals)
 
 # system imports
 import os.path as osp
+import os
 
 # third-party library imports
 from qtpy.QtWidgets import QVBoxLayout
@@ -25,17 +26,17 @@ from ..plugins.base import PluginWidget
 
 
 # Initial content
-DEFAULT_CONTENT = """# The following line helps with future compatibility with Python 3
-# print must now be used as a function, e.g print('Hello','World')
-from __future__ import (absolute_import, division, print_function, unicode_literals)
+DEFAULT_CONTENT = "# The following line helps with future compatibility with Python 3" + os.linesep + \
+"# print must now be used as a function, e.g print('Hello','World')" + os.linesep + \
+"from __future__ import (absolute_import, division, print_function, unicode_literals)" + os.linesep + \
+os.linesep + \
+"# import mantid algorithms, numpy and matplotlib" + os.linesep + \
+"from mantid.simpleapi import *" + os.linesep + \
+os.linesep + \
+"import matplotlib.pyplot as plt" + os.linesep + \
+os.linesep + \
+"import numpy as np" + os.linesep
 
-# import mantid algorithms, numpy and matplotlib
-from mantid.simpleapi import *
-
-import matplotlib.pyplot as plt
-
-import numpy as np
-"""
 # Accepted extensions for drag-and-drop to editor
 ACCEPTED_FILE_EXTENSIONS = ['.py', '.pyw']
 # QSettings key for session tabs

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -175,6 +175,7 @@ public:
   void setSelection(int lineFrom, int indexFrom, int lineTo, int indexTo);
   void setTabWidth(int width);
   void setText(const QString &text);
+  void setEolVisibility(bool state);
   void setWhitespaceVisibility(WhitespaceVisibility mode);
   void updateCompletionAPI(const QStringList & completions);
 

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -95,7 +95,8 @@ class EditorIO(object):
             self.editor.setFileName(filename)
 
         try:
-            with io.open(filename, 'w', encoding='utf8') as f:
+            a= self.editor.text()
+            with io.open(filename, 'w', encoding='utf8', newline='') as f:
                 f.write(self.editor.text())
             self.editor.setModified(False)
         except IOError as exc:
@@ -225,9 +226,11 @@ class PythonFileInterpreter(QWidget):
         self.replace_text(SPACE_CHAR * TAB_WIDTH, TAB_CHAR)
 
     def set_whitespace_visible(self):
+        self.editor.setEolVisibility(True);
         self.editor.setWhitespaceVisibility(CodeEditor.WsVisible)
 
     def set_whitespace_invisible(self):
+        self.editor.setEolVisibility(False);
         self.editor.setWhitespaceVisibility(CodeEditor.WsInvisible)
 
     def toggle_comment(self):

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -95,7 +95,6 @@ class EditorIO(object):
             self.editor.setFileName(filename)
 
         try:
-            a= self.editor.text()
             with io.open(filename, 'w', encoding='utf8', newline='') as f:
                 f.write(self.editor.text())
             self.editor.setModified(False)
@@ -226,11 +225,11 @@ class PythonFileInterpreter(QWidget):
         self.replace_text(SPACE_CHAR * TAB_WIDTH, TAB_CHAR)
 
     def set_whitespace_visible(self):
-        self.editor.setEolVisibility(True);
+        self.editor.setEolVisibility(True)
         self.editor.setWhitespaceVisibility(CodeEditor.WsVisible)
 
     def set_whitespace_invisible(self):
-        self.editor.setEolVisibility(False);
+        self.editor.setEolVisibility(False)
         self.editor.setWhitespaceVisibility(CodeEditor.WsInvisible)
 
     def toggle_comment(self):


### PR DESCRIPTION
**Description of work.**

Does 3 things
1. Fixes Toggle Whitespace so it shows line endings
1. Stops double spacing for saved python files on windows
1.  Changes the header for new python files to only include the compatibility imports for python 2

**Report to:** James Lord

**To test:**
1. Load workbench
1. start a new script
1. look at the header, it should not contain the from future import bit if it is a python 3 build
1. put in some text like
   ```
   a
   b
   c
   ```
1. click the options in the corner of the editor and select Toggle WhitespaceVisible, see line endings
1. Save the file
1. Check it in a text editor, it should look the same
1. load it back into workbench it should look the same

Fixes #27558
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
