### PR TITLE
Convfit using correct resolutions

### DIFF
--- a/qt/scientific_interfaces/Indirect/ConvFit.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFit.cpp
@@ -63,15 +63,13 @@ void ConvFit::setupFitTab() {
   setConvolveMembers(true);
 
   // Initialise fitTypeStrings
-  m_fitStrings["None"] = "";
-  m_fitStrings["One Lorentzian"] = "1L";
-  m_fitStrings["Two Lorentzians"] = "2L";
+  m_fitStrings["Lorentzian"] = "L";
   m_fitStrings["InelasticDiffSphere"] = "IDS";
   m_fitStrings["InelasticDiffRotDiscreteCircle"] = "IDC";
   m_fitStrings["ElasticDiffSphere"] = "EDS";
   m_fitStrings["ElasticDiffRotDiscreteCircle"] = "EDC";
   m_fitStrings["StretchedExpFT"] = "SFT";
-  m_fitStrings["Teixeira Water"] = "TxWater";
+  m_fitStrings["TeixeiraWaterSQE"] = "TxWater";
 
   auto &functionFactory = FunctionFactory::Instance();
   auto lorentzian = functionFactory.createFunction("Lorentzian");
@@ -140,15 +138,20 @@ void ConvFit::fitFunctionChanged() {
  * Assertions used to guard against any future changes that don't take
  * workspace naming into account.
  *
- * @returns the generated QString.
+ * @returns the generated string.
  */
 std::string ConvFit::fitTypeString() const {
   std::string fitType;
+  for (auto fitFunctionName : m_fitStrings) {
+    auto occurances = numberOfCustomFunctions(fitFunctionName.first);
+    if (occurances > 0) {
+      fitType += std::to_string(occurances) + fitFunctionName.second;
+    }
+  }
 
-  if (numberOfCustomFunctions("DeltaFunction") > 0)
+  if (numberOfCustomFunctions("DeltaFunction") > 0) {
     fitType += "Delta";
-
-  fitType += m_fitStrings[selectedFitType()];
+  }
 
   return fitType;
 }

--- a/qt/scientific_interfaces/Indirect/ConvFit.h
+++ b/qt/scientific_interfaces/Indirect/ConvFit.h
@@ -50,7 +50,7 @@ private:
 
   std::unique_ptr<Ui::ConvFit> m_uiForm;
   // ShortHand Naming for fit functions
-  QHash<QString, std::string> m_fitStrings;
+  std::unordered_map<std::string, std::string> m_fitStrings;
   ConvFitModel *m_convFittingModel;
 };
 

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -332,14 +332,18 @@ IAlgorithm_sptr ConvFitModel::simultaneousFitAlgorithm() const {
 
 std::string ConvFitModel::sequentialFitOutputName() const {
   if (isMultiFit())
-    return "MultiConvFit_" + m_fitType + m_backgroundString + "_Results";
-  return createOutputName("%1%_conv_" + m_fitType + m_backgroundString +
+    return "MultiConvFit_seq_" + m_fitType + m_backgroundString + "_Results";
+  return createOutputName("%1%_conv_seq_" + m_fitType + m_backgroundString +
                               "_s%2%",
                           "_to_", TableDatasetIndex{0});
 }
 
 std::string ConvFitModel::simultaneousFitOutputName() const {
-  return sequentialFitOutputName();
+  if (isMultiFit())
+    return "MultiConvFit_sim_" + m_fitType + m_backgroundString + "_Results";
+  return createOutputName("%1%_conv_sim_" + m_fitType + m_backgroundString +
+                              "_s%2%",
+                          "_to_", TableDatasetIndex{0});
 }
 
 std::string ConvFitModel::singleFitOutputName(TableDatasetIndex index,
@@ -398,14 +402,6 @@ void ConvFitModel::setTemperature(const boost::optional<double> &temperature) {
 void ConvFitModel::addWorkspace(MatrixWorkspace_sptr workspace,
                                 const Spectra &spectra) {
   IndirectFittingModel::addWorkspace(workspace, spectra);
-
-  // const auto dataSize = numberOfWorkspaces();
-  // if (m_resolution.size() < dataSize)
-  //   m_resolution.emplace_back(MatrixWorkspace_sptr());
-  // else if (m_resolution.size() == dataSize &&
-  //          m_resolution[dataSize - TableDatasetIndex{1}].lock() &&
-  //          m_extendedResolution.size() < dataSize)
-  //   addExtendedResolution(dataSize - TableDatasetIndex{1});
 }
 
 void ConvFitModel::removeWorkspace(TableDatasetIndex index) {

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.cpp
@@ -399,13 +399,13 @@ void ConvFitModel::addWorkspace(MatrixWorkspace_sptr workspace,
                                 const Spectra &spectra) {
   IndirectFittingModel::addWorkspace(workspace, spectra);
 
-  const auto dataSize = numberOfWorkspaces();
-  if (m_resolution.size() < dataSize)
-    m_resolution.emplace_back(MatrixWorkspace_sptr());
-  else if (m_resolution.size() == dataSize &&
-           m_resolution[dataSize - TableDatasetIndex{1}].lock() &&
-           m_extendedResolution.size() < dataSize)
-    addExtendedResolution(dataSize - TableDatasetIndex{1});
+  // const auto dataSize = numberOfWorkspaces();
+  // if (m_resolution.size() < dataSize)
+  //   m_resolution.emplace_back(MatrixWorkspace_sptr());
+  // else if (m_resolution.size() == dataSize &&
+  //          m_resolution[dataSize - TableDatasetIndex{1}].lock() &&
+  //          m_extendedResolution.size() < dataSize)
+  //   addExtendedResolution(dataSize - TableDatasetIndex{1});
 }
 
 void ConvFitModel::removeWorkspace(TableDatasetIndex index) {

--- a/qt/scientific_interfaces/Indirect/ConvFitModel.h
+++ b/qt/scientific_interfaces/Indirect/ConvFitModel.h
@@ -48,7 +48,8 @@ public:
 
   void addOutput(Mantid::API::IAlgorithm_sptr fitAlgorithm) override;
 
-  std::vector<std::pair<std::string, int>> getResolutionsForFit() const;
+  std::vector<std::pair<std::string, int>>
+  getResolutionsForFit() const override;
 
 private:
   Mantid::API::IAlgorithm_sptr sequentialFitAlgorithm() const override;

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -709,7 +709,8 @@ QStringList IndirectFitAnalysisTab::getDatasetNames() const {
 void IndirectFitAnalysisTab::updateDataReferences() {
   m_fitPropertyBrowser->updateFunctionBrowserData(
       m_fittingModel->getNumberOfDomains(), getDatasetNames(),
-      m_fittingModel->getQValuesForData());
+      m_fittingModel->getQValuesForData(),
+      m_fittingModel->getResolutionsForFit());
   m_fittingModel->setFitFunction(m_fitPropertyBrowser->getFittingFunction());
 }
 
@@ -734,7 +735,8 @@ void IndirectFitAnalysisTab::respondToChangeOfSpectraRange(
   m_dataPresenter->updateSpectraInTable(i);
   m_fitPropertyBrowser->updateFunctionBrowserData(
       m_fittingModel->getNumberOfDomains(), getDatasetNames(),
-      m_fittingModel->getQValuesForData());
+      m_fittingModel->getQValuesForData(),
+      m_fittingModel->getResolutionsForFit());
   setModelFitFunction();
   updateParameterEstimationData();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.cpp
@@ -354,12 +354,14 @@ TableRowIndex IndirectFitPropertyBrowser::currentDataset() const {
 
 void IndirectFitPropertyBrowser::updateFunctionBrowserData(
     TableRowIndex nData, const QStringList &datasetNames,
-    const std::vector<double> &qValues) {
+    const std::vector<double> &qValues,
+    const std::vector<std::pair<std::string, int>> &fitResolutions) {
   m_functionBrowser->setNumberOfDatasets(nData.value);
   m_functionBrowser->setDatasetNames(datasetNames);
   m_templateBrowser->setNumberOfDatasets(nData.value);
   m_templateBrowser->setDatasetNames(datasetNames);
   m_templateBrowser->setQValues(qValues);
+  m_templateBrowser->setResolution(fitResolutions);
 }
 
 void IndirectFitPropertyBrowser::setFitEnabled(bool) {}

--- a/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPropertyBrowser.h
@@ -63,9 +63,10 @@ public:
   void setFitEnabled(bool enable);
   void setCurrentDataset(TableRowIndex i);
   TableRowIndex currentDataset() const;
-  void updateFunctionBrowserData(TableRowIndex nData,
-                                 const QStringList &datasetNames,
-                                 const std::vector<double> &qValues);
+  void updateFunctionBrowserData(
+      TableRowIndex nData, const QStringList &datasetNames,
+      const std::vector<double> &qValues,
+      const std::vector<std::pair<std::string, int>> &fitResolutions);
   void updatePlotGuess(MatrixWorkspace_const_sptr sampleWorkspace);
   void setErrorsEnabled(bool enabled);
   void

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -965,6 +965,11 @@ std::vector<double> IndirectFittingModel::getQValuesForData() const {
   return qValues;
 }
 
+std::vector<std::pair<std::string, int>>
+IndirectFittingModel::getResolutionsForFit() const {
+  return std::vector<std::pair<std::string, int>>();
+}
+
 } // namespace IDA
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.h
@@ -143,6 +143,7 @@ public:
   getDataForParameterEstimation(EstimationDataSelector selector) const;
 
   std::vector<double> getQValuesForData() const;
+  virtual std::vector<std::pair<std::string, int>> getResolutionsForFit() const;
 
 protected:
   Mantid::API::IAlgorithm_sptr getFittingAlgorithm(FittingMode mode) const;


### PR DESCRIPTION
**Description of work.**

On the ConvFit tab loaded resolution files can have either one entry or the same number of entries as the input data workspace. In the case where the resolution workspace had the same number of entries as the data workspace entry each entry uses the corrosponding one from the resolution workspace.

If you loaded a workspace with many entries and then chose to only fit a section of these however you still just used the first n entries from the resolution workspace.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
I have some data from a scientist which shows this issue nicely as the first two entries of the resolution workspace produce flatline fits. Slack me if you want to review and I'll send it to you.

  * Try loading the data in both single and mult input modes and check that it is correctly loaded.
  * Adjust the selected spectra to fit and check that the correct reolution workspace is used to fit each spectrum. (I have found the easiest way to do this is to examine the form of the FitFunction in workspace history. The resolution function there specifies both a resolution workspace and which workspace index to use for each spectrum to be fitted.)

<!-- Instructions for testing. -->

Fixes #28123  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because this fixes an issue introduced this release


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
