### PR TITLE
Also catch IndexError for numpy array access with bool

### DIFF
--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -195,7 +195,7 @@ class ColorbarWidget(QWidget):
                 try:
                     self.cmin_value = data[~data.mask].min()
                     self.cmax_value = data[~data.mask].max()
-                except AttributeError:
+                except (AttributeError, IndexError):
                     self.cmin_value = np.nanmin(data)
                     self.cmax_value = np.nanmax(data)
             except (ValueError, RuntimeWarning):


### PR DESCRIPTION
**Description of work.**

v1.12 of numpy (on Python 3 on RHEL) raises an IndexError of a scalar boolean is
given to access an array but this was reverted in later
versions. The behaviour should be essentially the same
as there is no mask so we add it to the existing exception
list.

**To test:**

See the original issue and test the file now works and looks the same as a colorfill plot.

Fixes #27994

*This does not require release notes* because **it was broken during the Python 3 move.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
