### PR TITLE
Add tolerance to polris chopper mode selection

### DIFF
--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from __future__ import (absolute_import, division, print_function)
 import numpy as np
+import math
 
 import mantid.simpleapi as mantid
 from six import string_types
@@ -178,13 +179,13 @@ def _load_qlims(q_lims):
 
 def _determine_chopper_mode(ws):
     if ws.getRun().hasProperty('Frequency'):
-        frequency = ws.getRun()['Frequency'].lastValue()
-        print("No chopper mode provided")
-        if frequency == 50:
-            print("automatically chose Rietveld")
+        frequency = ws.getRun()['Frequency'].timeAverageValue()
+        print("Found chopper frequency of {} in log file.".format(frequency))
+        if math.isclose(frequency, 50, rel_tol=1):
+            print("Automatically chose Rietveld mode")
             return 'Rietveld', polaris_advanced_config.rietveld_focused_cropping_values
-        if frequency == 0:
-            print("automatically chose PDF")
+        if math.isclose(frequency, 0, rel_tol=1):
+            print("Automatically chose PDF mode")
             return 'PDF', polaris_advanced_config.pdf_focused_cropping_values
     else:
         raise ValueError("Chopper frequency not in log data. Please specify a chopper mode")

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -181,10 +181,10 @@ def _determine_chopper_mode(ws):
     if ws.getRun().hasProperty('Frequency'):
         frequency = ws.getRun()['Frequency'].timeAverageValue()
         print("Found chopper frequency of {} in log file.".format(frequency))
-        if math.isclose(frequency, 50, rel_tol=1):
+        if math.isclose(frequency, 50, abs_tol=1):
             print("Automatically chose Rietveld mode")
             return 'Rietveld', polaris_advanced_config.rietveld_focused_cropping_values
-        if math.isclose(frequency, 0, rel_tol=1):
+        if math.isclose(frequency, 0, abs_tol=1):
             print("Automatically chose PDF mode")
             return 'PDF', polaris_advanced_config.pdf_focused_cropping_values
     else:


### PR DESCRIPTION
**Description of work:**

Added a tolerance when selecting the chopper mode for Polaris. At present it expects a discrete value of 0 or 50 however, if the copper is spinning up/down this will skew the value and make automatic selection of the mode fail. This is occurring roughly 1 in 20 runs on ISIS autoreduction at present.

*Automatic mode selection is only really used by the autoreduction system. Instrument scientist tend to specify mode explicitly if they are using the isis_powder scripts* 


**To test:**

Run the following script before applying the changes from this branch and see that it produces None as a return value:
```
import isis_powder

ws = Load(Filename=r'\\isis\inst$\NDXPOLARIS\Instrument\data\cycle_19_4\

POLARIS00125549.nxs', OutputWorkspace='POLARIS00125549')
print(isis_powder.polaris_routines.polaris_algs._determine_chopper_mode(ws))
```
Re-running this after the changes will show that it now identifies the file as Rietveld mode. 

I do not have a (not quite) 0 Hz PDF file to try as this very rarely happens when running in PDF mode as the chopper is stationary. An example of a PDF file is here:
```
\\isis\inst$\NDXPOLARIS\Instrument\data\cycle_19_4\POLARIS00125389.nxs
```
For those not at ISIS please drop me a message and I can send you the files (too big for git upload)

**Issue/Release notes**
*There is no associated issue.*

*This does not require release notes because it is not actively used by instrument scientists/users only by the autoreduction system.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
