### PR TITLE
Add new commands to ISISCommandInterface

### DIFF
--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -235,6 +235,22 @@ def SetMergeQRange(q_min=None, q_max=None):
     _printMessage('#Set merge range values')
 
 
+def SetDetectorMaskFiles(filenames):
+    assert isinstance(filenames, str),\
+        "Expected a command seperated list of filenames, got %r instead" % filenames
+    ReductionSingleton().settings["MaskFiles"] = filenames
+    _printMessage('#Set masking file names to {0}'.format(filenames))
+
+
+def SetMonDirect(correction_file):
+    if not ReductionSingleton().instrument:
+        raise RuntimeError("You must create an instrument object first")
+
+    ReductionSingleton().instrument.cur_detector().correction_file = correction_file
+    ReductionSingleton().instrument.other_detector().correction_file = correction_file
+    _printMessage('#Set MonDirect to {0}'.format(correction_file))
+
+
 def TransFit(mode, lambdamin=None, lambdamax=None, selector='BOTH'):
     """
         Sets the fit method to calculate the transmission fit and the wavelength range


### PR DESCRIPTION
**Description of work.**
Adds two new commands to the ISISCommandInterface (legacy) :
- SetMonDirect which sets the correction file
- SetDetectorMaskFile which sets the masking file (not detector masks)

These are not added to the release notes as the ISISCommandInterface is
deprecated. However, these calls are littered around some tube calib
scripts which are being prototyped.

On weighing up the balance, we will add them to make it easier to later
merge the calib scripts (#27386 ). Since similar functionality is difficult to get
at using the new command interface.

**Report to:** ISIS/Richard (Already emailed)

**To test:**
Run the following and check it doesn't throw:
```python
from ISISCommandInterface import *

SANS2D()
SetMonDirect("test.xml")
SetDetectorMaskFiles("test.xml")
```

Fixes #27663 . 

*This does not require release notes* because see PR description

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
