### PR TITLE
Fix error when changing normalisation on single spectra plot from script

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -173,10 +173,11 @@ class MantidAxes(Axes):
             return None
         elif getattr(workspace, 'getNumberHistograms', lambda: -1)() == 1:
             # If the workspace has one histogram, just plot that
-            kwargs['wkspIndex'] = 0
             if MantidAxes.is_axis_of_type(MantidAxType.BIN, kwargs):
-                return kwargs['wkspIndex']
-            return MantidAxes.get_spec_num_from_wksp_index(workspace, kwargs['wkspIndex'])
+                kwargs['specNum'] = 0
+            else:
+                kwargs['specNum'] = MantidAxes.get_spec_num_from_wksp_index(workspace, 0)
+            return kwargs['specNum']
         else:
             return None
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plots__init__Test.py
@@ -481,6 +481,8 @@ class Plots__init__Test(unittest.TestCase):
         self.ax.plot(ws)
         ws_artist = self.ax.tracked_workspaces[ws_name][0]
         self.assertEqual(1, ws_artist.spec_num)
+        self.assertTrue('specNum' in self.ax.creation_args[0])
+        self.assertFalse('wkspIndex' in self.ax.creation_args[0])
 
     def test_that_plotting_ws_without_giving_spec_num_raises_if_ws_has_more_than_1_histogram(self):
         self.assertRaises(RuntimeError, self.ax.plot, self.ws2d_histo)

--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -102,6 +102,7 @@ Bugfixes
 - MonitorLiveData now appears promptly in the algorithm details window, allowing live data sessions to be cancelled.
 - Figure options on bin plots open without throwing an error.
 - The help button in fitting now finds the relevant page.
+- Fixed an issue with changing normalisation on single spectra plots done from a script
 - Fixed an issue where fitting a distribution workspace was normalised twice.
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.


### PR DESCRIPTION
**Description of work.**
This PR fixes the issue that a plot of a single spectra done from a script would vanish if changing the normalisation. This is due to the `specNum` and `wkspIndex` both being set when the plot is created.

**To test:**
Open workbench
Run the following: 
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# Create a workspace that has a Gaussian peak
x = np.arange(20)
y0 = 10.+50*np.exp(-(x-10)**2/20)
err=np.sqrt(y0)
y = 10.+50*np.exp(-(x-10)**2/20)
y += err*np.random.normal(size=len(err))
err = np.sqrt(y)
w = CreateWorkspace(DataX=x, DataY=y, DataE=err, NSpec=1, UnitX='DeltaE')

# Plot - note that the projection='mantid' keyword is passed to all axes
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot(w,) # plot the workspace with errorbars, using red squares
ax.legend() # show the legend
fig.show()
```
Right-click on the plot and change the normalisation.
It should normalise and the plot should not vanish

Fixes #28079 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
