### PR TITLE
Fix plotting in old Muon Analysis GUI

### DIFF
--- a/MantidPlot/src/PythonScript.cpp
+++ b/MantidPlot/src/PythonScript.cpp
@@ -389,11 +389,17 @@ void PythonScript::clearLocals() {
     PyObject *value = PyDict_GetItemString(localDict, "__file__");
     if (value)
       PyDict_SetItemString(cleanLocals, "__file__", value);
+
     // reset locals
     Py_DECREF(localDict);
     localDict = nullptr;
   }
   localDict = cleanLocals;
+  auto mod = PyImport_ImportModule("mantid.simpleapi");
+  PyObject_DelAttrString(mod, "plotSpectrum");
+  PyObject_DelAttrString(mod, "plotBin");
+  PyErr_Clear();
+  Py_DECREF(mod);
 }
 
 /**


### PR DESCRIPTION
The old Muon Anaylsis GUI could no longer plot data. The error was occurring as the old Muon GUI was calling the newly exposed version of plotSpectrum, rather than the old qtplotting version.

**Description of work.**
The old GUI now calls the intended version of the function

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Launch MantidPlot
2. Open the old Muon Analysis Interface
3. Load some data
4. **Should now be able to plot the data**

<!-- Instructions for testing. -->

Fixes #28080. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
