### PR TITLE
Fixed CrystalField init bug if symm is cubic

### DIFF
--- a/docs/source/release/v4.3.0/direct_geometry.rst
+++ b/docs/source/release/v4.3.0/direct_geometry.rst
@@ -9,8 +9,19 @@ Direct Geometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+New
+###
+
 * New ``NOW4`` instrument definition for SNS
 
+Improvements
+############
+
 - For Panther and IN5 the :ref:`DirectILLReduction <algm-DirectILLReduction-v1>` will now correctly mask the non-overlapping bins before grouping the pixels onto Debye-Scherrer rings.
+
+BugFixes
+########
+
+- Fixed a bug in the :ref:`Crystal Field Python Interface` which prevented users from defining a cubic crystal field model.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -59,7 +59,7 @@ def cfpstrmaker(x, pref='B'):
 
 def getSymmAllowedParam(sym_str):
     if 'T' in sym_str or 'O' in sym_str:
-        return ['B40', 'B44', 'B60', 'B64']
+        return ['B40', 'B60']
     if any([sym_str == val for val in ['C1', 'Ci']]):
         return sum([cfpstrmaker(i) for i in range(7)] +
                    [cfpstrmaker(i, 'IB') for i in range(1, 7)],[])
@@ -214,10 +214,15 @@ class CrystalField(object):
             elif key not in free_parameters:
                 raise RuntimeError('Unknown attribute/parameters %s' % key)
 
+        # Cubic is a special case where B44=5*B40, B64=-21*B60
+        is_cubic = self.Symmetry.startswith('T') or self.Symmetry.startswith('O')
+        symm_allowed_par = getSymmAllowedParam(self.Symmetry)
+
         for param in CrystalField.field_parameter_names:
             if param in free_parameters:
                 self.function.setParameter(param, free_parameters[param])
-            symm_allowed_par = getSymmAllowedParam(self.Symmetry)
+            if is_cubic and (param == 'B44' or param == 'B64'):
+                continue
             if param not in symm_allowed_par:
                 self.function.fixParameter(param)
             else:


### PR DESCRIPTION
**Description of work.**

Fixes initialization error in the `CrystalField` class when a cubic symmetry is used.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run

```py
import CrystalField
cf = CrystalField.CrystalField('Er', Symmetry='Oh', Temperature=5, B40=0.1)
```

And check that no errors are raised. You can also use other cubic point symmetry such as `'Td'`, `'Th'`, `'T'` or `'O'`.

<!-- Instructions for testing. -->

Fixes #27931. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
