### PR TITLE
Fix bug with context menu for plots of MDHistoWorkspace

### DIFF
--- a/docs/source/release/v4.3.0/mantidworkbench.rst
+++ b/docs/source/release/v4.3.0/mantidworkbench.rst
@@ -106,5 +106,6 @@ Bugfixes
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.
 - Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
+- Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 
 :ref:`Release 4.3.0 <v4.3.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -708,7 +708,11 @@ class FigureInteraction(object):
         plotted_normalized = []
         axis = ax.creation_args[0].get('axis', None)
         for workspace_name, artists in ax.tracked_workspaces.items():
-            if axis != MantidAxType.BIN and not ads.retrieve(workspace_name).isDistribution() and ax.data_replaced:
+            if hasattr(ads.retrieve(workspace_name), "isDistribution"):
+                is_dist = ads.retrieve(workspace_name).isDistribution()
+            else:
+                is_dist = True
+            if axis != MantidAxType.BIN and not is_dist and ax.data_replaced:
                 plotted_normalized += [a.is_normalized for a in artists]
             else:
                 return False


### PR DESCRIPTION
This PR fixes a bug in in the mantid plotting in workbench where if a MDHistoWorkspace, or any workbench without an `isDistribution()` method, was plotted users would not be able to open the context menu as it would encounter an error when tying to work out if it is possible to normalize the plot.

**To test:**

1. Open workbench
2. Run this script to get the plot:
```
import matplotlib.pyplot as plt
from mantid import plots
from mantid.simpleapi import Load, ConvertToMD, BinMD, ConvertUnits, Rebin
from matplotlib.colors import LogNorm

# generate a nice 2D multi-dimensional workspace
data = Load('CNCS_7860')
data = ConvertUnits(InputWorkspace=data,Target='DeltaE', EMode='Direct', EFixed=3)
data = Rebin(InputWorkspace=data, Params='-3,0.025,3', PreserveEvents=False)
md = ConvertToMD(InputWorkspace=data,
                 QDimensions='|Q|',
                 dEAnalysisMode='Direct')
sqw = BinMD(InputWorkspace=md,
            AlignedDim0='|Q|,0,3,100',
            AlignedDim1='DeltaE,-3,3,100')

#2D plot
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c = ax.pcolormesh(sqw, norm=LogNorm())
cbar=fig.colorbar(c)
cbar.set_label('Intensity (arb. units)') #add text to colorbar
fig.show()
```
3. right click on the plot.
4. The context menu should open as expected without the option to normalise.

Fixes #28082

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
