### PR TITLE
Fix crash when double clicking MD workspace

### DIFF
--- a/qt/applications/workbench/workbench/plugins/workspacewidget.py
+++ b/qt/applications/workbench/workbench/plugins/workspacewidget.py
@@ -231,7 +231,7 @@ class WorkspaceWidget(PluginWidget):
             TableWorkspaceDisplay.supports(ws)
             self._do_show_data([name])
         except ValueError:
-            if ws.blocksize() == 1:
+            if hasattr(ws, 'blocksize') and ws.blocksize() == 1:
                 #this is just single bin data, it makes more sense to plot the bin
                 plot_kwargs = {"axis": MantidAxType.BIN}
                 plot([ws],errors=False, overplot=False, wksp_indices=[0], plot_kwargs=plot_kwargs)


### PR DESCRIPTION
**Description of work.**
See title

**To test:**
Open workbench
Load an MD workspace or create one using 
```
ws = CreateMDWorkspace(Dimensions=2, Extents="-1,1,-1,1", Names="A,B", Units="U1,U2")
```
Double-click the workspace
It should give a warning to say it cannot be plotted and should not crash

Fixes #28256 

*This does not require release notes* because **it is a regression**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
