### PR TITLE
Ignore SyntaxWarning on package workbench/mantidplot on Windows

### DIFF
--- a/buildconfig/CMake/Packaging/launch_mantidplot.bat
+++ b/buildconfig/CMake/Packaging/launch_mantidplot.bat
@@ -30,6 +30,8 @@ set PV_PLUGIN_PATH=%_INSTALL_DIR%\plugins\paraview\qt4
 if "%MPLBACKEND%"=="" (
   set MPLBACKEND=qt4agg
 )
+:: Ignore Python SyntaxWarning
+set PYTHONWARNINGS=default::DeprecationWarning:__main__,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ImportWarning,ignore::ResourceWarning,ignore::SyntaxWarning
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 :: Start MantidPlot

--- a/buildconfig/CMake/Packaging/launch_workbench.ps1
+++ b/buildconfig/CMake/Packaging/launch_workbench.ps1
@@ -36,6 +36,8 @@ else {
 $env:QT_PLUGIN_PATH = Resolve-Path("$scriptRootDirectory/../plugins/qt5")
 # Appends the Mantid install/bin directory to the PATH so that the import can find the QT DLLs
 $env:PATH += ";$scriptRootDirectory"
+# Set Python warnings filter to ignore SyntaxWarnings
+$env:PYTHONWARNINGS = "default::DeprecationWarning:__main__,ignore::DeprecationWarning,ignore::PendingDeprecationWarning,ignore::ImportWarning,ignore::ResourceWarning,ignore::SyntaxWarning"
 
 # The 2>&1 at the end flushes STDERR into STDOUT and removes the new popup Windows that come from PS2EXE
 # Additionally that will correctly capture the output when run with just python.exe (console visible)


### PR DESCRIPTION
**Description of work.**

Python 3.8 produces `SyntaxWarning` for code such as `if x is "some string"` as this is not strictly valid code a CPython implementation detail means it works. We have eliminated all of these problems in our own code but the some packages in the 3rd party bundle on Windows still have issues. As our users can do nothing about them we choose to add an ignore for SyntaxWarning to the default warning specification.

**To test:**

* Build a package and install it.
* Remove `C:\MantidNightlyInstall\bin\Lib\site-packages\jupyter_client\__pycache__\manager.cpython-38.pyc` and start `MantidPlot`
* Remove `C:\MantidNightlyInstall\bin\Lib\site-packages\jupyter_client\__pycache__\manager.cpython-38.pyc` and start `MantidWorkbench`

There should be no warnings.

Fixes #28159 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
