### PR TITLE
Stop for loop in Rebin2D asking for next element after the last bin

### DIFF
--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -84,7 +84,7 @@ void Rebin2D::exec() {
         "If it is a spectra axis try running ConvertSpectrumAxis first.");
   }
 
-  const auto &oldXEdges = inputWS->x(0);
+  const auto &oldXEdges = inputWS->binEdges(0);
   const size_t numXBins = inputWS->blocksize();
   const size_t numYBins = inputWS->getNumberHistograms();
   // This will convert plain NumericAxis to bin edges while

--- a/Framework/Algorithms/test/Rebin2DTest.h
+++ b/Framework/Algorithms/test/Rebin2DTest.h
@@ -208,7 +208,6 @@ public:
     TS_ASSERT_EQUALS(outputWS->blocksize(), 6);
 
     double errors[6] = {3., 3., 3., 3., 3., 2.236067977};
-    auto nhist = outputWS->getNumberHistograms();
     const double epsilon(1e-08);
     for (size_t i = 0; i < outputWS->getNumberHistograms(); ++i) {
       const auto &y = outputWS->y(i);

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -608,7 +608,7 @@ void rebinToFractionalOutput(const Quadrilateral &inputQ,
                              RebinnedOutput &outputWS,
                              const std::vector<double> &verticalAxis,
                              const RebinnedOutput_const_sptr &inputRB) {
-  const auto &inX = inputWS->x(i);
+  const auto &inX = inputWS->binEdges(i);
   const auto &inY = inputWS->y(i);
   const auto &inE = inputWS->e(i);
   double signal = inY[j];

--- a/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
+++ b/Framework/TestHelpers/inc/MantidTestHelpers/WorkspaceCreationHelper.h
@@ -171,6 +171,13 @@ Mantid::DataObjects::Workspace2D_sptr
 create2DWorkspaceBinned(size_t nhist, size_t numVals, double x0 = 0.0,
                         double deltax = 1.0);
 
+/** Create a 2D workspace with this many point-histograms and bins.
+ * Filled with Y = 2.0 and E = M_SQRT2
+ */
+Mantid::DataObjects::Workspace2D_sptr
+create2DWorkspacePoints(size_t nhist, size_t numVals, double x0 = 0.0,
+                        double deltax = 1.0);
+
 /** Create a 2D workspace with this many histograms and bins. The bins are
  * assumed to be non-uniform and given by the input array
  * Filled with Y = 2.0 and E = sqrt(2.0)w

--- a/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
+++ b/Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
@@ -322,6 +322,17 @@ Workspace2D_sptr create2DWorkspaceBinned(size_t nhist, size_t numVals,
   return create<Workspace2D>(nhist, Histogram(x, y, e));
 }
 
+/** Create a 2D workspace with this many point-histograms and bins.
+ * Filled with Y = 2.0 and E = M_SQRT2w
+ */
+Workspace2D_sptr create2DWorkspacePoints(size_t nhist, size_t numVals,
+                                         double x0, double deltax) {
+  Points x(numVals, LinearGenerator(x0, deltax));
+  Counts y(numVals, 2);
+  CountStandardDeviations e(numVals, M_SQRT2);
+  return create<Workspace2D>(nhist, Histogram(x, y, e));
+}
+
 /** Create a 2D workspace with this many histograms and bins. The bins are
  * assumed to be non-uniform and given by the input array
  * Filled with Y = 2.0 and E = M_SQRT2w


### PR DESCRIPTION
One line bug fix, stopping a for loop in Rebin2D asking for next element after the last bin.

**To test:**
This script (see fixed issue) should no longer cause an exception 

```
from mantid import mtd
from mantid.simpleapi import *
    
ws = DirectILLCollectData('ILL/IN4/087294.nxs')
DirectILLReduction(ws, OutputWorkspace='sqw', OutputSofThetaEnergyWorkspace='stw')
temperature = ws.run().getProperty('sample.temperature').value
dos = ComputeIncoherentDOS('stw',  Temperature=temperature, EnergyBinning='0, Emax')
```

Fixes #28179

Labelled as Not Ready because I just want to check why the script contained in the documentation for Rebin2D doesn't crash

```
ws = CreateSampleWorkspace()
#Convert the Spectrum Axis to theta
wsc = ConvertSpectrumAxis(ws,"theta")

rb = Rebin2D(wsc,[0,100,20000],[0,0.01,1.2],UseFractionalArea=True)
print("Bins in the X axis: {}".format(rb.blocksize()))
print("Bins in the Y axis: {}".format(rb.getNumberHistograms()))
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
