### PR TITLE
Indirect multidataset naming

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SRC_FILES
     src/Algorithms/PlotPeakByLogValueHelper.cpp
     src/Algorithms/QENSFitSequential.cpp
     src/Algorithms/QENSFitSimultaneous.cpp
+    src/Algorithms/QENSFitUtilities.cpp
     src/Algorithms/RefinePowderInstrumentParameters.cpp
     src/Algorithms/RefinePowderInstrumentParameters3.cpp
     src/Algorithms/SplineBackground.cpp
@@ -185,6 +186,7 @@ set(INC_FILES
     inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
     inc/MantidCurveFitting/Algorithms/QENSFitSequential.h
     inc/MantidCurveFitting/Algorithms/QENSFitSimultaneous.h
+    inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
     inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
     inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters3.h
     inc/MantidCurveFitting/Algorithms/SplineBackground.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSequential.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSequential.h
@@ -71,7 +71,7 @@ private:
                         std::vector<std::string> const &spectra,
                         std::string const &outputBaseName,
                         std::string const &endOfSuffix,
-                        std::vector<API::MatrixWorkspace_sptr> const &names);
+                        std::vector<std::string> const &names);
   void renameGroupWorkspace(std::string const &currentName,
                             std::vector<std::string> const &spectra,
                             std::string const &outputBaseName,

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSimultaneous.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSimultaneous.h
@@ -65,6 +65,13 @@ private:
                           const std::string &outputWsName) const;
 
   std::string getOutputBaseName() const;
+  std::vector<std::string> getWorkspaceNames() const;
+  std::vector<std::string> getWorkspaceIndices() const;
+  void renameWorkspaces(API::WorkspaceGroup_sptr outputGroup,
+                        std::vector<std::string> const &spectra,
+                        std::string const &outputBaseName,
+                        std::string const &endOfSuffix,
+                        std::vector<std::string> const &inputWorkspaceNames);
 };
 
 } // namespace Algorithms

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2015 ISIS Rutherford Appleton Laboratory UKRI,
+//     NScD Oak Ridge National Laboratory, European Spallation Source
+//     & Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#ifndef MANTID_ALGORITHMS_QENSFITUTILITIES_H_
+#define MANTID_ALGORITHMS_QENSFITUTILITIES_H_
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAPI/WorkspaceGroup.h"
+
+#include <functional>
+
+namespace Mantid {
+namespace API {
+
+void renameWorkspacesInQENSFit(
+    Algorithm *qensFit, IAlgorithm_sptr renameAlgorithm,
+    WorkspaceGroup_sptr outputGroup, std::string const &outputBaseName,
+    std::string const &groupSuffix,
+    std::function<std::string(std::size_t)> const &getNameSuffix);
+
+bool containsMultipleData(const std::vector<MatrixWorkspace_sptr> &workspaces);
+
+} // namespace API
+} // namespace Mantid
+#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
@@ -69,6 +69,7 @@ protected:
   /// Pointer to a domain creator
   boost::shared_ptr<API::IDomainCreator> m_domainCreator;
   std::vector<std::string> m_workspacePropertyNames;
+  std::vector<std::string> m_workspaceIndexPropertyNames;
 
   friend class API::IDomainCreator;
 };

--- a/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitSequential.cpp
@@ -155,17 +155,25 @@ std::string constructInputString(MatrixWorkspace_sptr workspace, int specMin,
   return input.str();
 }
 
-std::vector<MatrixWorkspace_sptr> extractWorkspaces(const std::string &input) {
-  std::vector<MatrixWorkspace_sptr> workspaces;
-
-  auto extractWorkspace = [&](const std::string &name) {
-    workspaces.emplace_back(getADSMatrixWorkspace(name));
-  };
-
+std::vector<std::string> extractWorkspaceNames(const std::string &input) {
+  std::vector<std::string> v;
   boost::regex reg("([^,;]+),");
   std::for_each(
       boost::sregex_token_iterator(input.begin(), input.end(), reg, 1),
-      boost::sregex_token_iterator(), extractWorkspace);
+      boost::sregex_token_iterator(),
+      [&v](const std::string &name) { v.emplace_back(name); });
+  return v;
+}
+
+std::vector<MatrixWorkspace_sptr> extractWorkspaces(const std::string &input) {
+  const auto workspaceNames = extractWorkspaceNames(input);
+
+  std::vector<MatrixWorkspace_sptr> workspaces;
+
+  for (const auto &wsName : workspaceNames) {
+    workspaces.emplace_back(getADSMatrixWorkspace(wsName));
+  }
+
   return workspaces;
 }
 
@@ -532,11 +540,13 @@ void QENSFitSequential::exec() {
   AnalysisDataService::Instance().addOrReplace(
       getPropertyValue("OutputWorkspace"), resultWs);
 
-  if (containsMultipleData(workspaces))
+  if (containsMultipleData(workspaces)) {
+    const auto inputString = getPropertyValue("Input");
     renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace",
-                     inputWorkspaces);
-  else
+                     extractWorkspaceNames(inputString));
+  } else {
     renameWorkspaces(groupWs, spectra, outputBaseName, "_Workspace");
+  }
 
   copyLogs(resultWs, workspaces);
 
@@ -691,10 +701,12 @@ QENSFitSequential::processParameterTable(ITableWorkspace_sptr parameterTable) {
 void QENSFitSequential::renameWorkspaces(
     WorkspaceGroup_sptr outputGroup, std::vector<std::string> const &spectra,
     std::string const &outputBaseName, std::string const &endOfSuffix,
-    std::vector<MatrixWorkspace_sptr> const &inputWorkspaces) {
+    std::vector<std::string> const &inputWorkspaceNames) {
   auto rename = createChildAlgorithm("RenameWorkspace", -1.0, -1.0, false);
   const auto getNameSuffix = [&](std::size_t i) {
-    return inputWorkspaces[i]->getName() + "_" + spectra[i] + endOfSuffix;
+    std::string workspaceName =
+        inputWorkspaceNames[i] + "_" + spectra[i] + endOfSuffix;
+    return workspaceName;
   };
   return renameWorkspacesInQENSFit(this, rename, outputGroup, outputBaseName,
                                    endOfSuffix + "s", getNameSuffix);
@@ -763,8 +775,10 @@ std::string QENSFitSequential::getInputString(
 
 std::vector<MatrixWorkspace_sptr> QENSFitSequential::getWorkspaces() const {
   const auto inputString = getPropertyValue("Input");
-  if (!inputString.empty())
-    return extractWorkspaces(inputString);
+  if (!inputString.empty()) {
+    auto workspaceList = extractWorkspaces(inputString);
+    return workspaceList;
+  }
   // The static_cast should not be necessary but it is required to avoid a
   // "internal compiler error: segmentation fault" when compiling with gcc
   // and std=c++1z

--- a/Framework/CurveFitting/src/Algorithms/QENSFitUtilities.cpp
+++ b/Framework/CurveFitting/src/Algorithms/QENSFitUtilities.cpp
@@ -1,0 +1,59 @@
+#include "MantidCurveFitting/Algorithms/QENSFitUtilities.h"
+#include <unordered_map>
+namespace Mantid {
+namespace API {
+
+void renameWorkspacesWith(
+    WorkspaceGroup_sptr groupWorkspace,
+    std::function<std::string(std::size_t)> const &getName,
+    std::function<void(Workspace_sptr, const std::string &)> const &renamer) {
+  std::unordered_map<std::string, std::size_t> nameCount;
+  for (auto i = 0u; i < groupWorkspace->size(); ++i) {
+    const auto name = getName(i);
+    auto count = nameCount.find(name);
+
+    if (count == nameCount.end()) {
+      renamer(groupWorkspace->getItem(i), name);
+      nameCount[name] = 1;
+    } else
+      renamer(groupWorkspace->getItem(i),
+              name + "(" + std::to_string(++count->second) + ")");
+  }
+}
+
+void renameWorkspace(IAlgorithm_sptr renamer, Workspace_sptr workspace,
+                     const std::string &newName) {
+  renamer->setProperty("InputWorkspace", workspace);
+  renamer->setProperty("OutputWorkspace", newName);
+  renamer->executeAsChildAlg();
+}
+
+bool containsMultipleData(const std::vector<MatrixWorkspace_sptr> &workspaces) {
+  const auto &first = workspaces.front();
+  return std::any_of(
+      workspaces.cbegin(), workspaces.cend(),
+      [&first](const auto &workspace) { return workspace != first; });
+}
+
+void renameWorkspacesInQENSFit(
+    Algorithm *qensFit, IAlgorithm_sptr renameAlgorithm,
+    WorkspaceGroup_sptr outputGroup, std::string const &outputBaseName,
+    std::string const &,
+    std::function<std::string(std::size_t)> const &getNameSuffix) {
+  Progress renamerProg(qensFit, 0.98, 1.0, outputGroup->size() + 1);
+  renamerProg.report("Renaming group workspaces...");
+
+  auto getName = [&](std::size_t i) {
+    std::string name = outputBaseName + "_" + getNameSuffix(i);
+    return name;
+  };
+
+  auto renamer = [&](Workspace_sptr workspace, const std::string &name) {
+    renameWorkspace(renameAlgorithm, workspace, name);
+    renamerProg.report("Renamed workspace in group.");
+  };
+  renameWorkspacesWith(outputGroup, getName, renamer);
+}
+
+} // namespace API
+} // namespace Mantid

--- a/Framework/CurveFitting/src/IFittingAlgorithm.cpp
+++ b/Framework/CurveFitting/src/IFittingAlgorithm.cpp
@@ -169,10 +169,15 @@ void IFittingAlgorithm::setFunction() {
   size_t ndom = m_function->getNumberDomains();
   if (ndom > 1) {
     m_workspacePropertyNames.resize(ndom);
+    m_workspaceIndexPropertyNames.resize(ndom);
     m_workspacePropertyNames[0] = "InputWorkspace";
+    m_workspaceIndexPropertyNames[0] = "WorkspaceIndex";
     for (size_t i = 1; i < ndom; ++i) {
       std::string workspacePropertyName = "InputWorkspace_" + std::to_string(i);
       m_workspacePropertyNames[i] = workspacePropertyName;
+      std::string workspaceIndexPropertyName =
+          "WorkspaceIndex_" + std::to_string(i);
+      m_workspaceIndexPropertyNames[i] = workspaceIndexPropertyName;
       if (!existsProperty(workspacePropertyName)) {
         declareProperty(
             std::make_unique<API::WorkspaceProperty<API::Workspace>>(
@@ -182,6 +187,7 @@ void IFittingAlgorithm::setFunction() {
     }
   } else {
     m_workspacePropertyNames.resize(1, "InputWorkspace");
+    m_workspaceIndexPropertyNames.resize(1, "WorkspaceIndex");
   }
 }
 
@@ -288,6 +294,7 @@ void IFittingAlgorithm::addWorkspaces() {
     creator->declareDatasetProperties("", true);
     m_domainCreator.reset(creator.release());
     m_workspacePropertyNames.clear();
+    m_workspaceIndexPropertyNames.clear();
   }
 }
 


### PR DESCRIPTION




**Description of work.**

In the indirect GUI the multidataset names do not contain the workspace names like they should. This PR fixes this so that now all the fitting tabs should have the dataset names correct.

**To test:**
  * Relevant data to test this issue can be found in [iqtFitData.zip](https://github.com/mantidproject/mantid/files/4231767/iqtFitData.zip), [ConvFitData.zip](https://github.com/mantidproject/mantid/files/4231771/ConvFitData.zip)
  * In the fitting tabs, IqtFit, and Conv try to run a multidataset fit.
  * Check that the names for the workspaces produced contain the name of the workspace which that spectrum came from.
  * Check that single dataset fits still produce sensible names.

<!-- Instructions for testing. -->

Re-Fixes #27284  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this fixes a regression introduced in this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
