### PR TITLE
Minor fix to unscripted testing instructions

### DIFF
--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -39,7 +39,7 @@ Loading batch files
 - Browse to the file that you want to load (e.g. ``INTER_NR_test.json``).
 - The interface should now have all of the information for the runs and settings from the batch file populated in the display.
 - Compare against a version of the batch file opened in your favourite text editor.
-- Try to re-open the batch file again. You should be asked if you want to discard the changes.
+- Try to re-open the batch file again. You should not be asked if you want to discard the changes (unless you changed anything).
 
 Changing the Default instrument
 -------------------------------


### PR DESCRIPTION
This PR fixes a minor error in the ISIS Reflectometry GUI manual testing instructions - there should be no "discard" warning when re-loading a batch file if no changes were made.

Refs #28033

*This does not require release notes* because **it is a developer docs change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
