### PR TITLE
Fix issue related to the Log option from the double click axis menu

### DIFF
--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -108,5 +108,6 @@ Bugfixes
 - Axes limits of a plot no longer automatically rescale when errorbars are on/off 
 - Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
+- Fixed a bug which caused graphic scaling issues when the double-click menu was used to set an axis as log-scaled.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -20,7 +20,7 @@ from matplotlib.colors import LogNorm, Normalize
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
 
-SYMLOG_LIN_THRESHOLD = 0.01
+TREAT_LOG_NEGATIVE_VALUES = 'clip'
 
 
 class PropertiesEditorBase(QDialog):
@@ -94,7 +94,6 @@ class LabelEditor(PropertiesEditorBase):
 
 
 class AxisEditorModel(object):
-
     min = None
     max = None
     log = None
@@ -122,9 +121,10 @@ class AxisEditor(PropertiesEditorBase):
 
         self.axes = axes
         self.axis_id = axis_id
+        self.lim_getter = getattr(axes, 'get_{}lim'.format(axis_id))
         self.lim_setter = getattr(axes, 'set_{}lim'.format(axis_id))
         self.scale_setter = getattr(axes, 'set_{}scale'.format(axis_id))
-        self.linthresholdkw = 'linthres' + axis_id
+        self.nonposkw = 'nonpos' + axis_id
         # Grid has no direct accessor from the axes
         self.axis = axes.xaxis if axis_id == 'x' else axes.yaxis
 
@@ -133,8 +133,8 @@ class AxisEditor(PropertiesEditorBase):
         self._memento = memento
         memento.min, memento.max = getattr(self.axes, 'get_{}lim'.format(self.axis_id))()
         memento.log = getattr(self.axes, 'get_{}scale'.format(self.axis_id))() != 'linear'
-        ticks =  self.axis.majorTicks[0]
-        if hasattr(ticks,"get_visible"):
+        ticks = self.axis.majorTicks[0]
+        if hasattr(ticks, "get_visible"):
             memento.grid = ticks.get_visible()
         else:
             memento.grid = ticks.gridOn
@@ -147,11 +147,15 @@ class AxisEditor(PropertiesEditorBase):
         axes = self.axes
 
         self.limit_min, self.limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
-        self.lim_setter(self.limit_min, self.limit_max)
+
         if self.ui.logBox.isChecked():
-            self.scale_setter('symlog', **{self.linthresholdkw: SYMLOG_LIN_THRESHOLD})
+            self.scale_setter('log', **{self.nonposkw: TREAT_LOG_NEGATIVE_VALUES})
+            self.limit_min, self.limit_max = self._check_log_limits(self.limit_min, self.limit_max)
         else:
             self.scale_setter('linear')
+
+        self.lim_setter(self.limit_min, self.limit_max)
+
         axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id)
 
     def error_occurred(self, exc):
@@ -166,6 +170,16 @@ class AxisEditor(PropertiesEditorBase):
         self.ui.editor_max.setText(str(model.max))
         self.ui.logBox.setChecked(model.log)
         self.ui.gridBox.setChecked(model.grid)
+
+    def _check_log_limits(self, editor_min, editor_max):
+        # Check that the limits from the editor are sensible for a log graph
+        # As these limits are not necessarily in numeric order we have to check both
+        lim_min, lim_max = self.lim_getter()
+        if editor_min <= 0:
+            editor_min = lim_min
+        if editor_max <= 0:
+            editor_max = lim_max
+        return editor_min, editor_max
 
 
 class XAxisEditor(AxisEditor):

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -173,7 +173,7 @@ class AxisEditor(PropertiesEditorBase):
 
     def _check_log_limits(self, editor_min, editor_max):
         # Check that the limits from the editor are sensible for a log graph
-        # As these limits are not necessarily in numeric order we have to check both
+        # These limits are not necessarily in numeric order we have to check both
         lim_min, lim_max = self.lim_getter()
         if editor_min <= 0:
             editor_min = lim_min


### PR DESCRIPTION
The double click log option was performing a symlog, whereas the right click menu performed a conventional log. This PR fixes this inconsistency.

**Description of work.**
Changed the double click menu to perform a normal log, which is consistent with the checkbox name. To fix the issue with the axis scaling #28100 I had to sanity check the editor limits before setting them. 


**Report to:**  [Jos Cooper]/[ISIS] 


**To test:**
Plot a 1D spectrum and try to set one axis as logarithmic in the two different ways.
Ask @StephenSmith25  or @DanielMurphy22  for the .dat file in question to see how in that case the double-click on the axis does nothing!

But this can also be tested using any data and setting one of the axis as logarithmic in the two different ways. This scaling should no longer mess up and both methods should now perform a normal log, which can be verified by right clicking setting Log x / Lin y and then checking the log checkbox is now ticked in the double click menu.

<!-- Instructions for testing. -->

Fixes #27759  and the related #28100 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
