### PR TITLE
Fix Beam Centre Only Working on LAB

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinder.py
@@ -215,7 +215,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
         avg_lr_residual = lr_results.total_residual / lr_results.num_points_considered
         avg_tb_residual = tb_results.total_residual / tb_results.num_points_considered
 
-        iter_details = "Itr {:02d}: ({:7.3f}, {:7.3f})  SX={:<8.4f}\tSY={:<8.4f}\t Points: {:3d} (Unaligned: {:2d})" \
+        iter_details = "Itr {:02d}: ({:7.3f}, {:7.3f})  SX={:.3e}  SY={:.3e}  Points: {:3d} (Unaligned: {:2d})" \
             .format(iteration, scaled_lr, scaled_tb,
                     avg_lr_residual, avg_tb_residual,
                     lr_results.num_points_considered, lr_results.mismatched_points)
@@ -360,8 +360,7 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
 
         return state
 
-    @staticmethod
-    def _calculate_residuals(quartile1, quartile2):
+    def _calculate_residuals(self, quartile1, quartile2):
         yvalsAX = quartile1.readY(0)
         yvalsBX = quartile2.readY(0)
         qvalsAX = quartile1.readX(0)
@@ -385,6 +384,8 @@ class SANSBeamCentreFinder(DataProcessorAlgorithm):
 
         for key in A_vals_dict and B_vals_dict:
             residue += pow(A_vals_dict[key] - B_vals_dict[key], 2)
+
+        self.logger.information("Beam Centre Diff: {0}".format(residue))
 
         return _ResidualsDetails(mismatched_points=mismatched_points, num_points_considered=len(A_vals_dict),
                                  total_residual=residue)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANS/SANSBeamCentreFinderCore.py
@@ -119,16 +119,14 @@ class SANSBeamCentreFinderCore(DataProcessorAlgorithm):
         state.mask.phi_max = -90.0
         state.mask.use_mask_phi_mirror = True
 
-        # Set compatibility mode
-        # state.compatibility.use_compatibility_mode = self.getProperty('CompatibilityMode').value
+        component_as_string = self.getProperty("Component").value
 
         # Set test centre
-        state.move.detectors[DetectorType.LAB.value].sample_centre_pos1 = \
+        state.move.detectors[component_as_string].sample_centre_pos1 = \
             self.getProperty("Centre1").value
-        state.move.detectors[DetectorType.LAB.value].sample_centre_pos2 = \
+        state.move.detectors[component_as_string].sample_centre_pos2 = \
             self.getProperty("Centre2").value
 
-        component_as_string = self.getProperty("Component").value
         progress = self._get_progress()
 
         # --------------------------------------------------------------------------------------------------------------

--- a/docs/source/release/v5.0.0/sans.rst
+++ b/docs/source/release/v5.0.0/sans.rst
@@ -31,7 +31,9 @@ Fixed
 - Tabbing between columns has been improved in the data GUI table. Users
   can now single tab between unmodified columns, or double tab for modified.
 - Saving a CSV with sample geometry enabled, then reloading works correctly.
-- Hitting Shift+Enter on the top row no longer causes an exception
+- Hitting Shift+Enter on the top row no longer causes an exception.
+- The beam centre finder correctly centres HAB and LAB banks, previously it
+  only worked for LAB.
 
 Changes
 #######

--- a/scripts/Interface/ui/sans_isis/beam_centre.py
+++ b/scripts/Interface/ui/sans_isis/beam_centre.py
@@ -112,20 +112,14 @@ class BeamCentre(QtWidgets.QWidget, Ui_BeamCentre):
         self.instrument = instrument
         component_list = get_detector_strings_for_gui(self.instrument)
         self.set_component_options(component_list)
-        self.lab_centre_label.setText('Centre Position {}'.format(component_list[0]))
-        self.update_lab_check_box.setText('Update {}'.format(component_list[0]))
         if len(component_list) < 2:
             self.hab_pos_1_line_edit.setEnabled(False)
             self.hab_pos_2_line_edit.setEnabled(False)
             self.update_hab_check_box.setEnabled(False)
-            self.hab_centre_label.setText('Centre Position HAB')
-            self.update_hab_check_box.setText('Update HAB')
         else:
             self.hab_pos_1_line_edit.setEnabled(True)
             self.hab_pos_2_line_edit.setEnabled(True)
             self.update_hab_check_box.setEnabled(True)
-            self.hab_centre_label.setText('Centre Position {}'.format(component_list[1]))
-            self.update_hab_check_box.setText('Update {}'.format(component_list[1]))
 
     # ------------------------------------------------------------------------------------------------------------------
     # Actions

--- a/scripts/Interface/ui/sans_isis/beam_centre.ui
+++ b/scripts/Interface/ui/sans_isis/beam_centre.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1015</width>
-    <height>709</height>
+    <height>750</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -68,14 +68,14 @@
          <item row="4" column="1">
           <widget class="QCheckBox" name="update_lab_check_box">
            <property name="text">
-            <string>Update LAB</string>
+            <string>Use LAB Centre in Reduction</string>
            </property>
           </widget>
          </item>
          <item row="5" column="1">
           <widget class="QCheckBox" name="update_hab_check_box">
            <property name="text">
-            <string>Update HAB</string>
+            <string>Use HAB Centre in Reduction</string>
            </property>
           </widget>
          </item>

--- a/scripts/SANS/sans/algorithm_detail/centre_finder_new.py
+++ b/scripts/SANS/sans/algorithm_detail/centre_finder_new.py
@@ -6,20 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 
-from sans.common.general_functions import create_managed_non_child_algorithm
-from sans.common.enums import (SANSDataType, FindDirectionEnum, DetectorType)
-from sans.algorithm_detail.batch_execution import (provide_loaded_data, get_reduction_packages)
 from mantid.simpleapi import CreateEmptyTableWorkspace
-
-
+from sans.algorithm_detail.batch_execution import (provide_loaded_data, get_reduction_packages)
+from sans.common.enums import (SANSDataType, DetectorType)
+from sans.common.general_functions import create_managed_non_child_algorithm
 # ----------------------------------------------------------------------------------------------------------------------
 # Functions for the execution of a single batch iteration
 # ----------------------------------------------------------------------------------------------------------------------
 from sans.state.Serializer import Serializer
 
 
-def centre_finder_new(state, r_min = 0.06, r_max = 0.26, iterations = 10, position_1_start = 0.0, position_2_start = 0.0
-                      , tolerance = 0.0001251, find_direction = FindDirectionEnum.ALL, verbose=False, component=DetectorType.LAB):
+def centre_finder_new(state, r_min, r_max, iterations, position_1_start, position_2_start,
+                      tolerance, find_direction, verbose, component):
     """
     Finds the beam centre from a good initial guess.
 

--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -27,8 +27,8 @@ class BeamCentrePresenter(object):
             super(BeamCentrePresenter.CentreFinderListener, self).__init__()
             self._presenter = presenter
 
-        def on_processing_finished(self, result):
-            self._presenter.on_processing_finished_centre_finder(result)
+        def on_processing_finished(self, _):
+            self._presenter.on_processing_finished_centre_finder()
 
         def on_processing_error(self, error):
             self._presenter.on_processing_error_centre_finder(error)
@@ -65,20 +65,14 @@ class BeamCentrePresenter(object):
     def on_update_rows(self):
         self._beam_centre_model.reset_inst_defaults(self._parent_presenter.instrument)
 
-    def on_processing_finished_centre_finder(self, result):
+    def on_processing_finished_centre_finder(self):
         # Enable button
         self._view.set_run_button_to_normal()
         # Update Centre Positions in model and GUI
-        if self._beam_centre_model.update_lab:
-            self._beam_centre_model.lab_pos_1 = result['pos1']
-            self._beam_centre_model.lab_pos_2 = result['pos2']
-            self._view.lab_pos_1 = self._beam_centre_model.lab_pos_1 * self._beam_centre_model.scale_1
-            self._view.lab_pos_2 = self._beam_centre_model.lab_pos_2 * self._beam_centre_model.scale_2
-        if self._beam_centre_model.update_hab:
-            self._beam_centre_model.hab_pos_1 = result['pos1']
-            self._beam_centre_model.hab_pos_2 = result['pos2']
-            self._view.hab_pos_1 = self._beam_centre_model.hab_pos_1 * self._beam_centre_model.scale_1
-            self._view.hab_pos_2 = self._beam_centre_model.hab_pos_2 * self._beam_centre_model.scale_2
+        self._view.lab_pos_1 = self._beam_centre_model.lab_pos_1 * self._beam_centre_model.scale_1
+        self._view.lab_pos_2 = self._beam_centre_model.lab_pos_2 * self._beam_centre_model.scale_2
+        self._view.hab_pos_1 = self._beam_centre_model.hab_pos_1 * self._beam_centre_model.scale_1
+        self._view.hab_pos_2 = self._beam_centre_model.hab_pos_2 * self._beam_centre_model.scale_2
 
     def on_processing_error_centre_finder(self, error):
         self._logger.warning("There has been an error. See more: {}".format(error))

--- a/scripts/test/SANS/gui_logic/beam_centre_model_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_model_test.py
@@ -66,13 +66,16 @@ class BeamCentreModelTest(unittest.TestCase):
     def test_that_find_beam_centre_calls_centre_finder_once_when_COM_is_False(self):
         state = mock.MagicMock()
 
+        starting_lab_positions = {"pos1": self.beam_centre_model.lab_pos_1,
+                                  "pos2": self.beam_centre_model.lab_pos_2}
+
         self.beam_centre_model.find_beam_centre(state)
 
         self.SANSCentreFinder.return_value.assert_called_once_with(state, r_min=self.beam_centre_model.r_min,
                                                                    r_max=self.beam_centre_model.r_max,
                                                                    max_iter=self.beam_centre_model.max_iterations,
-                                                                   x_start=self.beam_centre_model.lab_pos_1,
-                                                                   y_start=self.beam_centre_model.lab_pos_2,
+                                                                   x_start=starting_lab_positions["pos1"],
+                                                                   y_start=starting_lab_positions["pos2"],
                                                                    tolerance=self.beam_centre_model.tolerance,
                                                                    find_direction=FindDirectionEnum.ALL,
                                                                    reduction_method=True,
@@ -81,6 +84,9 @@ class BeamCentreModelTest(unittest.TestCase):
     def test_that_find_beam_centre_calls_centre_finder_twice_when_COM_is_TRUE(self):
         state = mock.MagicMock()
         self.beam_centre_model.COM = True
+
+        starting_lab_positions = {"pos1": self.beam_centre_model.lab_pos_1,
+                                  "pos2": self.beam_centre_model.lab_pos_2}
 
         self.beam_centre_model.find_beam_centre(state)
 
@@ -99,8 +105,8 @@ class BeamCentreModelTest(unittest.TestCase):
         self.SANSCentreFinder.return_value.assert_any_call(state, r_min=self.beam_centre_model.r_min,
                                                            r_max=self.beam_centre_model.r_max,
                                                            max_iter=self.beam_centre_model.max_iterations,
-                                                           x_start=self.beam_centre_model.lab_pos_1,
-                                                           y_start=self.beam_centre_model.lab_pos_2,
+                                                           x_start=starting_lab_positions["pos1"],
+                                                           y_start=starting_lab_positions["pos2"],
                                                            tolerance=self.beam_centre_model.tolerance,
                                                            find_direction=FindDirectionEnum.ALL,
                                                            reduction_method=False, component=DetectorType.LAB)

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -74,48 +74,26 @@ class BeamCentrePresenterTest(unittest.TestCase):
         self.presenter.on_update_instrument(SANSInstrument.LARMOR)
         self.view.on_update_instrument.assert_called_once_with(SANSInstrument.LARMOR)
 
-    def test_that_on_processing_finished_updates_view_and_model(self):
+    def test_that_on_processing_finished_updates_view(self):
         self.presenter.set_view(self.view)
-        result = {'pos1': 0.1, 'pos2': -0.1}
-        self.presenter._beam_centre_model.scale_1 = 1000
-        self.presenter._beam_centre_model.scale_2 = 1000
-        self.presenter._beam_centre_model.update_lab = True
-        self.presenter._beam_centre_model.update_hab = True
 
-        self.presenter.on_processing_finished_centre_finder(result)
-        self.assertEqual(result['pos1'], self.presenter._beam_centre_model.lab_pos_1)
-        self.assertEqual(result['pos2'], self.presenter._beam_centre_model.lab_pos_2)
-        self.assertEqual(self.view.lab_pos_1, self.presenter._beam_centre_model.scale_1*result['pos1'])
-        self.assertEqual(self.view.lab_pos_2, self.presenter._beam_centre_model.scale_2*result['pos2'])
-        self.assertEqual(result['pos1'], self.presenter._beam_centre_model.hab_pos_1)
-        self.assertEqual(result['pos2'], self.presenter._beam_centre_model.hab_pos_2)
-        self.assertEqual(self.view.hab_pos_1, self.presenter._beam_centre_model.scale_1 * result['pos1'])
-        self.assertEqual(self.view.hab_pos_2, self.presenter._beam_centre_model.scale_2 * result['pos2'])
+        self.BeamCentreModel.lab_pos_1 = 1
+        self.BeamCentreModel.lab_pos_2 = 2
+        self.BeamCentreModel.hab_pos_1 = 3
+        self.BeamCentreModel.hab_pos_2 = 4
+
+        scale_1 = 1000
+        scale_2 = 2000
+        self.BeamCentreModel.scale_1 = scale_1
+        self.BeamCentreModel.scale_2 = scale_2
+
+        self.presenter.on_processing_finished_centre_finder()
+        self.assertEqual(self.BeamCentreModel.lab_pos_1 * scale_1, self.view.lab_pos_1)
+        self.assertEqual(self.BeamCentreModel.lab_pos_2 * scale_2, self.view.lab_pos_2)
+
+        self.assertEqual(self.BeamCentreModel.hab_pos_1 * scale_1, self.view.hab_pos_1)
+        self.assertEqual(self.BeamCentreModel.hab_pos_2 * scale_2, self.view.hab_pos_2)
         self.view.set_run_button_to_normal.assert_called_once_with()
-
-    def test_that_on_processing_finished_updates_does_not_update_view_and_model_when_update_disabled(self):
-        self.presenter.set_view(self.view)
-        result = {'pos1': 0.1, 'pos2': -0.1}
-        result_1 = {'pos1': 0.2, 'pos2': -0.2}
-        self.presenter._beam_centre_model.scale_1 = 1000
-        self.presenter._beam_centre_model.scale_2 = 1000
-        self.presenter._beam_centre_model.update_lab = True
-        self.presenter._beam_centre_model.update_hab = True
-        self.presenter.on_processing_finished_centre_finder(result)
-        self.presenter._beam_centre_model.update_lab = False
-        self.presenter._beam_centre_model.update_hab = False
-
-        self.presenter.on_processing_finished_centre_finder(result_1)
-
-        self.assertEqual(result['pos1'], self.presenter._beam_centre_model.lab_pos_1)
-        self.assertEqual(result['pos2'], self.presenter._beam_centre_model.lab_pos_2)
-        self.assertEqual(self.view.lab_pos_1, self.presenter._beam_centre_model.scale_1*result['pos1'])
-        self.assertEqual(self.view.lab_pos_2, self.presenter._beam_centre_model.scale_2*result['pos2'])
-        self.assertEqual(result['pos1'], self.presenter._beam_centre_model.hab_pos_1)
-        self.assertEqual(result['pos2'], self.presenter._beam_centre_model.hab_pos_2)
-        self.assertEqual(self.view.hab_pos_1, self.presenter._beam_centre_model.scale_1 * result['pos1'])
-        self.assertEqual(self.view.hab_pos_2, self.presenter._beam_centre_model.scale_2 * result['pos2'])
-        self.assertEqual(self.view.set_run_button_to_normal.call_count, 2)
 
     def test_that_update_hab_selected_enabled_hab_and_disabled_lab(self):
         self.presenter.set_view(self.view)


### PR DESCRIPTION
**Description of work.**
Fixes the BeamCentreFinder only working on Low Angle Banks. Additionally clarifies in the UI what various tick boxes do.

**Report to:** ISIS/Steve

**To test:**
- Download the ISIS Training Data
- Open the SANS GUI 
- Load the userfile `Maskfile.txt` in the `loqdemo` folder 
- Load the batch file in the `loqdemo` folder
- Hit load
- Switch to beam centre
- Take a quick note of the centres for the HAB and LAB, they should be the same
- Hit run, after it finises only the LAB value should be updated
- Change the bank to HAB, hit run again
- Check the LAB value hasn't changed, but the HAB value has
- Do the checkbox descriptions ("Update...") make sense to you?


Fixes #28122 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
