### PR TITLE
Fix hard crash when extra details selected in plot error reporter

### DIFF
--- a/scripts/ErrorReporter/errorreport.py
+++ b/scripts/ErrorReporter/errorreport.py
@@ -108,8 +108,8 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
 
     def check_placeholder_text(self):
         if not self.free_text_edited:
-            self.input_free_text.setPlainText("")
             self.free_text_edited = True
+            self.input_free_text.setPlainText("")
 
     def launch_privacy_policy(self, link):
         self.interface_manager.showWebPage(link)


### PR DESCRIPTION
**Description of work.**
For some reason mantid plot would recurse until segfaulting when the
text entry was selected when it crashed "softly".
Making the edited flag false before maming the edit seems to have
solved the issue.

**To test:**
1. Soft Crash mantid plot, this is one method:
 a. Load `Training_Exercise3a_SNS` from the training data.
 b. Attempt to run the `NormaliseToMonitor`algorithm.
 c. Mantid should soft crash.
2. Attempt to type into the additional information field. 
3. Send the report and check that the report was sent to the error-reports slack channel. 

Fixes #28073 

*This does not require release notes* because **the bug was introduced this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
