### PR TITLE
Fix BeamCentreFinder not running at all

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -128,6 +128,8 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
     axes = [MantidAxes.from_mpl_axes(ax, ignore_artists=[Legend]) if not isinstance(ax, MantidAxes) else ax
             for ax in axes]
 
+    assert axes, "No axes are associated with this plot"
+
     if tiled:
         ws_index = [(ws, index) for ws in workspaces for index in nums]
         for index, ax in enumerate(axes):
@@ -263,12 +265,20 @@ def get_plot_fig(overplot=None, ax_properties=None, window_title=None, axes_num=
     :return: Matplotlib fig and axes objects
     """
     import matplotlib.pyplot as plt
+
     if fig and overplot:
         fig = fig
     elif fig:
         fig, _, _, _ = create_subplots(axes_num, fig)
     elif overplot:
+        # The create subplot below assumes no figure was passed in, this is ensured by the elif above
+        # but add an assert which prevents a future refactoring from breaking this assumption
+        assert not fig
         fig = plt.gcf()
+        if not fig.axes:
+            plt.close(fig)
+            # The user is likely trying to overplot on a non-existent plot, create one for them
+            fig, _, _, _ = create_subplots(axes_num)
     else:
         fig, _, _, _ = create_subplots(axes_num)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -251,8 +251,9 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
     def _publish_to_ADS(self, sample_quartiles):
         output_workspaces = []
         for key in sample_quartiles:
-            output_workspaces.append(MaskingQuadrant.to_string(key))
-            AnalysisDataService.addOrReplace(MaskingQuadrant.to_string(key), sample_quartiles[key])
+            assert isinstance(key, MaskingQuadrant)
+            output_workspaces.append(key.value)
+            AnalysisDataService.addOrReplace(key.value, sample_quartiles[key])
 
         return output_workspaces
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -17,17 +17,14 @@ import matplotlib
 
 matplotlib.use('AGG')  # noqa
 import matplotlib.pyplot as plt
-import numpy as np
 
 # local imports
 # register mantid projection
-import mantid.plots  # noqa
 from mantid.api import AnalysisDataService, WorkspaceFactory
 from mantid.kernel import config
 from mantid.plots import MantidAxes
-from mantid.py3compat import mock
 from mantid.plots.plotfunctions import (figure_title,
-                                         manage_workspace_names, plot)
+                                        manage_workspace_names, plot)
 
 
 # Avoid importing the whole of mantid for a single mock of the workspace class
@@ -161,6 +158,13 @@ class FunctionsTest(unittest.TestCase):
         ax = plt.gca()
 
         self.assertFalse(ax.is_waterfall())
+
+    def test_overplotting_supports_first_time_plot(self):
+        # Note how we call overplot true first time round
+        starting_fig = plt.figure()
+        for _ in range(2):
+            plot([self._test_ws], wksp_indices=[1], overplot=True)
+        self.assertNotEqual(starting_fig, plt.figure(), "A new figure wasn't created")
 
     def test_overplotting_onto_waterfall_plot_maintains_waterfall(self):
         fig = plt.figure()

--- a/qt/python/mantidqt/plotting/test/test_tiledplots.py
+++ b/qt/python/mantidqt/plotting/test/test_tiledplots.py
@@ -97,10 +97,12 @@ class TiledPlotsTest(TestCase):
         initial_fig = plt.Figure()
         set_figure_as_current_figure(initial_fig)
 
+        # If not figure is provided we provide a user a new figure plot, since this allows
+        # overplotting in a loop, which requires there to be a figure with an associated axis
         fig, axes = get_plot_fig(overplot=True)
 
-        self.assertEqual(fig, initial_fig)
-        self.assertEqual(0, len(fig.axes))
+        self.assertNotEqual(fig, initial_fig)
+        self.assertNotEqual(0, len(fig.axes))
 
     def test_no_figure_provided_and_overplot_is_false_returns_new_figure_with_correct_axes_number(self):
         fig, axes = get_plot_fig(overplot=False, axes_num=5)

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -36,6 +36,8 @@ def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
     if not isinstance(output_workspaces, list):
         output_workspaces = [output_workspaces]
 
+    assert output_workspaces, "No workspaces were passed into plotting"
+
     plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
          plot_kwargs=plot_kwargs, window_title=title)
 


### PR DESCRIPTION
**Description of work.**

Fixes up two errors in the beam centre finder:

- The first is an erronous to_string which was introduced with the
conversion to Python enums in PR #27508
- The second is an error with plotting in workbench which has always
existed. A seperate issue is open, however we can work around it in the
mean time for safety.

**To test:**
On both Workbench and Mantid Plot:
- Download the ISIS Training Data
- Open the ISIS SANS GUI (not old)
- Click user file and browse to the `loqdemo` folder in ISIS Training Data
- Open `MaskFile.txt`
- Load `batch_mode_reduction.csv` into the Batch file
- Hit Load
- Click Beam Centre
- Hit Run
- Check it runs more than 1 iteration, don't worry if it fails to converge after 10 iteration

Fixes #27973 .

*This does not require release notes* because this was a regression introduced during development and has not been noticed by users (yet)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
