### PR TITLE
Fix crash when adding some functions to multidataset fitting

### DIFF
--- a/Framework/CurveFitting/src/Functions/GaussianComptonProfile.cpp
+++ b/Framework/CurveFitting/src/Functions/GaussianComptonProfile.cpp
@@ -109,6 +109,9 @@ void GaussianComptonProfile::massProfile(double *result, const size_t nData,
 
   const auto &modq = modQ();
   const auto &ei = e0();
+  if (modq.empty() || ei.empty()) {
+    throw std::runtime_error("The Q values or e0 values have not been set");
+  }
   // Include e_i^0.1*mass/q pre-factor
   for (size_t j = 0; j < nData; ++j) {
     const double q = modq[j];

--- a/Framework/CurveFitting/src/Functions/GramCharlierComptonProfile.cpp
+++ b/Framework/CurveFitting/src/Functions/GramCharlierComptonProfile.cpp
@@ -322,6 +322,10 @@ void GramCharlierComptonProfile::addFSETerm(std::vector<double> &lhs) const {
   if (m_userFixedFSE)
     kfse *= getParameter("C_0");
 
+  if (m_yfine.empty() || m_qfine.empty()) {
+    throw std::runtime_error("The Y values or Q values have not been set");
+  }
+
   for (int j = 0; j < NFINE_Y; ++j) {
     const double y = m_yfine[j] / M_SQRT2 / wg;
     const double he3 = boost::math::hermite(3, y);

--- a/Framework/CurveFitting/src/Functions/MultivariateGaussianComptonProfile.cpp
+++ b/Framework/CurveFitting/src/Functions/MultivariateGaussianComptonProfile.cpp
@@ -134,6 +134,9 @@ void MultivariateGaussianComptonProfile::massProfile(
 
   const auto &yspace = ySpace();
   const auto &modq = modQ();
+  if (modq.empty() || yspace.empty()) {
+    throw std::runtime_error("Y values or Q values not set");
+  }
 
   for (size_t i = 0; i < nData; i++) {
     const double y(yspace[i]);

--- a/docs/source/release/v5.0.0/mantidplot.rst
+++ b/docs/source/release/v5.0.0/mantidplot.rst
@@ -12,6 +12,8 @@ Bugfixes
 ########
 - The Show Instruments right click menu option is now disabled for workspaces that have had their spectrum axis converted to another axis using :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis>`.  Once this axis has been converetd the workspace loses it's link between the data values and the detectors they were recorded on so we cannot display it in the instrument view.
 - Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
+- Fixed an issue where adding specific functions to the multi-dataset fitting interface caused it to crash
 - Fixed an issue where mantid crashed if you cleared the functions in the multi-dataset fitting interface
+
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/scientific_interfaces/MultiDatasetFit/MDFFunctionPlotData.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MDFFunctionPlotData.cpp
@@ -56,6 +56,7 @@ void MDFFunctionPlotData::setDomain(double startX, double endX, size_t nX) {
   Mantid::API::FunctionDomain1DVector x(startX, endX, nX);
   Mantid::API::FunctionValues y(x);
   try {
+    m_function.get()->setUpForFit();
     m_function->function(x, y);
   } catch (std::invalid_argument &) {
     // Do nothing.


### PR DESCRIPTION
**Description of work.**
This PR fixes a hard crash when adding any of the `compton profile` functions. 

**To test:**
Open Mantidplot
Go to `Interfaces` -> `General`->`Multi dataset fitting`
Right-click on the function box and `add function`
Add `ComptonPeakProfile`.
This should load the function and not crash mantid.

Do the same for the functions: `GaussianComptonProfile`, `GramCharlierComptonProfile`, `MultivariateGaussianComptonProfile` and  `VesuvioResolution `
 
Fixes #28055 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
