### PR TITLE
Only show relevant facilities in some interface drop-down menus

### DIFF
--- a/docs/source/release/v4.3.0/diffraction.rst
+++ b/docs/source/release/v4.3.0/diffraction.rst
@@ -66,6 +66,8 @@ Powder Diffraction
 - A bug has been fixed that prevented lists being given for `q_lims` in polaris create_total_scattering_pdf while merging banks.
 - A bug has been fixed that caused SavePDF to fail when asked to save histogram data
 - A bug has been fixed that prevented lists being given for `q_lims` in polaris create_total_scattering_pdf while merging banks.
+- Bug fixed affecting Diffraction > Powder Diffraction Reduction interface - only facilities with applicable instruments can now be selected.
+
 
 Engineering Diffraction
 -----------------------

--- a/docs/source/release/v4.3.0/direct_geometry.rst
+++ b/docs/source/release/v4.3.0/direct_geometry.rst
@@ -23,5 +23,6 @@ BugFixes
 ########
 
 - Fixed a bug in the :ref:`Crystal Field Python Interface` which prevented users from defining a cubic crystal field model.
+- Bug fixed affecting Direct > DGS Reduction interface - only facilities with applicable instruments can now be selected.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/docs/source/release/v4.3.0/sans.rst
+++ b/docs/source/release/v4.3.0/sans.rst
@@ -46,5 +46,7 @@ Fixed
   number of points considered. This allows for direct comparisons of different
   radius limits, which previously summed the difference across different
   numbers of points.
+- Bug fixed affecting SANS > ORNL_SANS interface - only facilities with applicable instruments can now be selected.
+
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/Interface/reduction_application.py
+++ b/scripts/Interface/reduction_application.py
@@ -4,7 +4,7 @@
 #     NScD Oak Ridge National Laboratory, European Spallation Source
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 """
     Main window for reduction UIs
 """
@@ -39,6 +39,7 @@ STARTUP_WARNING = ""
 if CAN_REDUCE:
     try:
         import reduction  # noqa
+
         if os.path.splitext(os.path.basename(reduction.__file__))[0] == "reduction":
             home_dir = os.path.expanduser('~')
             if os.path.abspath(reduction.__file__).startswith(home_dir):
@@ -253,10 +254,10 @@ class ReductionGUI(QMainWindow):
             if fname != self._filename and QFile.exists(fname) and fname not in recent_files:
                 recent_files.append(fname)
 
-        if len(recent_files)>0:
+        if len(recent_files) > 0:
             self.file_menu.addSeparator()
             for i, fname in enumerate(recent_files):
-                action = QAction("&%d %s" % (i+1, QFileInfo(fname).fileName()), self)
+                action = QAction("&%d %s" % (i + 1, QFileInfo(fname).fileName()), self)
                 action.setData(fname)
                 action.triggered.connect(self.open_file)
                 self.file_menu.addAction(action)
@@ -283,6 +284,7 @@ class ReductionGUI(QMainWindow):
         """
             Invoke an instrument selection dialog
         """
+
         class InstrDialog(QDialog):
             def __init__(self, instrument_list=None):
                 QDialog.__init__(self)
@@ -290,7 +292,8 @@ class ReductionGUI(QMainWindow):
                 self.instrument_list = instrument_list
                 self.instr_combo.clear()
                 self.facility_combo.clear()
-                instruments = sorted(INSTRUMENT_DICT.keys())
+                instruments = sorted([fac for fac in INSTRUMENT_DICT.keys() if
+                                      any([inst in INSTRUMENT_DICT[fac] for inst in instrument_list])])
                 instruments.reverse()
                 for facility in instruments:
                     self.facility_combo.addItem(facility)
@@ -311,7 +314,7 @@ class ReductionGUI(QMainWindow):
         else:
             dialog = InstrDialog(self._instrument_list)
         dialog.exec_()
-        if dialog.result()==1:
+        if dialog.result() == 1:
             self._instrument = dialog.instr_combo.currentText()
             self._facility = dialog.facility_combo.currentText()
             self.setup_layout()
@@ -338,8 +341,8 @@ class ReductionGUI(QMainWindow):
         """
         if False:
             reply = QMessageBox.question(self, 'Message',
-                                               "Are you sure you want to quit this application?",
-                                               QMessageBox.Yes, QMessageBox.No)
+                                         "Are you sure you want to quit this application?",
+                                         QMessageBox.Yes, QMessageBox.No)
 
             if reply == QMessageBox.Yes:
                 event.accept()
@@ -427,7 +430,7 @@ class ReductionGUI(QMainWindow):
             found_instrument = self._interface.scripter.verify_instrument(file_path)
         except:
             msg = "The file you attempted to load doesn't have a recognized format:\n" \
-                  + file_path+"\n\n" \
+                  + file_path + "\n\n" \
                   + "Please make sure it has been produced by this application."
             QMessageBox.warning(self, "Error loading reduction parameter file", msg)
             print(sys.exc_info()[1])
@@ -453,7 +456,7 @@ class ReductionGUI(QMainWindow):
 
         if file_path in self._recent_files:
             self._recent_files.remove(file_path)
-        self._recent_files.insert(0,file_path)
+        self._recent_files.insert(0, file_path)
         while len(self._recent_files) > 10:
             self._recent_files.pop()
 
@@ -497,7 +500,7 @@ class ReductionGUI(QMainWindow):
                 self.statusBar().showMessage("Saved as %s" % self._filename)
                 self._set_window_title()
             except:
-                #TODO: put this in a log window, and in a file
+                # TODO: put this in a log window, and in a file
                 print(sys.exc_info()[1])
                 self.statusBar().showMessage("Failed to save %s" % self._filename)
 
@@ -524,7 +527,7 @@ class ReductionGUI(QMainWindow):
             fname += ".xml"
         if fname in self._recent_files:
             self._recent_files.remove(fname)
-        self._recent_files.insert(0,fname)
+        self._recent_files.insert(0, fname)
         while len(self._recent_files) > 10:
             self._recent_files.pop()
         self._last_directory = QFileInfo(fname).path()
@@ -558,7 +561,8 @@ class ReductionGUI(QMainWindow):
         else:
             self.statusBar().showMessage("Could not save file")
 
-#--------------------------------------------------------------------------------------------------------
+
+# --------------------------------------------------------------------------------------------------------
 
 
 def start():
@@ -570,6 +574,7 @@ def start():
     reducer.show()
     if not within_mantid:
         sys.exit(app.exec_())
+
 
 if __name__ == '__main__':
     start()

--- a/scripts/Interface/reduction_application.py
+++ b/scripts/Interface/reduction_application.py
@@ -292,13 +292,13 @@ class ReductionGUI(QMainWindow):
                 self.instrument_list = instrument_list
                 self.instr_combo.clear()
                 self.facility_combo.clear()
-                instruments = sorted([fac for fac in INSTRUMENT_DICT.keys() if
-                                      any([inst in INSTRUMENT_DICT[fac] for inst in instrument_list])])
-                instruments.reverse()
-                for facility in instruments:
+                facilities = sorted([fac for fac in INSTRUMENT_DICT.keys() if
+                                     any([inst in INSTRUMENT_DICT[fac] for inst in instrument_list])])
+                facilities.reverse()
+                for facility in facilities:
                     self.facility_combo.addItem(facility)
 
-                self._facility_changed(instruments[0])
+                self._facility_changed(facilities[0])
                 self.facility_combo.activated.connect(self._facility_changed)
 
             def _facility_changed(self, facility):


### PR DESCRIPTION
One line bug fix to show only the facilities which house the instruments for which the interface was designed. This affects the following interfaces:
- Diffraction > Powder Diffraction Reduction
- SANS > ORNL_SANS
- Direct > DGS Reduction

To Test
1. open workbench
2. Open each of the interfaces above (e.g.  Interfaces->Diffraction->Powder Diffraction Reduction)
If this is your first time opening the gui the dialog box should open, if not go to Tools->Change Instrument
3. Change the facilities in the drop-down menu - there should be no facilities with an empty instrument list
 
Fixes #28039