### PR TITLE
Replace header guards in PythonInterface with pragma once

### DIFF
--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/CallMethod.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/CallMethod.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CALLMETHOD_H_
-#define MANTID_PYTHONINTERFACE_CALLMETHOD_H_
+#pragma once
 
 #include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
@@ -102,5 +101,3 @@ ReturnType callMethod(PyObject *obj, const char *methodName,
 }
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_CALLMETHOD_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/CArrayToNDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/CArrayToNDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CARRAYTONDARRAY_H_
-#define MANTID_PYTHONINTERFACE_CARRAYTONDARRAY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidPythonInterface/core/Converters/WrapWithNumpy.h"
@@ -37,5 +36,3 @@ struct CArrayToNDArray {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_CARRAYTONDARRAY_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/CloneToNDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/CloneToNDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CLONETONDARRAY_H_
-#define MANTID_PYTHONINTERFACE_CLONETONDARRAY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <boost/python/detail/prefix.hpp>
@@ -54,5 +53,3 @@ struct Clone {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_CLONETONDARRAY_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/ContainerDtype.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/ContainerDtype.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
-#define MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_
+#pragma once
 
 #include <string>
 #include <type_traits>
@@ -41,5 +40,3 @@ std::string dtype(const Container<HeldType> &) {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /*MANTID_PYTHONINTERFACE_CONVERTERS_CONTAINERDTYPE_H_*/

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/DateAndTime.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/DateAndTime.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINERFACE_CORE_DATEANDTIME_H_
-#define MANTID_PYTHONINERFACE_CORE_DATEANDTIME_H_
+#pragma once
 
 #include "MantidKernel/DateAndTime.h"
 #include "MantidPythonInterface/core/DllConfig.h"
@@ -28,5 +27,3 @@ to_dateandtime(const boost::python::api::object &value);
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINERFACE_CORE_DATEANDTIME_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/MapToPyDictionary.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/MapToPyDictionary.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINERFACE_MAPTOPYDICTIONARY_H_
-#define MANTID_PYTHONINERFACE_MAPTOPYDICTIONARY_H_
+#pragma once
 
 /** Converter to generate a python dictionary from a std::map
  */
@@ -43,5 +42,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINERFACE_MAPTOPYDICTIONARY_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/MatrixToNDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/MatrixToNDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_MATRIXTONDARRAY_H_
-#define MANTID_PYTHONINTERFACE_MATRIXTONDARRAY_H_
+#pragma once
 
 #include "MantidKernel/Matrix.h"
 #include "MantidPythonInterface/core/Converters/WrapWithNDArray.h"
@@ -43,5 +42,3 @@ struct DLLExport MatrixToNDArray {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /// MANTID_PYTHONINTERFACE_MATRIXTONDARRAY_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NDArrayToVector.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NDArrayToVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_NDARRAYTOVECTORCONVERTER_H_
-#define MANTID_PYTHONINTERFACE_NDARRAYTOVECTORCONVERTER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidPythonInterface/core/NDArray.h"
@@ -39,5 +38,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_NDARRAYTOVECTORCONVERTER_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NDArrayTypeIndex.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NDArrayTypeIndex.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_NDARRAYTYPEINDEX_H_
-#define MANTID_PYTHONINTERFACE_NDARRAYTYPEINDEX_H_
+#pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
 
@@ -30,5 +29,3 @@ template <typename T> struct MANTID_PYTHONINTERFACE_CORE_DLL NDArrayTypeIndex {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_NDARRAYTYPEINDEX_H_*/

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NumpyFunctions.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/NumpyFunctions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef NUMPY_FUNCTIONS_H
-#define NUMPY_FUNCTIONS_H
+#pragma once
 
 #ifdef __GNUC__
 #pragma GCC system_header
@@ -48,4 +47,3 @@ func_PyArray_Descr(const char *datadescr);
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-#endif // NUMPY_FUNCTIONS_H

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToMatrix.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToMatrix.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINERFACE_PYOBJECTTOMATRIX_H_
-#define MANTID_PYTHONINERFACE_PYOBJECTTOMATRIX_H_
+#pragma once
 
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
@@ -34,5 +33,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINERFACE_PYOBJECTTOMATRIX_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToV3D.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToV3D.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINERFACE_PYOBJECTTOV3D_H_
-#define MANTID_PYTHONINERFACE_PYOBJECTTOV3D_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidKernel/V3D.h"
@@ -34,5 +33,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINERFACE_PYOBJECTTOV3D_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToVMD.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PyObjectToVMD.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINERFACE_PYOBJECTTOVMD_H_
-#define MANTID_PYTHONINERFACE_PYOBJECTTOVMD_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
@@ -34,5 +33,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINERFACE_PYOBJECTTOVMD_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PySequenceToVector.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/PySequenceToVector.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PYSEQUENCETOVECTORCONVERTER_H_
-#define MANTID_PYTHONINTERFACE_PYSEQUENCETOVECTORCONVERTER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <boost/python/extract.hpp>
@@ -102,5 +101,3 @@ private:
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_PYSEQUENCETOVECTORCONVERTER_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/ToPyList.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/ToPyList.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TOPYLIST_H_
-#define MANTID_PYTHONINTERFACE_TOPYLIST_H_
+#pragma once
 
 #include <boost/python/list.hpp>
 #include <vector>
@@ -38,5 +37,3 @@ template <typename ElementType> struct ToPyList {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_TOPYLIST_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/VectorToNDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/VectorToNDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_VECTORTONDARRAY_H_
-#define MANTID_PYTHONINTERFACE_VECTORTONDARRAY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 
@@ -40,5 +39,3 @@ struct VectorToNDArray {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_VECTORTONDARRAY_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/WrapWithNDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Converters/WrapWithNDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_WRAPWITHNDARRAY_H_
-#define MANTID_PYTHONINTERFACE_WRAPWITHNDARRAY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <boost/python/detail/prefix.hpp>
@@ -100,5 +99,3 @@ struct WrapReadWrite {
 } // namespace Converters
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_WRAPWITHNDARRAY_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Copyable.h
@@ -5,8 +5,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_COPYABLE_H_
-#define MANTID_PYTHONINTERFACE_COPYABLE_H_
+#pragma once
 #include <boost/python/class.hpp>
 #include <boost/python/dict.hpp>
 #include <boost/python/extract.hpp>
@@ -64,4 +63,3 @@ bp::object generic__deepcopy__(const bp::object &copyable, bp::dict &memo) {
 }
 } // namespace PythonInterface
 } // namespace Mantid
-#endif // MANTID_PYTHONINTERFACE_COPYABLE_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_DATASERVICEEXPORTER_H_
-#define MANTID_PYTHONINTERFACE_DATASERVICEEXPORTER_H_
+#pragma once
 
 #include "MantidKernel/Exception.h"
 #include "MantidPythonInterface/core/WeakPtr.h"
@@ -173,5 +172,3 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_DATASERVICEEXPORTER_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DllConfig.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CORE_DLLCONFIG_H_
-#define MANTID_PYTHONINTERFACE_CORE_DLLCONFIG_H_
+#pragma once
 /*
   This file contains the DLLExport/DLLImport linkage configuration for the
   PythonInterfaceCore library
@@ -17,5 +16,3 @@
 #else
 #define MANTID_PYTHONINTERFACE_CORE_DLL DLLImport
 #endif // IN_MANTID_PYTHONINTERFACE_CORE
-
-#endif // MANTID_PYTHONINTERFACE_CORE_DLLCONFIG_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ErrorHandling.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ErrorHandling.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ERRORHANDLING_H
-#define MANTID_PYTHONINTERFACE_ERRORHANDLING_H
+#pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
 #include <stdexcept>
@@ -30,5 +29,3 @@ public:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_ERRORHANDLING_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ExtractWorkspace.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ExtractWorkspace.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_EXTRACTWORKSPACE_H_
-#define MANTID_PYTHONINTERFACE_EXTRACTWORKSPACE_H_
+#pragma once
 
 #include "MantidAPI/Workspace.h"
 
@@ -24,5 +23,3 @@ private:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_EXTRACTWORKSPACE_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/GetPointer.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/GetPointer.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_KERNEL_GETPOINTER_H_
-#define MANTID_PYTHONINTERFACE_KERNEL_GETPOINTER_H_
+#pragma once
 
 #if defined(_MSC_FULL_VER) && _MSC_FULL_VER > 190023918 &&                     \
     _MSC_FULL_VER < 191125506
@@ -20,4 +19,3 @@
 #else
 #define GET_POINTER_SPECIALIZATION(TYPE)
 #endif
-#endif // MANTID_PYTHONINTERFACE_KERNEL_GETPOINTER_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/GlobalInterpreterLock.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/GlobalInterpreterLock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_GLOBALINTERPRETERLOCK_H_
-#define MANTID_PYTHONINTERFACE_GLOBALINTERPRETERLOCK_H_
+#pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
 #include "MantidPythonInterface/core/WrapPython.h"
@@ -46,5 +45,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_GLOBALINTERPRETERLOCK_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/IsNone.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_KERNEL_ISNONE_H_
-#define MANTID_PYTHONINTERFACE_KERNEL_ISNONE_H_
+#pragma once
 
 #include <boost/python/object.hpp>
 
@@ -39,5 +38,3 @@ inline bool isNone(const boost::python::object &obj) {
 }
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* #ifndef MANTID_PYTHONINTERFACE_KERNEL_ISNONE_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/NDArray.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/NDArray.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PYTHONINTERFACE_CORE_NDARRAY_H_
-#define PYTHONINTERFACE_CORE_NDARRAY_H_
+#pragma once
 #include "MantidPythonInterface/core/DllConfig.h"
 
 #include <boost/python/object.hpp>
@@ -64,5 +63,3 @@ struct MANTID_PYTHONINTERFACE_CORE_DLL
 } // end namespace converter
 } // end namespace python
 } // end namespace boost
-
-#endif // PYTHONINTERFACE_CORE_NDARRAY_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/AsType.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/AsType.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ASTYPE_H_
-#define MANTID_PYTHONINTERFACE_ASTYPE_H_
+#pragma once
 
 #include <boost/mpl/and.hpp>
 #include <boost/python/detail/prefix.hpp>
@@ -69,5 +68,3 @@ template <class ReturnType> struct AsType {
 } // namespace Policies
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_ASTYPE_H */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/MatrixToNumpy.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/MatrixToNumpy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_MATRIXTONUMPY_H_
-#define MANTID_PYTHONINTERFACE_MATRIXTONUMPY_H_
+#pragma once
 
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/System.h"
@@ -123,5 +122,3 @@ struct MatrixToNumpy {
 } // namespace Policies
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_MATRIXTONUMPY_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/RemoveConst.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/RemoveConst.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_REMOVECONST_H_
-#define MANTID_PYTHONINTERFACE_REMOVECONST_H_
+#pragma once
 
 #include <boost/python/detail/prefix.hpp>
 #include <boost/python/to_python_value.hpp>
@@ -138,5 +137,3 @@ struct RemoveConstSharedPtr {
 } // namespace Policies
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_REMOVECONST_H_REMOVECONST_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/ToWeakPtr.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/ToWeakPtr.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TOWEAKPTR_H_
-#define MANTID_PYTHONINTERFACE_TOWEAKPTR_H_
+#pragma once
 
 #include <boost/python/detail/prefix.hpp>
 #include <boost/python/to_python_value.hpp>
@@ -74,5 +73,3 @@ struct ToWeakPtr {
 } // namespace Policies
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_REMOVECONST_H_REMOVECONST_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/VectorToNumpy.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Policies/VectorToNumpy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_VECTORTONUMPY_H_
-#define MANTID_PYTHONINTERFACE_VECTORTONUMPY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include "MantidPythonInterface/core/Converters/CloneToNDArray.h"
@@ -120,5 +119,3 @@ struct VectorToNumpy {
 } // namespace Policies
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_VECTORTONUMPY_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PropertyWithValueExporter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEEXPORTER_H_
-#define MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEEXPORTER_H_
+#pragma once
 
 #include "MantidKernel/PropertyWithValue.h"
 #include "MantidPythonInterface/core/Converters/ContainerDtype.h"
@@ -56,5 +55,3 @@ struct PropertyWithValueExporter {
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEEXPORTER_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectInstantiator.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/PythonObjectInstantiator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PYTHONALGORITHMINSTANTIATOR_H_
-#define MANTID_PYTHONINTERFACE_PYTHONALGORITHMINSTANTIATOR_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -105,5 +104,3 @@ Base *PythonObjectInstantiator<Base>::createUnwrappedInstance() const {
 }
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_PYTHONALGORITHMINSTANTIATOR_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_RELEASEGLOBALINTERPRETERLOCK_H_
-#define MANTID_PYTHONINTERFACE_RELEASEGLOBALINTERPRETERLOCK_H_
+#pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
 #include <boost/python/detail/wrap_python.hpp>
@@ -33,5 +32,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_RELEASEGLOBALINTERPRETERLock_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/StlExportDefinitions.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/StlExportDefinitions.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_STLEXPORTDEFINITIONS_H_
-#define MANTID_PYTHONINTERFACE_STLEXPORTDEFINITIONS_H_
+#pragma once
 /**
     This file contains the export definitions for various stl containers.
 */
@@ -155,5 +154,3 @@ template <typename ElementType> struct std_set_exporter {
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_STLEXPORTDEFINITIONS_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PYTHONINTERFACECPP_PYTHONINTERPRETERGLOBALFIXTURE_H
-#define PYTHONINTERFACECPP_PYTHONINTERPRETERGLOBALFIXTURE_H
+#pragma once
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidPythonInterface/core/NDArray.h"
@@ -53,5 +52,3 @@ public:
     return true;
   }
 };
-
-#endif // PYTHONINTERFACECPP_PYTHONINTERPRETERGLOBALFIXTURE_H

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/TypedValidatorExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/TypedValidatorExporter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TYPEDVALIDATOREXPORTER_H_
-#define MANTID_PYTHONINTERFACE_TYPEDVALIDATOREXPORTER_H_
+#pragma once
 
 #include "MantidKernel/TypedValidator.h"
 #include <boost/python/class.hpp>
@@ -33,5 +32,3 @@ template <typename Type> struct TypedValidatorExporter {
 #define EXPORT_TYPEDVALIDATOR(Type)
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_TYPEDVALIDATOREXPORTER_H_

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/UninstallTrace.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/UninstallTrace.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_UNINSTALLTRACE_H
-#define MANTID_PYTHONINTERFACE_UNINSTALLTRACE_H
+#pragma once
 
 #include "MantidPythonInterface/core/DllConfig.h"
 #include "MantidPythonInterface/core/WrapPython.h"
@@ -27,5 +26,3 @@ private:
 };
 
 } // namespace Mantid::PythonInterface
-
-#endif // MANTID_PYTHONINTERFACE_UNINSTALLTRACE_H

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/VersionCompat.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/VersionCompat.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CORE_PYTHONCOMPAT_H
-#define MANTID_PYTHONINTERFACE_CORE_PYTHONCOMPAT_H
+#pragma once
 
 #include "MantidPythonInterface/core/WrapPython.h"
 
@@ -29,5 +28,3 @@
 #define CODE_OBJECT(x) (PyCodeObject *)x
 #define FROM_LONG PyInt_FromLong
 #endif
-
-#endif // MANTID_PYTHONINTERFACE_CORE_PYTHONCOMPAT_H

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WeakPtr.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WeakPtr.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_WEAKPTR_H_
-#define MANTID_PYTHONINTERFACE_WEAKPTR_H_
+#pragma once
 /*
 
   This file declares the get_pointer template function to allow
@@ -37,5 +36,3 @@ inline HeldType *get_pointer(const boost::weak_ptr<HeldType> &dataItem) {
   }
 }
 } // namespace boost
-
-#endif /* MANTID_PYTHONINTERFACE_WEAKPTR_H_ */

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WrapPython.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WrapPython.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CORE_WRAPPYTHON_H
-#define MANTID_PYTHONINTERFACE_CORE_WRAPPYTHON_H
+#pragma once
 
 // Including Python.h from a location where a "slots" is an active macro,
 // e.g. when a Qt header is included, causes a failure under Python 3
@@ -17,5 +16,3 @@
 #undef slots
 #include <boost/python/detail/wrap_python.hpp>
 #pragma pop_macro("slots")
-
-#endif // MANTID_PYTHONINTERFACE_CORE_WRAPPYTHON_H

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WrapperHelpers.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/WrapperHelpers.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_WRAPPERHELPERS_H_
-#define MANTID_PYTHONINTERFACE_WRAPPERHELPERS_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -30,5 +29,3 @@ bool MANTID_PYTHONINTERFACE_CORE_DLL typeHasAttribute(
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_WRAPPERHELPERS_H_

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/AlgorithmIDProxy.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/AlgorithmIDProxy.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ALGORITHMIDPROXY_H_
-#define MANTID_PYTHONINTERFACE_ALGORITHMIDPROXY_H_
+#pragma once
 
 #include "MantidAPI/IAlgorithm.h" // for AlgorithmID typedef
 
@@ -25,5 +24,3 @@ struct AlgorithmIDProxy {
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_ALGORITHMIDPROXY_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmFactoryObserverAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmFactoryObserverAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ALGORITHMFACTORYOBSERVERADAPTER_H_
-#define MANTID_PYTHONINTERFACE_ALGORITHMFACTORYOBSERVERADAPTER_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmFactoryObserver.h"
 #include <boost/python/wrapper.hpp>
@@ -40,5 +39,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /*MANTID_PYTHONINTERFACE_ALGORITHMFACTORYOBSERVERADAPTER_H_*/

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmObserverAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/AlgorithmObserverAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ALGORITHMOBSERVERADAPTER_H_
-#define MANTID_PYTHONINTERFACE_ALGORITHMOBSERVERADAPTER_H_
+#pragma once
 
 #include "MantidAPI/AlgorithmObserver.h"
 #include <boost/python/wrapper.hpp>
@@ -42,5 +41,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_ALGORITHMOBSERVERADAPTER_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/RunPythonScript.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/Algorithms/RunPythonScript.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPT_H_
-#define MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPT_H_
+#pragma once
 
 #include "MantidAPI/Algorithm.h"
 
@@ -44,5 +43,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPT_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/AnalysisDataServiceObserverAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/AnalysisDataServiceObserverAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ANALYSISDATASERVICEOBSERVERADAPTER_H_
-#define MANTID_PYTHONINTERFACE_ANALYSISDATASERVICEOBSERVERADAPTER_H_
+#pragma once
 
 #include "MantidAPI/AnalysisDataServiceObserver.h"
 #include <boost/python/wrapper.hpp>
@@ -54,5 +53,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /*MANTID_PYTHONINTERFACE_ANALYSISDATASERVICEOBSERVERADAPTER_H_*/

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/BinaryOperations.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/BinaryOperations.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_BINARYOPERATIONS_H_
-#define MANTID_PYTHONINTERFACE_BINARYOPERATIONS_H_
+#pragma once
 //-----------------------------------------------------------------------------
 // Includes
 //-----------------------------------------------------------------------------
@@ -46,5 +45,3 @@ ResultType performBinaryOpMDWithDouble(const LHSType lhs, const double value,
 //@}
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_BINARYOPERATIONS_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/CloneMatrixWorkspace.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/CloneMatrixWorkspace.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_CLONEMATRIXWORKSPACE_H_
-#define MANTID_PYTHONINTERFACE_CLONEMATRIXWORKSPACE_H_
+#pragma once
 
 #include <vector>
 
@@ -30,5 +29,3 @@ PyObject *cloneDx(API::MatrixWorkspace &self);
 ///@}
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_CLONEMATRIXWORKSPACE_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunction1DAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunction1DAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTER_H_
-#define MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTER_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -67,5 +66,3 @@ public:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTER_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_IFUNCTIONADAPTER_H_
-#define MANTID_PYTHONINTERFACE_IFUNCTIONADAPTER_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -119,5 +118,3 @@ private:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_IFUNCTIONADAPTER_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IPeakFunctionAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IPeakFunctionAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_IPEAKFUNCTIONADAPTER_H_
-#define MANTID_PYTHONINTERFACE_IPEAKFUNCTIONADAPTER_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -84,5 +83,3 @@ private:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_IPEAKFUNCTIONADAPTER_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_ALGORITHMADAPTER_H_
-#define MANTID_PYTHONINTERFACE_ALGORITHMADAPTER_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -130,5 +129,3 @@ private:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_ALGORITHMADAPTER_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/DataProcessorAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/DataProcessorAdapter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHON_INTERFACE_DATAPROCESSORADAPTER_H
-#define MANTID_PYTHON_INTERFACE_DATAPROCESSORADAPTER_H
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -129,5 +128,3 @@ public:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHON_INTERFACE_DATAPROCESSORADAPTER_H

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/SpectrumInfoPythonIterator.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/SpectrumInfoPythonIterator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_SPECTRUMINFOPYTHONITERATOR_H_
-#define MANTID_PYTHONINTERFACE_SPECTRUMINFOPYTHONITERATOR_H_
+#pragma once
 
 #include "MantidAPI/SpectrumInfo.h"
 #include "MantidAPI/SpectrumInfoItem.h"
@@ -66,5 +65,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_SPECTRUMINFOPYTHONITERATOR_H_ */

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/WorkspacePropertyExporter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/WorkspacePropertyExporter.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_WORKSPACEPROPERTYMACRO_H_
-#define MANTID_PYTHONINTERFACE_WORKSPACEPROPERTYMACRO_H_
+#pragma once
 
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidPythonInterface/core/PropertyWithValueExporter.h"
@@ -141,5 +140,3 @@ template <typename WorkspaceType> struct WorkspacePropertyExporter {
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_WORKSPACEPROPERTYMACRO_H_ */

--- a/Framework/PythonInterface/mantid/geometry/inc/MantidPythonInterface/geometry/ComponentInfoPythonIterator.h
+++ b/Framework/PythonInterface/mantid/geometry/inc/MantidPythonInterface/geometry/ComponentInfoPythonIterator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_COMPONENTINFOPYTHONITERATOR_H_
-#define MANTID_PYTHONINTERFACE_COMPONENTINFOPYTHONITERATOR_H_
+#pragma once
 
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidGeometry/Instrument/ComponentInfoItem.h"
@@ -53,5 +52,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_COMPONENTINFOPYTHONITERATOR_H_ */

--- a/Framework/PythonInterface/mantid/geometry/inc/MantidPythonInterface/geometry/DetectorInfoPythonIterator.h
+++ b/Framework/PythonInterface/mantid/geometry/inc/MantidPythonInterface/geometry/DetectorInfoPythonIterator.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_DETECTORINFOPYTHONITERATOR_H_
-#define MANTID_PYTHONINTERFACE_DETECTORINFOPYTHONITERATOR_H_
+#pragma once
 
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Instrument/DetectorInfoItem.h"
@@ -62,5 +61,3 @@ private:
 
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_DETECTORINFOPYTHONITERATOR_H_ */

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/DllConfig.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/DllConfig.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_KERNEL_DLLCONFIG_H_
-#define MANTID_PYTHONINTERFACE_KERNEL_DLLCONFIG_H_
+#pragma once
 
 /*
     This file contains the DLLExport/DLLImport linkage configuration for the
@@ -20,5 +19,3 @@
 #else
 #define PYTHON_KERNEL_DLL DLLImport
 #endif
-
-#endif // MANTID_PYTHONINTERFACE_KERNEL_DLLCONFIG_H_

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/MappingTypeHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/MappingTypeHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_MAPPINGTYPEHANDLER_H
-#define MANTID_PYTHONINTERFACE_MAPPINGTYPEHANDLER_H
+#pragma once
 
 #include "MantidPythonInterface/kernel/Registry/PropertyValueHandler.h"
 
@@ -29,5 +28,3 @@ class MappingTypeHandler final : public PropertyValueHandler {
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_MAPPINGTYPEHANDLER_H

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyManagerFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H
-#define MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H
+#pragma once
 
 #include <boost/python/dict.hpp>
 #include <boost/shared_ptr.hpp>
@@ -23,5 +22,3 @@ createPropertyManager(const boost::python::dict &mapping);
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_PROPERTYMANAGERFACTORY_H

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyValueHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyValueHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PROPERTYVALUEHANDLER_H_
-#define MANTID_PYTHONINTERFACE_PROPERTYVALUEHANDLER_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <boost/python/object.hpp>
@@ -43,5 +42,3 @@ struct DLLExport PropertyValueHandler {
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_PROPERTYVALUEHANDLER_H_ */

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/PropertyWithValueFactory.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEFACTORY_H_
-#define MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEFACTORY_H_
+#pragma once
 
 //-----------------------------------------------------------------------------
 // Includes
@@ -51,5 +50,3 @@ private:
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // MANTID_PYTHONINTERFACE_PROPERTYWITHVALUEFACTORY_H_

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/RegisterWorkspacePtrToPython.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_DATEITEMINTERFACE_H_
-#define MANTID_PYTHONINTERFACE_DATEITEMINTERFACE_H_
+#pragma once
 
 #include "MantidPythonInterface/core/WeakPtr.h"
 #include "MantidPythonInterface/kernel/Registry/TypeRegistry.h"
@@ -41,5 +40,3 @@ template <typename IType> struct DLLExport RegisterWorkspacePtrToPython {
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_DATEITEMINTERFACE_H_ */

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/SequenceTypeHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/SequenceTypeHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_SEQUENCETYPEHANDLER_H_
-#define MANTID_PYTHONINTERFACE_SEQUENCETYPEHANDLER_H_
+#pragma once
 
 #include "MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h"
 
@@ -34,5 +33,3 @@ struct DLLExport SequenceTypeHandler
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_SEQUENCETYPEHANDLER_H_ */

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/TypeRegistry.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/TypeRegistry.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TYPEREGISTRY_H_
-#define MANTID_PYTHONINTERFACE_TYPEREGISTRY_H_
+#pragma once
 
 #include "MantidKernel/System.h"
 #include <typeinfo>
@@ -46,5 +45,3 @@ public:
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_TYPEREGISTRY_H_*/

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/Registry/TypedPropertyValueHandler.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TYPEDPROPERTYVALUEHANDLER_H_
-#define MANTID_PYTHONINTERFACE_TYPEDPROPERTYVALUEHANDLER_H_
+#pragma once
 
 #include "MantidPythonInterface/core/ExtractWorkspace.h"
 #include "MantidPythonInterface/core/IsNone.h" // includes object.hpp
@@ -144,5 +143,3 @@ struct DLLExport TypedPropertyValueHandler<
 } // namespace Registry
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif /* MANTID_PYTHONINTERFACE_TYPEDPROPERTYVALUEHANDLER_H_ */

--- a/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/kernel.h
+++ b/Framework/PythonInterface/mantid/kernel/inc/MantidPythonInterface/kernel/kernel.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_KERNEL_H_
-#define MANTID_PYTHONINTERFACE_KERNEL_H_
+#pragma once
 /*
  * Provides a function to initialize the numpy c api
  * function pointer table in the kernel module. This
@@ -33,5 +32,3 @@
 
 DLLExport void kernel_dll_import_numpy_capi_for_unittest();
 #endif
-
-#endif // MANTID_PYTHONINTERFACE_KERNEL_H_H

--- a/Framework/PythonInterface/test/cpp/FunctionAdapterTestCommon.h
+++ b/Framework/PythonInterface/test/cpp/FunctionAdapterTestCommon.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef FUNCTIONADAPTERTESTCOMMON_H
-#define FUNCTIONADAPTERTESTCOMMON_H
+#pragma once
 
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
@@ -111,5 +110,3 @@ private:
 };
 } // namespace PythonInterface
 } // namespace Mantid
-
-#endif // FUNCTIONADAPTERTESTCOMMON_H

--- a/Framework/PythonInterface/test/cpp/IFunction1DAdapterTest.h
+++ b/Framework/PythonInterface/test/cpp/IFunction1DAdapterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTERTEST_H
-#define MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTERTEST_H
+#pragma once
 
 #include "FunctionAdapterTestCommon.h"
 #include "MantidPythonInterface/api/FitFunctions/IFunction1DAdapter.h"
@@ -150,5 +149,3 @@ private:
   TestDataType m_xdata;
   TestDataType m_result;
 };
-
-#endif // MANTID_PYTHONINTERFACE_IFUNCTION1DADAPTERTEST_H

--- a/Framework/PythonInterface/test/cpp/IPeakFunctionAdapterTest.h
+++ b/Framework/PythonInterface/test/cpp/IPeakFunctionAdapterTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef IPEAKFUNCTIONADAPTERTEST_H
-#define IPEAKFUNCTIONADAPTERTEST_H
+#pragma once
 
 #include "FunctionAdapterTestCommon.h"
 #include "MantidPythonInterface/api/FitFunctions/IPeakFunctionAdapter.h"
@@ -101,5 +100,3 @@ public:
     TS_ASSERT_DELTA(2000, jacobian.get(0, 0), 1e-05);
   }
 };
-
-#endif // IPEAKFUNCTIONADAPTERTEST_H

--- a/Framework/PythonInterface/test/cpp/PropertyWithValueFactoryTest.h
+++ b/Framework/PythonInterface/test/cpp/PropertyWithValueFactoryTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PROPERTYWITHVALUEFACTORYTEST_H_
-#define PROPERTYWITHVALUEFACTORYTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 #ifdef _MSC_VER
@@ -154,5 +153,3 @@ private:
     TS_ASSERT_EQUALS(srcValue[0], propValue[0]);
   }
 };
-
-#endif /* PROPERTYWITHVALUEFACTORYTEST_H_ */

--- a/Framework/PythonInterface/test/cpp/PySequenceToVectorTest.h
+++ b/Framework/PythonInterface/test/cpp/PySequenceToVectorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PYSEQUENCETOVECTORCONVERTERTEST_H_
-#define PYSEQUENCETOVECTORCONVERTERTEST_H_
+#pragma once
 
 #include "MantidPythonInterface/core/Converters/PySequenceToVector.h"
 #include <boost/python/dict.hpp>
@@ -67,5 +66,3 @@ public:
     return testlist;
   }
 };
-
-#endif /* PYSEQUENCETOVECTORCONVERTERTEST_H_ */

--- a/Framework/PythonInterface/test/cpp/PythonAlgorithmInstantiatorTest.h
+++ b/Framework/PythonInterface/test/cpp/PythonAlgorithmInstantiatorTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PYTHONOBJECTINSTANTIATORTEST_H_
-#define PYTHONOBJECTINSTANTIATORTEST_H_
+#pragma once
 
 #include "MantidAPI/IAlgorithm.h"
 
@@ -74,5 +73,3 @@ private:
   /// Instantiator instance
   std::unique_ptr<PythonAlgorithmInstantiator> m_creator;
 };
-
-#endif /* PYTHONOBJECTINSTANTIATORTEST_H_ */

--- a/Framework/PythonInterface/test/cpp/PythonInterfaceCppTestInitialization.h
+++ b/Framework/PythonInterface/test/cpp/PythonInterfaceCppTestInitialization.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef PYTHONINTERFACE_CPP_GLOBALTESTINITIALIZATION_H
-#define PYTHONINTERFACE_CPP_GLOBALTESTINITIALIZATION_H
+#pragma once
 
 #include "MantidPythonInterface/core/Testing/PythonInterpreterGlobalFixture.h"
 #ifdef _WIN32
@@ -33,5 +32,3 @@ class ImportNumpyCAPI : CxxTest::GlobalFixture {
 //------------------------------------------------------------------------------
 static PythonInterpreterGlobalFixture PYTHON_INTERPRETER;
 static ImportNumpyCAPI IMPORT_NUMPY_C_API_KERNEL;
-
-#endif // PYTHONINTERFACE_CPP_GLOBALTESTINITIALIZATION_H

--- a/Framework/PythonInterface/test/cpp/RunPythonScriptTest.h
+++ b/Framework/PythonInterface/test/cpp/RunPythonScriptTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPTTEST_H_
-#define MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPTTEST_H_
+#pragma once
 
 #include <cxxtest/TestSuite.h>
 
@@ -45,5 +44,3 @@ public:
     TS_ASSERT(alg.existsProperty("Filename"));
   }
 };
-
-#endif /* MANTID_PYTHONINTERFACE_RUNPYTHONSCRIPTTEST_H_ */

--- a/Framework/PythonInterface/test/cpp/ToPyListTest.h
+++ b/Framework/PythonInterface/test/cpp/ToPyListTest.h
@@ -4,8 +4,7 @@
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
-#ifndef MANTID_PYTHONINTERFACE_TOPYLISTTEST_H
-#define MANTID_PYTHONINTERFACE_TOPYLISTTEST_H
+#pragma once
 
 #include "MantidPythonInterface/core/Converters/ToPyList.h"
 #include <boost/python/errors.hpp>
@@ -36,5 +35,3 @@ public:
 private:
   struct UnregisteredType {};
 };
-
-#endif // MANTID_PYTHONINTERFACE_TOPYLISTTEST_H


### PR DESCRIPTION
This PR replaces all header guards in PythonInterface with #pragma once

**To test:**

Any issues in this PR should be caught by jenkins. just code review to check that no definitions or endifs have been removed by mistake

This pr is a part of #28200

*This does not require release notes* because **it is an internal change to the codebase.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
