### PR TITLE
Determine the total number of detectors used in the spectrum info

### DIFF
--- a/Framework/API/inc/MantidAPI/SpectrumInfo.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfo.h
@@ -57,6 +57,7 @@ public:
   ~SpectrumInfo();
 
   size_t size() const;
+  size_t detectorCount() const;
 
   const SpectrumDefinition &spectrumDefinition(const size_t index) const;
   const Kernel::cow_ptr<std::vector<SpectrumDefinition>> &

--- a/Framework/API/inc/MantidAPI/SpectrumInfoItem.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfoItem.h
@@ -12,8 +12,8 @@
 #include "MantidTypes/SpectrumDefinition.h"
 #include <type_traits>
 
-using Mantid::Kernel::V3D;
 using Mantid::SpectrumDefinition;
+using Mantid::Kernel::V3D;
 
 namespace Mantid {
 namespace API {

--- a/Framework/API/inc/MantidAPI/SpectrumInfoItem.h
+++ b/Framework/API/inc/MantidAPI/SpectrumInfoItem.h
@@ -12,8 +12,8 @@
 #include "MantidTypes/SpectrumDefinition.h"
 #include <type_traits>
 
-using Mantid::SpectrumDefinition;
 using Mantid::Kernel::V3D;
+using Mantid::SpectrumDefinition;
 
 namespace Mantid {
 namespace API {
@@ -59,6 +59,8 @@ public:
   bool hasUniqueDetector() const {
     return m_spectrumInfo->hasUniqueDetector(m_index);
   }
+
+  bool hasDetectors() const { return m_spectrumInfo->hasDetectors(m_index); }
 
   const Mantid::SpectrumDefinition &spectrumDefinition() const {
     return m_spectrumInfo->spectrumDefinition(m_index);

--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -33,6 +33,10 @@ SpectrumInfo::~SpectrumInfo() = default;
 /// Returns the size of the SpectrumInfo, i.e., the number of spectra.
 size_t SpectrumInfo::size() const { return m_spectrumInfo.size(); }
 
+size_t SpectrumInfo::detectorCount() const {
+  return m_spectrumInfo.detectorCount();
+}
+
 /// Returns a const reference to the SpectrumDefinition of the spectrum.
 const SpectrumDefinition &
 SpectrumInfo::spectrumDefinition(const size_t index) const {

--- a/Framework/Beamline/inc/MantidBeamline/SpectrumInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/SpectrumInfo.h
@@ -47,6 +47,7 @@ public:
       Kernel::cow_ptr<std::vector<SpectrumDefinition>> spectrumDefinition);
 
   size_t size() const;
+  size_t detectorCount() const;
 
   const SpectrumDefinition &spectrumDefinition(const size_t index) const;
   void setSpectrumDefinition(const size_t index, SpectrumDefinition def);

--- a/Framework/Beamline/src/SpectrumInfo.cpp
+++ b/Framework/Beamline/src/SpectrumInfo.cpp
@@ -28,7 +28,7 @@ size_t SpectrumInfo::size() const {
 
 /// Return count of all detectors used within spectrum
 size_t SpectrumInfo::detectorCount() const {
-    size_t count = 0;
+  size_t count = 0;
   for (const auto &spec : *m_spectrumDefinition) {
     count += spec.size();
   }

--- a/Framework/Beamline/src/SpectrumInfo.cpp
+++ b/Framework/Beamline/src/SpectrumInfo.cpp
@@ -26,6 +26,15 @@ size_t SpectrumInfo::size() const {
   return m_spectrumDefinition->size();
 }
 
+/// Return count of all detectors used within spectrum
+size_t SpectrumInfo::detectorCount() const {
+    size_t count = 0;
+  for (const auto &spec : *m_spectrumDefinition) {
+    count += spec.size();
+  }
+  return count;
+}
+
 /// Returns a const reference to the SpectrumDefinition of the spectrum.
 const SpectrumDefinition &
 SpectrumInfo::spectrumDefinition(const size_t index) const {

--- a/Framework/Beamline/test/SpectrumInfoTest.h
+++ b/Framework/Beamline/test/SpectrumInfoTest.h
@@ -108,6 +108,19 @@ public:
                        (std::pair<size_t, size_t>(i, 0)));
     }
   }
+
+  void test_detectorCount() {
+    SpectrumDefinition def1;
+    def1.add(1);
+    def1.add(2);
+    SpectrumDefinition def2;
+    def2.add(1);
+    SpectrumInfo info{2};
+    info.setSpectrumDefinition(0, def1);
+    info.setSpectrumDefinition(1, def2);
+    TS_ASSERT_EQUALS(info.size(), 2);
+    TS_ASSERT_EQUALS(info.detectorCount(), 3);
+  }
 };
 
 #endif /* MANTID_BEAMLINE_SPECTRUMINFOTEST_H_ */

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -15,11 +15,11 @@
 #include <boost/python/list.hpp>
 #include <boost/python/return_value_policy.hpp>
 
+using Mantid::SpectrumDefinition;
 using Mantid::API::SpectrumInfo;
 using Mantid::API::SpectrumInfoItem;
 using Mantid::API::SpectrumInfoIterator;
 using Mantid::PythonInterface::SpectrumInfoPythonIterator;
-using Mantid::SpectrumDefinition;
 using namespace boost::python;
 
 // Helper method to make the python iterator

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -15,11 +15,11 @@
 #include <boost/python/list.hpp>
 #include <boost/python/return_value_policy.hpp>
 
-using Mantid::SpectrumDefinition;
 using Mantid::API::SpectrumInfo;
 using Mantid::API::SpectrumInfoItem;
 using Mantid::API::SpectrumInfoIterator;
 using Mantid::PythonInterface::SpectrumInfoPythonIterator;
+using Mantid::SpectrumDefinition;
 using namespace boost::python;
 
 // Helper method to make the python iterator
@@ -76,5 +76,7 @@ void export_SpectrumInfo() {
       .def("getSpectrumDefinition", &SpectrumInfo::spectrumDefinition,
            return_value_policy<return_by_value>(), (arg("self"), arg("index")),
            "Returns the SpectrumDefinition of the spectrum with the given "
-           "index.");
+           "index.")
+      .def("detectorCount", &SpectrumInfo::detectorCount, arg("self"),
+           "Returns the total number of detectors used across spectrum info.");
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfoItem.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfoItem.cpp
@@ -27,6 +27,8 @@ void export_SpectrumInfoItem() {
       .add_property("signedTwoTheta",
                     &SpectrumInfoItem<SpectrumInfo>::signedTwoTheta)
       .add_property("l2", &SpectrumInfoItem<SpectrumInfo>::l2)
+      .add_property("hasDetectors",
+                    &SpectrumInfoItem<SpectrumInfo>::hasDetectors)
       .add_property("hasUniqueDetector",
                     &SpectrumInfoItem<SpectrumInfo>::hasUniqueDetector)
       .add_property(

--- a/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
@@ -43,7 +43,9 @@ class SpectrumInfoTest(unittest.TestCase):
     def test_detectorCount(self):
         """ Check total detector count """
         info = self._ws.spectrumInfo()
-        self.assertEqual(info.detectorCount, 3)
+        # One detector cleared. So not counted.
+        self.assertEqual(info.detectorCount(), 2)
+
 
     def test_isMonitor(self):
         """ Check if a monitor is present. """

--- a/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/SpectrumInfoTest.py
@@ -40,6 +40,11 @@ class SpectrumInfoTest(unittest.TestCase):
         info = self._ws.spectrumInfo()
         self.assertEqual(info.size(), 3)
 
+    def test_detectorCount(self):
+        """ Check total detector count """
+        info = self._ws.spectrumInfo()
+        self.assertEqual(info.detectorCount, 3)
+
     def test_isMonitor(self):
         """ Check if a monitor is present. """
         info = self._ws.spectrumInfo()


### PR DESCRIPTION
What should be trivial in determining the number of detectors via spectrum info is not.

* One cannot rely on a fixed spectra to detector mapping in the case that detectors are unique, and for some.
* In some cases, such as `iris26176_graphite002_sqw.nxs` detectors are used between different "spectrum".

New `detectorCount` method solves that. This is exposed to python.