### PR TITLE
Convert Mac line endings to Unix for CHESS

### DIFF
--- a/instrument/CHESS_Definition.xml
+++ b/instrument/CHESS_Definition.xml
@@ -1,1 +1,2225 @@
-<?xml version='1.0' encoding='ASCII'?><instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-10-01 14:11:19.918208" name="CHESS" valid-from="2019-01-01 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">  <!--Created by Gabriele Sala-->  <defaults>    <length unit="metre"/>    <angle unit="degree"/>    <reference-frame>      <along-beam axis="z"/>      <pointing-up axis="y"/>      <handedness val="right"/>      <theta-sign axis="x"/>    </reference-frame>  </defaults><!--SOURCE and SAMPLE positions--><component type="moderator">  <location z="-29.53"/></component><type is="Source" name="moderator"/><component type="sample-position">  <location x="0.0" y="0.0" z="0.0"/></component><type is="SamplePos" name="sample-position"/><!--MONITORS--><component idlist="monitors" type="monitors">  <location/></component><type name="monitors">  <component type="monitor">    <location name="monitor1" z="-15.50"/>    <location name="monitor2" z="-1.57"/>  </component></type><!--DETECTOR bank IDs--><component idlist="detectors" type="detectors">  <location/></component><type name="detectors">  <component type="bank1">    <location/>  </component>  <component type="bank2">    <location/>  </component>  <component type="bank3">    <location/>  </component>  <component type="bank4">    <location/>  </component>  <component type="bank5">    <location/>  </component>  <component type="bank6">    <location/>  </component>  <component type="bank7">    <location/>  </component>  <component type="bank8">    <location/>  </component>  <component type="bank9">    <location/>  </component>  <component type="bank10">    <location/>  </component>  <component type="bank11">    <location/>  </component>  <component type="bank12">    <location/>  </component>  <component type="bank13">    <location/>  </component>  <component type="bank14">    <location/>  </component>  <component type="bank15">    <location/>  </component>  <component type="bank16">    <location/>  </component>  <component type="bank17">    <location/>  </component>  <component type="bank18">    <location/>  </component>  <component type="bank19">    <location/>  </component>  <component type="bank20">    <location/>  </component>  <component type="bank21">    <location/>  </component>  <component type="bank22">    <location/>  </component>  <component type="bank23">    <location/>  </component>  <component type="bank24">    <location/>  </component>  <component type="bank25">    <location/>  </component>  <component type="bank26">    <location/>  </component>  <component type="bank27">    <location/>  </component>  <component type="bank28">    <location/>  </component>  <component type="bank29">    <location/>  </component>  <component type="bank30">    <location/>  </component>  <component type="bank31">    <location/>  </component>  <component type="bank32">    <location/>  </component>  <component type="bank33">    <location/>  </component>  <component type="bank34">    <location/>  </component>  <component type="bank35">    <location/>  </component>  <component type="bank36">    <location/>  </component>  <component type="bank37">    <location/>  </component>  <component type="bank38">    <location/>  </component>  <component type="bank39">    <location/>  </component>  <component type="bank40">    <location/>  </component>  <component type="bank41">    <location/>  </component>  <component type="bank42">    <location/>  </component>  <component type="bank43">    <location/>  </component>  <component type="bank44">    <location/>  </component>  <component type="bank45">    <location/>  </component>  <component type="bank46">    <location/>  </component>  <component type="bank47">    <location/>  </component>  <component type="bank48">    <location/>  </component>  <component type="bank49">    <location/>  </component>  <component type="bank50">    <location/>  </component>  <component type="bank51">    <location/>  </component>  <component type="bank52">    <location/>  </component>  <component type="bank53">    <location/>  </component>  <component type="bank54">    <location/>  </component>  <component type="bank55">    <location/>  </component>  <component type="bank56">    <location/>  </component>  <component type="bank57">    <location/>  </component>  <component type="bank58">    <location/>  </component>  <component type="bank59">    <location/>  </component>  <component type="bank60">    <location/>  </component>  <component type="bank61">    <location/>  </component>  <component type="bank62">    <location/>  </component>  <component type="bank63">    <location/>  </component>  <component type="bank64">    <location/>  </component>  <component type="bank65">    <location/>  </component>  <component type="bank66">    <location/>  </component>  <component type="bank67">    <location/>  </component>  <component type="bank68">    <location/>  </component>  <component type="bank69">    <location/>  </component>  <component type="bank70">    <location/>  </component>  <component type="bank71">    <location/>  </component>  <component type="bank72">    <location/>  </component>  <component type="bank73">    <location/>  </component>  <component type="bank74">    <location/>  </component>  <component type="bank75">    <location/>  </component>  <component type="bank76">    <location/>  </component>  <component type="bank77">    <location/>  </component>  <component type="bank78">    <location/>  </component>  <component type="bank79">    <location/>  </component>  <component type="bank80">    <location/>  </component>  <component type="bank81">    <location/>  </component>  <component type="bank82">    <location/>  </component>  <component type="bank83">    <location/>  </component>  <component type="bank84">    <location/>  </component>  <component type="bank85">    <location/>  </component>  <component type="bank86">    <location/>  </component>  <component type="bank87">    <location/>  </component>  <component type="bank88">    <location/>  </component>  <component type="bank89">    <location/>  </component>  <component type="bank90">    <location/>  </component>  <component type="bank91">    <location/>  </component>  <component type="bank92">    <location/>  </component>  <component type="bank93">    <location/>  </component>  <component type="bank94">    <location/>  </component>  <component type="bank95">    <location/>  </component>  <component type="bank96">    <location/>  </component>  <component type="bank97">    <location/>  </component>  <component type="bank98">    <location/>  </component>  <component type="bank99">    <location/>  </component>  <component type="bank100">    <location/>  </component>  <component type="bank101">    <location/>  </component>  <component type="bank102">    <location/>  </component>  <component type="bank103">    <location/>  </component>  <component type="bank104">    <location/>  </component>  <component type="bank105">    <location/>  </component>  <component type="bank106">    <location/>  </component>  <component type="bank107">    <location/>  </component>  <component type="bank108">    <location/>  </component>  <component type="bank109">    <location/>  </component>  <component type="bank110">    <location/>  </component>  <component type="bank111">    <location/>  </component>  <component type="bank112">    <location/>  </component>  <component type="bank113">    <location/>  </component>  <component type="bank114">    <location/>  </component>  <component type="bank115">    <location/>  </component>  <component type="bank116">    <location/>  </component>  <component type="bank117">    <location/>  </component>  <component type="bank118">    <location/>  </component>  <component type="bank119">    <location/>  </component>  <component type="bank120">    <location/>  </component>  <component type="bank121">    <location/>  </component>  <component type="bank122">    <location/>  </component>  <component type="bank123">    <location/>  </component>  <component type="bank124">    <location/>  </component>  <component type="bank125">    <location/>  </component>  <component type="bank126">    <location/>  </component>  <component type="bank127">    <location/>  </component>  <component type="bank128">    <location/>  </component>  <component type="bank129">    <location/>  </component>  <component type="bank130">    <location/>  </component>  <component type="bank131">    <location/>  </component>  <component type="bank132">    <location/>  </component>  <component type="bank133">    <location/>  </component>  <component type="bank134">    <location/>  </component>  <component type="bank135">    <location/>  </component>  <component type="bank136">    <location/>  </component>  <component type="bank137">    <location/>  </component>  <component type="bank138">    <location/>  </component>  <component type="bank139">    <location/>  </component>  <component type="bank140">    <location/>  </component>  <component type="bank141">    <location/>  </component>  <component type="bank142">    <location/>  </component>  <component type="bank143">    <location/>  </component>  <component type="bank144">    <location/>  </component>  <component type="bank145">    <location/>  </component>  <component type="bank146">    <location/>  </component>  <component type="bank147">    <location/>  </component>  <component type="bank148">    <location/>  </component>  <component type="bank149">    <location/>  </component>  <component type="bank150">    <location/>  </component>  <component type="bank151">    <location/>  </component>  <component type="bank152">    <location/>  </component>  <component type="bank153">    <location/>  </component>  <component type="bank154">    <location/>  </component>  <component type="bank155">    <location/>  </component>  <component type="bank156">    <location/>  </component>  <component type="bank157">    <location/>  </component>  <component type="bank158">    <location/>  </component>  <component type="bank159">    <location/>  </component>  <component type="bank160">    <location/>  </component>  <component type="bank161">    <location/>  </component>  <component type="bank162">    <location/>  </component>  <component type="bank163">    <location/>  </component></type><!--DETECTOR bank positions and orientations--><type name="bank1">  <component type="eightpack">    <location x="-1.795189" y="0.000000" z="-1.733478">      <rot axis-x="0" axis-y="1" axis-z="0" val="226.000">      </rot>    </location>  </component></type><type name="bank2">  <component type="eightpack">    <location x="-1.911737" y="0.000000" z="-1.604030">      <rot axis-x="0" axis-y="1" axis-z="0" val="230.000">      </rot>    </location>  </component></type><type name="bank3">  <component type="eightpack">    <location x="-2.018972" y="0.000000" z="-1.466766">      <rot axis-x="0" axis-y="1" axis-z="0" val="234.000">      </rot>    </location>  </component></type><type name="bank4">  <component type="eightpack">    <location x="-2.116370" y="0.000000" z="-1.322357">      <rot axis-x="0" axis-y="1" axis-z="0" val="238.000">      </rot>    </location>  </component></type><type name="bank5">  <component type="eightpack">    <location x="-2.203458" y="0.000000" z="-1.171505">      <rot axis-x="0" axis-y="1" axis-z="0" val="242.000">      </rot>    </location>  </component></type><type name="bank6">  <component type="eightpack">    <location x="-2.279810" y="0.000000" z="-1.014946">      <rot axis-x="0" axis-y="1" axis-z="0" val="246.000">      </rot>    </location>  </component></type><type name="bank7">  <component type="eightpack">    <location x="-2.345056" y="0.000000" z="-0.853442">      <rot axis-x="0" axis-y="1" axis-z="0" val="250.000">      </rot>    </location>  </component></type><type name="bank8">  <component type="eightpack">    <location x="-2.398877" y="0.000000" z="-0.687780">      <rot axis-x="0" axis-y="1" axis-z="0" val="254.000">      </rot>    </location>  </component></type><type name="bank9">  <component type="eightpack">    <location x="-2.441010" y="0.000000" z="-0.518768">      <rot axis-x="0" axis-y="1" axis-z="0" val="258.000">      </rot>    </location>  </component></type><type name="bank10">  <component type="eightpack">    <location x="-2.471251" y="0.000000" z="-0.347228">      <rot axis-x="0" axis-y="1" axis-z="0" val="262.000">      </rot>    </location>  </component></type><type name="bank11">  <component type="eightpack">    <location x="-2.489453" y="0.000000" z="-0.173996">      <rot axis-x="0" axis-y="1" axis-z="0" val="266.000">      </rot>    </location>  </component></type><type name="bank12">  <component type="eightpack">    <location x="-2.495526" y="0.000000" z="0.000083">      <rot axis-x="0" axis-y="1" axis-z="0" val="270.000">      </rot>    </location>  </component></type><type name="bank13">  <component type="eightpack">    <location x="-2.489441" y="0.000000" z="0.174162">      <rot axis-x="0" axis-y="1" axis-z="0" val="274.000">      </rot>    </location>  </component></type><type name="bank14">  <component type="eightpack">    <location x="-2.471228" y="0.000000" z="0.347392">      <rot axis-x="0" axis-y="1" axis-z="0" val="278.000">      </rot>    </location>  </component></type><type name="bank15">  <component type="eightpack">    <location x="-2.440976" y="0.000000" z="0.518930">      <rot axis-x="0" axis-y="1" axis-z="0" val="282.000">      </rot>    </location>  </component></type><type name="bank16">  <component type="eightpack">    <location x="-2.398831" y="0.000000" z="0.687940">      <rot axis-x="0" axis-y="1" axis-z="0" val="286.000">      </rot>    </location>  </component></type><type name="bank17">  <component type="eightpack">    <location x="-2.344999" y="0.000000" z="0.853598">      <rot axis-x="0" axis-y="1" axis-z="0" val="290.000">      </rot>    </location>  </component></type><type name="bank18">  <component type="eightpack">    <location x="-2.279743" y="0.000000" z="1.015098">      <rot axis-x="0" axis-y="1" axis-z="0" val="294.000">      </rot>    </location>  </component></type><type name="bank19">  <component type="eightpack">    <location x="-2.203380" y="0.000000" z="1.171652">      <rot axis-x="0" axis-y="1" axis-z="0" val="298.000">      </rot>    </location>  </component></type><type name="bank20">  <component type="eightpack">    <location x="-2.116282" y="0.000000" z="1.322498">      <rot axis-x="0" axis-y="1" axis-z="0" val="302.000">      </rot>    </location>  </component></type><type name="bank21">  <component type="eightpack">    <location x="-2.018874" y="0.000000" z="1.466901">      <rot axis-x="0" axis-y="1" axis-z="0" val="306.000">      </rot>    </location>  </component></type><type name="bank22">  <component type="eightpack">    <location x="-1.911631" y="0.000000" z="1.604157">      <rot axis-x="0" axis-y="1" axis-z="0" val="310.000">      </rot>    </location>  </component></type><type name="bank23">  <component type="eightpack">    <location x="-1.795074" y="0.000000" z="1.733598">      <rot axis-x="0" axis-y="1" axis-z="0" val="314.000">      </rot>    </location>  </component></type><type name="bank24">  <component type="eightpack">    <location x="-1.669771" y="0.000000" z="1.854593">      <rot axis-x="0" axis-y="1" axis-z="0" val="318.000">      </rot>    </location>  </component></type><type name="bank25">  <component type="eightpack">    <location x="-1.536334" y="0.000000" z="1.966553">      <rot axis-x="0" axis-y="1" axis-z="0" val="322.000">      </rot>    </location>  </component></type><type name="bank26">  <component type="eightpack">    <location x="-1.395412" y="0.000000" z="2.068932">      <rot axis-x="0" axis-y="1" axis-z="0" val="326.000">      </rot>    </location>  </component></type><type name="bank27">  <component type="eightpack">    <location x="-1.247691" y="0.000000" z="2.161231">      <rot axis-x="0" axis-y="1" axis-z="0" val="330.000">      </rot>    </location>  </component></type><type name="bank28">  <component type="eightpack">    <location x="-1.093892" y="0.000000" z="2.243001">      <rot axis-x="0" axis-y="1" axis-z="0" val="334.000">      </rot>    </location>  </component></type><type name="bank29">  <component type="eightpack">    <location x="-0.934764" y="0.000000" z="2.313843">      <rot axis-x="0" axis-y="1" axis-z="0" val="338.000">      </rot>    </location>  </component></type><type name="bank30">  <component type="eightpack">    <location x="-0.771081" y="0.000000" z="2.373412">      <rot axis-x="0" axis-y="1" axis-z="0" val="342.000">      </rot>    </location>  </component></type><type name="bank31">  <component type="eightpack">    <location x="-0.603642" y="0.000000" z="2.421419">      <rot axis-x="0" axis-y="1" axis-z="0" val="346.000">      </rot>    </location>  </component></type><type name="bank32">  <component type="eightpack">    <location x="-0.433262" y="0.000000" z="2.457628">      <rot axis-x="0" axis-y="1" axis-z="0" val="350.000">      </rot>    </location>  </component></type><type name="bank33">  <component type="eightpack">    <location x="-0.260771" y="0.000000" z="2.481864">      <rot axis-x="0" axis-y="1" axis-z="0" val="354.000">      </rot>    </location>  </component></type><type name="bank34">  <component type="eightpack">    <location x="-0.087010" y="0.000000" z="2.494009">      <rot axis-x="0" axis-y="1" axis-z="0" val="358.000">      </rot>    </location>  </component></type><type name="bank35">  <component type="eightpack">    <location x="0.087176" y="0.000000" z="2.494003">      <rot axis-x="0" axis-y="1" axis-z="0" val="2.000">      </rot>    </location>  </component></type><type name="bank36">  <component type="eightpack">    <location x="0.260936" y="0.000000" z="2.481847">      <rot axis-x="0" axis-y="1" axis-z="0" val="6.000">      </rot>    </location>  </component></type><type name="bank37">  <component type="eightpack">    <location x="0.433425" y="0.000000" z="2.457599">      <rot axis-x="0" axis-y="1" axis-z="0" val="10.000">      </rot>    </location>  </component></type><type name="bank38">  <component type="eightpack">    <location x="0.603803" y="0.000000" z="2.421378">      <rot axis-x="0" axis-y="1" axis-z="0" val="14.000">      </rot>    </location>  </component></type><type name="bank39">  <component type="eightpack">    <location x="0.771239" y="0.000000" z="2.373361">      <rot axis-x="0" axis-y="1" axis-z="0" val="18.000">      </rot>    </location>  </component></type><type name="bank40">  <component type="eightpack">    <location x="0.934918" y="0.000000" z="2.313781">      <rot axis-x="0" axis-y="1" axis-z="0" val="22.000">      </rot>    </location>  </component></type><type name="bank41">  <component type="eightpack">    <location x="1.094041" y="0.000000" z="2.242928">      <rot axis-x="0" axis-y="1" axis-z="0" val="26.000">      </rot>    </location>  </component></type><type name="bank42">  <component type="eightpack">    <location x="1.247835" y="0.000000" z="2.161148">      <rot axis-x="0" axis-y="1" axis-z="0" val="30.000">      </rot>    </location>  </component></type><type name="bank43">  <component type="eightpack">    <location x="1.395550" y="0.000000" z="2.068839">      <rot axis-x="0" axis-y="1" axis-z="0" val="34.000">      </rot>    </location>  </component></type><type name="bank44">  <component type="eightpack">    <location x="1.536465" y="0.000000" z="1.966450">      <rot axis-x="0" axis-y="1" axis-z="0" val="38.000">      </rot>    </location>  </component></type><type name="bank45">  <component type="eightpack">    <location x="1.669895" y="0.000000" z="1.854482">      <rot axis-x="0" axis-y="1" axis-z="0" val="42.000">      </rot>    </location>  </component></type><type name="bank46">  <component type="eightpack">    <location x="1.795189" y="0.000000" z="1.733478">      <rot axis-x="0" axis-y="1" axis-z="0" val="46.000">      </rot>    </location>  </component></type><type name="bank47">  <component type="eightpack">    <location x="1.911737" y="0.000000" z="1.604030">      <rot axis-x="0" axis-y="1" axis-z="0" val="50.000">      </rot>    </location>  </component></type><type name="bank48">  <component type="eightpack">    <location x="2.018972" y="0.000000" z="1.466766">      <rot axis-x="0" axis-y="1" axis-z="0" val="54.000">      </rot>    </location>  </component></type><type name="bank49">  <component type="eightpack">    <location x="2.116370" y="0.000000" z="1.322357">      <rot axis-x="0" axis-y="1" axis-z="0" val="58.000">      </rot>    </location>  </component></type><type name="bank50">  <component type="eightpack">    <location x="2.203458" y="0.000000" z="1.171505">      <rot axis-x="0" axis-y="1" axis-z="0" val="62.000">      </rot>    </location>  </component></type><type name="bank51">  <component type="eightpack">    <location x="2.279810" y="0.000000" z="1.014946">      <rot axis-x="0" axis-y="1" axis-z="0" val="66.000">      </rot>    </location>  </component></type><type name="bank52">  <component type="eightpack">    <location x="2.345056" y="0.000000" z="0.853442">      <rot axis-x="0" axis-y="1" axis-z="0" val="70.000">      </rot>    </location>  </component></type><type name="bank53">  <component type="eightpack">    <location x="2.398877" y="0.000000" z="0.687780">      <rot axis-x="0" axis-y="1" axis-z="0" val="74.000">      </rot>    </location>  </component></type><type name="bank54">  <component type="eightpack">    <location x="2.441010" y="0.000000" z="0.518768">      <rot axis-x="0" axis-y="1" axis-z="0" val="78.000">      </rot>    </location>  </component></type><type name="bank55">  <component type="eightpack">    <location x="2.471251" y="0.000000" z="0.347228">      <rot axis-x="0" axis-y="1" axis-z="0" val="82.000">      </rot>    </location>  </component></type><type name="bank56">  <component type="eightpack">    <location x="2.489453" y="0.000000" z="0.173996">      <rot axis-x="0" axis-y="1" axis-z="0" val="86.000">      </rot>    </location>  </component></type><type name="bank57">  <component type="eightpack">    <location x="2.495526" y="0.000000" z="-0.000083">      <rot axis-x="0" axis-y="1" axis-z="0" val="90.000">      </rot>    </location>  </component></type><type name="bank58">  <component type="eightpack">    <location x="2.489441" y="0.000000" z="-0.174162">      <rot axis-x="0" axis-y="1" axis-z="0" val="94.000">      </rot>    </location>  </component></type><type name="bank59">  <component type="eightpack">    <location x="2.471228" y="0.000000" z="-0.347392">      <rot axis-x="0" axis-y="1" axis-z="0" val="98.000">      </rot>    </location>  </component></type><type name="bank60">  <component type="eightpack">    <location x="2.440976" y="0.000000" z="-0.518930">      <rot axis-x="0" axis-y="1" axis-z="0" val="102.000">      </rot>    </location>  </component></type><type name="bank61">  <component type="eightpack">    <location x="2.398831" y="0.000000" z="-0.687940">      <rot axis-x="0" axis-y="1" axis-z="0" val="106.000">      </rot>    </location>  </component></type><type name="bank62">  <component type="eightpack">    <location x="2.344999" y="0.000000" z="-0.853598">      <rot axis-x="0" axis-y="1" axis-z="0" val="110.000">      </rot>    </location>  </component></type><type name="bank63">  <component type="eightpack">    <location x="2.279743" y="0.000000" z="-1.015098">      <rot axis-x="0" axis-y="1" axis-z="0" val="114.000">      </rot>    </location>  </component></type><type name="bank64">  <component type="eightpack">    <location x="2.203380" y="0.000000" z="-1.171652">      <rot axis-x="0" axis-y="1" axis-z="0" val="118.000">      </rot>    </location>  </component></type><type name="bank65">  <component type="eightpack">    <location x="2.116282" y="0.000000" z="-1.322498">      <rot axis-x="0" axis-y="1" axis-z="0" val="122.000">      </rot>    </location>  </component></type><type name="bank66">  <component type="eightpack">    <location x="2.018874" y="0.000000" z="-1.466901">      <rot axis-x="0" axis-y="1" axis-z="0" val="126.000">      </rot>    </location>  </component></type><type name="bank67">  <component type="eightpack">    <location x="1.911631" y="0.000000" z="-1.604157">      <rot axis-x="0" axis-y="1" axis-z="0" val="130.000">      </rot>    </location>  </component></type><type name="bank68">  <component type="eightpack">    <location x="1.795074" y="0.000000" z="-1.733598">      <rot axis-x="0" axis-y="1" axis-z="0" val="134.000">      </rot>    </location>  </component></type><type name="bank69">  <component type="eightpack">    <location x="0.000000" y="2.270867" z="1.034802">      <rot axis-x="1" axis-y="0" axis-z="0" val="294.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank70">  <component type="eightpack">    <location x="0.000000" y="2.193151" z="1.190689">      <rot axis-x="1" axis-y="0" axis-z="0" val="298.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank71">  <component type="eightpack">    <location x="0.000000" y="2.104750" z="1.340775">      <rot axis-x="1" axis-y="0" axis-z="0" val="302.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank72">  <component type="eightpack">    <location x="0.000000" y="2.006095" z="1.484329">      <rot axis-x="1" axis-y="0" axis-z="0" val="306.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank73">  <component type="eightpack">    <location x="0.000000" y="1.897667" z="1.620651">      <rot axis-x="1" axis-y="0" axis-z="0" val="310.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank74">  <component type="eightpack">    <location x="0.000000" y="1.779994" z="1.749078">      <rot axis-x="1" axis-y="0" axis-z="0" val="314.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank75">  <component type="eightpack">    <location x="0.000000" y="1.653648" z="1.868984">      <rot axis-x="1" axis-y="0" axis-z="0" val="318.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank76">  <component type="eightpack">    <location x="0.000000" y="1.519246" z="1.979784">      <rot axis-x="1" axis-y="0" axis-z="0" val="322.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank77">  <component type="eightpack">    <location x="0.000000" y="1.377443" z="2.080938">      <rot axis-x="1" axis-y="0" axis-z="0" val="326.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank78">  <component type="eightpack">    <location x="0.000000" y="1.228928" z="2.171955">      <rot axis-x="1" axis-y="0" axis-z="0" val="330.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank79">  <component type="eightpack">    <location x="0.000000" y="1.074427" z="2.252389">      <rot axis-x="1" axis-y="0" axis-z="0" val="334.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank80">  <component type="eightpack">    <location x="0.000000" y="0.914691" z="2.321851">      <rot axis-x="1" axis-y="0" axis-z="0" val="338.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank81">  <component type="eightpack">    <location x="0.000000" y="-0.954920" z="2.305597">      <rot axis-x="1" axis-y="0" axis-z="0" val="22.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank82">  <component type="eightpack">    <location x="0.000000" y="-1.113424" z="2.233369">      <rot axis-x="1" axis-y="0" axis-z="0" val="26.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank83">  <component type="eightpack">    <location x="0.000000" y="-1.266504" z="2.150260">      <rot axis-x="1" axis-y="0" axis-z="0" val="30.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank84">  <component type="eightpack">    <location x="0.000000" y="-1.413413" z="2.056676">      <rot axis-x="1" axis-y="0" axis-z="0" val="34.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank85">  <component type="eightpack">    <location x="0.000000" y="-1.553437" z="1.953071">      <rot axis-x="1" axis-y="0" axis-z="0" val="38.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank86">  <component type="eightpack">    <location x="0.000000" y="-1.685892" z="1.839951">      <rot axis-x="1" axis-y="0" axis-z="0" val="42.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank87">  <component type="eightpack">    <location x="0.000000" y="-1.810134" z="1.717867">      <rot axis-x="1" axis-y="0" axis-z="0" val="46.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank88">  <component type="eightpack">    <location x="0.000000" y="-1.925557" z="1.587414">      <rot axis-x="1" axis-y="0" axis-z="0" val="50.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank89">  <component type="eightpack">    <location x="0.000000" y="-2.031598" z="1.449227">      <rot axis-x="1" axis-y="0" axis-z="0" val="54.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank90">  <component type="eightpack">    <location x="0.000000" y="-2.127742" z="1.303980">      <rot axis-x="1" axis-y="0" axis-z="0" val="58.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank91">  <component type="eightpack">    <location x="0.000000" y="-2.213521" z="1.152380">      <rot axis-x="1" axis-y="0" axis-z="0" val="62.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank92">  <component type="eightpack">    <location x="0.000000" y="-2.288514" z="0.995165">      <rot axis-x="1" axis-y="0" axis-z="0" val="66.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank93">  <component type="eightpack">    <location x="0.000000" y="-2.352359" z="0.833102">      <rot axis-x="1" axis-y="0" axis-z="0" val="70.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank94">  <component type="eightpack">    <location x="0.000000" y="-2.404743" z="0.666981">      <rot axis-x="1" axis-y="0" axis-z="0" val="74.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank95">  <component type="eightpack">    <location x="0.000000" y="-2.445411" z="0.497609">      <rot axis-x="1" axis-y="0" axis-z="0" val="78.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank96">  <component type="eightpack">    <location x="0.000000" y="-2.474166" z="0.325814">      <rot axis-x="1" axis-y="0" axis-z="0" val="82.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank97">  <component type="eightpack">    <location x="0.000000" y="-2.490867" z="0.152431">      <rot axis-x="1" axis-y="0" axis-z="0" val="86.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank98">  <component type="eightpack">    <location x="0.000000" y="-2.495432" z="-0.021694">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank99">  <component type="eightpack">    <location x="0.000000" y="-2.487840" z="-0.195714">      <rot axis-x="1" axis-y="0" axis-z="0" val="94.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank100">  <component type="eightpack">    <location x="0.000000" y="-2.468127" z="-0.368780">      <rot axis-x="1" axis-y="0" axis-z="0" val="98.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank101">  <component type="eightpack">    <location x="0.000000" y="-2.436390" z="-0.540050">      <rot axis-x="1" axis-y="0" axis-z="0" val="102.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank102">  <component type="eightpack">    <location x="0.000000" y="-2.392783" z="-0.708688">      <rot axis-x="1" axis-y="0" axis-z="0" val="106.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank103">  <component type="eightpack">    <location x="0.000000" y="-2.337519" z="-0.873874">      <rot axis-x="1" axis-y="0" axis-z="0" val="110.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank104">  <component type="eightpack">    <location x="0.000000" y="-2.270867" z="-1.034802">      <rot axis-x="1" axis-y="0" axis-z="0" val="114.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank105">  <component type="eightpack">    <location x="0.000000" y="-2.193151" z="-1.190689">      <rot axis-x="1" axis-y="0" axis-z="0" val="118.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank106">  <component type="eightpack">    <location x="0.000000" y="-2.104750" z="-1.340775">      <rot axis-x="1" axis-y="0" axis-z="0" val="122.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank107">  <component type="eightpack">    <location x="0.000000" y="-2.006095" z="-1.484329">      <rot axis-x="1" axis-y="0" axis-z="0" val="126.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank108">  <component type="eightpack">    <location x="0.000000" y="-1.897667" z="-1.620651">      <rot axis-x="1" axis-y="0" axis-z="0" val="130.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank109">  <component type="eightpack">    <location x="0.000000" y="-1.779994" z="-1.749078">      <rot axis-x="1" axis-y="0" axis-z="0" val="134.500">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank110">  <component type="eightpack">    <location x="0.000000" y="1.764662" z="-1.764545">      <rot axis-x="1" axis-y="0" axis-z="0" val="225.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank111">  <component type="eightpack">    <location x="0.000000" y="1.883452" z="-1.637150">      <rot axis-x="1" axis-y="0" axis-z="0" val="229.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank112">  <component type="eightpack">    <location x="0.000000" y="1.993066" z="-1.501779">      <rot axis-x="1" axis-y="0" axis-z="0" val="233.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank113">  <component type="eightpack">    <location x="0.000000" y="2.092970" z="-1.359091">      <rot axis-x="1" axis-y="0" axis-z="0" val="237.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank114">  <component type="eightpack">    <location x="0.000000" y="2.182677" z="-1.209782">      <rot axis-x="1" axis-y="0" axis-z="0" val="241.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank115">  <component type="eightpack">    <location x="0.000000" y="2.261750" z="-1.054580">      <rot axis-x="1" axis-y="0" axis-z="0" val="245.000">      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>      </rot>    </location>  </component></type><type name="bank116">  <component type="eightpack">    <location x="1.034802" y="2.270867" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="245.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank117">  <component type="eightpack">    <location x="1.190689" y="2.193151" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="241.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank118">  <component type="eightpack">    <location x="1.340775" y="2.104750" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="237.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank119">  <component type="eightpack">    <location x="1.484329" y="2.006095" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="233.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank120">  <component type="eightpack">    <location x="1.620651" y="1.897667" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="229.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank121">  <component type="eightpack">    <location x="1.749078" y="1.779994" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="225.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank122">  <component type="eightpack">    <location x="1.868984" y="1.653648" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="221.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank123">  <component type="eightpack">    <location x="1.979784" y="1.519246" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="217.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank124">  <component type="eightpack">    <location x="2.080938" y="1.377443" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="213.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank125">  <component type="eightpack">    <location x="2.171955" y="1.228928" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="209.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank126">  <component type="eightpack">    <location x="2.252389" y="1.074427" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="205.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank127">  <component type="eightpack">    <location x="2.321851" y="0.914691" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="201.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank128">  <component type="eightpack">    <location x="2.297112" y="-0.975156" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="157.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank129">  <component type="eightpack">    <location x="2.223493" y="-1.133019" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="153.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank130">  <component type="eightpack">    <location x="2.139041" y="-1.285362" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="149.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank131">  <component type="eightpack">    <location x="2.044168" y="-1.431443" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="145.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank132">  <component type="eightpack">    <location x="1.939336" y="-1.570550" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="141.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank133">  <component type="eightpack">    <location x="1.825056" y="-1.702006" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="137.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank134">  <component type="eightpack">    <location x="1.701884" y="-1.825169" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="133.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank135">  <component type="eightpack">    <location x="1.570421" y="-1.939440" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="129.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank136">  <component type="eightpack">    <location x="1.431307" y="-2.044263" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="125.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank137">  <component type="eightpack">    <location x="1.285220" y="-2.139126" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="121.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank138">  <component type="eightpack">    <location x="1.132871" y="-2.223568" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="117.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank139">  <component type="eightpack">    <location x="0.975003" y="-2.297177" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="113.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank140">  <component type="eightpack">    <location x="-1.034954" y="2.270798" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="114.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank141">  <component type="eightpack">    <location x="-1.190835" y="2.193071" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="118.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank142">  <component type="eightpack">    <location x="-1.340915" y="2.104661" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="122.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank143">  <component type="eightpack">    <location x="-1.484463" y="2.005996" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="126.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank144">  <component type="eightpack">    <location x="-1.620778" y="1.897559" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="130.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank145">  <component type="eightpack">    <location x="-1.749197" y="1.779877" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="134.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank146">  <component type="eightpack">    <location x="-1.869094" y="1.653523" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="138.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank147">  <component type="eightpack">    <location x="-1.979885" y="1.519114" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="142.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank148">  <component type="eightpack">    <location x="-2.081030" y="1.377304" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="146.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank149">  <component type="eightpack">    <location x="-2.172037" y="1.228784" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="150.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank150">  <component type="eightpack">    <location x="-2.252461" y="1.074277" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="154.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank151">  <component type="eightpack">    <location x="-2.321912" y="0.914536" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="158.500">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank152">  <component type="eightpack">    <location x="-2.297177" y="-0.975003" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="203.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank153">  <component type="eightpack">    <location x="-2.223568" y="-1.132871" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="207.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank154">  <component type="eightpack">    <location x="-2.139126" y="-1.285220" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="211.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank155">  <component type="eightpack">    <location x="-2.044263" y="-1.431307" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="215.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank156">  <component type="eightpack">    <location x="-1.939440" y="-1.570421" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="219.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank157">  <component type="eightpack">    <location x="-1.825169" y="-1.701884" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="223.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank158">  <component type="eightpack">    <location x="-1.702006" y="-1.825056" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="227.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank159">  <component type="eightpack">    <location x="-1.570550" y="-1.939336" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="231.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank160">  <component type="eightpack">    <location x="-1.431443" y="-2.044168" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="235.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank161">  <component type="eightpack">    <location x="-1.285362" y="-2.139041" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="239.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank162">  <component type="eightpack">    <location x="-1.133019" y="-2.223493" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="243.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><type name="bank163">  <component type="eightpack">    <location x="-0.975156" y="-2.297112" z="0.000000">      <rot axis-x="0" axis-y="0" axis-z="1" val="247.000">      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>        </rot>      </rot>    </location>  </component></type><!--STANDARD 8-PACK--><type name="eightpack">  <properties/>  <component type="tube">    <location name="tube1" x="-0.075629" y="0.000000" z="-0.020205"/>    <location name="tube2" x="-0.054856" y="0.000000" z="0.018452"/>    <location name="tube3" x="-0.032416" y="0.000000" z="-0.019262"/>    <location name="tube4" x="-0.010972" y="0.000000" z="0.019026"/>    <location name="tube5" x="0.010806" y="0.000000" z="-0.019073"/>    <location name="tube6" x="0.032915" y="0.000000" z="0.018835"/>    <location name="tube7" x="0.054025" y="0.000000" z="-0.019639"/>    <location name="tube8" x="0.076792" y="0.000000" z="0.017877"/>  </component></type><!--STANDARD 1.5m 128 PIXEL TUBE--><type name="tube" outline="yes">  <properties/>  <component type="pixel">    <location name="pixel1" y="-0.744141"/>    <location name="pixel2" y="-0.732422"/>    <location name="pixel3" y="-0.720703"/>    <location name="pixel4" y="-0.708984"/>    <location name="pixel5" y="-0.697266"/>    <location name="pixel6" y="-0.685547"/>    <location name="pixel7" y="-0.673828"/>    <location name="pixel8" y="-0.662109"/>    <location name="pixel9" y="-0.650391"/>    <location name="pixel10" y="-0.638672"/>    <location name="pixel11" y="-0.626953"/>    <location name="pixel12" y="-0.615234"/>    <location name="pixel13" y="-0.603516"/>    <location name="pixel14" y="-0.591797"/>    <location name="pixel15" y="-0.580078"/>    <location name="pixel16" y="-0.568359"/>    <location name="pixel17" y="-0.556641"/>    <location name="pixel18" y="-0.544922"/>    <location name="pixel19" y="-0.533203"/>    <location name="pixel20" y="-0.521484"/>    <location name="pixel21" y="-0.509766"/>    <location name="pixel22" y="-0.498047"/>    <location name="pixel23" y="-0.486328"/>    <location name="pixel24" y="-0.474609"/>    <location name="pixel25" y="-0.462891"/>    <location name="pixel26" y="-0.451172"/>    <location name="pixel27" y="-0.439453"/>    <location name="pixel28" y="-0.427734"/>    <location name="pixel29" y="-0.416016"/>    <location name="pixel30" y="-0.404297"/>    <location name="pixel31" y="-0.392578"/>    <location name="pixel32" y="-0.380859"/>    <location name="pixel33" y="-0.369141"/>    <location name="pixel34" y="-0.357422"/>    <location name="pixel35" y="-0.345703"/>    <location name="pixel36" y="-0.333984"/>    <location name="pixel37" y="-0.322266"/>    <location name="pixel38" y="-0.310547"/>    <location name="pixel39" y="-0.298828"/>    <location name="pixel40" y="-0.287109"/>    <location name="pixel41" y="-0.275391"/>    <location name="pixel42" y="-0.263672"/>    <location name="pixel43" y="-0.251953"/>    <location name="pixel44" y="-0.240234"/>    <location name="pixel45" y="-0.228516"/>    <location name="pixel46" y="-0.216797"/>    <location name="pixel47" y="-0.205078"/>    <location name="pixel48" y="-0.193359"/>    <location name="pixel49" y="-0.181641"/>    <location name="pixel50" y="-0.169922"/>    <location name="pixel51" y="-0.158203"/>    <location name="pixel52" y="-0.146484"/>    <location name="pixel53" y="-0.134766"/>    <location name="pixel54" y="-0.123047"/>    <location name="pixel55" y="-0.111328"/>    <location name="pixel56" y="-0.099609"/>    <location name="pixel57" y="-0.087891"/>    <location name="pixel58" y="-0.076172"/>    <location name="pixel59" y="-0.064453"/>    <location name="pixel60" y="-0.052734"/>    <location name="pixel61" y="-0.041016"/>    <location name="pixel62" y="-0.029297"/>    <location name="pixel63" y="-0.017578"/>    <location name="pixel64" y="-0.005859"/>    <location name="pixel65" y="0.005859"/>    <location name="pixel66" y="0.017578"/>    <location name="pixel67" y="0.029297"/>    <location name="pixel68" y="0.041016"/>    <location name="pixel69" y="0.052734"/>    <location name="pixel70" y="0.064453"/>    <location name="pixel71" y="0.076172"/>    <location name="pixel72" y="0.087891"/>    <location name="pixel73" y="0.099609"/>    <location name="pixel74" y="0.111328"/>    <location name="pixel75" y="0.123047"/>    <location name="pixel76" y="0.134766"/>    <location name="pixel77" y="0.146484"/>    <location name="pixel78" y="0.158203"/>    <location name="pixel79" y="0.169922"/>    <location name="pixel80" y="0.181641"/>    <location name="pixel81" y="0.193359"/>    <location name="pixel82" y="0.205078"/>    <location name="pixel83" y="0.216797"/>    <location name="pixel84" y="0.228516"/>    <location name="pixel85" y="0.240234"/>    <location name="pixel86" y="0.251953"/>    <location name="pixel87" y="0.263672"/>    <location name="pixel88" y="0.275391"/>    <location name="pixel89" y="0.287109"/>    <location name="pixel90" y="0.298828"/>    <location name="pixel91" y="0.310547"/>    <location name="pixel92" y="0.322266"/>    <location name="pixel93" y="0.333984"/>    <location name="pixel94" y="0.345703"/>    <location name="pixel95" y="0.357422"/>    <location name="pixel96" y="0.369141"/>    <location name="pixel97" y="0.380859"/>    <location name="pixel98" y="0.392578"/>    <location name="pixel99" y="0.404297"/>    <location name="pixel100" y="0.416016"/>    <location name="pixel101" y="0.427734"/>    <location name="pixel102" y="0.439453"/>    <location name="pixel103" y="0.451172"/>    <location name="pixel104" y="0.462891"/>    <location name="pixel105" y="0.474609"/>    <location name="pixel106" y="0.486328"/>    <location name="pixel107" y="0.498047"/>    <location name="pixel108" y="0.509766"/>    <location name="pixel109" y="0.521484"/>    <location name="pixel110" y="0.533203"/>    <location name="pixel111" y="0.544922"/>    <location name="pixel112" y="0.556641"/>    <location name="pixel113" y="0.568359"/>    <location name="pixel114" y="0.580078"/>    <location name="pixel115" y="0.591797"/>    <location name="pixel116" y="0.603516"/>    <location name="pixel117" y="0.615234"/>    <location name="pixel118" y="0.626953"/>    <location name="pixel119" y="0.638672"/>    <location name="pixel120" y="0.650391"/>    <location name="pixel121" y="0.662109"/>    <location name="pixel122" y="0.673828"/>    <location name="pixel123" y="0.685547"/>    <location name="pixel124" y="0.697266"/>    <location name="pixel125" y="0.708984"/>    <location name="pixel126" y="0.720703"/>    <location name="pixel127" y="0.732422"/>    <location name="pixel128" y="0.744141"/>  </component></type><!--PIXEL FOR STANDARD 1.5m 128 PIXEL TUBE--><type is="detector" name="pixel">  <cylinder id="cyl-approx">    <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>    <axis x="0" y="1" z="0"/>    <radius val="0.012700"/>    <height val="0.011719"/>  </cylinder>  <algebra val="cyl-approx"/></type><!--MONITOR shape--><type is="monitor" name="monitor">  <cylinder id="cyl-approx">    <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>    <axis x="0" y="1" z="0"/>    <radius val="0.01"/>    <height val="0.03"/>  </cylinder>  <algebra val="cyl-approx"/></type><!--DETECTOR IDs (128 * 8 * # of banks)--><idlist idname="detectors">  <id end="166911" start="0"/></idlist><!--MONITOR IDs--><idlist idname="monitors">  <id val="-1"/>  <id val="-2"/></idlist><!--DETECTOR parameters--><component-link name="detectors">  <parameter name="tube_pressure">    <value units="atm" val="10.0"/>  </parameter>  <parameter name="tube_thickness">    <value units="metre" val="0.001016"/>  </parameter>  <parameter name="tube_temperature">    <value units="K" val="292.0"/>  </parameter></component-link></instrument>
+<?xml version='1.0' encoding='ASCII'?>
+<instrument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.mantidproject.org/IDF/1.0" last-modified="2019-10-01 14:11:19.918208" name="CHESS" valid-from="2019-01-01 00:00:00" valid-to="2100-01-31 23:59:59" xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd">
+  <!--Created by Gabriele Sala-->
+  <defaults>
+    <length unit="metre"/>
+    <angle unit="degree"/>
+    <reference-frame>
+      <along-beam axis="z"/>
+      <pointing-up axis="y"/>
+      <handedness val="right"/>
+      <theta-sign axis="x"/>
+    </reference-frame>
+  </defaults>
+
+<!--SOURCE and SAMPLE positions-->
+<component type="moderator">
+  <location z="-29.53"/>
+</component>
+<type is="Source" name="moderator"/>
+<component type="sample-position">
+  <location x="0.0" y="0.0" z="0.0"/>
+</component>
+<type is="SamplePos" name="sample-position"/>
+
+<!--MONITORS-->
+<component idlist="monitors" type="monitors">
+  <location/>
+</component>
+<type name="monitors">
+  <component type="monitor">
+    <location name="monitor1" z="-15.50"/>
+    <location name="monitor2" z="-1.57"/>
+  </component>
+</type>
+
+<!--DETECTOR bank IDs-->
+<component idlist="detectors" type="detectors">
+  <location/>
+</component>
+<type name="detectors">
+  <component type="bank1">
+    <location/>
+  </component>
+  <component type="bank2">
+    <location/>
+  </component>
+  <component type="bank3">
+    <location/>
+  </component>
+  <component type="bank4">
+    <location/>
+  </component>
+  <component type="bank5">
+    <location/>
+  </component>
+  <component type="bank6">
+    <location/>
+  </component>
+  <component type="bank7">
+    <location/>
+  </component>
+  <component type="bank8">
+    <location/>
+  </component>
+  <component type="bank9">
+    <location/>
+  </component>
+  <component type="bank10">
+    <location/>
+  </component>
+  <component type="bank11">
+    <location/>
+  </component>
+  <component type="bank12">
+    <location/>
+  </component>
+  <component type="bank13">
+    <location/>
+  </component>
+  <component type="bank14">
+    <location/>
+  </component>
+  <component type="bank15">
+    <location/>
+  </component>
+  <component type="bank16">
+    <location/>
+  </component>
+  <component type="bank17">
+    <location/>
+  </component>
+  <component type="bank18">
+    <location/>
+  </component>
+  <component type="bank19">
+    <location/>
+  </component>
+  <component type="bank20">
+    <location/>
+  </component>
+  <component type="bank21">
+    <location/>
+  </component>
+  <component type="bank22">
+    <location/>
+  </component>
+  <component type="bank23">
+    <location/>
+  </component>
+  <component type="bank24">
+    <location/>
+  </component>
+  <component type="bank25">
+    <location/>
+  </component>
+  <component type="bank26">
+    <location/>
+  </component>
+  <component type="bank27">
+    <location/>
+  </component>
+  <component type="bank28">
+    <location/>
+  </component>
+  <component type="bank29">
+    <location/>
+  </component>
+  <component type="bank30">
+    <location/>
+  </component>
+  <component type="bank31">
+    <location/>
+  </component>
+  <component type="bank32">
+    <location/>
+  </component>
+  <component type="bank33">
+    <location/>
+  </component>
+  <component type="bank34">
+    <location/>
+  </component>
+  <component type="bank35">
+    <location/>
+  </component>
+  <component type="bank36">
+    <location/>
+  </component>
+  <component type="bank37">
+    <location/>
+  </component>
+  <component type="bank38">
+    <location/>
+  </component>
+  <component type="bank39">
+    <location/>
+  </component>
+  <component type="bank40">
+    <location/>
+  </component>
+  <component type="bank41">
+    <location/>
+  </component>
+  <component type="bank42">
+    <location/>
+  </component>
+  <component type="bank43">
+    <location/>
+  </component>
+  <component type="bank44">
+    <location/>
+  </component>
+  <component type="bank45">
+    <location/>
+  </component>
+  <component type="bank46">
+    <location/>
+  </component>
+  <component type="bank47">
+    <location/>
+  </component>
+  <component type="bank48">
+    <location/>
+  </component>
+  <component type="bank49">
+    <location/>
+  </component>
+  <component type="bank50">
+    <location/>
+  </component>
+  <component type="bank51">
+    <location/>
+  </component>
+  <component type="bank52">
+    <location/>
+  </component>
+  <component type="bank53">
+    <location/>
+  </component>
+  <component type="bank54">
+    <location/>
+  </component>
+  <component type="bank55">
+    <location/>
+  </component>
+  <component type="bank56">
+    <location/>
+  </component>
+  <component type="bank57">
+    <location/>
+  </component>
+  <component type="bank58">
+    <location/>
+  </component>
+  <component type="bank59">
+    <location/>
+  </component>
+  <component type="bank60">
+    <location/>
+  </component>
+  <component type="bank61">
+    <location/>
+  </component>
+  <component type="bank62">
+    <location/>
+  </component>
+  <component type="bank63">
+    <location/>
+  </component>
+  <component type="bank64">
+    <location/>
+  </component>
+  <component type="bank65">
+    <location/>
+  </component>
+  <component type="bank66">
+    <location/>
+  </component>
+  <component type="bank67">
+    <location/>
+  </component>
+  <component type="bank68">
+    <location/>
+  </component>
+  <component type="bank69">
+    <location/>
+  </component>
+  <component type="bank70">
+    <location/>
+  </component>
+  <component type="bank71">
+    <location/>
+  </component>
+  <component type="bank72">
+    <location/>
+  </component>
+  <component type="bank73">
+    <location/>
+  </component>
+  <component type="bank74">
+    <location/>
+  </component>
+  <component type="bank75">
+    <location/>
+  </component>
+  <component type="bank76">
+    <location/>
+  </component>
+  <component type="bank77">
+    <location/>
+  </component>
+  <component type="bank78">
+    <location/>
+  </component>
+  <component type="bank79">
+    <location/>
+  </component>
+  <component type="bank80">
+    <location/>
+  </component>
+  <component type="bank81">
+    <location/>
+  </component>
+  <component type="bank82">
+    <location/>
+  </component>
+  <component type="bank83">
+    <location/>
+  </component>
+  <component type="bank84">
+    <location/>
+  </component>
+  <component type="bank85">
+    <location/>
+  </component>
+  <component type="bank86">
+    <location/>
+  </component>
+  <component type="bank87">
+    <location/>
+  </component>
+  <component type="bank88">
+    <location/>
+  </component>
+  <component type="bank89">
+    <location/>
+  </component>
+  <component type="bank90">
+    <location/>
+  </component>
+  <component type="bank91">
+    <location/>
+  </component>
+  <component type="bank92">
+    <location/>
+  </component>
+  <component type="bank93">
+    <location/>
+  </component>
+  <component type="bank94">
+    <location/>
+  </component>
+  <component type="bank95">
+    <location/>
+  </component>
+  <component type="bank96">
+    <location/>
+  </component>
+  <component type="bank97">
+    <location/>
+  </component>
+  <component type="bank98">
+    <location/>
+  </component>
+  <component type="bank99">
+    <location/>
+  </component>
+  <component type="bank100">
+    <location/>
+  </component>
+  <component type="bank101">
+    <location/>
+  </component>
+  <component type="bank102">
+    <location/>
+  </component>
+  <component type="bank103">
+    <location/>
+  </component>
+  <component type="bank104">
+    <location/>
+  </component>
+  <component type="bank105">
+    <location/>
+  </component>
+  <component type="bank106">
+    <location/>
+  </component>
+  <component type="bank107">
+    <location/>
+  </component>
+  <component type="bank108">
+    <location/>
+  </component>
+  <component type="bank109">
+    <location/>
+  </component>
+  <component type="bank110">
+    <location/>
+  </component>
+  <component type="bank111">
+    <location/>
+  </component>
+  <component type="bank112">
+    <location/>
+  </component>
+  <component type="bank113">
+    <location/>
+  </component>
+  <component type="bank114">
+    <location/>
+  </component>
+  <component type="bank115">
+    <location/>
+  </component>
+  <component type="bank116">
+    <location/>
+  </component>
+  <component type="bank117">
+    <location/>
+  </component>
+  <component type="bank118">
+    <location/>
+  </component>
+  <component type="bank119">
+    <location/>
+  </component>
+  <component type="bank120">
+    <location/>
+  </component>
+  <component type="bank121">
+    <location/>
+  </component>
+  <component type="bank122">
+    <location/>
+  </component>
+  <component type="bank123">
+    <location/>
+  </component>
+  <component type="bank124">
+    <location/>
+  </component>
+  <component type="bank125">
+    <location/>
+  </component>
+  <component type="bank126">
+    <location/>
+  </component>
+  <component type="bank127">
+    <location/>
+  </component>
+  <component type="bank128">
+    <location/>
+  </component>
+  <component type="bank129">
+    <location/>
+  </component>
+  <component type="bank130">
+    <location/>
+  </component>
+  <component type="bank131">
+    <location/>
+  </component>
+  <component type="bank132">
+    <location/>
+  </component>
+  <component type="bank133">
+    <location/>
+  </component>
+  <component type="bank134">
+    <location/>
+  </component>
+  <component type="bank135">
+    <location/>
+  </component>
+  <component type="bank136">
+    <location/>
+  </component>
+  <component type="bank137">
+    <location/>
+  </component>
+  <component type="bank138">
+    <location/>
+  </component>
+  <component type="bank139">
+    <location/>
+  </component>
+  <component type="bank140">
+    <location/>
+  </component>
+  <component type="bank141">
+    <location/>
+  </component>
+  <component type="bank142">
+    <location/>
+  </component>
+  <component type="bank143">
+    <location/>
+  </component>
+  <component type="bank144">
+    <location/>
+  </component>
+  <component type="bank145">
+    <location/>
+  </component>
+  <component type="bank146">
+    <location/>
+  </component>
+  <component type="bank147">
+    <location/>
+  </component>
+  <component type="bank148">
+    <location/>
+  </component>
+  <component type="bank149">
+    <location/>
+  </component>
+  <component type="bank150">
+    <location/>
+  </component>
+  <component type="bank151">
+    <location/>
+  </component>
+  <component type="bank152">
+    <location/>
+  </component>
+  <component type="bank153">
+    <location/>
+  </component>
+  <component type="bank154">
+    <location/>
+  </component>
+  <component type="bank155">
+    <location/>
+  </component>
+  <component type="bank156">
+    <location/>
+  </component>
+  <component type="bank157">
+    <location/>
+  </component>
+  <component type="bank158">
+    <location/>
+  </component>
+  <component type="bank159">
+    <location/>
+  </component>
+  <component type="bank160">
+    <location/>
+  </component>
+  <component type="bank161">
+    <location/>
+  </component>
+  <component type="bank162">
+    <location/>
+  </component>
+  <component type="bank163">
+    <location/>
+  </component>
+</type>
+
+<!--DETECTOR bank positions and orientations-->
+<type name="bank1">
+  <component type="eightpack">
+    <location x="-1.795189" y="0.000000" z="-1.733478">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="226.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank2">
+  <component type="eightpack">
+    <location x="-1.911737" y="0.000000" z="-1.604030">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="230.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank3">
+  <component type="eightpack">
+    <location x="-2.018972" y="0.000000" z="-1.466766">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="234.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank4">
+  <component type="eightpack">
+    <location x="-2.116370" y="0.000000" z="-1.322357">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="238.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank5">
+  <component type="eightpack">
+    <location x="-2.203458" y="0.000000" z="-1.171505">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="242.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank6">
+  <component type="eightpack">
+    <location x="-2.279810" y="0.000000" z="-1.014946">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="246.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank7">
+  <component type="eightpack">
+    <location x="-2.345056" y="0.000000" z="-0.853442">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="250.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank8">
+  <component type="eightpack">
+    <location x="-2.398877" y="0.000000" z="-0.687780">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="254.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank9">
+  <component type="eightpack">
+    <location x="-2.441010" y="0.000000" z="-0.518768">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="258.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank10">
+  <component type="eightpack">
+    <location x="-2.471251" y="0.000000" z="-0.347228">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="262.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank11">
+  <component type="eightpack">
+    <location x="-2.489453" y="0.000000" z="-0.173996">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="266.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank12">
+  <component type="eightpack">
+    <location x="-2.495526" y="0.000000" z="0.000083">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="270.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank13">
+  <component type="eightpack">
+    <location x="-2.489441" y="0.000000" z="0.174162">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="274.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank14">
+  <component type="eightpack">
+    <location x="-2.471228" y="0.000000" z="0.347392">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="278.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank15">
+  <component type="eightpack">
+    <location x="-2.440976" y="0.000000" z="0.518930">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="282.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank16">
+  <component type="eightpack">
+    <location x="-2.398831" y="0.000000" z="0.687940">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="286.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank17">
+  <component type="eightpack">
+    <location x="-2.344999" y="0.000000" z="0.853598">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="290.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank18">
+  <component type="eightpack">
+    <location x="-2.279743" y="0.000000" z="1.015098">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="294.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank19">
+  <component type="eightpack">
+    <location x="-2.203380" y="0.000000" z="1.171652">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="298.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank20">
+  <component type="eightpack">
+    <location x="-2.116282" y="0.000000" z="1.322498">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="302.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank21">
+  <component type="eightpack">
+    <location x="-2.018874" y="0.000000" z="1.466901">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="306.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank22">
+  <component type="eightpack">
+    <location x="-1.911631" y="0.000000" z="1.604157">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="310.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank23">
+  <component type="eightpack">
+    <location x="-1.795074" y="0.000000" z="1.733598">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="314.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank24">
+  <component type="eightpack">
+    <location x="-1.669771" y="0.000000" z="1.854593">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="318.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank25">
+  <component type="eightpack">
+    <location x="-1.536334" y="0.000000" z="1.966553">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="322.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank26">
+  <component type="eightpack">
+    <location x="-1.395412" y="0.000000" z="2.068932">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="326.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank27">
+  <component type="eightpack">
+    <location x="-1.247691" y="0.000000" z="2.161231">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="330.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank28">
+  <component type="eightpack">
+    <location x="-1.093892" y="0.000000" z="2.243001">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="334.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank29">
+  <component type="eightpack">
+    <location x="-0.934764" y="0.000000" z="2.313843">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="338.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank30">
+  <component type="eightpack">
+    <location x="-0.771081" y="0.000000" z="2.373412">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="342.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank31">
+  <component type="eightpack">
+    <location x="-0.603642" y="0.000000" z="2.421419">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="346.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank32">
+  <component type="eightpack">
+    <location x="-0.433262" y="0.000000" z="2.457628">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="350.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank33">
+  <component type="eightpack">
+    <location x="-0.260771" y="0.000000" z="2.481864">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="354.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank34">
+  <component type="eightpack">
+    <location x="-0.087010" y="0.000000" z="2.494009">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="358.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank35">
+  <component type="eightpack">
+    <location x="0.087176" y="0.000000" z="2.494003">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="2.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank36">
+  <component type="eightpack">
+    <location x="0.260936" y="0.000000" z="2.481847">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="6.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank37">
+  <component type="eightpack">
+    <location x="0.433425" y="0.000000" z="2.457599">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="10.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank38">
+  <component type="eightpack">
+    <location x="0.603803" y="0.000000" z="2.421378">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="14.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank39">
+  <component type="eightpack">
+    <location x="0.771239" y="0.000000" z="2.373361">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="18.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank40">
+  <component type="eightpack">
+    <location x="0.934918" y="0.000000" z="2.313781">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="22.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank41">
+  <component type="eightpack">
+    <location x="1.094041" y="0.000000" z="2.242928">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="26.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank42">
+  <component type="eightpack">
+    <location x="1.247835" y="0.000000" z="2.161148">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="30.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank43">
+  <component type="eightpack">
+    <location x="1.395550" y="0.000000" z="2.068839">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="34.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank44">
+  <component type="eightpack">
+    <location x="1.536465" y="0.000000" z="1.966450">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="38.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank45">
+  <component type="eightpack">
+    <location x="1.669895" y="0.000000" z="1.854482">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="42.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank46">
+  <component type="eightpack">
+    <location x="1.795189" y="0.000000" z="1.733478">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="46.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank47">
+  <component type="eightpack">
+    <location x="1.911737" y="0.000000" z="1.604030">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="50.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank48">
+  <component type="eightpack">
+    <location x="2.018972" y="0.000000" z="1.466766">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="54.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank49">
+  <component type="eightpack">
+    <location x="2.116370" y="0.000000" z="1.322357">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="58.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank50">
+  <component type="eightpack">
+    <location x="2.203458" y="0.000000" z="1.171505">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="62.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank51">
+  <component type="eightpack">
+    <location x="2.279810" y="0.000000" z="1.014946">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="66.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank52">
+  <component type="eightpack">
+    <location x="2.345056" y="0.000000" z="0.853442">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="70.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank53">
+  <component type="eightpack">
+    <location x="2.398877" y="0.000000" z="0.687780">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="74.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank54">
+  <component type="eightpack">
+    <location x="2.441010" y="0.000000" z="0.518768">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="78.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank55">
+  <component type="eightpack">
+    <location x="2.471251" y="0.000000" z="0.347228">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="82.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank56">
+  <component type="eightpack">
+    <location x="2.489453" y="0.000000" z="0.173996">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="86.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank57">
+  <component type="eightpack">
+    <location x="2.495526" y="0.000000" z="-0.000083">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="90.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank58">
+  <component type="eightpack">
+    <location x="2.489441" y="0.000000" z="-0.174162">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="94.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank59">
+  <component type="eightpack">
+    <location x="2.471228" y="0.000000" z="-0.347392">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="98.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank60">
+  <component type="eightpack">
+    <location x="2.440976" y="0.000000" z="-0.518930">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="102.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank61">
+  <component type="eightpack">
+    <location x="2.398831" y="0.000000" z="-0.687940">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="106.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank62">
+  <component type="eightpack">
+    <location x="2.344999" y="0.000000" z="-0.853598">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="110.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank63">
+  <component type="eightpack">
+    <location x="2.279743" y="0.000000" z="-1.015098">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="114.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank64">
+  <component type="eightpack">
+    <location x="2.203380" y="0.000000" z="-1.171652">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="118.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank65">
+  <component type="eightpack">
+    <location x="2.116282" y="0.000000" z="-1.322498">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="122.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank66">
+  <component type="eightpack">
+    <location x="2.018874" y="0.000000" z="-1.466901">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="126.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank67">
+  <component type="eightpack">
+    <location x="1.911631" y="0.000000" z="-1.604157">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="130.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank68">
+  <component type="eightpack">
+    <location x="1.795074" y="0.000000" z="-1.733598">
+      <rot axis-x="0" axis-y="1" axis-z="0" val="134.000">
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank69">
+  <component type="eightpack">
+    <location x="0.000000" y="2.270867" z="1.034802">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="294.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank70">
+  <component type="eightpack">
+    <location x="0.000000" y="2.193151" z="1.190689">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="298.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank71">
+  <component type="eightpack">
+    <location x="0.000000" y="2.104750" z="1.340775">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="302.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank72">
+  <component type="eightpack">
+    <location x="0.000000" y="2.006095" z="1.484329">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="306.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank73">
+  <component type="eightpack">
+    <location x="0.000000" y="1.897667" z="1.620651">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="310.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank74">
+  <component type="eightpack">
+    <location x="0.000000" y="1.779994" z="1.749078">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="314.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank75">
+  <component type="eightpack">
+    <location x="0.000000" y="1.653648" z="1.868984">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="318.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank76">
+  <component type="eightpack">
+    <location x="0.000000" y="1.519246" z="1.979784">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="322.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank77">
+  <component type="eightpack">
+    <location x="0.000000" y="1.377443" z="2.080938">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="326.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank78">
+  <component type="eightpack">
+    <location x="0.000000" y="1.228928" z="2.171955">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="330.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank79">
+  <component type="eightpack">
+    <location x="0.000000" y="1.074427" z="2.252389">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="334.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank80">
+  <component type="eightpack">
+    <location x="0.000000" y="0.914691" z="2.321851">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="338.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank81">
+  <component type="eightpack">
+    <location x="0.000000" y="-0.954920" z="2.305597">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="22.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank82">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.113424" z="2.233369">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="26.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank83">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.266504" z="2.150260">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="30.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank84">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.413413" z="2.056676">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="34.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank85">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.553437" z="1.953071">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="38.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank86">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.685892" z="1.839951">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="42.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank87">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.810134" z="1.717867">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="46.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank88">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.925557" z="1.587414">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="50.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank89">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.031598" z="1.449227">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="54.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank90">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.127742" z="1.303980">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="58.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank91">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.213521" z="1.152380">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="62.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank92">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.288514" z="0.995165">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="66.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank93">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.352359" z="0.833102">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="70.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank94">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.404743" z="0.666981">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="74.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank95">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.445411" z="0.497609">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="78.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank96">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.474166" z="0.325814">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="82.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank97">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.490867" z="0.152431">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="86.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank98">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.495432" z="-0.021694">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank99">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.487840" z="-0.195714">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="94.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank100">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.468127" z="-0.368780">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="98.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank101">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.436390" z="-0.540050">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="102.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank102">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.392783" z="-0.708688">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="106.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank103">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.337519" z="-0.873874">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="110.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank104">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.270867" z="-1.034802">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="114.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank105">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.193151" z="-1.190689">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="118.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank106">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.104750" z="-1.340775">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="122.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank107">
+  <component type="eightpack">
+    <location x="0.000000" y="-2.006095" z="-1.484329">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="126.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank108">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.897667" z="-1.620651">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="130.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank109">
+  <component type="eightpack">
+    <location x="0.000000" y="-1.779994" z="-1.749078">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="134.500">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank110">
+  <component type="eightpack">
+    <location x="0.000000" y="1.764662" z="-1.764545">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="225.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank111">
+  <component type="eightpack">
+    <location x="0.000000" y="1.883452" z="-1.637150">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="229.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank112">
+  <component type="eightpack">
+    <location x="0.000000" y="1.993066" z="-1.501779">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="233.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank113">
+  <component type="eightpack">
+    <location x="0.000000" y="2.092970" z="-1.359091">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="237.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank114">
+  <component type="eightpack">
+    <location x="0.000000" y="2.182677" z="-1.209782">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="241.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank115">
+  <component type="eightpack">
+    <location x="0.000000" y="2.261750" z="-1.054580">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="245.000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="90.000"/>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank116">
+  <component type="eightpack">
+    <location x="1.034802" y="2.270867" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="245.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank117">
+  <component type="eightpack">
+    <location x="1.190689" y="2.193151" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="241.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank118">
+  <component type="eightpack">
+    <location x="1.340775" y="2.104750" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="237.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank119">
+  <component type="eightpack">
+    <location x="1.484329" y="2.006095" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="233.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank120">
+  <component type="eightpack">
+    <location x="1.620651" y="1.897667" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="229.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank121">
+  <component type="eightpack">
+    <location x="1.749078" y="1.779994" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="225.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank122">
+  <component type="eightpack">
+    <location x="1.868984" y="1.653648" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="221.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank123">
+  <component type="eightpack">
+    <location x="1.979784" y="1.519246" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="217.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank124">
+  <component type="eightpack">
+    <location x="2.080938" y="1.377443" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="213.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank125">
+  <component type="eightpack">
+    <location x="2.171955" y="1.228928" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="209.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank126">
+  <component type="eightpack">
+    <location x="2.252389" y="1.074427" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="205.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank127">
+  <component type="eightpack">
+    <location x="2.321851" y="0.914691" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="201.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank128">
+  <component type="eightpack">
+    <location x="2.297112" y="-0.975156" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="157.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank129">
+  <component type="eightpack">
+    <location x="2.223493" y="-1.133019" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="153.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank130">
+  <component type="eightpack">
+    <location x="2.139041" y="-1.285362" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="149.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank131">
+  <component type="eightpack">
+    <location x="2.044168" y="-1.431443" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="145.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank132">
+  <component type="eightpack">
+    <location x="1.939336" y="-1.570550" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="141.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank133">
+  <component type="eightpack">
+    <location x="1.825056" y="-1.702006" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="137.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank134">
+  <component type="eightpack">
+    <location x="1.701884" y="-1.825169" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="133.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank135">
+  <component type="eightpack">
+    <location x="1.570421" y="-1.939440" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="129.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank136">
+  <component type="eightpack">
+    <location x="1.431307" y="-2.044263" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="125.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank137">
+  <component type="eightpack">
+    <location x="1.285220" y="-2.139126" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="121.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank138">
+  <component type="eightpack">
+    <location x="1.132871" y="-2.223568" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="117.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank139">
+  <component type="eightpack">
+    <location x="0.975003" y="-2.297177" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="113.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="-90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank140">
+  <component type="eightpack">
+    <location x="-1.034954" y="2.270798" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="114.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank141">
+  <component type="eightpack">
+    <location x="-1.190835" y="2.193071" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="118.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank142">
+  <component type="eightpack">
+    <location x="-1.340915" y="2.104661" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="122.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank143">
+  <component type="eightpack">
+    <location x="-1.484463" y="2.005996" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="126.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank144">
+  <component type="eightpack">
+    <location x="-1.620778" y="1.897559" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="130.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank145">
+  <component type="eightpack">
+    <location x="-1.749197" y="1.779877" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="134.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank146">
+  <component type="eightpack">
+    <location x="-1.869094" y="1.653523" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="138.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank147">
+  <component type="eightpack">
+    <location x="-1.979885" y="1.519114" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="142.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank148">
+  <component type="eightpack">
+    <location x="-2.081030" y="1.377304" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="146.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank149">
+  <component type="eightpack">
+    <location x="-2.172037" y="1.228784" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="150.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank150">
+  <component type="eightpack">
+    <location x="-2.252461" y="1.074277" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="154.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank151">
+  <component type="eightpack">
+    <location x="-2.321912" y="0.914536" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="158.500">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank152">
+  <component type="eightpack">
+    <location x="-2.297177" y="-0.975003" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="203.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank153">
+  <component type="eightpack">
+    <location x="-2.223568" y="-1.132871" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="207.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank154">
+  <component type="eightpack">
+    <location x="-2.139126" y="-1.285220" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="211.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank155">
+  <component type="eightpack">
+    <location x="-2.044263" y="-1.431307" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="215.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank156">
+  <component type="eightpack">
+    <location x="-1.939440" y="-1.570421" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="219.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank157">
+  <component type="eightpack">
+    <location x="-1.825169" y="-1.701884" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="223.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank158">
+  <component type="eightpack">
+    <location x="-1.702006" y="-1.825056" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="227.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank159">
+  <component type="eightpack">
+    <location x="-1.570550" y="-1.939336" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="231.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank160">
+  <component type="eightpack">
+    <location x="-1.431443" y="-2.044168" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="235.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank161">
+  <component type="eightpack">
+    <location x="-1.285362" y="-2.139041" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="239.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank162">
+  <component type="eightpack">
+    <location x="-1.133019" y="-2.223493" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="243.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+<type name="bank163">
+  <component type="eightpack">
+    <location x="-0.975156" y="-2.297112" z="0.000000">
+      <rot axis-x="0" axis-y="0" axis-z="1" val="247.000">
+      <rot axis-x="1" axis-y="0" axis-z="0" val="90.000">
+        <rot axis-x="0" axis-y="1" axis-z="0" val="90.000"/>
+        </rot>
+      </rot>
+    </location>
+  </component>
+</type>
+
+<!--STANDARD 8-PACK-->
+<type name="eightpack">
+  <properties/>
+  <component type="tube">
+    <location name="tube1" x="-0.075629" y="0.000000" z="-0.020205"/>
+    <location name="tube2" x="-0.054856" y="0.000000" z="0.018452"/>
+    <location name="tube3" x="-0.032416" y="0.000000" z="-0.019262"/>
+    <location name="tube4" x="-0.010972" y="0.000000" z="0.019026"/>
+    <location name="tube5" x="0.010806" y="0.000000" z="-0.019073"/>
+    <location name="tube6" x="0.032915" y="0.000000" z="0.018835"/>
+    <location name="tube7" x="0.054025" y="0.000000" z="-0.019639"/>
+    <location name="tube8" x="0.076792" y="0.000000" z="0.017877"/>
+  </component>
+</type>
+
+<!--STANDARD 1.5m 128 PIXEL TUBE-->
+<type name="tube" outline="yes">
+  <properties/>
+  <component type="pixel">
+    <location name="pixel1" y="-0.744141"/>
+    <location name="pixel2" y="-0.732422"/>
+    <location name="pixel3" y="-0.720703"/>
+    <location name="pixel4" y="-0.708984"/>
+    <location name="pixel5" y="-0.697266"/>
+    <location name="pixel6" y="-0.685547"/>
+    <location name="pixel7" y="-0.673828"/>
+    <location name="pixel8" y="-0.662109"/>
+    <location name="pixel9" y="-0.650391"/>
+    <location name="pixel10" y="-0.638672"/>
+    <location name="pixel11" y="-0.626953"/>
+    <location name="pixel12" y="-0.615234"/>
+    <location name="pixel13" y="-0.603516"/>
+    <location name="pixel14" y="-0.591797"/>
+    <location name="pixel15" y="-0.580078"/>
+    <location name="pixel16" y="-0.568359"/>
+    <location name="pixel17" y="-0.556641"/>
+    <location name="pixel18" y="-0.544922"/>
+    <location name="pixel19" y="-0.533203"/>
+    <location name="pixel20" y="-0.521484"/>
+    <location name="pixel21" y="-0.509766"/>
+    <location name="pixel22" y="-0.498047"/>
+    <location name="pixel23" y="-0.486328"/>
+    <location name="pixel24" y="-0.474609"/>
+    <location name="pixel25" y="-0.462891"/>
+    <location name="pixel26" y="-0.451172"/>
+    <location name="pixel27" y="-0.439453"/>
+    <location name="pixel28" y="-0.427734"/>
+    <location name="pixel29" y="-0.416016"/>
+    <location name="pixel30" y="-0.404297"/>
+    <location name="pixel31" y="-0.392578"/>
+    <location name="pixel32" y="-0.380859"/>
+    <location name="pixel33" y="-0.369141"/>
+    <location name="pixel34" y="-0.357422"/>
+    <location name="pixel35" y="-0.345703"/>
+    <location name="pixel36" y="-0.333984"/>
+    <location name="pixel37" y="-0.322266"/>
+    <location name="pixel38" y="-0.310547"/>
+    <location name="pixel39" y="-0.298828"/>
+    <location name="pixel40" y="-0.287109"/>
+    <location name="pixel41" y="-0.275391"/>
+    <location name="pixel42" y="-0.263672"/>
+    <location name="pixel43" y="-0.251953"/>
+    <location name="pixel44" y="-0.240234"/>
+    <location name="pixel45" y="-0.228516"/>
+    <location name="pixel46" y="-0.216797"/>
+    <location name="pixel47" y="-0.205078"/>
+    <location name="pixel48" y="-0.193359"/>
+    <location name="pixel49" y="-0.181641"/>
+    <location name="pixel50" y="-0.169922"/>
+    <location name="pixel51" y="-0.158203"/>
+    <location name="pixel52" y="-0.146484"/>
+    <location name="pixel53" y="-0.134766"/>
+    <location name="pixel54" y="-0.123047"/>
+    <location name="pixel55" y="-0.111328"/>
+    <location name="pixel56" y="-0.099609"/>
+    <location name="pixel57" y="-0.087891"/>
+    <location name="pixel58" y="-0.076172"/>
+    <location name="pixel59" y="-0.064453"/>
+    <location name="pixel60" y="-0.052734"/>
+    <location name="pixel61" y="-0.041016"/>
+    <location name="pixel62" y="-0.029297"/>
+    <location name="pixel63" y="-0.017578"/>
+    <location name="pixel64" y="-0.005859"/>
+    <location name="pixel65" y="0.005859"/>
+    <location name="pixel66" y="0.017578"/>
+    <location name="pixel67" y="0.029297"/>
+    <location name="pixel68" y="0.041016"/>
+    <location name="pixel69" y="0.052734"/>
+    <location name="pixel70" y="0.064453"/>
+    <location name="pixel71" y="0.076172"/>
+    <location name="pixel72" y="0.087891"/>
+    <location name="pixel73" y="0.099609"/>
+    <location name="pixel74" y="0.111328"/>
+    <location name="pixel75" y="0.123047"/>
+    <location name="pixel76" y="0.134766"/>
+    <location name="pixel77" y="0.146484"/>
+    <location name="pixel78" y="0.158203"/>
+    <location name="pixel79" y="0.169922"/>
+    <location name="pixel80" y="0.181641"/>
+    <location name="pixel81" y="0.193359"/>
+    <location name="pixel82" y="0.205078"/>
+    <location name="pixel83" y="0.216797"/>
+    <location name="pixel84" y="0.228516"/>
+    <location name="pixel85" y="0.240234"/>
+    <location name="pixel86" y="0.251953"/>
+    <location name="pixel87" y="0.263672"/>
+    <location name="pixel88" y="0.275391"/>
+    <location name="pixel89" y="0.287109"/>
+    <location name="pixel90" y="0.298828"/>
+    <location name="pixel91" y="0.310547"/>
+    <location name="pixel92" y="0.322266"/>
+    <location name="pixel93" y="0.333984"/>
+    <location name="pixel94" y="0.345703"/>
+    <location name="pixel95" y="0.357422"/>
+    <location name="pixel96" y="0.369141"/>
+    <location name="pixel97" y="0.380859"/>
+    <location name="pixel98" y="0.392578"/>
+    <location name="pixel99" y="0.404297"/>
+    <location name="pixel100" y="0.416016"/>
+    <location name="pixel101" y="0.427734"/>
+    <location name="pixel102" y="0.439453"/>
+    <location name="pixel103" y="0.451172"/>
+    <location name="pixel104" y="0.462891"/>
+    <location name="pixel105" y="0.474609"/>
+    <location name="pixel106" y="0.486328"/>
+    <location name="pixel107" y="0.498047"/>
+    <location name="pixel108" y="0.509766"/>
+    <location name="pixel109" y="0.521484"/>
+    <location name="pixel110" y="0.533203"/>
+    <location name="pixel111" y="0.544922"/>
+    <location name="pixel112" y="0.556641"/>
+    <location name="pixel113" y="0.568359"/>
+    <location name="pixel114" y="0.580078"/>
+    <location name="pixel115" y="0.591797"/>
+    <location name="pixel116" y="0.603516"/>
+    <location name="pixel117" y="0.615234"/>
+    <location name="pixel118" y="0.626953"/>
+    <location name="pixel119" y="0.638672"/>
+    <location name="pixel120" y="0.650391"/>
+    <location name="pixel121" y="0.662109"/>
+    <location name="pixel122" y="0.673828"/>
+    <location name="pixel123" y="0.685547"/>
+    <location name="pixel124" y="0.697266"/>
+    <location name="pixel125" y="0.708984"/>
+    <location name="pixel126" y="0.720703"/>
+    <location name="pixel127" y="0.732422"/>
+    <location name="pixel128" y="0.744141"/>
+  </component>
+</type>
+
+<!--PIXEL FOR STANDARD 1.5m 128 PIXEL TUBE-->
+<type is="detector" name="pixel">
+  <cylinder id="cyl-approx">
+    <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+    <axis x="0" y="1" z="0"/>
+    <radius val="0.012700"/>
+    <height val="0.011719"/>
+  </cylinder>
+  <algebra val="cyl-approx"/>
+</type>
+
+<!--MONITOR shape-->
+<type is="monitor" name="monitor">
+  <cylinder id="cyl-approx">
+    <centre-of-bottom-base p="0.0" r="0.0" t="0.0"/>
+    <axis x="0" y="1" z="0"/>
+    <radius val="0.01"/>
+    <height val="0.03"/>
+  </cylinder>
+  <algebra val="cyl-approx"/>
+</type>
+
+<!--DETECTOR IDs (128 * 8 * # of banks)-->
+<idlist idname="detectors">
+  <id end="166911" start="0"/>
+</idlist>
+
+<!--MONITOR IDs-->
+<idlist idname="monitors">
+  <id val="-1"/>
+  <id val="-2"/>
+</idlist>
+
+<!--DETECTOR parameters-->
+<component-link name="detectors">
+  <parameter name="tube_pressure">
+    <value units="atm" val="10.0"/>
+  </parameter>
+  <parameter name="tube_thickness">
+    <value units="metre" val="0.001016"/>
+  </parameter>
+  <parameter name="tube_temperature">
+    <value units="K" val="292.0"/>
+  </parameter>
+</component-link>
+</instrument>
+


### PR DESCRIPTION
**Description of work.**

Mac-only eol characters confuse our checksum calculator
and it causes the IDF to be downloaded even when this is not
necessary and the downloaded content matches the installed
content.

**To test:**

To check the issue before the merge:
* Close Workbench
* Remove `github.json` & all `.xml` files in `~/.mantid/instrument` (Mac/Linux) or `%APPDATA%\mantidproject\mantid\instrument`
* Add `UpdateInstrumentDefinitions.OnStartup = 1` to `Mantid.user.properties`
* Start Workbench and observe that 1 new definition is downloaded.
* Check `~/.mantid/instrument` or `%APPDATA%\mantidproject\mantid\instrument` and you should see `CHESS_Definition.xml`
* Close Workbench
* Remove `github.json` & all `.xml` files in `~/.mantid/instrument` (Mac/Linux) or `%APPDATA%\mantidproject\mantid\instrument` again.

Merge the fix and redo the above steps but now nothing should be reported as downloaded.

*There is no associated issue.*

*This does not require release notes* because **it's a new IDF for this cycle.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
