### PR TITLE
Fixed issue with legend in Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/Common/plotting_widget/dockable_plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/dockable_plot_toolbar.py
@@ -1,0 +1,40 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+from __future__ import (absolute_import, division, print_function)
+
+from matplotlib.backends.qt_compat import is_pyqt5
+
+if is_pyqt5():
+    from matplotlib.backends.backend_qt5agg import (
+        NavigationToolbar2QT as NavigationToolbar)
+else:
+    from matplotlib.backends.backend_qt4agg import (
+        NavigationToolbar2QT as NavigationToolbar)
+
+
+class DockablePlotToolbar(NavigationToolbar):
+    def __init__(self, figure_canvas, parent=None):
+        self.toolitems = (('Home', 'Reset original view', 'home', 'home'),
+                          ('Back', 'Back to previous view', 'back', 'back'),
+                          ('Forward', 'Forward to next view', 'forward', 'forward'),
+                          (None, None, None, None),
+                          ('Pan', 'Pan axes with left mouse, zoom with right', 'move', 'pan'),
+                          ('Zoom', 'Zoom to rectangle', 'zoom_to_rect', 'zoom'),
+                          (None, None, None, None),
+                          ('Subplots', 'Edit subplots', 'subplots', 'configure_subplots'),
+                          ('Save', 'Save the figure', 'filesave', 'save_figure'),
+                          (None, None, None, None),
+                          ('Show/hide legend', 'Toggles the legend on/off', "select", 'toggle_legend'),
+                          )
+
+        NavigationToolbar.__init__(self, figure_canvas, parent=parent)
+
+    def toggle_legend(self):
+        for ax in self.canvas.figure.get_axes():
+            if ax.get_legend() is not None:
+                ax.get_legend().set_visible(not ax.get_legend().get_visible())
+        self.canvas.draw()

--- a/scripts/Muon/GUI/Common/plotting_widget/dockable_plot_toolbar.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/dockable_plot_toolbar.py
@@ -37,4 +37,5 @@ class DockablePlotToolbar(NavigationToolbar):
         for ax in self.canvas.figure.get_axes():
             if ax.get_legend() is not None:
                 ax.get_legend().set_visible(not ax.get_legend().get_visible())
+        self.canvas.figure.tight_layout()
         self.canvas.draw()

--- a/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
+++ b/scripts/Muon/GUI/Common/plotting_widget/plotting_widget_view.py
@@ -8,17 +8,16 @@ from __future__ import (absolute_import, division, print_function)
 
 from qtpy import QtWidgets
 import Muon.GUI.Common.message_box as message_box
+from Muon.GUI.Common.plotting_widget.dockable_plot_toolbar import DockablePlotToolbar
 from matplotlib.figure import Figure
 from mantid.plots.plotfunctions import get_plot_fig
 from matplotlib.backends.qt_compat import is_pyqt5
 from MultiPlotting.QuickEdit.quickEdit_widget import QuickEditWidget
 
 if is_pyqt5():
-    from matplotlib.backends.backend_qt5agg import (
-        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+    from matplotlib.backends.backend_qt5agg import FigureCanvas
 else:
-    from matplotlib.backends.backend_qt4agg import (
-        FigureCanvas, NavigationToolbar2QT as NavigationToolbar)
+    from matplotlib.backends.backend_qt4agg import FigureCanvas
 
 
 class PlotWidgetView(QtWidgets.QWidget):
@@ -116,7 +115,7 @@ class PlotWidgetView(QtWidgets.QWidget):
         # create the figure
         self.fig = Figure()
         self.fig.canvas = FigureCanvas(self.fig)
-        self.toolBar = NavigationToolbar(self.fig.canvas, self)
+        self.toolBar = DockablePlotToolbar(self.fig.canvas, self)
         # set size policy
         self.toolBar.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
 


### PR DESCRIPTION
When a large number of lines were plotted in the dockable plot within the Muon Analysis 2 interface the graph would become unreadable. As a workaround to this issue, the legend can now be hidden. This issue was raised by Adrian Hillier in beta testing.

**Description of work.**
Modified the figure toolbar to include a toggle legend option.

**Report to:** [Adrian Hillier]


**To test:**

1. Open the Muon Analysis 2 interface
2. Load data (e.g MUSR 62260-4)
3. Check that the toggle legend option works.
4. Verify that the button works for tiled plotting as well.

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
