### PR TITLE
Fix colorbar ticks not appearing in instrument view

### DIFF
--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -112,5 +112,6 @@ Bugfixes
 - Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 - Fixed a bug which caused graphic scaling issues when the double-click menu was used to set an axis as log-scaled.
+- Fixed a bug where the colorbar in the instrument view would sometimes have no markers if the scale was set to SymmetricLog10.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/widgets/mplcpp/src/Colors.cpp
+++ b/qt/widgets/mplcpp/src/Colors.cpp
@@ -179,9 +179,14 @@ Python::Object SymLogNorm::tickLocator() const {
   // Create log transform with base=10
   auto transform = scaleModule().attr("SymmetricalLogTransform")(
       10, Python::Object(pyobj().attr("linthresh")), m_linscale);
+
+  // Sets the subs parameter to be [1,2,...,10]. The parameter determines where
+  // the ticks on the colorbar are placed and setting it to this ensures that
+  // any range of values will have ticks.
   std::vector<float> subsVector(10);
-  std::iota(subsVector.begin(), subsVector.end(), 1);
+  std::iota(subsVector.begin(), subsVector.end(), 1.f);
   auto subs = Converters::ToPyList<float>()(subsVector);
+
   return Python::Object(
       tickerModule().attr("SymmetricalLogLocator")(transform, subs));
 }

--- a/qt/widgets/mplcpp/src/Colors.cpp
+++ b/qt/widgets/mplcpp/src/Colors.cpp
@@ -197,7 +197,7 @@ Python::Object SymLogNorm::tickLocator() const {
  */
 Python::Object SymLogNorm::labelFormatter() const {
   GlobalInterpreterLock lock;
-  return Python::Object(tickerModule().attr("LogFormatterMathtext")());
+  return Python::Object(tickerModule().attr("LogFormatterSciNotation")());
 }
 
 // ------------------------ PowerNorm ------------------------------------------

--- a/qt/widgets/mplcpp/src/Colors.cpp
+++ b/qt/widgets/mplcpp/src/Colors.cpp
@@ -5,12 +5,14 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/MplCpp/Colors.h"
+#include "MantidPythonInterface/core/Converters/ToPyList.h"
 #include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 
 #include <boost/optional.hpp>
 
 #include <algorithm>
+#include <numeric>
 #include <tuple>
 
 using boost::none;
@@ -20,6 +22,7 @@ using Mantid::PythonInterface::PythonException;
 
 using OptionalTupleDouble = optional<std::tuple<double, double>>;
 
+using namespace Mantid::PythonInterface;
 using namespace MantidQt::Widgets::Common;
 
 namespace MantidQt {
@@ -176,8 +179,11 @@ Python::Object SymLogNorm::tickLocator() const {
   // Create log transform with base=10
   auto transform = scaleModule().attr("SymmetricalLogTransform")(
       10, Python::Object(pyobj().attr("linthresh")), m_linscale);
+  std::vector<float> subsVector(10);
+  std::iota(subsVector.begin(), subsVector.end(), 1);
+  auto subs = Converters::ToPyList<float>()(subsVector);
   return Python::Object(
-      tickerModule().attr("SymmetricalLogLocator")(transform));
+      tickerModule().attr("SymmetricalLogLocator")(transform, subs));
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the colorbar in the instrument view would sometimes have no ticks when the scale was set to SymmetricLog10.

![image](https://user-images.githubusercontent.com/52415735/75699216-010b4b80-5ca8-11ea-8cc8-9fbbc2f63a99.png)

**To test:**
1. Load MUSR62250
2. Switch the colorbar to SymmetricLog10
3. Check there are tick marks.

Fixes #28142 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
