### PR TITLE
 Fix deprecation warning: h5py calls from Abins

### DIFF
--- a/scripts/AbinsModules/IOmodule.py
+++ b/scripts/AbinsModules/IOmodule.py
@@ -355,7 +355,7 @@ class IOmodule(object):
 
         # noinspection PyUnresolvedReferences,PyProtectedMember
         if isinstance(hdf_group, h5py._hl.dataset.Dataset):
-            return hdf_group.value
+            return hdf_group[()]
         elif all([self._get_subgrp_name(hdf_group[el].name).isdigit() for el in hdf_group.keys()]):
             structured_dataset_list = []
             # here we make an assumption about keys which have a numeric values; we assume that always : 1, 2, 3... Max
@@ -383,7 +383,7 @@ class IOmodule(object):
         for key, item in hdf_file[path].items():
             # noinspection PyUnresolvedReferences,PyProtectedMember,PyProtectedMember
             if isinstance(item, h5py._hl.dataset.Dataset):
-                ans[key] = item.value
+                ans[key] = item[()]
             elif isinstance(item, h5py._hl.group.Group):
                 ans[key] = cls._recursively_load_dict_contents_from_group(hdf_file, path + key + '/')
         return ans


### PR DESCRIPTION
Closes #27972 

**Description of work.**
See issue #27972 for background.

h5py syntax now requires that values are access by indexing/slicing to encourage efficient access rather than copying large arrays. This is controversial as it now means that `x = dataset.value` should be replaced by more intimidating `x = dataset[()]` even when the value is not an array but, say, a single-character string or a scalar int. This operation is performed many times in Abins as part of the IOmodule routines, leading to a crowded and mystifying error log.

**To test:**
Run Abins as shown in the Issue (which includes a link to sample data).
The warning only manifests with recent versions of h5py, as included in the Nightly. To reproduce the problem in a development Docker image I needed to update h5py (using Pip with `--no-binary` to avoid compatibility issues with the installed hdf5 library).

`import h5py; print(h5py.version.info)` gives me
```
Summary of the h5py configuration
---------------------------------

h5py    2.10.0
HDF5    1.10.0
Python  3.6.7 (default, Oct 22 2018, 11:32:17) 
[GCC 8.2.0]
sys.platform    linux
sys.maxsize     9223372036854775807
numpy   1.18.1
```

Fixes #27972 

I don't think this requires release notes; it fixes a new problem that otherwise appears in the new release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
