### PR TITLE
Replace header guards in Nexus and NexusGeometry with pragma once

### DIFF
--- a/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
+++ b/Framework/Nexus/inc/MantidNexus/MuonNexusReader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MUONNEXUSREADER_H
-#define MUONNEXUSREADER_H
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 #include "MantidDataObjects/Workspace2D.h"
@@ -99,5 +98,3 @@ public:
   int numDetectors;                      ///< detector count
   std::string getInstrumentName() const; ///< return instrument name
 };
-
-#endif /* MUONNEXUSREADER_H */

--- a/Framework/Nexus/inc/MantidNexus/NexusClasses.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusClasses.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUS_NEXUSCLASSES_H_
-#define MANTID_NEXUS_NEXUSCLASSES_H_
+#pragma once
 
 //----------------------------------------------------------------------
 // Includes
@@ -983,5 +982,3 @@ private:
 
 } // namespace NeXus
 } // namespace Mantid
-
-#endif /*MANTID_NEXUS_NEXUSCLASSES_H_*/

--- a/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusFileIO.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NEXUSFILEIO_H
-#define NEXUSFILEIO_H
+#pragma once
 #include "MantidAPI/ITableWorkspace_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Progress.h"
@@ -417,5 +416,3 @@ using NexusFileIO_sptr = boost::shared_ptr<NexusFileIO>;
 
 } // namespace NeXus
 } // namespace Mantid
-
-#endif /* NEXUSFILEIO_H */

--- a/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
+++ b/Framework/Nexus/inc/MantidNexus/NexusIOHelper.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NEXUSIOHELPER_H
-#define NEXUSIOHELPER_H
+#pragma once
 
 #include "MantidIndexing/DllConfig.h"
 #include <algorithm>
@@ -192,5 +191,3 @@ T readNexusValue(::NeXus::File &file, std::string entry = "") {
 } // namespace NeXusIOHelper
 } // namespace NeXus
 } // namespace Mantid
-
-#endif /* NEXUSIOHELPER_H */

--- a/Framework/Nexus/inc/MantidNexus/PrecompiledHeader.h
+++ b/Framework/Nexus/inc/MantidNexus/PrecompiledHeader.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUS_PRECOMPILEDHEADER_H_
-#define MANTID_NEXUS_PRECOMPILEDHEADER_H_
+#pragma once
 
 // NeXus
 #include "MantidNexusCPP/NeXusFile.hpp"
@@ -15,5 +14,3 @@
 #include <map>
 #include <string>
 #include <vector>
-
-#endif // MANTID_NEXUS_PRECOMPILEDHEADER_H_

--- a/Framework/Nexus/test/NexusIOHelperTest.h
+++ b/Framework/Nexus/test/NexusIOHelperTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NEXUSIOHELPERTEST_H_
-#define NEXUSIOHELPERTEST_H_
+#pragma once
 
 #include "MantidAPI/FileFinder.h"
 #include "MantidNexus/NexusIOHelper.h"
@@ -173,5 +172,3 @@ public:
     file.close();
   }
 };
-
-#endif /*NEXUSIOHELPERTEST_H_*/

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/AbstractLogger.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/AbstractLogger.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_ABSTRACTLOGGER_H_
-#define MANTID_NEXUSGEOMETRY_ABSTRACTLOGGER_H_
+#pragma once
 
 #include "MantidNexusGeometry/DllConfig.h"
 #include <memory>
@@ -63,5 +62,3 @@ template <typename T> std::unique_ptr<AbstractLogger> makeLogger(T *adaptee) {
 
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif /* MANTID_NEXUSGEOMETRY_ABSTRACTLOGGER_H_ */

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/H5ForwardCompatibility.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/H5ForwardCompatibility.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_H5FORWARDCOMPATIBILITY
-#define MANTIDNEXUSGEOMETRY_H5FORWARDCOMPATIBILITY
+#pragma once
 
 #include "MantidNexusGeometry/DllConfig.h"
 #include <H5Cpp.h>
@@ -31,5 +30,3 @@ std::string getObjName(const H5::H5File &obj);
 } // namespace H5ForwardCompatibility
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif // MANTIDNEXUSGEOMETRY_H5FORWARDCOMPATIBILITY

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/Hdf5Version.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/Hdf5Version.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDHDF5_VERSION_H_
-#define MANTIDHDF5_VERSION_H_
+#pragma once
 
 #include "MantidNexusGeometry/DllConfig.h"
 
@@ -24,5 +23,3 @@ MANTID_NEXUSGEOMETRY_DLL bool checkVariableLengthStringSupport();
 } // namespace Hdf5Version
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif // MANTIDHDF5_VERSION_H_

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/InstrumentBuilder.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/InstrumentBuilder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_INSTRUMENTBUILDER_H
-#define MANTIDNEXUSGEOMETRY_INSTRUMENTBUILDER_H
+#pragma once
 
 #include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Objects/IObject.h"
@@ -81,4 +80,3 @@ private:
 };
 } // namespace NexusGeometry
 } // namespace Mantid
-#endif // MANTIDNEXUSGEOMETRY_INSTRUMENTBUILDER_H

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/JSONGeometryParser.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/JSONGeometryParser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_JSONGEOMETRYPARSER_H_
-#define MANTID_NEXUSGEOMETRY_JSONGEOMETRYPARSER_H_
+#pragma once
 
 #include "MantidGeometry/IDTypes.h"
 #include "MantidNexusGeometry/DllConfig.h"
@@ -188,5 +187,3 @@ private:
 
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif /* MANTID_NEXUSGEOMETRY_JSONGEOMETRYPARSER_H_ */

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/JSONInstrumentBuilder.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/JSONInstrumentBuilder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDER_H_
-#define MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDER_H_
+#pragma once
 
 #include "MantidGeometry/Instrument_fwd.h"
 #include "MantidNexusGeometry/DllConfig.h"
@@ -36,5 +35,3 @@ private:
 
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif /* MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDER_H_ */

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryDefinitions.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryDefinitions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_NEXUSGEOMETRYDEFINITIONS_H
-#define MANTIDNEXUSGEOMETRY_NEXUSGEOMETRYDEFINITIONS_H
+#pragma once
 
 #include <H5Cpp.h>
 #include <string>
@@ -82,5 +81,3 @@ const std::string NEXUS_STRUCTURE = "nexus_structure";
 
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif // MANTIDNEXUSGEOMETRY_NEXUSGEOMETRYDEFINITIONS_H

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryParser.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryParser.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_PARSER_H_
-#define MANTIDNEXUSGEOMETRY_PARSER_H_
+#pragma once
 
 #include "MantidNexusGeometry/AbstractLogger.h"
 #include "MantidNexusGeometry/DllConfig.h"
@@ -30,5 +29,3 @@ getMangledName(const std::string &fileName, const std::string &instName);
 } // namespace NexusGeometryParser
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif // MANTIDNEXUSGEOMETRY_PARSER_H_

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometrySave.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometrySave.h
@@ -14,8 +14,7 @@
  * @date 07/08/2019
  */
 
-#ifndef MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVE_H_
-#define MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVE_H_
+#pragma once
 
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidNexusGeometry/AbstractLogger.h"
@@ -67,5 +66,3 @@ MANTID_NEXUSGEOMETRY_DLL void saveInstrument(
 } // namespace NexusGeometrySave
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif /* MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVE_H_ */

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryUtilities.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusGeometryUtilities.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYUTILITIES_H_
-#define MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYUTILITIES_H_
+#pragma once
 
 #include "MantidNexusGeometry/DllConfig.h"
 #include <H5Cpp.h>
@@ -45,5 +44,3 @@ bool isNamed(const H5::H5Object &obj, const std::string &name);
 } // namespace utilities
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif /* MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYUTILITIES_H_ */

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusShapeFactory.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/NexusShapeFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_SHAPEFACTORY_H
-#define MANTIDNEXUSGEOMETRY_SHAPEFACTORY_H
+#pragma once
 
 #include "MantidNexusGeometry/DllConfig.h"
 
@@ -56,4 +55,3 @@ createFromOFFMesh(const std::vector<uint32_t> &faceIndices,
 } // namespace NexusShapeFactory
 } // namespace NexusGeometry
 } // namespace Mantid
-#endif // MANTIDNEXUSGEOMETRY_SHAPEFACTORY_H

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/TubeBuilder.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/TubeBuilder.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_TUBEBUILDER_H
-#define MANTIDNEXUSGEOMETRY_TUBEBUILDER_H
+#pragma once
 #include "MantidNexusGeometry/DllConfig.h"
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -56,5 +55,3 @@ private:
 } // namespace detail
 } // namespace NexusGeometry
 } // namespace Mantid
-
-#endif // MANTIDNEXUSGEOMETRY_TUBEBUILDER_H

--- a/Framework/NexusGeometry/inc/MantidNexusGeometry/TubeHelpers.h
+++ b/Framework/NexusGeometry/inc/MantidNexusGeometry/TubeHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTIDNEXUSGEOMETRY_TUBEHELPERS_H
-#define MANTIDNEXUSGEOMETRY_TUBEHELPERS_H
+#pragma once
 
 #include "MantidGeometry/IDTypes.h"
 #include "MantidNexusGeometry/TubeBuilder.h"
@@ -33,4 +32,3 @@ notInTubes(const std::vector<detail::TubeBuilder> &tubes,
 } // namespace TubeHelpers
 } // namespace NexusGeometry
 } // namespace Mantid
-#endif // MANTIDNEXUSGEOMETRY_TUBEHELPER_H

--- a/Framework/NexusGeometry/test/InstrumentBuilderTest.h
+++ b/Framework/NexusGeometry/test/InstrumentBuilderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef INSTRUMENT_GEOMETRY_ABSTRACTION_TEST_H_
-#define INSTRUMENT_GEOMETRY_ABSTRACTION_TEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -87,5 +86,3 @@ private:
   boost::shared_ptr<const Geometry::IObject> shape =
       boost::make_shared<const Geometry::CSGObject>();
 };
-
-#endif // INSTRUMENT_GEOMETRY_ABSTRACTION_TEST_H_

--- a/Framework/NexusGeometry/test/JSONGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/JSONGeometryParserTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_JSONGEOMETRYPARSERTEST_H_
-#define MANTID_NEXUSGEOMETRY_JSONGEOMETRYPARSERTEST_H_
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Strings.h"
@@ -477,5 +476,3 @@ public:
 private:
   std::string instrument;
 };
-
-#endif /* MANTID_GEOMETRY_JSONGEOMETRYPARSERTEST_H_ */

--- a/Framework/NexusGeometry/test/JSONInstrumentBuilderTest.h
+++ b/Framework/NexusGeometry/test/JSONInstrumentBuilderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDERTEST_H_
-#define MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDERTEST_H_
+#pragma once
 
 #include "MantidGeometry/Instrument.h"
 #include "MantidNexusGeometry/JSONGeometryParser.h"
@@ -61,5 +60,3 @@ public:
     TS_ASSERT_EQUALS(max_id, 90000); // monitor
   }
 };
-
-#endif /* MANTID_NEXUSGEOMETRY_JSONINSTRUMENTBUILDERTEST_H_ */

--- a/Framework/NexusGeometry/test/NexusGeometryParserTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometryParserTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NEXUSGEOMETRYPARSERTEST_H_
-#define NEXUSGEOMETRYPARSERTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -392,4 +391,3 @@ private:
   std::string m_sans2dHDF5DefinitionPath;
   std::string m_lokiHDF5DefinitionPath;
 };
-#endif

--- a/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
+++ b/Framework/NexusGeometry/test/NexusGeometrySaveTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVETEST_H_
-#define MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVETEST_H_
+#pragma once
 
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentInfoBankHelpers.h"
@@ -1163,5 +1162,3 @@ Instrument cache.
                      H5::GroupIException &);
   }
 };
-
-#endif /* MANTID_NEXUSGEOMETRY_NEXUSGEOMETRYSAVETEST_H_ */

--- a/Framework/NexusGeometry/test/TubeBuilderTest.h
+++ b/Framework/NexusGeometry/test/TubeBuilderTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TUBE_TEST_H_
-#define TUBE_TEST_H_
+#pragma once
 
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidGeometry/Rendering/GeometryHandler.h"
@@ -68,5 +67,3 @@ public:
     TS_ASSERT_EQUALS(tube.size(), 1);
   }
 };
-
-#endif // TUBE_TEST_H_

--- a/Framework/NexusGeometry/test/TubeHelpersTest.h
+++ b/Framework/NexusGeometry/test/TubeHelpersTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef TUBEHELPERS_TEST_H_
-#define TUBEHELPERS_TEST_H_
+#pragma once
 
 #include "MantidGeometry/Objects/IObject.h"
 #include "MantidNexusGeometry/NexusShapeFactory.h"
@@ -81,5 +80,3 @@ public:
     TS_ASSERT_EQUALS(notInTubes[1], detIds[3]);
   }
 };
-
-#endif // TUBEHELPERS_TEST_H_

--- a/Framework/NexusGeometry/test/mockobjects.h
+++ b/Framework/NexusGeometry/test/mockobjects.h
@@ -1,5 +1,4 @@
-#ifndef NEXUSGEOMETRY_MOCKOBJECTS_H
-#define NEXUSGEOMETRY_MOCKOBJECTS_H
+#pragma once
 #include "MantidKernel/ProgressBase.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidNexusGeometry/AbstractLogger.h"
@@ -19,5 +18,3 @@ public:
   MOCK_METHOD1(error, void(const std::string &));
   GNU_DIAG_ON_SUGGEST_OVERRIDE
 };
-
-#endif // NEXUSGEOMETRY_MOCKOBJECTS_H


### PR DESCRIPTION
This PR replaces all header guards in Nexus and NexusGeometry with #pragma once

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
