### PR TITLE
Workbench: Set QTool flags on figure window and add option to disable

### DIFF
--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -88,6 +88,7 @@ Improvements
 - A help button has been added to the fitting add function dialog.
 - The progress reporting for scripts has been vastly improved and now reports at the line level.
 - Warnings from the Python ``warnings`` module are now show as warnings and not errors in the log display.
+- The mechanism for keeping plot windows on top of the main window has been changed to avoid some scenarios where the script editor could not be accessed.
 
 Bugfixes
 ########
@@ -108,12 +109,14 @@ Bugfixes
 - Fixed an issue where adding a Bk2BkExpConvPV function to the fit browser caused a crash
 - Overplots will be normalized by bin width if they are overplotting a curve from a workspace which is a distribution.
 - Several bugs in the way Python scripts were parsed and executed, including blank lines after a colon and tabs in strings, have been fixed.
-- Axes limits of a plot no longer automatically rescale when errorbars are on/off 
+- Axes limits of a plot no longer automatically rescale when errorbars are on/off
 - Axes editor menu now reads the grid visibility of the plot (i.e. the grid checkbox will always show the current grid visibility when an axis is double clicked)
-- Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters. 
+- Fixed a crash in the TOFConverter interface when leaving input fields blank or using invalid characters.
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 - Fixed a bug which caused graphic scaling issues when the double-click menu was used to set an axis as log-scaled.
 - Fixed a bug where the colorbar in the instrument view would sometimes have no markers if the scale was set to SymmetricLog10.
 - Fixed an unhandled exception when you set the min or max value of the colorbar scale in a colorfill plot to negative when the scale is set to logarithmic.
+- The mechanism to keep plots on top of the main Workbench window has been changed because some window managers would not release focus to their script editor rendering it useless.
+  This has the effect on some Linux environments of removing the ability to minimize the figure. The control within the Plots toolbox still allows visibility to be toggled on/off if required.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -792,6 +792,11 @@ def start_workbench(app, command_line_options):
     # The ordering here is very delicate. Test thoroughly when
     # changing anything!
     main_window = MainWindow()
+
+    # Set the mainwindow as the parent for additional QMainWindow instances
+    from workbench.config import set_additional_windows_parent
+    set_additional_windows_parent(main_window)
+
     # decorates the excepthook callback with the reference to the main window
     # this is used in case the user wants to terminate the workbench from the error window shown
     sys.excepthook = partial(exception_logger, main_window)

--- a/qt/applications/workbench/workbench/config/__init__.py
+++ b/qt/applications/workbench/workbench/config/__init__.py
@@ -19,17 +19,28 @@ and use it to access the settings
 from __future__ import (absolute_import, unicode_literals)
 
 # std imports
+from collections import namedtuple
 import os
 import sys
 
 # third-party imports
-from qtpy.QtCore import QSettings
+from qtpy.QtCore import Qt, QSettings
 
 # local imports
 from .user import UserConfig
 
+# Type to hold properties for additional QMainWindow instances
+WindowConfig = namedtuple("WindowConfig", ("parent", "flags"))
+
 # -----------------------------------------------------------------------------
-# Constants
+# "Private" Constants
+# -----------------------------------------------------------------------------
+
+# Default parent for additional QMainWindow instances
+_ADDITIONAL_MAINWINDOWS_PARENT = None
+
+# -----------------------------------------------------------------------------
+# Public Constants
 # -----------------------------------------------------------------------------
 ORGANIZATION = 'mantidproject'
 ORG_DOMAIN = 'mantidproject.org'
@@ -47,6 +58,21 @@ DEFAULT_SCRIPT_CONTENT += "# import mantid algorithms, numpy and matplotlib" + o
                           "import matplotlib.pyplot as plt" + os.linesep + \
                           "import numpy as np" + os.linesep + os.linesep
 
+# Flags defining a standard Window
+WINDOW_STANDARD_FLAGS = Qt.WindowFlags(Qt.Window)
+
+# Flags defining our meaning of keeping figure windows on top.
+# On Windows the standard Qt.Window flags + setting a parent keeps the widget on top
+# Other OSs use the Qt.Tool type with a close button
+if sys.platform == 'win32':
+    WINDOW_ONTOP_FLAGS = WINDOW_STANDARD_FLAGS
+elif sys.platform == 'darwin':
+    WINDOW_ONTOP_FLAGS = (Qt.Tool | Qt.CustomizeWindowHint | Qt.WindowCloseButtonHint
+                          | Qt.WindowMinimizeButtonHint)
+else:
+    WINDOW_ONTOP_FLAGS = (Qt.Tool | Qt.CustomizeWindowHint | Qt.WindowCloseButtonHint
+                          | Qt.WindowMinimizeButtonHint)
+
 # Iterable containing defaults for each configurable section of the code
 # General application settings are in the main section
 DEFAULTS = {
@@ -55,6 +81,9 @@ DEFAULTS = {
         'size': (1260, 740),
         'position': (10, 10),
     },
+    'AdditionalWindows': {
+        'ontop': True
+    },
     'project': {
         'prompt_save_on_close': True,
         'prompt_save_editor_modified': True,
@@ -62,8 +91,35 @@ DEFAULTS = {
     }
 }
 
-# -----------------------------------------------------------------------------
 # 'Singleton' instance
-# -----------------------------------------------------------------------------
 QSettings.setDefaultFormat(QSettings.IniFormat)
 CONF = UserConfig(ORGANIZATION, APPNAME, defaults=DEFAULTS)
+
+
+# Configuration for additional MainWindow instances: matplotlib figures, custom user interfaces etc
+def get_window_config():
+    """
+    :return: A WindowConfig object describing the desired window configuration based on the current settings
+    """
+    try:
+        windows_on_top = CONF.get("AdditionalWindows", "ontop", type=bool)
+    except KeyError:
+        windows_on_top = False
+
+    if windows_on_top:
+        parent = _ADDITIONAL_MAINWINDOWS_PARENT
+        flags = WINDOW_ONTOP_FLAGS
+    else:
+        parent = None
+        flags = WINDOW_STANDARD_FLAGS
+
+    return WindowConfig(parent, flags)
+
+
+def set_additional_windows_parent(widget):
+    """
+    Sets the parent for any new MainWindow instances created and updates the existing QMainWindow instances
+    :param widget: A QWidget that will act as a parent for a each new window
+    """
+    global _ADDITIONAL_MAINWINDOWS_PARENT
+    _ADDITIONAL_MAINWINDOWS_PARENT = widget

--- a/qt/applications/workbench/workbench/config/test/test_user.py
+++ b/qt/applications/workbench/workbench/config/test/test_user.py
@@ -135,6 +135,12 @@ class ConfigUserTest(TestCase):
     def test_get_raises_error_with_invalid_option_type(self):
         self.assertRaises(TypeError, self.cfg.get, 'section', 1)
 
+    def test_get_raises_error_with_missing_key_when_type_provided(self):
+        self.assertRaises(KeyError, self.cfg.get, 'not_a_key', type=bool)
+
+    def test_get_raises_error_with_existing_kkey_but_wrong_type(self):
+        self.assertRaises(TypeError, self.cfg.get, 'main', 'bool_option', type='QStringList')
+
     def test_get_raises_keyerror_with_no_saved_setting_or_default(self):
         self.assertRaises(KeyError, self.cfg.get, 'main', 'missing-key')
         self.assertRaises(KeyError, self.cfg.get, 'main/missing-key')

--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -79,21 +79,32 @@ class UserConfig(object):
     def filename(self):
         return self.qsettings.fileName()
 
-    def get(self, option, second=None):
+    def get(self, option, second=None, type=None):
         """Return a value for an option. If two arguments are given the first
         is the group/section and the second is the option within it.
         ``config.get('main', 'window/size')`` is equivalent to
         ``config.get('main/window/size')`` If no option is found then
         a KeyError is raised
         """
-        option = self._check_section_option_is_valid(option, second)
-        value = self.qsettings.value(option)
 
-        # qsettings appears to return None if the option isn't found
-        if value is None:
+        def raise_keyerror(key):
             raise KeyError('Unknown config item requested: "{}"'.format(option))
+
+        full_option = self._check_section_option_is_valid(option, second)
+        if type is None:
+            # return whatever the QSettings object returns
+            value = self.qsettings.value(full_option)
+            if value is None:
+                raise_keyerror(full_option)
+            else:
+                return value
         else:
-            return value
+            # PyQt QSettings with the type parameter tries to always return the type even if no value exists
+            # We still want a KeyError if it does not exist
+            if self.has(option, second):
+                return self.qsettings.value(full_option, type=type)
+            else:
+                raise_keyerror(option)
 
     def has(self, option, second=None):
         """Return a True if the key exists in the
@@ -150,9 +161,10 @@ class UserConfig(object):
             if not is_text_string(option):
                 raise TypeError('Found invalid type ({}) for option ({}) must be a string'.format(type(option), option))
             return option
-        else: # fist argument is actually the section/group
+        else:  # fist argument is actually the section/group
             if not is_text_string(option):
-                raise TypeError('Found invalid type ({}) for section ({}) must be a string'.format(type(option), option))
+                raise TypeError(
+                    'Found invalid type ({}) for section ({}) must be a string'.format(type(option), option))
             if not is_text_string(second):
                 raise TypeError('Found invalid type ({}) for option ({}) must be a string'.format(type(second), second))
             return joinsettings(option, second)

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -24,13 +24,17 @@ MPL_BACKEND = 'module://workbench.plotting.backend_workbench'
 
 # Our style defaults
 DEFAULT_RCPARAMS = {
-    'figure.facecolor':  'w',
+    'figure.facecolor': 'w',
     'figure.max_open_warning': 200
 }
 
 
 def initialize_matplotlib():
-    """Configures our defaults"""
+    """
+    Configure our defaults for matplotlib.
+    :param figure_window_parent: An QWidget that will become the parent of any figure window. Can be None
+    :param figure_window_flags: A Qt.WindowFlags enumeration defining the window flags for a figure window
+    """
     # Replace vanilla Gcf with our custom manager
     setattr(_pylab_helpers, 'Gcf', GlobalFigureManager)
     # Set our defaults

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -33,6 +33,7 @@ from mantidqt.widgets.plotconfigdialog import curve_in_ax
 from mantidqt.widgets.plotconfigdialog.presenter import PlotConfigDialogPresenter
 from mantidqt.widgets.waterfallplotfillareadialog.presenter import WaterfallPlotFillAreaDialogPresenter
 from mantidqt.widgets.waterfallplotoffsetdialog.presenter import WaterfallPlotOffsetDialogPresenter
+from workbench.config import get_window_config
 from workbench.plotting.figureinteraction import FigureInteraction
 from workbench.plotting.figurewindow import FigureWindow
 from workbench.plotting.plotscriptgenerator import generate_script
@@ -41,6 +42,7 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar, ToolbarStateM
 
 def _catch_exceptions(func):
     """Catch all exceptions in method and print a traceback to stderr"""
+
     @wraps(func)
     def wrapper(*args, **kwargs):
         try:
@@ -159,6 +161,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         The qt.QMainWindow
 
     """
+
     def __init__(self, canvas, num):
         QObject.__init__(self)
         FigureManagerBase.__init__(self, canvas, num)
@@ -174,7 +177,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         self.fig_visibility_changed_orig = self.fig_visibility_changed
         self.fig_visibility_changed = QAppThreadCall(self.fig_visibility_changed_orig)
 
-        self.window = FigureWindow(canvas)
+        parent, flags = get_window_config()
+        self.window = FigureWindow(canvas, parent=parent, window_flags=flags)
         self.window.activated.connect(self._window_activated)
         self.window.closing.connect(canvas.close_event)
         self.window.closing.connect(self.destroy)
@@ -212,9 +216,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_generate_plot_script_file_triggered.connect(
                 self.generate_plot_script_file)
             self.toolbar.sig_home_clicked.connect(self.set_figure_zoom_to_display_all)
-            self.toolbar.sig_waterfall_reverse_order_triggered.connect(self.waterfall_reverse_line_order)
-            self.toolbar.sig_waterfall_offset_amount_triggered.connect(self.launch_waterfall_offset_options)
-            self.toolbar.sig_waterfall_fill_area_triggered.connect(self.launch_waterfall_fill_area_options)
+            self.toolbar.sig_waterfall_reverse_order_triggered.connect(
+                self.waterfall_reverse_line_order)
+            self.toolbar.sig_waterfall_offset_amount_triggered.connect(
+                self.launch_waterfall_offset_options)
+            self.toolbar.sig_waterfall_fill_area_triggered.connect(
+                self.launch_waterfall_fill_area_options)
             self.toolbar.sig_waterfall_conversion.connect(self.update_toolbar_waterfall_plot)
             self.toolbar.setFloatable(False)
             tbs_height = self.toolbar.sizeHint().height()
@@ -292,11 +299,13 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         # For plot-to-script button to show, we must have a MantidAxes with lines in it
         # Plot-to-script currently doesn't work with waterfall plots so the button is hidden for that plot type.
         if not any((isinstance(ax, MantidAxes) and curve_in_ax(ax))
-                   for ax in self.canvas.figure.get_axes()) or self.canvas.figure.get_axes()[0].is_waterfall():
+                   for ax in self.canvas.figure.get_axes()) or self.canvas.figure.get_axes(
+        )[0].is_waterfall():
             self.toolbar.set_generate_plot_script_enabled(False)
 
         # Only show options specific to waterfall plots if the axes is a MantidAxes and is a waterfall plot.
-        if not isinstance(self.canvas.figure.get_axes()[0], MantidAxes) or not self.canvas.figure.get_axes()[0].is_waterfall():
+        if not isinstance(self.canvas.figure.get_axes()[0], MantidAxes) or \
+                not self.canvas.figure.get_axes()[0].is_waterfall():
             self.toolbar.set_waterfall_options_enabled(False)
 
     def destroy(self, *args):
@@ -312,6 +321,11 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.destroy()
         self._ads_observer.observeAll(False)
         del self._ads_observer
+        # disconnect window events before calling Gcf.destroy. window.close is not guaranteed to
+        # delete the object and do this for us. On macOS it was observed that closing the figure window
+        # would produce an extraneous activated event that would add a new figure to the plots list
+        # right after deleted the old one.
+        self.window.disconnect()
         self._fig_interaction.disconnect()
         self.window.close()
 
@@ -386,20 +400,17 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def generate_plot_script_file(self):
         script = generate_script(self.canvas.figure)
-        filepath = open_a_file_dialog(
-            parent=self.canvas,
-            default_suffix=".py",
-            file_filter="Python Files (*.py)",
-            accept_mode=QFileDialog.AcceptSave,
-            file_mode=QFileDialog.AnyFile
-        )
+        filepath = open_a_file_dialog(parent=self.canvas,
+                                      default_suffix=".py",
+                                      file_filter="Python Files (*.py)",
+                                      accept_mode=QFileDialog.AcceptSave,
+                                      file_mode=QFileDialog.AnyFile)
         if filepath:
             try:
                 with open(filepath, 'w') as f:
                     f.write(script)
             except IOError as io_error:
-                logger.error("Could not write file: {}\n{}"
-                             "".format(filepath, io_error))
+                logger.error("Could not write file: {}\n{}" "".format(filepath, io_error))
 
     def set_figure_zoom_to_display_all(self):
         axes = self.canvas.figure.get_axes()
@@ -441,6 +452,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
     def update_toolbar_waterfall_plot(self, is_waterfall):
         self.toolbar.set_waterfall_options_enabled(is_waterfall)
         self.toolbar.set_generate_plot_script_enabled(not is_waterfall)
+
 
 # -----------------------------------------------------------------------------
 # Figure control

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -16,48 +16,32 @@ import weakref
 # 3rdparty imports
 from qtpy.QtCore import QEvent, Qt, Signal, Slot
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QMainWindow
+from qtpy.QtWidgets import QMainWindow
 
 # local imports
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.widgets.observers.observing_view import ObservingView
-from workbench.app import MAIN_WINDOW_OBJECT_NAME
 
 
 class FigureWindow(QMainWindow, ObservingView):
     """A MainWindow that will hold plots"""
+    # signals
     activated = Signal()
     closing = Signal()
     visibility_changed = Signal()
     show_context_menu = Signal()
     close_signal = Signal()
 
-    def __init__(self, canvas, parent=None):
-        QMainWindow.__init__(self, parent=parent)
+    def __init__(self, canvas, parent=None, window_flags=None):
+        if window_flags is not None:
+            QMainWindow.__init__(self, parent, window_flags)
+        else:
+            QMainWindow.__init__(self, parent)
         # attributes
         self._canvas = weakref.proxy(canvas)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
 
-        # We use the focusWindowChanged event to bring this window back to the
-        # top when the main window gets focus. This does cause a slight flicker
-        # effect as the window is hidden and quickly brought back to the front.
-
-        # Using the parent-child method was tried. This worked on windows but
-        # not on Ubuntu as the child is NOT kept above the parent.
-        # However this is not used for windows as whenever a plot was done by
-        # an interface it moved behind workbench.
-
-        # Using the Qt.WindowStaysOnTopFlag was tried, however this caused the
-        # window to stay on top of all other windows, including external
-        # applications. This flag could be toggled off when the application
-        # was inactive, however a QWindow needs to be re-drawn when it is given
-        # new flags, which again, causes a flicker.
-
-        # Using the Qt.Tool flag, and setting the main window as this window's
-        # parent, keeps this window on top. However it does not allow the
-        # window to be minimized.
-        QApplication.instance().focusWindowChanged.connect(self._on_focusWindowChanged)
         self.close_signal.connect(self._run_close)
         self.setAcceptDrops(True)
 
@@ -115,8 +99,8 @@ class FigureWindow(QMainWindow, ObservingView):
                 dpi_ratio = self._canvas.devicePixelRatio() or 1
             except AttributeError:
                 dpi_ratio = 1
-            x = dpi_ratio*event.pos().x()
-            y = dpi_ratio*self._canvas.figure.bbox.height/dpi_ratio - event.pos().y()
+            x = dpi_ratio * event.pos().x()
+            y = dpi_ratio * self._canvas.figure.bbox.height / dpi_ratio - event.pos().y()
 
         location_event = LocationEvent('AxesGetterEvent', self._canvas, x, y)
         ax = location_event.inaxes if location_event.inaxes else self._canvas.figure.axes[0]
@@ -148,24 +132,3 @@ class FigureWindow(QMainWindow, ObservingView):
         else:
             plot_from_names(names, errors=(fig_type == FigureType.Errorbar),
                             overplot=ax, fig=fig)
-
-    def _on_focusWindowChanged(self, window):
-        """
-        The figure window should always remain on top of the main
-        Workbench window.
-        """
-        # We hook into focusWindowChanged instead of focusChanged here.
-        # focusChanged returns the widget that now has focus. We can determine
-        # if this widget is a child of the main window but, we do not want to
-        # raise this window above all children of the main window,e.g. matrix
-        # workspace display. We only want to raise the window above the main
-        # window's window.
-
-        # The window object returned here is a QtGui.QWindow https://doc.qt.io/qt-5/qwindow.html
-        # which only has access to the widget whose focus is being changed to,
-        # e.g. MessageDisplay, but for reasons given above we cannot use this.
-        # The object name of the window appears to be the object name of the
-        # window's central widget with "Window" appended to it; so we check for
-        # this.
-        if window and MAIN_WINDOW_OBJECT_NAME + 'Window' == window.objectName():
-            self.raise_()


### PR DESCRIPTION
**Description of work.**

Attempts a different method at keeping plots on top of the Workbench window to avoid issues with window managers being confused when we tried to force the figure window to the top of the stack. Some like Xfce did not ever relinquish focus back to the main window.

Ideally this would go on to master at this point in the dev cycle but the problem exist on IDAaaS and is not so esoteric as first thought so we have little choice but to fix it.


**To test:**

A new setting "Plots on Top" has been introduced. This should be testing with both default on and setting it off.

* Create some data and make different types of plot
* By default the plot window should stay on top of the main window.
* Try opening interfaces
* Try moving the plots to separate monitors
* Both with plots open and no plots on the screen try changing the "Plots on Top"  setting in "Settings->Plots" and observe the plots change from "floating" to "on top".

Fixes #27883

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
