### PR TITLE
Fix plot not converting to waterfall correctly after normalisation is changed

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -690,8 +690,8 @@ class FigureInteraction(object):
 
         ax.autoscale()
 
+        datafunctions.set_initial_dimensions(ax)
         if waterfall:
-            datafunctions.set_initial_dimensions(ax)
             ax.update_waterfall(x, y)
 
         self.canvas.draw()


### PR DESCRIPTION
**To test:**
Make a normal plot of multiple spectra.
Right-click the figure and select Plot Type -> Waterfall.

Make another normal plot of multiple spectra.
Right-click the figure and select Normalization -> whichever option isn't currently set.
Right-click again and select Plot Type -> Waterfall.

The curves on the two plots should look the same.

Fixes #28197 

No release notes because waterfall plots aren't in a release yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
