### PR TITLE
Remove all header guards in CurveFitting and replace with pragma once

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateChiSquared.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateChiSquared.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CALCULATECHISQUARED_H_
-#define MANTID_CURVEFITTING_CALCULATECHISQUARED_H_
+#pragma once
 
 #include "MantidCurveFitting/IFittingAlgorithm.h"
 #include "MantidKernel/System.h"
@@ -43,5 +42,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CALCULATECHISQUARED_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateCostFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CalculateCostFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CALCULATECOSTFUNCTION_H_
-#define MANTID_CURVEFITTING_CALCULATECOSTFUNCTION_H_
+#pragma once
 
 #include "MantidCurveFitting/IFittingAlgorithm.h"
 #include "MantidKernel/System.h"
@@ -43,5 +42,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CALCULATECOSTFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvertToYSpace.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CONVERTTOYSPACE_H_
-#define MANTID_CURVEFITTING_CONVERTTOYSPACE_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/SpectrumInfo.h"
@@ -100,5 +99,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CONVERTTOYSPACE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolutionFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolutionFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_CONVOLUTIONFIT_H_
-#define MANTID_ALGORITHMS_CONVOLUTIONFIT_H_
+#pragma once
 
 #include "MantidAPI/Column.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -44,5 +43,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIAL_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolveWorkspaces.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolveWorkspaces.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ConvolveWorkspaces_H_
-#define MANTID_CURVEFITTING_ConvolveWorkspaces_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -54,5 +53,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_ConvolveWorkspaces_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/CrystalFieldEnergies.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDENERGIES_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDENERGIES_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidCurveFitting/DllConfig.h"
@@ -29,5 +28,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDENERGIES_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EstimateFitParameters.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EstimateFitParameters.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ESTIMATEFITPARAMETERS_H_
-#define MANTID_CURVEFITTING_ESTIMATEFITPARAMETERS_H_
+#pragma once
 
 #include "MantidCurveFitting/IFittingAlgorithm.h"
 #include "MantidKernel/System.h"
@@ -35,5 +34,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_ESTIMATEFITPARAMETERS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EstimatePeakErrors.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EstimatePeakErrors.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ESTIMATEPEAKERRORS_H_
-#define MANTID_CURVEFITTING_ESTIMATEPEAKERRORS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 
@@ -35,5 +34,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_ESTIMATEPEAKERRORS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EvaluateFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/EvaluateFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EVALUATEFUNCTION_H_
-#define MANTID_CURVEFITTING_EVALUATEFUNCTION_H_
+#pragma once
 
 #include "MantidCurveFitting/IFittingAlgorithm.h"
 #include "MantidKernel/System.h"
@@ -34,5 +33,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_EVALUATEFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FIT_H_
-#define MANTID_CURVEFITTING_FIT_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -113,5 +112,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_FIT_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/Fit1D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FIT1D_H_
-#define MANTID_CURVEFITTING_FIT1D_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -125,5 +124,3 @@ protected:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_FIT1D_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/FitPowderDiffPeaks.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FITPOWDERDIFFPEAKS_H_
-#define MANTID_CURVEFITTING_FITPOWDERDIFFPEAKS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/CompositeFunction.h"
@@ -435,5 +434,3 @@ std::string getFunctionInfo(API::IFunction_sptr function);
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FITPOWDERDIFFPEAKS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_IQTFITSEQUENTIAL_H_
-#define MANTID_ALGORITHMS_IQTFITSEQUENTIAL_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace.h"
 
@@ -36,5 +35,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEBAILFIT_H_
-#define MANTID_CURVEFITTING_LEBAILFIT_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/CompositeFunction.h"
@@ -314,5 +313,3 @@ void writeRfactorsToFile(std::vector<double> vecX,
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_LEBAILFIT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/LeBailFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEBAILFUNCTION_H_
-#define MANTID_CURVEFITTING_LEBAILFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IPowderDiffPeakFunction.h"
@@ -209,5 +208,3 @@ using LeBailFunction_sptr = boost::shared_ptr<LeBailFunction>;
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_LEBAILFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/NormaliseByPeakArea.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/NormaliseByPeakArea.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_NORMALISEBYPEAKAREA_H_
-#define MANTID_CURVEFITTING_NORMALISEBYPEAKAREA_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/System.h"
@@ -86,5 +85,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_NORMALISEBYPEAKAREA_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PawleyFit.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PAWLEYFIT_H_
-#define MANTID_CURVEFITTING_PAWLEYFIT_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/ITableWorkspace_fwd.h"
@@ -86,5 +85,3 @@ protected:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PAWLEYFIT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValue.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PLOTPEAKBULOGVALUE_H_
-#define MANTID_CURVEFITTING_PLOTPEAKBULOGVALUE_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -110,5 +109,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_PLOTPEAKBULOGVALUE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/PlotPeakByLogValueHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PLOTPEAKBULOGVALUEHELPER_H_
-#define MANTID_CURVEFITTING_PLOTPEAKBULOGVALUEHELPER_H_
+#pragma once
 #include "MantidAPI/DllConfig.h"
 
 #include "MantidAPI/AlgorithmManager.h"
@@ -52,5 +51,3 @@ enum SpecialIndex {
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_PLOTPEAKBYLOGVALUEHELPER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSequential.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSequential.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_QENSFITSEQUENTIAL_H_
-#define MANTID_ALGORITHMS_QENSFITSEQUENTIAL_H_
+#pragma once
 
 #include "MantidAPI/DataProcessorAlgorithm.h"
 #include "MantidAPI/ITableWorkspace.h"
@@ -98,5 +97,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSimultaneous.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitSimultaneous.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_QENSFITSIMULTANEOUS_H_
-#define MANTID_ALGORITHMS_QENSFITSIMULTANEOUS_H_
+#pragma once
 
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
@@ -77,5 +76,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/QENSFitUtilities.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_ALGORITHMS_QENSFITUTILITIES_H_
-#define MANTID_ALGORITHMS_QENSFITUTILITIES_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -26,4 +25,3 @@ bool containsMultipleData(const std::vector<MatrixWorkspace_sptr> &workspaces);
 
 } // namespace API
 } // namespace Mantid
-#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERS_H_
-#define MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERS_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/CompositeFunction.h"
@@ -200,5 +199,3 @@ inline double linearInterpolateY(double x0, double xf, double y0, double yf,
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters3.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/RefinePowderInstrumentParameters3.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_RefinePowderInstrumentParameters3_H_
-#define MANTID_CURVEFITTING_RefinePowderInstrumentParameters3_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -217,5 +216,3 @@ double calculateFunctionChiSquare(const std::vector<double> &modelY,
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_RefinePowderInstrumentParameters3_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SPLINEBACKGROUND_H_
-#define MANTID_CURVEFITTING_SPLINEBACKGROUND_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -89,5 +88,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_SPLINEBACKGROUND_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineInterpolation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineInterpolation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SPLINEINTERPOLATION_H_
-#define MANTID_CURVEFITTING_SPLINEINTERPOLATION_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidCurveFitting/Functions/CubicSpline.h"
@@ -90,5 +89,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_SPLINEINTERPOLATION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/SplineSmoothing.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SPLINESMOOTHING_H_
-#define MANTID_CURVEFITTING_SPLINESMOOTHING_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/WorkspaceFactory.h"
@@ -110,5 +109,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_SPLINESMOOTHING_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateGammaBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VESUVIOCALCULATEGAMMABACKGROUND_H_
-#define MANTID_CURVEFITTING_VESUVIOCALCULATEGAMMABACKGROUND_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidGeometry/IComponent.h"
@@ -132,5 +131,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_VESUVIOCALCULATEGAMMABACKGROUND_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateMS.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/VesuvioCalculateMS.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VESUVIOCALCULATEMS_H_
-#define MANTID_CURVEFITTING_VESUVIOCALCULATEMS_H_
+#pragma once
 //-----------------------------------------------------------------------------
 // Includes
 //-----------------------------------------------------------------------------
@@ -138,5 +137,3 @@ private:
 } // namespace Algorithms
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_VESUVIOCALCULATEMS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/AugmentedLagrangianOptimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/AugmentedLagrangianOptimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_AUGMENTEDLAGRANGIANOPTIMIZER_H_
-#define MANTID_CURVEFITTING_AUGMENTEDLAGRANGIANOPTIMIZER_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidKernel/Matrix.h"
@@ -156,5 +155,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_AUGMENTEDLAGRANGIANOPTIMIZER_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/ComplexMatrix.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ComplexMatrix.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPLEXMATRIX_H_
-#define MANTID_CURVEFITTING_COMPLEXMATRIX_H_
+#pragma once
 
 #include "MantidCurveFitting/ComplexVector.h"
 #include "MantidCurveFitting/DllConfig.h"
@@ -446,5 +445,3 @@ inline ComplexType operator/(const ComplexMatrixValueConverter &conv,
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_COMPLEXMATRIX_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/ComplexVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ComplexVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPLEXVECTOR_H_
-#define MANTID_CURVEFITTING_COMPLEXVECTOR_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include <gsl/gsl_vector.h>
@@ -138,5 +137,3 @@ inline ComplexType operator*(const ComplexType &c,
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_COMPLEXVECTOR_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Constraints/BoundaryConstraint.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Constraints/BoundaryConstraint.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BOUNDARYCONSTRAINT_H_
-#define MANTID_CURVEFITTING_BOUNDARYCONSTRAINT_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -123,5 +122,3 @@ private:
 } // namespace Constraints
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BOUNDARYCONSTRAINT_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncFitting.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncFitting.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCFITTING_H_
-#define MANTID_CURVEFITTING_COSTFUNCFITTING_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -142,5 +141,3 @@ protected:
 } // namespace CostFunctions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_COSTFUNCFITTING_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncLeastSquares.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncLeastSquares.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCLEASTSQUARES_H_
-#define MANTID_CURVEFITTING_COSTFUNCLEASTSQUARES_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -55,5 +54,3 @@ protected:
 } // namespace CostFunctions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_COSTFUNCLEASTSQUARES_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncPoisson.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncPoisson.h
@@ -1,5 +1,4 @@
-#ifndef MANTID_CURVEFITTING_COSTFUNCPOISSON_H_
-#define MANTID_CURVEFITTING_COSTFUNCPOISSON_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain.h"
 #include "MantidAPI/FunctionValues.h"
@@ -62,5 +61,3 @@ private:
 } // namespace CostFunctions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_COSTFUNCPOISSON_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncRwp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncRwp.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCRWP_H_
-#define MANTID_CURVEFITTING_COSTFUNCRWP_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -80,5 +79,3 @@ private:
 } // namespace CostFunctions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_COSTFUNCRWP_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncUnweightedLeastSquares.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncUnweightedLeastSquares.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARES_H_
-#define MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARES_H_
+#pragma once
 
 #include "MantidCurveFitting/CostFunctions/CostFuncLeastSquares.h"
 #include "MantidKernel/System.h"
@@ -43,5 +42,3 @@ protected:
 } // namespace CostFunctions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARES_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/DllConfig.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_DLLCONFIG_H_
-#define MANTID_CURVEFITTING_DLLCONFIG_H_
+#pragma once
 
 /*
     This file contains the DLLExport/DLLImport linkage configuration for the
@@ -22,5 +21,3 @@
 #define MANTID_CURVEFITTING_DLL DLLImport
 #define EXTERN_MANTID_CURVEFITTING EXTERN_IMPORT
 #endif /* IN_MANTID_CURVEFITTING*/
-
-#endif // MANTID_CURVEFITTING_DLLCONFIG_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/ExcludeRangeFinder.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ExcludeRangeFinder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EXCLUDERANGEFINDER_H_
-#define MANTID_CURVEFITTING_EXCLUDERANGEFINDER_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 
@@ -46,5 +45,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_EXCLUDERANGEFINDER_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FitMW.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FitMW.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FITMW_H_
-#define MANTID_CURVEFITTING_FITMW_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -87,5 +86,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_FITMW_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FortranDefs.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FortranDefs.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FORTRANDEFS_H_
-#define MANTID_CURVEFITTING_FORTRANDEFS_H_
+#pragma once
 
 #include "MantidCurveFitting/ComplexMatrix.h"
 #include "MantidCurveFitting/FortranMatrix.h"
@@ -23,5 +22,3 @@ using IntFortranVector = FortranVector<std::vector<int>>;
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FORTRANDEFS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FortranMatrix.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FortranMatrix.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FORTRANMATRIX_H_
-#define MANTID_CURVEFITTING_FORTRANMATRIX_H_
+#pragma once
 
 #include <cstddef>
 #include <stdexcept>
@@ -153,5 +152,3 @@ template <class MatrixClass> int FortranMatrix<MatrixClass>::len2() const {
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FORTRANMATRIX_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FortranVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FORTRANVECTOR_H_
-#define MANTID_CURVEFITTING_FORTRANVECTOR_H_
+#pragma once
 
 #include <utility>
 
@@ -145,5 +144,3 @@ template <class VectorClass> int FortranVector<VectorClass>::len() const {
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FORTRANVECTOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/BFGS_Minimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/BFGS_Minimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BFGS_MINIMIZERMINIMIZER_H_
-#define MANTID_CURVEFITTING_BFGS_MINIMIZERMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -41,5 +40,3 @@ protected:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BFGS_MINIMIZERMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/DampedGaussNewtonMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/DampedGaussNewtonMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_DAMPEDGAUSSNEWTONMINIMIZER_H_
-#define MANTID_CURVEFITTING_DAMPEDGAUSSNEWTONMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -53,5 +52,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_DAMPEDGAUSSNEWTONMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/DerivMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/DerivMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_DERIVMINIMIZERMINIMIZER_H_
-#define MANTID_CURVEFITTING_DERIVMINIMIZERMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -83,5 +82,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BFGS_MINIMIZERMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/FABADAMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/FABADAMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FABADAMINIMIZER_H_
-#define MANTID_CURVEFITTING_FABADAMINIMIZER_H_
+#pragma once
 
 #include "MantidAPI/IFuncMinimizer.h"
 #include "MantidCurveFitting/CostFunctions/CostFuncLeastSquares.h"
@@ -175,5 +174,3 @@ public:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FABADAMINIMIZER_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/FRConjugateGradientMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/FRConjugateGradientMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FRCONJUGATEGRADIENTMINIMIZER_H_
-#define MANTID_CURVEFITTING_FRCONJUGATEGRADIENTMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -40,5 +39,3 @@ protected:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_FRCONJUGATEGRADIENTMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMDMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMDMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEVENBERGMARQUARDTMDMINIMIZER_H_
-#define MANTID_CURVEFITTING_LEVENBERGMARQUARDTMDMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -61,5 +60,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_LEVENBERGMARQUARDTMDMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/LevenbergMarquardtMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEVENBERGMARQUARDTMINIMIZER_H_
-#define MANTID_CURVEFITTING_LEVENBERGMARQUARDTMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -68,5 +67,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_LEVENBERGMARQUARDTMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/PRConjugateGradientMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/PRConjugateGradientMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRCONJUGATEGRADIENTMINIMIZER_H_
-#define MANTID_CURVEFITTING_PRCONJUGATEGRADIENTMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -40,5 +39,3 @@ protected:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_PRCONJUGATEGRADIENTMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/SimplexMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/SimplexMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SIMPLEXMINIMIZER_H_
-#define MANTID_CURVEFITTING_SIMPLEXMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -76,5 +75,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_SIMPLEXMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/SteepestDescentMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/SteepestDescentMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STEEPESTDESCENT_MINIMIZERMINIMIZER_H_
-#define MANTID_CURVEFITTING_STEEPESTDESCENT_MINIMIZERMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -40,5 +39,3 @@ protected:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_STEEPESTDESCENT_MINIMIZERMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_TRUSTREGIONMINIMIZER_H_
-#define MANTID_CURVEFITTING_TRUSTREGIONMINIMIZER_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -77,5 +76,3 @@ private:
 } // namespace FuncMinimisers
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_TRUSTREGIONMINIMIZER_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FunctionDomain1DSpectrumCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FunctionDomain1DSpectrumCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATOR_H_
-#define MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATOR_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/IDomainCreator.h"
@@ -56,5 +55,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Abragam.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Abragam.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ABRAGAM_H_
-#define MANTID_CURVEFITTING_ABRAGAM_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -50,5 +49,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_ABRAGAM_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BSpline.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BSPLINE_H_
-#define MANTID_CURVEFITTING_BSPLINE_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -65,5 +64,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BSPLINE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackToBackExponential.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackToBackExponential.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BACKTOBACKEXPONENTIAL_H_
-#define MANTID_CURVEFITTING_BACKTOBACKEXPONENTIAL_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -76,5 +75,3 @@ using BackToBackExponential_sptr = boost::shared_ptr<BackToBackExponential>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BACKTOBACKEXPONENTIAL_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackgroundFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BackgroundFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BACKGROUNDFUNCTION_H_
-#define MANTID_CURVEFITTING_BACKGROUNDFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -63,5 +62,3 @@ using BackgroundFunction_sptr = boost::shared_ptr<BackgroundFunction>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_BACKGROUNDFUNCTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/BivariateNormal.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BIVARIATENORMAL_H_
-#define MANTID_CURVEFITTING_BIVARIATENORMAL_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/IFunctionMW.h"
@@ -167,5 +166,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Bk2BkExpConvPV.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BK2BKEXPCONVPV_H_
-#define MANTID_CURVEFITTING_BK2BKEXPCONVPV_H_
+#pragma once
 
 #include "MantidAPI/IFunctionMW.h"
 #include "MantidAPI/IPeakFunction.h"
@@ -80,5 +79,3 @@ using Bk2BkExpConvPV_sptr = boost::shared_ptr<Bk2BkExpConvPV>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_BK2BKEXPCONVPV_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ChebfunBase.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CHEBFUNBASE_H
-#define MANTID_CURVEFITTING_CHEBFUNBASE_H
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/GSLMatrix.h"
@@ -209,5 +208,3 @@ boost::shared_ptr<ChebfunBase> ChebfunBase::bestFitAnyTolerance(
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_CURVEFITTING_CHEBFUNBASE_H

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Chebyshev.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CHEBYSHEV_H_
-#define MANTID_CURVEFITTING_CHEBYSHEV_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -60,5 +59,3 @@ using Chebyshev_sptr = boost::shared_ptr<Chebyshev>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CHEBYSHEV_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonPeakProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonPeakProfile.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPTONPEAKPROFILE_H_
-#define MANTID_CURVEFITTING_COMPTONPEAKPROFILE_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -70,5 +69,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_COMPTONPEAKPROFILE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonProfile.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPTONPROFILE_H_
-#define MANTID_CURVEFITTING_COMPTONPROFILE_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -139,5 +138,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_COMPTONPROFILE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATE_H_
-#define MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATE_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidCurveFitting/Functions/ComptonProfile.h"
@@ -81,5 +80,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Convolution.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CONVOLUTION_H_
-#define MANTID_CURVEFITTING_CONVOLUTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -143,5 +142,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CONVOLUTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalElectricField.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalElectricField.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALELECTRICFIELD_H_
-#define MANTID_CURVEFITTING_CRYSTALELECTRICFIELD_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -59,5 +58,3 @@ void MANTID_CURVEFITTING_DLL calculateMagneticMomentMatrix(
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CRYSTALELECTRICFIELD_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldControl.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldControl.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDCONTROL_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDCONTROL_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/ParamFunction.h"
@@ -102,5 +101,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDCONTROL_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDFUNCTION_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionValues.h"
@@ -232,5 +231,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CRYSTALFIELDFUNCTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldHeatCapacity.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldHeatCapacity.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDHEATCAPACITY_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDHEATCAPACITY_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -59,5 +58,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDHEATCAPACITY_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMagnetisation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMagnetisation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDMAGNETISATION_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDMAGNETISATION_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -61,5 +60,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDMAGNETISATION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMoment.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMoment.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDMOMENT_H
-#define MANTID_CURVEFITTING_CRYSTALFIELDMOMENT_H
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -61,5 +60,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDMOMENT_H */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldMultiSpectrum.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDMULTISPECTRUM_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDMULTISPECTRUM_H_
+#pragma once
 
 #include "MantidAPI/FunctionGenerator.h"
 #include "MantidAPI/FunctionValues.h"
@@ -72,5 +71,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CRYSTALFIELDMULTISPECTRUM_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeakUtils.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeakUtils.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDPEAKUTILS_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDPEAKUTILS_H_
+#pragma once
 #include <string>
 #include <vector>
 
@@ -44,5 +43,3 @@ size_t calculateMaxNPeaks(size_t nPeaks);
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CRYSTALFIELDPEAKUTILS_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeaks.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeaks.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDPEAKS_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDPEAKS_H_
+#pragma once
 
 #include "MantidAPI/IFunctionGeneral.h"
 #include "MantidCurveFitting/Functions/CrystalFieldPeaksBase.h"
@@ -38,5 +37,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDPEAKS_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeaksBase.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldPeaksBase.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDPEAKSBASE_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDPEAKSBASE_H_
+#pragma once
 
 #include "MantidAPI/FunctionValues.h"
 #include "MantidAPI/ParamFunction.h"
@@ -53,5 +52,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDPEAKSBASE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSpectrum.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDSPECTRUM_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDSPECTRUM_H_
+#pragma once
 
 #include "MantidAPI/FunctionGenerator.h"
 
@@ -35,5 +34,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CRYSTALFIELDSPECTRUM_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSusceptibility.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldSusceptibility.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDSUSCEPTIBILITY_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDSUSCEPTIBILITY_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -62,5 +61,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDSUSCEPTIBILITY_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CubicSpline.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CubicSpline_H_
-#define MANTID_CURVEFITTING_CubicSpline_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -106,5 +105,3 @@ using CubicSpline_const_sptr = const boost::shared_ptr<CubicSpline>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_CubicSpline_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DeltaFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DeltaFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_DELTAFUNCTION_H_
-#define MANTID_CURVEFITTING_DELTAFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -65,5 +64,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_DELTAFUNCTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffRotDiscreteCircle.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_DIFFROTDISCRETECIRCLE_H_
-#define MANTID_DIFFROTDISCRETECIRCLE_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -61,5 +60,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_DIFFROTDISCRETECIRCLE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DiffSphere.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_DIFFSPHERE_H_
-#define MANTID_DIFFSPHERE_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -61,5 +60,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_DIFFSPHERE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DynamicKuboToyabe.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_
-#define MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -73,5 +72,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_DYNAMICKUBOTOYABE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffRotDiscreteCircle.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ELASTICDIFFROTDISCRETECIRCLE_H_
-#define MANTID_ELASTICDIFFROTDISCRETECIRCLE_H_
+#pragma once
 
 // Mantid Coding standards <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -47,5 +46,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_ELASTICDIFFROTDISCRETECIRCLE_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticDiffSphere.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ELASTICDIFFSPHERE_H_
-#define MANTID_ELASTICDIFFSPHERE_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -47,5 +46,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_ELASTICDIFFSPHERE_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticIsoRotDiff.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ElasticIsoRotDiff.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ELASTICISOROTDIFF_H_
-#define MANTID_ELASTICISOROTDIFF_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -45,5 +44,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_ELASTICISOROTDIFF_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/EndErfc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/EndErfc.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ENDERFC_H_
-#define MANTID_CURVEFITTING_ENDERFC_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -43,5 +42,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_ENDERFC_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecay.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EXPDECAY_H_
-#define MANTID_CURVEFITTING_EXPDECAY_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -43,5 +42,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_EXPDECAY_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayMuon.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EXPDECAYMUON_H_
-#define MANTID_CURVEFITTING_EXPDECAYMUON_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -45,5 +44,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_EXPDECAYMUON_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ExpDecayOsc.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EXPDECAYOSC_H_
-#define MANTID_CURVEFITTING_EXPDECAYOSC_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -47,5 +46,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_EXPDECAYOSC_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FlatBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FlatBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FLATBACKGROUND_H_
-#define MANTID_CURVEFITTING_FLATBACKGROUND_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/BackgroundFunction.h"
 #include "MantidKernel/System.h"
@@ -40,5 +39,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FLATBACKGROUND_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FullprofPolynomial.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FULLPROFPOLYNOMIAL_H_
-#define MANTID_CURVEFITTING_FULLPROFPOLYNOMIAL_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/BackgroundFunction.h"
 #include "MantidKernel/System.h"
@@ -63,5 +62,3 @@ using FullprofPolynomial_sptr = boost::shared_ptr<FullprofPolynomial>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_FULLPROFPOLYNOMIAL_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionQDepends.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/FunctionQDepends.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FUNCTIONQDEPENDS_H_
-#define MANTID_CURVEFITTING_FUNCTIONQDEPENDS_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 
@@ -62,5 +61,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_FUNCTIONQDEPENDS_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausDecay.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GAUSDECAY_H_
-#define MANTID_CURVEFITTING_GAUSDECAY_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -45,5 +44,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GAUSDECAY_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GausOsc.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GAUSOSC_H_
-#define MANTID_CURVEFITTING_GAUSOSC_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -45,5 +44,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GAUSOSC_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Gaussian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Gaussian.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GAUSSIAN_H_
-#define MANTID_CURVEFITTING_GAUSSIAN_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -78,5 +77,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GAUSSIAN_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GaussianComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GaussianComptonProfile.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILE_H_
-#define MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILE_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/Functions/ComptonProfile.h"
@@ -54,5 +53,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlier.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlier.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GRAMCHARLIER_H_
-#define MANTID_CURVEFITTING_GRAMCHARLIER_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -32,5 +31,3 @@ public:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_GRAMCHARLIER_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlierComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/GramCharlierComptonProfile.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILE_H_
-#define MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILE_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/Functions/ComptonProfile.h"
@@ -85,5 +84,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/IkedaCarpenterPV.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/IkedaCarpenterPV.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_IKEDACARPENTERPV_H_
-#define MANTID_CURVEFITTING_IKEDACARPENTERPV_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -77,5 +76,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_IKEDACARPENTERPV_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffRotDiscreteCircle.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffRotDiscreteCircle.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INELASTICDIFFROTDISCRETECIRCLE_H_
-#define MANTID_INELASTICDIFFROTDISCRETECIRCLE_H_
+#pragma once
 
 // Mantid Coding standards <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -53,5 +52,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_INELASTICDIFFROTDISCRETECIRCLE_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffSphere.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticDiffSphere.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INELASTICDIFFSPHERE_H_
-#define MANTID_INELASTICDIFFSPHERE_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -102,5 +101,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_INELASTICDIFFSPHERE_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticIsoRotDiff.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/InelasticIsoRotDiff.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_INELASTICISOROTDIFF_H_
-#define MANTID_INELASTICISOROTDIFF_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -49,5 +48,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_INELASTICISOROTDIFF_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/IsoRotDiff.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/IsoRotDiff.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ISOROTDIFF_H_
-#define MANTID_ISOROTDIFF_H_
+#pragma once
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
 #include "MantidCurveFitting/Functions/ElasticIsoRotDiff.h"
@@ -61,5 +60,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_ISOROTDIFF_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Keren.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Keren.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_KEREN_H_
-#define MANTID_CURVEFITTING_KEREN_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -50,5 +49,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_KEREN_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/LinearBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/LinearBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LINEARBACKGROUND_H_
-#define MANTID_CURVEFITTING_LINEARBACKGROUND_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -54,5 +53,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_LINEARBACKGROUND_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/LogNormal.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/LogNormal.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LOGNORMAL_H_
-#define MANTID_CURVEFITTING_LOGNORMAL_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -41,5 +40,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_LOGNORMAL_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Lorentzian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Lorentzian.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LORENTZIAN_H_
-#define MANTID_CURVEFITTING_LORENTZIAN_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -76,5 +75,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_LORENTZIAN_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MultivariateGaussianComptonProfile.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MultivariateGaussianComptonProfile.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILE_H_
-#define MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILE_H_
+#pragma once
 
 #include <cmath>
 
@@ -88,5 +87,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILE_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MuonFInteraction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/MuonFInteraction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_MUONFINTERACTION_H_
-#define MANTID_CURVEFITTING_MUONFINTERACTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -43,5 +42,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_MUONFINTERACTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/NeutronBk2BkExpConvPVoigt.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGT_H_
-#define MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGT_H_
+#pragma once
 
 #include "MantidAPI/IPowderDiffPeakFunction.h"
 #include "MantidKernel/System.h"
@@ -117,5 +116,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PawleyFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PAWLEYFUNCTION_H_
-#define MANTID_CURVEFITTING_PAWLEYFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/IPawleyFunction.h"
@@ -162,5 +161,3 @@ using PawleyFunction_sptr = boost::shared_ptr<PawleyFunction>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PAWLEYFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PeakParameterFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PeakParameterFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PEAKPARAMETERFUNCTION_H_
-#define MANTID_CURVEFITTING_PEAKPARAMETERFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/FunctionParameterDecorator.h"
 #include "MantidAPI/IFunction1D.h"
@@ -52,5 +51,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PEAKPARAMETERFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Polynomial.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Polynomial.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_POLYNOMIAL_H_
-#define MANTID_CURVEFITTING_POLYNOMIAL_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/BackgroundFunction.h"
 #include "MantidKernel/System.h"
@@ -58,5 +57,3 @@ using Polynomial_sptr = boost::shared_ptr<Polynomial>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_POLYNOMIAL_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProcessBackground.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PROCESSBACKGROUND_H_
-#define MANTID_CURVEFITTING_PROCESSBACKGROUND_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/FunctionDomain1D.h"
@@ -126,5 +125,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PROCESSBACKGROUND_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRODUCTFUNCTION_H_
-#define MANTID_CURVEFITTING_PRODUCTFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -46,5 +45,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_PRODUCTFUNCTIONMW_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductLinearExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductLinearExp.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRODUCTLINEAREXP_H_
-#define MANTID_CURVEFITTING_PRODUCTLINEAREXP_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -37,5 +36,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PRODUCTLINEAREXP_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductQuadraticExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ProductQuadraticExp.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRODUCTQUADRATICEXP_H_
-#define MANTID_CURVEFITTING_PRODUCTQUADRATICEXP_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -37,5 +36,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PRODUCTQUADRATICEXP_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PseudoVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/PseudoVoigt.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PSEUDOVOIGT_H_
-#define MANTID_CURVEFITTING_PSEUDOVOIGT_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidKernel/System.h"
@@ -81,5 +80,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PSEUDOVOIGT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Quadratic.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Quadratic.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_QUADRATIC_H_
-#define MANTID_CURVEFITTING_QUADRATIC_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -46,5 +45,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_QUADRATIC_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ReflectivityMulf.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ReflectivityMulf.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_REFLECTIVITYMULF_H_
-#define MANTID_CURVEFITTING_REFLECTIVITYMULF_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -48,5 +47,3 @@ using ReflectivityMulf_sptr = boost::shared_ptr<ReflectivityMulf>;
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_REFLECTIVITYMULF_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Resolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Resolution.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_RESOLUTION_H_
-#define MANTID_CURVEFITTING_RESOLUTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -57,5 +56,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_RESOLUTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/SimpleChebfun.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/SimpleChebfun.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SIMPLECHEBFUN_H_
-#define MANTID_CURVEFITTING_SIMPLECHEBFUN_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/ChebfunBase.h"
 #include "MantidKernel/System.h"
@@ -87,5 +86,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_SIMPLECHEBFUN_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabe.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABE_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABE_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -43,5 +42,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_STATICKUBOTOYABE_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesExpDecay.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAY_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAY_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -40,5 +39,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAY_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesGausDecay.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAY_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAY_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -40,5 +39,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAY_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StaticKuboToyabeTimesStretchExp.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -42,5 +41,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXP_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExp.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExp.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STRETCHEXP_H_
-#define MANTID_CURVEFITTING_STRETCHEXP_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -42,5 +41,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_STRETCHEXP_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/StretchExpMuon.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STRETCHEXPMUON_H_
-#define MANTID_CURVEFITTING_STRETCHEXPMUON_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -37,5 +36,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_STRETCHEXPMUON_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TabulatedFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TabulatedFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_TABULATEDFUNCTION_H_
-#define MANTID_CURVEFITTING_TABULATEDFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -125,5 +124,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_TABULATEDFUNCTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/TeixeiraWaterSQE.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_TEIXEIRAWATERSQE_H_
-#define MANTID_TEIXEIRAWATERSQE_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Mantid Headers from the same project
@@ -49,5 +48,3 @@ protected:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_TEIXEIRAWATERSQE_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpAlpha.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpAlpha.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHA_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHA_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -56,5 +55,3 @@ using ThermalNeutronBk2BkExpAlpha_sptr =
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHA_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpBeta.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpBeta.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETA_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETA_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -56,5 +55,3 @@ using ThermalNeutronBk2BkExpBeta_sptr =
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETA_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpConvPVoigt.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVOIGT_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVOIGT_H_
+#pragma once
 
 #include "MantidAPI/IPowderDiffPeakFunction.h"
 #include "MantidKernel/System.h"
@@ -184,5 +183,3 @@ inline double calCubicDSpace(double a, int h, int k, int l)
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVOIGT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpSigma.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronBk2BkExpSigma.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMA_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMA_H_
+#pragma once
 
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
@@ -55,5 +54,3 @@ using ThermalNeutronBk2BkExpSigma_sptr =
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMA_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/ThermalNeutronDtoTOFFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTION_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain.h"
 #include "MantidAPI/FunctionValues.h"
@@ -84,5 +83,3 @@ inline double calThermalNeutronTOF(double dh, double dtt1, double dtt1t,
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_USERFUNCTION_H_
-#define MANTID_CURVEFITTING_USERFUNCTION_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -86,5 +85,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_USERFUNCTION_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/UserFunction1D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_USERFUNCTION1D_H_
-#define MANTID_CURVEFITTING_USERFUNCTION1D_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -109,5 +108,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GAUSSIAN1D_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/VesuvioResolution.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/VesuvioResolution.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VESUVIORESOLUTION_H_
-#define MANTID_CURVEFITTING_VESUVIORESOLUTION_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -109,5 +108,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_VESUVIORESOLUTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Voigt.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Voigt.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VOIGT_H_
-#define MANTID_CURVEFITTING_VOIGT_H_
+#pragma once
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidCurveFitting/DllConfig.h"
@@ -59,5 +58,3 @@ private:
 } // namespace Functions
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_VOIGT_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLFunctions.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLFunctions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GSLFUNCTIONS_H_
-#define MANTID_CURVEFITTING_GSLFUNCTIONS_H_
+#pragma once
 
 #include "MantidAPI/ICostFunction.h"
 #include "MantidAPI/IFunction.h"
@@ -53,5 +52,3 @@ int gsl_fdf(const gsl_vector *x, void *params, gsl_vector *f, gsl_matrix *J);
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GSLFUNCTIONS_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLJacobian.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GSLJACOBIAN_H_
-#define MANTID_CURVEFITTING_GSLJACOBIAN_H_
+#pragma once
 
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/Jacobian.h"
@@ -144,5 +143,3 @@ public:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GSLJACOBIAN_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLMatrix.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLMatrix.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GSLMATRIX_H_
-#define MANTID_CURVEFITTING_GSLMATRIX_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/GSLVector.h"
@@ -272,5 +271,3 @@ inline double &GSLMatrix::operator()(size_t i, size_t j) {
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GSLMATRIX_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLVector.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GSLVECTOR_H_
-#define MANTID_CURVEFITTING_GSLVECTOR_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include <gsl/gsl_vector.h>
@@ -111,5 +110,3 @@ MANTID_CURVEFITTING_DLL std::ostream &operator<<(std::ostream &ostr,
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_GSLVECTOR_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GeneralDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GeneralDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GENERALDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_GENERALDOMAINCREATOR_H_
+#pragma once
 
 #include "MantidAPI/IDomainCreator.h"
 #include "MantidAPI/Workspace_fwd.h"
@@ -87,5 +86,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_GENERALDOMAINCREATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/HalfComplex.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/HalfComplex.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_HALFCOMPLEX_H_
-#define MANTID_CURVEFITTING_HALFCOMPLEX_H_
+#pragma once
 
 namespace Mantid {
 namespace CurveFitting {
@@ -75,5 +74,3 @@ public:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_HALFCOMPLEX_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/HistogramDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/HistogramDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATOR_H_
+#pragma once
 
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidCurveFitting/IMWDomainCreator.h"
@@ -60,5 +59,3 @@ public:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/IFittingAlgorithm.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_IFITTINGALGORITHM_H_
-#define MANTID_CURVEFITTING_IFITTINGALGORITHM_H_
+#pragma once
 
 #include "MantidAPI/IDomainCreator.h"
 #include "MantidAPI/ParallelAlgorithm.h"
@@ -76,5 +75,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_IFITTINGALGORITHM_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/IMWDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/IMWDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_IMWDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_IMWDOMAINCREATOR_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -119,5 +118,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_IMWDOMAINCREATOR_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Jacobian.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_Jacobian_H_
-#define MANTID_CURVEFITTING_Jacobian_H_
+#pragma once
 
 #include "MantidAPI/Jacobian.h"
 
@@ -77,5 +76,3 @@ public:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_Jacobian_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/LatticeDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/LatticeDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LATTICEDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_LATTICEDOMAINCREATOR_H_
+#pragma once
 
 #include "MantidAPI/IDomainCreator.h"
 #include "MantidAPI/IPeaksWorkspace_fwd.h"
@@ -61,5 +60,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_LATTICEDOMAINCREATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/LatticeFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/LatticeFunction.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LATTICEFUNCTION_H_
-#define MANTID_CURVEFITTING_LATTICEFUNCTION_H_
+#pragma once
 
 #include "MantidAPI/ILatticeFunction.h"
 #include "MantidKernel/System.h"
@@ -53,5 +52,3 @@ using LatticeFunction_sptr = boost::shared_ptr<LatticeFunction>;
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_LATTICEFUNCTION_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/MSVesuvioHelpers.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/MSVesuvioHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_MSVESUVIOHELPERS_H
-#define MANTID_CURVEFITTING_MSVESUVIOHELPERS_H
+#pragma once
 
 #include "MantidKernel/normal_distribution.h"
 #include <random>
@@ -66,5 +65,3 @@ struct SimulationAggregator {
 } // namespace MSVesuvioHelper
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // MANTID_CURVEFITTING_MSVESUVIOHELPERS_H

--- a/Framework/CurveFitting/inc/MantidCurveFitting/MultiDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/MultiDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_MULTIDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_MULTIDOMAINCREATOR_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -59,5 +58,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_MULTIDOMAINCREATOR_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/ParDomain.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ParDomain.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PARDOMAIN_H_
-#define MANTID_CURVEFITTING_PARDOMAIN_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -39,5 +38,3 @@ public:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_PARDOMAIN_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/ParameterEstimator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ParameterEstimator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PARAMETERESTIMATOR_H_
-#define MANTID_CURVEFITTING_PARAMETERESTIMATOR_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -31,5 +30,3 @@ void DLLExport estimate(API::IFunction &function,
 } // namespace ParameterEstimator
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_PARAMETERESTIMATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/PrecompiledHeader.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/PrecompiledHeader.h
@@ -4,11 +4,8 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRECOMPILEDHEADER_H_
-#define MANTID_CURVEFITTING_PRECOMPILEDHEADER_H_
+#pragma once
 
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTID_CURVEFITTING_PRECOMPILEDHEADER_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/TrustRegion.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/TrustRegion.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_RAL_NLLS_TRUST_REGION_H_
-#define CURVEFITTING_RAL_NLLS_TRUST_REGION_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -46,5 +45,3 @@ void allEigSymm(const DoubleFortranMatrix &A, DoubleFortranVector &ew,
 } // namespace NLLS
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // CURVEFITTING_RAL_NLLS_TRUST_REGION_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/Workspaces.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/RalNlls/Workspaces.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_RAL_NLLS_WORKSPACES_H_
-#define CURVEFITTING_RAL_NLLS_WORKSPACES_H_
+#pragma once
 
 #include "MantidCurveFitting/DllConfig.h"
 #include "MantidCurveFitting/FortranDefs.h"
@@ -279,5 +278,3 @@ struct NLLS_workspace {
 } // namespace NLLS
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif // CURVEFITTING_RAL_NLLS_WORKSPACES_H_

--- a/Framework/CurveFitting/inc/MantidCurveFitting/SeqDomain.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/SeqDomain.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SEQDOMAIN_H_
-#define MANTID_CURVEFITTING_SEQDOMAIN_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -72,5 +71,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_SEQDOMAIN_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/SeqDomainSpectrumCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/SeqDomainSpectrumCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATOR_H_
-#define MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATOR_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/IDomainCreator.h"
@@ -58,5 +57,3 @@ protected:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /* MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATOR_H_ */

--- a/Framework/CurveFitting/inc/MantidCurveFitting/SpecialFunctionSupport.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/SpecialFunctionSupport.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SPECIALFUNCTIONSUPPORT_H_
-#define SPECIALFUNCTIONSUPPORT_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -34,5 +33,3 @@ std::complex<double>
 } // namespace SpecialFunctionSupport
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*SPECIALFUNCTIONSUPPORT_H_*/

--- a/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/TableWorkspaceDomainCreator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATOR_H_
-#define MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATOR_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -158,5 +157,3 @@ private:
 
 } // namespace CurveFitting
 } // namespace Mantid
-
-#endif /*MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATOR_H_*/

--- a/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
+++ b/Framework/CurveFitting/test/Algorithms/CalculateChiSquaredTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CALCULATECHISQUAREDTEST_H_
-#define MANTID_CURVEFITTING_CALCULATECHISQUAREDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -518,5 +517,3 @@ private:
     }
   };
 };
-
-#endif /* MANTID_CURVEFITTING_CALCULATECHISQUAREDTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/CalculateCostFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/CalculateCostFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CALCULATECOSTFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_CALCULATECOSTFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -96,5 +95,3 @@ public:
     TS_ASSERT_DELTA(value, sum / 2, 1e-15);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_CALCULATECOSTFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvertToYSpaceTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CONVERTTOYSPACETEST_H_
-#define MANTID_CURVEFITTING_CONVERTTOYSPACETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -187,5 +186,3 @@ public:
 private:
   IAlgorithm_sptr convertToYSpaceAlg;
 };
-
-#endif /* MANTID_CURVEFITTING_CONVERTTOYSPACETEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolutionFitSequentialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIALTEST_H_
-#define MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -421,5 +420,3 @@ public:
     AnalysisDataService::Instance().add("__ConvFit_Resolution", convFitRes);
   }
 };
-
-#endif /* MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIALTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
+++ b/Framework/CurveFitting/test/Algorithms/ConvolveWorkspacesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ConvolveWorkspacesTEST_H_
-#define ConvolveWorkspacesTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -127,5 +126,3 @@ public:
 private:
   Workspace2D_sptr ws1, ws2;
 };
-
-#endif /*ConvolveWorkspacesTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/EstimateFitParametersTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EstimateFitParametersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ESTIMATEFITPARAMETERSTEST_H_
-#define MANTID_CURVEFITTING_ESTIMATEFITPARAMETERSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -281,5 +280,3 @@ public:
     AnalysisDataService::Instance().clear();
   }
 };
-
-#endif /* MANTID_CURVEFITTING_ESTIMATEFITPARAMETERSTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/EstimatePeakErrorsTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EstimatePeakErrorsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ESTIMATEPEAKERRORSTEST_H_
-#define ESTIMATEPEAKERRORSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -304,5 +303,3 @@ private:
     return ws;
   }
 };
-
-#endif /*CHEBYSHEVTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/EvaluateFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_EVALUATEFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_EVALUATEFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -331,5 +330,3 @@ private:
     }
   };
 };
-
-#endif /* MANTID_CURVEFITTING_EVALUATEFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/FitPowderDiffPeaksTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitPowderDiffPeaksTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FITPOWDERDIFFPEAKSTEST_H_
-#define MANTID_CURVEFITTING_FITPOWDERDIFFPEAKSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -548,5 +547,3 @@ private:
   DataObjects::TableWorkspace_sptr peakparamws;
   DataObjects::TableWorkspace_sptr geomparamws;
 };
-
-#endif /* MANTID_CURVEFITTING_FITPOWDERDIFFPEAKSTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/FitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_FITTEST_H_
-#define CURVEFITTING_FITTEST_H_
+#pragma once
 
 #include "MantidTestHelpers/FakeObjects.h"
 #include <cxxtest/TestSuite.h>
@@ -2354,5 +2353,3 @@ private:
   API::MatrixWorkspace_sptr m_smoothWS;
   API::MatrixWorkspace_sptr m_onePeakWS;
 };
-
-#endif /*CURVEFITTING_FITMWTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/FitTestHelpers.h
+++ b/Framework/CurveFitting/test/Algorithms/FitTestHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FITTESTHELPERS_H_
-#define FITTESTHELPERS_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 
@@ -133,5 +132,3 @@ static API::MatrixWorkspace_sptr generateSmoothCurveWorkspace() {
   return ws;
 }
 } // namespace FitTestHelpers
-
-#endif /* FITTESTHELPERS_H_ */

--- a/Framework/CurveFitting/test/Algorithms/LeBailFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/LeBailFitTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEBAILFITTEST_H_
-#define MANTID_CURVEFITTING_LEBAILFITTEST_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <cxxtest/TestSuite.h>
@@ -1484,5 +1483,3 @@ private:
   TableWorkspace_sptr hkl220ws;
   TableWorkspace_sptr hkl111110ws;
 };
-
-#endif /* MANTID_CURVEFITTING_LEBAILFITTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/LeBailFunctionTest.h
+++ b/Framework/CurveFitting/test/Algorithms/LeBailFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LEBAILFITTEST_H_
-#define MANTID_CURVEFITTING_LEBAILFITTEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Algorithms/LeBailFunction.h"
 #include <cxxtest/TestSuite.h>
@@ -693,5 +692,3 @@ public:
     return;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_LEBAILFITTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/NormaliseByPeakAreaTest.h
+++ b/Framework/CurveFitting/test/Algorithms/NormaliseByPeakAreaTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_NORMALISEBYPEAKAREATEST_H_
-#define MANTID_CURVEFITTING_NORMALISEBYPEAKAREATEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -310,5 +309,3 @@ public:
 private:
   Mantid::API::MatrixWorkspace_sptr testWS;
 };
-
-#endif /* MANTID_CURVEFITTING_NORMALISEBYPEAKAREATEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PawleyFitTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PAWLEYFITTEST_H_
-#define MANTID_CURVEFITTING_PAWLEYFITTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -262,5 +261,3 @@ private:
     return ws;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PAWLEYFITTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueHelperTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PLOTPEAKBYLOGVALUEHELPERTEST_H_
-#define PLOTPEAKBYLOGVALUEHELPERTEST_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
@@ -114,5 +113,3 @@ public:
     TS_ASSERT_EQUALS(inputWithWorkspace.name, "saveNISTDAT_data.nxs");
   }
 };
-
-#endif /*PLOTPEAKBYLOGVALUEHELPERTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
+++ b/Framework/CurveFitting/test/Algorithms/PlotPeakByLogValueTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PLOTPEAKBYLOGVALUETEST_H_
-#define PLOTPEAKBYLOGVALUETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -686,5 +685,3 @@ private:
     m_wsg.reset();
   }
 };
-
-#endif /*PLOTPEAKBYLOGVALUETEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/QENSFitSequentialTest.h
+++ b/Framework/CurveFitting/test/Algorithms/QENSFitSequentialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_QENSFITSEQUENTIALTEST_H_
-#define MANTID_ALGORITHMS_QENSFITSEQUENTIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -226,5 +225,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIALTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/QENSFitSimultaneousTest.h
+++ b/Framework/CurveFitting/test/Algorithms/QENSFitSimultaneousTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_QENSFITSIMULTANEOUSTEST_H_
-#define MANTID_ALGORITHMS_QENSFITSIMULTANEOUSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -244,5 +243,3 @@ private:
     return multiDomainFunction;
   }
 };
-
-#endif /* MANTID_ALGORITHMS_CONVOLUTIONFITSEQUENTIALTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/RefinePowderInstrumentParameters3Test.h
+++ b/Framework/CurveFitting/test/Algorithms/RefinePowderInstrumentParameters3Test.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_RefinePowderInstrumentParameters3TEST_H_
-#define MANTID_CURVEFITTING_RefinePowderInstrumentParameters3TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -368,4 +367,3 @@ public:
     alg.execute();
   }
 };
-#endif /* MANTID_CURVEFITTING_RefinePowderInstrumentParameters3TEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/RefinePowderInstrumentParametersTest.h
+++ b/Framework/CurveFitting/test/Algorithms/RefinePowderInstrumentParametersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERSTEST_H_
-#define MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -505,5 +504,3 @@ public:
     return;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_REFINEPOWDERINSTRUMENTPARAMETERSTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SeqDomainSpectrumCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATORTEST_H_
-#define MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -446,5 +445,3 @@ private:
     }
   };
 };
-
-#endif /* MANTID_CURVEFITTING_SEQDOMAINSPECTRUMCREATORTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SPLINEBACKGROUNDTEST_H_
-#define SPLINEBACKGROUNDTEST_H_
+#pragma once
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
@@ -118,4 +117,3 @@ private:
     double operator()(double x, int) { return std::sin(x); }
   };
 };
-#endif /*SPLINEBACKGROUNDTEST_H_*/

--- a/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineInterpolationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SPLINEINTERPOLATIONTEST_H_
-#define MANTID_CURVEFITTING_SPLINEINTERPOLATIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -303,4 +302,3 @@ private:
     double operator()(double x, int) { return x * 2; }
   };
 };
-#endif /* MANTID_CURVEFITTING_SPLINEINTERPOLATIONTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/SplineSmoothingTest.h
+++ b/Framework/CurveFitting/test/Algorithms/SplineSmoothingTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_SPLINETEST_H_
-#define MANTID_ALGORITHMS_SPLINETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -125,5 +124,3 @@ public:
     TS_ASSERT(alg.isExecuted());
   }
 };
-
-#endif /* MANTID_ALGORITHMS_SPLINETEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateGammaBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VESUVIOCALCULATEGAMMABACKGROUNDTEST_H_
-#define MANTID_CURVEFITTING_VESUVIOCALCULATEGAMMABACKGROUNDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -310,4 +309,3 @@ private:
   const std::string outBackWsName = "backgroundWs";
   const std::string outCorrWsName = "correctedWs";
 };
-#endif /* MANTID_ALGORITHMS_VesuvioCalculateGammaBackgroundTEST_H_ */

--- a/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
+++ b/Framework/CurveFitting/test/Algorithms/VesuvioCalculateMSTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CALCULATEMSVESUIVIOTEST_H_
-#define MANTID_CURVEFITTING_CALCULATEMSVESUIVIOTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -283,4 +282,3 @@ public:
 private:
   Mantid::API::IAlgorithm_sptr alg;
 };
-#endif /* MANTID_CURVEFITTING_CALCULATEMSVESUIVIOTEST_H_ */

--- a/Framework/CurveFitting/test/AugmentedLagrangianOptimizerTest.h
+++ b/Framework/CurveFitting/test/AugmentedLagrangianOptimizerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_KERNEL_AUGMENTEDLAGRANGIANOPTIMIZERTEST_H_
-#define MANTID_KERNEL_AUGMENTEDLAGRANGIANOPTIMIZERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -211,5 +210,3 @@ private:
 
   const size_t m_nparams;
 };
-
-#endif /* MANTID_KERNEL_UGMENTEDLAGRANGIANOPTIMIZERTEST_H_ */

--- a/Framework/CurveFitting/test/ComplexMatrixTest.h
+++ b/Framework/CurveFitting/test/ComplexMatrixTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ComplexMatrixTEST_H_
-#define ComplexMatrixTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -609,5 +608,3 @@ public:
     TS_ASSERT_EQUALS(m.gsl(), gsl);
   }
 };
-
-#endif /*ComplexMatrixTEST_H_*/

--- a/Framework/CurveFitting/test/ComplexVectorTest.h
+++ b/Framework/CurveFitting/test/ComplexVectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ComplexVectorTEST_H_
-#define ComplexVectorTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -234,5 +233,3 @@ private:
     return v;
   }
 };
-
-#endif /*ComplexVectorTEST_H_*/

--- a/Framework/CurveFitting/test/CompositeFunctionTest.h
+++ b/Framework/CurveFitting/test/CompositeFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_COMPOSITEFUNCTIONTEST_H_
-#define CURVEFITTING_COMPOSITEFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -517,5 +516,3 @@ public:
                                       "ties=(f0.Sigma=f1.A1)");
   }
 };
-
-#endif /*CURVEFITTING_COMPOSITEFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Constraints/BoundaryConstraintTest.h
+++ b/Framework/CurveFitting/test/Constraints/BoundaryConstraintTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef BOUNDARYCONSTRAINTTEST_H_
-#define BOUNDARYCONSTRAINTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -178,5 +177,3 @@ public:
     TS_ASSERT_DELTA(bc->upper(), 3.4, 0.0001);
   }
 };
-
-#endif /*BOUNDARYCONSTRAINTTEST_H_*/

--- a/Framework/CurveFitting/test/CostFuncPoissonTest.h
+++ b/Framework/CurveFitting/test/CostFuncPoissonTest.h
@@ -1,5 +1,4 @@
-#ifndef MANTID_CURVEFITTING_COSTFUNCPOISSONTEST_H_
-#define MANTID_CURVEFITTING_COSTFUNCPOISSONTEST_H_
+#pragma once
 
 #include <cmath>
 #include <numeric>
@@ -305,5 +304,3 @@ public:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_COSTFUNCPOISSONTEST_H_ */

--- a/Framework/CurveFitting/test/CostFunctions/CostFuncFittingTest.h
+++ b/Framework/CurveFitting/test/CostFunctions/CostFuncFittingTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCFITTINGTEST_H_
-#define MANTID_CURVEFITTING_COSTFUNCFITTINGTEST_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -72,5 +71,3 @@ public:
     TS_ASSERT_EQUALS(costFun.parameterName(2), "f1.Lifetime");
   }
 };
-
-#endif /* MANTID_CURVEFITTING_COSTFUNCFITTINGTEST_H_ */

--- a/Framework/CurveFitting/test/CostFunctions/CostFuncUnweightedLeastSquaresTest.h
+++ b/Framework/CurveFitting/test/CostFunctions/CostFuncUnweightedLeastSquaresTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARESTEST_H_
-#define MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARESTEST_H_
+#pragma once
 
 #include "MantidAPI/FunctionDomain1D.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -89,5 +88,3 @@ private:
     friend class CostFuncUnweightedLeastSquaresTest;
   };
 };
-
-#endif /* MANTID_CURVEFITTING_COSTFUNCUNWEIGHTEDLEASTSQUARESTEST_H_ */

--- a/Framework/CurveFitting/test/CostFunctions/LeastSquaresTest.h
+++ b/Framework/CurveFitting/test/CostFunctions/LeastSquaresTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_LEASTSQUARESTEST_H_
-#define CURVEFITTING_LEASTSQUARESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -343,5 +342,3 @@ public:
     }
   }
 };
-
-#endif /*CURVEFITTING_LEASTSQUARESTEST_H_*/

--- a/Framework/CurveFitting/test/FitMWTest.h
+++ b/Framework/CurveFitting/test/FitMWTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_FITMWTEST_H_
-#define CURVEFITTING_FITMWTEST_H_
+#pragma once
 
 #include "MantidTestHelpers/FakeObjects.h"
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
@@ -1353,4 +1352,3 @@ private:
   const size_t NVectors = 2000;
   const size_t YLength = 10000;
 };
-#endif /*CURVEFITTING_FITMWTEST_H_*/

--- a/Framework/CurveFitting/test/FortranMatrixTest.h
+++ b/Framework/CurveFitting/test/FortranMatrixTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FORTRANMATRIXTEST_H_
-#define MANTID_CURVEFITTING_FORTRANMATRIXTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -202,5 +201,3 @@ public:
     TS_ASSERT_EQUALS(m.size2(), 9);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_FORTRANMATRIXTEST_H_ */

--- a/Framework/CurveFitting/test/FortranVectorTest.h
+++ b/Framework/CurveFitting/test/FortranVectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FORTRANVECTORTEST_H_
-#define MANTID_CURVEFITTING_FORTRANVECTORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -229,5 +228,3 @@ public:
     TS_ASSERT_EQUALS(ivec(1), 33);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_FORTRANVECTORTEST_H_ */

--- a/Framework/CurveFitting/test/FuncMinimizers/BFGSTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/BFGSTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_BFGSTEST_H_
-#define CURVEFITTING_BFGSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -76,5 +75,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*CURVEFITTING_BFGSTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/DampedGaussNewtonMinimizerTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/DampedGaussNewtonMinimizerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_DAMPEDGAUSSNEWTONTEST_H_
-#define CURVEFITTING_DAMPEDGAUSSNEWTONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -269,5 +268,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*CURVEFITTING_DAMPEDGAUSSNEWTONTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/ErrorMessagesTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/ErrorMessagesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_MINIMIZER_ERROR_MESSAGES_TEST_H_
-#define CURVEFITTING_MINIMIZER_ERROR_MESSAGES_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -282,5 +281,3 @@ private:
     return ws;
   }
 };
-
-#endif /*CURVEFITTING_MINIMIZER_ERROR_MESSAGES_TEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/FABADAMinimizerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FABADAMINIMIZERTEST_H_
-#define MANTID_CURVEFITTING_FABADAMINIMIZERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -475,4 +474,3 @@ public:
 private:
   MatrixWorkspace_sptr ws;
 };
-#endif /* MANTID_CURVEFITTING_FABADAMINIMIZERTEST_H_ */

--- a/Framework/CurveFitting/test/FuncMinimizers/FRConjugateGradientTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/FRConjugateGradientTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_FRCONJUGATEGRADIENTTEST_H_
-#define CURVEFITTING_FRCONJUGATEGRADIENTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -80,5 +79,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*CURVEFITTING_FRCONJUGATEGRADIENTTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtMDTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtMDTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_LEVENBERGMARQUARDMDTTEST_H_
-#define CURVEFITTING_LEVENBERGMARQUARDMDTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -494,5 +493,3 @@ private:
     return costFun->val();
   }
 };
-
-#endif /*CURVEFITTING_LevenbergMarquardtMDTest_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/LevenbergMarquardtTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_LEVENBERGMARQUARDTTEST_H_
-#define CURVEFITTING_LEVENBERGMARQUARDTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -333,5 +332,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "Changes in function value are too small");
   }
 };
-
-#endif /*CURVEFITTING_LEVENBERGMARQUARDTTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/PRConjugateGradientTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/PRConjugateGradientTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_PRCONJUGATEGRADIENTTEST_H_
-#define CURVEFITTING_PRCONJUGATEGRADIENTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -80,5 +79,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*CURVEFITTING_PRCONJUGATEGRADIENTTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/SimplexTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/SimplexTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_SIMPLEXTEST_H_
-#define CURVEFITTING_SIMPLEXTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -65,5 +64,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*FUNCMINIMIZERFACTORYTEST_H_*/

--- a/Framework/CurveFitting/test/FuncMinimizers/TrustRegionMinimizerTest.h
+++ b/Framework/CurveFitting/test/FuncMinimizers/TrustRegionMinimizerTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_TRUSTREGIONMINIMIZERTTEST_H_
-#define CURVEFITTING_TRUSTREGIONMINIMIZERTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -261,5 +260,3 @@ public:
     TS_ASSERT_EQUALS(s.getError(), "success");
   }
 };
-
-#endif /*CURVEFITTING_TRUSTREGIONMINIMIZERTTEST_H_*/

--- a/Framework/CurveFitting/test/FunctionDomain1DSpectrumCreatorTest.h
+++ b/Framework/CurveFitting/test/FunctionDomain1DSpectrumCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATORTEST_H_
-#define MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -138,5 +137,3 @@ private:
     ~TestableFunctionDomain1DSpectrumCreator() override {}
   };
 };
-
-#endif /* MANTID_CURVEFITTING_FUNCTIONDOMAIN1DSPECTRUMCREATORTEST_H_ */

--- a/Framework/CurveFitting/test/FunctionFactoryConstraintTest.h
+++ b/Framework/CurveFitting/test/FunctionFactoryConstraintTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FunctionFactoryConstraintTest_H_
-#define FunctionFactoryConstraintTest_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -440,5 +439,3 @@ public:
     TS_ASSERT(fun1->isActive(3));
   }
 };
-
-#endif /*FunctionFactoryConstraintTest_H_*/

--- a/Framework/CurveFitting/test/FunctionParameterDecoratorFitTest.h
+++ b/Framework/CurveFitting/test/FunctionParameterDecoratorFitTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FUNCTIONPARAMETERDECORATORFITTEST_H
-#define FUNCTIONPARAMETERDECORATORFITTEST_H
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -100,5 +99,3 @@ public:
     TS_ASSERT_DELTA(fitFunction->getParameter("A0"), 1.5, 1e-15);
   }
 };
-
-#endif // FUNCTIONPARAMETERDECORATORFITTEST_H

--- a/Framework/CurveFitting/test/Functions/AbragamTest.h
+++ b/Framework/CurveFitting/test/Functions/AbragamTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ABRAGAMTEST_H_
-#define ABRAGAMTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -51,5 +50,3 @@ public:
     TS_ASSERT_DELTA(y[9], 0.0360, 1e-4);
   }
 };
-
-#endif /*ABRAGAMTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/BSplineTest.h
+++ b/Framework/CurveFitting/test/Functions/BSplineTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef BSPLINETEST_H_
-#define BSPLINETEST_H_
+#pragma once
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidCurveFitting/Functions/BSpline.h"
@@ -196,5 +195,3 @@ public:
     TS_ASSERT_EQUALS(breaks[2], 6.0);
   }
 };
-
-#endif /*BSPLINETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/BackToBackExponentialTest.h
+++ b/Framework/CurveFitting/test/Functions/BackToBackExponentialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef BACKTOBACKEXPONENTIALTEST_H_
-#define BACKTOBACKEXPONENTIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -192,5 +191,3 @@ public:
     TS_ASSERT_EQUALS(b2bExp.getParameter("I"), 3.0);
   }
 };
-
-#endif /*BACKTOBACKEXPONENTIALTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/BivariateNormalTest.h
+++ b/Framework/CurveFitting/test/Functions/BivariateNormalTest.h
@@ -11,8 +11,7 @@
  *      Author: Ruth Mikkelson
  */
 
-#ifndef BIVARIATENORMALTEST_H_
-#define BIVARIATENORMALTEST_H_
+#pragma once
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/Jacobian.h"
@@ -198,4 +197,3 @@ public:
     TS_ASSERT(categories[0] == "Peak");
   }
 };
-#endif /* BIVARIATENORMALTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/Bk2BkExpConvPVTest.h
+++ b/Framework/CurveFitting/test/Functions/Bk2BkExpConvPVTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_BK2BKEXPCONVPVTEST_H_
-#define MANTID_CURVEFITTING_BK2BKEXPCONVPVTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #include <fstream>
@@ -47,5 +46,3 @@ public:
     TS_ASSERT_DELTA(y[99], 0.0000, 1e-4);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_BK2BKEXPCONVPVTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ChebfunBaseTest.h
+++ b/Framework/CurveFitting/test/Functions/ChebfunBaseTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CHEBFUNBASETEST_H_
-#define CHEBFUNBASETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -190,5 +189,3 @@ private:
     }
   }
 };
-
-#endif /*CHEBFUNBASETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ChebyshevTest.h
+++ b/Framework/CurveFitting/test/Functions/ChebyshevTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CHEBYSHEVTEST_H_
-#define CHEBYSHEVTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -164,5 +163,3 @@ public:
     TS_ASSERT_EQUALS(cheb.getParameter(3), 1.0);
   }
 };
-
-#endif /*CHEBYSHEVTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ComptonPeakProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/ComptonPeakProfileTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_ComptonPeakProfileTEST_H_
-#define MANTID_CURVEFITTING_ComptonPeakProfileTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -87,5 +86,3 @@ private:
     return profile;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_COMPTONPEAKPROFILETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPTONPROFILETEST_H_
-#define MANTID_CURVEFITTING_COMPTONPROFILETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -72,5 +71,3 @@ private:
     return profile;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_COMPTONPROFILETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
+++ b/Framework/CurveFitting/test/Functions/ComptonProfileTestHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef COMPTONPROFILETESTHELPERS_H_
-#define COMPTONPROFILETESTHELPERS_H_
+#pragma once
 
 #include "MantidAPI/Axis.h"
 #include "MantidGeometry/Instrument/Detector.h"
@@ -207,5 +206,3 @@ static void addFoilResolution(const Mantid::API::MatrixWorkspace_sptr &ws,
   pmap.addDouble(compID, "sigma_gauss", 20);
 }
 } // namespace ComptonProfileTestHelpers
-
-#endif /* COMPTONPROFILETESTHELPERS_H_ */

--- a/Framework/CurveFitting/test/Functions/ComptonScatteringCountRateTest.h
+++ b/Framework/CurveFitting/test/Functions/ComptonScatteringCountRateTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATETEST_H_
-#define MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATETEST_H_
+#pragma once
 
 #include "ComptonProfileTestHelpers.h"
 #include "MantidCurveFitting/Functions/ComptonScatteringCountRate.h"
@@ -336,5 +335,3 @@ private:
     return profile;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_COMPTONSCATTERINGCOUNTRATETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ConvolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/ConvolutionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CONVOLUTIONTEST_H_
-#define CONVOLUTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -409,5 +408,3 @@ public:
     TS_ASSERT(categories[0] == "General");
   }
 };
-
-#endif /*CONVOLUTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDCONTROLTEST_H_
-#define CRYSTALFIELDCONTROLTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -374,5 +373,3 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 };
-
-#endif /*CRYSTALFIELDCONTROLTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldEnergiesTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldEnergiesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDENERGIESTEST_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDENERGIESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -328,5 +327,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDENERGIESTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDFUNCTIONTEST_H_
-#define CRYSTALFIELDFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -866,5 +865,3 @@ private:
     return out;
   }
 };
-
-#endif /*CRYSTALFIELDFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldHeatCapacityTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldHeatCapacityTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDHEATCAPACITYTEST_H_
-#define CRYSTALFIELDHEATCAPACITYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -112,5 +111,3 @@ public:
     API::AnalysisDataService::Instance().clear();
   }
 };
-
-#endif /*CRYSTALFIELDHEATCAPACITYTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldMagnetisationTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldMagnetisationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDMAGNETISATIONTEST_H_
-#define CRYSTALFIELDMAGNETISATIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -79,5 +78,3 @@ public:
     TS_ASSERT_EQUALS(nTies, 0);
   }
 };
-
-#endif /*CRYSTALFIELDMAGNETISATIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldMomentTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldMomentTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDMOMENTTEST_H_
-#define CRYSTALFIELDMOMENTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -82,5 +81,3 @@ public:
     TS_ASSERT_EQUALS(nTies, 0);
   }
 };
-
-#endif /*CRYSTALFIELDMOMENTTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldMultiSpectrumTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldMultiSpectrumTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDMULTISPECTRUMTEST_H_
-#define CRYSTALFIELDMULTISPECTRUMTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -565,5 +564,3 @@ private:
     return ws;
   }
 };
-
-#endif /*CRYSTALFIELDMULTISPECTRUMTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldPeaksTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDPEAKSTEST_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDPEAKSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -542,5 +541,3 @@ private:
     fun.setAttributeValue("Symmetry", symm);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDPEAKSTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/CrystalFieldSpectrumTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldSpectrumTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDSPECTRUMTEST_H_
-#define CRYSTALFIELDSPECTRUMTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -879,5 +878,3 @@ private:
     return ws;
   }
 };
-
-#endif /*CRYSTALFIELDSPECTRUMTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldSusceptibilityTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldSusceptibilityTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CRYSTALFIELDSUSCEPTIBILITYTEST_H_
-#define CRYSTALFIELDSUSCEPTIBILITYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -79,5 +78,3 @@ public:
     TS_ASSERT_EQUALS(nTies, 0);
   }
 };
-
-#endif /*CRYSTALFIELDSUSCEPTIBILITYTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/CrystalFieldTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_CRYSTALFIELDTEST_H_
-#define MANTID_CURVEFITTING_CRYSTALFIELDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -255,5 +254,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_CRYSTALFIELDTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/CubicSplineTest.h
+++ b/Framework/CurveFitting/test/Functions/CubicSplineTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CubicSplineTEST_H_
-#define CubicSplineTEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/CubicSpline.h"
 
@@ -244,5 +243,3 @@ private:
     }
   }
 };
-
-#endif /*CubicSplineTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/DeltaFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/DeltaFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef DELTAFUNCTIONTEST_H
-#define DELTAFUNCTIONTEST_H
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -224,5 +223,3 @@ public:
   }
 
 }; // end of DeltaFunctionTest
-
-#endif /* DELTAFUNCTIONTEST_H */

--- a/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffRotDiscreteCircleTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef DIFFROTDISCRETECIRCLETEST_H_
-#define DIFFROTDISCRETECIRCLETEST_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -610,5 +609,3 @@ private:
     return ws;
   }
 };
-
-#endif /* DIFFROTDISCRETECIRCLETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/DiffSphereTest.h
+++ b/Framework/CurveFitting/test/Functions/DiffSphereTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef DIFFSPHERETEST_H_
-#define DIFFSPHERETEST_H_
+#pragma once
 
 #include <boost/lexical_cast.hpp>
 #include <cxxtest/TestSuite.h>
@@ -549,5 +548,3 @@ private:
   }
 
 }; // class DiffSphereTest
-
-#endif /*DIFFSPHERETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/DynamicKuboToyabeTest.h
+++ b/Framework/CurveFitting/test/Functions/DynamicKuboToyabeTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef DYNAMICKUBOTOYABETEST_H_
-#define DYNAMICKUBOTOYABETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -134,5 +133,3 @@ public:
     TS_ASSERT_DELTA(y[4], 0.177036, 0.000001);
   }
 };
-
-#endif /*DYNAMICKUBOTOYABETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ElasticIsoRotDiffTest.h
+++ b/Framework/CurveFitting/test/Functions/ElasticIsoRotDiffTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ELASTICISOROTDIFFTEST_H_
-#define ELASTICISOROTDIFFTEST_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Main Module Header
@@ -87,5 +86,3 @@ private:
     return func;
   }
 };
-
-#endif /*ELASTICISOROTDIFFTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/EndErfcTest.h
+++ b/Framework/CurveFitting/test/Functions/EndErfcTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ENDERFCTEST_H_
-#define ENDERFCTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -49,5 +48,3 @@ public:
     TS_ASSERT_DELTA(y[9], 2.0000, 1e-4);
   }
 };
-
-#endif /*ENDERFCTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayMuonTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef EXPDECAYMUONTEST_H_
-#define EXPDECAYMUONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -48,5 +47,3 @@ public:
     TS_ASSERT_DELTA(y[9], 0.0619, 1e-4);
   }
 };
-
-#endif /*EXPDECAYMUONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayOscTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef EXPDECAYOSCTEST_H_
-#define EXPDECAYOSCTEST_H_
+#pragma once
 
 #include <cmath>
 #include <cxxtest/TestSuite.h>
@@ -50,5 +49,3 @@ public:
     TS_ASSERT_DELTA(y[9], -0.1218, 1e-4);
   }
 };
-
-#endif /*EXPDECAYOSCTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ExpDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/ExpDecayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef EXPDECAYTEST_H_
-#define EXPDECAYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -50,5 +49,3 @@ public:
     TS_ASSERT_DELTA(y[9], 2.56709, 1e-4);
   }
 };
-
-#endif /*EXPDECAYTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/FlatBackgroundTest.h
+++ b/Framework/CurveFitting/test/Functions/FlatBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FLATBACKGROUNDTEST_H_
-#define MANTID_CURVEFITTING_FLATBACKGROUNDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -51,5 +50,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_FLATBACKGROUNDTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/FullprofPolynomialTest.h
+++ b/Framework/CurveFitting/test/Functions/FullprofPolynomialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FULLPROFPOLYNOMIALTEST_H_
-#define MANTID_CURVEFITTING_FULLPROFPOLYNOMIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -81,5 +80,3 @@ public:
     TS_ASSERT_DELTA(yValues[999], 0.55583, 1.0E-5);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_FULLPROFPOLYNOMIALTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/FunctionQDependsTest.h
+++ b/Framework/CurveFitting/test/Functions/FunctionQDependsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_FUNCTIONQDEPENDSTEST_H
-#define MANTID_CURVEFITTING_FUNCTIONQDEPENDSTEST_H
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 
@@ -175,5 +174,3 @@ private:
     return WorkspaceCreationHelper::createEventWorkspace();
   }
 };
-
-#endif /* MANTID_API_FUNCTIONQDEPENDSTEST_H */

--- a/Framework/CurveFitting/test/Functions/GausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/GausDecayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GAUSDECAYTEST_H_
-#define GAUSDECAYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -45,5 +44,3 @@ public:
     TS_ASSERT_DELTA(y[9], 0.0033, 1e-4);
   }
 };
-
-#endif /*GAUSDECAYTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/GausOscTest.h
+++ b/Framework/CurveFitting/test/Functions/GausOscTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GAUSOSCTEST_H_
-#define GAUSOSCTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -49,5 +48,3 @@ public:
     TS_ASSERT_DELTA(y[9], -0.6201, 1e-4);
   }
 };
-
-#endif /*GAUSOSCTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GaussianComptonProfileTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILETEST_H_
-#define MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILETEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/GaussianComptonProfile.h"
 #include <cxxtest/TestSuite.h>
@@ -103,5 +102,3 @@ private:
     return profile;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_GAUSSIANCOMPTONPROFILETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/GaussianTest.h
+++ b/Framework/CurveFitting/test/Functions/GaussianTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GAUSSIANTEST_H_
-#define GAUSSIANTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -172,5 +171,3 @@ public:
     TS_ASSERT_DELTA(fn.getParameter("Height"), 0.398942, 1e-6);
   }
 };
-
-#endif /*GAUSSIANTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/GramCharlierComptonProfileTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILETEST_H_
-#define MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILETEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/GramCharlierComptonProfile.h"
 #include <cxxtest/TestSuite.h>
@@ -165,5 +164,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_GRAMCHARLIERCOMPTONPROFILETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/IkedaCarpenterPVTest.h
+++ b/Framework/CurveFitting/test/Functions/IkedaCarpenterPVTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef IKEDACARPENTERPVTEST_H_
-#define IKEDACARPENTERPVTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -77,5 +76,3 @@ public:
     TS_ASSERT_DELTA(fn.intensity(), 810.7256, 1e-4);
   }
 };
-
-#endif /*IKEDACARPENTERPVTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/InelasticIsoRotDiffTest.h
+++ b/Framework/CurveFitting/test/Functions/InelasticIsoRotDiffTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INELASTICISOROTDIFFTEST_H_
-#define INELASTICISOROTDIFFTEST_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Main Module Header
@@ -126,5 +125,3 @@ private:
     return func;
   }
 };
-
-#endif /*INELASTICISOROTDIFFTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/IsoRotDiffTest.h
+++ b/Framework/CurveFitting/test/Functions/IsoRotDiffTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef ISOROTDIFFTEST_H_
-#define ISOROTDIFFTEST_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Main Module Header
@@ -70,4 +69,3 @@ private:
     return func;
   }
 };
-#endif /*ISOROTDIFFTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/KerenTest.h
+++ b/Framework/CurveFitting/test/Functions/KerenTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_KERENTEST_H_
-#define MANTID_CURVEFITTING_KERENTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -106,5 +105,3 @@ public:
     TS_ASSERT_DELTA(y, 0.8141, 0.001);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_KERENTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/LinearBackgroundTest.h
+++ b/Framework/CurveFitting/test/Functions/LinearBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LINEARBACKGROUNDTEST_H_
-#define MANTID_CURVEFITTING_LINEARBACKGROUNDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -63,5 +62,3 @@ public:
     }
   }
 };
-
-#endif /*MANTID_CURVEFITTING_LINEARBACKGROUNDTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/LogNormalTest.h
+++ b/Framework/CurveFitting/test/Functions/LogNormalTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef LOGNORMALTEST_H_
-#define LOGNORMALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -45,5 +44,3 @@ public:
     TS_ASSERT_DELTA(y[9], 3.3453, 1e-4);
   }
 };
-
-#endif /*LOGNORMALTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/LorentzianTest.h
+++ b/Framework/CurveFitting/test/Functions/LorentzianTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef LORENTZIANTEST_H_
-#define LORENTZIANTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -151,5 +150,3 @@ private:
     return func;
   }
 };
-
-#endif /*LORENTZIANTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
+++ b/Framework/CurveFitting/test/Functions/MultivariateGaussianComptonProfileTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILETEST_H_
-#define MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILETEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/MultivariateGaussianComptonProfile.h"
 #include <cxxtest/TestSuite.h>
@@ -129,5 +128,3 @@ private:
     return profile;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_MULTIVARIATEGAUSSIANCOMPTONPROFILETEST_H_ */

--- a/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
+++ b/Framework/CurveFitting/test/Functions/MuonFInteractionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MUONFINTERACTIONTEST_H_
-#define MUONFINTERACTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -114,5 +113,3 @@ public:
     AnalysisDataService::Instance().remove(wsName);
   }
 };
-
-#endif /*MUONFINTERACTONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/NeutronBk2BkExpConvPVoigtTest.h
+++ b/Framework/CurveFitting/test/Functions/NeutronBk2BkExpConvPVoigtTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGTTEST_H_
-#define MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -267,5 +266,3 @@ public:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_NEUTRONBK2BKEXPCONVPVOIGTTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/PawleyFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PAWLEYFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_PAWLEYFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -442,5 +441,3 @@ private:
     TS_ASSERT_DELTA(cell.gamma(), gamma, 1e-9);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PAWLEYFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/PeakParameterFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/PeakParameterFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PEAKPARAMETERFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_PEAKPARAMETERFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -137,5 +136,3 @@ public:
                      const std::invalid_argument &);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PEAKPARAMETERFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/PolynomialTest.h
+++ b/Framework/CurveFitting/test/Functions/PolynomialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_POLYNOMIALTEST_H_
-#define MANTID_CURVEFITTING_POLYNOMIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -113,5 +112,3 @@ public:
     TS_ASSERT_EQUALS(pol.getParameter(3), 1.0);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_POLYNOMIALTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ProcessBackgroundTest.h
+++ b/Framework/CurveFitting/test/Functions/ProcessBackgroundTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_ALGORITHMS_PROCESSBACKGROUNDTEST_H_
-#define MANTID_ALGORITHMS_PROCESSBACKGROUNDTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -540,5 +539,3 @@ public:
 private:
   ProcessBackground sbfif;
 };
-
-#endif /* MANTID_ALGORITHMS_PROCESSBACKGROUNDTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ProductFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/ProductFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PRODUCTFUNCTIONTEST_H_
-#define PRODUCTFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -267,5 +266,3 @@ public:
 
 private:
 };
-
-#endif /*PRODUCTFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ProductLinearExpTest.h
+++ b/Framework/CurveFitting/test/Functions/ProductLinearExpTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRODUCTLINEAREXPTEST_H_
-#define MANTID_CURVEFITTING_PRODUCTLINEAREXPTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -235,5 +234,3 @@ public:
     do_test_function_calculation(A0, A1, Height, Lifetime);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PRODUCTLINEAREXPTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ProductQuadraticExpTest.h
+++ b/Framework/CurveFitting/test/Functions/ProductQuadraticExpTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PRODUCTQUADRATICEXPTEST_H_
-#define MANTID_CURVEFITTING_PRODUCTQUADRATICEXPTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -234,5 +233,3 @@ public:
     do_test_function_calculation(A0, A1, A2, Height, Lifetime);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PRODUCTQUADRATICEXPTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/PseudoVoigtTest.h
+++ b/Framework/CurveFitting/test/Functions/PseudoVoigtTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PSEUDOVOIGTTEST_H_
-#define MANTID_CURVEFITTING_PSEUDOVOIGTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -512,5 +511,3 @@ private:
 
   std::vector<double> m_xValues;
 };
-
-#endif /* MANTID_CURVEFITTING_PSEUDOVOIGTTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/QuadraticTest.h
+++ b/Framework/CurveFitting/test/Functions/QuadraticTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef QUADRATICTEST_H_
-#define QUADRATICTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -73,5 +72,3 @@ public:
     }
   }
 };
-
-#endif /*QUADRATICTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ReflectivityMulfTest.h
+++ b/Framework/CurveFitting/test/Functions/ReflectivityMulfTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef REFLECTIVITYMULFTEST_H_
-#define REFLECTIVITYMULFTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -81,5 +80,3 @@ public:
     TS_ASSERT_EQUALS(fun.getAttribute("nlayer").asInt(), 2);
   }
 };
-
-#endif /*REFLECTIVITYMULFTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/ResolutionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef RESOLUTIONTEST_H_
-#define RESOLUTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -162,5 +161,3 @@ private:
   double yErr;
   const std::string resFileName;
 };
-
-#endif /*RESOLUTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/SimpleChebfunTest.h
+++ b/Framework/CurveFitting/test/Functions/SimpleChebfunTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_SIMPLECHEBFUNTEST_H_
-#define MANTID_CURVEFITTING_SIMPLECHEBFUNTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -241,5 +240,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_SIMPLECHEBFUNTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef STATICKUBOTOYABETEST_H_
-#define STATICKUBOTOYABETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -48,5 +47,3 @@ public:
     TS_ASSERT_DELTA(y[9], 0.0372, 1e-4);
   }
 };
-
-#endif /*STATICKUBOTOYABETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesExpDecayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAYTEST_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -71,5 +70,3 @@ public:
 
   StaticKuboToyabeTimesExpDecay fn;
 };
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESEXPDECAYTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesGausDecayTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAYTEST_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -69,5 +68,3 @@ public:
 
   StaticKuboToyabeTimesGausDecay fn;
 };
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESGAUSDECAYTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StaticKuboToyabeTimesStretchExpTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_
-#define MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -70,5 +69,3 @@ public:
 
   StaticKuboToyabeTimesStretchExp fn;
 };
-
-#endif /* MANTID_CURVEFITTING_STATICKUBOTOYABETIMESSTRETCHEXPTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpMuonTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef STRETCHEXPMUONTEST_H_
-#define STRETCHEXPMUONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -47,5 +46,3 @@ public:
     TS_ASSERT_DELTA(y[9], 0.1068, 1e-4);
   }
 };
-
-#endif /*STRETCHEXPTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/StretchExpTest.h
+++ b/Framework/CurveFitting/test/Functions/StretchExpTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef STRETCHEXPTEST_H_
-#define STRETCHEXPTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -59,5 +58,3 @@ public:
     TS_ASSERT_THROWS(fn.function(x, y), const std::runtime_error &);
   }
 };
-
-#endif /*STRETCHEXPTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/TabulatedFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/TabulatedFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TABULATEDFUNCTIONTEST_H_
-#define TABULATEDFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -341,5 +340,3 @@ private:
   const std::string m_asciiFileName;
   const std::string m_nexusFileName;
 };
-
-#endif /*TABULATEDFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
+++ b/Framework/CurveFitting/test/Functions/TeixeiraWaterSQETest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TEIXEIRAWATERSQETEST_H_
-#define TEIXEIRAWATERSQETEST_H_
+#pragma once
 
 // Mantid Coding standars <http://www.mantidproject.org/Coding_Standards>
 // Main Module Header
@@ -103,5 +102,3 @@ private:
     return func;
   }
 };
-
-#endif /*TEIXEIRAWATERSQETEST_H_*/

--- a/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpAlphaTest.h
+++ b/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpAlphaTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHATEST_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHATEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -55,5 +54,3 @@ public:
     return;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPALPHATEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpBetaTest.h
+++ b/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpBetaTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETATEST_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETATEST_H_
+#pragma once
 
 #include <array>
 #include <cxxtest/TestSuite.h>
@@ -56,5 +55,3 @@ public:
     return;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPBETATEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpConvPVoigtTest.h
+++ b/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpConvPVoigtTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVTEST_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVTEST_H_
+#pragma once
 
 #include <array>
 #include <cmath>
@@ -384,5 +383,3 @@ public:
         0.106100, 0.105800};
   }
 };
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPCONVPVTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpSigmaTest.h
+++ b/Framework/CurveFitting/test/Functions/ThermalNeutronBk2BkExpSigmaTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMATEST_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMATEST_H_
+#pragma once
 
 #include <array>
 #include <cxxtest/TestSuite.h>
@@ -52,5 +51,3 @@ public:
     return;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONBK2BKEXPSIGMATEST_H_ */

--- a/Framework/CurveFitting/test/Functions/ThermalNeutronDtoTOFFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/ThermalNeutronDtoTOFFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTIONTEST_H_
+#pragma once
 
 #include <array>
 #include <cxxtest/TestSuite.h>
@@ -138,5 +137,3 @@ public:
   }
   */
 };
-
-#endif /* MANTID_CURVEFITTING_THERMALNEUTRONDTOTOFFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/UserFunction1DTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunction1DTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef USERFUNCTION1DTEST_H_
-#define USERFUNCTION1DTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -91,5 +90,3 @@ private:
     return ws;
   }
 };
-
-#endif /*USERFUNCTION1DTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef USERFUNCTIONTEST_H_
-#define USERFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -85,5 +84,3 @@ public:
     TS_ASSERT(categories[0] == "General");
   }
 };
-
-#endif /*USERFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/Functions/VesuvioResolutionTest.h
+++ b/Framework/CurveFitting/test/Functions/VesuvioResolutionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VESUVIORESOLUTIONTEST_H_
-#define MANTID_CURVEFITTING_VESUVIORESOLUTIONTEST_H_
+#pragma once
 
 #include "MantidCurveFitting/Functions/VesuvioResolution.h"
 #include <cxxtest/TestSuite.h>
@@ -88,5 +87,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_VESUVIORESOLUTIONTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/VoigtTest.h
+++ b/Framework/CurveFitting/test/Functions/VoigtTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_VOIGTTEST_H_
-#define MANTID_CURVEFITTING_VOIGTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -293,5 +292,3 @@ private:
   /// Input domain
   boost::shared_ptr<Mantid::API::FunctionDomain1DVector> m_domain;
 };
-
-#endif /* MANTID_CURVEFITTING_VOIGTTEST_H_ */

--- a/Framework/CurveFitting/test/Functions/valgrind.h
+++ b/Framework/CurveFitting/test/Functions/valgrind.h
@@ -69,8 +69,7 @@
    problem, you can compile with the NVALGRIND symbol defined (gcc
    -DNVALGRIND) so that client requests are not even compiled in.  */
 
-#ifndef __VALGRIND_H
-#define __VALGRIND_H
+#pragma once
 
 /* ------------------------------------------------------------------ */
 /* VERSION NUMBER OF VALGRIND                                         */
@@ -4431,5 +4430,3 @@ static int
 #undef PLAT_arm_linux
 #undef PLAT_s390x_linux
 #undef PLAT_mips32_linux
-
-#endif /* __VALGRIND_H */

--- a/Framework/CurveFitting/test/GSLMatrixTest.h
+++ b/Framework/CurveFitting/test/GSLMatrixTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GSLMATRIXTEST_H_
-#define GSLMATRIXTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -427,5 +426,3 @@ public:
     TS_ASSERT_EQUALS(bb[1], 2.0);
   }
 };
-
-#endif /*GSLMATRIXTEST_H_*/

--- a/Framework/CurveFitting/test/GSLVectorTest.h
+++ b/Framework/CurveFitting/test/GSLVectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef GSLVECTORTEST_H_
-#define GSLVECTORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -347,5 +346,3 @@ private:
     return v;
   }
 };
-
-#endif /*GSLVECTORTEST_H_*/

--- a/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/GeneralDomainCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GENERALDOMAINCREATORTEST_H_
-#define MANTID_CURVEFITTING_GENERALDOMAINCREATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -467,5 +466,3 @@ private:
     return ws;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_GENERALDOMAINCREATORTEST_H_ */

--- a/Framework/CurveFitting/test/GramCharlierTest.h
+++ b/Framework/CurveFitting/test/GramCharlierTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_GRAMCHARLIERTEST_H_
-#define MANTID_CURVEFITTING_GRAMCHARLIERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -73,5 +72,3 @@ private:
     }
   }
 };
-
-#endif /* MANTID_CURVEFITTING_GRAMCHARLIERTEST_H_ */

--- a/Framework/CurveFitting/test/HistogramDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/HistogramDomainCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATORTEST_H_
-#define MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -523,5 +522,3 @@ private:
     return createFitWorkspace(ny, cumulFun);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_HISTOGRAMDOMAINCREATORTEST_H_ */

--- a/Framework/CurveFitting/test/IPeakFunctionCentreParameterNameTest.h
+++ b/Framework/CurveFitting/test/IPeakFunctionCentreParameterNameTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef IPEAKFUNCTIONCENTREPARAMETERNAMETEST_H
-#define IPEAKFUNCTIONCENTREPARAMETERNAMETEST_H
+#pragma once
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -61,5 +60,3 @@ public:
 private:
   std::map<std::string, std::string> m_expectedResults;
 };
-
-#endif // IPEAKFUNCTIONCENTREPARAMETERNAMETEST_H

--- a/Framework/CurveFitting/test/IPeakFunctionIntensityTest.h
+++ b/Framework/CurveFitting/test/IPeakFunctionIntensityTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef IPEAKFUNCTIONINTENSITYTEST_H
-#define IPEAKFUNCTIONINTENSITYTEST_H
+#pragma once
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
@@ -162,5 +161,3 @@ private:
   std::vector<ParameterSet> m_parameterSets;
   std::unordered_set<std::string> m_blackList;
 };
-
-#endif // IPEAKFUNCTIONINTENSITYTEST_H

--- a/Framework/CurveFitting/test/LatticeDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/LatticeDomainCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LATTICEDOMAINCREATORTEST_H_
-#define MANTID_CURVEFITTING_LATTICEDOMAINCREATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -235,5 +234,3 @@ private:
     }
   };
 };
-
-#endif /* MANTID_CURVEFITTING_LATTICEDOMAINCREATORTEST_H_ */

--- a/Framework/CurveFitting/test/LatticeFunctionTest.h
+++ b/Framework/CurveFitting/test/LatticeFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_LATTICEFUNCTIONTEST_H_
-#define MANTID_CURVEFITTING_LATTICEFUNCTIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -120,5 +119,3 @@ public:
     TS_ASSERT_DELTA(values[3], 0.88880, 1e-5);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_LATTICEFUNCTIONTEST_H_ */

--- a/Framework/CurveFitting/test/MultiDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/MultiDomainCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MULTIDOMAINCREATORTEST_H_
-#define MULTIDOMAINCREATORTEST_H_
+#pragma once
 
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionDomain1D.h"
@@ -319,5 +318,3 @@ private:
 
   MatrixWorkspace_sptr ws1, ws2, ws3;
 };
-
-#endif /*MULTIDOMAINCREATORTEST_H_*/

--- a/Framework/CurveFitting/test/MultiDomainFunctionTest.h
+++ b/Framework/CurveFitting/test/MultiDomainFunctionTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MULTIDOMAINFUNCTIONTEST_H_
-#define MULTIDOMAINFUNCTIONTEST_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
@@ -72,5 +71,3 @@ public:
         multi = Mantid::TestHelpers::makeMultiDomainFunction3());
   }
 };
-
-#endif /*MULTIDOMAINFUNCTIONTEST_H_*/

--- a/Framework/CurveFitting/test/ParameterEstimatorTest.h
+++ b/Framework/CurveFitting/test/ParameterEstimatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_PARAMETERESTIMATORTEST_H_
-#define MANTID_CURVEFITTING_PARAMETERESTIMATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -344,5 +343,3 @@ private:
     ParameterEstimator::estimate(function, domain, values);
   }
 };
-
-#endif /* MANTID_CURVEFITTING_PARAMETERESTIMATORTEST_H_ */

--- a/Framework/CurveFitting/test/PrecompiledHeader.h
+++ b/Framework/CurveFitting/test/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTINGTEST_PRECOMPILED_HEADER_H_
-#define MANTID_CURVEFITTINGTEST_PRECOMPILED_HEADER_H_
+#pragma once
 
 // cxxtest
 #include <cxxtest/WrappedTestSuite.h>
@@ -19,5 +18,3 @@
 #include <set>
 #include <string>
 #include <vector>
-
-#endif // MANTID_CURVEFITTING_PRECOMPILED_HEADER_H_

--- a/Framework/CurveFitting/test/RalNlls/NLLSTest.h
+++ b/Framework/CurveFitting/test/RalNlls/NLLSTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef CURVEFITTING_RAL_NLLS_NLLSTEST_H_
-#define CURVEFITTING_RAL_NLLS_NLLSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -145,5 +144,3 @@ private:
     return ws;
   }
 };
-
-#endif // CURVEFITTING_RAL_NLLS_NLLSTEST_H_

--- a/Framework/CurveFitting/test/SpecialFunctionSupportTest.h
+++ b/Framework/CurveFitting/test/SpecialFunctionSupportTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef SPECIALFUNCTIONSUPPORTTEST_H_
-#define SPECIALFUNCTIONSUPPORTTEST_H_
+#pragma once
 
 #include "MantidCurveFitting/SpecialFunctionSupport.h"
 #include <complex>
@@ -72,5 +71,3 @@ public:
     TS_ASSERT_DELTA(z.imag(), -0.0984, 0.001);
   }
 };
-
-#endif /*SPECIALFUNCTIONSUPPORTTEST_H_*/

--- a/Framework/CurveFitting/test/TableWorkspaceDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/TableWorkspaceDomainCreatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATORTEST_H_
-#define MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATORTEST_H_
+#pragma once
 
 #include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
@@ -786,5 +785,3 @@ private:
     return fit;
   }
 };
-
-#endif /* MANTID_CURVEFITTING_TABLEWORKSPACEDOMAINCREATORTEST_H_ */


### PR DESCRIPTION
This PR replaces all header guards in CurveFitting with #pragma once.

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
