### PR TITLE
Add Python API to get SpecNums

### DIFF
--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -133,10 +133,11 @@ target_link_libraries(PythonAPIModule
                               PythonGeometryModule
                               PythonKernelModule
                               API
-                              Types
-                              Kernel
-                              HistogramData
                               Geometry
+                              HistogramData
+                              Indexing
+                              Kernel
+                              Types
                               ${PYTHON_LIBRARIES}
                               ${POCO_LIBRARIES}
                               ${Boost_LIBRARIES})

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -5,10 +5,12 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/MatrixWorkspace.h"
+
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/WarningSuppressions.h"
 
 #include "MantidPythonInterface/api/CloneMatrixWorkspace.h"
@@ -23,6 +25,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/implicit.hpp>
+#include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
@@ -118,6 +121,22 @@ boost::weak_ptr<Workspace> getMonitorWorkspace(MatrixWorkspace &self) {
 void clearMonitorWorkspace(MatrixWorkspace &self) {
   MatrixWorkspace_sptr monWS;
   self.setMonitorWorkspace(monWS);
+}
+
+/**
+ * @param self :: A reference to the calling object
+ *
+ * @return a list of associated spectrum numbers
+ */
+list getSpectrumNumbers(const MatrixWorkspace &self) {
+  const auto &spectrumNums = self.indexInfo().spectrumNumbers();
+  list spectra;
+
+  for (const auto index : spectrumNums) {
+    spectra.append(static_cast<int32_t>(index));
+  }
+
+  return spectra;
 }
 
 /**
@@ -283,6 +302,8 @@ void export_MatrixWorkspace() {
            "Returns size of the Y data array")
       .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms,
            arg("self"), "Returns the number of spectra in the workspace")
+      .def("getSpectrumNumbers", &getSpectrumNumbers, arg("self"),
+           "Returns a list of all spectrum numbers in the workspace")
       .def("yIndexOfX", &MatrixWorkspace::yIndexOfX,
            MatrixWorkspace_yIndexOfXOverloads(
                (arg("self"), arg("xvalue"), arg("workspaceIndex"),

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -90,6 +90,13 @@ class MatrixWorkspaceTest(unittest.TestCase):
         for i in range(len(ids)):
             self.assertEqual(expected[i], ids[i])
 
+    def test_spectrum_numbers_returned(self):
+        num_vec = 11
+        test_ws = WorkspaceFactory.create("Workspace2D", num_vec, 1, 1)
+
+        spec_nums = test_ws.getSpectrumNumbers()
+        self.assertEqual([x for x in range(1, num_vec + 1)], spec_nums)
+
     def test_detector_two_theta(self):
         det = self._test_ws.getDetector(1)
         two_theta = self._test_ws.detectorTwoTheta(det)

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -20,5 +20,7 @@ Data Objects
 
 Python
 ------
+- A list of spectrum numbers can be got by calling getSpectrumNumbers on a 
+  workspace. For example: spec_nums = ws.getSpectrumNumbers()
 
 :ref:`Release 5.1.0 <v5.1.0>`


### PR DESCRIPTION
**Description of work.**
Adds a new API to getSpectrumNumbers from a Matrix workspace. This was implemented as a indirect call to IndexInfo rather than exposing IndexInfo, since there are few other things a user could want to call.

This is part of work which will target the next nightly for Mantid 5.1 and will block some investigation work in the near future. I've not targetted the release since it's a new feature.

**To test:**
- Create a sample workspace or load some data
- Run the following replacing your_ws as appropriate and check the output makes sense
```
print(your_ws.getSpectrumNumbers())
```


Part of (but doesn't fully fix) #28181 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
