### PR TITLE
Make beam centre results comparible

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -128,6 +128,8 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
     axes = [MantidAxes.from_mpl_axes(ax, ignore_artists=[Legend]) if not isinstance(ax, MantidAxes) else ax
             for ax in axes]
 
+    assert axes, "No axes are associated with this plot"
+
     if tiled:
         ws_index = [(ws, index) for ws in workspaces for index in nums]
         for index, ax in enumerate(axes):
@@ -263,12 +265,20 @@ def get_plot_fig(overplot=None, ax_properties=None, window_title=None, axes_num=
     :return: Matplotlib fig and axes objects
     """
     import matplotlib.pyplot as plt
+
     if fig and overplot:
         fig = fig
     elif fig:
         fig, _, _, _ = create_subplots(axes_num, fig)
     elif overplot:
+        # The create subplot below assumes no figure was passed in, this is ensured by the elif above
+        # but add an assert which prevents a future refactoring from breaking this assumption
+        assert not fig
         fig = plt.gcf()
+        if not fig.axes:
+            plt.close(fig)
+            # The user is likely trying to overplot on a non-existent plot, create one for them
+            fig, _, _, _ = create_subplots(axes_num)
     else:
         fig, _, _, _ = create_subplots(axes_num)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -251,8 +251,9 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
     def _publish_to_ADS(self, sample_quartiles):
         output_workspaces = []
         for key in sample_quartiles:
-            output_workspaces.append(MaskingQuadrant.to_string(key))
-            AnalysisDataService.addOrReplace(MaskingQuadrant.to_string(key), sample_quartiles[key])
+            assert isinstance(key, MaskingQuadrant)
+            output_workspaces.append(key.value)
+            AnalysisDataService.addOrReplace(key.value, sample_quartiles[key])
 
         return output_workspaces
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -17,17 +17,14 @@ import matplotlib
 
 matplotlib.use('AGG')  # noqa
 import matplotlib.pyplot as plt
-import numpy as np
 
 # local imports
 # register mantid projection
-import mantid.plots  # noqa
 from mantid.api import AnalysisDataService, WorkspaceFactory
 from mantid.kernel import config
 from mantid.plots import MantidAxes
-from mantid.py3compat import mock
 from mantid.plots.plotfunctions import (figure_title,
-                                         manage_workspace_names, plot)
+                                        manage_workspace_names, plot)
 
 
 # Avoid importing the whole of mantid for a single mock of the workspace class
@@ -161,6 +158,13 @@ class FunctionsTest(unittest.TestCase):
         ax = plt.gca()
 
         self.assertFalse(ax.is_waterfall())
+
+    def test_overplotting_supports_first_time_plot(self):
+        # Note how we call overplot true first time round
+        starting_fig = plt.figure()
+        for _ in range(2):
+            plot([self._test_ws], wksp_indices=[1], overplot=True)
+        self.assertNotEqual(starting_fig, plt.figure(), "A new figure wasn't created")
 
     def test_overplotting_onto_waterfall_plot_maintains_waterfall(self):
         fig = plt.figure()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSBeamCentreFinderTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/sans/SANSBeamCentreFinderTest.py
@@ -1,0 +1,77 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from mantid.py3compat import mock
+from plugins.algorithms.WorkflowAlgorithms.SANS.SANSBeamCentreFinder import SANSBeamCentreFinder, _ResidualsDetails
+
+
+class SANSBeamCentreFinderTest(unittest.TestCase):
+    @staticmethod
+    def gen_mock_data(q_vals, y_vals):
+        assert len(q_vals) == len(y_vals)
+        mocked_quartile = mock.Mock()
+        mocked_quartile.readX.return_value = q_vals
+        mocked_quartile.readY.return_value = y_vals
+        return mocked_quartile
+
+    def test_points_calculates_correctly(self):
+        points_1 = [1.0, 2.0, 4.0]
+        points_2 = [1.0, 3.0, 5.0]
+
+        q1_data = self.gen_mock_data(points_1, [0., 0., 0.])
+        q2_data = self.gen_mock_data(points_2, [0., 0., 0.])
+
+        expected_points = len(set().union(points_1, points_2))
+        mismatched_points = len(set(points_1).symmetric_difference(set(points_2)))
+
+        obj = SANSBeamCentreFinder()
+        result = obj._calculate_residuals(q1_data, q2_data)
+        self.assertIsInstance(result, _ResidualsDetails)
+        self.assertEqual(mismatched_points, result.mismatched_points)
+        self.assertEqual(expected_points, result.num_points_considered)
+
+    def test_residual_diff_with_only_mismatched(self):
+        q1_data = self.gen_mock_data([1.0, 3.0], [0.0, 1.0])
+        q2_data = self.gen_mock_data([1.0, 2.0], [0.0, 1.0])
+
+        # Mismatched points should always contribute their entire val, not the diff (i.e. 1. above)
+        obj = SANSBeamCentreFinder()
+        result = obj._calculate_residuals(q1_data, q2_data)
+        self.assertEqual(2.0, result.total_residual)
+
+    def test_residual_diff_with_only_matched(self):
+        y_data_1 = [1.0, 10.0]
+        y_data_2 = [2.0, 10.0]
+        q1_data = self.gen_mock_data([1.0, 2.0], y_data_1)
+        q2_data = self.gen_mock_data([1.0, 2.0], y_data_2)
+
+        expected_matched = (y_data_1[0] - y_data_2[0]) ** 2
+
+        obj = SANSBeamCentreFinder()
+        result = obj._calculate_residuals(q1_data, q2_data)
+
+        self.assertEqual(expected_matched, result.total_residual)
+
+    def test_residual_diff_with_mixed_mismatched(self):
+        y_data_1 = [1.0, 10.0]
+        y_data_2 = [2.0, 10.0]
+        q1_data = self.gen_mock_data([1.0, 3.0], y_data_1)
+        q2_data = self.gen_mock_data([1.0, 2.0], y_data_2)
+
+        obj = SANSBeamCentreFinder()
+        result = obj._calculate_residuals(q1_data, q2_data)
+
+        # Matched bins contribute the diff ([0]) whilst mismatched ([1]) contribute all
+        expected_matched = (y_data_1[0] - y_data_2[0]) ** 2
+        expected_mismatched = (y_data_1[1] ** 2) + (y_data_2[1] ** 2)
+        squared_expected = expected_matched + expected_mismatched
+        self.assertEqual(squared_expected, result.total_residual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/release/v4.3.0/sans.rst
+++ b/docs/source/release/v4.3.0/sans.rst
@@ -42,5 +42,9 @@ Fixed
 - A zero monitor shift did not previously account for the position
   of the rear detector for Zoom. A 0.0mm offset now works correctly when
   processing data from the SANS GUI or command interface.
+- The Beam Centre Finder will now prints the average error in X, Y and the
+  number of points considered. This allows for direct comparisons of different
+  radius limits, which previously summed the difference across different
+  numbers of points.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/python/mantidqt/plotting/test/test_tiledplots.py
+++ b/qt/python/mantidqt/plotting/test/test_tiledplots.py
@@ -97,10 +97,12 @@ class TiledPlotsTest(TestCase):
         initial_fig = plt.Figure()
         set_figure_as_current_figure(initial_fig)
 
+        # If not figure is provided we provide a user a new figure plot, since this allows
+        # overplotting in a loop, which requires there to be a figure with an associated axis
         fig, axes = get_plot_fig(overplot=True)
 
-        self.assertEqual(fig, initial_fig)
-        self.assertEqual(0, len(fig.axes))
+        self.assertNotEqual(fig, initial_fig)
+        self.assertNotEqual(0, len(fig.axes))
 
     def test_no_figure_provided_and_overplot_is_false_returns_new_figure_with_correct_axes_number(self):
         fig, axes = get_plot_fig(overplot=False, axes_num=5)

--- a/qt/python/mantidqt/plotting/test/test_tiledplots.py
+++ b/qt/python/mantidqt/plotting/test/test_tiledplots.py
@@ -93,7 +93,7 @@ class TiledPlotsTest(TestCase):
         self.assertEqual(fig, initial_fig)
         self.assertEqual(6, len(fig.axes))
 
-    def test_get_plot_fig_with_no_figure_provided_and_overplot_is_true_returns_current_figure_unmodified(self):
+    def test_get_plot_fig_with_no_figure_provided_and_overplot_is_true_returns_new_figure(self):
         initial_fig = plt.Figure()
         set_figure_as_current_figure(initial_fig)
 

--- a/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
+++ b/scripts/SANS/sans/algorithm_detail/beamcentrefinder_plotting.py
@@ -36,6 +36,8 @@ def _plot_quartiles_matplotlib(output_workspaces, sample_scatter):
     if not isinstance(output_workspaces, list):
         output_workspaces = [output_workspaces]
 
+    assert output_workspaces, "No workspaces were passed into plotting"
+
     plot(output_workspaces, wksp_indices=[0], ax_properties=ax_properties, overplot=True,
          plot_kwargs=plot_kwargs, window_title=title)
 


### PR DESCRIPTION
**Description of work.**
    Change the SANS Beam Centre Finder to prints the average residual change
    between two quarters. This allows for direct comparisons, previously if
    a user increased the radius limit it would appear to perform worse,
    despite actually doing better. This was because the additional number of
    points was not accounted for.

I'd recommend you review the second commit, the first commit (the majority of the diff) split a method call out of PyExec

**Report to:** ISIS/Steve

**To test:**
- Download the ISIS Training Data
- Open the SANS GUI 
- Use `maskfile.txt` in the user file box
- Load `batch_mode_reduction` in the batch file box
- Hit load
- Switch to Beam Centre on the left
- Hit run, check the value are well formatted and readable


Fixes #27966 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
