### PR TITLE
Fix crash when remove function and closing interface

### DIFF
--- a/docs/source/release/v4.3.0/mantidplot.rst
+++ b/docs/source/release/v4.3.0/mantidplot.rst
@@ -12,5 +12,6 @@ Bugfixes
 ########
 - The Show Instruments right click menu option is now disabled for workspaces that have had their spectrum axis converted to another axis using :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.  Once this axis has been converetd the workspace loses it's link between the data values and the detectors they were recorded on so we cannot display it in the instrument view.
 - Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
+- Fixed an issue where mantid crashed if you cleared the functions in the multi-dataset fitting interface
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/widgets/common/src/FitOptionsBrowser.cpp
+++ b/qt/widgets/common/src/FitOptionsBrowser.cpp
@@ -307,7 +307,9 @@ void FitOptionsBrowser::createSequentialFitProperties() {
   // Create LogValue property
   m_plotParameter = m_enumManager->addProperty("Plot parameter");
   {
-    m_propertyNameMap["PlotParameter"] = m_plotParameter;
+    addProperty("PlotParameter", m_plotParameter,
+                &FitOptionsBrowser::getStringEnumProperty,
+                &FitOptionsBrowser::setStringEnumProperty);
     m_sequentialProperties << m_plotParameter;
   }
 }

--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -184,9 +184,11 @@ void FunctionModel::setParameterTie(const QString &parName, QString tie) {
 
 QStringList FunctionModel::getParameterNames() const {
   QStringList names;
-  const auto paramNames = getCurrentFunction()->getParameterNames();
-  for (auto const name : paramNames) {
-    names << QString::fromStdString(name);
+  if (hasFunction()) {
+    const auto paramNames = getCurrentFunction()->getParameterNames();
+    for (auto const name : paramNames) {
+      names << QString::fromStdString(name);
+    }
   }
   return names;
 }
@@ -398,7 +400,7 @@ void FunctionModel::setGlobalParameters(const QStringList &globals) {
 
 QStringList FunctionModel::getLocalParameters() const {
   QStringList locals;
-  for (auto const name : getParameterNames()) {
+  for (auto const &name : getParameterNames()) {
     if (!m_globalParameterNames.contains(name))
       locals << name;
   }


### PR DESCRIPTION
**Description of work.**
This PR fixes the issue when if you add a function and then remove it in the multi dataset fitting gui it crashed mantid. It also fixes the issue where closing the interface caused a crash.

**To test:**
Open mantidplot (this interface is not in workbench yet)
Open `Interfaces`->`General`->`Multi dataset fitting`
Right-click on the left-hand box and add a function
Remove the function - mantid should not crash!
Close the interface - it should close successfully and not crash mantid

Fixes #28047 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
