### PR TITLE
Fix crash with Indirect data analysis when spectra is removed

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataTablePresenter.cpp
@@ -627,9 +627,10 @@ void IndirectDataTablePresenter::updateDataPositionsInCells(
     TableDatasetIndex from, TableDatasetIndex to) {
   for (auto i = from; i < to; ++i) {
     const auto nextPosition = getNextPosition(i);
-    for (auto row = m_dataPositions[i]; row < nextPosition; ++row)
+    for (auto row = m_dataPositions[i]; row < nextPosition; ++row) {
       m_dataTable->item(row.value, 0)
           ->setData(Qt::UserRole, getVariant(i.value));
+    }
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -424,10 +424,13 @@ void IndirectFitAnalysisTab::updateParameterValues(
 
 void IndirectFitAnalysisTab::updateFitBrowserParameterValues() {
   IFunction_sptr fun = m_fittingModel->getFittingFunction();
-  if (fun->getNumberDomains() > 1)
-    m_fitPropertyBrowser->updateMultiDatasetParameters(*fun);
-  else
-    m_fitPropertyBrowser->updateParameters(*fun);
+  if (fun) {
+    if (fun->getNumberDomains() > 1) {
+      m_fitPropertyBrowser->updateMultiDatasetParameters(*fun);
+    } else {
+      m_fitPropertyBrowser->updateParameters(*fun);
+    }
+  }
 }
 
 void IndirectFitAnalysisTab::updateFitBrowserParameterValuesFromAlg() {


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug that resulted in a crash when a spectra was removed from the selected spectra if there was no fit function selected. This bug resulted from the plot attempting to remove the fit function but not finding one.

**To test:**
Try for Workbench and plot

1. Open `Indirect-Data Analysis`
2. Go to the MSD fit tab
3. Go to the multiple input tab
4. Add workspace with multiple spectra
5. Select a workspace and remove it.
6. If mantid does not crash then the fix has worked.

Fixes #28086 

*This does not require release notes* because **This bug was only introduced in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
