### PR TITLE
Moves a locally allocated vector to be persistent

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/ProcessBankData.h
@@ -93,6 +93,8 @@ private:
   detid_t m_max_id;
   /// timer for performance
   Mantid::Kernel::Timer m_timer;
+  /// store event counts
+  std::vector<std::size_t> m_counts;
 }; // ENDDEF-CLASS ProcessBankData
 } // namespace DataHandling
 } // namespace Mantid


### PR DESCRIPTION
**Description of work.**
Replace local count to member m_count so memory is reused in every call to
`ProcessBankData::run` rather than created/destroyed

**Report to:**
@peterfpeterson 

**To test:**
Minor refactoring, ctest should be enough

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
