### PR TITLE
Fix progress arrow for Workbench

### DIFF
--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -209,7 +209,7 @@ using MantidQt::Widgets::Common::Python::CodeExecution;
 
 public:
   CodeExecution(ScriptEditor*);
-  SIP_PYOBJECT execute(const QString &, const QString &, int, SIP_PYOBJECT);
+  SIP_PYOBJECT execute(const QString &, const QString &, int, SIP_PYOBJECT, int);
 private:
   CodeExecution(const CodeExecution&);
 };

--- a/qt/python/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/widgets/codeeditor/execution.py
@@ -100,12 +100,13 @@ class PythonCodeExecution(QObject):
         if self._task is not None:
             self._task.abort()
 
-    def execute_async(self, code_str, filename=None, blocking=False):
+    def execute_async(self, code_str, line_offset, filename=None, blocking=False):
         """
         Execute the given code string on a separate thread. This function
         returns as soon as the new thread starts
 
         :param code_str: A string containing code to execute
+        :param line_offset: See PythonCodeExecution.execute()
         :param filename: See PythonCodeExecution.execute()
         :param blocking: If True the call will block until the task is finished
         :returns: The created async task, only returns task if the blocking is False
@@ -113,24 +114,25 @@ class PythonCodeExecution(QObject):
         # Stack is chopped on error to avoid the  AsyncTask.run->self.execute calls appearing
         # as these are not useful for the user in this context
         if not blocking:
-            task = AsyncTask(self.execute, args=(code_str, filename),
+            task = AsyncTask(self.execute, args=(code_str, line_offset, filename),
                              success_cb=self._on_success, error_cb=self._on_error)
             task.start()
             self._task = task
             return task
         else:
-            self._task = BlockingAsyncTaskWithCallback(self.execute, args=(code_str, filename),
+            self._task = BlockingAsyncTaskWithCallback(self.execute, args=(code_str, line_offset, filename),
                                                        success_cb=self._on_success, error_cb=self._on_error,
                                                        blocking_cb=QApplication.processEvents)
             return self._task.start()
 
-    def execute(self, code_str, filename=None):
+    def execute(self, code_str,  line_offset, filename=None):
         """Execute the given code on the calling thread
         within the provided context.
 
         :param code_str: A string containing code to execute
         :param filename: An optional identifier specifying the file source of the code. If None then '<string>'
         is used
+        :param line_offset: The number of lines offset into the script that the code_str starts at
         :raises: Any error that the code generates
         """
         if not filename:
@@ -140,7 +142,7 @@ class PythonCodeExecution(QObject):
         flags = get_future_import_compiler_flags(code_str)
         with AddedToSysPath([os.path.dirname(filename)]):
             executor = CodeExecution(self._editor)
-            executor.execute(code_str, filename, flags, self.globals_ns)
+            executor.execute(code_str, filename, flags, self.globals_ns, line_offset)
 
     def reset_context(self):
         # create new context for execution

--- a/qt/python/mantidqt/widgets/codeeditor/interpreter.py
+++ b/qt/python/mantidqt/widgets/codeeditor/interpreter.py
@@ -316,7 +316,9 @@ class PythonFileInterpreterPresenter(QObject):
         self.is_executing = True
         self.view.set_editor_readonly(True)
         self.view.set_status_message(RUNNING_STATUS_MSG)
-        return self.model.execute_async(code_str, self.view.filename, blocking)
+        return self.model.execute_async(code_str=code_str,
+                                        line_offset=self._code_start_offset,
+                                        filename=self.view.filename, blocking=blocking)
 
     def _get_code_for_execution(self, ignore_selection):
         editor = self.view.editor
@@ -362,8 +364,3 @@ class PythonFileInterpreterPresenter(QObject):
 
     def _create_status_msg(self, status, timestamp, elapsed_time):
         return IDLE_STATUS_MSG + ' ' + LAST_JOB_MSG_TEMPLATE.format(status, timestamp, elapsed_time)
-
-    def _on_progress_update(self, lineno):
-        """Update progress on the view taking into account if a selection of code is
-        running"""
-        self.view.editor.updateProgressMarker(lineno + self._code_start_offset, False)

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/CodeExecution.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/CodeExecution.h
@@ -24,7 +24,7 @@ class EXPORT_OPT_MANTIDQT_COMMON CodeExecution {
 public:
   CodeExecution(ScriptEditor *editor);
   PyObject *execute(const QString &codeStr, const QString &filename, int flags,
-                    PyObject *globals) const;
+                    PyObject *globals, int lineOffset) const;
 
 private:
   ScriptEditor *m_editor{nullptr};

--- a/qt/widgets/common/src/Python/CodeExecution.cpp
+++ b/qt/widgets/common/src/Python/CodeExecution.cpp
@@ -16,8 +16,13 @@ using Mantid::PythonInterface::GlobalInterpreterLock;
 
 namespace {
 
+struct ScriptEditorDetails {
+  ScriptEditor *editor;
+  int lineOffset;
+};
+
 // Map co_filename objects from PyCodeObject to an editor object
-QHash<PyObject *, ScriptEditor *> EDITOR_LOOKUP;
+QHash<PyObject *, ScriptEditorDetails> EDITOR_LOOKUP;
 
 /**
  * A callback, set using PyEval_SetTrace, that is called by Python
@@ -39,7 +44,9 @@ int traceLineNumber(PyObject *obj, PyFrameObject *frame, int event,
     return 0;
   auto iter = EDITOR_LOOKUP.constFind(frame->f_code->co_filename);
   if (iter != EDITOR_LOOKUP.constEnd()) {
-    iter.value()->updateProgressMarkerFromThread(frame->f_lineno, false);
+    const auto &details = iter.value();
+    int lineLoc = frame->f_lineno + details.lineOffset;
+    details.editor->updateProgressMarkerFromThread(lineLoc, false);
   }
   return 0;
 }
@@ -60,32 +67,35 @@ CodeExecution::CodeExecution(ScriptEditor *editor) : m_editor(editor) {}
  * @param filename A string containing the filename of the source code
  * @param flags An OR-ed combination of compiler flags
  * @param globals A dictionary containing the current globals mapping
+ * @param lineOffset The number of lines offset to apply to the marker
  */
 PyObject *CodeExecution::execute(const QString &codeStr,
                                  const QString &filename, int flags,
-                                 PyObject *globals) const {
+                                 PyObject *globals, int lineOffset) const {
   GlobalInterpreterLock gil;
   PyCompilerFlags compileFlags;
   compileFlags.cf_flags = flags;
   auto compiledCode = Py_CompileStringFlags(codeStr.toUtf8().constData(),
                                             filename.toUtf8().constData(),
                                             Py_file_input, &compileFlags);
-  if (compiledCode) {
-    if (m_editor) {
-      const auto coFileObject = ((PyCodeObject *)compiledCode)->co_filename;
-      const auto posIter = EDITOR_LOOKUP.insert(coFileObject, m_editor);
-      PyEval_SetTrace((Py_tracefunc)&traceLineNumber, nullptr);
-      const auto result =
-          PyEval_EvalCode(CODE_OBJECT(compiledCode), globals, globals);
-      PyEval_SetTrace(nullptr, nullptr);
-      EDITOR_LOOKUP.erase(posIter);
-      return result;
-    } else {
-      return PyEval_EvalCode(CODE_OBJECT(compiledCode), globals, globals);
-    }
-  } else {
+  if (!compiledCode) {
     return nullptr;
   }
-}
+
+  if (!m_editor) {
+    return PyEval_EvalCode(CODE_OBJECT(compiledCode), globals, globals);
+  }
+
+  ScriptEditorDetails editor_details{m_editor, lineOffset};
+  const auto coFileObject = ((PyCodeObject *)compiledCode)->co_filename;
+  const auto posIter = EDITOR_LOOKUP.insert(coFileObject, editor_details);
+  PyEval_SetTrace((Py_tracefunc)&traceLineNumber, nullptr);
+  const auto result =
+      PyEval_EvalCode(CODE_OBJECT(compiledCode), globals, globals);
+  PyEval_SetTrace(nullptr, nullptr);
+  EDITOR_LOOKUP.erase(posIter);
+  return result;
+
+} // namespace MantidQt::Widgets::Common::Python
 
 } // namespace MantidQt::Widgets::Common::Python


### PR DESCRIPTION
**Description of work.**
Fixes the progress arrow which previously only pointed at the first
line, irrespective of selection. Additionally removes a method which is
completely unused in the code-base, but looks like it would do a similar
thing as it's misleading.

A struct is used in case we need to add additional fields, and for the
extra readability when we dereference the map iterator. This avoids a
iter->value.at<0> in favour of having named fields of a struct.

**To test:**
- Run the following multiple times 
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

import time

time.sleep(2)
time.sleep(2)
time.sleep(2)
time.sleep(2)
time.sleep(2)
```

- Try selecting different subsets the script (e.g. the last 3 lines)
- Check the progress arrow always starts at the right location
<!-- Instructions for testing. -->

Fixes #28266 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
