### PR TITLE
Double-click algorithm with multiple versions should open dialog

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -45,6 +45,7 @@ Bugfixes
 - Fixed a couple of errors in the python scripts generated from plots for newer versions of Matplotlib.
 - Colorbar scale no longer vanish on colorfill plots with a logarithmic scale
 - Figure options no longer causes a crash when using 2d plots created from a script.
+- You can now execute algorithms with multiple versions by double clicking on them in the algorithm toolbox, this will now execute them rather than opening the tree to show previous versions.  You can still click on the arrow to see and execute previous versions.
 - Running an algorithm that reduces the number of spectra on an active plot (eg SumSpectra) no longer causes an error
 - Fix crash when loading a script with syntax errors
 - The Show Instruments right click menu option is now disabled for workspaces that have had their spectrum axis converted to another axis using :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.  Once this axis has been converetd the workspace loses it's link between the data values and the detectors they were recorded on so we cannot display it in the instrument view.

--- a/qt/python/mantidqt/widgets/algorithmselector/widget.py
+++ b/qt/python/mantidqt/widgets/algorithmselector/widget.py
@@ -46,9 +46,10 @@ class AlgorithmTreeWidget(QTreeWidget):
 
     def mouseDoubleClickEvent(self, mouse_event):
         if mouse_event.button() == Qt.LeftButton:
-            if self.selectedItems() and not self.selectedItems()[0].child(0):
+            if self.selectedItems() and get_name_and_version_from_item_label(self.selectedItems()[0].text(0)):
                 self.parent.execute_algorithm()
-            super(AlgorithmTreeWidget, self).mouseDoubleClickEvent(mouse_event)
+            else:
+                super(AlgorithmTreeWidget, self).mouseDoubleClickEvent(mouse_event)
 
 
 class AlgorithmSelectorWidget(IAlgorithmSelectorView, QWidget):


### PR DESCRIPTION
**Description of work.**

Double click on any algorithm should execute it
This now checks that the name is parsable, rather than the absence of children,

**To test:**

1. Open Workbench
1. in the workspaces toolbox using the tree open DataHanlign->Text
1. Double click on LoadAscii v2
1. The algotithm dialog should appear
1. check you can still access LoadAscii v1 by clicking the arrow
1. check that other algorithms with only one version still work with a double click
1. check that you can still navigate the levels of the tree ok.

Fixes #27617
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
