### PR TITLE
Fixing Muon sequential TF asymmetry fits bug

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
+++ b/scripts/Muon/GUI/Common/fitting_tab_widget/fitting_tab_model.py
@@ -102,7 +102,7 @@ class FittingTabModel(object):
         self._handle_single_fit_results(parameter_dict['InputWorkspace'], function_object, fitting_parameters_table,
                                         output_workspace, covariance_matrix, plot_fit)
 
-        return function_object.clone(), output_status, output_chi_squared
+        return function_object, output_status, output_chi_squared
 
     def do_single_tf_fit(self, parameter_dict, plot_fit=True):
         alg = mantid.AlgorithmManager.create("CalculateMuonAsymmetry")
@@ -114,7 +114,7 @@ class FittingTabModel(object):
                                         fitting_parameters_table, output_workspace, covariance_matrix,
                                         plot_fit)
 
-        return function_object.clone(), output_status, output_chi_squared
+        return function_object, output_status, output_chi_squared
 
     def do_single_fit_and_return_workspace_parameters_and_fit_function(
             self, parameters_dict):
@@ -210,7 +210,6 @@ class FittingTabModel(object):
         output_chi_squared_list = []
 
         for i, input_workspace in enumerate(workspace_list):
-
             params = self.get_parameters_for_single_fit(input_workspace)
 
             if not use_initial_values and i >= 1:
@@ -220,8 +219,8 @@ class FittingTabModel(object):
 
             function_object, output_status, output_chi_squared = self.do_single_fit(params,
                                                                                     plot_fit)
-            function_object_list.append(function_object)
 
+            function_object_list.append(function_object)
             output_status_list.append(output_status)
             output_chi_squared_list.append(output_chi_squared)
 
@@ -245,7 +244,6 @@ class FittingTabModel(object):
                                                                                           self.global_parameters,
                                                                                           plot_fit)
             function_object_list.append(function_object)
-
             output_status_list.append(output_status)
             output_chi_squared_list.append(output_chi_squared)
 
@@ -261,14 +259,13 @@ class FittingTabModel(object):
 
             if not use_initial_values and i >= 1:
                 previous_values = self.get_fit_function_parameter_values(function_object_list[i - 1])
-                self.set_fit_function_parameter_values(params['Function'],
+                self.set_fit_function_parameter_values(params['InputFunction'],
                                                        previous_values)
 
             function_object, output_status, output_chi_squared = self.do_single_tf_fit(params,
                                                                                        plot_fit)
 
             function_object_list.append(function_object)
-
             output_status_list.append(output_status)
             output_chi_squared_list.append(output_chi_squared)
 
@@ -284,7 +281,7 @@ class FittingTabModel(object):
 
             if not use_initial_values and i >= 1:
                 previous_values = self.get_fit_function_parameter_values(function_object_list[i - 1])
-                self.set_fit_function_parameter_values(params['Function'],
+                self.set_fit_function_parameter_values(params['InputFunction'],
                                                        previous_values)
 
             function_object, output_status, output_chi_squared = self.do_simultaneous_tf_fit(params,
@@ -292,7 +289,6 @@ class FittingTabModel(object):
                                                                                              plot_fit)
 
             function_object_list.append(function_object)
-
             output_status_list.append(output_status)
             output_chi_squared_list.append(output_chi_squared)
 


### PR DESCRIPTION
Sequential TF asymmetry fits were broken due to a key error in the parameter dictionary, which only occurred if the parameters from a previous fit were carried forward. 

**Description of work.**
Changed the dictionary lookup so that it now searches for the correct key. Also removed two unnecessary function clones which slipped through. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Open Muon Analysis
2. Set the instrument MUSR
3. Load 62260
4. Go to fitting
5. Tick simultaneous
6. Add a GaussOsc function
7. Tick TF asymmetry mode
8. Go to the sequential fit tab
9. Click fit - **An error should no longer pop up**

<!-- Instructions for testing. -->

Fixes #28078. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
