### PR TITLE
Eng Diff 2: Allow Focusing of Multiple Files

### DIFF
--- a/docs/source/interfaces/Engineering Diffraction 2.rst
+++ b/docs/source/interfaces/Engineering Diffraction 2.rst
@@ -100,15 +100,15 @@ Focus
 
 This tab allows for the focusing of data files by making use of the :ref:`EnggFocus<algm-EnggFocus>` algorithm.
 
-Files can be selected by providing a run number or selecting the files manually using the browse button.
+Files can be selected by providing run numbers or selecting the files manually using the browse button.
 
 In order to use the tab, a new or existing calibration must be created or loaded (see above).
 
 The interface allows for two kinds of focusing:
 
 - **Normal Focusing:**
-    A run number can be entered and both banks will be focused.
-    The output workspaces will have a suffix denoting which bank they are for.
+    Run numbers can be entered and both banks will be focused for each workspace.
+    The output workspaces will have a prefix for the run they are for and a suffix denoting which bank they are for.
 
 - **Cropped Focusing:**
     The entered workspace can be cropped to one of the two banks or to a user defined set of spectra.
@@ -118,7 +118,7 @@ Ticking the "Plot Focused Workspace" checkbox will create a plot of the focused 
 complete. The number of plots that are generated is dependent on the type of focusing done. Normal focusing generates
 a plot for each bank and cropped focusing generates a plot for the single bank or one for the chosen spectra.
 
-Clicking the focus button will begin the focusing algorithm for the selected run file. The button and plotting checkbox
+Clicking the focus button will begin the focusing algorithm for the selected run files. The button and plotting checkbox
 will be disabled until the fitting algorithm is complete.
 
 The focused output files are saved in NeXus, GSS, and raw XYE format to:
@@ -133,7 +133,7 @@ Parameters
 ^^^^^^^^^^
 
 Sample Run Number
-    The run number of or file path to the data file to be focused.
+    The run numbers of or file paths to the data files to be focused.
     
 Bank/Spectra
     Select which bank to restrict the focusing to or allow for the entry of custom spectra. 

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -896,6 +896,7 @@ public:
 
     QString getText();
     QString getFirstFilename() const;
+    QStringList getFilenames() const;
     void isForRunFiles(bool /*mode*/);
     void isForDirectory(bool /*mode*/);
     void allowMultipleFiles(bool /*allow*/);

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -136,7 +136,7 @@ class FocusModel(object):
             path_handling.get_output_path(), "Focus",
             self._generate_output_file_name(instrument, sample_path, bank, ".gss"))
         SaveGSS(InputWorkspace=sample_workspace, Filename=gss_output_path)
-        if rb_num is not None:
+        if rb_num:
             gss_output_path = path.join(
                 path_handling.get_output_path(), "User", rb_num, "Focus",
                 self._generate_output_file_name(instrument, sample_path, bank, ".gss"))
@@ -148,7 +148,7 @@ class FocusModel(object):
             path_handling.get_output_path(), "Focus",
             self._generate_output_file_name(instrument, sample_path, bank, ".nxs"))
         SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
-        if rb_num is not None:
+        if rb_num:
             nexus_output_path = path.join(
                 path_handling.get_output_path(), "User", rb_num, "Focus",
                 self._generate_output_file_name(instrument, sample_path, bank, ".nxs"))
@@ -160,7 +160,7 @@ class FocusModel(object):
             path_handling.get_output_path(), "Focus",
             self._generate_output_file_name(instrument, sample_path, bank, ".dat"))
         SaveFocusedXYE(InputWorkspace=sample_workspace, Filename=xye_output_path, SplitFiles=False)
-        if rb_num is not None:
+        if rb_num:
             xye_output_path = path.join(
                 path_handling.get_output_path(), "User", rb_num, "Focus",
                 self._generate_output_file_name(instrument, sample_path, bank, ".dat"))

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -14,6 +14,8 @@ from Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_widge
 from mantidqt.utils.asynchronous import AsyncTask
 from mantidqt.utils.observer_pattern import Observer
 
+from qtpy.QtWidgets import QMessageBox
+
 
 class FocusPresenter(object):
     def __init__(self, model, view):
@@ -41,7 +43,8 @@ class FocusPresenter(object):
             return
         banks, spectrum_numbers = self._get_banks()
         focus_paths = self.view.get_focus_filenames()
-        self.start_focus_worker(focus_paths, banks, self.view.get_plot_output(), self.rb_num, spectrum_numbers)
+        if self._number_of_files_warning(focus_paths):
+            self.start_focus_worker(focus_paths, banks, self.view.get_plot_output(), self.rb_num, spectrum_numbers)
 
     def start_focus_worker(self, focus_paths, banks, plot_output, rb_num, spectrum_numbers=None):
         """
@@ -93,6 +96,16 @@ class FocusPresenter(object):
             create_error_message(self.view, "Check cropping values are valid.")
             return False
         return True
+
+    def _number_of_files_warning(self, paths):
+        if len(paths) > 10:  # Just a guess on the warning for now. May change in future.
+            response = QMessageBox.warning(
+                self.view, 'Engineering Diffraction - Warning',
+                'You are attempting to focus {} workspaces. This may take some time.\n\n Would you like to continue?'
+                .format(len(paths)), QMessageBox.Ok | QMessageBox.Cancel)
+            return response == QMessageBox.Ok
+        else:
+            return True
 
     def _on_worker_error(self, _):
         self.emit_enable_button_signal()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -40,20 +40,20 @@ class FocusPresenter(object):
         if not self._validate():
             return
         banks, spectrum_numbers = self._get_banks()
-        focus_path = self.view.get_focus_filename()
-        self.start_focus_worker(focus_path, banks, self.view.get_plot_output(), self.rb_num, spectrum_numbers)
+        focus_paths = self.view.get_focus_filenames()
+        self.start_focus_worker(focus_paths, banks, self.view.get_plot_output(), self.rb_num, spectrum_numbers)
 
-    def start_focus_worker(self, focus_path, banks, plot_output, rb_num, spectrum_numbers=None):
+    def start_focus_worker(self, focus_paths, banks, plot_output, rb_num, spectrum_numbers=None):
         """
         Focus data in a separate thread to stop the main GUI from hanging.
-        :param focus_path: The path to the file containing the data to focus.
+        :param focus_paths: List of paths to the files containing the data to focus.
         :param banks: A list of banks that are to be focused.
         :param plot_output: True if the output should be plotted.
         :param rb_num: The RB Number from the main window (often an experiment id)
         :param spectrum_numbers: Optional parameter to crop to a specific list of spectrum numbers.
         """
         self.worker = AsyncTask(self.model.focus_run,
-                                (focus_path, banks, plot_output, self.instrument, rb_num, spectrum_numbers),
+                                (focus_paths, banks, plot_output, self.instrument, rb_num, spectrum_numbers),
                                 error_cb=self._on_worker_error,
                                 finished_cb=self.emit_enable_button_signal)
         self.set_focus_controls_enabled(False)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -41,11 +41,12 @@ class FocusModelTest(unittest.TestCase):
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", banks, False, "ENGINX", "0", None)
+        self.model.focus_run(["305761"], banks, False, "ENGINX", "0", None)
+
         self.assertEqual(len(banks), run_focus.call_count)
         run_focus.assert_called_with("mocked_sample",
-                                     model.FOCUSED_OUTPUT_WORKSPACE_NAME + banks[-1], "test_wsp",
-                                     "test_wsp", banks[-1], None)
+                                     "305761_" + model.FOCUSED_OUTPUT_WORKSPACE_NAME + banks[-1],
+                                     "test_wsp", "test_wsp", banks[-1], None)
 
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
@@ -56,11 +57,12 @@ class FocusModelTest(unittest.TestCase):
         spectra = "20-50"
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", None, False, "ENGINX", "0", spectra)
+        self.model.focus_run(["305761"], None, False, "ENGINX", "0", spectra)
+
         self.assertEqual(1, run_focus.call_count)
         run_focus.assert_called_with("mocked_sample",
-                                     model.FOCUSED_OUTPUT_WORKSPACE_NAME + "cropped", "test_wsp",
-                                     "test_wsp", None, None, spectra)
+                                     "305761_" + model.FOCUSED_OUTPUT_WORKSPACE_NAME + "cropped",
+                                     "test_wsp", "test_wsp", None, None, spectra)
 
     @patch(file_path + ".Ads")
     @patch(file_path + ".FocusModel._save_output")
@@ -75,7 +77,8 @@ class FocusModelTest(unittest.TestCase):
         banks = ["1", "2"]
         load_focus.return_value = "mocked_sample"
 
-        self.model.focus_run("305761", banks, True, "ENGINX", "0", None)
+        self.model.focus_run(["305761"], banks, True, "ENGINX", "0", None)
+
         self.assertEqual(1, plot_focus.call_count)
 
     @patch(file_path + ".Ads")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_presenter.py
@@ -30,7 +30,7 @@ class FocusPresenterTest(unittest.TestCase):
         self.presenter.current_calibration = CalibrationInfo(vanadium_path="Fake/Path",
                                                              sample_path="Fake/Path",
                                                              instrument="ENGINX")
-        self.view.get_focus_filename.return_value = "305738"
+        self.view.get_focus_filenames.return_value = "305738"
         self.presenter.cropping_widget.get_bank.return_value = "2"
         self.presenter.cropping_widget.is_custom.return_value = False
         self.view.get_plot_output.return_value = True
@@ -46,7 +46,7 @@ class FocusPresenterTest(unittest.TestCase):
         self.presenter.current_calibration = CalibrationInfo(vanadium_path="Fake/Path",
                                                              sample_path="Fake/Path",
                                                              instrument="ENGINX")
-        self.view.get_focus_filename.return_value = "305738"
+        self.view.get_focus_filenames.return_value = "305738"
         self.presenter.cropping_widget.get_custom_spectra.return_value = "2-45"
         self.view.get_plot_output.return_value = True
         self.view.is_searching.return_value = False

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/view.py
@@ -23,6 +23,7 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
 
         self.finder_focus.setLabelText("Sample Run #")
         self.finder_focus.setInstrumentOverride(instrument)
+        self.finder_focus.allowMultipleFiles(True)
 
     # =================
     # Slot Connectors
@@ -57,8 +58,8 @@ class FocusView(QtWidgets.QWidget, Ui_focus):
     # Component Getters
     # =================
 
-    def get_focus_filename(self):
-        return self.finder_focus.getFirstFilename()
+    def get_focus_filenames(self):
+        return self.finder_focus.getFilenames()
 
     def get_focus_valid(self):
         return self.finder_focus.isValid()


### PR DESCRIPTION
**Description of work.**
Allows the user to enter a range of run numbers to focus. 

**To test:**
1. Open the Engineering Diffraction 2 interface and load a calibration (S: 305738 V: 307521)
2. Switch to the Focus tab and enter a range of run numbers in various forms.
3. Check that the relevant workspaces and file have all been created.
4. Check that plots are arranged with the 2 banks of each run on the same plot if the Plot Focused Workspace checkbox is ticked. 

Fixes #27965

*This does not require release notes* because **the GUI has not been seen by users yet**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
