### PR TITLE
Fix normalisation when overplotting onto a plot with errors of distribution data

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -218,6 +218,7 @@ def errorbar(axes, workspace, *args, **kwargs):
     if kwargs.pop('update_axes_labels', True):
         _setLabels1D(axes, workspace, indices,
                      normalize_by_bin_width=normalize_by_bin_width, axis=axis)
+    kwargs.pop('normalize_by_bin_width', None)
 
     return axes.errorbar(x, y, dy, dx, *args, **kwargs)
 

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -657,11 +657,13 @@ class MantidAxes(Axes):
 
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
-            is_normalized, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
+            normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
+            is_normalized = normalize_by_bin_width or workspace.isDistribution()
 
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(workspace,
-                                                     axesfunctions.errorbar(self, *args, **kwargs),
+                                                     axesfunctions.errorbar(self, normalize_by_bin_width = is_normalized,
+                                                                            *args, **kwargs),
                                                      _data_update, spec_num, is_normalized,
                                                      MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
             return artist

--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -100,5 +100,6 @@ Bugfixes
 - MonitorLiveData now appears promptly in the algorithm details window, allowing live data sessions to be cancelled.
 - Figure options on bin plots open without throwing an error.
 - The help button in fitting now finds the relevant page.
+- Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 
 :ref:`Release 4.3.0 <v4.3.0>`


### PR DESCRIPTION
**Description of work.**
This PR sets a plot with errors to be treated as normalised if the workspace has the distribution flag set to true. This means when a curve is overplotted onto it, it will be normalised. 
This is the way it works for plots without errors.

**Report to:** Hamish

**To test:**
Contact me or @DanielMurphy22 for the data given by the user

Load a distribution and non distribution workspace.
Plot the distribution and the non-distribution together to produce the correct one.

Now do a plot of the distribution workspace.
Overplot the non-distribution workspace on top.
The non-distribution curve should be normalised (the same as when plotted together)

Plot the distribution workspace then open the figure options.
Change the Draw style to Steps and press ok (this replots it as an errorbar plot even if errors are hidden).
Overplot the non-distribution data and the data should be normalised .

Fixes #27970 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
