### PR TITLE
Fix Interface Opening Exceptions

### DIFF
--- a/scripts/DGSPlanner/InstrumentSetupWidget.py
+++ b/scripts/DGSPlanner/InstrumentSetupWidget.py
@@ -271,7 +271,6 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
         self.gonfig.text(1,0,-2.5,'X',zdir=None,color='black')
         self.gonfig.plot([0,0],[-3,-3],[-2,-0.5],zdir='y',color='black',linewidth=3)
         self.gonfig.text(0,-1,-2.5,'Beam',zdir=None,color='black')
-        self.gonfig.set_aspect('equal', adjustable='datalim')
         self.gonfig.view_init(10,45)
 
         colors=['b','g','r']

--- a/scripts/HFIR_4Circle_Reduction/PreprocessWindow.py
+++ b/scripts/HFIR_4Circle_Reduction/PreprocessWindow.py
@@ -7,10 +7,10 @@
 import os
 import time
 import csv
-import reduce4circleControl
-import guiutility as gui_util
-import HFIR_4Circle_Reduction.fourcircle_utility as fourcircle_utility
-import NTableWidget
+from HFIR_4Circle_Reduction import reduce4circleControl
+from HFIR_4Circle_Reduction import guiutility as gui_util
+from HFIR_4Circle_Reduction import fourcircle_utility as fourcircle_utility
+from HFIR_4Circle_Reduction import NTableWidget
 from qtpy.QtWidgets import (QFileDialog, QMainWindow)  # noqa
 from mantid.kernel import Logger
 try:


### PR DESCRIPTION
Testing for this PR should be done on *at least* windows and one other OS before being approved. 

**Description of work.**
 - Fixed imports in HFIR Diffraction GUI
- Removed `set_aspect` call on 3d plot which never worked properly on 3d plots and was removed from matplotlib 3.1 and was stopping the Direct DGS planner opening. 
- QECoverage didn't seem to require changes and may have been fixed by a previous PR. 
 
**To test:**
1. Check all interfaces open, particularly:
a. Diffraction -> HFIR 4Circle
b. Direct -> DGSPlanner
c. Utility -> QECoverage


Fixes #28050 

*This does not require release notes* because **it fixes issues not present in the previous release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
