### PR TITLE
Fix sans gui state bugs

### DIFF
--- a/scripts/SANS/sans/gui_logic/models/RowEntries.py
+++ b/scripts/SANS/sans/gui_logic/models/RowEntries.py
@@ -82,7 +82,11 @@ class RowEntries(_UserEntries):
 
     @sample_shape.setter
     def sample_shape(self, val):
-        if val is SampleShape:
+        if not val:
+            self._sample_shape = None
+            return
+
+        if isinstance(val, SampleShape):
             self._sample_shape = val
             return
 

--- a/scripts/SANS/sans/gui_logic/models/batch_process_runner.py
+++ b/scripts/SANS/sans/gui_logic/models/batch_process_runner.py
@@ -59,7 +59,11 @@ class BatchProcessRunner(QObject):
         for row, index in row_index_pair:
 
             # TODO update the get_states_func to support one per call
-            states, errors = get_states_func(row_entries=[row])
+            try:
+                states, errors = get_states_func(row_entries=[row])
+            except Exception as e:
+                self.row_failed_signal.emit(index, str(e))
+                continue
 
             assert len(states) + len(errors) == 1, \
                 "Expected 1 error to return got {0}".format(len(states) + len(errors))
@@ -85,7 +89,11 @@ class BatchProcessRunner(QObject):
 
     def _load_workspaces_on_thread(self, row_index_pair, get_states_func):
         for row, index in row_index_pair:
-            states, errors = get_states_func(row_entries=[row])
+            try:
+                states, errors = get_states_func(row_entries=[row])
+            except Exception as e:
+                self.row_failed_signal.emit(index, str(e))
+                continue
 
             for error in itervalues(errors):
                 self.row_failed_signal.emit(index, error)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -737,6 +737,7 @@ class RunTabPresenter(PresenterCommon):
 
         row_entry.state = RowState.PROCESSED
         row_entry.tool_tip = None
+        self.update_view_from_table_model()
 
     def increment_progress(self):
         self.progress += 1

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -631,6 +631,7 @@ class RunTabPresenter(PresenterCommon):
         row = self._table_model.get_row(row_index)
         row.state = RowState.ERROR
         row.tool_tip = error_msg
+        self.sans_logger.error(error_msg)
         self.update_view_from_table_model()
 
     def on_processing_finished(self, result):

--- a/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/run_tab_presenter_test.py
@@ -467,6 +467,7 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.assertEqual(RowState.PROCESSED, mocked_row.state)
         self.assertIsNone(mocked_row.tool_tip)
+        self.presenter.update_view_from_table_model.assert_called_with()
 
         mocked_row.options.set_developer_option.assert_called_with('MergeShift', 0.0)
 


### PR DESCRIPTION
**Description of work.**
Fixes several SANS data processor table bugs noticed by Adam

**To test:**
- Check processing multiple rows updates each row to processed as they finish
- Check that processing bad run numbers marks them as failed, sets the tooltip and attempts all rows in the GUI

Fixes #28066 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
