### PR TITLE
Prevent notifications for the same message within the same 5 seconds

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/NotificationService.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/NotificationService.h
@@ -11,6 +11,15 @@
 #include <QObject>
 #include <QSystemTrayIcon>
 
+// namespace Mantid
+namespace Mantid {
+namespace Kernel {
+// forward declaration
+class Timer;
+}
+} // namespace Mantid
+
+
 /** The base class from which mantid custom widgets are derived contains
  *  some useful functions
  */
@@ -33,15 +42,22 @@ public:
   /// Display a notification
   static void showMessage(const QString &title, const QString &message,
                           MessageIcon icon = MessageIcon::Information,
-                          int millisecondsTimeoutHint = 10000);
+                          int millisecondsTimeoutHint = 5000);
 
   /// Is the notification service enabled through the config service?
   static bool isEnabled();
 
   static const std::string NOTIFICATIONS_ENABLED_KEY;
+  static const float MIN_SECONDS_BETWEEN_IDENTICAL_NOTIFICATIONS;
+
 
   /// Are notifications supported by this OS?
   static bool isSupportedByOS();
+
+private:
+  static QString g_lastMessage;
+  static QString g_lastTitle;
+  static Mantid::Kernel::Timer g_timer;
 };
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/NotificationService.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/NotificationService.h
@@ -16,9 +16,8 @@ namespace Mantid {
 namespace Kernel {
 // forward declaration
 class Timer;
-}
+} // namespace Kernel
 } // namespace Mantid
-
 
 /** The base class from which mantid custom widgets are derived contains
  *  some useful functions
@@ -49,7 +48,6 @@ public:
 
   static const std::string NOTIFICATIONS_ENABLED_KEY;
   static const float MIN_SECONDS_BETWEEN_IDENTICAL_NOTIFICATIONS;
-
 
   /// Are notifications supported by this OS?
   static bool isSupportedByOS();

--- a/qt/widgets/common/src/NotificationService.cpp
+++ b/qt/widgets/common/src/NotificationService.cpp
@@ -7,38 +7,56 @@
 #include "MantidQtWidgets/Common/NotificationService.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Exception.h"
+#include "MantidKernel/Timer.h"
 #include <QApplication>
 
 namespace MantidQt {
 namespace MantidWidgets {
 
-// Key for the "normalize data to bin width" plot option
+// Key for the "Notifications.Enabled" option
 const std::string NotificationService::NOTIFICATIONS_ENABLED_KEY =
     "Notifications.Enabled";
+// Minimum number os seconds between identical warnings
+const float NotificationService::MIN_SECONDS_BETWEEN_IDENTICAL_NOTIFICATIONS =
+    5.0;
+
+// setup static variables
+QString NotificationService::g_lastMessage = "";
+QString NotificationService::g_lastTitle = "";
+Mantid::Kernel::Timer NotificationService::g_timer;
 
 void NotificationService::showMessage(const QString &title,
                                       const QString &message, MessageIcon icon,
                                       int millisecondsTimeoutHint) {
   if (isEnabled() && isSupportedByOS()) {
-    QSystemTrayIcon sysTrayIcon(qApp);
-    // get the window icon for the app
-    QIcon windowIcon = qApp->windowIcon();
-    // if no icon is set then use the mantid icon
-    if (windowIcon.isNull()) {
-      try {
-        windowIcon = QIcon(":/images/MantidIcon.ico");
-      } catch (const std::exception &) {
-        // if we cannot use the embedded icon, use a blank one
-        windowIcon = QIcon(QPixmap(32, 32));
+    if ((g_lastMessage != message) || (g_lastTitle != title) ||
+        (g_timer.elapsed_no_reset() >
+         MIN_SECONDS_BETWEEN_IDENTICAL_NOTIFICATIONS)) {
+      // remeber the last message details
+      g_lastMessage = message;
+      g_lastTitle = title;
+      g_timer.reset();
+
+      QSystemTrayIcon sysTrayIcon(qApp);
+      // get the window icon for the app
+      QIcon windowIcon = qApp->windowIcon();
+      // if no icon is set then use the mantid icon
+      if (windowIcon.isNull()) {
+        try {
+          windowIcon = QIcon(":/images/MantidIcon.ico");
+        } catch (const std::exception &) {
+          // if we cannot use the embedded icon, use a blank one
+          windowIcon = QIcon(QPixmap(32, 32));
+        }
       }
+      // set this as the window icon otherwise you get a warning on the console
+      sysTrayIcon.setIcon(windowIcon);
+
+      sysTrayIcon.show();
+      sysTrayIcon.showMessage(title, message, icon, millisecondsTimeoutHint);
+
+      sysTrayIcon.hide();
     }
-    // set this as the window icon otherwise you get a warning on the console
-    sysTrayIcon.setIcon(windowIcon);
-
-    sysTrayIcon.show();
-    sysTrayIcon.showMessage(title, message, icon, millisecondsTimeoutHint);
-
-    sysTrayIcon.hide();
   }
 }
 


### PR DESCRIPTION
**Description of work.**
see title

**To test:**

1. run this in workbench, you should only see one notification, and not 30.  If you increase the number you should only get one every 5 sec or so.
``` python
for i in range(30):
    Pause(0.1)
    Segfault(DryRun=True)
```

Fixes #28126

<!-- delete this if you added release notes
*This does not require release notes* because **notifications were added in this release**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
