### PR TITLE
LoadMuonLogs keeps processing when duplicate is found

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonLog.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonLog.h
@@ -11,6 +11,8 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidNexus/MuonNexusReader.h"
 
 namespace Mantid {
 
@@ -65,7 +67,9 @@ private:
 
   /// Overwrites Algorithm method
   void exec() override;
-
+  /// Adds a log to the workspace
+  void addLogValueFromIndex(MuonNexusReader &nxload, const int &index,
+                            API::MatrixWorkspace_sptr &localWorkspace, std::set<std::string> &logNames);
   /// The name and path of an input file. This may be the filename of a raw
   /// datafile or the name of a specific log file.
   std::string m_filename;

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadMuonLog.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadMuonLog.h
@@ -69,7 +69,8 @@ private:
   void exec() override;
   /// Adds a log to the workspace
   void addLogValueFromIndex(MuonNexusReader &nxload, const int &index,
-                            API::MatrixWorkspace_sptr &localWorkspace, std::set<std::string> &logNames);
+                            API::MatrixWorkspace_sptr &localWorkspace,
+                            std::set<std::string> &logNames);
   /// The name and path of an input file. This may be the filename of a raw
   /// datafile or the name of a specific log file.
   std::string m_filename;

--- a/Framework/DataHandling/src/LoadMuonLog.cpp
+++ b/Framework/DataHandling/src/LoadMuonLog.cpp
@@ -105,14 +105,15 @@ void LoadMuonLog::addLogValueFromIndex(
   // check if log name already exists
   if (logNames.find(logNameLower) != logNames.end()) {
     g_log.warning("The log " + newLogName +
-                  " is already in the nexus file. The sample log names are case insensitive.");
+                  " is already in the nexus file. The sample log names are "
+                  "case insensitive.");
     return;
   }
   logNames.insert(newLogName);
-      auto l_PropertyDouble =
+  auto l_PropertyDouble =
       std::make_unique<TimeSeriesProperty<double>>(newLogName);
   auto l_PropertyString =
-          std::make_unique<TimeSeriesProperty<std::string>>(newLogName);
+      std::make_unique<TimeSeriesProperty<std::string>>(newLogName);
 
   // Read log file into Property which is then stored in Sample object
   if (!nxload.logTypeNumeric(index)) {

--- a/Framework/DataHandling/src/LoadMuonLog.cpp
+++ b/Framework/DataHandling/src/LoadMuonLog.cpp
@@ -10,9 +10,16 @@
 #include "MantidAPI/Sample.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/TimeSeriesProperty.h"
-#include "MantidNexus/MuonNexusReader.h"
 
+#include <algorithm>
 #include <ctime>
+
+namespace {
+void toLower(std::string &name) {
+  std::transform(name.begin(), name.end(), name.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+}
+} // namespace
 
 namespace Mantid {
 namespace DataHandling {
@@ -56,7 +63,6 @@ void LoadMuonLog::exec() {
   // on the filename
 
   m_filename = getPropertyValue("Filename");
-
   MuonNexusReader nxload;
   nxload.readLogData(m_filename);
 
@@ -65,47 +71,72 @@ void LoadMuonLog::exec() {
   // Also set the sample name at this point, as part of the sample related log
   // data.
 
-  const MatrixWorkspace_sptr localWorkspace = getProperty("Workspace");
+  MatrixWorkspace_sptr localWorkspace = getProperty("Workspace");
   localWorkspace->mutableSample().setName(nxload.getSampleName());
+
+  std::set<std::string> logNames;
+  auto logs = localWorkspace->mutableRun().getLogData();
+  // need to remove case
+  for (auto log : logs) {
+    std::string name = log->name();
+    toLower(name);
+    logNames.insert(name);
+  }
 
   // Attempt to load the content of each NXlog section into the Sample object
   // Assumes that MuonNexusReader has read all log data
   // Two cases of double or string data allowed
   Progress prog(this, 0.0, 1.0, nxload.numberOfLogs());
   for (int i = 0; i < nxload.numberOfLogs(); i++) {
-    std::string logName = nxload.getLogName(i);
-    auto l_PropertyDouble =
-        std::make_unique<TimeSeriesProperty<double>>(logName);
-    auto l_PropertyString =
-        std::make_unique<TimeSeriesProperty<std::string>>(logName);
-
-    // Read log file into Property which is then stored in Sample object
-    if (!nxload.logTypeNumeric(i)) {
-      std::string logValue;
-      std::time_t logTime;
-      for (int j = 0; j < nxload.getLogLength(i); j++) {
-        nxload.getLogStringValues(i, j, logTime, logValue);
-        l_PropertyString->addValue(logTime, logValue);
-      }
-    } else {
-      double logValue;
-      std::time_t logTime;
-      for (int j = 0; j < nxload.getLogLength(i); j++) {
-        nxload.getLogValues(i, j, logTime, logValue);
-        l_PropertyDouble->addValue(logTime, logValue);
-      }
-    }
-
-    // store Property in Sample object and delete unused object
-    if (nxload.logTypeNumeric(i)) {
-      localWorkspace->mutableRun().addLogData(std::move(l_PropertyDouble));
-    } else {
-      localWorkspace->mutableRun().addLogData(std::move(l_PropertyString));
-    }
+    addLogValueFromIndex(nxload, i, localWorkspace, logNames);
     prog.report();
-  } // end for
-
+  }
   // operation was a success and ended normally
+}
+
+void LoadMuonLog::addLogValueFromIndex(
+    MuonNexusReader &nxload, const int &index,
+    API::MatrixWorkspace_sptr &localWorkspace,
+    std::set<std::string> &logNames) {
+  std::string newLogName = nxload.getLogName(index);
+  // want to keep the original case for the logs
+  std::string logNameLower = nxload.getLogName(index);
+  toLower(logNameLower);
+  // check if log name already exists
+  if (logNames.find(logNameLower) != logNames.end()) {
+    g_log.warning("The log " + newLogName +
+                  " is already in the nexus file. The sample log names are case insensitive.");
+    return;
+  }
+  logNames.insert(newLogName);
+      auto l_PropertyDouble =
+      std::make_unique<TimeSeriesProperty<double>>(newLogName);
+  auto l_PropertyString =
+          std::make_unique<TimeSeriesProperty<std::string>>(newLogName);
+
+  // Read log file into Property which is then stored in Sample object
+  if (!nxload.logTypeNumeric(index)) {
+    std::string logValue;
+    std::time_t logTime;
+    for (int j = 0; j < nxload.getLogLength(index); j++) {
+      nxload.getLogStringValues(index, j, logTime, logValue);
+      l_PropertyString->addValue(logTime, logValue);
+    }
+  } else {
+    double logValue;
+    std::time_t logTime;
+    for (int j = 0; j < nxload.getLogLength(index); j++) {
+      nxload.getLogValues(index, j, logTime, logValue);
+      l_PropertyDouble->addValue(logTime, logValue);
+    }
+  }
+
+  // store Property in Sample object and delete unused object
+  if (nxload.logTypeNumeric(index)) {
+    localWorkspace->mutableRun().addLogData(std::move(l_PropertyDouble));
+  } else {
+    localWorkspace->mutableRun().addLogData(std::move(l_PropertyString));
+  }
 }
 
 /** change each element of the string to lower case


### PR DESCRIPTION
**Description of work.**
LoadMuonLogs would stop loading logs once it found a duplicate. This PR fixes that.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Load MUSR 62260 - look at the sample logs. This is one the worked originally. 
Load MUSR 81380 - it has sample_temp twice. It use to stop loading everything after sample_temp. You should now get an warning and then it carries on.

<!-- Instructions for testing. -->

Fixes #28155. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
