### PR TITLE
Fix unhandled exception when opening figure options on plot with empty legend

### DIFF
--- a/Framework/PythonInterface/mantid/plots/legend.py
+++ b/Framework/PythonInterface/mantid/plots/legend.py
@@ -34,6 +34,9 @@ class LegendProperties(dict):
 
     @classmethod
     def from_legend(cls, legend):
+        if not (legend and legend.get_texts()):
+            return None
+
         props = dict()
 
         props['visible'] = legend.get_visible()
@@ -130,6 +133,10 @@ class LegendProperties(dict):
 
     @classmethod
     def create_legend(cls, props, ax):
+        if not props:
+            legend_set_draggable(ax.legend(), True)
+            return
+
         if int(matplotlib.__version__[0]) >= 2:
             legend = ax.legend(ncol=props['columns'],
                                prop={'size': props['entries_size']},

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -406,11 +406,8 @@ class MantidAxes(Axes):
             self.update_datalim(xys)
 
     def make_legend(self):
-        if self.legend_ is None:
-            legend_set_draggable(self.legend(), True)
-        else:
-            props = LegendProperties.from_legend(self.legend_)
-            LegendProperties.create_legend(props, self)
+        props = LegendProperties.from_legend(self.legend_)
+        LegendProperties.create_legend(props, self)
 
     @staticmethod
     def is_empty(axes):

--- a/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/plots/CMakeLists.txt
@@ -5,7 +5,7 @@ add_subdirectory(modest_image)
 set(TEST_PY_FILES
     datafunctionsTest.py axesfunctionsTest.py axesfunctions3DTest.py
     plotfunctionsTest.py plots__init__Test.py ScalesTest.py UtilityTest.py
-    compatabilityTest.py
+    compatabilityTest.py legendTest.py
 )
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})

--- a/Framework/PythonInterface/test/python/mantid/plots/legendTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/legendTest.py
@@ -1,0 +1,33 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#     NScD Oak Ridge National Laboratory, European Spallation Source
+#     & Institut Laue - Langevin
+# SPDX - License - Identifier: GPL - 3.0 +
+#
+
+import unittest
+
+import matplotlib.pyplot as plt
+
+from mantid.plots.legend import LegendProperties
+
+
+class LegendTest(unittest.TestCase):
+    def test_get_properties_from_legend_returns_none_if_legend_has_no_entries(self):
+        legend = plt.legend()
+
+        props = LegendProperties.from_legend(legend)
+
+        self.assertEqual(props, None)
+
+    def test_calling_create_legend_with_no_props_adds_legend_to_plot(self):
+        ax = plt.gca()
+
+        LegendProperties.create_legend(props=None, ax=ax)
+
+        self.assertNotEqual(ax.get_legend(), None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -28,6 +28,7 @@ Bugfixes
 - Fixed a crash when you selected a spectra to plot that was not present in a workspace.
 - Fixed a crash when you defined a new Fit Function after deleting a plot.
 - The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
-
+- Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
+- Opening figure options on a plot with an empty legend no longer causes an unhandled exception.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/python/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/project/plotsloader.py
@@ -223,7 +223,9 @@ class PlotsLoader(object):
         if not legend["exists"] and ax.get_legend():
             ax.get_legend().remove()
             return
-        LegendProperties.create_legend(legend, ax)
+
+        if legend["exists"]:
+            LegendProperties.create_legend(legend, ax)
 
     def update_properties(self, ax, properties):
         ax.set_position(properties["bounds"])

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -110,10 +110,9 @@ class PlotsSaver(object):
         ax_dict["textFromArtists"] = artist_text_dict
 
         legend_dict = {}
-        legend = ax.get_legend()
-        if legend is not None:
+        if ax.get_legend() and ax.get_legend().get_texts():
             legend_dict["exists"] = True
-            legend_dict.update(LegendProperties.from_legend(legend))
+            legend_dict.update(LegendProperties.from_legend(ax.get_legend()))
         else:
             legend_dict["exists"] = False
         ax_dict["legend"] = legend_dict

--- a/qt/python/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/project/plotssaver.py
@@ -110,9 +110,10 @@ class PlotsSaver(object):
         ax_dict["textFromArtists"] = artist_text_dict
 
         legend_dict = {}
-        if ax.get_legend() and ax.get_legend().get_texts():
+        legend = ax.get_legend()
+        if legend is not None:
             legend_dict["exists"] = True
-            legend_dict.update(LegendProperties.from_legend(ax.get_legend()))
+            legend_dict.update(LegendProperties.from_legend(legend))
         else:
             legend_dict["exists"] = False
         ax_dict["legend"] = legend_dict

--- a/qt/python/mantidqt/widgets/plotconfigdialog/__init__.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/__init__.py
@@ -73,7 +73,7 @@ def image_in_figure(fig):
 def legend_in_figure(fig):
     """Return True if there's a legend in the Figure object"""
     for ax in fig.get_axes():
-        if ax.get_legend() or ax.legend_:
+        if ax.get_legend() and ax.get_legend().get_texts():
             return True
     return False
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -40,11 +40,17 @@ class LegendTabWidgetPresenter:
         self.view.advanced_options.rejected.connect(self.advanced_options_cancelled)
 
     def init_view(self):
+        """Sets all of the initial values of the input fields when the tab is first loaded"""
         if int(matplotlib.__version__[0]) < 2:
             self.view.hide_box_properties()
 
-        """Sets all of the initial values of the input fields when the tab is first loaded"""
-        legend_props = LegendProperties.from_legend(self.axes[0].get_legend())
+        legend_props = None
+        for ax in self.axes:
+            if ax.get_legend():
+                legend_props = LegendProperties.from_legend(ax.get_legend())
+
+        assert legend_props, "None of the axes have a legend."
+
         self.check_font_in_list(legend_props.entries_font)
         self.check_font_in_list(legend_props.title_font)
 
@@ -93,7 +99,8 @@ class LegendTabWidgetPresenter:
             return
 
         for ax in self.axes:
-            LegendProperties.create_legend(props, ax)
+            if ax.get_legend():
+                LegendProperties.create_legend(props, ax)
 
         self.current_view_properties = props
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/legendtabwidget/presenter.py
@@ -46,10 +46,13 @@ class LegendTabWidgetPresenter:
 
         legend_props = None
         for ax in self.axes:
-            if ax.get_legend():
-                legend_props = LegendProperties.from_legend(ax.get_legend())
+            legend_props = LegendProperties.from_legend(ax.get_legend())
+            if legend_props:
+                break
 
-        assert legend_props, "None of the axes have a legend."
+        # This *should* never raise an error because there's a check before this presenter is created that at least one
+        # axes on the plot has a legend with text. This is here just to be on the safe side.
+        assert legend_props, "None of the axes have a non-empty legend."
 
         self.check_font_in_list(legend_props.entries_font)
         self.check_font_in_list(legend_props.title_font)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/test/test_plotconfigdialogpresenter.py
@@ -146,6 +146,21 @@ class PlotConfigDialogPresenterTest(unittest.TestCase):
         self.assert_called_x_times_with(3, expected_call_args,
                                         mock_view.add_tab_widget)
 
+    def test_correct_tabs_present_axes_and_curve_legend_has_no_text(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        ax.plot([0], [0])
+        ax.legend()
+        mock_view = Mock()
+        presenter = PlotConfigDialogPresenter(fig, mock_view)
+        expected_presenter_list = [None, self.axes_mock.return_value,
+                                   self.curves_mock.return_value, None]
+        self.assertEqual(expected_presenter_list, presenter.tab_widget_presenters)
+        expected_call_args = [(self.axes_mock.return_value.view, 'Axes'),
+                              (self.curves_mock.return_value.view, 'Curves')]
+        self.assert_called_x_times_with(2, expected_call_args,
+                                        mock_view.add_tab_widget)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
This PR adds a check so that the legend tab in the figure options is only shown if the plot has a legend *and* that legend has text, this prevents an unhandled exception from occurring.

**To test:**
```
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot([0,1],[0,1])
ax.legend()
fig.show()
```
Open figure options.

Fixes #28198 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
