### PR TITLE
Do not clear variable from cmake after setting

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -370,7 +370,6 @@ if(PROFILE_ALGORITHM_LINUX)
 else()
   set(SRC_FILES "${SRC_FILES}" "src/AlgorithmExecute.cpp")
 endif()
-unset(PROFILE_ALGORITHM_LINUX CACHE)
 
 set(TEST_FILES
     ADSValidatorTest.h


### PR DESCRIPTION
The old behavior is that newer cmake did not use the variable in the source files because it is unset.

**To test:**

Follow the [instructions for profiling mantid algorithms](https://developer.mantidproject.org/AlgorithmProfiler.html) which should work again.

*There is no associated issue.*

*This does not require release notes* because it only affects developers trying to use the algorithm profiling tool.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
