### PR TITLE
Workbench: Redirect warnings module messages to mantid warning logger

### DIFF
--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -87,6 +87,7 @@ Improvements
 - You can now search for functions when doing fits.
 - A help button has been added to the fitting add function dialog.
 - The progress reporting for scripts has been vastly improved and now reports at the line level.
+- Warnings from the Python ``warnings`` module are now show as warnings and not errors in the log display.
 
 Bugfixes
 ########
@@ -105,8 +106,8 @@ Bugfixes
 - Fixed an issue where fitting a distribution workspace was normalised twice.
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.
-- Axes limits of a plot no longer automatically rescale when errorbars are on/off 
-- Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
+- Axes limits of a plot no longer automatically rescale when errorbars are on/off
+- Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters.
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 
 :ref:`Release 5.0.0 <v5.0.0>`


### PR DESCRIPTION
**Description of work.**

In workbench warnings shown as errors meant that any deprecation
warnings would show as errors when in fact a script should still complete
successfully. This captures them at the correct level.

**To test:**

Emit a warning using the `warnings` module:
```python
import warnings
warnings.warn("My important warning")
```

This should show up in the log message window in orange rather than red and not trigger the desktop error notifications.

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
