### PR TITLE
Fix links between error and y cols in table workspaces

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -150,6 +150,10 @@ public:
   /// Set plot type where
   void setPlotType(int t);
 
+  int getLinkedYCol() const { return m_linkedYCol; }
+
+  void setLinkedYCol(const int yCol);
+
   /**
    * Fills a std vector with values from the column if the types are compatible.
    * @param maxSize :: Set size to less than the full column.
@@ -201,6 +205,9 @@ protected:
   /// NotSet = -1000 (this is the default and means plot style has not been set)
   /// X = 1, Y = 2, Z = 3, xErr = 4, yErr = 5, Label = 6
   int m_plotType;
+
+  /// For error columns - the index of the related data column
+  int m_linkedYCol = -1;
 
   /// Column read-only flag
   bool m_isReadOnly;

--- a/Framework/API/src/Column.cpp
+++ b/Framework/API/src/Column.cpp
@@ -36,6 +36,8 @@ void Column::setPlotType(int t) {
   }
 }
 
+void Column::setLinkedYCol(const int yCol) { m_linkedYCol = yCol; }
+
 /**
  * No implementation by default.
  */

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidKernel/V3D.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/Converters/CloneToNDArray.h"
 #include "MantidPythonInterface/core/Converters/NDArrayToVector.h"
 #include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
@@ -249,7 +250,13 @@ void setPlotType(ITableWorkspace &self, const object &column, int ptype,
   self.modified();
 }
 
+GNU_DIAG_OFF("unused-local-typedef")
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GNU_DIAG_OFF("conversion")
 BOOST_PYTHON_FUNCTION_OVERLOADS(setPlotType_overloads, setPlotType, 3, 4)
+GNU_DIAG_ON("conversion")
+GNU_DIAG_ON("unused-local-typedef")
 
 /**
  * Get the data column associated with a Y error column

--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -114,5 +114,6 @@ Bugfixes
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 - Fixed a bug which caused graphic scaling issues when the double-click menu was used to set an axis as log-scaled.
 - Fixed a bug where the colorbar in the instrument view would sometimes have no markers if the scale was set to SymmetricLog10.
+- Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
+++ b/qt/python/mantidqt/utils/testing/mocks/mock_mantid.py
@@ -114,3 +114,5 @@ class MockWorkspace:
         self.emit_repaint = StrictMock()
 
         self.getPlotType = StrictMock()
+
+        self.getLinkedYCol = StrictMock()

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/error_column.py
@@ -12,13 +12,11 @@ class ErrorColumn:
     CANNOT_SET_Y_TO_BE_OWN_YERR_MESSAGE = "Cannot set Y column to be its own YErr"
     UNHANDLED_COMPARISON_LOGIC_MESSAGE = "Unhandled comparison logic with type {}"
 
-    def __init__(self, column, related_y_column, label_index):
+    def __init__(self, column, related_y_column):
         self.column = column
         self.related_y_column = related_y_column
         if self.column == self.related_y_column:
             raise ValueError(self.CANNOT_SET_Y_TO_BE_OWN_YERR_MESSAGE)
-
-        self.label_index = label_index
 
     def __eq__(self, other):
         if isinstance(other, ErrorColumn):
@@ -35,3 +33,6 @@ class ErrorColumn:
             return self.column == other
         else:
             raise RuntimeError(self.UNHANDLED_COMPARISON_LOGIC_MESSAGE.format(type(other)))
+
+    def __int__(self):
+        return self.column

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/io.py
@@ -30,8 +30,7 @@ class TableWorkspaceDisplayEncoder(TableWorkspaceDisplayAttributes):
     def _encode_marked_columns(marked_columns):
         as_y_err = []
         for y_err in marked_columns.as_y_err:
-            as_y_err.append({"column": y_err.column, "relatedY": y_err.related_y_column,
-                             "labelIndex": y_err.label_index})
+            as_y_err.append({"column": y_err.column, "relatedY": y_err.related_y_column})
 
         return {"as_x": marked_columns.as_x, "as_y": marked_columns.as_y, "as_y_err": as_y_err}
 
@@ -54,7 +53,7 @@ class TableWorkspaceDisplayDecoder(TableWorkspaceDisplayAttributes):
 
         error_columns = []
         for y_err in obj_dic["markedColumns"]["as_y_err"]:
-            error_columns.append(ErrorColumn(column=y_err["column"], label_index=y_err["labelIndex"],
+            error_columns.append(ErrorColumn(column=y_err["column"],
                                              related_y_column=y_err["relatedY"]))
         pres.model.marked_columns.as_y_err = error_columns
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/marked_columns.py
@@ -18,14 +18,6 @@ class MarkedColumns:
         self.as_y = []
         self.as_y_err = []
 
-    def _add(self, col_index, add_to, remove_from):
-        assert all(
-            add_to is not remove for remove in remove_from), "Can't add and remove from the same list at the same time!"
-        self._remove(col_index, remove_from)
-
-        if col_index not in add_to:
-            add_to.append(col_index)
-
     def _remove(self, col_index, remove_from):
         """
         Remove the column index from all lists
@@ -34,21 +26,37 @@ class MarkedColumns:
         :param remove_from: List of lists from which the column index will be removed
         :return:
         """
+        removed_cols=[]
         for list in remove_from:
             try:
-                list.remove(col_index)
+                # remove all (for error cols there could be more than one match)
+                for _ in range(list.count(col_index)):
+                    list_index = list.index(col_index)
+                    col_to_remove = list.pop(list_index)
+                    if col_to_remove not in removed_cols:
+                        removed_cols.append(col_to_remove)
             except ValueError:
                 # column not in this list, but might be in another one so we continue the loop
                 continue
-
-        # if the column previously had a Y Err associated with it -> this will remove it from the YErr list
-        self._remove_associated_yerr_columns(col_index)
+        return removed_cols
 
     def add_x(self, col_index):
-        self._add(col_index, self.as_x, [self.as_y, self.as_y_err])
+        removed_items = self._remove(col_index, [self.as_y, self.as_y_err])
+        # if the column previously had a Y Err associated with it -> this will remove it from the YErr list
+        self._remove_associated_yerr_columns(col_index, removed_items)
+
+        if col_index not in self.as_x:
+            self.as_x.append(col_index)
+
+        return removed_items
 
     def add_y(self, col_index):
-        self._add(col_index, self.as_y, [self.as_x, self.as_y_err])
+        removed_items = self._remove(col_index, [self.as_x, self.as_y_err])
+
+        if col_index not in self.as_y:
+            self.as_y.append(col_index)
+
+        return removed_items
 
     def add_y_err(self, err_column):
         if err_column.related_y_column in self.as_x:
@@ -56,26 +64,28 @@ class MarkedColumns:
         elif err_column.related_y_column in self.as_y_err:
             raise ValueError("Trying to add YErr for column marked as YErr.")
         # remove all labels for the column index
-        len_before_remove = len(self.as_y)
-        self._remove(err_column, [self.as_x, self.as_y, self.as_y_err])
+        removed_items = self._remove(err_column, [self.as_x, self.as_y, self.as_y_err])
+        # if the column previously had a Y Err associated with it -> this will remove it from the YErr list
+        # this case isn't handled by the __eq__ and __comp__ functions on the ErrorColumn class
+        self._remove_associated_yerr_columns(err_column, removed_items)
 
-        # Check if the length of the list with columns marked Y has shrunk
-        # -> This means that columns have been removed, and the label_index is now _wrong_
-        # and has to be decremented to match the new label index correctly
-        len_after_remove = len(self.as_y)
-        if err_column.related_y_column > err_column.column and len_after_remove < len_before_remove:
-            err_column.label_index -= (len_before_remove - len_after_remove)
         self.as_y_err.append(err_column)
 
-    def remove(self, col_index):
-        self._remove(col_index, [self.as_x, self.as_y, self.as_y_err])
+        return removed_items
 
-    def _remove_associated_yerr_columns(self, col_index):
+    def remove(self, col_index):
+        removed_cols = self._remove(col_index, [self.as_x, self.as_y, self.as_y_err])
+        # if the column previously had a Y Err associated with it -> this will remove it from the YErr list
+        self._remove_associated_yerr_columns(col_index, removed_cols)
+
+    def _remove_associated_yerr_columns(self, col_index, removed_cols):
         # we can only have 1 Y Err for Y, so iterating and removing's iterator invalidation is not an
         # issue as the code will exit immediately after the removal
         for col in self.as_y_err:
             if col.related_y_column == col_index:
                 self.as_y_err.remove(col)
+                if col not in removed_cols:
+                    removed_cols.append(col)
                 break
 
     def _make_labels(self, list, label):
@@ -85,8 +95,9 @@ class MarkedColumns:
         extra_labels = []
         extra_labels.extend(self._make_labels(self.as_x, self.X_LABEL))
         extra_labels.extend(self._make_labels(self.as_y, self.Y_LABEL))
-        err_labels = [(err_col.column, self.Y_ERR_LABEL.format(err_col.label_index),) for index, err_col in
-                      enumerate(self.as_y_err)]
+        err_labels = [(err_col.column, self.Y_ERR_LABEL.format(self.as_y.index(err_col.related_y_column)),) for
+                      index, err_col in
+                      enumerate(self.as_y_err) if self.as_y.count(err_col.related_y_column)>0]
         extra_labels.extend(err_labels)
         return extra_labels
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/model.py
@@ -69,16 +69,9 @@ class TableWorkspaceDisplayModel:
             elif plot_type == TableWorkspaceColumnTypeMapping.Y:
                 self.marked_columns.add_y(col)
             elif plot_type == TableWorkspaceColumnTypeMapping.YERR:
-                # mark YErrs only if there are any columns that have been marked as Y
-                # if there are none then do not mark anything as YErr
-                if len(self.marked_columns.as_y) > len(self.marked_columns.as_y_err):
-                    # Assume all the YErrs are associated with the first available (no other YErr has it) Y column.
-                    # There isn't a way to know the correct Y column, as that information is not stored
-                    # in the table workspace - the original table workspace does not associate Y errors
-                    # columns with specific Y columns
-                    err_for_column = self.marked_columns.as_y[len(self.marked_columns.as_y_err)]
-                    label = str(len(self.marked_columns.as_y_err))
-                    self.marked_columns.add_y_err(ErrorColumn(col, err_for_column, label))
+                err_for_column = self.ws.getLinkedYCol(col)
+                if err_for_column >= 0:
+                    self.marked_columns.add_y_err(ErrorColumn(col, err_for_column))
 
     def _get_v3d_from_str(self, string):
         if '[' in string and ']' in string:
@@ -147,5 +140,5 @@ class TableWorkspaceDisplayModel:
             SortTableWorkspace(InputWorkspace=self.ws, OutputWorkspace=self.ws, Columns=column_name,
                                Ascending=sort_ascending)
 
-    def set_column_type(self, col, type):
-        self.ws.setPlotType(col, type)
+    def set_column_type(self, col, type, linked_col_index=-1):
+        self.ws.setPlotType(col, type, linked_col_index)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -237,7 +237,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
     def action_set_as_y(self):
         self._action_set_as(self.model.marked_columns.add_y, 2)
 
-    def action_set_as_y_err(self, related_y_column, label_index):
+    def action_set_as_y_err(self, related_y_column):
         """
 
         :param related_y_column: The real index of the column for which the error is being marked
@@ -250,13 +250,18 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
             return
 
         try:
-            err_column = ErrorColumn(selected_column, related_y_column, label_index)
+            err_column = ErrorColumn(selected_column, related_y_column)
         except ValueError as e:
             self.view.show_warning(str(e))
             return
 
-        self.model.marked_columns.add_y_err(err_column)
-        self.model.set_column_type(selected_column, 5)
+        removed_items = self.model.marked_columns.add_y_err(err_column)
+        # if a column other than the one the user has just picked as a y err column has been affected,
+        # reset it's type to None
+        for col in removed_items:
+            if col != selected_column:
+                self.model.set_column_type(int(col),0)
+        self.model.set_column_type(selected_column, 5, related_y_column)
         self.update_column_headers()
 
     def action_set_as_none(self):

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_error_column.py
@@ -6,28 +6,32 @@ from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 class ErrorColumnTest(unittest.TestCase):
 
     def test_correct_init(self):
-        ErrorColumn(0, 1, 0)
+        ErrorColumn(0, 1)
 
     def test_raises_for_same_y_and_yerr(self):
-        self.assertRaises(ValueError, lambda: ErrorColumn(2, 2, 3))
+        self.assertRaises(ValueError, lambda: ErrorColumn(2, 2))
 
     def test_eq_versus_ErrorColumn(self):
-        ec1 = ErrorColumn(0, 1, 0)
-        ec2 = ErrorColumn(0, 1, 0)
+        ec1 = ErrorColumn(0, 1)
+        ec2 = ErrorColumn(0, 1)
         self.assertEqual(ec1, ec2)
 
-        ec1 = ErrorColumn(0, 3, 0)
-        ec2 = ErrorColumn(0, 1, 0)
+        ec1 = ErrorColumn(0, 3)
+        ec2 = ErrorColumn(0, 1)
         self.assertEqual(ec1, ec2)
 
-        ec1 = ErrorColumn(2, 3, 0)
-        ec2 = ErrorColumn(0, 3, 0)
+        ec1 = ErrorColumn(2, 3)
+        ec2 = ErrorColumn(0, 3)
         self.assertEqual(ec1, ec2)
 
     def test_eq_versus_same_int(self):
-        ec = ErrorColumn(150, 1, 0)
+        ec = ErrorColumn(150, 1)
         self.assertEqual(ec, 150)
 
     def test_eq_unsupported_type(self):
-        ec = ErrorColumn(150, 1, 0)
+        ec = ErrorColumn(150, 1)
         self.assertRaises(RuntimeError, lambda: ec == "awd")
+
+    def test_int(self):
+        ec = ErrorColumn(1, 2)
+        self.assertEqual(int(ec), 1)

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_io.py
@@ -17,7 +17,7 @@ from mantidqt.widgets.workspacedisplay.table import StatusBarView
 
 
 TABLEWORKSPACEDISPLAY_DICT = {"markedColumns": {"as_y": [2], "as_x": [1],
-                                                "as_y_err": [{"column": 3, "relatedY": 2, "labelIndex": 0}]},
+                                                "as_y_err": [{"column": 3, "relatedY": 2}]},
                               "workspace": "ws", "windowName": "ws"}
 
 
@@ -52,9 +52,6 @@ class TableWorkspaceDisplayDecoderTest(unittest.TestCase):
         self.assertEqual(
             TABLEWORKSPACEDISPLAY_DICT["markedColumns"]["as_y_err"][0]["relatedY"],
             view.presenter.model.marked_columns.as_y_err[0].related_y_column)
-        self.assertEqual(
-            TABLEWORKSPACEDISPLAY_DICT["markedColumns"]["as_y_err"][0]["labelIndex"],
-            view.presenter.model.marked_columns.as_y_err[0].label_index)
         self.assertEqual(1, len(view.presenter.model.marked_columns.as_y_err))
 
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_marked_columns.py
@@ -45,13 +45,13 @@ class MarkedColumnsTest(unittest.TestCase):
         Test adding YErr columns that do not overlap in any way
         """
         mc = MarkedColumns()
-        ec = ErrorColumn(2, 4, 0)
+        ec = ErrorColumn(2, 4)
         mc.add_y_err(ec)
         self.assertEqual(1, len(mc.as_y_err))
-        ec = ErrorColumn(3, 5, 0)
+        ec = ErrorColumn(3, 5)
         mc.add_y_err(ec)
         self.assertEqual(2, len(mc.as_y_err))
-        ec = ErrorColumn(1, 6, 0)
+        ec = ErrorColumn(1, 6)
         mc.add_y_err(ec)
         self.assertEqual(3, len(mc.as_y_err))
 
@@ -75,14 +75,14 @@ class MarkedColumnsTest(unittest.TestCase):
 
     def test_add_y_err_duplicate_column(self):
         mc = MarkedColumns()
-        ec = ErrorColumn(2, 4, 0)
+        ec = ErrorColumn(2, 4)
 
         mc.add_y_err(ec)
         self.assertEqual(1, len(mc.as_y_err))
         mc.add_y_err(ec)
         self.assertEqual(1, len(mc.as_y_err))
 
-        ec2 = ErrorColumn(3, 5, 0)
+        ec2 = ErrorColumn(3, 5)
         mc.add_y_err(ec2)
         self.assertEqual(2, len(mc.as_y_err))
         mc.add_y_err(ec2)
@@ -123,7 +123,7 @@ class MarkedColumnsTest(unittest.TestCase):
         -> The new YErr must replace the old one
         """
         mc = MarkedColumns()
-        ec = ErrorColumn(column=2, related_y_column=4, label_index=0)
+        ec = ErrorColumn(column=2, related_y_column=4)
         mc.add_y_err(ec)
         self.assertEqual(1, len(mc.as_y_err))
         self.assertEqual(2, mc.as_y_err[0].column)
@@ -131,7 +131,7 @@ class MarkedColumnsTest(unittest.TestCase):
 
         # different source column but contains error for the same column
         # adding this one should replace the first one
-        ec2 = ErrorColumn(column=2, related_y_column=5, label_index=0)
+        ec2 = ErrorColumn(column=2, related_y_column=5)
         mc.add_y_err(ec2)
         self.assertEqual(1, len(mc.as_y_err))
         self.assertEqual(2, mc.as_y_err[0].column)
@@ -143,7 +143,7 @@ class MarkedColumnsTest(unittest.TestCase):
         -> The new YErr must replace the old one
         """
         mc = MarkedColumns()
-        ec = ErrorColumn(column=2, related_y_column=4, label_index=0)
+        ec = ErrorColumn(column=2, related_y_column=4)
         mc.add_y_err(ec)
         self.assertEqual(1, len(mc.as_y_err))
         self.assertEqual(2, mc.as_y_err[0].column)
@@ -151,7 +151,7 @@ class MarkedColumnsTest(unittest.TestCase):
 
         # different source column but contains error for the same column
         # adding this one should replace the first one
-        ec2 = ErrorColumn(column=3, related_y_column=4, label_index=0)
+        ec2 = ErrorColumn(column=3, related_y_column=4)
         mc.add_y_err(ec2)
         self.assertEqual(1, len(mc.as_y_err))
         self.assertEqual(3, mc.as_y_err[0].column)
@@ -164,7 +164,7 @@ class MarkedColumnsTest(unittest.TestCase):
         """
         mc = MarkedColumns()
         mc.add_y(4)
-        ec = ErrorColumn(column=2, related_y_column=4, label_index=0)
+        ec = ErrorColumn(column=2, related_y_column=4)
         mc.add_y_err(ec)
 
         # check that we have both a Y col and an associated YErr
@@ -177,6 +177,11 @@ class MarkedColumnsTest(unittest.TestCase):
         self.assertEqual(0, len(mc.as_y))
         self.assertEqual(0, len(mc.as_y_err))
 
+        # check setting the column back to Y does not automatically reinstate the error column
+        mc.add_y(4)
+        self.assertEqual(1, len(mc.as_y))
+        self.assertEqual(0, len(mc.as_y_err))
+
     def test_changing_y_to_none_removes_associated_yerr_columns(self):
         """
         Test to check if a first column is marked as Y, a second column YErr is associated with it, but then
@@ -184,7 +189,7 @@ class MarkedColumnsTest(unittest.TestCase):
         """
         mc = MarkedColumns()
         mc.add_y(4)
-        ec = ErrorColumn(column=2, related_y_column=4, label_index=0)
+        ec = ErrorColumn(column=2, related_y_column=4)
         mc.add_y_err(ec)
 
         # check that we have both a Y col and an associated YErr
@@ -197,11 +202,16 @@ class MarkedColumnsTest(unittest.TestCase):
         self.assertEqual(0, len(mc.as_y))
         self.assertEqual(0, len(mc.as_y_err))
 
+        # check adding the Y column back in does not automatically reinstate the error column
+        mc.add_y(4)
+        self.assertEqual(1, len(mc.as_y))
+        self.assertEqual(0, len(mc.as_y_err))
+
     def test_remove_column(self):
         mc = MarkedColumns()
         mc.add_y(4)
         mc.add_x(3)
-        ec = ErrorColumn(column=2, related_y_column=6, label_index=0)
+        ec = ErrorColumn(column=2, related_y_column=6)
         mc.add_y_err(ec)
 
         self.assertEqual(1, len(mc.as_x))
@@ -249,12 +259,12 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
 
         # change one of the columns to YErr
-        mc.add_y_err(ErrorColumn(1, 0, 0))
+        mc.add_y_err(ErrorColumn(1, 0))
         expected = [(0, '[Y0]'), (2, '[Y1]'), (1, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
         # change the last Y column to YErr
-        mc.add_y_err(ErrorColumn(2, 0, 0))
+        mc.add_y_err(ErrorColumn(2, 0))
         expected = [(0, '[Y0]'), (2, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
@@ -265,13 +275,13 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
 
         # change one of the columns to YErr
-        mc.add_y_err(ErrorColumn(0, 1, 1))
+        mc.add_y_err(ErrorColumn(0, 1))
         # note: the first column is being set -> this decreases the label index of all columns to its right by 1
         expected = [(1, '[Y0]'), (2, '[Y1]'), (0, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
         # change the last Y column to YErr
-        mc.add_y_err(ErrorColumn(2, 1, 0))
+        mc.add_y_err(ErrorColumn(2, 1))
         expected = [(1, '[Y0]'), (2, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
@@ -282,7 +292,7 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
         mc.add_y(3)
 
-        mc.add_y_err(ErrorColumn(1, 0, 0))
+        mc.add_y_err(ErrorColumn(1, 0))
         expected = [(0, '[Y0]'), (2, '[Y1]'), (3, '[Y2]'), (1, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
@@ -291,7 +301,16 @@ class MarkedColumnsTest(unittest.TestCase):
         self.assertEqual(expected, mc.build_labels())
 
         expected = [(1, '[X0]'), (2, '[Y0]'), (3, '[Y1]'), (0, '[Y1_YErr]')]
-        mc.add_y_err(ErrorColumn(0, 3, 2))
+        mc.add_y_err(ErrorColumn(0, 3))
+        self.assertEqual(expected, mc.build_labels())
+
+    def test_build_labels_y_with_only_some_having_yerr(self):
+        mc = MarkedColumns()
+        mc.add_y(0)
+        mc.add_y(1)
+        mc.add_y_err(ErrorColumn(2,1))
+
+        expected = [(0, '[Y0]'), (1, '[Y1]'), (2, '[Y1_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
     def test_fail_to_add_yerr_for_x(self):
@@ -301,7 +320,7 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
         mc.add_y(3)
 
-        mc.add_y_err(ErrorColumn(1, 0, 0))
+        mc.add_y_err(ErrorColumn(1, 0))
         expected = [(0, '[Y0]'), (2, '[Y1]'), (3, '[Y2]'), (1, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
@@ -309,7 +328,7 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_x(1)
         self.assertEqual(expected, mc.build_labels())
 
-        self.assertRaises(ValueError, lambda: mc.add_y_err(ErrorColumn(0, 1, 2)))
+        self.assertRaises(ValueError, lambda: mc.add_y_err(ErrorColumn(0, 1)))
 
     def test_fail_to_add_yerr_for_another_yerr(self):
         mc = MarkedColumns()
@@ -318,11 +337,11 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
         mc.add_y(3)
 
-        mc.add_y_err(ErrorColumn(1, 0, 0))
+        mc.add_y_err(ErrorColumn(1, 0))
         expected = [(0, '[Y0]'), (2, '[Y1]'), (3, '[Y2]'), (1, '[Y0_YErr]')]
         self.assertEqual(expected, mc.build_labels())
 
-        self.assertRaises(ValueError, lambda: mc.add_y_err(ErrorColumn(0, 1, 2)))
+        self.assertRaises(ValueError, lambda: mc.add_y_err(ErrorColumn(0, 1)))
 
     def test_find_yerr(self):
         mc = MarkedColumns()
@@ -331,13 +350,13 @@ class MarkedColumnsTest(unittest.TestCase):
         mc.add_y(2)
         mc.add_y(3)
 
-        mc.add_y_err(ErrorColumn(4, 1, 1))
+        mc.add_y_err(ErrorColumn(4, 1))
         expected = {1: 4}
         self.assertEqual(expected, mc.find_yerr([1]))
         # Replace the Y column, which has an associated YErr. This should remove the YErr as well
-        mc.add_y_err(ErrorColumn(1, 3, 1))
+        mc.add_y_err(ErrorColumn(1, 3))
         expected = {3: 1}
         self.assertEqual(expected, mc.find_yerr([0, 1, 2, 3]))
-        mc.add_y_err(ErrorColumn(4, 2, 1))
+        mc.add_y_err(ErrorColumn(4, 2))
         expected = {2: 4, 3: 1}
         self.assertEqual(expected, mc.find_yerr([0, 1, 2, 3]))

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -110,6 +110,7 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         mock_column_types = [TableWorkspaceColumnTypeMapping.X, TableWorkspaceColumnTypeMapping.Y,
                              TableWorkspaceColumnTypeMapping.YERR] * num_of_repeated_columns
         ws.getPlotType = lambda i: mock_column_types[i]
+        ws.getLinkedYCol = lambda i: i-1
         model = TableWorkspaceDisplayModel(ws)
 
         self.assertEqual(num_of_repeated_columns, len(model.marked_columns.as_x))
@@ -118,27 +119,6 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
 
         for i, col in enumerate(range(2, 30, 3)):
             self.assertEqual(col - 1, model.marked_columns.as_y_err[i].related_y_column)
-
-    def test_initialise_marked_columns_yerr_before_y_doesnt_mark_yerr(self):
-        """
-        Test if there are column marking such as [X, Y, YERR, X, YERR, Y]
-                                                                   ^ this YErr
-        won't be associated with any Y column, as there isn't one at the time of adding the YErr column
-        :return:
-        """
-        ws = MockWorkspace()
-        # add 5 columns as that is how many the default mock WS has
-        mock_column_types = [TableWorkspaceColumnTypeMapping.X, TableWorkspaceColumnTypeMapping.YERR,
-                             TableWorkspaceColumnTypeMapping.Y, TableWorkspaceColumnTypeMapping.X,
-                             TableWorkspaceColumnTypeMapping.Y]
-        ws.getPlotType = lambda i: mock_column_types[i]
-        model = TableWorkspaceDisplayModel(ws)
-
-        self.assertEqual(2, len(model.marked_columns.as_x))
-        self.assertEqual(2, len(model.marked_columns.as_y))
-        # no YErr is added because the Y column hasn't been added yet,
-        # and there isn't anything to associate the error with
-        self.assertEqual(0, len(model.marked_columns.as_y_err))
 
     def test_initialise_marked_columns_multiple_y_before_yerr(self):
         ws = MockWorkspace()
@@ -150,16 +130,14 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         ws.columnCount = StrictMock(return_value=len(mock_column_types))
 
         ws.getPlotType = lambda i: mock_column_types[i]
+        ws.getLinkedYCol = StrictMock(side_effect=[1,3,4])
         model = TableWorkspaceDisplayModel(ws)
 
         self.assertEqual(2, len(model.marked_columns.as_x))
         self.assertEqual(3, len(model.marked_columns.as_y))
-        # no YErr is added because the Y column hasn't been added yet,
-        # and there isn't anything to associate the error with
         self.assertEqual(3, len(model.marked_columns.as_y_err))
 
         self.assertEqual(1, model.marked_columns.as_y_err[0].related_y_column)
-        # the YErr associates with the FIRST Y column that doesn't have a Y Err
         self.assertEqual(3, model.marked_columns.as_y_err[1].related_y_column)
         self.assertEqual(4, model.marked_columns.as_y_err[2].related_y_column)
 

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -278,23 +278,22 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
     @with_mock_presenter(add_selection_model=True)
     def test_action_set_as_y_err(self, ws, view, twd):
         view.mock_selection_model.selectedColumns = Mock(return_value=[MockQModelIndex(1, 1)])
-        twd.action_set_as_y_err(2, "0")
+        twd.action_set_as_y_err(2)
         self.assertEqual(1, len(twd.model.marked_columns.as_y_err))
         err_col = twd.model.marked_columns.as_y_err[0]
         self.assertEqual(1, err_col.column)
         self.assertEqual(2, err_col.related_y_column)
-        self.assertEqual("0", err_col.label_index)
 
     @with_mock_presenter(add_selection_model=True)
     def test_action_set_as_y_err_too_many_selected(self, ws, view, twd):
-        twd.action_set_as_y_err(2, "0")
+        twd.action_set_as_y_err(2)
         view.show_warning.assert_called_once_with(TableWorkspaceDisplay.TOO_MANY_TO_SET_AS_Y_ERR_MESSAGE)
 
     @with_mock_presenter(add_selection_model=True)
     def test_action_set_as_y_err_failed_to_create_ErrorColumn(self, ws, view, twd):
         view.mock_selection_model.selectedColumns = Mock(return_value=[MockQModelIndex(1, 1)])
         # this will fail as we're trying to set an YErr column for itself -> (try to set col 1 to be YERR for col 1)
-        twd.action_set_as_y_err(1, "0")
+        twd.action_set_as_y_err(1)
         view.show_warning.assert_called_once_with(ErrorColumn.CANNOT_SET_Y_TO_BE_OWN_YERR_MESSAGE)
 
     @patch('mantidqt.widgets.workspacedisplay.table.model.SortTableWorkspace')
@@ -560,7 +559,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_x)]
         twd.action_set_as_x()
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y_err)]
-        twd.action_set_as_y_err(col_as_y, '0')
+        twd.action_set_as_y_err(col_as_y)
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y)]
         if append_yerr_to_selection:
             view.mock_selection_model.selectedColumns.return_value.append(MockQModelIndex(1, col_as_y_err))
@@ -640,9 +639,9 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         twd.action_set_as_x()
 
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y1_err)]
-        twd.action_set_as_y_err(col_as_y1, '0')
+        twd.action_set_as_y_err(col_as_y1)
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y2_err)]
-        twd.action_set_as_y_err(col_as_y2, '1')
+        twd.action_set_as_y_err(col_as_y2)
 
         view.mock_selection_model.selectedColumns.return_value = [MockQModelIndex(1, col_as_y1),
                                                                   MockQModelIndex(1, col_as_y2)]

--- a/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/table/view.py
@@ -191,7 +191,7 @@ class TableWorkspaceDisplayView(QTableWidget):
                 # label_index here holds the index in the LABEL (multiple Y columns have labels Y0, Y1, YN...)
                 # this is NOT the same as the column relative to the WHOLE table
                 set_as_y_err.triggered.connect(
-                    partial(self.presenter.action_set_as_y_err, related_y_column, label_index))
+                    partial(self.presenter.action_set_as_y_err, related_y_column))
                 menu_set_as_y_err.addAction(set_as_y_err)
             menu_main.addMenu(menu_set_as_y_err)
 


### PR DESCRIPTION
**Description of work.**

The features for setting columns in a table workspace to X, Y or Y Error weren't working properly in the case where a workspace had a mix of Y columns with\without associated error cols (code was designed with assumption that all Y cols had associated error cols or no Y cols had associated error cols).

Made some changes to fix this. The C++ table workspace class now stores the linked Y column for a column that has been set to "Y Error". The python code has also been updated to calculate the "label index" on the fly when building the column titles instead of storing this in the ErrorColumn class

**To test:**

Problem was in workbench only.

Run the script on the linked issue and then right click on resulting workspace called "table" and select Show Data. Set columns to various combinations of X, Y and Y error using the right click menu. The original problem was visible without actually plotting anything in that the column headers didn't reflect the actions taken properly. Here's what the column headers should look like following the fix:

![TableWorkspaceWithCorrectColumnHeadings](https://user-images.githubusercontent.com/56295817/75895240-486f1480-5e2d-11ea-9b25-cc0be24b04df.PNG)


Worth spending some time on the various permutations here - particularly cases where a column has been set up initially as one type and then switching to another eg set up a column as Y error and then change it to X

Finally having checked the column headers react properly to changes I suggest you test the plotting works by right clicking on a Y column and selected Plot, Line with Y Errors

Fixes #27915.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
