### PR TITLE
Disconnected signals in Indirect Data Analysis

### DIFF
--- a/qt/scientific_interfaces/Indirect/JumpFit.cpp
+++ b/qt/scientific_interfaces/Indirect/JumpFit.cpp
@@ -58,10 +58,6 @@ void JumpFit::setupFitTab() {
   m_uiForm->cbParameter->setEnabled(false);
 
   connect(m_uiForm->pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-  connect(m_uiForm->cbParameterType, SIGNAL(currentIndexChanged(int)), this,
-          SLOT(updateAvailableFitTypes()));
-  connect(this, SIGNAL(updateAvailableFitTypes()), this,
-          SLOT(updateAvailableFitTypes()));
 }
 
 void JumpFit::updateModelFitTypeString() {


### PR DESCRIPTION
**Description of work.**

When you launch MantidPlot from a terminal and then open the data Analysis interface there are some warnings about signals connecting to slots which don't exist in the terminal. This PR removes these connections. These connections should have been removed [here](https://github.com/mantidproject/mantid/commit/2f062c103783931a789bc56c55b4027c62ac2436#diff-e1e66e448261b72ba5afba459d79ae16) but were missed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

  * Check that the warnings no longer appear in the terminal.
  * Run through the testing instructions from #28136

<!-- Instructions for testing. -->

Fixes #28178  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because this issue was introduced in this release.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
