### PR TITLE
Fix import path in Muon GUI

### DIFF
--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
@@ -9,7 +9,7 @@ from __future__ import (absolute_import, division, print_function)
 from qtpy import QtWidgets
 import Muon.GUI.Common.message_box as message_box
 from matplotlib.figure import Figure
-from mantidqt.plotting.functions import get_plot_fig
+from mantid.plots.plotfunctions import get_plot_fig
 from matplotlib.backends.qt_compat import is_pyqt5
 from MultiPlotting.QuickEdit.quickEdit_widget import QuickEditWidget
 


### PR DESCRIPTION
**Description of work.**
In the `FrequencyDomainAnalysis` and `MuonAnalysis` GUI's one of the imports was wrong due to some refactoring changes causing the interfaces to crash when they were opened

**To test:**
Open `Interfaces`->`Muon`->`FrequencyDomainAnalysis`
It should open without crashing.
Similarly open  `Interfaces`->`Muon`->`MuonAnalysis`
It should also open without crashing

Fixes #27990 

*This does not require release notes* because **it was not broken in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
