### PR TITLE
Fix import_qt Causing Failure of Packaged Nightly

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -31,7 +31,7 @@ from mantidqt.utils.asynchronous import AsyncTask, BlockingAsyncTaskWithCallback
 from mantidqt.utils.qt import import_qt
 
 # Core object to execute the code with optinal progress tracking
-CodeExecution = import_qt('..._common', 'mantidqt.widgets.codeeditor.execution', 'CodeExecution')
+CodeExecution = import_qt('..._common', 'mantidqt.widgets.codeeditor', 'CodeExecution')
 
 EMPTY_FILENAME_ID = '<string>'
 FILE_ATTR = '__file__'


### PR DESCRIPTION
**Description of work.**

Using the import_qt method with the file, rather than the directory, was
causing the a packaged version of mantid workbench not to launch.

This PR changes that path to the directory. 

**To test:**
1. Perform testing instructions from: #27986 using a **packaged** version of mantid. 


*This does not require release notes* because **the break was introduced in this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
