### PR TITLE
Modified Metadata handling in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -53,6 +53,9 @@ public:
 
 bool exists(::NeXus::File &file, const std::string &name);
 
+bool exists(const std::map<std::string, std::string> &entries,
+            const std::string &name);
+
 /** @class LoadEventNexus LoadEventNexus.h Nexus/LoadEventNexus.h
 
   Load Event Nexus files.
@@ -599,8 +602,11 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   ::NeXus::File file(nexusfilename);
   file.openGroup(entry_name, "NXentry");
 
+  // only generating the entriesMap once
+  const std::map<std::string, std::string> entriesNxentry = file.getEntries();
+
   // get the title
-  if (exists(file, "title")) {
+  if (exists(entriesNxentry, "title")) {
     file.openData("title");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string title = file.getStrData();
@@ -611,7 +617,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the notes
-  if (exists(file, "notes")) {
+  if (exists(entriesNxentry, "notes")) {
     file.openData("notes");
     if (file.getInfo().type == ::NeXus::CHAR) {
       std::string notes = file.getStrData();
@@ -622,7 +628,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // Get the run number
-  if (exists(file, "run_number")) {
+  if (exists(entriesNxentry, "run_number")) {
     file.openData("run_number");
     std::string run;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -641,7 +647,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the experiment identifier
-  if (exists(file, "experiment_identifier")) {
+  if (exists(entriesNxentry, "experiment_identifier")) {
     file.openData("experiment_identifier");
     std::string expId;
     if (file.getInfo().type == ::NeXus::CHAR) {
@@ -655,7 +661,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
 
   // get the sample name - nested try/catch to leave the handle in an
   // appropriate state
-  if (exists(file, "sample")) {
+  if (exists(entriesNxentry, "sample")) {
     file.openGroup("sample", "NXsample");
     try {
       if (exists(file, "name")) {
@@ -686,7 +692,7 @@ void LoadEventNexus::loadEntryMetadata(const std::string &nexusfilename, T WS,
   }
 
   // get the duration
-  if (exists(file, "duration")) {
+  if (exists(entriesNxentry, "duration")) {
     file.openData("duration");
     std::vector<double> duration;
     file.getDataCoerce(duration);

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -62,7 +62,12 @@ const std::string NULL_STR("NULL");
  * @return true only if it exists
  */
 bool exists(::NeXus::File &file, const std::string &name) {
-  auto entries = file.getEntries();
+  const auto entries = file.getEntries();
+  return exists(entries, name);
+}
+
+bool exists(const std::map<std::string, std::string> &entries,
+            const std::string &name) {
   return entries.find(name) != entries.end();
 }
 


### PR DESCRIPTION
**Description of work.**
Reuse map from NeXus file getEntries prevents creation and destruction
of std::map resulting in modest performance gains benefits for NeXus files with large metadata.

`ctest -R DataHandlingTest_LoadEventNexusTest`
test time on a Ubuntu 18.04 Intel core i7-7700:
`master:` 87.78s
`this PR:` 70.97s     (18% runtime improvement)

**Report to:**
@peterfpeterson 

**To test:**
<!-- Instructions for testing. -->
This is a modest refactoring so running the current CI would test appropriately.

Refs to #27952

*This does not require release notes* because is a minor refactoring

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
