### PR TITLE
Turn unhandled logic error into handled runtime_error

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -553,7 +553,11 @@ void IndirectFittingModel::addWorkspace(const std::string &workspaceName,
   if (workspaceName.empty() || !doesExistInADS(workspaceName))
     throw std::runtime_error("A valid sample file needs to be selected.");
 
-  addWorkspace(workspaceName, Spectra(spectra));
+  try {
+    addWorkspace(workspaceName, Spectra(spectra));
+  } catch (std::logic_error &e) {
+    throw std::runtime_error(e.what());
+  }
 }
 
 void IndirectFittingModel::addWorkspace(const std::string &workspaceName,


### PR DESCRIPTION
**Description of work.**

Attempting to use an improperly defined spectra range (e.g. 5-3)
causes appendValue in PropertyHelper.h to throw a logic error.  The
gui alerts the user to runtime errors, but fails over on logic errors.
We now catch the logic error and demote it to a runtime error.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #27440. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
