### PR TITLE
Trap further exceptions when attempting to iterate over processes

### DIFF
--- a/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
@@ -17,7 +17,7 @@ from glob import glob
 
 import psutil
 
-from mantid.kernel import ConfigService
+from mantid.kernel import ConfigService, logger
 from workbench.projectrecovery.projectrecoveryloader import ProjectRecoveryLoader
 from workbench.projectrecovery.projectrecoverysaver import ProjectRecoverySaver
 
@@ -217,10 +217,12 @@ class ProjectRecovery(object):
             pid_checkpoints = self.listdir_fullpath(self.recovery_directory_hostname)
             num_of_other_mantid_processes = self._number_of_other_workbench_processes()
             return len(pid_checkpoints) != 0 and len(pid_checkpoints) > num_of_other_mantid_processes
-        except Exception as e:
-            if isinstance(e, KeyboardInterrupt):
+        except Exception as exc:
+            if isinstance(exc, KeyboardInterrupt):
                 raise
-            # fail silently and return false
+
+            # log and return no recovery possible
+            logger.warning("Error checking if project can be recovered: {}".format(str(exc)))
             return False
 
     def _number_of_other_workbench_processes(self):
@@ -233,8 +235,8 @@ class ProjectRecovery(object):
             try:
                 if self._is_mantid_workbench_process(proc.cmdline()):
                     total_mantids += 1
-            except IndexError:
-                # Ignore these errors as it's checking the cmdline which causes this on process with no args
+            except Exception:
+                # if we can't access the process properties then we assume it is not a mantid process
                 pass
 
         # One of these will be the mantid process running the information


### PR DESCRIPTION
**Description of work.**

Accessing the cmdline on Windows for certain SYSTEM processes such
as the registry was causing a PermissionError. If we can't access
info about the process assume it is not mantid...


**To test:**

<!-- Instructions for testing. -->

Fixes #28075 

*This does not require release notes* because **it was broken by the psutil upgrade in moving to Python 3.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
