### PR TITLE
Project Recovery: Recover Tiled Plots Correctly

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -8,6 +8,8 @@ MantidWorkbench Changes
 Improvements
 ############
 
+- Tile plots are now reloaded correctly by project recovery.
+
 Bugfixes
 ########
 

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -17,10 +17,9 @@ from matplotlib import axis, ticker  # noqa
 from mantid import logger
 from mantid.api import AnalysisDataService as ADS
 from mantid.plots.legend import LegendProperties
-from mantid.plots.plotfunctions import plot, create_subplots
+from mantid.plots.plotfunctions import create_subplots
 # Constants set in workbench.plotting.functions but would cause backwards reliability
 from mantidqt.plotting.functions import pcolormesh
-
 
 SUBPLOT_WSPACE = 0.5
 SUBPLOT_HSPACE = 0.5
@@ -41,7 +40,8 @@ class PlotsLoader(object):
                 # Catch all errors in here so it can fail silently-ish
                 if isinstance(e, KeyboardInterrupt):
                     raise KeyboardInterrupt(str(e))
-                logger.warning("A plot was unable to be loaded from the save file. Error: " + str(e))
+                logger.warning("A plot was unable to be loaded from the save file. Error: " +
+                               str(e))
 
     def make_fig(self, plot_dict, create_plot=True):
         """
@@ -49,9 +49,7 @@ class PlotsLoader(object):
         :param plot_dict: dictionary; A dictionary of various items intended to recreate a figure
         :param create_plot: Bool; whether or not to make the plot, or to return the figure.
         :return: matplotlib.figure; Only returns if create_plot=False
-        """
-        import matplotlib.pyplot as plt
-        # Grab creation arguments
+        """        # Grab creation arguments
         creation_args = plot_dict["creationArguments"]
 
         if len(creation_args) == 0:
@@ -98,10 +96,20 @@ class PlotsLoader(object):
         if "cmap" in creation_arg:
             creation_arg["cmap"] = getattr(matplotlib.cm, creation_arg["cmap"])
 
-        function_dict = {"plot": axes.plot, "scatter": axes.scatter, "errorbar": axes.errorbar,
-                         "pcolor": axes.pcolor, "pcolorfast": axes.pcolorfast, "pcolormesh": pcolormesh,
-                         "imshow": pcolormesh, "contour": axes.contour, "contourf": axes.contourf,
-                         "tripcolor": axes.tripcolor, "tricontour": axes.tricontour, "tricontourf": axes.tricontourf}
+        function_dict = {
+            "plot": axes.plot,
+            "scatter": axes.scatter,
+            "errorbar": axes.errorbar,
+            "pcolor": axes.pcolor,
+            "pcolorfast": axes.pcolorfast,
+            "pcolormesh": pcolormesh,
+            "imshow": pcolormesh,
+            "contour": axes.contour,
+            "contourf": axes.contourf,
+            "tripcolor": axes.tripcolor,
+            "tricontour": axes.tricontour,
+            "tricontourf": axes.tricontourf
+        }
 
         func = function_dict[function_to_call]
         # Plotting is done via an Axes object unless a colorbar needs to be added
@@ -176,14 +184,16 @@ class PlotsLoader(object):
         ax.text(x=dic["position"][0],
                 y=dic["position"][1],
                 s=dic["text"],
-                fontdict={u'alpha': style_dic["alpha"],
-                          u'color': style_dic["color"],
-                          u'rotation': style_dic["rotation"],
-                          u'fontsize': style_dic["textSize"],
-                          u'zorder': style_dic["zOrder"],
-                          u'usetex': dic["useTeX"],
-                          u'horizontalalignment': style_dic["hAlign"],
-                          u'verticalalignment': style_dic["vAlign"]})
+                fontdict={
+                    u'alpha': style_dic["alpha"],
+                    u'color': style_dic["color"],
+                    u'rotation': style_dic["rotation"],
+                    u'fontsize': style_dic["textSize"],
+                    u'zorder': style_dic["zOrder"],
+                    u'usetex': dic["useTeX"],
+                    u'horizontalalignment': style_dic["hAlign"],
+                    u'verticalalignment': style_dic["vAlign"]
+                })
 
     @staticmethod
     def update_lines(ax, line):
@@ -299,8 +309,9 @@ class PlotsLoader(object):
         try:
             image.axes.set_cmap(cm.get_cmap(dic["cmap"]))
         except AttributeError as e:
-            logger.debug("PlotsLoader - The Image accessed did not have an axes with the ability to set the cmap: "
-                         + str(e))
+            logger.debug(
+                "PlotsLoader - The Image accessed did not have an axes with the ability to set the cmap: "
+                + str(e))
 
         # Redraw
         image.axes.figure.canvas.draw()


### PR DESCRIPTION
**Description of work.**
Added functionality to save tiled plots in project recovery. 

**To test:**
1. Open workbench
1. Go to the settings and change the time between project recovery checkpoints to something bearable. 
1. Load some workspaces and create some tiled and conventional plots. 
1. Make a note of the plots and their appearance
1. Wait for project recovery to save the project
2. Crash mantid (using the SegFault algorithm)
3. Relaunch mantid 
4. Load from project recovery
5. Check that the recovered plots match what should have been saved. 

Fixes #28110 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
