### PR TITLE
Fix Unhandled Exception when Changing Curves Options on Non-Workspace Plots

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/figureerrorsmanager.py
@@ -110,9 +110,10 @@ class FigureErrorsManager(object):
     @classmethod
     def replot_curve(cls, ax, curve, plot_kwargs):
         if isinstance(ax, MantidAxes):
-            axis = ax.creation_args[0].get('axis', None)
-            if axis:
-                plot_kwargs['axis'] = axis
+            if ax.creation_args:
+                axis = ax.creation_args[0].get('axis', None)
+                if axis:
+                    plot_kwargs['axis'] = axis
             try:
                 new_curve = ax.replot_artist(curve, errorbars=True, **plot_kwargs)
             except ValueError:  # ValueError raised if Artist not tracked by Axes

--- a/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureerrorsmanager.py
@@ -138,6 +138,12 @@ class FigureErrorsManagerTest(unittest.TestCase):
 
         self.assertFalse(array_equal(self.ax.get_lines()[0].get_data(), self.ax.get_lines()[1].get_data()))
 
+    def test_creation_args_not_accessed_for_non_workspace_plots(self):
+        self.ax.plot([1, 2], [1, 2])
+
+        self.errors_manager.replot_curve(self.ax, self.ax.lines[0], {})
+        self.assertEqual(0, len(self.ax.creation_args))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Similar to the changes in #28199.

Axes created from a script that do not relate to a workspace do not have `creation_args` associated with them, so threw an exception when an attempt was made to access the first element. 

This PR adds a check that there is at least one creation arg to access, avoiding the `IndexError`.

**To test:**
1. Open Workbench
2. Run this to get a plot:
```
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot([1,2],[1,2])
fig.show()
```
3. Open the plot options (cog button)
4. Switch to the Curves tab
5. Change something such as the line or marker style
6. Click Ok or Apply
7. No exception should occur

Fixes #28230 

*This does not require release notes* because **it fixes an issue introduced this release**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
