### PR TITLE
Catch exception in code completion when variable assigned to plot

### DIFF
--- a/qt/python/mantidqt/widgets/codeeditor/completion.py
+++ b/qt/python/mantidqt/widgets/codeeditor/completion.py
@@ -196,16 +196,16 @@ def generate_call_tips(definitions, prepend_module_name=None):
         for attr in dir(py_object):
             try:
                 f_attr = getattr(py_object, attr)
+                if attr.startswith('_'):
+                    continue
+                if hasattr(f_attr, 'im_func') or inspect.isfunction(f_attr) or inspect.ismethod(f_attr):
+                    call_tip = name + '.' + attr + get_function_spec(f_attr)
+                else:
+                    call_tip = name + '.' + attr
+                if isinstance(module_name, string_types):
+                    call_tips.append(module_name + '.' + call_tip)
             except Exception:
                 continue
-            if attr.startswith('_'):
-                continue
-            if hasattr(f_attr, 'im_func') or inspect.isfunction(f_attr) or inspect.ismethod(f_attr):
-                call_tip = name + '.' + attr + get_function_spec(f_attr)
-            else:
-                call_tip = name + '.' + attr
-            if isinstance(module_name, string_types):
-                call_tips.append(module_name + '.' + call_tip)
     return call_tips
 
 


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where assigning a variable to a plot and closing the plot caused an exception to be thrown when doing the code completion. 

**To test:**
Run this entire script
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace(Function='Powder Diffraction')
plot1 = plotSpectrum(ws,1,error_bars=True)
```
Close the plot
Highlight the line `ws = ...` and execute just it.

Fixes #28267 

*This does not require release notes* because **it was not in the last release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
