### PR TITLE
Update PYTHONPATH for windows error reporter launch

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat
@@ -43,5 +43,8 @@ start "MantidPlot" /B /WAIT %_BIN_DIR%\MantidPlot.exe %*
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 if %errorlevel% NEQ 0 (
 set QT_API=pyqt4
+:: sip is now private inside PyQt4 folder but qtpy tries to "import sip" plain. Fixup the path so
+:: it can find the private sip.
+set PYTHONPATH=%_INSTALL_DIR%\bin\Lib\site-packages\PyQt4;%PYTHONPATH%
 python %_INSTALL_DIR%\scripts\ErrorReporter\error_dialog_app.py --exitcode=%errorlevel% --directory=%_BIN_DIR% --application=mantidplot
 )


### PR DESCRIPTION
**Description of work.**

As part of Python 3 migration `sip` got installed inside `PyQt4` on Windows. MantidPlot fixes up the Python path so this isn't an issue but the error reporter startup needs to do the same.

**To test:**

To test properly you will need to build a package. You could also just take the changes and modify and existing `launch_mantidplot.bat` in the currently nightly and see it works...

Fixes #28072 

*This does not require release notes* because **broken this dev cycle**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
