### PR TITLE
Fix Colour Bar Scales on Ragged Workspaces

### DIFF
--- a/docs/source/release/v5.1.0/mantidworkbench.rst
+++ b/docs/source/release/v5.1.0/mantidworkbench.rst
@@ -15,5 +15,6 @@ Bugfixes
 ########
 
 - Fixed a bug where setting columns to Y error in table workspaces wasn't working. The links between the Y error and Y columns weren't being set up properly
+- The scale of the color bars on colorfill plots of ragged workspaces now uses the maximum and minimum values of the data.
 
 :ref:`Release 5.1.0 <v5.1.0>`

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -12,6 +12,7 @@ Defines interaction behaviour for plotting.
 from __future__ import (absolute_import, unicode_literals)
 
 # std imports
+import numpy as np
 from collections import OrderedDict
 from copy import copy
 from functools import partial
@@ -703,6 +704,12 @@ class FigureInteraction(object):
                         ws_artist.replace_data(workspace, arg_set_copy)
         if ax.lines:  # Relim causes issues with colour plots, which have no lines.
             ax.relim()
+
+        if ax.images:  # Colour bar limits are wrong if workspace is ragged. Set them manually.
+            colorbar_min = np.nanmin(ax.images[-1].get_array())
+            colorbar_max = np.nanmax(ax.images[-1].get_array())
+            for image in ax.images:
+                image.set_clim(colorbar_min, colorbar_max)
 
         ax.autoscale()
 

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -27,7 +27,7 @@ from mantid.plots import MantidAxes
 from mantid.py3compat.mock import MagicMock, PropertyMock, call, patch
 from mantid.simpleapi import CreateWorkspace
 from mantidqt.plotting.figuretype import FigureType
-from mantidqt.plotting.functions import plot
+from mantidqt.plotting.functions import plot, pcolormesh_from_names
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figureinteraction import FigureInteraction
 
@@ -377,6 +377,19 @@ class FigureInteractionTest(unittest.TestCase):
         fig_interactor._quick_change_axes(scale_types, ax)
         current_scale_types2 = (ax.get_xscale(), ax.get_yscale())
         self.assertNotEqual(current_scale_types2, current_scale_types1)
+
+    def test_scale_on_ragged_workspaces_maintained_when_toggling_normalisation(self):
+        ws = CreateWorkspace(DataX=[1, 2, 3, 4, 2, 4, 6, 8], DataY=[2] * 8, NSpec=2, OutputWorkspace="ragged_ws")
+        fig = pcolormesh_from_names([ws])
+        mock_canvas = MagicMock(figure=fig)
+        fig_manager_mock = MagicMock(canvas=mock_canvas)
+        fig_interactor = FigureInteraction(fig_manager_mock)
+        fig_interactor._toggle_normalization(fig.axes[0])
+
+        clim = fig.axes[0].images[0].get_clim()
+        fig_interactor._toggle_normalization(fig.axes[0])
+        self.assertEqual(clim, fig.axes[0].images[0].get_clim())
+        self.assertNotEqual((-0.1, 0.1), fig.axes[0].images[0].get_clim())
 
     # Private methods
     def _create_mock_fig_manager_to_accept_right_click(self):

--- a/qt/python/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/plotting/functions.py
@@ -162,6 +162,10 @@ def pcolormesh(workspaces, fig=None):
         if subplot_idx < workspaces_len:
             ws = workspaces[subplot_idx]
             pcm = pcolormesh_on_axis(ax, ws)
+            if pcm:  # Colour bar limits are wrong if workspace is ragged. Set them manually.
+                colorbar_min = np.nanmin(pcm.get_array())
+                colorbar_max = np.nanmax(pcm.get_array())
+                pcm.set_clim(colorbar_min, colorbar_max)
             if col_idx < ncols - 1:
                 col_idx += 1
             else:

--- a/qt/python/mantidqt/plotting/test/test_functions.py
+++ b/qt/python/mantidqt/plotting/test/test_functions.py
@@ -23,6 +23,7 @@ import numpy as np
 # register mantid projection
 import mantid.plots  # noqa
 from mantid.api import AnalysisDataService, WorkspaceFactory
+from mantid.simpleapi import CreateWorkspace
 from mantid.kernel import config
 from mantid.plots import MantidAxes
 from mantid.py3compat import mock
@@ -150,6 +151,11 @@ class FunctionsTest(TestCase):
         AnalysisDataService.Instance().addOrReplace(ws_name, self._test_ws)
         pcolormesh_from_names([ws_name])
         self.assertEqual(1, pcolormesh_mock.call_count)
+
+    def test_scale_is_correct_on_pcolourmesh_of_ragged_workspace(self):
+        ws = CreateWorkspace(DataX=[1, 2, 3, 4, 2, 4, 6, 8], DataY=[2] * 8, NSpec=2)
+        fig = pcolormesh_from_names([ws])
+        self.assertEqual((1.8, 2.2), fig.axes[0].images[0].get_clim())
 
     def test_pcolormesh_from_names(self):
         ws_name = 'test_pcolormesh_from_names-1'


### PR DESCRIPTION
**Description of work.**
Fixes a bug where plotting a colourfill of a ragged workspace would have a colourbar set to -1 to 1. 

**To test:**
1. Workbench
2. Run this
```
Load(Filename='GEM38370_Focussed.nxs', OutputWorkspace='GEM38370_Focussed')
ConvertUnits(InputWorkspace='GEM38370_Focussed', OutputWorkspace='ws_lambda', Target='Wavelength')
```
3. Colourfill
4. Valid colourbar

Fixes #28227 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
