### PR TITLE
Fix sans gui catching wrong exception

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -218,7 +218,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         iter_details = "Itr {:02d}: ({:7.3f}, {:7.3f})  SX={:<8.4f}\tSY={:<8.4f}\t Points: {:3d} (Unaligned: {:2d})" \
             .format(iteration, scaled_lr, scaled_tb,
                     avg_lr_residual, avg_tb_residual,
-                    lr_results.num_points_considered, lr_results.num_points_considered)
+                    lr_results.num_points_considered, lr_results.mismatched_points)
 
         self.logger.notice(iter_details)
 

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1660,7 +1660,7 @@ class SANSDataProcessorGui(QMainWindow,
         # Hedge for trying to read out
         try:
             return RangeStepType(q_1d_step_type_as_string)
-        except RuntimeError:
+        except ValueError:
             return None
 
     @q_1d_step_type.setter

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -631,7 +631,6 @@ class RunTabPresenter(PresenterCommon):
         row = self._table_model.get_row(row_index)
         row.state = RowState.ERROR
         row.tool_tip = error_msg
-        self.sans_logger.error(error_msg)
         self.update_view_from_table_model()
 
     def on_processing_finished(self, result):


### PR DESCRIPTION
**Description of work.**
Fixes an incorrectly caught exception for the SANS data processor GUI. This restores the original behaviour or returning None if we couldn't cast to an enum to represent Variable binning (I know....)

**To test:**
- Open the SANS GUI
- Open the LOQ mask file in the ISIS data set
- Open the batch file in the same folder
- Go to settings -> Q, Wavelength.... -> Q Limits
- In the Q1D row change the step type to `Variable`
- Change the Rebin String to `0.007,-0.05,0.255,0.0125,1.4`
- Go back to the main window and hit process all
- It should either succeed or fail with a missing file `DIRECT_LOQ_MAIN_143B.TXT` (which means we fixed the serialisation of the GUI which was failing)

Fixes #28097 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
