### PR TITLE
Fix changing the normalisation on a waterfall plot with filled areas removing the filled areas

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1054,10 +1054,10 @@ class MantidAxes(Axes):
         if enable:
             datafunctions.waterfall_create_fill(self)
 
-            if colour:
-                datafunctions.solid_colour_fill(self, colour)
-            else:
+            if colour is None:
                 datafunctions.line_colour_fill(self)
+            else:
+                datafunctions.solid_colour_fill(self, colour)
         else:
             if bool(colour):
                 raise RuntimeError("You have set fill to false but have given a colour.")

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -658,6 +658,15 @@ class FigureInteraction(object):
         waterfall = isinstance(ax, MantidAxes) and ax.is_waterfall()
         if waterfall:
             x, y = ax.waterfall_x_offset, ax.waterfall_y_offset
+            has_fill = ax.waterfall_has_fill()
+
+            if has_fill:
+                line_colour_fill = datafunctions.waterfall_fill_is_line_colour(ax)
+                if line_colour_fill:
+                    fill_colour = None
+                else:
+                    fill_colour = datafunctions.get_waterfall_fills(ax)[0].get_facecolor()
+
             ax.update_waterfall(0, 0)
 
         is_normalized = self._is_normalized(ax)
@@ -693,6 +702,9 @@ class FigureInteraction(object):
         datafunctions.set_initial_dimensions(ax)
         if waterfall:
             ax.update_waterfall(x, y)
+
+            if has_fill:
+                ax.set_waterfall_fill(True, fill_colour)
 
         self.canvas.draw()
 


### PR DESCRIPTION
**To test:**
Load a workspace and double-click it.
In the spectra selector dialog enter multiple spectrum numbers and change the plot type to Waterfall.
When the plot is created, open the fill menu (the paint bucket button in the toolbar) and enable the area under each curve being filled.
Right-click the plot and do Normalization -> whichever option isn't currently selected.
See that the curves still have filled areas.

Fixes #28223 

No release notes because waterfall plots aren't in a release yet.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
