### PR TITLE
ChecksumHelper: Only convert CRLF to LF and not plain CR

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ChecksumHelper.h
+++ b/Framework/Kernel/inc/MantidKernel/ChecksumHelper.h
@@ -10,8 +10,7 @@
 #include "MantidKernel/DllConfig.h"
 #include <string>
 
-namespace Mantid {
-namespace Kernel {
+namespace Mantid::Kernel {
 
 /** ChecksumHelper : A selection of helper methods for calculating checksums
  */
@@ -30,7 +29,6 @@ MANTID_KERNEL_DLL std::string sha1FromFile(const std::string &filepath,
 MANTID_KERNEL_DLL std::string gitSha1FromFile(const std::string &filepath);
 } // namespace ChecksumHelper
 
-} // namespace Kernel
-} // namespace Mantid
+} // namespace Mantid::Kernel
 
 #endif /* MANTID_KERNEL_CHECKSUMHELPER_H_ */

--- a/Framework/Kernel/test/ChecksumHelperTest.h
+++ b/Framework/Kernel/test/ChecksumHelperTest.h
@@ -75,7 +75,7 @@ public:
     Poco::File(filename).remove();
   }
 
-  void testGitSha1FromFileWithWindowsLineEndings() {
+  void testGitSha1FromFileWithWindowsLineEndingsFirstConvertsToLF() {
     const std::string filename(
         "ChecksumHelperTest_testGitSha1FromFileWithWindowsLineEndings.txt");
     const std::string data = "ChecksumHelperTest_"
@@ -86,6 +86,20 @@ public:
     std::string response = ChecksumHelper::gitSha1FromFile(filename);
     TSM_ASSERT_EQUALS("The calculated git-hash is not as expected",
                       "23dcaeaefce51ed7cae98f6420f67e0ba0e2058a", response);
+    Poco::File(filename).remove();
+  }
+
+  void testGitSha1FromFileWithOldStyleMacLineEndingsDoesNotConvertToLF() {
+    const std::string filename(
+        "ChecksumHelperTest_testGitSha1FromFileWithOldStyleMacLineEndings.txt");
+    const std::string data = "ChecksumHelperTest_"
+                             "testGitSha1FromFileWithLinuxLineEndings\rTest "
+                             "this string out for size\r in a file";
+    createFile(filename, data);
+
+    std::string response = ChecksumHelper::gitSha1FromFile(filename);
+    TSM_ASSERT_EQUALS("The calculated git-hash is not as expected",
+                      "7b7e77332c1610df14fd26476d1601a22a34f11f", response);
     Poco::File(filename).remove();
   }
 


### PR DESCRIPTION
**Description of work.**

Git only converts CRLF to LF and not CR so to produce
the same SHA as git we must do the same.


**To test:**

Code review. Check new tests are sensible.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
