### PR TITLE
IndexProperty - Append bad index to out of range exception

### DIFF
--- a/Framework/API/src/IndexProperty.cpp
+++ b/Framework/API/src/IndexProperty.cpp
@@ -34,8 +34,9 @@ std::string IndexProperty::isValid() const {
     getIndices();
   } catch (std::runtime_error &e) {
     error = e.what();
-  } catch (std::out_of_range &) {
-    error = "Indices provided to IndexProperty are out of range.";
+  } catch (std::out_of_range &e) {
+    error = "Indices provided to IndexProperty are out of range: ";
+    error.append(e.what());
   } catch (std::logic_error &) {
     error = "Duplicate indices supplied to IndexProperty.";
   }

--- a/Framework/API/test/IndexPropertyTest.h
+++ b/Framework/API/test/IndexPropertyTest.h
@@ -132,8 +132,10 @@ public:
     auto error = indexProp.setValue("30:35");
 
     TS_ASSERT(
-        error.find("Indices provided to IndexProperty are out of range.") !=
+        error.find("Indices provided to IndexProperty are out of range") !=
         std::string::npos);
+
+    TS_ASSERT(error.find("following value") != std::string::npos);
   }
 
   void testIndexAccessWithOperator() {

--- a/Framework/Indexing/inc/MantidIndexing/IndexType.h
+++ b/Framework/Indexing/inc/MantidIndexing/IndexType.h
@@ -7,6 +7,7 @@
 #ifndef MANTID_INDEXING_INDEXTYPE_H_
 #define MANTID_INDEXING_INDEXTYPE_H_
 
+#include <string>
 #include <type_traits>
 
 namespace Mantid {
@@ -48,6 +49,7 @@ public:
   template <class T> bool operator<=(const T &other) const noexcept {
     return m_data <= IndexType(other).m_data;
   }
+  std::string str() const { return std::to_string(m_data); }
 
 private:
   Int m_data;


### PR DESCRIPTION
**Description of work.**
Previously, the at() access on the IndexProperty map would throw with an
invalid key message that didn't specify which key. This is useless for anyone who is using IndexProperty algorithms, such as MaskSpectra. 

With a range of specra (such as 500) you have to guess if the min / max or middle value(s) were bad.

Updates the IndexType to have a new method to convert to a string, this reduction in strict type safety could mean developers could abuse SpectrumIndex -> String conversions. However, it enables us to print a string representation of an index.

*I'm open to alternatives for ways to pack the value into an exception without exposing a string representation, however I personally can't think of one. So this is the best I can come up with.*

**Report to:** ISIS/Steve - Part of a larger issue I'm working on

**To test:**
- Run the following script
```
ws = CreateSampleWorkspace()
ws = MaskSpectra(ws, "SpectrumNumber", [900])
```
- Check it informs the user index 900 is incorrect

Fixes #28119 .

This does not require release notes because it's a small QOL fix not worth documenting

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
