### PR TITLE
Dont try to mask missing ws spectra

### DIFF
--- a/Framework/PythonInterface/mantid/api/CMakeLists.txt
+++ b/Framework/PythonInterface/mantid/api/CMakeLists.txt
@@ -133,10 +133,11 @@ target_link_libraries(PythonAPIModule
                               PythonGeometryModule
                               PythonKernelModule
                               API
-                              Types
-                              Kernel
-                              HistogramData
                               Geometry
+                              HistogramData
+                              Indexing
+                              Kernel
+                              Types
                               ${PYTHON_LIBRARIES}
                               ${POCO_LIBRARIES}
                               ${Boost_LIBRARIES})

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -5,10 +5,12 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/MatrixWorkspace.h"
+
 #include "MantidAPI/Axis.h"
 #include "MantidAPI/Run.h"
 #include "MantidAPI/WorkspaceOpOverloads.h"
 #include "MantidGeometry/IDetector.h"
+#include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/WarningSuppressions.h"
 
 #include "MantidPythonInterface/api/CloneMatrixWorkspace.h"
@@ -23,6 +25,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/implicit.hpp>
+#include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
@@ -118,6 +121,22 @@ boost::weak_ptr<Workspace> getMonitorWorkspace(MatrixWorkspace &self) {
 void clearMonitorWorkspace(MatrixWorkspace &self) {
   MatrixWorkspace_sptr monWS;
   self.setMonitorWorkspace(monWS);
+}
+
+/**
+ * @param self :: A reference to the calling object
+ *
+ * @return a list of associated spectrum numbers
+ */
+list getSpectrumNumbers(const MatrixWorkspace &self) {
+  const auto &spectrumNums = self.indexInfo().spectrumNumbers();
+  list spectra;
+
+  for (const auto index : spectrumNums) {
+    spectra.append(static_cast<int32_t>(index));
+  }
+
+  return spectra;
 }
 
 /**
@@ -283,6 +302,8 @@ void export_MatrixWorkspace() {
            "Returns size of the Y data array")
       .def("getNumberHistograms", &MatrixWorkspace::getNumberHistograms,
            arg("self"), "Returns the number of spectra in the workspace")
+      .def("getSpectrumNumbers", &getSpectrumNumbers, arg("self"),
+           "Returns a list of all spectrum numbers in the workspace")
       .def("yIndexOfX", &MatrixWorkspace::yIndexOfX,
            MatrixWorkspace_yIndexOfXOverloads(
                (arg("self"), arg("xvalue"), arg("workspaceIndex"),

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -90,6 +90,13 @@ class MatrixWorkspaceTest(unittest.TestCase):
         for i in range(len(ids)):
             self.assertEqual(expected[i], ids[i])
 
+    def test_spectrum_numbers_returned(self):
+        num_vec = 11
+        test_ws = WorkspaceFactory.create("Workspace2D", num_vec, 1, 1)
+
+        spec_nums = test_ws.getSpectrumNumbers()
+        self.assertEqual([x for x in range(1, num_vec + 1)], spec_nums)
+
     def test_detector_two_theta(self):
         det = self._test_ws.getDetector(1)
         two_theta = self._test_ws.detectorTwoTheta(det)

--- a/docs/source/release/v5.1.0/framework.rst
+++ b/docs/source/release/v5.1.0/framework.rst
@@ -20,5 +20,7 @@ Data Objects
 
 Python
 ------
+- A list of spectrum numbers can be got by calling getSpectrumNumbers on a 
+  workspace. For example: spec_nums = ws.getSpectrumNumbers()
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/docs/source/release/v5.1.0/sans.rst
+++ b/docs/source/release/v5.1.0/sans.rst
@@ -5,6 +5,14 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
+Bug Fixed
+#########
+
+- Applying a mask to a range of spectra after cropping to a bank could fail
+  if there were gaps in the spectrum numbers. The masking will now skip
+  over any spectrum numbers not in workspace and emit a warning.
+
+
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.

--- a/scripts/SANS/sans/algorithm_detail/mask_workspace.py
+++ b/scripts/SANS/sans/algorithm_detail/mask_workspace.py
@@ -10,6 +10,8 @@ from abc import (ABCMeta, abstractmethod)
 
 from six import with_metaclass
 
+from mantid.kernel import Logger
+
 from sans.algorithm_detail.mask_functions import SpectraBlock
 from sans.algorithm_detail.xml_shapes import (add_cylinder, add_outside_cylinder, create_phi_mask, create_line_mask)
 from sans.common.constants import EMPTY_NAME
@@ -260,17 +262,31 @@ def mask_spectra(mask_info, workspace, spectra_block, detector_type):
         for horizontal, vertical in zip(block_cross_horizontal, block_cross_vertical):
             total_spectra.extend(spectra_block.get_block(horizontal, vertical, 1, 1))
 
+    if not total_spectra:
+        return workspace
+
     # Perform the masking
-    if total_spectra:
-        mask_name = "MaskSpectra"
-        mask_options = {"InputWorkspace": workspace,
-                        "InputWorkspaceIndexType": "SpectrumNumber",
-                        "OutputWorkspace": "__dummy"}
-        mask_alg = create_unmanaged_algorithm(mask_name, **mask_options)
-        mask_alg.setProperty("InputWorkspaceIndexSet", list(set(total_spectra)))
-        mask_alg.setProperty("OutputWorkspace", workspace)
-        mask_alg.execute()
-        workspace = mask_alg.getProperty("OutputWorkspace").value
+    ws_spectra_list = workspace.getSpectrumNumbers()
+    # Any gaps in the spectra list we skip over attempting to mask
+    filtered_mask_spectra = [spec for spec in total_spectra if spec in ws_spectra_list]
+
+    if len(filtered_mask_spectra) != len(total_spectra):
+        log = Logger("SANS - Mask Workspace")
+        log.warning("Skipped masking some spectrum numbers that do not exist in the workspace. Re-run"
+                    " with logging set to information for more details")
+        log.information("The following spectrum numbers do not exist in the ws (cropped to component):")
+        for i in list(set(total_spectra) - set(filtered_mask_spectra)):
+            log.information(str(i))
+
+    mask_name = "MaskSpectra"
+    mask_options = {"InputWorkspace": workspace,
+                    "InputWorkspaceIndexType": "SpectrumNumber",
+                    "OutputWorkspace": "__dummy"}
+    mask_alg = create_unmanaged_algorithm(mask_name, **mask_options)
+    mask_alg.setProperty("InputWorkspaceIndexSet", list(set(filtered_mask_spectra)))
+    mask_alg.setProperty("OutputWorkspace", workspace)
+    mask_alg.execute()
+    workspace = mask_alg.getProperty("OutputWorkspace").value
     return workspace
 
 


### PR DESCRIPTION
**Description of work.**
    Skips any missing ws spectra whilst masking. This can happen if a user
    crops to a component, causing sepctra gaps between banks.
    We now filter any spectrum numbers not in the WS and emit a warning to
    the user when this happens

**Report to:** ISIS/Steve - Already contacted

**To test:**
You will need access to ISIS - Babylon
- Go to the Babylon->Public->David Fairbrother->individual hab module
- Open the SANS GUI
- Set the user file to any of the .txt files
- Open the batch file as repro.csv
- Ensure your user directories are pointed to the public drive (should be automatic) and search data archive is on
- Hit process all, it should run to completion with a warning now emitted

Fixes #28181 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
