### PR TITLE
Fix crash when adding Bk2BkExpConvPV to fitting

### DIFF
--- a/Framework/CurveFitting/src/Functions/Bk2BkExpConvPV.cpp
+++ b/Framework/CurveFitting/src/Functions/Bk2BkExpConvPV.cpp
@@ -69,11 +69,13 @@ double Bk2BkExpConvPV::fwhm() const {
 }
 
 /** Set FWHM
- * It is an illegal operation of this type of peak
+ * This cannot be set directly so we assume Gamma is 0 and set Sigma by doing
+ * the reverse of calHandEta
  */
 void Bk2BkExpConvPV::setFwhm(const double w) {
-  UNUSED_ARG(w);
-  throw std::invalid_argument("Bk2BkExpConvPV is not allowed to set FWHM.");
+  this->setParameter("Gamma", 0);
+  auto sigma2 = std::pow(w, 2) / (8.0 * M_LN2);
+  this->setParameter("Sigma2", sigma2);
 }
 
 /** Set peak center

--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -105,6 +105,7 @@ Bugfixes
 - The help button in fitting now finds the relevant page.
 - Fixed an issue with changing normalisation on single spectra plots done from a script
 - Fixed an issue where fitting a distribution workspace was normalised twice.
+- Fixed an issue where adding a Bk2BkExpConvPV function to the fit browser caused a crash
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.
 - Axes limits of a plot no longer automatically rescale when errorbars are on/off 


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where adding a `Bk2BkExpConvPV` function in the fit property browser caused mantid to crash. This was caused by an exception thrown when setting FWMH. To fix this I have changed `setFwhm` to set `gamma` to 0 and calculate `sigma` from the width.

**To test:**
1. load focussed data into workbench (e.g. GEM38370_focussed.nxs)
2. (Optional) convert unit to TOF (originally d-spacing)
3. Plot a spectrum (e.g spectrum 4)
4. Open fitting tab
5. Select peak type to be Bk2bkExpConvPV
6. Add a peak - the peak should be added as expected and you should be able to change the width and fit the peak.

Fixes #28153 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
