### PR TITLE
Add prevention to prevent duplicate algorithms details in dialog

### DIFF
--- a/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
+++ b/qt/widgets/common/src/AlgorithmProgress/AlgorithmProgressDialogPresenter.cpp
@@ -47,9 +47,11 @@ void AlgorithmProgressDialogPresenter::algorithmStartedSlot(
   // original algorithm has already finished, before we got a shared pointer.
   // This ensures that the tracking only looks after an algorithm that has not
   // finished
-  if (algInstance) {
-    auto treeItem = m_view->addAlgorithm(algInstance);
-    m_progressBars.insert(std::make_pair(alg, treeItem));
+  if (m_progressBars.find(alg) == m_progressBars.end()) {
+    if (algInstance) {
+      auto treeItem = m_view->addAlgorithm(algInstance);
+      m_progressBars.insert(std::make_pair(alg, treeItem));
+    }
   }
 }
 /// This slot is triggered whenever an algorithm reports progress.


### PR DESCRIPTION
**Description of work.**
Just a simple don't add duplicates check


**To test:**
1 .open workbench
1. open the pause algorithm dialog box and select keep open
1. open the algorithm prograss details dialog
1. Run Pause (with keep open)
1. Let it complete
1. Run Pause again (with keep open)
1. still get one entry that runs normally to completion

Fixes #27985. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because it is minor and found by devs


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
