### PR TITLE
Fix crash in indirect analysis when a function is removed/changed

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -263,7 +263,8 @@ QString IndirectFitAnalysisTab::selectedFitType() const {
  */
 size_t IndirectFitAnalysisTab::numberOfCustomFunctions(
     const std::string &functionName) const {
-  if (auto fittingFunction = m_fittingModel->getFittingFunction())
+  auto fittingFunction = m_fittingModel->getFittingFunction();
+  if (fittingFunction->nFunctions() > 0)
     return getNumberOfSpecificFunctionContained(
         functionName, fittingFunction->getFunction(0).get());
   else


### PR DESCRIPTION
**Description of work.**
The check on whether a fitting function was present was obsolete, as the getFittingfunction always returned a MultiDomainFunction object regardless. This has now been changed to ensure there is a function defined within the MultiDomainFunction pointer.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open the indirect data analysis interface
Go to the I(Q,t) Fit tab
Tick Stretch Exponential
Untick it again
**Mantid should no longer crash**

Similarly if you click see full function
Right-click and add a function.
Remove the function
**Mantid should no longer crash**


<!-- Instructions for testing. -->

Fixes #28103. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
