### PR TITLE
Fix crash when adding a user function to the multi dataset fitting gui

### DIFF
--- a/Framework/CurveFitting/src/Functions/UserFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/UserFunction.cpp
@@ -112,7 +112,11 @@ void UserFunction::function1D(double *out, const double *xValues,
                               const size_t nData) const {
   for (size_t i = 0; i < nData; i++) {
     m_x = xValues[i];
-    out[i] = m_parser->Eval();
+    try {
+      out[i] = m_parser->Eval();
+    } catch (mu::Parser::exception_type &e) {
+      throw std::invalid_argument("Error evaluating function: " + e.GetMsg());
+    }
   }
 }
 

--- a/docs/source/release/v5.0.0/mantidplot.rst
+++ b/docs/source/release/v5.0.0/mantidplot.rst
@@ -14,6 +14,7 @@ Bugfixes
 - Fixed an issue with Workspace History where unrolling consecutive workflow algorithms would result in only one of the algorithms being unrolled.
 - Fixed an issue where adding specific functions to the multi-dataset fitting interface caused it to crash
 - Fixed an issue where mantid crashed if you cleared the functions in the multi-dataset fitting interface
+- Fixed an issue where adding a UserFunction to the multi-dataset fitting interface caused a crash
 
 
 :ref:`Release 5.0.0 <v5.0.0>`


### PR DESCRIPTION
**Description of work.**
This PR fixes the crash that was caused by adding the user function to the mutli dataset fitting gui

**To test:**
Open mantidplot
Open `Interfaces`->`General`->`Multi dataset fitting`
Right-click on the function box and click `add function`
Add a `user function`
Mantid should not crash
Try to fit a user function - it should work as expected

Fixes #28060 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
