### PR TITLE
Exception when sequentially fitting after removing spectra in multidataset fit

### DIFF
--- a/docs/source/release/v5.0.0/mantidplot.rst
+++ b/docs/source/release/v5.0.0/mantidplot.rst
@@ -15,6 +15,7 @@ Bugfixes
 - Fixed an issue where adding specific functions to the multi-dataset fitting interface caused it to crash
 - Fixed an issue where mantid crashed if you cleared the functions in the multi-dataset fitting interface
 - Fixed an issue where adding a UserFunction to the multi-dataset fitting interface caused a crash
+- Fixed an issue in the multi-dataset fitting interface where it crashed when doing a sequential fit with one spectra.
 
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
+++ b/qt/scientific_interfaces/MultiDatasetFit/MultiDatasetFit.cpp
@@ -496,7 +496,8 @@ void MultiDatasetFit::finishFit(bool error) {
     Mantid::API::IFunction_sptr fun;
     auto algorithm = m_fitRunner->getAlgorithm();
     if (m_fitOptionsBrowser->getCurrentFittingType() ==
-        MantidWidgets::FitOptionsBrowser::Simultaneous) {
+            MantidWidgets::FitOptionsBrowser::Simultaneous ||
+        getNumberOfSpectra() == 1) {
       // After a simultaneous fit
       fun = algorithm->getProperty("Function");
       updateParameters(*fun);


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where mantid hard crashed if you did a sequential fit with one spectra after doing an earlier sequential fit with more spectrum.

**To test:**
Open Mantidplot
Load a workspace with more than one spectra
Go to `Interfaces`->`General`->`Multi dataset fitting`
Add the workspace to the GUI (more than one spectrum)
Add a function
Change `Fitting` to `sequential`
Do the fit
Remove all but one of the spectra
Do the fit again
It should do the fit as expected and not crash

Fixes #28049 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
