### PR TITLE
Fix plotting/index.rst API call

### DIFF
--- a/docs/source/plotting/index.rst
+++ b/docs/source/plotting/index.rst
@@ -722,19 +722,19 @@ beginning of the run), but one can also plot absolute time using `FullTime=True`
 
 
 Note that the parasite axes in matplotlib do not accept the projection keyword.
-So one needs to use :func:`mantid.plots.plotfunctions.plot<mantid.plots.plotfunctions.plot>` instead.
+So one needs to use :func:`mantid.plots.axesfunctions.plot<mantid.plots.axesfunctions.plot>` instead.
 
 .. plot::
    :include-source:
 
    import matplotlib.pyplot as plt
-   from mantid import plots
+   import mantid.plots.axesfunctions as axesfuncs
    from mantid.simpleapi import Load
    w=Load('CNCS_7860')
    fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
    ax.plot(w,LogName='ChopperStatus5')
    axt=ax.twiny()
-   plots.axesfunctions.plot(axt,w,LogName='ChopperStatus5', FullTime=True)
+   axesfuncs.plot(axt,w,LogName='ChopperStatus5', FullTime=True)
    #fig.show()
 
 Complex plots

--- a/docs/source/plotting/index.rst
+++ b/docs/source/plotting/index.rst
@@ -734,7 +734,7 @@ So one needs to use :func:`mantid.plots.plotfunctions.plot<mantid.plots.plotfunc
    fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
    ax.plot(w,LogName='ChopperStatus5')
    axt=ax.twiny()
-   plots.plotfunctions.plot(axt,w,LogName='ChopperStatus5', FullTime=True)
+   plots.axesfunctions.plot(axt,w,LogName='ChopperStatus5', FullTime=True)
    #fig.show()
 
 Complex plots


### PR DESCRIPTION
**Description of work.**

Fixes an API call to plotfunctions.plot(..., LogName=""), to
axesfunctions.plot(..., LogName) which resolves the issue of the warning on master

**To test:**
- In your build folder remove your `docs/doctree` folder
- Build docs-html, check there is no warning building `plotting/index.rst`

Fixes: #27991 
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
