### PR TITLE
Fix unhandled exception when a colorfill plot's scale is set to logarithmic and negative limits are entered

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1014,10 +1014,12 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
     :param vmax: the maximum value on the colorbar
     """
     if vmin <= 0 and scale == LogNorm:
-        vmin = 1e-6  # Avoid 0 log scale error
+        vmin = 0.0001  # Avoid 0 log scale error
+        mantid.kernel.logger.error("Scale is set to logarithmic so non-positive min value has been changed to 0.0001.")
 
     if vmax <= 0 and scale == LogNorm:
         vmax = 1  # Avoid 0 log scale error
+        mantid.kernel.logger.error("Scale is set to logarithmic so non-positive max value has been changed to 1.")
 
     image.set_norm(scale(vmin=vmin, vmax=vmax))
     if image.colorbar:

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1013,8 +1013,12 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
     :param vmin: the minimum value on the colorbar
     :param vmax: the maximum value on the colorbar
     """
-    if vmin == 0 and scale == LogNorm:
-        vmin += 1e-6  # Avoid 0 log scale error
+    if vmin <= 0 and scale == LogNorm:
+        vmin = 1e-6  # Avoid 0 log scale error
+
+    if vmax <= 0 and scale == LogNorm:
+        vmax = 1  # Avoid 0 log scale error
+
     image.set_norm(scale(vmin=vmin, vmax=vmax))
     if image.colorbar:
         image.colorbar.remove()

--- a/docs/source/release/v5.0.0/mantidworkbench.rst
+++ b/docs/source/release/v5.0.0/mantidworkbench.rst
@@ -114,5 +114,6 @@ Bugfixes
 - Fixed bug that caused an error if a MDHistoWorkspace was plotted and a user attempted to open a context menu.
 - Fixed a bug which caused graphic scaling issues when the double-click menu was used to set an axis as log-scaled.
 - Fixed a bug where the colorbar in the instrument view would sometimes have no markers if the scale was set to SymmetricLog10.
+- Fixed an unhandled exception when you set the min or max value of the colorbar scale in a colorfill plot to negative when the scale is set to logarithmic.
 
 :ref:`Release 5.0.0 <v5.0.0>`

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -141,15 +141,15 @@ class AxisEditor(PropertiesEditorBase):
         # apply properties
         axes = self.axes
 
-        self.limit_min, self.limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
+        self.min, self.limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
 
         if self.ui.logBox.isChecked():
             self.scale_setter('log', **{self.nonposkw: TREAT_LOG_NEGATIVE_VALUES})
-            self.limit_min, self.limit_max = self._check_log_limits(self.limit_min, self.limit_max)
+            self.min, self.limit_max = self._check_log_limits(self.min, self.limit_max)
         else:
             self.scale_setter('linear')
 
-        self.lim_setter(self.limit_min, self.limit_max)
+        self.lim_setter(self.min, self.limit_max)
 
         axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id)
 
@@ -203,11 +203,19 @@ class ColorbarAxisEditor(AxisEditor):
         self.create_model()
 
     def changes_accepted(self):
-        super(ColorbarAxisEditor, self).changes_accepted()
+        self.ui.errors.hide()
+
+        limit_min, limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
+
         scale = Normalize
         if isinstance(self.images[0].norm, LogNorm):
             scale = LogNorm
-        update_colorbar_scale(self.canvas.figure, self.images[0], scale, self.limit_min, self.limit_max)
+
+        if scale == LogNorm and (limit_min <= 0 or limit_max <= 0):
+            raise ValueError("Limits must be positive\nwhen scale is logarithmic.")
+
+        self.lim_setter(limit_min, limit_max)
+        update_colorbar_scale(self.canvas.figure, self.images[0], scale, limit_min, limit_max)
 
     def create_model(self):
         memento = AxisEditorModel()

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -141,15 +141,15 @@ class AxisEditor(PropertiesEditorBase):
         # apply properties
         axes = self.axes
 
-        self.min, self.limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
+        self.limit_min, self.limit_max = float(self.ui.editor_min.text()), float(self.ui.editor_max.text())
 
         if self.ui.logBox.isChecked():
             self.scale_setter('log', **{self.nonposkw: TREAT_LOG_NEGATIVE_VALUES})
-            self.min, self.limit_max = self._check_log_limits(self.min, self.limit_max)
+            self.limit_min, self.limit_max = self._check_log_limits(self.limit_min, self.limit_max)
         else:
             self.scale_setter('linear')
 
-        self.lim_setter(self.min, self.limit_max)
+        self.lim_setter(self.limit_min, self.limit_max)
 
         axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id)
 

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -30,6 +30,7 @@ class ImagesTabWidgetPresenter:
         # Signals
         self.view.select_image_combo_box.currentIndexChanged.connect(
             self.update_view)
+        self.view.scale_combo_box.currentTextChanged.connect(self.scale_changed)
 
     def apply_properties(self):
         props = self.view.get_properties()
@@ -112,3 +113,6 @@ class ImagesTabWidgetPresenter:
                 self.generate_image_name(img), img, self.image_names_dict)
         self.view.populate_select_image_combo_box(
             sorted(self.image_names_dict.keys()))
+
+    def scale_changed(self, scale):
+        self.view.set_min_max_ranges(scale)

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -24,13 +24,15 @@ class ImagesTabWidgetPresenter:
         else:
             self.view = view
 
+        # This connection is here so that when the view is updated below the min/max spin boxes have the correct range
+        # for the scale.
+        self.view.scale_combo_box.currentTextChanged.connect(self.scale_changed)
+
         self.image_names_dict = dict()
         self.populate_select_image_combo_box_and_update_view()
 
-        # Signals
         self.view.select_image_combo_box.currentIndexChanged.connect(
             self.update_view)
-        self.view.scale_combo_box.currentTextChanged.connect(self.scale_changed)
 
     def apply_properties(self):
         props = self.view.get_properties()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -141,8 +141,29 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
         presenter.apply_properties()
         self.assertEqual("New Label", img.get_label())
         self.assertEqual('jet', img.cmap.name)
-        self.assertEqual(1e-6, img.norm.vmin)
+        self.assertEqual(0.0001, img.norm.vmin)
         self.assertEqual(4, img.norm.vmax)
+        self.assertTrue(isinstance(img.norm, LogNorm))
+
+    def test_apply_properties_log_scale_with_negative_vmin_and_vmax(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        img = ax.imshow([[0, 2], [2, 0]], label='img label')
+        props = {'title': '(0, 0) - img label',
+                 'label': 'New Label',
+                 'colormap': 'jet',
+                 'vmin': -10,
+                 'vmax': -5,
+                 'scale': 'Logarithmic',
+                 'interpolation': 'Hanning'}
+        mock_view = Mock(get_selected_image_name=lambda: '(0, 0) - img label',
+                         get_properties=lambda: ImageProperties(props))
+        presenter = self._generate_presenter(fig=fig, view=mock_view)
+        presenter.apply_properties()
+        self.assertEqual("New Label", img.get_label())
+        self.assertEqual('jet', img.cmap.name)
+        self.assertEqual(0.0001, img.norm.vmin)
+        self.assertEqual(1, img.norm.vmax)
         self.assertTrue(isinstance(img.norm, LogNorm))
 
     def test_interpolation_disabled_for_pcolormesh_image(self):

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -53,7 +53,7 @@ class ImagesTabWidgetView(QWidget):
             if scale == "Linear":
                 spin_box.setRange(np.finfo(np.float32).min, np.finfo(np.float32).max)
             else:
-                spin_box.setRange(0, np.finfo(np.float32).max)
+                spin_box.setRange(0.0001, np.finfo(np.float32).max)
 
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():

--- a/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/imagestabwidget/view.py
@@ -42,12 +42,18 @@ class ImagesTabWidgetView(QWidget):
         self._populate_interpolation_combo_box()
         self._populate_scale_combo_box()
 
+        self.set_min_max_ranges(self.get_scale())
+
+        self.max_min_value_warning.setVisible(False)
+
+    def set_min_max_ranges(self, scale):
         # Set maximum and minimum for the min/max spin boxes
         for bound in ['min', 'max']:
             spin_box = getattr(self, '%s_value_spin_box' % bound)
-            spin_box.setRange(0, np.finfo(np.float32).max)
-
-        self.max_min_value_warning.setVisible(False)
+            if scale == "Linear":
+                spin_box.setRange(np.finfo(np.float32).min, np.finfo(np.float32).max)
+            else:
+                spin_box.setRange(0, np.finfo(np.float32).max)
 
     def _populate_colormap_combo_box(self):
         for cmap_name in get_colormap_names():


### PR DESCRIPTION
**To test:**
Load a workspace, right-click it and select Plot->Colorfill.
Open figure options, go to Images tab.
Check that when the scale is set to Linear you can enter negative numbers for min value and max value.
Check that when the scale is set to Logarithmic any negative values become zero and you can't enter negative values.
Apply the settings with the scale set to Logarithmic and close figure options.
Double-click the colorbar axis, check that no exception is thrown if you enter a negative number for the min and max value. The min value should change to 1e-6 and the max value should change to 1.

Fixes #28226 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
