### PR TITLE
Replace header guards in HistogramData with pragma once

### DIFF
--- a/Framework/HistogramData/inc/MantidHistogramData/Addable.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Addable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ADDABLE_H_
-#define MANTID_HISTOGRAMDATA_ADDABLE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -73,5 +72,3 @@ private:
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_ADDABLE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/BinEdges.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/BinEdges.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_BINEDGES_H_
-#define MANTID_HISTOGRAMDATA_BINEDGES_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramX.h"
@@ -55,5 +54,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_BINEDGES_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/CountStandardDeviations.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/CountStandardDeviations.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONS_H_
-#define MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONS_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramE.h"
@@ -58,5 +57,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONS_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/CountVariances.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/CountVariances.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTVARIANCES_H_
-#define MANTID_HISTOGRAMDATA_COUNTVARIANCES_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramE.h"
@@ -55,5 +54,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTVARIANCES_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Counts.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Counts.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTS_H_
-#define MANTID_HISTOGRAMDATA_COUNTS_H_
+#pragma once
 
 #include "MantidHistogramData/Addable.h"
 #include "MantidHistogramData/DllConfig.h"
@@ -67,5 +66,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTS_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/EValidation.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/EValidation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_EVALIDATION_H_
-#define MANTID_HISTOGRAMDATA_EVALIDATION_H_
+#pragma once
 
 #include "MantidHistogramData/Validation.h"
 
@@ -30,5 +29,3 @@ bool isValid(const T &eData) {
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_EVALIDATION_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/EstimatePolynomial.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/EstimatePolynomial.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIAL_H_
-#define MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIAL_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
@@ -52,5 +51,3 @@ estimatePolynomial(const size_t order,
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIAL_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FixedLengthVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTOR_H_
-#define MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTOR_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Validation.h"
@@ -167,5 +166,3 @@ public:
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTOR_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Frequencies.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Frequencies.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCIES_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCIES_H_
+#pragma once
 
 #include "MantidHistogramData/Addable.h"
 #include "MantidHistogramData/DllConfig.h"
@@ -67,5 +66,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCIES_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/FrequencyStandardDeviations.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FrequencyStandardDeviations.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONS_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONS_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramE.h"
@@ -60,5 +59,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONS_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/FrequencyVariances.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/FrequencyVariances.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCYVARIANCES_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCYVARIANCES_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramE.h"
@@ -55,5 +54,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCYVARIANCES_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Histogram.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAM_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAM_H_
+#pragma once
 
 #include "MantidHistogramData/BinEdges.h"
 #include "MantidHistogramData/CountStandardDeviations.h"
@@ -434,5 +433,3 @@ MANTID_HISTOGRAMDATA_DLL Histogram::XMode getHistogramXMode(size_t xLength,
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAM_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramBuilder.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramBuilder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMBUILDER_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMBUILDER_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
@@ -53,5 +52,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMBUILDER_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramDx.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramDx.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMDX_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMDX_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/FixedLengthVector.h"
@@ -43,5 +42,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMDX_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramE.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramE.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAME_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAME_H_
+#pragma once
 
 #include "MantidHistogramData/Addable.h"
 #include "MantidHistogramData/DllConfig.h"
@@ -61,5 +60,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAME_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramItem.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMITEM_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMITEM_H_
+#pragma once
 
 #include "MantidHistogramData/BinEdges.h"
 #include "MantidHistogramData/DllConfig.h"
@@ -150,5 +149,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramIterator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramIterator.h
@@ -5,8 +5,7 @@
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMITERATOR_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMITERATOR_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramItem.h"
@@ -79,5 +78,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramMath.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramMath.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMMATH_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMMATH_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -48,5 +47,3 @@ MANTID_HISTOGRAMDATA_DLL Histogram operator/(Histogram histogram,
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMMATH_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramX.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramX.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMX_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMX_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/FixedLengthVector.h"
@@ -55,5 +54,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMX_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/HistogramY.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/HistogramY.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMY_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMY_H_
+#pragma once
 
 #include "MantidHistogramData/Addable.h"
 #include "MantidHistogramData/DllConfig.h"
@@ -71,5 +70,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMY_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Interpolate.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_INTERPOLATE_H_
-#define MANTID_HISTOGRAMDATA_INTERPOLATE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -44,5 +43,3 @@ size_t minSizeForLinearInterpolation();
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_INTERPOLATE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Iterable.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Iterable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ITERABLE_H_
-#define MANTID_HISTOGRAMDATA_ITERABLE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -111,5 +110,3 @@ auto cend(const Iterable<T> &container) -> decltype(container.cend()) {
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_ITERABLE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/LinearGenerator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_LINEARGENERATOR_H_
-#define MANTID_HISTOGRAMDATA_LINEARGENERATOR_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -32,5 +31,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_LINEARGENERATOR_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/LogarithmicGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/LogarithmicGenerator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_LOGARITHMICGENERATOR_H_
-#define MANTID_HISTOGRAMDATA_LOGARITHMICGENERATOR_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -32,5 +31,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_LOGARITHMICGENERATOR_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Multipliable.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Multipliable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_MULTIPLIABLE_H_
-#define MANTID_HISTOGRAMDATA_MULTIPLIABLE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -73,5 +72,3 @@ private:
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_MULTIPLIABLE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Offsetable.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Offsetable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_OFFSETABLE_H_
-#define MANTID_HISTOGRAMDATA_OFFSETABLE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -56,5 +55,3 @@ protected:
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_OFFSETABLE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/PointStandardDeviations.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/PointStandardDeviations.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONS_H_
-#define MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONS_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramDx.h"
@@ -51,5 +50,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONS_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/PointVariances.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/PointVariances.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTVARIANCES_H_
-#define MANTID_HISTOGRAMDATA_POINTVARIANCES_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramDx.h"
@@ -50,5 +49,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_POINTVARIANCES_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Points.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Points.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTS_H_
-#define MANTID_HISTOGRAMDATA_POINTS_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/HistogramX.h"
@@ -56,5 +55,3 @@ public:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_POINTS_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/QuadraticGenerator.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/QuadraticGenerator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_QUADRATICGENERATOR_H_
-#define MANTID_HISTOGRAMDATA_QUADRATICGENERATOR_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -33,5 +32,3 @@ private:
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_QUADRATICGENERATOR_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Rebin.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Rebin.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMREBIN_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMREBIN_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 namespace Mantid {
@@ -17,5 +16,3 @@ MANTID_HISTOGRAMDATA_DLL Histogram rebin(const Histogram &input,
                                          const BinEdges &binEdges);
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMREBIN_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Scalable.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Scalable.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_SCALABLE_H_
-#define MANTID_HISTOGRAMDATA_SCALABLE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 
@@ -68,5 +67,3 @@ inline T operator*(const double lhs, T rhs) {
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_SCALABLE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Slice.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Slice.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_SLICE_H_
-#define MANTID_HISTOGRAMDATA_SLICE_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Histogram.h"
@@ -23,5 +22,3 @@ MANTID_HISTOGRAMDATA_DLL Histogram slice(const Histogram &histogram,
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_SLICE_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/StandardDeviationVectorOf.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/StandardDeviationVectorOf.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROF_H_
-#define MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROF_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Iterable.h"
@@ -117,5 +116,3 @@ operator=(Variances &&variances) & {
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROF_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/Validation.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/Validation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_VALIDATION_H_
-#define MANTID_HISTOGRAMDATA_VALIDATION_H_
+#pragma once
 
 #include <algorithm>
 #include <cfloat>
@@ -94,5 +93,3 @@ template <class T> void Validator<HistogramE>::checkValidity(const T &data) {
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_VALIDATION_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/VarianceVectorOf.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/VarianceVectorOf.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_VARIANCEVECTOROF_H_
-#define MANTID_HISTOGRAMDATA_VARIANCEVECTOROF_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidHistogramData/Iterable.h"
@@ -108,5 +107,3 @@ operator=(Sigmas &&sigmas) & {
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_VARIANCEVECTOROF_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/VectorOf.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/VectorOf.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_VECTOROF_H_
-#define MANTID_HISTOGRAMDATA_VECTOROF_H_
+#pragma once
 
 #include "MantidHistogramData/DllConfig.h"
 #include "MantidKernel/cow_ptr.h"
@@ -161,5 +160,3 @@ protected:
 } // namespace detail
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_VECTOROF_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/XValidation.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/XValidation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_XVALIDATION_H_
-#define MANTID_HISTOGRAMDATA_XVALIDATION_H_
+#pragma once
 
 #include "MantidHistogramData/Validation.h"
 
@@ -25,5 +24,3 @@ bool isValid(const T &xData) {
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_XVALIDATION_H_ */

--- a/Framework/HistogramData/inc/MantidHistogramData/YValidation.h
+++ b/Framework/HistogramData/inc/MantidHistogramData/YValidation.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_YVALIDATION_H_
-#define MANTID_HISTOGRAMDATA_YVALIDATION_H_
+#pragma once
 
 #include "MantidHistogramData/Validation.h"
 
@@ -25,5 +24,3 @@ bool isValid(const T &eData) {
 
 } // namespace HistogramData
 } // namespace Mantid
-
-#endif /* MANTID_HISTOGRAMDATA_YVALIDATION_H_ */

--- a/Framework/HistogramData/test/AddableTest.h
+++ b/Framework/HistogramData/test/AddableTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ADDABLETEST_H_
-#define MANTID_HISTOGRAMDATA_ADDABLETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -94,5 +93,3 @@ public:
     TS_ASSERT_DELTA(lhs[1], 0.22, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_ADDABLETEST_H_ */

--- a/Framework/HistogramData/test/BinEdgesTest.h
+++ b/Framework/HistogramData/test/BinEdgesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_BINEDGESTEST_H_
-#define MANTID_HISTOGRAMDATA_BINEDGESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -70,5 +69,3 @@ public:
     TS_ASSERT_DELTA(edges[4], 19.0, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_BINEDGESTEST_H_ */

--- a/Framework/HistogramData/test/CountStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/CountStandardDeviationsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONSTEST_H_
-#define MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -132,5 +131,3 @@ public:
     TS_ASSERT_EQUALS(&counts[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTSTANDARDDEVIATIONSTEST_H_ */

--- a/Framework/HistogramData/test/CountVariancesTest.h
+++ b/Framework/HistogramData/test/CountVariancesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTVARIANCESTEST_H_
-#define MANTID_HISTOGRAMDATA_COUNTVARIANCESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -139,5 +138,3 @@ public:
     TS_ASSERT_EQUALS(&counts[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTVARIANCESTEST_H_ */

--- a/Framework/HistogramData/test/CountsTest.h
+++ b/Framework/HistogramData/test/CountsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_COUNTSTEST_H_
-#define MANTID_HISTOGRAMDATA_COUNTSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -114,5 +113,3 @@ public:
     TS_ASSERT_DIFFERS(&counts[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_COUNTSTEST_H_ */

--- a/Framework/HistogramData/test/EValidationTest.h
+++ b/Framework/HistogramData/test/EValidationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_EVALIDATIONTEST_H_
-#define MANTID_HISTOGRAMDATA_EVALIDATIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -79,5 +78,3 @@ public:
     TS_ASSERT(!isValid(makeE({-INFINITY})));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_EVALIDATIONTEST_H_ */

--- a/Framework/HistogramData/test/EstimatePolynomialTest.h
+++ b/Framework/HistogramData/test/EstimatePolynomialTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIALTEST_H_
-#define MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIALTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -128,5 +127,3 @@ public:
     TS_ASSERT_EQUALS(bg2, -3.);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_ESTIMATEPOLYNOMIALTEST_H_ */

--- a/Framework/HistogramData/test/FixedLengthVectorTest.h
+++ b/Framework/HistogramData/test/FixedLengthVectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTORTEST_H_
-#define MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -302,5 +301,3 @@ public:
     TS_ASSERT_DELTA(data.sum(0, 2, 10.0), 10.3, 1e-6);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_FIXEDLENGTHVECTORTEST_H_ */

--- a/Framework/HistogramData/test/FrequenciesTest.h
+++ b/Framework/HistogramData/test/FrequenciesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCIESTEST_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCIESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -114,5 +113,3 @@ public:
     TS_ASSERT_DIFFERS(&frequencies[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCIESTEST_H_ */

--- a/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/FrequencyStandardDeviationsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONSTEST_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -139,5 +138,3 @@ public:
     TS_ASSERT_EQUALS(&frequencies[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCYSTANDARDDEVIATIONSTEST_H_ */

--- a/Framework/HistogramData/test/FrequencyVariancesTest.h
+++ b/Framework/HistogramData/test/FrequencyVariancesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_FREQUENCYVARIANCESTEST_H_
-#define MANTID_HISTOGRAMDATA_FREQUENCYVARIANCESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -142,5 +141,3 @@ public:
     TS_ASSERT_EQUALS(&frequencies[0], old_ptr);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_FREQUENCYVARIANCESTEST_H_ */

--- a/Framework/HistogramData/test/HistogramBuilderTest.h
+++ b/Framework/HistogramData/test/HistogramBuilderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMBUILDERTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMBUILDERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -97,5 +96,3 @@ public:
     TS_ASSERT_EQUALS(hist.xMode(), Histogram::XMode::BinEdges);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMBUILDERTEST_H_ */

--- a/Framework/HistogramData/test/HistogramDxTest.h
+++ b/Framework/HistogramData/test/HistogramDxTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMDXTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMDXTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -33,5 +32,3 @@ public:
         UNUSED_ARG(dynamic_cast<detail::FixedLengthVector<HistogramDx> &>(dx)));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMDXTEST_H_ */

--- a/Framework/HistogramData/test/HistogramETest.h
+++ b/Framework/HistogramData/test/HistogramETest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMETEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -38,5 +37,3 @@ public:
         UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramE> &>(e)));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMETEST_H_ */

--- a/Framework/HistogramData/test/HistogramIteratorTest.h
+++ b/Framework/HistogramData/test/HistogramIteratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMITERATORTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMITERATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -343,5 +342,3 @@ private:
   const size_t histSize = 1000000;
   Histogram m_hist;
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMITERATORTEST_H_ */

--- a/Framework/HistogramData/test/HistogramMathTest.h
+++ b/Framework/HistogramData/test/HistogramMathTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMMATHTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMMATHTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -327,5 +326,3 @@ public:
     TS_ASSERT_THROWS(hist1 / hist2, const std::runtime_error &);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMMATHTEST_H_ */

--- a/Framework/HistogramData/test/HistogramTest.h
+++ b/Framework/HistogramData/test/HistogramTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -1237,5 +1236,3 @@ private:
   std::vector<Histogram> hists;
   HistogramX xData;
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMTEST_H_ */

--- a/Framework/HistogramData/test/HistogramXTest.h
+++ b/Framework/HistogramData/test/HistogramXTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMXTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMXTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -39,5 +38,3 @@ public:
         UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramX> &>(x)));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMXTEST_H_ */

--- a/Framework/HistogramData/test/HistogramYTest.h
+++ b/Framework/HistogramData/test/HistogramYTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_HISTOGRAMYTEST_H_
-#define MANTID_HISTOGRAMDATA_HISTOGRAMYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -45,5 +44,3 @@ public:
         UNUSED_ARG(dynamic_cast<detail::Scalable<HistogramY> &>(y)));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_HISTOGRAMYTEST_H_ */

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_
-#define MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -356,5 +355,3 @@ private:
   const size_t nIters = 5000;
   Histogram hist;
 };
-
-#endif /* MANTID_HISTOGRAMDATA_INTERPOLATETEST_H_ */

--- a/Framework/HistogramData/test/IterableTest.h
+++ b/Framework/HistogramData/test/IterableTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_ITERABLETEST_H_
-#define MANTID_HISTOGRAMDATA_ITERABLETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -80,5 +79,3 @@ public:
     TS_ASSERT_EQUALS(&clone[0], &testee[0]);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_ITERABLETEST_H_ */

--- a/Framework/HistogramData/test/LinearGeneratorTest.h
+++ b/Framework/HistogramData/test/LinearGeneratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_LINEARGENERATORTEST_H_
-#define MANTID_HISTOGRAMDATA_LINEARGENERATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -42,5 +41,3 @@ public:
     TS_ASSERT_DELTA(x, std::vector<double>({0.1, 0.3}), 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_LINEARGENERATORTEST_H_ */

--- a/Framework/HistogramData/test/LogarithmicGeneratorTest.h
+++ b/Framework/HistogramData/test/LogarithmicGeneratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_LOGARITHMICGENERATORTEST_H_
-#define MANTID_HISTOGRAMDATA_LOGARITHMICGENERATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -50,5 +49,3 @@ public:
     TS_ASSERT_DELTA(x, std::vector<double>({0.1, 0.3, 0.9, 2.7}), 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_LOGARITHMICGENERATORTEST_H_ */

--- a/Framework/HistogramData/test/MultipliableTest.h
+++ b/Framework/HistogramData/test/MultipliableTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_MULTIPLIABLETEST_H_
-#define MANTID_HISTOGRAMDATA_MULTIPLIABLETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -94,5 +93,3 @@ public:
     TS_ASSERT_DELTA(lhs[1], 0.8, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_MULTIPLIABLETEST_H_ */

--- a/Framework/HistogramData/test/OffsetableTest.h
+++ b/Framework/HistogramData/test/OffsetableTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_OFFSETABLETEST_H_
-#define MANTID_HISTOGRAMDATA_OFFSETABLETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -85,5 +84,3 @@ public:
     TS_ASSERT_DELTA(lhs[1], 0.21, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_OFFSETABLETEST_H_ */

--- a/Framework/HistogramData/test/PointStandardDeviationsTest.h
+++ b/Framework/HistogramData/test/PointStandardDeviationsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONSTEST_H_
-#define MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -35,5 +34,3 @@ public:
     TS_ASSERT(!points);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_POINTSTANDARDDEVIATIONSTEST_H_ */

--- a/Framework/HistogramData/test/PointVariancesTest.h
+++ b/Framework/HistogramData/test/PointVariancesTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTVARIANCESTEST_H_
-#define MANTID_HISTOGRAMDATA_POINTVARIANCESTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -43,5 +42,3 @@ public:
     TS_ASSERT_EQUALS(result[2], variances[2]);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_POINTVARIANCESTEST_H_ */

--- a/Framework/HistogramData/test/PointsTest.h
+++ b/Framework/HistogramData/test/PointsTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_POINTSTEST_H_
-#define MANTID_HISTOGRAMDATA_POINTSTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -65,5 +64,3 @@ public:
     TS_ASSERT_DELTA(points[2], 11.0, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_POINTSTEST_H_ */

--- a/Framework/HistogramData/test/QuadraticGeneratorTest.h
+++ b/Framework/HistogramData/test/QuadraticGeneratorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_QUADRATICGENERATORTEST_H_
-#define MANTID_HISTOGRAMDATA_QUADRATICGENERATORTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -42,5 +41,3 @@ public:
     TS_ASSERT_DELTA(x, std::vector<double>({3, 6}), 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_QUADRATICGENERATORTEST_H_ */

--- a/Framework/HistogramData/test/RebinTest.h
+++ b/Framework/HistogramData/test/RebinTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_REBINTEST_H_
-#define MANTID_HISTOGRAMDATA_REBINTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -464,5 +463,3 @@ private:
     histFreq.setFrequencyStandardDeviations(freqErrors);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_REBINTEST_H_ */

--- a/Framework/HistogramData/test/ScalableTest.h
+++ b/Framework/HistogramData/test/ScalableTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_SCALABLETEST_H_
-#define MANTID_HISTOGRAMDATA_SCALABLETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -93,5 +92,3 @@ public:
     TS_ASSERT_DELTA(lhs[1], 0.6, 1e-14);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_SCALABLETEST_H_ */

--- a/Framework/HistogramData/test/SliceTest.h
+++ b/Framework/HistogramData/test/SliceTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_SLICETEST_H_
-#define MANTID_HISTOGRAMDATA_SLICETEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -158,5 +157,3 @@ public:
     TS_ASSERT_EQUALS(sliced.e(), HistogramE({3, 4}));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_SLICETEST_H_ */

--- a/Framework/HistogramData/test/StandardDeviationVectorOfTest.h
+++ b/Framework/HistogramData/test/StandardDeviationVectorOfTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROFTEST_H_
-#define MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROFTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -100,5 +99,3 @@ public:
     TS_ASSERT_EQUALS(sigmas[1], 2.0);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_STANDARDDEVIATIONVECTOROFTEST_H_ */

--- a/Framework/HistogramData/test/VarianceVectorOfTest.h
+++ b/Framework/HistogramData/test/VarianceVectorOfTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_VARIANCEVECTOROFTEST_H_
-#define MANTID_HISTOGRAMDATA_VARIANCEVECTOROFTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -96,5 +95,3 @@ public:
     TS_ASSERT_EQUALS(variances[1], 4.0);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_VARIANCEVECTOROFTEST_H_ */

--- a/Framework/HistogramData/test/VectorOfTest.h
+++ b/Framework/HistogramData/test/VectorOfTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_VECTOROFTEST_H_
-#define MANTID_HISTOGRAMDATA_VECTOROFTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -414,5 +413,3 @@ public:
     TS_ASSERT_EQUALS(data.size(), 2);
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_VECTOROFTEST_H_ */

--- a/Framework/HistogramData/test/XValidationTest.h
+++ b/Framework/HistogramData/test/XValidationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_XVALIDATIONTEST_H_
-#define MANTID_HISTOGRAMDATA_XVALIDATIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -115,5 +114,3 @@ public:
     TS_ASSERT(!isValid(makeX({DBL_MIN / 2.0, DBL_MIN})));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_XVALIDATIONTEST_H_ */

--- a/Framework/HistogramData/test/YValidationTest.h
+++ b/Framework/HistogramData/test/YValidationTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_HISTOGRAMDATA_YVALIDATIONTEST_H_
-#define MANTID_HISTOGRAMDATA_YVALIDATIONTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -59,5 +58,3 @@ public:
     TS_ASSERT(!isValid(makeY({-INFINITY})));
   }
 };
-
-#endif /* MANTID_HISTOGRAMDATA_YVALIDATIONTEST_H_ */


### PR DESCRIPTION
This PR replaces all header guards in HistogramData with #pragma once

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
