### PR TITLE
Fix File Paths After Loading in Muon Analysis

### DIFF
--- a/docs/source/release/v5.0.0/muon.rst
+++ b/docs/source/release/v5.0.0/muon.rst
@@ -42,5 +42,6 @@ Bug Fixes
 - Fixed a bug with constraints in the Muon Analysis 2 GUI which would cause Mantid to crash.
 - Fixed a bug in Muon Analysis Old that prevented the muon fitting functions from appearing in the data analysis tab.
 - Data sets can now be reloaded while the Instrument View is open without crashing Mantid.
+- Fixed a bug where the incorrect path would be shown after loading a data file by run number.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/scripts/Muon/GUI/Common/utilities/load_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/load_utils.py
@@ -205,6 +205,9 @@ def load_workspace_from_filename(filename,
         alg, psi_data = create_load_algorithm(filename.split(os.sep)[-1], input_properties)
         alg.execute()
 
+    # The filename given to the loading algorithm can be different to the file that was actually loaded.
+    # Pulling the filename back out of the algorithm after loading ensures that the path is accurate.
+    filename = alg.getProperty("Filename").value
     workspace = AnalysisDataService.retrieve(alg.getProperty("OutputWorkspace").valueAsStr)
     if is_workspace_group(workspace):
         # handle multi-period data


### PR DESCRIPTION
**Description of work.**
The muon GUI generates a path that is given to the LoadMuonNexus algorithm which allows it to check the archive and any selected data directories. That file path was what was shown in the GUI even if it was not an accurate way of showing where the loaded file is.

Now, the file path is pulled from the algorithm after the load, so is much more accurate than previously.

**To test:**
0. Message me for a modified version of `MUSR62250.nxs`
1. Place it somewhere not included in the list of user directories.
1. Open the Muon Analysis GUI.
2. Change the instrument to MUSR
3. Type 62250 into the run number text field and hit enter
4. Check that the path below is pointing to the archive and there are two groups. 
5. Add the directory containing the modified file to the list of user directories.
6. Clear All
7. Type 62250 again and check that the file path is pointing to the location of the downloaded file. 

Fixes #27593 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
