### PR TITLE
Fix docker link in getting started page

### DIFF
--- a/dev-docs/source/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted.rst
@@ -98,7 +98,7 @@ Docker
 ------
 
 On Docker supported systems you may use the `mantid-development
-<https://github.com/mantidproject/dockerfiles/tree/master/mantid-development>`_
+<https://github.com/mantidproject/dockerfiles/tree/master/development>`_
 images to develop Mantid without having to configure your system as a suitable
 build environment. This will give you an out of the box working build
 environment, including ParaView/VATES, Python 3 (where available) and ccache.


### PR DESCRIPTION
**Description of work.**
Fixes a broken link to the docker repository in the getting started page

**To test:**
- Build the development docs
- Go to the getting started page
- Under the docker section click the link and check it works

<!-- Instructions for testing. -->

Fixes #27757 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
