### PR TITLE
Fix normalisation of distribution workspace in fitting

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -101,6 +101,7 @@ Bugfixes
 - MonitorLiveData now appears promptly in the algorithm details window, allowing live data sessions to be cancelled.
 - Figure options on bin plots open without throwing an error.
 - The help button in fitting now finds the relevant page.
+- Fixed an issue where fitting a distribution workspace was normalised twice.
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -123,7 +123,8 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             if hasattr(workspace, 'isDistribution') and workspace.isDistribution():
                 ws_is_distribution = True
         ws_artist = self._get_selected_workspace_artist()
-        self.normaliseData(ws_artist.is_normalized and not ws_is_distribution)
+        should_normalise_before_fit = ws_artist.is_normalized and not ws_is_distribution
+        self.normaliseData(should_normalise_before_fit)
 
     def closeEvent(self, event):
         """

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -10,10 +10,11 @@ import unittest
 
 import matplotlib
 matplotlib.use('AGG')  # noqa
+from numpy import zeros
 
 from mantid.api import AnalysisDataService, WorkspaceFactory
 from mantid.py3compat.mock import MagicMock, Mock, patch
-from mantid.simpleapi import CreateSampleWorkspace
+from mantid.simpleapi import CreateSampleWorkspace, CreateWorkspace
 from mantidqt.plotting.functions import plot
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
@@ -32,8 +33,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
     def test_initialization_does_not_raise(self):
         assertRaisesNothing(self, self._create_widget)
 
-    @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData'
-           )
+    @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData')
     def test_normalise_data_set_on_fit_menu_shown(self, normaliseData_mock):
         for normalised in [True, False]:
             ws_artist_mock = Mock(is_normalized=normalised, workspace_index=0)
@@ -44,6 +44,14 @@ class FitPropertyBrowserTest(unittest.TestCase):
                     property_browser.getFitMenu().aboutToShow.emit()
             property_browser.normaliseData.assert_called_once_with(normalised)
             normaliseData_mock.reset_mock()
+
+    @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData')
+    def test_normalise_data_set_to_false_for_distribution_workspace(self, normaliseData_mock):
+        fig, canvas = self._create_and_plot_matrix_workspace('ws_name', distribution=True)
+        property_browser = self._create_widget(canvas=canvas)
+        with patch.object(property_browser, 'workspaceName', lambda: 'ws_name'):
+            property_browser.getFitMenu().aboutToShow.emit()
+        property_browser.normaliseData.assert_called_once_with(False)
 
     def test_plot_guess_plots_for_table_workspaces(self):
         table = WorkspaceFactory.createTable()
@@ -226,9 +234,9 @@ class FitPropertyBrowserTest(unittest.TestCase):
     def _create_widget(self, canvas=MagicMock(), toolbar_manager=Mock()):
         return FitPropertyBrowser(canvas, toolbar_manager)
 
-    def _create_and_plot_matrix_workspace(self, name = "workspace"):
-        ws = WorkspaceFactory.Instance().create("Workspace2D", NVectors=2, YLength=5, XLength=5)
-        AnalysisDataService.Instance().addOrReplace(name, ws)
+    def _create_and_plot_matrix_workspace(self, name = "workspace", distribution = False):
+        ws = CreateWorkspace(OutputWorkspace = name, DataX=zeros(10), DataY=zeros(10),
+                             NSpec=2, Distribution=distribution)
         fig = plot([ws], spectrum_nums=[1])
         canvas = fig.canvas
         return fig, canvas


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where in workbench, normalisation was being set to true in the fitting algorithm for distribution workspaces which caused it to be normalised twice. This meant the parameter workspace was incorrect.

**To test:**
Load a distribution workspace e.g. a workspace in `GEM63437_focussed` from the training course data
Add a Fit function (e.g. a linearbackground and an IkedaCarpenterPV peak)
Run the Fit.
Do the plot guess - the curve should be the same as the calc curve

Fixes #27937 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
