### PR TITLE
Fix unhandled exceptions in TOFConverter

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -105,5 +105,6 @@ Bugfixes
 - Fixed an issue where fitting a distribution workspace was normalised twice.
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.
+- Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -131,15 +131,9 @@ class MainWindow(QMainWindow):
 
             self.ui.convertedVal.clear()
             self.ui.convertedVal.insert(str(self.output))
-        except UnboundLocalError as ule:
-            QMessageBox.warning(self, "TofConverter", str(ule))
+        except (UnboundLocalError, ArithmeticError, ValueError, RuntimeError) as err:
+            QMessageBox.warning(self, "TofConverter", str(err))
             return
-        except ArithmeticError as ae:
-            QMessageBox.warning(self, "TofConverter", str(ae))
-            return
-        except ValueError as ve:
-            QMessageBox.warning(self, "TofConverter", str(ve))
-            return
-        except RuntimeError as re:
-            QMessageBox.warning(self, "TofConverter", str(re))
+        except Exception as exc:
+            Logger.error(exc)
             return

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -15,7 +15,6 @@ from mantidqt.gui_helper import show_interface_help
 import math
 import TofConverter.convertUnits
 
-
 try:
     from mantidqt.utils.qt import load_ui
 except ImportError:
@@ -29,24 +28,24 @@ class MainWindow(QMainWindow):
     needsFlightPathInputList = ['Time of flight (microseconds)']
     needsFlightPathOutputList = ['Time of flight (microseconds)']
 
-    def thetaEnable (self, enabled):
+    def thetaEnable(self, enabled):
         self.ui.scatteringAngleInput.setEnabled(enabled)
-        if  not enabled:
+        if not enabled:
             self.ui.scatteringAngleInput.clear()
 
-    def flightPathEnable (self, enabled):
+    def flightPathEnable(self, enabled):
         self.ui.totalFlightPathInput.setEnabled(enabled)
-        if  not enabled:
+        if not enabled:
             self.ui.totalFlightPathInput.clear()
 
-    def setInstrumentInputs (self):
+    def setInstrumentInputs(self):
         #disable both
         self.thetaEnable(False)
         self.flightPathEnable(False)
 
         #get the values of the two unit strings
-        inOption=self.ui.inputUnits.currentText()
-        outOption=self.ui.outputUnits.currentText()
+        inOption = self.ui.inputUnits.currentText()
+        outOption = self.ui.outputUnits.currentText()
 
         #for theta: enable if input or output unit requires it
         if inOption in self.needsThetaInputList:
@@ -63,7 +62,7 @@ class MainWindow(QMainWindow):
             self.flightPathEnable(True)
 
     def __init__(self, parent=None):
-        QMainWindow.__init__(self,parent)
+        QMainWindow.__init__(self, parent)
         self.ui = load_ui(__file__, 'converter.ui', baseinstance=self)
         self.ui.InputVal.setValidator(QDoubleValidator(self.ui.InputVal))
         self.ui.totalFlightPathInput.setValidator(QDoubleValidator(self.ui.totalFlightPathInput))
@@ -83,7 +82,7 @@ class MainWindow(QMainWindow):
         self.assistant_process = QtCore.QProcess(self)
         # pylint: disable=protected-access
         import mantid
-        self.mantidplot_name='TOF Converter'
+        self.mantidplot_name = 'TOF Converter'
         self.collection_file = os.path.join(mantid._bindir, '../docs/qthelp/MantidProject.qhc')
         version = ".".join(mantid.__version__.split(".")[:2])
         self.qt_url = 'qthelp://org.sphinx.mantidproject.' + version + '/doc/interfaces/TOF Converter.html'
@@ -92,16 +91,14 @@ class MainWindow(QMainWindow):
         try:
             import mantid
             #register startup
-            mantid.UsageService.registerFeatureUsage(mantid.kernel.FeatureType.Interface,"TofConverter",False)
+            mantid.UsageService.registerFeatureUsage(mantid.kernel.FeatureType.Interface,
+                                                     "TofConverter", False)
         except ImportError:
             pass
 
     def helpClicked(self):
-        show_interface_help(self.mantidplot_name,
-                            self.assistant_process,
-                            self.collection_file,
-                            self.qt_url,
-                            self.external_url)
+        show_interface_help(self.mantidplot_name, self.assistant_process, self.collection_file,
+                            self.qt_url, self.external_url)
 
     def closeEvent(self, event):
         self.assistant_process.close()
@@ -128,7 +125,9 @@ class MainWindow(QMainWindow):
             else:
                 self.Theta = -1.0
 
-            self.output = TofConverter.convertUnits.doConversion(self.ui.InputVal.text(), inOption, outOption, self.Theta, self.flightpath)
+            self.output = TofConverter.convertUnits.doConversion(self.ui.InputVal.text(), inOption,
+                                                                 outOption, self.Theta,
+                                                                 self.flightpath)
 
             self.ui.convertedVal.clear()
             self.ui.convertedVal.insert(str(self.output))

--- a/scripts/TofConverter/converterGUI.py
+++ b/scripts/TofConverter/converterGUI.py
@@ -119,12 +119,14 @@ class MainWindow(QMainWindow):
                 raise RuntimeError("Input value must be greater than 0 for conversion")
             inOption = self.ui.inputUnits.currentText()
             outOption = self.ui.outputUnits.currentText()
-            if self.ui.totalFlightPathInput.text() !='':
+            if self.ui.totalFlightPathInput.text():
                 self.flightpath = float(self.ui.totalFlightPathInput.text())
             else:
                 self.flightpath = -1.0
-            if self.ui.scatteringAngleInput.text() !='':
+            if self.ui.scatteringAngleInput.text():
                 self.Theta = float(self.ui.scatteringAngleInput.text()) * math.pi / 360.0
+            else:
+                self.Theta = -1.0
 
             self.output = TofConverter.convertUnits.doConversion(self.ui.InputVal.text(), inOption, outOption, self.Theta, self.flightpath)
 
@@ -135,6 +137,9 @@ class MainWindow(QMainWindow):
             return
         except ArithmeticError as ae:
             QMessageBox.warning(self, "TofConverter", str(ae))
+            return
+        except ValueError as ve:
+            QMessageBox.warning(self, "TofConverter", str(ve))
             return
         except RuntimeError as re:
             QMessageBox.warning(self, "TofConverter", str(re))


### PR DESCRIPTION
**Description of work.**
Stops unhandled exceptions from occurring when invalid characters (`. , + -`) were used in the input fields or were left blank. 

**To test:**
1. Utility -> TOFConverter
2. Set input units to d-spacing and output to TOF to open both input fields.
3. Try a range of values, including blank, negative, float, just a symbol, etc
4. No unhandled exceptions should occur. 

Fixes #28108 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
