### PR TITLE
Avoid extra multiply in Plus and Minus

### DIFF
--- a/Framework/Algorithms/src/Minus.cpp
+++ b/Framework/Algorithms/src/Minus.cpp
@@ -37,9 +37,8 @@ void Minus::performBinaryOperation(const HistogramData::Histogram &lhs,
   // Only do E if non-zero, otherwise just copy
   if (rhsE != 0) {
     double rhsE2 = rhsE * rhsE;
-    std::transform(
-        lhs.e().begin(), lhs.e().end(), EOut.begin(),
-        [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
+    std::transform(lhs.e().begin(), lhs.e().end(), EOut.begin(),
+                   [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
   } else
     EOut = lhs.e();
 }

--- a/Framework/Algorithms/src/Minus.cpp
+++ b/Framework/Algorithms/src/Minus.cpp
@@ -22,7 +22,7 @@ void Minus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                    HistogramData::HistogramY &YOut,
                                    HistogramData::HistogramE &EOut) {
   std::transform(lhs.y().begin(), lhs.y().end(), rhs.y().begin(), YOut.begin(),
-                 std::minus<double>());
+                 std::minus<>());
   std::transform(lhs.e().begin(), lhs.e().end(), rhs.e().begin(), EOut.begin(),
                  VectorHelper::SumGaussError<double>());
 }
@@ -33,12 +33,14 @@ void Minus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                    HistogramData::HistogramE &EOut) {
   using std::placeholders::_1;
   std::transform(lhs.y().begin(), lhs.y().end(), YOut.begin(),
-                 std::bind(std::minus<double>(), _1, rhsY));
+                 [rhsY](const double &l) { return l - rhsY; });
   // Only do E if non-zero, otherwise just copy
-  if (rhsE != 0)
-    std::transform(lhs.e().begin(), lhs.e().end(), EOut.begin(),
-                   std::bind(VectorHelper::SumGaussError<double>(), _1, rhsE));
-  else
+  if (rhsE != 0) {
+    double rhsE2 = rhsE * rhsE;
+    std::transform(
+        lhs.e().begin(), lhs.e().end(), EOut.begin(),
+        [rhsE2](const double &l) { return std::sqrt(l * l + rhsE2); });
+  } else
     EOut = lhs.e();
 }
 

--- a/Framework/Algorithms/src/Minus.cpp
+++ b/Framework/Algorithms/src/Minus.cpp
@@ -33,13 +33,13 @@ void Minus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                    HistogramData::HistogramE &EOut) {
   using std::placeholders::_1;
   std::transform(lhs.y().begin(), lhs.y().end(), YOut.begin(),
-                 [rhsY](const double &l) { return l - rhsY; });
+                 [rhsY](double l) { return l - rhsY; });
   // Only do E if non-zero, otherwise just copy
   if (rhsE != 0) {
     double rhsE2 = rhsE * rhsE;
     std::transform(
         lhs.e().begin(), lhs.e().end(), EOut.begin(),
-        [rhsE2](const double &l) { return std::sqrt(l * l + rhsE2); });
+        [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
   } else
     EOut = lhs.e();
 }

--- a/Framework/Algorithms/src/Plus.cpp
+++ b/Framework/Algorithms/src/Plus.cpp
@@ -36,14 +36,14 @@ void Plus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                   HistogramData::HistogramE &EOut) {
   using std::placeholders::_1;
   std::transform(lhs.y().begin(), lhs.y().end(), YOut.begin(),
-                 [rhsY](const double &l) { return l + rhsY; });
+                 [rhsY](double l) { return l + rhsY; });
   // Only do E if non-zero, otherwise just copy
 
   if (rhsE != 0.) {
     double rhsE2 = rhsE * rhsE;
     std::transform(
         lhs.e().begin(), lhs.e().end(), EOut.begin(),
-        [rhsE2](const double &l) { return std::sqrt(l * l + rhsE2); });
+        [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
   } else
     EOut = lhs.e();
 }

--- a/Framework/Algorithms/src/Plus.cpp
+++ b/Framework/Algorithms/src/Plus.cpp
@@ -24,7 +24,7 @@ void Plus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                   HistogramData::HistogramY &YOut,
                                   HistogramData::HistogramE &EOut) {
   std::transform(lhs.y().begin(), lhs.y().end(), rhs.y().begin(), YOut.begin(),
-                 std::plus<double>());
+                 std::plus<>());
   std::transform(lhs.e().begin(), lhs.e().end(), rhs.e().begin(), EOut.begin(),
                  VectorHelper::SumGaussError<double>());
 }
@@ -36,12 +36,15 @@ void Plus::performBinaryOperation(const HistogramData::Histogram &lhs,
                                   HistogramData::HistogramE &EOut) {
   using std::placeholders::_1;
   std::transform(lhs.y().begin(), lhs.y().end(), YOut.begin(),
-                 std::bind(std::plus<double>(), _1, rhsY));
+                 [rhsY](const double &l) { return l + rhsY; });
   // Only do E if non-zero, otherwise just copy
-  if (rhsE != 0)
-    std::transform(lhs.e().begin(), lhs.e().end(), EOut.begin(),
-                   std::bind(VectorHelper::SumGaussError<double>(), _1, rhsE));
-  else
+
+  if (rhsE != 0.) {
+    double rhsE2 = rhsE * rhsE;
+    std::transform(
+        lhs.e().begin(), lhs.e().end(), EOut.begin(),
+        [rhsE2](const double &l) { return std::sqrt(l * l + rhsE2); });
+  } else
     EOut = lhs.e();
 }
 

--- a/Framework/Algorithms/src/Plus.cpp
+++ b/Framework/Algorithms/src/Plus.cpp
@@ -41,9 +41,8 @@ void Plus::performBinaryOperation(const HistogramData::Histogram &lhs,
 
   if (rhsE != 0.) {
     double rhsE2 = rhsE * rhsE;
-    std::transform(
-        lhs.e().begin(), lhs.e().end(), EOut.begin(),
-        [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
+    std::transform(lhs.e().begin(), lhs.e().end(), EOut.begin(),
+                   [rhsE2](double l) { return std::sqrt(l * l + rhsE2); });
   } else
     EOut = lhs.e();
 }


### PR DESCRIPTION
Noticed that rhsE*rhsE doesn't need to be repeated for each bin in the Histogram. Don't expect a measurable difference in performance, but every little bit helps...

**Description of work.**

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because negligible performance improvement

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
