### PR TITLE
Sample Logs: Catch exception reading log values/metadata

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -608,7 +608,11 @@ def get_sample_log(workspace, **kwargs):
     if not run.hasProperty(LogName):
         raise ValueError('The workspace does not contain the {} sample log'.format(LogName))
     tsp = run[LogName]
-    units = tsp.units
+    try:
+        units = tsp.units
+    except UnicodeDecodeError as exc:
+        mantid.kernel.logger.warning("Error retrieving units for log {}: {}".format(LogName, str(exc)))
+        units = "unknown"
     if not isinstance(tsp, (mantid.kernel.FloatTimeSeriesProperty,
                             mantid.kernel.Int32TimeSeriesProperty,
                             mantid.kernel.Int64TimeSeriesProperty)):

--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -138,8 +138,8 @@ class WorkspaceWidget(PluginWidget):
             except Exception as exception:
                 logger.warning("Could not open sample logs for workspace '{}'."
                                "".format(ws.name()))
-                logger.debug("{}: {}".format(type(exception).__name__,
-                                             exception))
+                logger.warning("{}: {}".format(type(exception).__name__,
+                                               exception))
 
     def _do_slice_viewer(self, names):
         """


### PR DESCRIPTION
**Description of work.**

See commit for more detail.

**Report to:** Spencer @ ISIS

**To test:**

Use the file specified in the issue and try to display the a sample logs in workbench. If should now warn on 2 logs giving a unicode decoding error. 

Fixes #28074 

*This does not require release notes* because **it's a minor issue with string encodings**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
