### PR TITLE
Fix Exception When Opening Context Menu on Scripted Plots

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -706,6 +706,8 @@ class FigureInteraction(object):
         :return: bool
         """
         plotted_normalized = []
+        if not ax.creation_args:
+            return False
         axis = ax.creation_args[0].get('axis', None)
         for workspace_name, artists in ax.tracked_workspaces.items():
             if hasattr(ads.retrieve(workspace_name), "isDistribution"):

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -314,6 +314,13 @@ class FigureInteractionTest(unittest.TestCase):
         self.interactor.errors_manager.toggle_all_errors(self.ax, make_visible=True)
         self.assertTrue(self.ax.containers[0][2][0].get_visible())
 
+    def test_no_normalisation_options_on_non_workspace_plot(self):
+        fig, self.ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        self.ax.plot([1, 2], [1, 2], label="myLabel")
+
+        anonymous_menu = QMenu()
+        self.assertEqual(None, self.interactor._add_normalization_option_menu(anonymous_menu, self.ax))
+
     # Failure tests
     def test_construction_with_non_qt_canvas_raises_exception(self):
         class NotQtCanvas(object):


### PR DESCRIPTION
**Description of work.**

**To test:**
1. Open workbench
2. Run this script:
 ``` python
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot([1,2],[1,2])
fig.show()
 ```
3. Right click the plot
4. No normalisation options should appear and there should be no exception raised. 

Fixes #28187 

*This does not require release notes* because **it fixes a bug introduced this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
