### PR TITLE
Addition of tooltip to the workbench plot 1D validation

### DIFF
--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -171,6 +171,12 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         self._parse_wksp_indices()
         ui.wkspIndicesValid.setVisible(not self._is_input_valid())
+        if self._is_input_valid():
+            ui.wkspIndicesValid.setVisible(False)
+            ui.wkspIndicesValid.setToolTip("")
+        else:
+            ui.wkspIndicesValid.setVisible(True)
+            ui.wkspIndicesValid.setToolTip("Not in " + ui.wkspIndices.placeholderText())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
 
     def _on_specnums_changed(self):
@@ -180,6 +186,13 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         self._parse_spec_nums()
         ui.specNumsValid.setVisible(not self._is_input_valid())
+        if self._is_input_valid():
+            ui.specNumsValid.setVisible(False)
+            ui.specNumsValid.setToolTip("")
+        else:
+            ui.specNumsValid.setVisible(True)
+            ui.specNumsValid.setToolTip("Not in " + ui.specNums.placeholderText())
+        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
 
     def _on_plot_type_changed(self, new_index):

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -79,6 +79,8 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
         self._init_ui()
         self._set_placeholder_text()
         self._setup_connections()
+        self._on_specnums_changed()
+        self._on_wkspindices_changed()
 
     def on_ok_clicked(self):
         if self._check_number_of_plots(self.selection):
@@ -171,7 +173,7 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         self._parse_wksp_indices()
         ui.wkspIndicesValid.setVisible(not self._is_input_valid())
-        if self._is_input_valid():
+        if self._is_input_valid() or ui.wkspIndices.text() == "":
             ui.wkspIndicesValid.setVisible(False)
             ui.wkspIndicesValid.setToolTip("")
         else:
@@ -186,13 +188,12 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         self._parse_spec_nums()
         ui.specNumsValid.setVisible(not self._is_input_valid())
-        if self._is_input_valid():
+        if self._is_input_valid() or ui.specNums.text() == "":
             ui.specNumsValid.setVisible(False)
             ui.specNumsValid.setToolTip("")
         else:
             ui.specNumsValid.setVisible(True)
             ui.specNumsValid.setToolTip("Not in " + ui.specNums.placeholderText())
-        ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
         ui.buttonBox.button(QDialogButtonBox.Ok).setEnabled(self._is_input_valid())
 
     def _on_plot_type_changed(self, new_index):


### PR DESCRIPTION
**Description of work.**

Just adds a tooltip to the validation * in the plot 1D dialog of workbench

**Report to:** @DanielMurphy22 

**To test:**
1. open workbench
1. load a workspace e.g. MAR11060
1. Double click to get the plot 1D selection dialog
1. enter an invalid value
1. mouse over the * to get a tooltip

Fixes #27911


*This does not require release notes* because **it is minor and only found by the dev team**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
