### PR TITLE
Disable context menu on Indirect data analysis fitting tabs.

### DIFF
--- a/docs/source/release/v5.0.0/indirect_geometry.rst
+++ b/docs/source/release/v5.0.0/indirect_geometry.rst
@@ -52,6 +52,6 @@ BugFixes
 - Fixed a bug crashing the ``Indirect ILL Data Reduction GUI`` when Run is clicked.
 - Indirect ILL reductions for BATS and Doppler QENS modes will now flag the outputs as distributions if the data is normalised by the monitor.
 - :ref:`IndirectILLReductionFWS <algm-IndirectILLReductionFWS>` will now allow for manual setting of the inelastic peak channels.
-- The context menu on the fitting preview plots has been temporarily disabled for maintenance on the interface.
+- The context menu on the fitting preview plots for Data Analysis has been temporarily disabled due to lack of communication between it and the interface causing bugs.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/docs/source/release/v5.0.0/indirect_geometry.rst
+++ b/docs/source/release/v5.0.0/indirect_geometry.rst
@@ -52,5 +52,6 @@ BugFixes
 - Fixed a bug crashing the ``Indirect ILL Data Reduction GUI`` when Run is clicked.
 - Indirect ILL reductions for BATS and Doppler QENS modes will now flag the outputs as distributions if the data is normalised by the monitor.
 - :ref:`IndirectILLReductionFWS <algm-IndirectILLReductionFWS>` will now allow for manual setting of the inelastic peak channels.
+- The context menu on the fitting preview plots has been temporarily disabled for maintenance on the interface.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -92,11 +92,13 @@ void IndirectFitPlotView::createSplitter() {
 
 PreviewPlot *IndirectFitPlotView::createTopPlot() {
   m_topPlot = std::make_unique<PreviewPlot>(m_splitter.get());
+  m_topPlot->disableContextMenu();
   return createPlot(m_topPlot.get(), QSize(0, 125), 0, 10);
 }
 
 PreviewPlot *IndirectFitPlotView::createBottomPlot() {
   m_bottomPlot = std::make_unique<PreviewPlot>(m_splitter.get());
+  m_bottomPlot->disableContextMenu();
   return createPlot(m_bottomPlot.get(), QSize(0, 75), 0, 6);
 }
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -170,6 +170,7 @@ private:
   QAction *m_contextResetView;
   QActionGroup *m_contextXScale, *m_contextYScale;
   QAction *m_contextLegend;
+  bool m_context_enabled;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
@@ -89,6 +89,7 @@ public:
   void setAxisRange(const QPair<double, double> &range,
                     AxisID axisID = AxisID::XBottom);
   std::tuple<double, double> getAxisRange(AxisID axisID = AxisID::XBottom);
+  void disableContextMenu();
 
 public slots:
   void clear();

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Qwt/PreviewPlot.h
@@ -111,6 +111,7 @@ public:
   QString getAxisType(int axisID);
 
   void disableYAxisMenu();
+  void disableContextMenu();
 
 signals:
   /// Signals that the plot should be refreshed

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -62,6 +62,7 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
   createActions();
 
   m_selectorActive = false;
+  m_context_enabled = true;
 
   m_canvas->installEventFilterToMplCanvas(this);
   watchADS(observeADS);
@@ -442,7 +443,9 @@ bool PreviewPlot::handleMouseReleaseEvent(QMouseEvent *evt) {
   bool stopEvent(false);
   if (evt->button() == Qt::RightButton) {
     stopEvent = true;
-    showContextMenu(evt);
+    if (m_context_enabled) {
+      showContextMenu(evt);
+    }
   } else if (evt->button() == Qt::LeftButton) {
     const auto position = evt->pos();
     if (!position.isNull())
@@ -702,7 +705,12 @@ void PreviewPlot::toggleLegend(const bool checked) {
 }
 
 void PreviewPlot::disableContextMenu() {
-  // Disable the context menu signal, this is currently in progress.
+  // Disable the context menu signal
+  // TODO Currently when changes are made to the plot through the context menu
+  // it is not communicated through to the perant gui which can cause issues,
+  // for now we are disabling the context menu but is should be made to
+  // communicate so it can be reactivated.
+  m_context_enabled = false;
 }
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp
@@ -701,5 +701,9 @@ void PreviewPlot::toggleLegend(const bool checked) {
   this->replot();
 }
 
+void PreviewPlot::disableContextMenu() {
+  // Disable the context menu signal, this is currently in progress.
+}
+
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -63,7 +63,6 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool init)
   m_uiForm.plot->setContextMenuPolicy(Qt::CustomContextMenu);
   connect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,
           SLOT(showContextMenu(QPoint)));
-
   // Create the plot tool list for context menu
   m_plotToolGroup = new QActionGroup(m_contextMenu);
   m_plotToolGroup->setExclusive(true);
@@ -898,7 +897,6 @@ QStringList PreviewPlot::getCurvesForWorkspace(const MatrixWorkspace_sptr ws) {
  * @param position Position at which to show menu
  */
 void PreviewPlot::showContextMenu(QPoint position) {
-  // Show the context menu
   m_contextMenu->popup(m_uiForm.plot->mapToGlobal(position));
 }
 
@@ -1011,4 +1009,14 @@ void PreviewPlot::disableYAxisMenu() {
     throw std::runtime_error("Y Axis menu object could not be retrieved.");
   else
     menu->setVisible(false);
+}
+
+void PreviewPlot::disableContextMenu() {
+  // Disable the context menu signal
+  // TODO Currently when changes are made to the plot through the context menu
+  // it is not communicated through to the perant gui which can cause issues, 
+  // for now we are disabling the context menu but is should be made to communicate 
+  // so it can be reactivated.
+  disconnect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,
+             SLOT(showContextMenu(QPoint)));
 }

--- a/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/Qwt/PreviewPlot.cpp
@@ -1014,9 +1014,9 @@ void PreviewPlot::disableYAxisMenu() {
 void PreviewPlot::disableContextMenu() {
   // Disable the context menu signal
   // TODO Currently when changes are made to the plot through the context menu
-  // it is not communicated through to the perant gui which can cause issues, 
-  // for now we are disabling the context menu but is should be made to communicate 
-  // so it can be reactivated.
+  // it is not communicated through to the perant gui which can cause issues,
+  // for now we are disabling the context menu but is should be made to
+  // communicate so it can be reactivated.
   disconnect(m_uiForm.plot, SIGNAL(customContextMenuRequested(QPoint)), this,
              SLOT(showContextMenu(QPoint)));
 }


### PR DESCRIPTION
This PR disables the context menu for figures in the `Indirect data analysis` fitting tabs. this is because currently the figure plot does not comunicate changes made through the context menu to the interface. this can lead to bugs and crashes. Properly fixing this issue may take too long for this release, and based on advice from Mathew the context menu is not often used in this interface. so until the bugs resulting from the context menu can be fixed it is best to disable it.

**To test:**

1. Open Mantid Plot
1. Open `Indirect`->`data analysis`
1. On the `MSD fit` tab right click on the miniplot window, the context menu should not appear.
1. Do the same on the other fit tabs.
1. Repeat this on workbench as well.
1. Check that the release notes are an accurate description of the change.

*This is related to issue #28104 but does not fix it.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
