### PR TITLE
Rename a private slot that was being hidden by a signal

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h
@@ -190,7 +190,7 @@ protected slots:
 
 private slots:
   void handleShowSaveAlgorithm();
-  void treeSelectionChanged();
+  void onTreeSelectionChanged();
   void onClickGroupButton();
   void onClickLoad();
   void onLoadAccept();

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -170,7 +170,7 @@ void WorkspaceTreeWidget::setupConnections() {
   connect(this, SIGNAL(signalClearView()), this, SLOT(handleClearView()),
           Qt::QueuedConnection);
   connect(m_tree, SIGNAL(itemSelectionChanged()), this,
-          SLOT(treeSelectionChanged()));
+          SLOT(onTreeSelectionChanged()));
   connect(m_tree, SIGNAL(itemExpanded(QTreeWidgetItem *)), this,
           SLOT(populateChildData(QTreeWidgetItem *)));
 }
@@ -900,7 +900,7 @@ bool WorkspaceTreeWidget::shouldBeSelected(QString name) const {
   return false;
 }
 
-void WorkspaceTreeWidget::treeSelectionChanged() {
+void WorkspaceTreeWidget::onTreeSelectionChanged() {
   // get selected workspaces
   auto items = m_tree->selectedItems();
 


### PR DESCRIPTION
**Description of work.**

Rename a private slot that was being hidden by a signal in a derived class,

re #28185

**To test:**
1. The warning as only visible on windows when starting mantid using ```python workbench-script.pyw```, so start mantid workbench that way and do not see:
    ```
   QMetaObject::indexOfSignal: signal treeSelectionChanged() from 
   MantidQt::MantidWidgets::WorkspaceTreeWidget redefined in 
   MantidQt::MantidWidgets::WorkspaceTreeWidgetSimple 
    ```
1. then check that the workbench and mantidplot workspace trees still work. this script will help populate them.
``` python
for i in range(50):
    CreateSampleWorkspace(OutputWorkspace="ws" + str(i))
```

Fixes #28185


*This does not require release notes* because **the warning was only visible to devs**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
