### PR TITLE
Fix error when removing constraints

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -215,7 +215,8 @@ protected:
   /// Check if a parameter property has a upper bound
   bool hasUpperBound(QtProperty *prop) const;
   /// Get a constraint string
-  QString getConstraint(const QString &paramName, const double &lowerBound = Mantid::EMPTY_DBL(),
+  QString getConstraint(const QString &paramName,
+                        const double &lowerBound = Mantid::EMPTY_DBL(),
                         const double &upperBound = Mantid::EMPTY_DBL()) const;
   /// Get a pair of function index (eg f0.f2.) and constraint expression given a
   /// parameter property

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionTreeView.h
@@ -10,6 +10,7 @@
 #include "DllOption.h"
 
 #include "MantidAPI/IFunction.h"
+#include "MantidKernel/EmptyValues.h"
 #include "MantidQtWidgets/Common/IFunctionView.h"
 
 #include <QMap>
@@ -214,8 +215,8 @@ protected:
   /// Check if a parameter property has a upper bound
   bool hasUpperBound(QtProperty *prop) const;
   /// Get a constraint string
-  QString getConstraint(const QString &paramName, const double &lowerBound,
-                        const double &upperBound) const;
+  QString getConstraint(const QString &paramName, const double &lowerBound = Mantid::EMPTY_DBL(),
+                        const double &upperBound = Mantid::EMPTY_DBL()) const;
   /// Get a pair of function index (eg f0.f2.) and constraint expression given a
   /// parameter property
   std::pair<QString, QString> getFunctionAndConstraint(QtProperty *prop) const;


### PR DESCRIPTION
**Description of work.**
This PR fixes the issue where if a constraint was removed from the gui or only one constraint was set, the empty constraint was set to a value near 0.

**To test:**
Open the Muon frequency domain analysis and load a run.
Go to the fitting tab, right-click on the function browser and add a function
Click on the Value box of one of the parameters and click the ... box that appears.
Click set then set constraint.
Enter a value for the constraint e.g. `0<Height<10` and press ok. You will see the set constraint in the `Role` column. Press ok.
Right-click on the lower bound and remove it.
Click on the ... button again and the constraint should be correct e.g. `Height<10`
Press `Fit` and this constraint should be used i.e. the height should be less than 10

Fixes #27997 

*This does not require release notes* because **it was not in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
