### PR TITLE
Disable desktop notifications for Qt 4

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -440,7 +440,6 @@ set(
   src/MuonFitDataSelector.cpp
   src/MuonFitPropertyBrowser.cpp
   src/MuonFunctionBrowser.cpp
-  src/NotificationService.cpp
   src/ProcessingAlgoWidget.cpp
   src/ProgressableView.cpp
   src/ProjectSavePresenter.cpp
@@ -553,7 +552,6 @@ set(
   inc/MantidQtWidgets/Common/MuonFitDataSelector.h
   inc/MantidQtWidgets/Common/MuonFitPropertyBrowser.h
   inc/MantidQtWidgets/Common/MuonFunctionBrowser.h
-  inc/MantidQtWidgets/Common/NotificationService.h
   inc/MantidQtWidgets/Common/pqHelpWindow.h
   inc/MantidQtWidgets/Common/PropertyHandler.h
   inc/MantidQtWidgets/Common/ProcessingAlgoWidget.h

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -244,7 +244,7 @@ void MessageDisplay::append(const Message &msg) {
     if (msg.priority() <= Message::Priority::PRIO_ERROR) {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
       NotificationService::showMessage(
-          "Mantid Workbench",
+          parentWidget() ? parentWidget()->windowTitle() : "Mantid",
           "Sorry, there was an error, please look at the message display for "
           "details.",
           NotificationService::MessageIcon::Critical);

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -11,7 +11,9 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Logger.h"
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include "MantidQtWidgets/Common/NotificationService.h"
+#endif
 
 #include <QAction>
 #include <QActionGroup>
@@ -240,11 +242,13 @@ void MessageDisplay::append(const Message &msg) {
     moveCursorToEnd();
 
     if (msg.priority() <= Message::Priority::PRIO_ERROR) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
       NotificationService::showMessage(
           "Mantid Workbench",
           "Sorry, there was an error, please look at the message display for "
           "details.",
           NotificationService::MessageIcon::Critical);
+#endif
       emit errorReceived(msg.text());
     }
     if (msg.priority() <= Message::Priority::PRIO_WARNING)

--- a/qt/widgets/common/src/NotificationService.cpp
+++ b/qt/widgets/common/src/NotificationService.cpp
@@ -27,7 +27,7 @@ void NotificationService::showMessage(const QString &title,
     if (windowIcon.isNull()) {
       try {
         windowIcon = QIcon(":/images/MantidIcon.ico");
-      } catch (std::exception) {
+      } catch (const std::exception &) {
         // if we cannot use the embedded icon, use a blank one
         windowIcon = QIcon(QPixmap(32, 32));
       }
@@ -48,11 +48,11 @@ bool NotificationService::isEnabled() {
     retVal = Mantid::Kernel::ConfigService::Instance()
                  .getValue<bool>(NOTIFICATIONS_ENABLED_KEY)
                  .get_value_or(true);
-  } catch (Mantid::Kernel::Exception::FileError) {
+  } catch (const Mantid::Kernel::Exception::FileError &) {
     // The Config Service could not find the properties file
     // Disable notifications
     retVal = false;
-  } catch (Poco::ExistsException) {
+  } catch (const Poco::ExistsException &) {
     // The Config Service could not find the properties file
     // Disable notifications
     retVal = false;


### PR DESCRIPTION
**Description of work.**

They currently cause MantidPlot to crash occasionally on macOS. They are intended as an enhancement for Workbench so disable them in MantidPlot.

**To test:**

Try the script in the attached issue in both MantidPlot and Workbench on macOS and ensure the desktop notifications only appear for Workbench.

Fixes #27943, #27858 .

*This does not require release notes* because **it was introduced in this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
